### PR TITLE
Fix prerelease downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Play ArenaNet's official Guild Wars client natively on your Mac — no Windows
 install, no Wine, no compatibility layer to configure.
 
-[Download](https://github.com/Mat4m0/gwonmac/releases/latest) ·
+[Download](https://github.com/Mat4m0/gwonmac/releases) ·
 [Install guide](docs/user-guide.md) ·
 [Discord](https://discord.gg/Z9ft52RBD3) ·
 [Report a bug](https://github.com/Mat4m0/gwonmac/issues/new?template=bug-report.yml) ·

--- a/apps/website/app/composables/useLatestRelease.ts
+++ b/apps/website/app/composables/useLatestRelease.ts
@@ -2,11 +2,16 @@
 import { EXTERNAL_URLS, RELEASE_REPO } from "../../../../src/shared/contracts";
 
 const FALLBACK_URL = EXTERNAL_URLS.releases;
-const API_URL = `https://api.github.com/repos/${RELEASE_REPO}/releases/latest`;
+const API_URL = `https://api.github.com/repos/${RELEASE_REPO}/releases?per_page=1`;
 
 interface ReleaseAsset {
   name: string;
   browser_download_url: string;
+}
+
+interface Release {
+  tag_name?: string;
+  assets?: ReleaseAsset[];
 }
 
 export function useLatestRelease() {
@@ -18,7 +23,9 @@ export function useLatestRelease() {
     try {
       const response = await fetch(API_URL);
       if (!response.ok) return;
-      const release: { tag_name?: string; assets?: ReleaseAsset[] } = await response.json();
+      const releases: Release[] = await response.json();
+      const release = releases[0];
+      if (!release) return;
       const assets = release.assets ?? [];
       // Releases ship the zipped .app; prefer an arch-tagged asset.
       const asset =

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -126,7 +126,7 @@ export const EXTERNAL_URLS: Record<ExternalLinkKind, string> = {
   github: `https://github.com/${RELEASE_REPO}`,
   discord: "https://discord.gg/Z9ft52RBD3",
   donate: "https://ko-fi.com/mat4m0",
-  releases: `https://github.com/${RELEASE_REPO}/releases/latest`,
+  releases: `https://github.com/${RELEASE_REPO}/releases`,
   // Official ArenaNet store, for players who do not own the game yet.
   store: "https://store.guildwars.com/en-us",
 };


### PR DESCRIPTION
## Summary

- resolve the newest published GitHub release, including prereleases
- send the website download button directly to the ARM64 ZIP asset
- replace broken `/releases/latest` fallbacks with the public releases list

## Why

GitHub excludes prereleases from its `latest` release endpoint, so the first alpha returned 404 and the website could not discover its ZIP.

## Validation

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:website`
- `pnpm test:release`
- live GitHub API lookup resolved `v0.0.1-alpha.1` to the expected ARM64 ZIP
