### PR TITLE
Add privacy-friendly website analytics

### DIFF
--- a/apps/website/app/app.vue
+++ b/apps/website/app/app.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 const { siteUrl } = useRuntimeConfig().public;
+useAnalytics();
 
 useSeoMeta({
   title: "Guild Wars for macOS — Native Launcher",

--- a/apps/website/app/components/DownloadCta.vue
+++ b/apps/website/app/components/DownloadCta.vue
@@ -1,9 +1,20 @@
 <script setup lang="ts">
-const props = withDefaults(defineProps<{ size?: "compact" | "large" }>(), {
-  size: "large",
-});
+import type { DownloadSource } from "../composables/useTracking";
+
+const props = withDefaults(
+  defineProps<{
+    size?: "compact" | "large";
+    source: DownloadSource;
+  }>(),
+  { size: "large" },
+);
 
 const { url, version } = useLatestRelease();
+const { trackDownload } = useTracking();
+
+function handleDownload(): void {
+  trackDownload(props.source, version.value);
+}
 </script>
 
 <template>
@@ -12,6 +23,7 @@ const { url, version } = useLatestRelease();
       :href="url"
       class="btn-primary"
       :class="props.size === 'large' ? 'px-8 py-4 text-lg' : 'px-4 py-2 text-sm'"
+      @click="handleDownload"
     >
       Download for macOS
     </a>

--- a/apps/website/app/components/FaqItem.vue
+++ b/apps/website/app/components/FaqItem.vue
@@ -1,9 +1,18 @@
 <script setup lang="ts">
-defineProps<{ question: string }>();
+const props = defineProps<{ question: string }>();
+const tracked = ref(false);
+const { trackFaqOpen } = useTracking();
+
+function handleToggle(event: Event): void {
+  const details = event.currentTarget as HTMLDetailsElement;
+  if (!details.open || tracked.value) return;
+  tracked.value = true;
+  trackFaqOpen(props.question);
+}
 </script>
 
 <template>
-  <details class="panel group px-5 py-4">
+  <details class="panel group px-5 py-4" @toggle="handleToggle">
     <summary class="cursor-pointer list-none text-parchment-100 select-none marker:content-none">
       <span class="mr-2 inline-block text-gold-400 transition-transform group-open:rotate-90">›</span>
       {{ question }}

--- a/apps/website/app/components/SiteFooter.vue
+++ b/apps/website/app/components/SiteFooter.vue
@@ -39,6 +39,12 @@ const LINKS = {
           QT Friz Quad font © QualiType, used under the
           <a href="/fonts/COPYING-QUALITYPE" class="underline hover:text-gold-200">SIL Open Font License 1.1</a>.
         </p>
+        <p>
+          This website uses cookie-free
+          <a href="https://plausible.io" class="underline hover:text-gold-200">Plausible Analytics</a>
+          for aggregate page views, download clicks, and FAQ opens. The Guild Wars application
+          itself uploads no telemetry.
+        </p>
       </div>
     </div>
   </footer>

--- a/apps/website/app/components/SiteNav.vue
+++ b/apps/website/app/components/SiteNav.vue
@@ -52,7 +52,7 @@ import { EXTERNAL_URLS } from "../../../../src/shared/contracts";
             />
           </svg>
         </a>
-        <DownloadCta size="compact" />
+        <DownloadCta size="compact" source="navigation" />
       </div>
     </nav>
   </header>

--- a/apps/website/app/composables/useAnalytics.ts
+++ b/apps/website/app/composables/useAnalytics.ts
@@ -1,0 +1,7 @@
+const PLAUSIBLE_SCRIPT_ID = "-X4qMlLVyMnUW4L8emwE_";
+
+export function useAnalytics(): void {
+  useScriptPlausibleAnalytics({
+    scriptId: PLAUSIBLE_SCRIPT_ID,
+  });
+}

--- a/apps/website/app/composables/useTracking.ts
+++ b/apps/website/app/composables/useTracking.ts
@@ -1,0 +1,31 @@
+export type DownloadSource =
+  | "final-cta"
+  | "hero"
+  | "install-guide"
+  | "navigation";
+
+export function useTracking() {
+  const plausibleTrack = (
+    event: string,
+    props?: Record<string, string | number>,
+  ): void => {
+    if (!import.meta.client) return;
+    window.plausible(event, props ? { props } : undefined);
+  };
+
+  const trackDownload = (
+    source: DownloadSource,
+    version: string | null,
+  ): void => {
+    plausibleTrack("Download Clicked", {
+      source,
+      version: version ?? "unknown",
+    });
+  };
+
+  const trackFaqOpen = (question: string): void => {
+    plausibleTrack("FAQ Clicked", { question });
+  };
+
+  return { trackDownload, trackFaqOpen };
+}

--- a/apps/website/app/pages/index.vue
+++ b/apps/website/app/pages/index.vue
@@ -35,7 +35,7 @@ const SCREENSHOTS = [
           Run the official Guild Wars client in a performant macOS app.
         </p>
         <div class="gold-rule h-px w-40" aria-hidden="true" />
-        <DownloadCta size="large" />
+        <DownloadCta size="large" source="hero" />
         <NuxtLink to="/install" class="text-sm text-parchment-300/70 underline hover:text-gold-200">
           How to install
         </NuxtLink>
@@ -108,7 +108,7 @@ const SCREENSHOTS = [
           Download Guild Wars for macOS and follow the short first-open guide.
         </p>
         <div class="flex flex-wrap items-center justify-center gap-4">
-          <DownloadCta size="large" />
+          <DownloadCta size="large" source="final-cta" />
           <NuxtLink to="/install" class="btn-secondary">Installation guide</NuxtLink>
         </div>
       </div>

--- a/apps/website/app/pages/install.vue
+++ b/apps/website/app/pages/install.vue
@@ -46,7 +46,7 @@ const STEPS = [
       are not yet notarized by Apple.
     </p>
     <div class="mt-6 flex justify-center">
-      <DownloadCta size="large" />
+      <DownloadCta size="large" source="install-guide" />
     </div>
 
     <ol class="mt-12 space-y-4">

--- a/apps/website/nuxt.config.ts
+++ b/apps/website/nuxt.config.ts
@@ -2,6 +2,7 @@ import tailwindcss from "@tailwindcss/vite";
 
 export default defineNuxtConfig({
   compatibilityDate: "2026-07-23",
+  modules: ["@nuxt/scripts"],
   css: ["~/assets/css/main.css"],
   vite: {
     plugins: [tailwindcss()],

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -16,5 +16,8 @@
     "typescript": "^5.9.2",
     "vue": "^3.5.18",
     "vue-tsc": "^3.0.4"
+  },
+  "dependencies": {
+    "@nuxt/scripts": "^0.13.4"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,10 @@ importers:
         version: 8.65.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)
 
   apps/website:
+    dependencies:
+      '@nuxt/scripts':
+        specifier: ^0.13.4
+        version: 0.13.4(@unhead/vue@2.1.16(vue@3.5.40(typescript@5.9.3)))(db0@0.3.4)(ioredis@5.11.1)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(typescript@5.9.3)(vue@3.5.40(typescript@5.9.3))
     devDependencies:
       '@tailwindcss/vite':
         specifier: ^4.1.11
@@ -808,6 +812,30 @@ packages:
     resolution: {integrity: sha512-RY4cH0z2JRlmcsAIrBBXlmRW8FnCBTRdHCByttog+lAxg1hrJ2W5OdnoHO0KMeZSJg67MdeYPOZu7ZszFEymgA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  '@nuxt/scripts@0.13.4':
+    resolution: {integrity: sha512-VYsoSAA7JIfSHN7f7WgBbSeKunwLFIzIlx171Cep2LTszgLFX20SjsRTeNbw746LuSB2aWjVSN40Sx+/g/6WdA==}
+    peerDependencies:
+      '@googlemaps/markerclusterer': ^2.6.2
+      '@paypal/paypal-js': ^8.1.2 || ^9.0.0
+      '@stripe/stripe-js': ^7.0.0 || ^8.0.0
+      '@types/google.maps': ^3.58.1
+      '@types/vimeo__player': ^2.18.3
+      '@types/youtube': ^0.1.0
+      '@unhead/vue': ^2.0.3
+    peerDependenciesMeta:
+      '@googlemaps/markerclusterer':
+        optional: true
+      '@paypal/paypal-js':
+        optional: true
+      '@stripe/stripe-js':
+        optional: true
+      '@types/google.maps':
+        optional: true
+      '@types/vimeo__player':
+        optional: true
+      '@types/youtube':
+        optional: true
+
   '@nuxt/telemetry@2.8.0':
     resolution: {integrity: sha512-zAwXY24KYvpLTmiV+osagd2EHkfs5IF+7oDZYTQoit5r0kPlwaCNlzHp5I/wUAWT4LBw6lG8gZ6bWidAdv/erQ==}
     engines: {node: '>=18.12.0'}
@@ -1560,6 +1588,9 @@ packages:
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
 
+  '@types/web-bluetooth@0.0.21':
+    resolution: {integrity: sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==}
+
   '@types/wrap-ansi@3.0.0':
     resolution: {integrity: sha512-ltIpx+kM7g/MLRZfkbL7EsCEjfzCcScLpkg37eXEtx5kmrAKBkTJwd1GIAjDSL8wTpM6Hzn5YO4pSb91BEwu1g==}
 
@@ -1648,6 +1679,11 @@ packages:
         optional: true
       webpack:
         optional: true
+
+  '@unhead/vue@2.1.16':
+    resolution: {integrity: sha512-t6QykImeMJcrUTbFB0Coy0cB/OZItHdQFRFLoH8GAVXKWmQORGPrwvueP9me7adOCuMH2uVvrv0nCkbi6zksaA==}
+    peerDependencies:
+      vue: '>=3.5.18'
 
   '@unhead/vue@3.2.3':
     resolution: {integrity: sha512-u1qi/0tDyytDSAex8+JMgeDMDlBh3RuzFmTaPOEmbAIx4BG9ej/18ChfM962DC0G7kKhOiuqiSpCfWR5S3XKGg==}
@@ -1770,6 +1806,19 @@ packages:
 
   '@vue/shared@3.5.40':
     resolution: {integrity: sha512-WxnBtruIqOoV3rA4jeKDWzrYI5h7Cp4+pjwDi8kWGHz+IslhiN+wguLVVhtv2l8VoU02rzDCVfDjgCl1lNpZVg==}
+
+  '@vueuse/core@14.3.0':
+    resolution: {integrity: sha512-aHfz47g0ZhMtTVHmIzMVpJy8ePhhOy68GY5bv110+5DVtZ+W7BsOx+m61UNQqfrWyPztIHIanWa3E2tib3NFIw==}
+    peerDependencies:
+      vue: ^3.5.0
+
+  '@vueuse/metadata@14.3.0':
+    resolution: {integrity: sha512-BwxmbAzwAVF50+MW57GXOUEV61nFBGnlBvrTqj49PqWJu3uw7hdu72ztXeZ33RdZtDY6kO+bfCAE1PCn88Tktw==}
+
+  '@vueuse/shared@14.3.0':
+    resolution: {integrity: sha512-bZpge9eSXwa4ToSiqJ7j6KRwhAsneMFoSz3LMWKQDkqimm3D/tbFlrklrs/IOqC8tEcYmXQZJ6N0UrjhBirVCg==}
+    peerDependencies:
+      vue: ^3.5.0
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -4567,6 +4616,9 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
@@ -4813,6 +4865,9 @@ packages:
 
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
+
+  unhead@2.1.16:
+    resolution: {integrity: sha512-cD2Q4a6SQHhW9/bPp17NT4GJ1yS0DSLe75WEHKQ8bKa/wjB6cIki3KeL86hhllNBcpv8i6bxdwtwQunneXPqKQ==}
 
   unhead@3.2.3:
     resolution: {integrity: sha512-BBkKvthUOufEJzG4C4u5NCdxnGMNaQdb//oPDI8lkv/6qj0faEqnPIvIPejt3FnSE501LX25Gbe2MVgKDuFnyQ==}
@@ -6387,6 +6442,36 @@ snapshots:
       - utf-8-validate
       - vue
 
+  '@nuxt/kit@4.5.0(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@2.3.11)':
+    dependencies:
+      c12: 3.3.4(magicast@0.5.3)
+      consola: 3.4.2
+      defu: 6.1.7
+      destr: 2.0.5
+      errx: 0.1.0
+      exsolve: 1.1.0
+      ignore: 7.0.6
+      jiti: 2.7.0
+      klona: 2.0.6
+      mlly: 1.8.2
+      nostics: 1.2.0
+      ohash: 2.0.11
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      rc9: 3.0.1
+      scule: 1.3.0
+      semver: 7.8.5
+      tinyglobby: 0.2.17
+      ufo: 1.6.4
+      unctx: 3.0.0(magic-string@0.30.21)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@2.3.11)
+      untyped: 2.0.0
+    transitivePeerDependencies:
+      - magic-string
+      - magicast
+      - oxc-parser
+      - rolldown
+      - unplugin
+
   '@nuxt/kit@4.5.0(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.22)))':
     dependencies:
       c12: 3.3.4(magicast@0.5.3)
@@ -6541,6 +6626,51 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 2.3.1
       std-env: 4.2.0
+
+  '@nuxt/scripts@0.13.4(@unhead/vue@2.1.16(vue@3.5.40(typescript@5.9.3)))(db0@0.3.4)(ioredis@5.11.1)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(typescript@5.9.3)(vue@3.5.40(typescript@5.9.3))':
+    dependencies:
+      '@nuxt/kit': 4.5.0(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@2.3.11)
+      '@unhead/vue': 2.1.16(vue@3.5.40(typescript@5.9.3))
+      '@vueuse/core': 14.3.0(vue@3.5.40(typescript@5.9.3))
+      consola: 3.4.2
+      defu: 6.1.7
+      h3: 1.15.11
+      magic-string: 0.30.21
+      ofetch: 1.5.1
+      ohash: 2.0.11
+      pathe: 2.0.3
+      pkg-types: 2.3.1
+      sirv: 3.0.2
+      std-env: 3.10.0
+      ufo: 1.6.4
+      unplugin: 2.3.11
+      unstorage: 1.17.5(db0@0.3.4)(ioredis@5.11.1)
+      valibot: 1.4.2(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - db0
+      - idb-keyval
+      - ioredis
+      - magicast
+      - oxc-parser
+      - rolldown
+      - typescript
+      - uploadthing
+      - vue
 
   '@nuxt/telemetry@2.8.0(@nuxt/kit@4.5.0(magic-string@1.0.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.22))))':
     dependencies:
@@ -7077,6 +7207,8 @@ snapshots:
     dependencies:
       '@types/node': 22.20.1
 
+  '@types/web-bluetooth@0.0.21': {}
+
   '@types/wrap-ansi@3.0.0': {}
 
   '@types/yauzl@2.10.3':
@@ -7200,6 +7332,12 @@ snapshots:
       - srvx
       - typescript
       - unloader
+
+  '@unhead/vue@2.1.16(vue@3.5.40(typescript@5.9.3))':
+    dependencies:
+      hookable: 6.1.1
+      unhead: 2.1.16
+      vue: 3.5.40(typescript@5.9.3)
 
   '@unhead/vue@3.2.3(esbuild@0.28.1)(lightningcss@1.33.0)(rolldown@1.2.0)(rollup@4.62.2)(srvx@0.11.22)(typescript@5.9.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(vue@3.5.40(typescript@5.9.3))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.22))':
     dependencies:
@@ -7418,6 +7556,19 @@ snapshots:
       '@vue/shared': 3.5.40
 
   '@vue/shared@3.5.40': {}
+
+  '@vueuse/core@14.3.0(vue@3.5.40(typescript@5.9.3))':
+    dependencies:
+      '@types/web-bluetooth': 0.0.21
+      '@vueuse/metadata': 14.3.0
+      '@vueuse/shared': 14.3.0(vue@3.5.40(typescript@5.9.3))
+      vue: 3.5.40(typescript@5.9.3)
+
+  '@vueuse/metadata@14.3.0': {}
+
+  '@vueuse/shared@14.3.0(vue@3.5.40(typescript@5.9.3))':
+    dependencies:
+      vue: 3.5.40(typescript@5.9.3)
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -10284,7 +10435,7 @@ snapshots:
       '@rollup/rollup-win32-ia32-msvc': 4.62.2
       '@rollup/rollup-win32-x64-gnu': 4.62.2
       '@rollup/rollup-win32-x64-msvc': 4.62.2
-      fsevents: 2.3.2
+      fsevents: 2.3.3
 
   rou3@0.8.1: {}
 
@@ -10459,6 +10610,8 @@ snapshots:
   standard-as-callback@2.1.0: {}
 
   statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
 
   std-env@4.2.0: {}
 
@@ -10679,6 +10832,13 @@ snapshots:
       magic-string: 0.30.21
       unplugin: 2.3.11
 
+  unctx@3.0.0(magic-string@0.30.21)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@2.3.11):
+    optionalDependencies:
+      magic-string: 0.30.21
+      oxc-parser: 0.140.0
+      rolldown: 1.2.0
+      unplugin: 2.3.11
+
   unctx@3.0.0(magic-string@0.30.21)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.22))):
     optionalDependencies:
       magic-string: 0.30.21
@@ -10705,6 +10865,10 @@ snapshots:
   unenv@2.0.0-rc.24:
     dependencies:
       pathe: 2.0.3
+
+  unhead@2.1.16:
+    dependencies:
+      hookable: 6.1.1
 
   unhead@3.2.3(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.22)):
     dependencies:


### PR DESCRIPTION
## Summary

- load the site-specific Plausible script through Nuxt Scripts
- track download clicks with placement and release-version properties
- track the first open of each FAQ item
- disclose aggregate website analytics separately from the telemetry-free desktop app

## Events

| Event | Properties |
| --- | --- |
| `Download Clicked` | `source`, `version` |
| `FAQ Clicked` | `question` |

Download sources are `navigation`, `hero`, `final-cta`, and `install-guide`.

## Verification

- `pnpm lint`
- `pnpm test:unit`
- `pnpm test:website`
- `pnpm test:release`
- `pnpm audit --audit-level=high`
- generated production HTML references `https://plausible.io/js/pa--X4qMlLVyMnUW4L8emwE_.js`

## Plausible dashboard

After the first production events arrive, add the matching `Download Clicked`
and `FAQ Clicked` custom-event goals in Plausible. This requires an authenticated
Plausible session; no API token is configured in the repository or environment.
