### PR TITLE
Fix template save/load/rename/delete, and insure it against client updates (#5)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ not only happy paths.
 | `src/tools/diagnostics/`  | `.gwdiag` validation, summary, comparison                     |
 | `tests/`                  | unit, integration, Electron, packaged, and release invariants |
 | `tools/`, `gwkey.py`      | developer-only binary analysis                                |
+| `internal/upstream/`      | upstream client defects, workaround, re-certification          |
 
 ## Load-bearing constraints
 
@@ -154,6 +155,12 @@ focus opt out and say why. The production-network smoke is explicitly opt-in:
 ```bash
 pnpm build && GW_LIVE_SMOKE=1 pnpm test:electron
 ```
+
+When an ArenaNet client update lands and build templates stop working, the
+`wasm.templateSaveCompatible` gauge in a `.gwdiag` says so, and
+`pnpm template:recertify` re-derives the certified build entry by shape rather
+than by remembered index. It recovers indices, not semantics —
+`internal/upstream/recertify.md` owns the rest.
 
 For Toolbox work, begin with `pnpm toolbox:doctor`, use the offline layers in
 `docs/toolbox-development.md`, and finish with one scoped `toolbox:live`

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -42,6 +42,7 @@ arbitrary filesystem or URL fetch capability.
 | `src/main/main.ts`        | composition root and application lifecycle                        |
 | `src/main/client-runtime.ts` | atomic generation, update, rollback, cache, selected WASM       |
 | `src/main/core/`          | updater, cache, DNS, sockets, credentials, settings, window state |
+| `src/main/core/wasm-binary.ts` | WASM section codec shared by both transforms and the re-certifier |
 | `src/main/protocol.ts`    | `gw://app` routing and range responses                            |
 | `src/main/ipc.ts`         | validated native capability handlers                              |
 | `src/main/diagnostics.ts` | bounded flight recorder, captures, export                         |
@@ -186,15 +187,61 @@ errno, and requested/written byte counts. It never records a filename, path, or
 file content, does not cross IPC, and is not included in `.gwdiag` exports.
 Normal launches retain the original imports unchanged.
 
-Static inspection identifies the pre-open failure as the web implementation of
-`PathCreateDirectory` in `EmscriptenPath.cpp`, which returns error 2 without
-touching Emscripten FS. For the exact certified client hash, a deterministic
-same-size transform redirects only that call to the existing
-`__syscall_stat64` import with an impossible stat-buffer sentinel. The renderer
-recognizes the sentinel, decodes the wide path, permits only
-`Templates/Skills` or `Templates/Equipment`, calls synchronous `FS.mkdirTree`,
-and returns the real success/error result. Ordinary stat calls remain
-unchanged.
+`internal/upstream/` holds the full record: the defect report written for
+ArenaNet, the client internals we had to recover, the bridge contract, the
+re-certification procedure for a new client build, and the investigation log.
+Read it before changing anything below.
+
+Every index and offset the transform carries belongs to one exact client build.
+`pnpm template:recertify` re-derives them from a new one by shape — body bytes,
+resolved signatures, and caller-set intersection — and refuses rather than
+guessing when a locator finds the wrong number of candidates. It recovers
+indices, not semantics; `internal/upstream/recertify.md` still owns re-measuring
+what the client's path helpers actually do.
+
+Four `Base/Os` file routines ship unimplemented and never reach Emscripten FS.
+Creating a directory returns error 2 unconditionally, which is why a build save
+fails before any syscall. Enumerating a directory does nothing, which is why
+"Load from Skills Template" lists nothing, and deriving an entry's name writes
+nothing. Deleting a file is `assert("not implemented")` followed by
+`unreachable`, so removing or renaming a build aborts the client. A fifth
+routine is implemented but wrong: `File::Open` mode 1 is meant to open an
+existing file, and the client uses it to ask whether a rename's destination is
+already taken — but in this build it opens `O_RDWR | O_CREAT`, so the probe
+creates the file it is testing for and every rename is refused. The module
+imports no `mkdir`, `getdents`, or `unlink`, so none of this is reachable from
+JavaScript as shipped.
+
+For the exact certified client hash, a deterministic transform appends five
+forwarders and repoints only the template, chat-log, and screenshot call sites
+at them. Appending leaves every existing function index valid, and the stub
+bodies stay intact so the model paths that also call them keep today's
+behaviour. Each forwarder passes the stub's arguments to the existing
+`__syscall_newfstatat` import behind a dirfd marker no real call can produce.
+The `File::Open` forwarder is the one exception: it asks the host first and
+calls the real function only when the file is there, so the load and write
+paths keep their own behaviour and only the probe changes.
+
+The renderer answers the five markers against the mounted IDBFS: create a
+directory tree, list a wildcard, turn an entry into the name the client keys a
+template by, delete a file, and answer whether one exists. Renaming needs no
+marker of its own — the client implements it as probe, write the new name, then
+delete the old. Paths must stay relative and free of traversal, so the client
+cannot address anything outside its own mount. Directory entries the
+mount cannot describe are skipped rather than failing the whole listing. The
+listing block is allocated with the client's own `malloc` because the client
+frees it. Ordinary `newfstatat` calls remain unchanged.
+
+Three details in that contract are load-bearing, and each one cost a round of
+build, ship, and try again. The enumeration flag selects the entry kind — the
+template scans ask for `*.txt` with files and `*` with directories — so
+answering both with files fills the subdirectory list with folders named after
+the templates. A template is keyed by its path below the type directory in
+Windows form with a leading separator, `\Test`, which is what the client's own
+save path builds and what its list filter matches against the current
+subdirectory; a bare `Test` registers but never lists. And the host removes the
+extension itself, because `Path::RemoveExtension` in this build takes the last
+character of the name with it.
 
 The downloaded official module remains canonical. The derived module is
 verified by input hash, instruction signature, WebAssembly validation, and

--- a/internal/upstream/README.md
+++ b/internal/upstream/README.md
@@ -1,0 +1,71 @@
+# Upstream client defects and the host workaround
+
+Everything we learned reverse-engineering ArenaNet's WebAssembly Guild Wars
+client while fixing [issue #5](https://github.com/Mat4m0/gwonmac/issues/5),
+"Can't save builds".
+
+The short version: the client's entire template file-management layer ships
+unimplemented. Saving, listing, naming and deleting a build are four separate
+stubs in `Base/Os/Emscripten`. Two further defects finish the job: an off-by-one
+in `Path::RemoveExtension` corrupts every name that survives the first four, and
+`File::Open` mode 1 creates the file it is asked to test for, so no rename can
+ever succeed.
+
+None of it is a macOS, Electron or IDBFS problem, and none of it can be repaired
+from JavaScript alone, because the module imports no `mkdir`, `getdents` or
+`unlink`: the client never reaches a syscall we could answer.
+
+We work around it with one derived module, accepted only for an exact official
+hash, that routes the broken routines back into the host.
+
+## The documents
+
+| File | Audience | Contents |
+| --- | --- | --- |
+| [upstream-defects.md](upstream-defects.md) | **ArenaNet** | Six defects, each with the function, signature, observed behaviour, reproduction, and expected behaviour. Self-contained; needs nothing from this repo. |
+| [client-internals.md](client-internals.md) | us | The reference we had to build: function indices, data layouts, path conventions, the list filter. Everything a future change to this area needs. |
+| [host-bridge.md](host-bridge.md) | us | What we actually ship: the transform, the five markers, the bridge contract, and the invariants that must hold. |
+| [recertify.md](recertify.md) | us | The procedure when ArenaNet publishes a new client. Every index and offset below is build-specific. |
+| [investigation-log.md](investigation-log.md) | us | The chronology, including every wrong turn and what corrected it. Read this before re-deriving anything. |
+
+## The build this describes
+
+| | |
+| --- | --- |
+| Artifact | `Gw.jspi.wasm` |
+| SHA-256 | `b0319704f3072d6948a66026a35af5eb0af12b48d70986783c293e7c77e98483` |
+| Size | 8,194,484 bytes |
+| Function imports | 219 |
+| Defined functions | 17,600 |
+| Derived module SHA-256 | `68c6e09cec0f6992058a44a5617ca9eac7fab4697be1421943bbf664e6d444f6` |
+| Derived size | 8,194,585 bytes |
+
+Every function index, local index and byte offset in these documents belongs to
+that exact build. A new client invalidates all of them — see
+[recertify.md](recertify.md). The transform refuses unknown hashes and falls
+back to the untouched official module, so a new build degrades to "templates
+broken again" rather than to a corrupted client.
+
+## The one technique worth remembering
+
+Static disassembly produced one confident, plausible, wrong answer after
+another. What ended the guessing every time was **running ArenaNet's own
+functions**:
+append export entries to the module, instantiate it in Node with stub imports,
+and call the function directly. Pure path helpers need no game state, no
+network and no login.
+
+That turned "I think `_wsplitpath` keeps the trailing separator" into a
+measurement, and it is how we found the `Path::RemoveExtension` off-by-one that
+no amount of reading had revealed. The recipe is in
+[recertify.md](recertify.md#probing-the-clients-own-functions).
+
+## Reporting this upstream
+
+[upstream-defects.md](upstream-defects.md) is written to be sent as-is. It
+names functions by index and signature rather than by symbol, because the
+shipped module is stripped — an ArenaNet engineer with the source tree will
+recognise each one immediately from its call sites and behaviour.
+
+We would much rather these were fixed at source than carry a growing derived
+module indefinitely.

--- a/internal/upstream/client-internals.md
+++ b/internal/upstream/client-internals.md
@@ -1,0 +1,243 @@
+# Client internals: the template subsystem
+
+The reference we had to reconstruct. Everything here is for build
+`b0319704…`; indices and offsets are build-specific.
+
+Function index = local code-section index + 219 (the function import count).
+
+## Call graph
+
+```
+UI                          Account client                  Base/Os
+──────────────────────────  ──────────────────────────────  ─────────────────────
+
+TemplatesSave.cpp
+  17012/17016 ─────────────► 9756  save skills ─────┐
+                             9755  save equipment ──┤
+                                                    ├─► 9757 write one file
+                                                    │     404  create directory  ← stub
+                                                    │     771  File::Open mode 1 ← probe, creates
+                                                    │     771  File::Open mode 2
+                                                    │     779  File::Write
+TemplatesList.cpp
+  16982 refresh ───────────► 9832 clear ─► 9734
+                             9819 rescan ─► 9745 ──┬─► 9746 scan directories
+                                                   │     405  find files        ← stub
+                                                   │     416  entry name        ← stub
+                                                   └─► 9747 scan files
+                                                         405, 416              ← stubs
+                                                         457  remove extension ← off by one
+  16979 build rows ────────► 9811 ─► 9738 iterate + filter
+                                       9736 next id
+  16976 add row
+
+TemplatesLoad.cpp
+  16988/16989 ─────────────► 9753 open one template
+                                     771, 769, 780
+
+TemplatesManage.cpp
+  16997 rename ────────────► 9821 ─► 9754 ─┬─► 9755/9756 write new name
+                                           └─► 9735 delete old
+  17000 delete ────────────► 9810 ─────────────► 9735 delete
+                                                 760  File::Delete
+                                                   730 ─► 678 ─► 552          ← abort
+```
+
+## The broken routines and their call sites
+
+| Function | Local | Signature | Problem |
+| --- | --- | --- | --- |
+| 404 create directory | 185 | `(path, recursive) -> errno` | `i32.const 2`, always fails |
+| 405 find files | 186 | `(out, pattern, flags) -> void` | empty body |
+| 416 entry name | 197 | `(dst, _, baseDir, _, path, chars) -> written` | `i32.const 0`, writes nothing |
+| 552 delete file | 333 | `(path) -> deleted` | `assert("not implemented"); unreachable` |
+| 771 `File::Open` | 552 | `(path, mode, err) -> handle` | implemented, but mode 1 carries `O_CREAT` |
+
+Call sites we repoint, as `(caller local, byte offset in body)`:
+
+| Stub | Sites |
+| --- | --- |
+| 404 | 9538+171 (#9757 template save), 11525+142 (#11744 chat log), 12214+127 (#12433 screenshot) |
+| 405 | 9527+157 (#9746 directories), 9528+157 (#9747 files), 11525+210, 12214+419 |
+| 416 | 9527+276, 9528+278 |
+| 552 | 459+201 (#678 `ExeFileDelete`) |
+| 771 | 9538+201 — the existence probe in #9757 only. The write call at 9538+226 and the load path keep the real function. |
+
+Not repointed, deliberately: 404 in #11460 (`ActDlgLogin`, result discarded),
+405 in #6656 (`FrApi`), 416 in #4463 and #4532 (the model paths — they test the
+result and currently take a working fallback branch, so changing it would be a
+regression risk in code we have not analysed).
+
+Every one of these `call` instructions uses LLVM's 5-byte padded index encoding,
+so a repoint fits in place without changing any body length.
+
+## Path helpers
+
+| Function | Meaning |
+| --- | --- |
+| 411 | `_wsplitpath(path, drive, dir, fname, ext)` |
+| 412 | `_wmakepath(path, chars, drive, dir, fname, ext)` |
+| 455 | `Path::GetDirectory(dst, src, chars)` |
+| 456 | `Path::Append(dst, dir, name, chars)` — `makepath(dir, fname)` |
+| 457 | `Path::RemoveExtension(dst, src, chars)` — **off by one, see defect 5** |
+| 459 | `Path::SetDefaultExtension(dst, src, ext, chars)` |
+| 408 | wide string copy, returns `dst[0] != 0` |
+| 410 | `PathIsRelative` — treats both `/` and `\` as separators |
+
+### `File::Open` modes
+
+Mode 1 is the client's open-an-existing-file mode and mode 2 its create-and-write
+mode, but both reach `openat` with `O_RDWR | O_CREAT | O_LARGEFILE` (32834).
+Captured live:
+
+```
+save    openat flags:32834 create:true → fd_pwrite 24/24 → fd_close
+rename  openat flags:32834 create:true → fd_close            ← probe, no write
+```
+
+`#9757` uses mode 1 to ask whether a rename's destination is taken, so the probe
+creates the file it is testing for and answers "taken" every time. The two
+signatures above — write versus no write after an identical open — are how to
+recognise it in a trace.
+
+Two further behaviours that cost us real time:
+
+- **`_wsplitpath` returns the directory including its trailing separator.** So
+  `Path::GetDirectory("Templates/Skills/Test.txt")` is `"Templates/Skills/"`,
+  not `"Templates/Skills"`. Measured, not inferred.
+- **`_wmakepath` joins with `/`**, and inserts a separator after a non-empty
+  directory only when it does not already end in `/` or `\`.
+
+Consequence: the client joins its type directory with `/` onto a record name
+that already begins with `\`, so **every file operation on a listed template
+arrives with a doubled separator**:
+
+```
+Templates/Skills  +  \Test  +  .txt  →  Templates/Skills/\Test.txt
+```
+
+That is a redundant separator, not a traversal attempt. A host that rejects it
+breaks delete and rename.
+
+## Template name conventions
+
+A template is keyed by **its path below the type directory, in Windows form
+with a leading separator**:
+
+| Location | Record name |
+| --- | --- |
+| `Templates/Skills/Test.txt` | `\Test` |
+| `Templates/Skills/Sub/Test.txt` | `\Sub\Test` |
+
+`TemplatesSave.cpp` (17012, 17016) builds exactly this before handing the name
+to the account client, which is why the in-game confirmation reads
+`The Skills Template named "\Test" has been saved.` — the leading backslash is
+the record name, not a display artefact. We spent two rounds treating it as an
+escaping bug.
+
+The extension is **not** part of the record name; `9753` re-appends `.txt` when
+opening.
+
+### Name sanitiser
+
+Both the save path (9756) and both scans (9746, 9747) run the same filter on the
+name:
+
+1. skip leading characters in `1..32`
+2. skip leading `.`
+3. drop every character `< 32` or in `` .*:/<>|"? ``
+4. trim trailing characters `<= 32`
+
+Note what is **absent from the reject set**: backslash. The leading `\` of a
+record name survives, by design.
+
+## The list filter
+
+`9738(ctx, type, filterPath, cursor)` yields one template id per call:
+
+```c
+while (next_id(ctx, type, 0, cursor)) {
+    record = ctx->refArray[*cursor];
+    match = wcsstr(record->name, filterPath);
+    if (match && !wcschr(match + wcslen(filterPath), L'\\'))
+        return 1;                       // direct child of the current directory
+}
+return 0;
+```
+
+`filterPath` is the dialog's current subdirectory, held at `this+0` of the
+`TemplatesList` object. `TemplatesList.cpp:16978` appends `<name>\` when
+entering a subdirectory and truncates at the last `\` when leaving — and asserts
+`subDir` if none is present, so **the root value is a single `\`**, not the empty
+string.
+
+This is why a record named `Test` registers correctly and never appears:
+`wcsstr("Test", "\\")` is null. It must be `\Test`.
+
+The header shown in the dialog (`Templates/Skills\`) is built separately, from
+`9816` → `9742`, and is not the filter.
+
+## Template record layout
+
+Two id-managed collections live in the account template context
+(`s_propContext[10] + 36`):
+
+| Collection | Array | Count | Hash | Populated by |
+| --- | --- | --- | --- | --- |
+| Subdirectories | +8 | +16 | +40 | 9746 (36-byte records) |
+| Template files | +76 | +84 | +108 | 9747 and the save paths (180-byte records) |
+
+The list dialog iterates the file collection only.
+
+Template file record, the fields we depend on:
+
+| Offset | Field |
+| --- | --- |
+| +28 | `wchar_t*` name — the `\Test` form above |
+| +32 | store — 0 |
+| +36 | type — 0 skills, 1 equipment |
+| +40 | template data |
+
+`9736` asserts `record->store == store` and `record->type == type`, which is how
+we confirmed the field order.
+
+## Scan state machine
+
+`9745(ctx, type)`:
+
+```c
+if (ctx->state[type] != 0) return;   // already scanned
+ctx->state[type] = 1;
+scan_directories(ctx, type);         // 9746
+scan_files(ctx, type);               // 9747
+ctx->state[type] = 2;                // "ready"
+notify_ui();
+```
+
+`AccountCliTemplateIsReady(type)` is `state[type] == 2`. A rescan is a no-op
+unless something resets the state first — which `9734` (clear) does, as its last
+statement, and which "Refresh List" therefore triggers via
+`16982 → 9832 → 9734`.
+
+## Latent defect on the save error path
+
+`9757`, on a failed create, falls through to `Handle::Release(NULL)`, which
+asserts `handle` and aborts. In the shipped build this is unreachable because
+defect 1 fails first. It is reachable in a build where directory creation
+succeeds but the open fails — which is exactly what happened when we first
+bypassed the guard naively.
+
+## Enumeration patterns, measured
+
+Replaying the client's own sequence for the skills scan:
+
+```
+full path       : "Templates/Skills/Test.txt"
+directory arg   : "Templates/Skills/"
+files pattern   : "Templates/Skills/*.txt"     flags 17
+dirs pattern    : "Templates/Skills/*"         flags 18
+```
+
+The `Templates/Skills` and `Templates/Equipment` literals are UTF-16 at
+`0x161600` and `0x161622`, reached through the table at `0x161654`
+(`s_templateDirs[type]`).

--- a/internal/upstream/host-bridge.md
+++ b/internal/upstream/host-bridge.md
@@ -1,0 +1,229 @@
+# The host bridge
+
+What we ship to work around the defects in
+[upstream-defects.md](upstream-defects.md).
+
+## Shape
+
+Two halves, one contract:
+
+| Half | File | Job |
+| --- | --- | --- |
+| Main | [`src/main/core/template-save-compat.ts`](../../src/main/core/template-save-compat.ts) | derive one module from the certified official hash |
+| Renderer | [`src/renderer/template-save-compatibility.js`](../../src/renderer/template-save-compatibility.js) | answer the derived module's calls against the mounted IDBFS |
+
+Selection and caching live in
+[`template-save-client.ts`](../../src/main/core/template-save-client.ts) and
+[`client-runtime.ts`](../../src/main/client-runtime.ts). Installation is
+[`harness.js`](../../src/renderer/harness.js) inside `Module.instantiateWasm`,
+before instantiation, so the import object can be wrapped.
+
+## Why a derived module at all
+
+The client never reaches a syscall for four of the five operations, and imports
+no `mkdir`, `getdents` or `unlink`. The fifth does reach a syscall, but with
+flags we cannot distinguish from a legitimate create. There is no
+JavaScript-only fix in either case: these are internal WebAssembly functions, so
+the module bytes have to change.
+
+## How the transform works
+
+For the certified input hash only:
+
+1. **Append** one forwarder per bridged routine to the type, function and code
+   sections. Appending leaves every existing function index valid, so nothing
+   else in the module changes meaning. Each forwarder reuses its target's own
+   type index.
+2. **Repoint** the specific call sites listed in
+   [client-internals.md](client-internals.md#the-broken-routines-and-their-call-sites)
+   at the forwarders. The `call` immediates use LLVM's 5-byte padded encoding,
+   so the replacement is the same width and no body length changes.
+3. **Leave the target bodies intact.** Callers we did not certify keep exactly
+   today's behaviour — which matters for `MdlDecomp.cpp` and `MdlTex.cpp`, which
+   also call 416 and currently take a working fallback branch, and for the load
+   path and the write call that still use the real `File::Open`.
+
+Each forwarder hands its arguments to `__syscall_newfstatat` (import 207) behind
+a dirfd no real call can produce:
+
+```wasm
+;; ensureDirectory(path, recursive) -> errno
+i32.const -70001
+local.get 0        ;; path
+i32.const 0
+local.get 1        ;; recursive
+call 207
+```
+
+`__syscall_newfstatat` was chosen because it already exists, takes four `i32`
+arguments and returns one, and its first argument is a directory descriptor —
+`AT_FDCWD` (-100) or a real fd, never our markers. Ordinary calls pass through
+untouched.
+
+### Markers
+
+| Marker | Operation |
+| --- | --- |
+| `-70001` | ensure directory |
+| `-70002` | find files |
+| `-70003` | entry name |
+| `-70004` | delete file |
+| `-70005` | does this file exist |
+
+The two halves hold these by hand. `tests/release/wasm-host.test.mjs` asserts
+both files list the same five, because drift would silently turn every bridged
+call into a real `stat`.
+
+Renaming needs no marker of its own: the client implements it as
+write-the-new-name followed by delete-the-old, gated by the existence probe.
+
+### Failing closed
+
+`rewriteTemplateSaveWasm` rejects, in order: an unexpected input hash, a stub
+whose body is not byte-for-byte what we certified (where we certify one — the
+`File::Open` bridge fronts a real implementation, and there the call site's own
+target index is the certification), a call site that does not
+contain the expected `call`, an output hash that differs from the pinned one,
+and a module that fails `WebAssembly.validate`. Any failure falls back to the
+untouched official module. A new client build therefore degrades to "templates
+broken again", never to a corrupted client.
+
+The derived module is cached under `game/compatibility/<input hash>/<abi>/` and
+is rebuildable from the official artifact at any time.
+
+## Bridge contract
+
+### ensure directory
+
+`(path) -> errno`, 0 on success. `FS.mkdirTree` on the normalised path.
+
+### find files
+
+`(pattern, out, flags) -> 0`
+
+- split the pattern at its last `/` into directory and glob; `*` and `?` match
+  within one component, case-insensitively
+- include an entry when `FS.isDir(mode) ? (flags & 2) : (flags & 1)`
+- sort by name, for a stable list
+- allocate `count * 544` bytes with **the client's own `malloc`**, because the
+  client frees the block; take every heap view *after* the allocation, since it
+  can grow memory
+- zero the 24-byte header, write the name (with extension) at +24
+- publish `entries` at `out+0` and `count` at `out+8`
+
+An entry the mount cannot describe is skipped rather than failing the listing —
+the client has no way to report a partial read.
+
+### entry name
+
+`(path, dst, chars) -> written`
+
+Returns the client's internal record form: a leading `\`, backslash separators,
+**extension removed**.
+
+Removing the extension here is not tidiness. The client calls
+`Path::RemoveExtension` on this result and that function is off by one (defect
+5), so anything with an extension loses its last character. Handing it a bare
+name leaves it nothing to trim. If ArenaNet fixes defect 5, this stays correct —
+stripping an absent extension is a no-op.
+
+### delete file
+
+`(path) -> deleted`, **non-zero on success** — that is what the caller reads.
+`FS.unlink` on the normalised path.
+
+### does this file exist
+
+`(path) -> exists`
+
+The one bridge that fronts a working function rather than replacing a stub.
+`#9757`'s no-overwrite probe calls `File::Open(path, 1)` to ask whether a
+rename's destination is taken, and mode 1 creates the file (defect 6). The
+forwarder asks the host first and only calls the real `File::Open` when the file
+is genuinely there:
+
+```wasm
+i32.const -70005
+local.get 0
+i32.const 0
+i32.const 0
+call 207           ;; newfstatat -> 1 exists, 0 absent
+if (result i32)
+  local.get 0
+  local.get 1
+  local.get 2
+  call 771         ;; the real File::Open, so the caller gets a real handle
+else
+  i32.const 0
+end
+```
+
+Returning a handle rather than a boolean matters: the caller passes the result
+to `Handle::Release`, which asserts on null.
+
+An undecidable path answers "exists", which refuses the rename rather than
+silently overwriting a template.
+
+Only the probe is repointed. The write call at `9538+226` and the load path in
+`#9753` keep the real function untouched.
+
+### Path normalisation
+
+Applies to every operation:
+
+1. backslashes to forward slashes
+2. collapse runs of separators — the client produces `Templates/Skills/\Test.txt`
+   on every file operation against a listed template
+3. strip leading and trailing separators
+4. drop an `app:/` prefix
+5. reject the path if any remaining segment is empty, `.` or `..`
+
+Step 5 keeps the client inside its own mount. Step 2 has to come first: without
+it the doubled separator produces an empty segment and step 5 rejects a
+perfectly ordinary path. That cost us a round on delete and rename.
+
+## Invariants
+
+- The official module stays canonical on disk; only the derived copy is
+  transformed, and only for an exact hash.
+- Function bodies are never modified, only call sites — so uncertified callers
+  are untouched.
+- The bridge stays inside the renderer: no IPC, no `fetch`, no native bridge.
+  Asserted in `tests/release/wasm-host.test.mjs`.
+- The listing block comes from the client's allocator.
+- Bump `TEMPLATE_SAVE_TRANSFORM_ABI` whenever the derived bytes or the bridge
+  contract change; it is part of the cache key.
+
+## Diagnostics
+
+`GW_TEMPLATE_FS_TRACE=1` adds `template-fs-trace=1` to the trusted renderer URL
+and enables two console-only traces:
+
+- `[template-fs-trace]` — the syscall wrappers, from
+  [`template-filesystem-trace.js`](../../src/renderer/template-filesystem-trace.js)
+- `[template-fs-bridge]` — the bridge itself: which marker fired, how many
+  entries were listed and matched, whether the block was published, and each
+  outcome
+
+Both record counts and outcomes only — no filename, path or content — and
+neither crosses IPC or appears in `.gwdiag`. Normal launches are unaffected.
+
+```bash
+GW_TEMPLATE_FS_TRACE=1 ELECTRON_ENABLE_LOGGING=1 \
+  "…/Guild Wars.app/Contents/MacOS/Guild Wars" 2>&1 \
+  | rg --line-buffered 'template-fs'
+```
+
+Reading a trace:
+
+| Shape | Meaning |
+| --- | --- |
+| only `installed` | the client never asked — the operation fails before the bridge |
+| `"listed":-1,"failed":…` | `FS.readdir` rejected the directory |
+| `"listed":N,"matched":0` | directory reads, the glob or the kind filter is wrong |
+| `"published":true` | the host handed over a correct list; any remaining failure is past the bridge |
+
+A trace that filters cannot prove absence. The first version of the syscall
+trace only recorded paths it recognised as template paths, and its silence was
+read as "no filesystem activity at all" — see
+[investigation-log.md](investigation-log.md).

--- a/internal/upstream/investigation-log.md
+++ b/internal/upstream/investigation-log.md
@@ -1,0 +1,270 @@
+# Investigation log
+
+Issue #5, "Can't save builds", from first report to working CRUD. Kept because
+the wrong turns are more instructive than the answer, and because anyone
+revisiting this area will be tempted by the same ones.
+
+Ten rounds. One of them was right first time. Every correction came from
+measuring the running client, never from reading more disassembly.
+
+## Round 0 — the reported bug
+
+> "The attempt to save the Skills Template named "\f" failed because the file
+> could not be created/written to"
+
+M3 MacBook Air, macOS 26.5.1.
+
+## Round 1 — wrong: host filesystem setup
+
+**Hypothesis.** The renderer mounts IDBFS at `app:` too late, does not create
+`Templates/Skills`, and the client builds mixed `Templates/Skills\Test.st`
+paths that Emscripten's POSIX layer cannot resolve. The `\f` in the message
+looked like the smoking gun.
+
+**Built.** Owning the mount in `preRun`, creating both template directories,
+`chdir` into the mount, and normalising backslashes at every public `FS`
+operation.
+
+**Wrong because** the client's `_wmakepath` joins with `/`. Measured later by
+executing it: the path is `Templates/Skills/Test.txt`, no backslash anywhere.
+The `\` in the message is the record name's leading separator (see round 7),
+not an escaping artefact.
+
+**Kept anyway** — owning the mount and the `chdir` are correct invariants on
+their own merits, and the backslash normalisation turned out to be load-bearing
+later, for a different reason.
+
+**Lesson.** A plausible story that explains the symptom is not evidence. The
+path builder was three lines of WASM away from being measured.
+
+## Round 2 — wrong: bypassing the guard
+
+**Found.** `func_404`, the create-directory routine, is four bytes:
+`i32.const 2`. It always fails. The save checks it before opening, so no
+syscall is ever attempted.
+
+**Built.** A patch that skipped the guard.
+
+**Result.** The client crashed on save.
+
+**Why.** Skipping the check is not the same as creating the directory. With the
+directory still missing, the open failed, and the client's untested error path
+calls `Handle::Release(NULL)`, which asserts and aborts.
+
+**Lesson.** When a stub gates an operation, implement it. A bypass sends the
+client down paths its author never ran.
+
+## Round 3 — wrong: reading a filtered trace as absence
+
+A syscall tracer was added over `openat`, `fd_write` and friends. A full
+session, with a save attempt, produced exactly one line:
+
+```
+[template-fs-trace] {"sequence":1,"operation":"enabled"}
+```
+
+**Read as** "the client performs no filesystem activity at all".
+
+**Actually** the tracer only recorded paths it classified as template paths, and
+the failure happens before any syscall. Both facts were true; the conclusion did
+not follow from the trace.
+
+Two defects in the instrument itself, found later:
+
+- it read `Module.HEAPU32`, which the generated glue never assigns — only
+  `HEAPU8` is published. Every byte count and open mode in the trace was
+  silently `undefined`.
+- its unit test passed a fabricated `HEAPU32` in the fixture, so the shape
+  mismatch could never surface.
+
+**Lesson.** A trace that filters cannot prove absence. And a fixture that hands
+the code under test a shape the real caller does not provide tests nothing.
+
+## Round 4 — right: the four stubs
+
+Systematic sweep instead of hypotheses. Reverse call graph from the syscall
+imports, forward from the template UI, then a scan for tiny bodies and for
+`assert("not implemented")`.
+
+Result: four unimplemented routines, listed in
+[upstream-defects.md](upstream-defects.md). Also the observation that the module
+imports no `mkdir`, `getdents` or `unlink` — so no JavaScript-only fix exists and
+the module bytes have to change.
+
+Built the transform: append forwarders, repoint certified call sites, route
+through `__syscall_newfstatat` behind impossible dirfd markers.
+
+## Round 5 — wrong: the trailing separator
+
+**Built.** The bridge matched the incoming directory against an allowlist of
+`Templates/Skills` and `Templates/Equipment`.
+
+**Result.** Save still failed, identically.
+
+**Why.** `_wsplitpath` returns the directory *including* its trailing separator
+and `_wmakepath` puts it back, so the client passes `Templates/Skills/`. The
+allowlist missed and the bridge returned error 2 — the same error the stub had
+returned, which is why the symptom did not change at all.
+
+Confirmed by executing the client's own helpers:
+
+```
+full path      : "Templates/Skills/Test.txt"
+directory arg  : "Templates/Skills/"
+func_404(dir,1): 2
+```
+
+**This is where the method changed.** From here on, every claim about client
+behaviour was measured by appending exports and calling the function. It found
+the remaining four bugs.
+
+**Lesson.** Test the shape the client actually passes, not the shape that seems
+reasonable. The old tests asserted the bare directory name, which is why the bug
+survived them.
+
+## Round 6 — wrong: ignoring the flags argument
+
+Save worked. The list stayed empty.
+
+Both template scans call find-files, and the only difference between them is the
+third argument: `17` for `Templates/Skills/*.txt` and `18` for
+`Templates/Skills/*`. Bit 0 means files, bit 1 means directories.
+
+The bridge ignored it and answered both with files, filling the subdirectory
+collection with phantom folders named after the templates.
+
+**Lesson.** An argument you do not understand is not an argument you can drop.
+
+## Round 7 — wrong: the record name form
+
+The list was still empty even though the bridge was provably delivering: five
+files found, five names written. So the failure had to be past the bridge, in
+the client's own bookkeeping — which we could not see.
+
+**What broke the deadlock.** A temporary probe that walked the client's template
+registry from the renderer, using the layout recovered from the disassembly. It
+reported three records with the right store and type, and:
+
+```
+"backslash": false
+```
+
+The client keys a template by its path below the type directory in Windows form
+with a leading separator — `\Test` — and its list filter matches records against
+the current subdirectory, which is `\` at the root. `wcsstr("Test", "\\")` is
+null, so every record registered correctly and none was ever listed.
+
+The in-game message had been telling us this from the first screenshot:
+`The Skills Template named "\Test" has been saved.` We spent two rounds treating
+that backslash as a UI artefact.
+
+**Lesson.** When a failure is past your own code, read the other side's data
+structures. And re-read the error text after you understand the system; it
+usually turns out to have been literal.
+
+The probe was removed once it had done its job — it hardcoded client memory
+offsets and had no business shipping.
+
+## Round 8 — wrong: keeping the extension
+
+The list populated. Every name was one character short — `ASDAs` showed as
+`ASDA` — and loading failed with "This Template's Template Code does not appear
+to be valid", because the client was opening `ASDA.txt`, which does not exist.
+
+The scan calls `Path::RemoveExtension` on the name. Measured:
+
+```
+Path::RemoveExtension("\ASDAs.txt") = "\ASDA"
+Path::RemoveExtension("\ASDAs")     = "\ASDAs"
+```
+
+The client's own helper is off by one: it removes the extension *and* the
+character before it. Not our bug, but ours to avoid — the bridge now strips the
+extension itself, leaving that function nothing to trim.
+
+**Lesson.** Reused helpers in the host code are not necessarily correct helpers.
+This one had presumably never been exercised, because nothing that calls it ever
+ran.
+
+## Round 9 — wrong: rejecting a redundant separator
+
+Delete aborted the client; the fourth stub, `assert("not implemented")` followed
+by `unreachable`, was the cause. Bridged it to `FS.unlink`.
+
+Delete then failed cleanly instead of crashing, and rename failed with it.
+
+**Why.** The client joins its type directory with `/` onto a record name that
+already begins with `\`:
+
+```
+Templates/Skills  +  \ASDAs  +  .txt  →  Templates/Skills/\ASDAs.txt
+```
+
+Normalising the backslash produced `Templates/Skills//ASDAs.txt`. The empty
+middle segment tripped the bridge's `.`/`..`/empty traversal guard, so the path
+was refused.
+
+The integration check had passed because it was fed `Templates/Skills/Test.txt`
+— a cleaner path than the client ever produces.
+
+**Lesson.** Repeat of round 5, at a different layer. Fixtures must use the real
+shape. Separator runs are redundant, not hostile; collapse them the way
+`PATH.normalize` does, then apply the traversal guard.
+
+## Round 10 — wrong: assuming rename was delete plus write
+
+Delete worked. Rename still failed, and the trace showed why it was hard to see:
+the bridge was never called at all. Rename fails *before* it reaches either the
+write or the delete, so every bridge-side hypothesis was unfalsifiable from the
+trace we had.
+
+**What broke the deadlock.** Redirecting the client's own log to a file and
+reading what the rename path did, rather than what the bridge saw. It reported
+the destination as already taken — for a name that did not exist.
+
+`#9757` asks that question by calling `File::Open(path, 1, err)`. Mode 1 is
+documented as open-existing, but in this build it opens `O_RDWR | O_CREAT` (see
+defect 6). The probe created the file it was testing for, then found it, then
+refused the rename. Every attempt also left an empty file behind.
+
+Fixed with a fifth marker and the only branching forwarder in the transform: ask
+the host whether the file exists, and call the real `File::Open` only when it
+does. The write call five instructions later, and the load path, keep the real
+function untouched.
+
+**Lesson.** When the instrument shows nothing, the failure is upstream of the
+instrument. Two rounds went into bridge-side theories that the trace had already
+ruled out — it recorded no bridge call, and we read that as "the bridge answered
+wrongly" instead of "the bridge was never asked". Round 3's lesson, inverted and
+unlearned.
+
+## What we would do differently
+
+1. **Measure the contract before writing the host side.** Executing the client's
+   path helpers takes minutes and needs no login. Every round from 5 onward
+   would have collapsed into one.
+2. **Enumerate the whole surface first.** The four stubs were all findable in one
+   sweep on day one. Discovering them one failure at a time cost four
+   build-and-test cycles with the user in the loop. But note what the sweep
+   cannot find: a stub has a recognisable shape, and defects 5 and 6 are
+   implemented functions that behave wrongly. Only measurement finds those.
+3. **Distrust silence from instruments.** Round 3's empty trace was the single
+   most expensive wrong conclusion, and the instrument had two independent
+   defects of its own.
+4. **Re-read the user's error text after understanding the system.** `"\f"` and
+   `"\Test"` were the answer to round 7, printed in the very first report.
+
+## Verification ladder that ended up working
+
+| Level | Proves | Cost |
+| --- | --- | --- |
+| `wasmscan` disassembly | a hypothesis worth testing | seconds |
+| export-and-call probe | ground truth for any pure client function | minutes |
+| derived module + real bridge in Node | the two halves agree | minutes |
+| packaged app + opt-in trace | it works against the real filesystem | one live run |
+| client log redirected to a file | what the client thinks happened | one live run |
+| registry probe | attributes a failure past the bridge | one live run |
+
+Use the lowest level that can actually decide the question. Levels 1 and 2 cost
+nothing; the ones with a human in the loop are the expensive ones and should be
+spent on questions the cheap levels cannot answer.

--- a/internal/upstream/recertify.md
+++ b/internal/upstream/recertify.md
@@ -1,0 +1,291 @@
+# Re-certifying a new client build
+
+Every function index, local index and byte offset in these documents belongs to
+build `b0319704…`. A new ArenaNet client invalidates all of them.
+
+Nothing breaks when that happens: `findTemplateSaveBuild` returns null for an
+unknown hash and the untouched official module is used, so the client keeps
+working and templates go back to being broken. Startup logs
+`wasm.templateSaveUnsupported`, and the `wasm.templateSaveCompatible` gauge is
+`false` in any `.gwdiag` a user sends — **check that first when someone reports
+that templates stopped working.**
+
+## The short version
+
+```bash
+# 0. Prove the tool still reproduces today's certified entry. Exits 0.
+pnpm template:recertify -- --expect-certified
+
+# 1. Point it at the new client and read the JSON.
+pnpm template:recertify -- "<path>/Gw.jspi.wasm"
+
+# 2. Get a paste-ready entry for TEMPLATE_SAVE_BUILDS (goes to stderr).
+pnpm template:recertify -- "<path>/Gw.jspi.wasm" --emit-ts
+```
+
+The tool re-derives every index and call-site offset by shape — body bytes,
+resolved signatures, and caller-set intersection — then runs the derived entry
+through the production transform to fill in `outputSha256`. It never guesses:
+each stage asserts an exact count and reports every candidate it rejected.
+
+Read the `status` field first:
+
+| `status` | Meaning |
+| --- | --- |
+| `certified` / `derived` with `matchesCertifiedEntry: true` | nothing to do |
+| `derived` | paste the entry, bump the ABI if the derived bytes changed |
+| `not-applicable` | no create-directory stub — **ArenaNet may have fixed it**, see step 1 below before doing anything else |
+| `failed` | read `diagnostics`; a locator found the wrong number of candidates and named them |
+
+**What this does not do.** It recovers indices, not semantics. Step 5 below —
+re-measuring what the path helpers actually do — still has to be done by hand,
+and skipping it is how you ship a bridge that resolves cleanly and behaves
+wrongly. Every one of the six upstream defects in
+[upstream-defects.md](upstream-defects.md) was a semantic finding, not an index.
+
+## Manual procedure
+
+Kept because the tool can only fail one way — by refusing — and when it does,
+this is what you fall back to.
+
+### 1. Check whether it is still needed
+
+Install the new client and try to save a build. If ArenaNet has fixed the
+defects, delete the whole bridge rather than re-certifying it — the point was
+never to own this code. `git log` for `template-save-compat` gives the full
+removal surface.
+
+### 2. Regenerate symbols
+
+```bash
+python3 tools/gensyms.py "<path>/Gw.jspi.wasm" build/
+```
+
+Produces `build/Gw.named.wasm` (loadable in Ghidra, Chrome DevTools, Binaryen),
+`build/symbols.csv` (function → source file and assertion strings) and
+`build/string_xrefs.csv`.
+
+Function index = local index + the function import count. Get the count from
+`tools/wasmscan.py`; do not assume 219.
+
+### 3. Find the four stubs, then `File::Open`
+
+Each has a recipe that does not depend on the old indices:
+
+**Create directory.** Body is a single `i32.const 2`. Cross-check the callers:
+one in `AcctCliTemplate.cpp`, one in `UiScreen.cpp`, one in `CtChatLog.cpp`, one
+in `ActDlgLogin.cpp`.
+
+**Find files.** Body is empty, signature `(i32,i32,i32) -> ()`. Its callers are
+the same set plus the two `AcctCliTemplate.cpp` scans.
+
+**Entry name.** Body is a single `i32.const 0`, signature `(i32 × 6) -> i32`,
+called from both scans.
+
+Both scans are easiest to reach from the data side — find the UTF-16
+`Templates/Skills` literal and the functions referencing it:
+
+```python
+import sys; sys.path.insert(0, 'tools')
+from wasmscan import WasmModule
+m = WasmModule('<path>/Gw.jspi.wasm')
+for base, blob in m.segs:
+    i = blob.find('Templates/Skills'.encode('utf-16-le'))
+    while i >= 0:
+        print(hex(base + i), m.refs_to(base + i))
+        i = blob.find('Templates/Skills'.encode('utf-16-le'), i + 1)
+```
+
+**Delete file.** Sweep for `assert("not implemented")` bodies and keep the ones
+with a live caller:
+
+```python
+def text(v):
+    for base, blob in m.segs:
+        if base <= v < base + len(blob):
+            o = v - base
+            return blob[o:blob.find(b'\0', o)].decode('ascii', 'replace')
+for s, e, f in m.funcs:
+    if e - s > 40: continue
+    ops = list(m.decode_body(s, e))
+    kinds = [op for _o, op, _v in ops]
+    if kinds[:3] == [0x41, 0x41, 0x41] and 0x10 in kinds and 0x00 in kinds:
+        consts = [v for _o, op, v in ops if op == 0x41]
+        print(f, text(consts[0]), text(consts[1]), consts[2])
+```
+
+**File::Open.** The only bridged target that is not a stub, so it has no
+distinguishing body — it is identified by how the template-write function uses
+it. In the write function (a caller of create-directory that is neither of the
+two scans nor a directory sink), find the `(i32,i32,i32) -> i32` callee that is
+called exactly twice, where the first call is preceded by `i32.const 1;
+i32.const 0` and the second by `i32.const 2; i32.const 0`.
+
+The mode is the *second*-to-last constant: both calls end with the literal `err`
+argument. Decode two instructions rather than matching raw bytes, or the recipe
+breaks silently the day that argument stops being a literal zero.
+
+Only the first of the two — the mode-1 existence probe — is repointed. The
+mode-2 write call and the load path keep the real function.
+
+### 4. Record the call sites
+
+For each stub, the callers to repoint and the byte offset of the `call` inside
+each caller's body:
+
+```python
+bodies = {f: (s, e) for s, e, f in m.funcs}
+for caller in CALLERS:
+    s, e = bodies[caller]
+    for off, op, val in m.decode_body(s, e):
+        if op == 0x10 and val == STUB_INDEX:
+            print(caller - IMPORTS, off - s)
+```
+
+Confirm each is a 6-byte padded encoding (`10` followed by five bytes). If a
+future toolchain emits canonical LEB there instead, the same-width repoint no
+longer applies and the transform needs to splice bodies rather than overwrite in
+place.
+
+### 5. Re-measure the conventions
+
+Do not assume the semantics carried over. Re-run the probes in the next section
+for at least:
+
+- `Path::GetDirectory` on a full template path — does it still keep the trailing
+  separator?
+- `_wmakepath` — still `/`?
+- `Path::RemoveExtension` on `"\Test.txt"` — is defect 5 still present? If it is
+  fixed, our extension stripping stays correct but the comment explaining it
+  should say so.
+- the enumeration patterns and their `flags` values
+
+### 6. Update, pin, verify
+
+`pnpm template:recertify -- <wasm> --emit-ts` does steps 1 and 2 for you.
+
+1. Add the new entry to `TEMPLATE_SAVE_BUILDS` with `outputSha256: ""`.
+2. Run the transform; the thrown error reports the actual derived hash. Pin it.
+3. Bump `TEMPLATE_SAVE_TRANSFORM_ABI` if the derived bytes or the contract
+   changed — it is part of the derived cache key.
+4. Update the hashes in `tests/release/wasm-host.test.mjs`.
+5. `pnpm check && pnpm build && pnpm test:release`
+6. Run the live checklist below.
+
+## Probing the client's own functions
+
+The technique that ended every round of guessing. Append export entries for the
+functions you care about, instantiate in Node with stub imports, and call them.
+Pure path helpers need no game state, network or login.
+
+Appending exports is safe: it changes only the export section's own length.
+
+```python
+import sys; sys.path.insert(0, 'tools')
+from wasmscan import WasmModule, uleb as rd
+
+def enc(v):
+    out = bytearray()
+    while True:
+        b = v & 0x7f; v >>= 7
+        if v: out.append(b | 0x80)
+        else:
+            out.append(b); return bytes(out)
+
+def name(s):
+    b = s.encode(); return enc(len(b)) + b
+
+WANT = [404, 411, 412, 455, 456, 457, 459, 895]     # whatever you need
+m = WasmModule('<path>/Gw.jspi.wasm'); d = m.d
+p, sec = 8, None
+while p < len(d):
+    sid = d[p]; hp = p; p += 1
+    ln, q = rd(d, p); body = q; p = q + ln
+    if sid == 7: sec = (hp, body, ln)
+hp, body, ln = sec
+n, q = rd(d, body)
+add = b''.join(name(f'probe_{f}') + bytes([0]) + enc(f) for f in WANT)
+new = enc(n + len(WANT)) + d[q:body + ln] + add
+open('build/Gw.probe.wasm', 'wb').write(
+    d[:hp] + bytes([7]) + enc(len(new)) + new + d[body + ln:])
+```
+
+```js
+import { readFile } from 'node:fs/promises';
+
+const mod = new WebAssembly.Module(await readFile('build/Gw.probe.wasm'));
+const imports = {};
+for (const { module, name } of WebAssembly.Module.imports(mod)) {
+  imports[module] ??= {};
+  imports[module][name] = () => 0;
+}
+const E = new WebAssembly.Instance(mod, imports).exports;
+
+const u16 = () => new Uint16Array(E.memory.buffer);
+const w = (a, s) => { const h = u16(), i = a >>> 1;
+  for (let k = 0; k < s.length; k += 1) h[i + k] = s.charCodeAt(k);
+  h[i + s.length] = 0; };
+const r = (a) => { const h = u16(); let i = a >>> 1, o = '';
+  while (h[i]) { o += String.fromCharCode(h[i]); i += 1; } return o; };
+
+// Scratch space well past the data segments; nothing else is running.
+const A = 0x400000, B = 0x410000;
+w(A, '\\Test.txt');
+E.probe_457(B, A, 260);
+console.log(JSON.stringify(r(B)));      // "\Test" if defect 5 is fixed
+```
+
+Notes:
+
+- Stub every import with `() => 0`. Nothing we probe uses them.
+- The stack pointer global is initialised, so functions with locals work without
+  running `__wasm_call_ctors`.
+- `malloc` and `memory` are already exported by the official module, so the
+  client's own allocator is available — that is how we proved the listing block
+  is allocated and freed correctly.
+- Use it on the **derived** module too, to prove the forwarders route to the
+  carrier with the right markers and arguments.
+
+## Integration check without the game
+
+Instantiate the derived module with the **real** bridge source over a fake
+filesystem, then drive the forwarders directly. This catches contract mistakes
+that unit tests with hand-made fixtures miss:
+
+```js
+const ctx = { ArrayBuffer, Math, RegExp, String,
+              Uint8Array, Uint16Array, Uint32Array, window: {}, FS: fakeFs };
+Object.assign(ctx, { globalThis: ctx });
+vm.runInNewContext(await readFile('src/renderer/template-save-compatibility.js', 'utf8'), ctx);
+ctx.window.gwInstallTemplateSaveCompatibility({
+  imports, module: Module, exports: () => instance?.exports ?? null,
+});
+```
+
+Feed it the path shapes the client actually produces — with the doubled
+separator, `Templates/Skills/\Test.txt`. A cleaner path passes when the real one
+would not; that exact mistake hid the delete bug through one full round.
+
+## Live checklist
+
+Requires a login. Run the whole cycle in order rather than each action alone.
+
+- [ ] Save a build → confirmation names it `"\<name>"`
+- [ ] Open "Load from Skills Template" → the build is listed, name complete
+- [ ] Load it → skills apply, no "Template Code" error
+- [ ] Rename it → the list shows the new name only, no duplicate left behind
+- [ ] Delete it → disappears, no crash
+- [ ] Restart the app → surviving templates are still listed
+- [ ] Create a subdirectory case if possible → nested templates list one level
+      down and not at the root
+- [ ] Take a screenshot → `Screens/` is written
+- [ ] Equipment templates → same cycle, type 1
+
+With `GW_TEMPLATE_FS_TRACE=1`, `[template-fs-bridge]` should show
+`ensureDirectory result 0`, `findFiles … published:true`, one `fileBaseName` per
+entry, `fileExists exists:false` before a rename that is allowed to proceed, and
+`deleteFile deleted:true`.
+
+If the bridge logs nothing at all for an action, the failure is upstream of the
+bridge and no bridge-side change will fix it — read the client's own log instead.
+That is what round 10 cost.

--- a/internal/upstream/upstream-defects.md
+++ b/internal/upstream/upstream-defects.md
@@ -1,0 +1,268 @@
+# Guild Wars WebAssembly client: template file management is unimplemented
+
+A report for ArenaNet. Nothing in it depends on our project.
+
+## Summary
+
+In the published WebAssembly client, saving, listing, renaming and deleting
+skill and equipment templates cannot work. Six defects are involved: four
+`Base/Os/Emscripten` routines that ship unimplemented, and two logic errors —
+one in path handling and one in the file open modes. The first two routines
+also disable screenshots and chat logs.
+
+Client examined:
+
+| | |
+| --- | --- |
+| Artifact | `Gw.jspi.wasm` |
+| SHA-256 | `b0319704f3072d6948a66026a35af5eb0af12b48d70986783c293e7c77e98483` |
+| Size | 8,194,484 bytes |
+
+The module is stripped, so functions are identified below by index, signature,
+call sites and observed behaviour. Source attribution comes from the assertion
+strings embedded in each translation unit.
+
+Every claim here was verified by executing the function in question, not by
+reading the disassembly. The method: append export entries for the target
+function to the module, instantiate it in Node with stub imports, call it. The
+path helpers are pure and need no game state.
+
+## User-visible symptoms
+
+| Action | Result |
+| --- | --- |
+| Save a skill template | *"The attempt to save the Skills Template named "…" failed because the file could not be created/written to"* |
+| Load from Skills Template | List is always empty, including after a successful save |
+| Rename a template | *"The attempt to rename the Skills Template named "…" failed"* |
+| Delete a template | Client aborts |
+| Screenshot (`Screens/`) | Never written |
+| Chat log | Never written |
+
+## Defect 1 — directory creation always fails
+
+**Function 404**, `(wchar_t* path, int recursive) -> int`, in
+`Base/Os/Emscripten/EmscriptenPath.cpp`.
+
+Entire body:
+
+```wasm
+i32.const 2
+end
+```
+
+It returns `2` (`ERROR_FILE_NOT_FOUND`) unconditionally, without touching the
+Emscripten filesystem.
+
+Callers, all of which treat a non-zero result as fatal to the operation:
+
+| Caller | Purpose |
+| --- | --- |
+| 9757, from `Gw/Account/Cli/AcctCliTemplate.cpp` | create `Templates/Skills` / `Templates/Equipment` before writing a template |
+| 12433, `Gw/Ui/UiScreen.cpp` | create `Screens` before a screenshot |
+| 11744, `CtChatLog.cpp` | create the chat-log directory |
+| 11460, `ActDlgLogin.cpp` | result discarded |
+
+**Consequence.** The template save path checks this before opening the file, so
+`AcctCliTemplate.cpp:1020` stores error 2 and the client reports that the file
+could not be created. No filesystem syscall is ever attempted. Verified: the
+save failure occurs with zero `openat` activity.
+
+```
+func_404(L"Templates/Skills/", 1) = 2
+```
+
+**Expected.** Create the directory (with parents when `recursive`) and return 0
+on success. The module imports no `mkdir`, so this needs an implementation
+against the Emscripten FS API — `FS.mkdirTree` is the direct equivalent.
+
+## Defect 2 — directory enumeration does nothing
+
+**Function 405**, `(FileList* out, const wchar_t* pattern, int flags) -> void`,
+same translation unit.
+
+Entire body is empty. It returns without writing to `out`, which the caller
+zeroed beforehand — so every directory reads as empty.
+
+The `out` structure, from the call sites:
+
+```c
+struct FileList {          // 16 bytes, caller-zeroed
+    Entry*   entries;      // +0   caller frees this with free()
+    uint32_t _pad;         // +4
+    uint32_t count;        // +8
+    uint32_t _pad2;        // +12
+};
+
+struct Entry {             // 544 bytes, stride confirmed at every call site
+    uint8_t  header[24];   // +0   no caller reads this
+    wchar_t  name[260];    // +24  file name, with extension
+};
+```
+
+`flags` selects the entry kind. Observed values:
+
+| Caller | Pattern | flags |
+| --- | --- | --- |
+| 9747, `AcctCliTemplate.cpp` | `Templates/Skills/*.txt` | 17 — files |
+| 9746, `AcctCliTemplate.cpp` | `Templates/Skills/*` | 18 — directories |
+| 11744, `CtChatLog.cpp` | `<dir>/gw???.txt` | 1 |
+| 12433, `UiScreen.cpp` | `Screens/gw???.???` | 1 |
+
+Bit 0 selects files and bit 1 selects directories; bit 4 is set by the template
+scans only and we did not determine its meaning.
+
+**Consequence.** "Load from Skills Template" is permanently empty, and the
+screenshot and chat-log paths cannot find the next free `gw000.*` index.
+
+**Expected.** Populate `out` with the matching entries. The module imports no
+`getdents`; `FS.readdir` plus `FS.stat` is the equivalent. Note the allocation
+contract: the caller frees `entries`, so it must come from the client's own
+allocator.
+
+## Defect 3 — entry-name derivation writes nothing
+
+**Function 416**,
+`(wchar_t* dst, int, const wchar_t* baseDir, int, const wchar_t* path, int dstChars) -> int`,
+same translation unit.
+
+Entire body:
+
+```wasm
+i32.const 0
+end
+```
+
+It returns 0 and writes nothing to `dst`.
+
+Callers: 9746 and 9747 (`AcctCliTemplate.cpp`, both template scans), 4463
+(`MdlDecomp.cpp`) and 4532 (`MdlTex.cpp`).
+
+**Consequence.** In the template scans the result is dropped and `dst` is read
+immediately afterwards, so the client sanitises and registers uninitialised
+stack memory as the template name. In the two model paths the result is tested,
+so those take their fallback branch instead.
+
+**Expected.** From the call sites, the intended result is `path` expressed
+relative to `baseDir`. In the template scans, `baseDir` is `Templates/Skills/`
+and `path` is an entry name from defect 2.
+
+## Defect 4 — file deletion aborts the client
+
+**Function 552**, `(const wchar_t* path) -> int`, in
+`Base/Os/Emscripten/Exe/EmscriptenExeFile.cpp`, line 840.
+
+Entire body:
+
+```wasm
+i32.const "not implemented"
+i32.const "../../../../Base/Os/Emscripten/Exe/EmscriptenExeFile.cpp"
+i32.const 840
+call <assert>
+unreachable
+```
+
+Reached from `File::Delete` → 730 → 678 → 552. Its caller reads a non-zero
+result as success and otherwise reports error 4.
+
+**Consequence.** Deleting a template aborts the client outright. Renaming is
+implemented as write-the-new-name followed by delete-the-old, so renaming aborts
+too — or, if the write half fails first, reports a rename failure.
+
+**Expected.** Delete the file and return non-zero on success. The module imports
+no `unlink`; `FS.unlink` is the equivalent.
+
+### Related: ten further `assert("not implemented")` bodies
+
+The same translation unit contains eight more (functions 526, 527, 532, 533,
+534, 535, 538, 539, at lines 490, 601, 608 and 634), plus two in
+`Net/DiagLib/Emscripten/EmscriptenDiagLib.cpp` at lines 23 and 28. None is
+currently reachable — the eight are vtable slots with no live caller, and the
+DiagLib pair sits behind a disabled flag — but they are latent aborts on those
+paths.
+
+## Defect 5 — `Path::RemoveExtension` drops the last character of the name
+
+`Base/Rtl/Path.cpp`'s remove-extension helper (function 457) splits with
+`_wsplitpath` (function 411) and rebuilds with `_wmakepath` (function 412),
+passing a null extension. The filename length passed to the split is one short,
+so the last character of the name is removed along with the extension.
+
+Measured by calling the shipped function directly:
+
+```
+Path::RemoveExtension("\ASDAs.txt")      = "\ASDA"        ← expected "\ASDAs"
+Path::RemoveExtension("\LOLOL.txt")      = "\LOLO"        ← expected "\LOLOL"
+Path::RemoveExtension("\Sub\Nested.txt") = "\Sub\Neste"   ← expected "\Sub\Nested"
+Path::RemoveExtension("ASDAs.txt")       = "ASDA"         ← expected "ASDAs"
+Path::RemoveExtension("\ASDAs")          = "\ASDAs"       ← correct, nothing to strip
+```
+
+The bug appears only when there is an extension to remove.
+
+**Consequence.** Function 9747 calls this on every enumerated template, so once
+defects 2 and 3 are fixed, every listed name is short by one character — and the
+subsequent load builds a path from that truncated name and cannot find the file.
+It also affects `MdlTex.cpp`, which calls the same helper.
+
+**Expected.** `dir + filename` without the extension, filename intact.
+
+## Defect 6 — `File::Open` mode 1 creates the file it is asked to open
+
+`File::Open(path, mode, err)` (function 771). Mode 1 is the client's
+open-an-existing-file mode: function 9753 uses it to read a template, and
+function 9757 uses it to ask whether a rename's destination name is already
+taken:
+
+```c
+if (!allowOverwrite) {
+    handle = File::Open(path, 1, NULL);
+    if (handle) return false;          // name already in use
+}
+handle = File::Open(path, 2, NULL);    // create and write
+```
+
+Both modes reach `openat` with identical flags. Captured live, from a save
+followed by a rename:
+
+```
+save    openat flags:32834 access:2 create:true errno:0 → fd_pwrite 24/24 → fd_close
+rename  openat flags:32834 access:2 create:true errno:0 → fd_close
+```
+
+`32834` is `O_RDWR | O_CREAT | O_LARGEFILE`. Mode 1 carries `O_CREAT`, so the
+probe **creates the file it is testing for**, observes that it now exists, and
+reports the name as taken.
+
+**Consequence.** Every rename fails, for every destination name, with "The
+attempt to rename the Skills Template named "…" failed" — and leaves a
+zero-length file behind at the destination. Loading is also affected: opening a
+missing template creates an empty file rather than failing.
+
+**Expected.** Mode 1 should open an existing file and fail when it is absent —
+no `O_CREAT`.
+
+## How to reproduce
+
+Reproduces on a stock client; no host modification required.
+
+1. Log in and open the skills panel.
+2. Save a build under any name → defect 1, save fails.
+3. Open "Load from Skills Template" → defects 2 and 3, list is empty.
+
+For defects 4 and 5 the earlier ones must be worked around first. With a build
+where directory creation and enumeration succeed:
+
+4. Delete a listed template → defect 4, client aborts.
+5. Compare a listed name against the file on disk → defect 5, one character
+   short.
+6. Rename a template to any unused name → defect 6, always fails, and a
+   zero-length file appears at the destination.
+
+Defect 5 alone can be confirmed without any of that, by calling function 457
+with `"\Test.txt"`.
+
+## Contact
+
+Filed from https://github.com/Mat4m0/gwonmac — a sandboxed macOS Electron host
+for the official client. We would rather these were fixed at source than carry a
+host-side workaround.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "toolbox:recertify": "pnpm build && node build/tools/toolbox-recertify.js",
     "toolbox:visual": "pnpm build && node scripts/toolbox-visual.mjs",
     "toolbox:transform": "pnpm build && node build/tools/toolbox-transform.js",
+    "template:recertify": "pnpm build && node build/tools/template-save-recertify.js",
     "test:website": "pnpm --filter gw-website typecheck && pnpm --filter gw-website generate && pnpm --filter gw-website build && node tests/website-smoke.mjs",
     "check": "pnpm typecheck && pnpm lint && pnpm test:unit",
     "test": "pnpm build && pnpm test:unit && pnpm test:integration && pnpm test:electron",

--- a/src/main/core/template-save-compat.ts
+++ b/src/main/core/template-save-compat.ts
@@ -1,17 +1,84 @@
+// ArenaNet's Emscripten port ships four unimplemented `Base/Os` file routines.
+// Creating a directory always fails with error 2, so a build cannot be saved.
+// Enumerating a directory does nothing and deriving a name from an entry writes
+// nothing, so "Load from Skills Template" stays empty. Deleting a file is
+// `assert("not implemented")` followed by `unreachable`, so removing or renaming
+// a build aborts the client.
+//
+// None of that can be repaired from JavaScript alone: the client never reaches
+// a syscall, and the module imports no `mkdir`, `getdents`, or `unlink`. So one
+// derived module, accepted only for an exact official hash, appends forwarders
+// and repoints the template, chat-log, and screenshot call sites at them. Each
+// forwarder hands the stub's arguments to `__syscall_newfstatat` behind a dirfd
+// that no real call can produce, where the renderer answers it.
 import { createHash } from "node:crypto";
+import {
+  concat,
+  encodeCode,
+  encodeIndexVector,
+  encodeSection,
+  paddedIndex,
+  parseCode,
+  parseIndexVector,
+  sectionById,
+  sleb,
+  splitSections,
+  uleb,
+  WASM_HEADER,
+  type Section,
+} from "./wasm-binary.js";
 
 declare const WebAssembly: {
   validate(bytes: Uint8Array): boolean;
 };
 
-export const TEMPLATE_SAVE_TRANSFORM_ABI = 1;
+export const TEMPLATE_SAVE_TRANSFORM_ABI = 2;
+
+// dirfd markers. `src/renderer/template-save-compatibility.js` mirrors these;
+// tests/release/wasm-host.test.mjs holds the two copies together.
+export const BRIDGE_ENSURE_DIRECTORY = -70_001;
+export const BRIDGE_FIND_FILES = -70_002;
+export const BRIDGE_FILE_BASE_NAME = -70_003;
+export const BRIDGE_DELETE_FILE = -70_004;
+export const BRIDGE_FILE_EXISTS = -70_005;
+
+export type BridgeKind =
+  | "ensureDirectory"
+  | "findFiles"
+  | "fileBaseName"
+  | "deleteFile"
+  | "fileExists";
+
+export interface CallSite {
+  /** Index into the code section, i.e. function index minus import count. */
+  readonly localFunction: number;
+  /** Byte offset of the `call` opcode inside that function body. */
+  readonly bodyOffset: number;
+}
+
+export interface StubBridge {
+  readonly kind: BridgeKind;
+  /**
+   * The function the certified call sites currently target. Its type is reused
+   * for the forwarder, and `fileExists` also calls it.
+   */
+  readonly stubFunction: number;
+  /**
+   * Whole body of the stub, so an unexpected build fails closed. Omitted when
+   * the target is a real implementation rather than a stub — there the call
+   * site's own target index is the certification.
+   */
+  readonly stubBody?: readonly number[];
+  readonly callSites: readonly CallSite[];
+}
 
 export interface KnownTemplateSaveBuild {
   readonly sha256: string;
   readonly outputSha256: string;
-  readonly callOffset: number;
-  readonly expectedCall: readonly number[];
-  readonly replacementCall: readonly number[];
+  readonly importCount: number;
+  /** Import index of `__syscall_newfstatat`, the bridge's carrier. */
+  readonly carrierImport: number;
+  readonly bridges: readonly StubBridge[];
 }
 
 export const TEMPLATE_SAVE_BUILDS: readonly KnownTemplateSaveBuild[] =
@@ -20,19 +87,181 @@ export const TEMPLATE_SAVE_BUILDS: readonly KnownTemplateSaveBuild[] =
       sha256:
         "b0319704f3072d6948a66026a35af5eb0af12b48d70986783c293e7c77e98483",
       outputSha256:
-        "1883197770cc74fe48d308f097359a08de839e29daec3829875ace587bb5d8d3",
-      callOffset: 0x365a23,
-      // `call 404`: ArenaNet's Emscripten PathCreateDirectory stub.
-      expectedCall: Object.freeze([0x10, 0x94, 0x83, 0x80, 0x80, 0x00]),
-      // `call 206`: __syscall_stat64 has the same (i32, i32) -> i32
-      // signature. Argument 1 is an impossible stat buffer and marks this one
-      // call for the renderer's synchronous mkdir bridge.
-      replacementCall: Object.freeze([0x10, 0xce, 0x81, 0x80, 0x80, 0x00]),
+        "68c6e09cec0f6992058a44a5617ca9eac7fab4697be1421943bbf664e6d444f6",
+      importCount: 219,
+      carrierImport: 207,
+      bridges: Object.freeze([
+        // PathCreateDirectory(path, recursive) -> error. `i32.const 2` is
+        // ERROR_FILE_NOT_FOUND, returned unconditionally.
+        Object.freeze({
+          kind: "ensureDirectory" as const,
+          stubFunction: 185,
+          stubBody: Object.freeze([0x00, 0x41, 0x02, 0x0b]),
+          callSites: Object.freeze([
+            Object.freeze({ localFunction: 9538, bodyOffset: 171 }), // template save
+            Object.freeze({ localFunction: 11525, bodyOffset: 142 }), // chat log
+            Object.freeze({ localFunction: 12214, bodyOffset: 127 }), // screenshot
+          ]),
+        }),
+        // FindFiles(out, pattern, flags) -> void. An empty body leaves the
+        // caller's list zeroed, so every directory reads as empty.
+        Object.freeze({
+          kind: "findFiles" as const,
+          stubFunction: 186,
+          stubBody: Object.freeze([0x00, 0x0b]),
+          callSites: Object.freeze([
+            Object.freeze({ localFunction: 9527, bodyOffset: 157 }), // skills list
+            Object.freeze({ localFunction: 9528, bodyOffset: 157 }), // equipment list
+            Object.freeze({ localFunction: 11525, bodyOffset: 210 }), // chat log
+            Object.freeze({ localFunction: 12214, bodyOffset: 419 }), // screenshot
+          ]),
+        }),
+        // FileBaseName(dst, _, baseDir, _, path, dstChars) -> written.
+        // `i32.const 0` leaves the caller reading uninitialised stack. Only the
+        // two template lists are repointed; the model paths that also call it
+        // keep the fallback branch they take today.
+        Object.freeze({
+          kind: "fileBaseName" as const,
+          stubFunction: 197,
+          stubBody: Object.freeze([0x00, 0x41, 0x00, 0x0b]),
+          callSites: Object.freeze([
+            Object.freeze({ localFunction: 9527, bodyOffset: 276 }),
+            Object.freeze({ localFunction: 9528, bodyOffset: 278 }),
+          ]),
+        }),
+        // DeleteFile(path) -> deleted. Not a silent stub like the others: the
+        // body is `assert("not implemented")` followed by `unreachable`, so
+        // deleting a build aborted the client outright.
+        Object.freeze({
+          kind: "deleteFile" as const,
+          stubFunction: 333,
+          stubBody: Object.freeze([
+            0x00,
+            0x41, 0x9e, 0x87, 0xc5, 0x80, 0x00,
+            0x41, 0x80, 0xbb, 0xc3, 0x80, 0x00,
+            0x41, 0xc8, 0x06,
+            0x10, 0xc2, 0x82, 0x80, 0x80, 0x00,
+            0x00,
+            0x0b,
+          ]),
+          callSites: Object.freeze([
+            Object.freeze({ localFunction: 459, bodyOffset: 201 }),
+          ]),
+        }),
+        // File::Open(path, mode, err). Mode 1 is meant to open an existing
+        // file, and `9757` uses it to ask whether a rename's destination is
+        // already taken — but in this build mode 1 opens O_RDWR|O_CREAT, the
+        // same as the write mode. The probe creates the file it is testing for,
+        // reports it present, and refuses every rename.
+        //
+        // Only the probe is repointed. The write call five instructions later
+        // keeps the real function, and so does the load path.
+        Object.freeze({
+          kind: "fileExists" as const,
+          stubFunction: 552,
+          callSites: Object.freeze([
+            Object.freeze({ localFunction: 9538, bodyOffset: 201 }),
+          ]),
+        }),
+      ]),
     }),
   ]);
 
+function fail(message: string): never {
+  throw new Error(`template-save transform: ${message}`);
+}
+
 function sha256(bytes: Uint8Array): string {
   return createHash("sha256").update(bytes).digest("hex");
+}
+
+function paddedCall(functionIndex: number): Uint8Array {
+  return concat(Uint8Array.of(0x10), paddedIndex(functionIndex));
+}
+
+/**
+ * Body of a forwarder that hands the stub's arguments to
+ * `__syscall_newfstatat(dirfd, path, buffer, flags)` behind a dirfd marker.
+ */
+function forwarder(
+  kind: BridgeKind,
+  carrier: number,
+  target: number,
+): Uint8Array {
+  const call = concat(Uint8Array.of(0x10), uleb(carrier));
+  const marker = (value: number) => concat(Uint8Array.of(0x41), sleb(value));
+  const local = (index: number) => Uint8Array.of(0x20, index);
+  const noLocals = Uint8Array.of(0x00);
+  const end = Uint8Array.of(0x0b);
+  if (kind === "ensureDirectory") {
+    // (path, recursive) -> error
+    return concat(
+      noLocals,
+      marker(BRIDGE_ENSURE_DIRECTORY),
+      local(0),
+      Uint8Array.of(0x41, 0x00),
+      local(1),
+      call,
+      end,
+    );
+  }
+  if (kind === "fileExists") {
+    // (path, mode, err) -> handle. Ask the host first; only open when the file
+    // is really there, so the probe cannot create its own answer.
+    return concat(
+      noLocals,
+      marker(BRIDGE_FILE_EXISTS),
+      local(0),
+      Uint8Array.of(0x41, 0x00),
+      Uint8Array.of(0x41, 0x00),
+      call,
+      Uint8Array.of(0x04, 0x7f), // if (result i32)
+      local(0),
+      local(1),
+      local(2),
+      Uint8Array.of(0x10),
+      uleb(target),
+      Uint8Array.of(0x05), // else
+      Uint8Array.of(0x41, 0x00),
+      Uint8Array.of(0x0b), // end if
+      end,
+    );
+  }
+  if (kind === "deleteFile") {
+    // (path) -> deleted
+    return concat(
+      noLocals,
+      marker(BRIDGE_DELETE_FILE),
+      local(0),
+      Uint8Array.of(0x41, 0x00),
+      Uint8Array.of(0x41, 0x00),
+      call,
+      end,
+    );
+  }
+  if (kind === "findFiles") {
+    // (out, pattern, flags) -> void
+    return concat(
+      noLocals,
+      marker(BRIDGE_FIND_FILES),
+      local(1),
+      local(0),
+      local(2),
+      call,
+      Uint8Array.of(0x1a),
+      end,
+    );
+  }
+  // (dst, _, baseDir, _, path, dstChars) -> written
+  return concat(
+    noLocals,
+    marker(BRIDGE_FILE_BASE_NAME),
+    local(4),
+    local(0),
+    local(5),
+    call,
+    end,
+  );
 }
 
 export function findTemplateSaveBuild(
@@ -51,22 +280,71 @@ export function rewriteTemplateSaveWasm(
   if (inputHash !== build.sha256) {
     throw new Error(`template-save transform: unsupported input ${inputHash}`);
   }
-  if (build.expectedCall.length !== build.replacementCall.length) {
-    throw new Error("template-save transform: call widths differ");
-  }
-  const end = build.callOffset + build.expectedCall.length;
-  if (
-    build.callOffset < 0
-    || end > input.byteLength
-    || !build.expectedCall.every(
-      (byte, index) => input[build.callOffset + index] === byte,
-    )
-  ) {
-    throw new Error("template-save transform: call signature mismatch");
+
+  const sections = splitSections(input);
+  const functionTypes = parseIndexVector(sectionById(sections, 3));
+  const bodies = parseCode(sectionById(sections, 10));
+  if (functionTypes.length !== bodies.length) {
+    fail("function and code sections disagree");
   }
 
-  const output = input.slice();
-  output.set(build.replacementCall, build.callOffset);
+  const nextTypes = [...functionTypes];
+  const nextBodies: Uint8Array[] = bodies.map((body) => body.slice());
+
+  for (const bridge of build.bridges) {
+    const stub = bodies[bridge.stubFunction]
+      ?? fail(`missing stub for ${bridge.kind}`);
+    const expectedBody = bridge.stubBody;
+    if (
+      expectedBody
+      && (stub.byteLength !== expectedBody.length
+        || !expectedBody.every((byte, index) => stub[index] === byte))
+    ) {
+      fail(`${bridge.kind} is not the expected stub`);
+    }
+
+    // Appending keeps every existing function index valid, so only the chosen
+    // call sites change meaning. The forwarder reuses the stub's own type.
+    const forwarderIndex = build.importCount + nextBodies.length;
+    nextTypes.push(functionTypes[bridge.stubFunction]!);
+    nextBodies.push(
+      forwarder(
+        bridge.kind,
+        build.carrierImport,
+        build.importCount + bridge.stubFunction,
+      ),
+    );
+
+    const expected = paddedCall(build.importCount + bridge.stubFunction);
+    const replacement = paddedCall(forwarderIndex);
+    for (const site of bridge.callSites) {
+      const body = nextBodies[site.localFunction]
+        ?? fail(`${bridge.kind} call site is out of range`);
+      const end = site.bodyOffset + expected.byteLength;
+      if (
+        site.bodyOffset < 0
+        || end > body.byteLength
+        || !expected.every(
+          (byte, index) => body[site.bodyOffset + index] === byte,
+        )
+      ) {
+        fail(`${bridge.kind} call site signature mismatch`);
+      }
+      body.set(replacement, site.bodyOffset);
+    }
+  }
+
+  const rewritten = sections.map((section): Section => {
+    if (section.id === 3) {
+      return { id: section.id, body: encodeIndexVector(nextTypes) };
+    }
+    if (section.id === 10) {
+      return { id: section.id, body: encodeCode(nextBodies) };
+    }
+    return section;
+  });
+  const output = concat(WASM_HEADER, ...rewritten.map(encodeSection));
+
   const outputHash = sha256(output);
   if (outputHash !== build.outputSha256) {
     throw new Error(`template-save transform: unexpected output ${outputHash}`);
@@ -77,9 +355,7 @@ export function rewriteTemplateSaveWasm(
   return output;
 }
 
-export function applyTemplateSaveCompatibility(
-  input: Uint8Array,
-): Uint8Array {
+export function applyTemplateSaveCompatibility(input: Uint8Array): Uint8Array {
   const build = findTemplateSaveBuild(sha256(input));
   return build ? rewriteTemplateSaveWasm(input, build) : input;
 }

--- a/src/main/core/template-save-recert.ts
+++ b/src/main/core/template-save-recert.ts
@@ -1,0 +1,794 @@
+// Re-derive a `KnownTemplateSaveBuild` entry from a client WASM, by shape
+// rather than by remembered index.
+//
+// Every number in the certified table belongs to one exact build, and ArenaNet
+// updates the client automatically. Recovering them by hand takes hours; this
+// recovers them in seconds and hands the result to the production transform for
+// validation. It removes the index-recovery work, not the semantic work — see
+// internal/upstream/recertify.md, which still owns re-measuring what the path
+// helpers actually do.
+//
+// Two measured facts make this cheap. Byte-scanning for the six-byte padded
+// `call` needle locates every call site with no false positives, so no
+// whole-module instruction decoder is needed. And caller-set intersection
+// identifies every target, so source-file attribution is not needed either —
+// which is just as well, because the most important call site here references
+// no source string at all.
+import { createHash } from "node:crypto";
+import {
+  countFunctionImports,
+  functionImportIndex,
+  paddedIndex,
+  parseCode,
+  parseIndexVector,
+  parseTypes,
+  readSleb,
+  readUleb,
+  sectionById,
+  splitSections,
+  uleb,
+  valueTypeName,
+  type FunctionType,
+} from "./wasm-binary.js";
+import {
+  findTemplateSaveBuild,
+  rewriteTemplateSaveWasm,
+  TEMPLATE_SAVE_BUILDS,
+  type BridgeKind,
+  type CallSite,
+  type KnownTemplateSaveBuild,
+  type StubBridge,
+} from "./template-save-compat.js";
+
+const CARRIER_IMPORT_NAME = "__syscall_newfstatat";
+const ASSERT_HOOK_IMPORT_NAME = "emscripten_asm_const_int";
+
+/** Shipped bodies of the four unimplemented routines. */
+const CREATE_DIRECTORY_BODY = [0x00, 0x41, 0x02, 0x0b];
+const FIND_FILES_BODY = [0x00, 0x0b];
+const FILE_BASE_NAME_BODY = [0x00, 0x41, 0x00, 0x0b];
+
+export type TargetName = BridgeKind | "assertHandler";
+
+export interface LocatedFunction {
+  /** Index into the code section, i.e. function index minus the import count. */
+  readonly localFunction: number;
+  readonly functionIndex: number;
+  readonly signature: string;
+  readonly bodyBytes: readonly number[];
+  readonly callers: readonly number[];
+  readonly rejected: readonly number[];
+}
+
+export interface TemplateSaveCandidateReport {
+  readonly sha256: string;
+  readonly validWasm: boolean;
+  readonly status: "certified" | "derived" | "not-applicable" | "failed";
+  readonly certified: boolean;
+  readonly matchesCertifiedEntry: boolean | null;
+  readonly importCount: number | null;
+  readonly carrierImport: number | null;
+  readonly targets: Partial<Record<TargetName, LocatedFunction>>;
+  readonly callSites: Partial<Record<BridgeKind, readonly CallSite[]>>;
+  readonly deleteAssertion: { message: string; file: string; line: number } | null;
+  readonly encodings: { padded: number; canonical: number };
+  readonly entry: KnownTemplateSaveBuild | null;
+  readonly diagnostics: readonly string[];
+}
+
+class RecertError extends Error {
+  constructor(message: string) {
+    super(`template-save recertify: ${message}`);
+  }
+}
+
+function fail(message: string): never {
+  throw new RecertError(message);
+}
+
+function sha256(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function signatureText(type: FunctionType): string {
+  const side = (values: number[]) => values.map(valueTypeName).join(",");
+  return `(${side(type.params)})->(${side(type.results)})`;
+}
+
+function sameBytes(body: Uint8Array, expected: readonly number[]): boolean {
+  return (
+    body.byteLength === expected.length
+    && expected.every((byte, index) => body[index] === byte)
+  );
+}
+
+/**
+ * Everything the locators need, read once. Function bodies are indexed by local
+ * index; callers are computed by scanning for the padded `call` needle.
+ */
+class ModuleView {
+  readonly input: Uint8Array;
+  readonly importSection: Uint8Array;
+  readonly importCount: number;
+  readonly bodies: Uint8Array[];
+  readonly signatures: string[];
+  readonly dataSegments: { base: number; bytes: Uint8Array }[];
+  private readonly callerCache = new Map<number, Set<number>>();
+
+  constructor(input: Uint8Array) {
+    this.input = input;
+    const sections = splitSections(input);
+    this.importSection = sectionById(sections, 2);
+    this.importCount = countFunctionImports(this.importSection);
+    const types = parseTypes(sectionById(sections, 1));
+    this.signatures = parseIndexVector(sectionById(sections, 3)).map(
+      (index) => signatureText(types[index] ?? fail(`unknown type ${index}`)),
+    );
+    this.bodies = parseCode(sectionById(sections, 10));
+    if (this.signatures.length !== this.bodies.length) {
+      fail("function and code sections disagree");
+    }
+    this.dataSegments = parseDataSegments(sections);
+  }
+
+  functionIndex(local: number): number {
+    return this.importCount + local;
+  }
+
+  /** Local indices of every function containing a padded call to `target`. */
+  callers(functionIndex: number): Set<number> {
+    const cached = this.callerCache.get(functionIndex);
+    if (cached) return cached;
+    const needle = callNeedle(functionIndex);
+    const found = new Set<number>();
+    this.bodies.forEach((body, local) => {
+      if (indexOfBytes(body, needle, 0) >= 0) found.add(local);
+    });
+    this.callerCache.set(functionIndex, found);
+    return found;
+  }
+
+  callSites(caller: number, functionIndex: number): number[] {
+    const body = this.bodies[caller] ?? fail(`function ${caller} is out of range`);
+    const needle = callNeedle(functionIndex);
+    const offsets: number[] = [];
+    for (let at = indexOfBytes(body, needle, 0); at >= 0;) {
+      offsets.push(at);
+      at = indexOfBytes(body, needle, at + 1);
+    }
+    return offsets;
+  }
+
+  /** NUL-terminated ASCII at a linear-memory address, or null. */
+  readString(address: number): string | null {
+    for (const segment of this.dataSegments) {
+      const offset = address - segment.base;
+      if (offset < 0 || offset >= segment.bytes.byteLength) continue;
+      let end = offset;
+      while (end < segment.bytes.byteLength && segment.bytes[end] !== 0) end += 1;
+      if (end === segment.bytes.byteLength) return null;
+      return new TextDecoder().decode(segment.bytes.slice(offset, end));
+    }
+    return null;
+  }
+}
+
+function parseDataSegments(
+  sections: readonly { id: number; body: Uint8Array }[],
+): { base: number; bytes: Uint8Array }[] {
+  const section = sections.find((entry) => entry.id === 11);
+  if (!section) return [];
+  const bytes = section.body;
+  const cursor = { offset: 0 };
+  const count = readUleb(bytes, cursor);
+  const segments: { base: number; bytes: Uint8Array }[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const flags = readUleb(bytes, cursor);
+    if (flags !== 0) return segments;
+    if (bytes[cursor.offset++] !== 0x41) return segments;
+    const base = readSleb(bytes, cursor);
+    if (bytes[cursor.offset++] !== 0x0b) return segments;
+    const size = readUleb(bytes, cursor);
+    segments.push({ base, bytes: bytes.slice(cursor.offset, cursor.offset + size) });
+    cursor.offset += size;
+  }
+  return segments;
+}
+
+/**
+ * A call encoded canonically rather than padded would be invisible to the
+ * needle scan, so we would locate fewer callers. The exact-cardinality checks
+ * on the scans and sinks catch that, and this heuristic count reports it
+ * directly. Three bytes can collide with an immediate, so it warns rather than
+ * gates.
+ */
+function canonicalCallCount(view: ModuleView, functionIndex: number): number {
+  const canonical = uleb(functionIndex);
+  const needle = new Uint8Array(canonical.byteLength + 1);
+  needle[0] = 0x10;
+  needle.set(canonical, 1);
+  let total = 0;
+  for (const body of view.bodies) {
+    for (let at = indexOfBytes(body, needle, 0); at >= 0;) {
+      total += 1;
+      at = indexOfBytes(body, needle, at + 1);
+    }
+  }
+  return total;
+}
+
+function callNeedle(functionIndex: number): Uint8Array {
+  const padded = paddedIndex(functionIndex);
+  const needle = new Uint8Array(padded.byteLength + 1);
+  needle[0] = 0x10;
+  needle.set(padded, 1);
+  return needle;
+}
+
+function indexOfBytes(
+  haystack: Uint8Array,
+  needle: Uint8Array,
+  from: number,
+): number {
+  outer: for (let at = from; at + needle.byteLength <= haystack.byteLength; at += 1) {
+    for (let index = 0; index < needle.byteLength; index += 1) {
+      if (haystack[at + index] !== needle[index]) continue outer;
+    }
+    return at;
+  }
+  return -1;
+}
+
+function intersect(left: Set<number>, right: Set<number>): number[] {
+  return [...left].filter((value) => right.has(value)).sort((a, b) => a - b);
+}
+
+function located(
+  view: ModuleView,
+  local: number,
+  rejected: readonly number[],
+): LocatedFunction {
+  return {
+    localFunction: local,
+    functionIndex: view.functionIndex(local),
+    signature: view.signatures[local]!,
+    bodyBytes: Array.from(view.bodies[local]!),
+    callers: [...view.callers(view.functionIndex(local))].sort((a, b) => a - b),
+    rejected,
+  };
+}
+
+function only(
+  candidates: readonly number[],
+  what: string,
+  extra = "",
+): number {
+  if (candidates.length === 1) return candidates[0]!;
+  fail(
+    `expected exactly one ${what}, found ${candidates.length}`
+      + ` [${candidates.join(", ")}]${extra ? `. ${extra}` : ""}`,
+  );
+}
+
+interface Located {
+  readonly view: ModuleView;
+  readonly carrierImport: number;
+  readonly targets: Record<TargetName, LocatedFunction>;
+  readonly writeFunction: number;
+  readonly probeOffset: number;
+  readonly writeOffset: number;
+  readonly scans: number[];
+  readonly sinks: number[];
+  readonly deleteAssertion: { message: string; file: string; line: number };
+  readonly diagnostics: string[];
+}
+
+/**
+ * The `not-applicable` signal: no function returns `i32.const 2` from a
+ * `(i32,i32)->i32`, so this build has no create-directory stub to bridge.
+ */
+class NotApplicableError extends Error {}
+
+function locate(view: ModuleView): Located {
+  const diagnostics: string[] = [];
+  const bySignature = (signature: string) =>
+    view.signatures.flatMap((value, local) => (value === signature ? [local] : []));
+
+  // L1 create directory — unique on body alone in the certified build.
+  const createCandidates = bySignature("(i32,i32)->(i32)").filter((local) =>
+    sameBytes(view.bodies[local]!, CREATE_DIRECTORY_BODY),
+  );
+  if (createCandidates.length === 0) {
+    throw new NotApplicableError(
+      "no (i32,i32)->i32 function returns i32.const 2; this build has no"
+        + " create-directory stub, so the bridge may no longer be needed",
+    );
+  }
+  // A vtable slot or an unrelated `return 2` can share the body, so narrow to
+  // the one that several places actually call before creating a file.
+  const createLive = createCandidates.filter(
+    (local) => view.callers(view.functionIndex(local)).size >= 3,
+  );
+  const createLocal = only(
+    createLive.length > 0 ? createLive : createCandidates,
+    "create-directory stub",
+    `${createCandidates.length} shared the body shape`,
+  );
+  const createCallers = view.callers(view.functionIndex(createLocal));
+
+  // L2 assert handler — the (i32,i32,i32)->() that reaches the asm_const abort.
+  const assertHook = functionImportIndex(view.importSection, ASSERT_HOOK_IMPORT_NAME);
+  if (assertHook === null) fail(`no ${ASSERT_HOOK_IMPORT_NAME} import`);
+  const assertHookNeedle = callNeedle(assertHook);
+  const assertCandidates = bySignature("(i32,i32,i32)->()").filter(
+    (local) => indexOfBytes(view.bodies[local]!, assertHookNeedle, 0) >= 0,
+  );
+  const ranked = assertCandidates
+    .map((local) => ({ local, callers: view.callers(view.functionIndex(local)).size }))
+    .sort((a, b) => b.callers - a.callers);
+  const top = ranked[0] ?? fail("no assert handler candidate");
+  const runnerUp = ranked[1]?.callers ?? 0;
+  if (top.callers < 100 * Math.max(runnerUp, 1)) {
+    fail(
+      `assert handler is ambiguous: ${top.local} has ${top.callers} callers,`
+        + ` runner-up has ${runnerUp}`,
+    );
+  }
+  const assertLocal = top.local;
+  diagnostics.push(
+    `assert handler ${assertLocal} chosen with ${top.callers} callers (runner-up ${runnerUp})`,
+  );
+
+  // L3 find files — empty body, sharing callers with create-directory.
+  const findAll = bySignature("(i32,i32,i32)->()").filter((local) =>
+    sameBytes(view.bodies[local]!, FIND_FILES_BODY),
+  );
+  const findCandidates = findAll.filter(
+    (local) => intersect(view.callers(view.functionIndex(local)), createCallers).length >= 2,
+  );
+  const findLocal = only(
+    findCandidates,
+    "find-files stub",
+    `${findAll.length} shared the body shape`,
+  );
+  const findCallers = view.callers(view.functionIndex(findLocal));
+
+  // L4 entry name — constant-zero body, sharing callers with find-files.
+  const nameAll = bySignature("(i32,i32,i32,i32,i32,i32)->(i32)").filter((local) =>
+    sameBytes(view.bodies[local]!, FILE_BASE_NAME_BODY),
+  );
+  const nameCandidates = nameAll.filter(
+    (local) => intersect(view.callers(view.functionIndex(local)), findCallers).length >= 2,
+  );
+  const nameLocal = only(
+    nameCandidates,
+    "entry-name stub",
+    `${nameAll.length} shared the body shape`,
+  );
+  const nameCallers = view.callers(view.functionIndex(nameLocal));
+
+  // L5/L6 — the two template scans, and the chat-log/screenshot pair.
+  const scans = intersect(findCallers, nameCallers);
+  if (scans.length !== 2) {
+    fail(
+      `expected exactly 2 template scans (callers of both find-files and`
+        + ` entry-name), found ${scans.length} [${scans.join(", ")}]`,
+    );
+  }
+  const sinks = intersect(createCallers, findCallers).filter(
+    (local) => !scans.includes(local),
+  );
+  if (sinks.length !== 2) {
+    fail(
+      `expected exactly 2 directory sinks (chat log and screenshot), found`
+        + ` ${sinks.length} [${sinks.join(", ")}]. A third caller that creates a`
+        + ` directory then enumerates it needs a human decision about whether to`
+        + ` repoint it`,
+    );
+  }
+
+  // L7 delete file — assert-and-abort body, one caller, and it says so.
+  const assertTail = callNeedle(view.functionIndex(assertLocal));
+  const deleteCandidates = bySignature("(i32)->(i32)").filter((local) => {
+    const body = view.bodies[local]!;
+    const at = indexOfBytes(body, assertTail, 0);
+    return (
+      at >= 0
+      && at + assertTail.byteLength + 2 === body.byteLength
+      && body[at + assertTail.byteLength] === 0x00
+      && body[body.byteLength - 1] === 0x0b
+      && view.callers(view.functionIndex(local)).size === 1
+    );
+  });
+  const deleteLocal = only(deleteCandidates, "delete-file stub");
+  const deleteAssertion = readAssertion(view, deleteLocal);
+  if (deleteAssertion.message !== "not implemented") {
+    fail(`delete-file stub asserts ${JSON.stringify(deleteAssertion.message)}`);
+  }
+  if (!deleteAssertion.file.endsWith("EmscriptenExeFile.cpp")) {
+    fail(`delete-file stub is attributed to ${deleteAssertion.file}`);
+  }
+
+  // L8 write function, File::Open, and which of its two calls is the probe.
+  const openMatches: {
+    caller: number;
+    target: number;
+    probe: number;
+    write: number;
+  }[] = [];
+  for (const caller of createCallers) {
+    const body = view.bodies[caller]!;
+    for (let local = 0; local < view.signatures.length; local += 1) {
+      if (view.signatures[local] !== "(i32,i32,i32)->(i32)") continue;
+      const offsets = view.callSites(caller, view.functionIndex(local));
+      if (offsets.length !== 2) continue;
+      const modes = offsets.map((offset) => precedingModes(body, offset));
+      if (modes[0]?.mode === 1 && modes[0].err === 0
+        && modes[1]?.mode === 2 && modes[1].err === 0) {
+        openMatches.push({
+          caller,
+          target: local,
+          probe: offsets[0]!,
+          write: offsets[1]!,
+        });
+      }
+    }
+  }
+  if (openMatches.length !== 1) {
+    fail(
+      `expected exactly one File::Open probe/write pair, found`
+        + ` ${openMatches.length}`
+        + ` [${openMatches.map((m) => `${m.target} in ${m.caller}`).join(", ")}]`,
+    );
+  }
+  const open = openMatches[0]!;
+  if (scans.includes(open.caller) || sinks.includes(open.caller)) {
+    fail(`write function ${open.caller} is also a scan or directory sink`);
+  }
+
+  return {
+    view,
+    carrierImport:
+      functionImportIndex(view.importSection, CARRIER_IMPORT_NAME)
+      ?? fail(`no ${CARRIER_IMPORT_NAME} import to carry the bridge`),
+    targets: {
+      ensureDirectory: located(view, createLocal, createCandidates.filter((l) => l !== createLocal)),
+      findFiles: located(view, findLocal, findAll.filter((l) => l !== findLocal)),
+      fileBaseName: located(view, nameLocal, nameAll.filter((l) => l !== nameLocal)),
+      deleteFile: located(view, deleteLocal, deleteCandidates.filter((l) => l !== deleteLocal)),
+      // The one target that is not a stub: a working `File::Open` whose mode-1
+      // probe is repointed. There is nothing to reject, only the pair to pick.
+      fileExists: located(view, open.target, []),
+      assertHandler: located(view, assertLocal, ranked.slice(1).map((entry) => entry.local)),
+    },
+    writeFunction: open.caller,
+    probeOffset: open.probe,
+    writeOffset: open.write,
+    scans,
+    sinks,
+    deleteAssertion,
+    diagnostics,
+  };
+}
+
+/** `i32.const <mode>; i32.const <err>` immediately before a call. */
+function precedingModes(
+  body: Uint8Array,
+  callOffset: number,
+): { mode: number; err: number } | null {
+  const err = constantEndingAt(body, callOffset);
+  if (err === null) return null;
+  const mode = constantEndingAt(body, err.start);
+  return mode === null ? null : { mode: mode.value, err: err.value };
+}
+
+function constantEndingAt(
+  body: Uint8Array,
+  end: number,
+): { value: number; start: number } | null {
+  // i32.const immediates are 1..5 bytes; LLVM pads the relocatable ones.
+  for (let width = 1; width <= 5; width += 1) {
+    const start = end - width - 1;
+    if (start < 0 || body[start] !== 0x41) continue;
+    const cursor = { offset: start + 1 };
+    let value: number;
+    try {
+      value = readSleb(body, cursor);
+    } catch {
+      continue;
+    }
+    if (cursor.offset === end) return { value, start };
+  }
+  return null;
+}
+
+function readAssertion(
+  view: ModuleView,
+  local: number,
+): { message: string; file: string; line: number } {
+  const body = view.bodies[local]!;
+  const constants: number[] = [];
+  const cursor = { offset: 1 };
+  while (cursor.offset < body.byteLength && constants.length < 3) {
+    if (body[cursor.offset] !== 0x41) break;
+    cursor.offset += 1;
+    constants.push(readSleb(body, cursor));
+  }
+  if (constants.length !== 3) fail(`delete-file stub is not an assert body`);
+  return {
+    message: view.readString(constants[0]!) ?? "",
+    file: view.readString(constants[1]!) ?? "",
+    line: constants[2]!,
+  };
+}
+
+function bridgeFor(
+  kind: BridgeKind,
+  stubFunction: number,
+  callSites: readonly CallSite[],
+  stubBody?: readonly number[],
+): StubBridge {
+  return stubBody
+    ? { kind, stubFunction, stubBody, callSites }
+    : { kind, stubFunction, callSites };
+}
+
+function sortSites(sites: readonly CallSite[]): CallSite[] {
+  return [...sites].sort(
+    (a, b) => a.localFunction - b.localFunction || a.bodyOffset - b.bodyOffset,
+  );
+}
+
+function sites(
+  view: ModuleView,
+  target: number,
+  callers: readonly number[],
+): CallSite[] {
+  return sortSites(
+    callers.flatMap((localFunction) =>
+      view
+        .callSites(localFunction, view.functionIndex(target))
+        .map((bodyOffset) => ({ localFunction, bodyOffset })),
+    ),
+  );
+}
+
+/** Build entry for an already-located module, with `outputSha256` still empty. */
+function draft(found: Located): KnownTemplateSaveBuild {
+  const { view, targets, scans, sinks, writeFunction } = found;
+
+  return {
+    sha256: sha256(view.input),
+    outputSha256: "",
+    importCount: view.importCount,
+    carrierImport: found.carrierImport,
+    bridges: [
+      bridgeFor(
+        "ensureDirectory",
+        targets.ensureDirectory.localFunction,
+        sites(view, targets.ensureDirectory.localFunction, [writeFunction, ...sinks]),
+        CREATE_DIRECTORY_BODY,
+      ),
+      bridgeFor(
+        "findFiles",
+        targets.findFiles.localFunction,
+        sites(view, targets.findFiles.localFunction, [...scans, ...sinks]),
+        FIND_FILES_BODY,
+      ),
+      bridgeFor(
+        "fileBaseName",
+        targets.fileBaseName.localFunction,
+        sites(view, targets.fileBaseName.localFunction, scans),
+        FILE_BASE_NAME_BODY,
+      ),
+      bridgeFor(
+        "deleteFile",
+        targets.deleteFile.localFunction,
+        sites(view, targets.deleteFile.localFunction, [
+          ...view.callers(view.functionIndex(targets.deleteFile.localFunction)),
+        ]),
+        Array.from(view.bodies[targets.deleteFile.localFunction]!),
+      ),
+      // Only the probe, never the write call that follows it.
+      bridgeFor("fileExists", targets.fileExists.localFunction, [
+        { localFunction: writeFunction, bodyOffset: found.probeOffset },
+      ]),
+    ],
+  };
+}
+
+/**
+ * Fill in `outputSha256` by running the production transform and reading the
+ * hash back out of its own mismatch error, so the entry has round-tripped
+ * through the shipping code path rather than a parallel one.
+ */
+function certify(
+  input: Uint8Array,
+  entry: KnownTemplateSaveBuild,
+): KnownTemplateSaveBuild {
+  try {
+    rewriteTemplateSaveWasm(input, { ...entry, outputSha256: "0".repeat(64) });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    const found = /unexpected output ([0-9a-f]{64})/.exec(message);
+    if (found) {
+      const certified = { ...entry, outputSha256: found[1]! };
+      rewriteTemplateSaveWasm(input, certified);
+      return certified;
+    }
+    throw error;
+  }
+  fail("the transform accepted a placeholder output hash");
+}
+
+/** Derive a build entry, with `outputSha256` still to be certified. */
+export function draftTemplateSaveBuild(
+  input: Uint8Array,
+): KnownTemplateSaveBuild {
+  return draft(locate(new ModuleView(input)));
+}
+
+export function deriveTemplateSaveBuild(
+  input: Uint8Array,
+): KnownTemplateSaveBuild {
+  return certify(input, draftTemplateSaveBuild(input));
+}
+
+/** Field-by-field difference against the checked-in entry; [] means identical. */
+export function compareToCertified(
+  entry: KnownTemplateSaveBuild,
+): string[] {
+  const certified = TEMPLATE_SAVE_BUILDS.find(
+    (build) => build.sha256 === entry.sha256,
+  );
+  if (!certified) return [`no certified entry for ${entry.sha256}`];
+  const differences: string[] = [];
+  const compare = (what: string, a: unknown, b: unknown) => {
+    if (JSON.stringify(a) !== JSON.stringify(b)) {
+      differences.push(`${what}: derived ${JSON.stringify(a)} vs certified ${JSON.stringify(b)}`);
+    }
+  };
+  compare("outputSha256", entry.outputSha256, certified.outputSha256);
+  compare("importCount", entry.importCount, certified.importCount);
+  compare("carrierImport", entry.carrierImport, certified.carrierImport);
+  compare(
+    "bridge kinds",
+    entry.bridges.map((bridge) => bridge.kind),
+    certified.bridges.map((bridge) => bridge.kind),
+  );
+  for (const bridge of entry.bridges) {
+    const other = certified.bridges.find((value) => value.kind === bridge.kind);
+    if (!other) continue;
+    compare(`${bridge.kind}.stubFunction`, bridge.stubFunction, other.stubFunction);
+    compare(`${bridge.kind}.stubBody`, bridge.stubBody ?? null, other.stubBody ?? null);
+    compare(
+      `${bridge.kind}.callSites`,
+      sortSites(bridge.callSites),
+      sortSites(other.callSites),
+    );
+  }
+  return differences;
+}
+
+export function inspectTemplateSaveCandidate(
+  input: Uint8Array,
+): TemplateSaveCandidateReport {
+  const hash = sha256(input);
+  const certified = findTemplateSaveBuild(hash) !== null;
+  const empty: TemplateSaveCandidateReport = {
+    sha256: hash,
+    validWasm: false,
+    status: "failed",
+    certified,
+    matchesCertifiedEntry: null,
+    importCount: null,
+    carrierImport: null,
+    targets: {},
+    callSites: {},
+    deleteAssertion: null,
+    encodings: { padded: 0, canonical: 0 },
+    entry: null,
+    diagnostics: [],
+  };
+
+  let view: ModuleView;
+  try {
+    view = new ModuleView(input);
+  } catch (error) {
+    return { ...empty, diagnostics: [String(error)] };
+  }
+
+  try {
+    const found = locate(view);
+    const entry = certify(input, draft(found));
+    const callSites: Partial<Record<BridgeKind, readonly CallSite[]>> = {};
+    let padded = 0;
+    for (const bridge of entry.bridges) {
+      callSites[bridge.kind] = bridge.callSites;
+      padded += bridge.callSites.length;
+    }
+    const canonical = entry.bridges.reduce(
+      (sum, bridge) =>
+        sum + canonicalCallCount(view, view.functionIndex(bridge.stubFunction)),
+      0,
+    );
+    const differences = certified ? compareToCertified(entry) : [];
+    return {
+      sha256: hash,
+      validWasm: true,
+      status: "derived",
+      certified,
+      matchesCertifiedEntry: certified ? differences.length === 0 : null,
+      importCount: view.importCount,
+      carrierImport: found.carrierImport,
+      targets: found.targets,
+      callSites,
+      deleteAssertion: found.deleteAssertion,
+      encodings: { padded, canonical },
+      entry,
+      diagnostics: [
+        ...found.diagnostics,
+        `template scans ${found.scans.join(", ")}`,
+        `directory sinks ${found.sinks.join(", ")}`,
+        `File::Open probe at +${found.probeOffset}, write at +${found.writeOffset}`,
+        ...(canonical > 0
+          ? [
+            `warning: ${canonical} possible canonically encoded call(s) to a`
+            + ` bridged target. A repoint only fits in place over the padded`
+            + ` five-byte form — see internal/upstream/recertify.md`,
+          ]
+          : []),
+        ...differences.map((value) => `differs from certified entry — ${value}`),
+      ],
+    };
+  } catch (error) {
+    if (error instanceof NotApplicableError) {
+      return {
+        ...empty,
+        validWasm: true,
+        status: "not-applicable",
+        importCount: view.importCount,
+        diagnostics: [error.message],
+      };
+    }
+    return {
+      ...empty,
+      validWasm: true,
+      importCount: view.importCount,
+      diagnostics: [error instanceof Error ? error.message : String(error)],
+    };
+  }
+}
+
+/** Paste-ready TypeScript for the entry, emitted to stderr by the CLI. */
+export function formatBuildEntry(entry: KnownTemplateSaveBuild): string {
+  const site = (value: CallSite) =>
+    `            Object.freeze({ localFunction: ${value.localFunction},`
+      + ` bodyOffset: ${value.bodyOffset} }),`;
+  const body = (values: readonly number[]) =>
+    values.map((value) => `0x${value.toString(16).padStart(2, "0")}`).join(", ");
+  const bridges = entry.bridges.map((bridge) => {
+    const stub = bridge.stubBody
+      ? `          stubBody: Object.freeze([${body(bridge.stubBody)}]),\n`
+      : "";
+    return (
+      `        Object.freeze({\n`
+      + `          kind: "${bridge.kind}" as const,\n`
+      + `          stubFunction: ${bridge.stubFunction},\n`
+      + stub
+      + `          callSites: Object.freeze([\n`
+      + `${sortSites(bridge.callSites).map(site).join("\n")}\n`
+      + `          ]),\n`
+      + `        }),`
+    );
+  });
+  return (
+    `    Object.freeze({\n`
+    + `      sha256:\n        "${entry.sha256}",\n`
+    + `      outputSha256:\n        "${entry.outputSha256}",\n`
+    + `      importCount: ${entry.importCount},\n`
+    + `      carrierImport: ${entry.carrierImport},\n`
+    + `      bridges: Object.freeze([\n${bridges.join("\n")}\n      ]),\n`
+    + `    }),`
+  );
+}

--- a/src/main/core/toolbox-transform.ts
+++ b/src/main/core/toolbox-transform.ts
@@ -5,6 +5,26 @@ import {
   type KnownToolboxBuild,
 } from "./toolbox-builds.js";
 import { applyTemplateSaveCompatibility } from "./template-save-compat.js";
+import {
+  concat,
+  countFunctionImports,
+  encodeCode,
+  encodeIndexVector,
+  encodeSection,
+  parseCode,
+  parseIndexVector,
+  parseTypes,
+  readSleb,
+  readUleb,
+  sectionById,
+  sleb,
+  splitSections,
+  uleb,
+  valueTypeName,
+  WASM_HEADER,
+  type FunctionType,
+  type Section,
+} from "./wasm-binary.js";
 
 declare const WebAssembly: {
   validate(bytes: Uint8Array): boolean;
@@ -15,196 +35,19 @@ export const TOOLBOX_HOOK_EXPORT = "toolbox_hook_slot";
 export const TOOLBOX_ORIGINAL_EXPORT = "toolbox_tick_original";
 export const TOOLBOX_MANIFEST_SECTION = "toolbox_manifest";
 
-const WASM_HEADER = Uint8Array.of(0, 97, 115, 109, 1, 0, 0, 0);
-const VALUE_TYPE_NAMES = new Map([
-  [0x7f, "i32"],
-  [0x7e, "i64"],
-  [0x7d, "f32"],
-  [0x7c, "f64"],
-]);
-
-interface Section {
-  id: number;
-  body: Uint8Array;
-}
-
-interface FunctionType {
-  params: number[];
-  results: number[];
-}
-
 interface WasmExport {
   name: string;
   kind: number;
   index: number;
 }
 
-interface Cursor {
-  offset: number;
-}
-
 function fail(message: string): never {
   throw new Error(`toolbox transform: ${message}`);
-}
-
-function readUleb(bytes: Uint8Array, cursor: Cursor): number {
-  let result = 0;
-  let shift = 0;
-  for (let count = 0; count < 5; count += 1) {
-    if (cursor.offset >= bytes.byteLength) fail("truncated LEB128");
-    const byte = bytes[cursor.offset++]!;
-    result |= (byte & 0x7f) << shift;
-    if ((byte & 0x80) === 0) return result >>> 0;
-    shift += 7;
-  }
-  return fail("oversized LEB128");
-}
-
-function uleb(value: number): Uint8Array {
-  if (!Number.isSafeInteger(value) || value < 0) fail("invalid unsigned value");
-  const out: number[] = [];
-  do {
-    let byte = value & 0x7f;
-    value = Math.floor(value / 128);
-    if (value !== 0) byte |= 0x80;
-    out.push(byte);
-  } while (value !== 0);
-  return Uint8Array.from(out);
-}
-
-function sleb(value: number): Uint8Array {
-  if (!Number.isSafeInteger(value)) fail("invalid signed value");
-  const out: number[] = [];
-  let more = true;
-  while (more) {
-    let byte = value & 0x7f;
-    value >>= 7;
-    const sign = (byte & 0x40) !== 0;
-    more = !((value === 0 && !sign) || (value === -1 && sign));
-    if (more) byte |= 0x80;
-    out.push(byte);
-  }
-  return Uint8Array.from(out);
-}
-
-function concat(...parts: readonly Uint8Array[]): Uint8Array {
-  const size = parts.reduce((sum, part) => sum + part.byteLength, 0);
-  const out = new Uint8Array(size);
-  let offset = 0;
-  for (const part of parts) {
-    out.set(part, offset);
-    offset += part.byteLength;
-  }
-  return out;
 }
 
 function encodeName(value: string): Uint8Array {
   const bytes = new TextEncoder().encode(value);
   return concat(uleb(bytes.byteLength), bytes);
-}
-
-function splitSections(bytes: Uint8Array): Section[] {
-  if (
-    bytes.byteLength < WASM_HEADER.byteLength ||
-    !WASM_HEADER.every((byte, index) => bytes[index] === byte)
-  ) {
-    fail("invalid WebAssembly header");
-  }
-  const sections: Section[] = [];
-  const cursor = { offset: WASM_HEADER.byteLength };
-  while (cursor.offset < bytes.byteLength) {
-    const id = bytes[cursor.offset++]!;
-    const size = readUleb(bytes, cursor);
-    const end = cursor.offset + size;
-    if (end > bytes.byteLength) fail("truncated section");
-    sections.push({ id, body: bytes.slice(cursor.offset, end) });
-    cursor.offset = end;
-  }
-  return sections;
-}
-
-function sectionById(sections: readonly Section[], id: number): Uint8Array {
-  const found = sections.find((section) => section.id === id);
-  return found?.body ?? fail(`missing section ${id}`);
-}
-
-function parseTypes(bytes: Uint8Array): FunctionType[] {
-  const cursor = { offset: 0 };
-  const count = readUleb(bytes, cursor);
-  const types: FunctionType[] = [];
-  for (let i = 0; i < count; i += 1) {
-    if (bytes[cursor.offset++] !== 0x60) fail("unsupported type form");
-    const paramCount = readUleb(bytes, cursor);
-    const params = Array.from(
-      bytes.slice(cursor.offset, cursor.offset + paramCount),
-    );
-    cursor.offset += paramCount;
-    const resultCount = readUleb(bytes, cursor);
-    const results = Array.from(
-      bytes.slice(cursor.offset, cursor.offset + resultCount),
-    );
-    cursor.offset += resultCount;
-    types.push({ params, results });
-  }
-  if (cursor.offset !== bytes.byteLength) fail("malformed type section");
-  return types;
-}
-
-function skipLimits(bytes: Uint8Array, cursor: Cursor): void {
-  const flags = readUleb(bytes, cursor);
-  readUleb(bytes, cursor);
-  if ((flags & 1) !== 0) readUleb(bytes, cursor);
-}
-
-function countFunctionImports(bytes: Uint8Array): number {
-  const cursor = { offset: 0 };
-  const count = readUleb(bytes, cursor);
-  let functions = 0;
-  for (let i = 0; i < count; i += 1) {
-    const moduleLength = readUleb(bytes, cursor);
-    cursor.offset += moduleLength;
-    const nameLength = readUleb(bytes, cursor);
-    cursor.offset += nameLength;
-    const kind = bytes[cursor.offset++]!;
-    if (kind === 0) {
-      functions += 1;
-      readUleb(bytes, cursor);
-    } else if (kind === 1) {
-      cursor.offset += 1;
-      skipLimits(bytes, cursor);
-    } else if (kind === 2) {
-      skipLimits(bytes, cursor);
-    } else if (kind === 3) {
-      cursor.offset += 2;
-    } else {
-      fail(`unsupported import kind ${kind}`);
-    }
-  }
-  return functions;
-}
-
-function parseVectorOfUleb(bytes: Uint8Array): number[] {
-  const cursor = { offset: 0 };
-  const count = readUleb(bytes, cursor);
-  const values: number[] = [];
-  for (let i = 0; i < count; i += 1) values.push(readUleb(bytes, cursor));
-  if (cursor.offset !== bytes.byteLength) fail("malformed index vector");
-  return values;
-}
-
-function parseCode(bytes: Uint8Array): Uint8Array[] {
-  const cursor = { offset: 0 };
-  const count = readUleb(bytes, cursor);
-  const bodies: Uint8Array[] = [];
-  for (let i = 0; i < count; i += 1) {
-    const size = readUleb(bytes, cursor);
-    const end = cursor.offset + size;
-    if (end > bytes.byteLength) fail("truncated function body");
-    bodies.push(bytes.slice(cursor.offset, end));
-    cursor.offset = end;
-  }
-  if (cursor.offset !== bytes.byteLength) fail("malformed code section");
-  return bodies;
 }
 
 function parseExports(bytes: Uint8Array): WasmExport[] {
@@ -243,20 +86,6 @@ function parseTable(bytes: Uint8Array): { min: number; max: number | null } {
   return { min, max };
 }
 
-function readSignedConst(bytes: Uint8Array, cursor: Cursor): number {
-  let result = 0;
-  let shift = 0;
-  let byte: number;
-  do {
-    if (cursor.offset >= bytes.byteLength) fail("truncated signed LEB128");
-    byte = bytes[cursor.offset++]!;
-    result |= (byte & 0x7f) << shift;
-    shift += 7;
-  } while ((byte & 0x80) !== 0 && shift < 35);
-  if (shift < 32 && (byte & 0x40) !== 0) result |= ~0 << shift;
-  return result;
-}
-
 function occupiedTableSlots(bytes: Uint8Array): Set<number> {
   const cursor = { offset: 0 };
   const count = readUleb(bytes, cursor);
@@ -265,7 +94,7 @@ function occupiedTableSlots(bytes: Uint8Array): Set<number> {
     const flags = readUleb(bytes, cursor);
     if (flags !== 0) fail(`unsupported element segment flags ${flags}`);
     if (bytes[cursor.offset++] !== 0x41) fail("expected element i32.const");
-    const base = readSignedConst(bytes, cursor);
+    const base = readSleb(bytes, cursor);
     if (bytes[cursor.offset++] !== 0x0b) fail("malformed element offset");
     const entries = readUleb(bytes, cursor);
     for (let i = 0; i < entries; i += 1) {
@@ -275,10 +104,6 @@ function occupiedTableSlots(bytes: Uint8Array): Set<number> {
   }
   if (cursor.offset !== bytes.byteLength) fail("malformed element section");
   return occupied;
-}
-
-function valueTypeName(value: number): string {
-  return VALUE_TYPE_NAMES.get(value) ?? `0x${value.toString(16)}`;
 }
 
 function dispatcher(
@@ -309,21 +134,6 @@ function dispatcher(
     uleb(0),
     Uint8Array.of(0x0b),
   );
-}
-
-function encodeIndexVector(values: readonly number[]): Uint8Array {
-  return concat(uleb(values.length), ...values.map(uleb));
-}
-
-function encodeCode(bodies: readonly Uint8Array[]): Uint8Array {
-  return concat(
-    uleb(bodies.length),
-    ...bodies.map((body) => concat(uleb(body.byteLength), body)),
-  );
-}
-
-function encodeSection(section: Section): Uint8Array {
-  return concat(Uint8Array.of(section.id), uleb(section.body.byteLength), section.body);
 }
 
 function buildManifestSection(build: KnownToolboxBuild): Section {
@@ -392,7 +202,7 @@ export function inspectToolboxCandidate(
   const sections = splitSections(input);
   const types = parseTypes(sectionById(sections, 1));
   const importCount = countFunctionImports(sectionById(sections, 2));
-  const functionTypes = parseVectorOfUleb(sectionById(sections, 3));
+  const functionTypes = parseIndexVector(sectionById(sections, 3));
   const mainLoopExport = parseExports(sectionById(sections, 7)).find(
     (entry) => entry.kind === 0 && entry.name === "EmscriptenExeThreadMainLoop",
   );
@@ -445,7 +255,7 @@ export function transformToolboxWasm(
   const sections = splitSections(compatibleInput);
   const types = parseTypes(sectionById(sections, 1));
   const importCount = countFunctionImports(sectionById(sections, 2));
-  const functionTypes = parseVectorOfUleb(sectionById(sections, 3));
+  const functionTypes = parseIndexVector(sectionById(sections, 3));
   const bodies = parseCode(sectionById(sections, 10));
   if (functionTypes.length !== bodies.length) fail("function/code count mismatch");
 

--- a/src/main/core/wasm-binary.ts
+++ b/src/main/core/wasm-binary.ts
@@ -1,0 +1,296 @@
+// WebAssembly section codec shared by everything that rewrites or inspects
+// ArenaNet's client: the Toolbox transform, the template-save compatibility
+// transform, and the re-certifier that re-derives a build entry.
+//
+// Callers keep their own domain-prefixed `fail()` for their own invariants;
+// everything here throws `wasm: …` so a structural fault is distinguishable
+// from a policy one.
+
+export interface Section {
+  id: number;
+  body: Uint8Array;
+}
+
+export interface Cursor {
+  offset: number;
+}
+
+export interface FunctionType {
+  params: number[];
+  results: number[];
+}
+
+export const WASM_HEADER = Uint8Array.of(0, 97, 115, 109, 1, 0, 0, 0);
+
+/** Width LLVM uses for relocatable call targets, so a repoint fits in place. */
+export const PADDED_INDEX_BYTES = 5;
+
+const VALUE_TYPE_NAMES = new Map([
+  [0x7f, "i32"],
+  [0x7e, "i64"],
+  [0x7d, "f32"],
+  [0x7c, "f64"],
+]);
+
+function fail(message: string): never {
+  throw new Error(`wasm: ${message}`);
+}
+
+/**
+ * A real copy, whatever the caller passed. `Buffer.prototype.slice` returns a
+ * view, so slicing a `readFile` result would hand out aliases into the caller's
+ * input — and a transform that rewrites a body would then corrupt it.
+ */
+function copyRange(bytes: Uint8Array, start: number, end: number): Uint8Array {
+  return new Uint8Array(bytes.subarray(start, end));
+}
+
+export function valueTypeName(value: number): string {
+  return VALUE_TYPE_NAMES.get(value) ?? `0x${value.toString(16)}`;
+}
+
+export function concat(...parts: readonly Uint8Array[]): Uint8Array {
+  const out = new Uint8Array(
+    parts.reduce((sum, part) => sum + part.byteLength, 0),
+  );
+  let offset = 0;
+  for (const part of parts) {
+    out.set(part, offset);
+    offset += part.byteLength;
+  }
+  return out;
+}
+
+export function uleb(value: number): Uint8Array {
+  if (!Number.isSafeInteger(value) || value < 0) fail("invalid unsigned value");
+  const out: number[] = [];
+  do {
+    const byte = value & 0x7f;
+    value = Math.floor(value / 128);
+    out.push(value === 0 ? byte : byte | 0x80);
+  } while (value !== 0);
+  return Uint8Array.from(out);
+}
+
+export function sleb(value: number): Uint8Array {
+  if (!Number.isSafeInteger(value)) fail("invalid signed value");
+  const out: number[] = [];
+  for (;;) {
+    const byte = value & 0x7f;
+    value >>= 7;
+    const sign = (byte & 0x40) !== 0;
+    if ((value === 0 && !sign) || (value === -1 && sign)) {
+      out.push(byte);
+      return Uint8Array.from(out);
+    }
+    out.push(byte | 0x80);
+  }
+}
+
+/**
+ * Deliberately capped at five bytes: this module is read-only over an 8 MB
+ * client, and a wider read would silently accept a malformed index rather than
+ * reporting it.
+ */
+export function readUleb(bytes: Uint8Array, cursor: Cursor): number {
+  let result = 0;
+  let shift = 0;
+  for (let count = 0; count < 5; count += 1) {
+    if (cursor.offset >= bytes.byteLength) fail("truncated LEB128");
+    const byte = bytes[cursor.offset++]!;
+    result |= (byte & 0x7f) << shift;
+    if ((byte & 0x80) === 0) return result >>> 0;
+    shift += 7;
+  }
+  return fail("oversized LEB128");
+}
+
+export function readSleb(bytes: Uint8Array, cursor: Cursor): number {
+  let result = 0;
+  let shift = 0;
+  let byte: number;
+  do {
+    if (cursor.offset >= bytes.byteLength) fail("truncated signed LEB128");
+    byte = bytes[cursor.offset++]!;
+    result |= (byte & 0x7f) << shift;
+    shift += 7;
+  } while ((byte & 0x80) !== 0 && shift < 35);
+  if (shift < 32 && (byte & 0x40) !== 0) result |= ~0 << shift;
+  return result;
+}
+
+/**
+ * Fixed-width index, so a rewritten `call` stays byte-for-byte as long. The
+ * bound is checked up front because `>>>` truncates to 32 bits, which would
+ * make a trailing check silently unreachable.
+ */
+export function paddedIndex(value: number): Uint8Array {
+  if (!Number.isSafeInteger(value) || value < 0 || value > 0xffff_ffff) {
+    fail("index does not fit the padded call width");
+  }
+  const out = new Uint8Array(PADDED_INDEX_BYTES);
+  for (let index = 0; index < PADDED_INDEX_BYTES; index += 1) {
+    out[index] = (value & 0x7f) | (index === PADDED_INDEX_BYTES - 1 ? 0 : 0x80);
+    value >>>= 7;
+  }
+  return out;
+}
+
+export function splitSections(bytes: Uint8Array): Section[] {
+  if (
+    bytes.byteLength < WASM_HEADER.byteLength
+    || !WASM_HEADER.every((byte, index) => bytes[index] === byte)
+  ) {
+    fail("invalid WebAssembly header");
+  }
+  const sections: Section[] = [];
+  const cursor = { offset: WASM_HEADER.byteLength };
+  while (cursor.offset < bytes.byteLength) {
+    const id = bytes[cursor.offset++]!;
+    const size = readUleb(bytes, cursor);
+    const end = cursor.offset + size;
+    if (end > bytes.byteLength) fail("truncated section");
+    sections.push({ id, body: copyRange(bytes, cursor.offset, end) });
+    cursor.offset = end;
+  }
+  return sections;
+}
+
+export function sectionById(
+  sections: readonly Section[],
+  id: number,
+): Uint8Array {
+  return (
+    sections.find((section) => section.id === id)?.body
+    ?? fail(`missing section ${id}`)
+  );
+}
+
+export function encodeSection(section: Section): Uint8Array {
+  return concat(
+    Uint8Array.of(section.id),
+    uleb(section.body.byteLength),
+    section.body,
+  );
+}
+
+export function parseTypes(bytes: Uint8Array): FunctionType[] {
+  const cursor = { offset: 0 };
+  const count = readUleb(bytes, cursor);
+  const types: FunctionType[] = [];
+  for (let i = 0; i < count; i += 1) {
+    if (bytes[cursor.offset++] !== 0x60) fail("unsupported type form");
+    const paramCount = readUleb(bytes, cursor);
+    const params = Array.from(
+      bytes.slice(cursor.offset, cursor.offset + paramCount),
+    );
+    cursor.offset += paramCount;
+    const resultCount = readUleb(bytes, cursor);
+    const results = Array.from(
+      bytes.slice(cursor.offset, cursor.offset + resultCount),
+    );
+    cursor.offset += resultCount;
+    types.push({ params, results });
+  }
+  if (cursor.offset !== bytes.byteLength) fail("malformed type section");
+  return types;
+}
+
+export function parseIndexVector(bytes: Uint8Array): number[] {
+  const cursor = { offset: 0 };
+  const count = readUleb(bytes, cursor);
+  const values: number[] = [];
+  for (let i = 0; i < count; i += 1) values.push(readUleb(bytes, cursor));
+  if (cursor.offset !== bytes.byteLength) fail("malformed index vector");
+  return values;
+}
+
+export function encodeIndexVector(values: readonly number[]): Uint8Array {
+  return concat(uleb(values.length), ...values.map(uleb));
+}
+
+export function parseCode(bytes: Uint8Array): Uint8Array[] {
+  const cursor = { offset: 0 };
+  const count = readUleb(bytes, cursor);
+  const bodies: Uint8Array[] = [];
+  for (let i = 0; i < count; i += 1) {
+    const size = readUleb(bytes, cursor);
+    const end = cursor.offset + size;
+    if (end > bytes.byteLength) fail("truncated function body");
+    bodies.push(copyRange(bytes, cursor.offset, end));
+    cursor.offset = end;
+  }
+  if (cursor.offset !== bytes.byteLength) fail("malformed code section");
+  return bodies;
+}
+
+export function encodeCode(bodies: readonly Uint8Array[]): Uint8Array {
+  return concat(
+    uleb(bodies.length),
+    ...bodies.map((body) => concat(uleb(body.byteLength), body)),
+  );
+}
+
+function skipLimits(bytes: Uint8Array, cursor: Cursor): void {
+  const flags = readUleb(bytes, cursor);
+  readUleb(bytes, cursor);
+  if ((flags & 1) !== 0) readUleb(bytes, cursor);
+}
+
+/**
+ * Walk the import section, reporting each imported function in order. Function
+ * indices start at the imports, so the callback index is the function index.
+ */
+function eachFunctionImport(
+  bytes: Uint8Array,
+  visit: (index: number, module: string, name: string) => void,
+): number {
+  const cursor = { offset: 0 };
+  const count = readUleb(bytes, cursor);
+  const text = new TextDecoder();
+  let functions = 0;
+  for (let i = 0; i < count; i += 1) {
+    const moduleLength = readUleb(bytes, cursor);
+    const module = text.decode(
+      bytes.slice(cursor.offset, cursor.offset + moduleLength),
+    );
+    cursor.offset += moduleLength;
+    const nameLength = readUleb(bytes, cursor);
+    const name = text.decode(
+      bytes.slice(cursor.offset, cursor.offset + nameLength),
+    );
+    cursor.offset += nameLength;
+    const kind = bytes[cursor.offset++]!;
+    if (kind === 0) {
+      visit(functions, module, name);
+      functions += 1;
+      readUleb(bytes, cursor);
+    } else if (kind === 1) {
+      cursor.offset += 1;
+      skipLimits(bytes, cursor);
+    } else if (kind === 2) {
+      skipLimits(bytes, cursor);
+    } else if (kind === 3) {
+      cursor.offset += 2;
+    } else {
+      fail(`unsupported import kind ${kind}`);
+    }
+  }
+  return functions;
+}
+
+export function countFunctionImports(bytes: Uint8Array): number {
+  return eachFunctionImport(bytes, () => {});
+}
+
+/** Function index of an imported function by field name, or null. */
+export function functionImportIndex(
+  bytes: Uint8Array,
+  name: string,
+): number | null {
+  let found: number | null = null;
+  eachFunctionImport(bytes, (index, _module, field) => {
+    if (field === name && found === null) found = index;
+  });
+  return found;
+}

--- a/src/renderer/gw-native.d.ts
+++ b/src/renderer/gw-native.d.ts
@@ -138,15 +138,15 @@ declare global {
       };
       module: {
         HEAPU8?: Uint8Array;
-        HEAPU32?: Uint32Array;
       };
     }): void;
-    gwInstallTemplateSaveCompatibility(
+    gwInstallTemplateSaveCompatibility(options: {
       imports: {
         env?: Record<string, (...args: unknown[]) => unknown>;
-      },
-      module: { HEAPU8?: Uint8Array },
-    ): void;
+      };
+      module: { HEAPU8?: Uint8Array };
+      exports(): { malloc?: (bytes: number) => number } | null;
+    }): void;
     gwTemplateFilesystemTrace?(): ReadonlyArray<Readonly<{
       sequence: number;
       operation: string;

--- a/src/renderer/harness.js
+++ b/src/renderer/harness.js
@@ -388,7 +388,17 @@ Module = {
   * @param {(instance: WebAssembly.Instance, module: WebAssembly.Module) => void} success
   */
   instantiateWasm(imports, success) {
-    window.gwInstallTemplateSaveCompatibility(imports, Module);
+    window.gwInstallTemplateSaveCompatibility({
+      imports,
+      module: Module,
+      // The directory listing hands the client a block it frees itself, so it
+      // has to come from the client's own allocator, which only exists once
+      // instantiation below resolves.
+      exports: () =>
+        /** @type {{ malloc?: (bytes: number) => number }} */ (
+          gameWasmInstance?.exports ?? null
+        ),
+    });
     window.gwInstallTemplateFilesystemTrace({
       imports,
       module: Module,

--- a/src/renderer/template-filesystem-trace.js
+++ b/src/renderer/template-filesystem-trace.js
@@ -75,22 +75,33 @@
   }
 
   /**
-   * @param {{ HEAPU32?: Uint32Array }} module
+   * The generated glue publishes only `Module.HEAPU8`, so every wider view has
+   * to be taken from its buffer. Reading `Module.HEAPU32` yields `undefined`
+   * and silently drops every byte count from the trace.
+   *
+   * @param {{ HEAPU8?: Uint8Array }} module
+   */
+  function words(module) {
+    return module.HEAPU8 ? new Uint32Array(module.HEAPU8.buffer) : undefined;
+  }
+
+  /**
+   * @param {{ HEAPU8?: Uint8Array }} module
    * @param {number} pointer
    */
   function readU32(module, pointer) {
-    const heap = module.HEAPU32;
+    const heap = words(module);
     const index = pointer >>> 2;
     return heap && pointer >= 0 && index < heap.length ? heap[index] : undefined;
   }
 
   /**
-   * @param {{ HEAPU32?: Uint32Array }} module
+   * @param {{ HEAPU8?: Uint8Array }} module
    * @param {number} iov
    * @param {number} count
    */
   function requestedBytes(module, iov, count) {
-    const heap = module.HEAPU32;
+    const heap = words(module);
     if (!heap || !Number.isSafeInteger(count) || count < 0 || count > 1024) {
       return undefined;
     }
@@ -111,7 +122,7 @@
    *     env?: Record<string, (...args: any[]) => any>;
    *     wasi_snapshot_preview1?: Record<string, (...args: any[]) => any>;
    *   };
-   *   module: { HEAPU8?: Uint8Array; HEAPU32?: Uint32Array };
+   *   module: { HEAPU8?: Uint8Array };
    * }} options
    */
   window.gwInstallTemplateFilesystemTrace = ({ imports, module }) => {

--- a/src/renderer/template-save-compatibility.js
+++ b/src/renderer/template-save-compatibility.js
@@ -1,22 +1,77 @@
+// Host half of the derived-client bridge in src/main/core/template-save-compat.ts.
+//
+// Four `Base/Os` file routines ship unimplemented in ArenaNet's Emscripten
+// build: creating a directory always fails, enumerating one does nothing,
+// deriving a name from an entry writes nothing, and deleting a file aborts the
+// client. A fifth is implemented but wrong — opening a file to test whether it
+// exists creates it. The derived module forwards all five to
+// `__syscall_newfstatat` behind dirfd markers that no real call produces, and
+// they are answered here against the mounted IDBFS.
 (() => {
   'use strict';
 
-  const BRIDGE_SENTINEL = 1;
-  const ALLOWED_DIRECTORIES = new Set([
-    'Templates/Skills',
-    'Templates/Equipment',
-  ]);
+  // Mirrors src/main/core/template-save-compat.ts.
+  const ENSURE_DIRECTORY = -70001;
+  const FIND_FILES = -70002;
+  const FILE_BASE_NAME = -70003;
+  const DELETE_FILE = -70004;
+  const FILE_EXISTS = -70005;
+
+  // The client's directory-entry record: a 24-byte header it never reads,
+  // then WCHAR name[260]. Callers stride by the whole record and free the
+  // block, so it has to come from the client's own allocator.
+  const RECORD_BYTES = 544;
+  const RECORD_NAME_OFFSET = 24;
+  const NAME_LIMIT = 260;
+
+  const PATH_LIMIT = 260;
+  const ERROR_NOT_FOUND = 2;
+
+  const TRACE_PARAMETER = 'template-fs-trace';
+  const TRACE_PREFIX = '[template-fs-bridge]';
+
+  /** @returns {{ (event: Record<string, unknown>): void; enabled: boolean }} */
+  function silent() {
+    const off = () => {};
+    off.enabled = false;
+    return off;
+  }
+
+  /**
+   * Counts and outcomes only, under the same opt-in flag as the syscall trace.
+   * No filename, path, or file content is recorded, and nothing is exported or
+   * leaves the renderer.
+   *
+   * @returns {{ (event: Record<string, unknown>): void; enabled: boolean }}
+   */
+  function tracer() {
+    let enabled;
+    try {
+      enabled = new URL(location.href).searchParams.get(TRACE_PARAMETER) === '1';
+    } catch {
+      return silent();
+    }
+    if (!enabled) return silent();
+    let sequence = 0;
+    /** @param {Record<string, unknown>} event */
+    const on = (event) => {
+      sequence += 1;
+      console.info(TRACE_PREFIX, JSON.stringify({ sequence, ...event }));
+    };
+    on.enabled = true;
+    return on;
+  }
 
   /**
    * @param {{ HEAPU8?: Uint8Array }} module
    * @param {number} pointer
    */
-  function readWidePath(module, pointer) {
+  function readWide(module, pointer) {
     const bytes = module.HEAPU8;
     if (!bytes || pointer <= 0 || (pointer & 1) !== 0) return null;
     const heap = new Uint16Array(bytes.buffer);
     const start = pointer >>> 1;
-    const endLimit = Math.min(heap.length, start + 260);
+    const endLimit = Math.min(heap.length, start + PATH_LIMIT);
     let end = start;
     while (end < endLimit && heap[end] !== 0) end += 1;
     if (end === endLimit) return null;
@@ -24,45 +79,338 @@
     for (let index = start; index < end; index += 1) {
       value += String.fromCharCode(heap[index] ?? 0);
     }
-    const normalized = value
-      .replace(/^[/\\]+/, '')
-      .replaceAll('\\', '/');
-    return normalized.startsWith('app:/') ? normalized.slice(5) : normalized;
+    return value;
+  }
+
+  /**
+   * Everything the client passes is relative to the mount. `_wsplitpath` and
+   * `_wmakepath` both keep the separator that ends a directory component, so a
+   * directory always arrives as `Templates/Skills/`.
+   *
+   * Runs of separators collapse the way `PATH.normalize` collapses them. The
+   * client joins its type directory with `/` onto a record name that already
+   * begins with `\`, so every file operation on a listed template arrives as
+   * `Templates/Skills/\Test.txt` — a redundant separator, not a traversal.
+   *
+   * @param {string} value
+   */
+  function normalize(value) {
+    const trimmed = value
+      .replaceAll('\\', '/')
+      .replace(/\/{2,}/g, '/')
+      .replace(/^\/+/, '')
+      .replace(/\/+$/, '');
+    const relative = trimmed.startsWith('app:/') ? trimmed.slice(5) : trimmed;
+    if (!relative) return null;
+    // Keep the client inside its own mount: no absolute paths, no traversal.
+    const parts = relative.split('/');
+    return parts.every((part) => part && part !== '.' && part !== '..')
+      ? relative
+      : null;
+  }
+
+  /** @param {string} glob */
+  function globToRegExp(glob) {
+    const source = glob.replaceAll(/[.+^${}()|[\]\\]/g, String.raw`\$&`)
+      .replaceAll('*', '[^/]*')
+      .replaceAll('?', '[^/]');
+    return new RegExp(`^${source}$`, 'i');
+  }
+
+  // Entry kinds the client asks for. `Templates/Skills/*.txt` is requested with
+  // FILES and `Templates/Skills/*` with DIRECTORIES, so answering both with
+  // files fills the subdirectory list with phantom folders.
+  const FIND_FILES_FLAG = 1;
+  const FIND_DIRECTORIES_FLAG = 2;
+
+  /**
+   * The client keys a template on its path below the type directory, in Windows
+   * form with a leading separator: `\Test`, or `\Sub\Test` one level down. Its
+   * own save path builds exactly that, and the list filter matches records
+   * against the current subdirectory prefix — so a bare `Test` never matches.
+   *
+   * The extension comes off here rather than being left to the client's
+   * `Path::RemoveExtension`, which is off by one in this build and takes the
+   * last character of the name with it: `\Test.txt` becomes `\Tes`. Handing it
+   * a name with no extension leaves it nothing to trim.
+   *
+   * @param {string} name
+   */
+  function internalPath(name) {
+    const relative = name.replaceAll('/', '\\').replace(/^\\+/, '');
+    const separator = relative.lastIndexOf('\\');
+    const dot = relative.lastIndexOf('.');
+    const bare = dot > separator + 1 ? relative.slice(0, dot) : relative;
+    return `\\${bare}`;
+  }
+
+  /**
+   * @param {{ HEAPU8?: Uint8Array }} module
+   * @param {number} pointer
+   * @param {string} value
+   * @param {number} limit Buffer size in characters, including the terminator.
+   */
+  function writeWide(module, pointer, value, limit) {
+    const bytes = module.HEAPU8;
+    if (!bytes || pointer <= 0 || (pointer & 1) !== 0 || limit < 1) return false;
+    const heap = new Uint16Array(bytes.buffer);
+    const start = pointer >>> 1;
+    const count = Math.min(value.length, limit - 1);
+    if (start + count >= heap.length) return false;
+    for (let index = 0; index < count; index += 1) {
+      heap[start + index] = value.charCodeAt(index);
+    }
+    heap[start + count] = 0;
+    return true;
+  }
+
+  /**
+   * @typedef {{
+   *   readdir(path: string): string[],
+   *   unlink(path: string): void,
+   *   analyzePath(path: string): { exists: boolean },
+   *   stat(path: string): { mode: number },
+   *   isFile(mode: number): boolean,
+   *   isDir(mode: number): boolean,
+   *   mkdirTree(path: string): void,
+   * }} EmscriptenFileSystem
+   */
+
+  /** @returns {EmscriptenFileSystem | null} */
+  function filesystem() {
+    const runtime = /** @type {{ FS?: EmscriptenFileSystem }} */ (globalThis);
+    return runtime.FS ?? null;
+  }
+
+  /**
+   * @param {EmscriptenFileSystem} fs
+   * @param {string} directory
+   * @param {RegExp} pattern
+   * @param {number} flags
+   */
+  function matchingEntries(fs, directory, pattern, flags) {
+    const wantFiles = (flags & FIND_FILES_FLAG) !== 0;
+    const wantDirectories = (flags & FIND_DIRECTORIES_FLAG) !== 0;
+    /** @type {string[]} */
+    const found = [];
+    for (const entry of fs.readdir(directory)) {
+      if (entry === '.' || entry === '..') continue;
+      if (!pattern.test(entry) || entry.length >= NAME_LIMIT) continue;
+      try {
+        const { mode } = fs.stat(`${directory}/${entry}`);
+        const wanted = fs.isDir(mode) ? wantDirectories : wantFiles;
+        if (wanted) found.push(entry);
+      } catch {
+        // An entry the mount cannot describe is left out of the listing, the
+        // way a directory read degrades. The client has no way to report it.
+      }
+    }
+    return found.sort();
   }
 
   /**
    * @param {{
-   *   env?: Record<string, (...args: any[]) => any>;
-   * }} imports
-   * @param {{ HEAPU8?: Uint8Array }} module
+   *   imports: { env?: Record<string, (...args: any[]) => any> },
+   *   module: { HEAPU8?: Uint8Array },
+   *   exports: () => { malloc?: (bytes: number) => number } | null | undefined,
+   * }} options
    */
-  window.gwInstallTemplateSaveCompatibility = (imports, module) => {
+  window.gwInstallTemplateSaveCompatibility = ({ imports, module, exports }) => {
     const env = imports.env;
-    const stat = env?.__syscall_stat64;
-    if (!env || typeof stat !== 'function') return;
+    const carrier = env?.__syscall_newfstatat;
+    const trace = tracer();
+    if (!env || typeof carrier !== 'function') {
+      trace({ operation: 'unavailable' });
+      return;
+    }
 
-    env.__syscall_stat64 = function (path, buffer) {
-      if (buffer !== BRIDGE_SENTINEL) {
-        return stat.call(this, path, buffer);
+    /** @param {number} path */
+    const ensureDirectory = (path) => {
+      const raw = readWide(module, path);
+      const directory = raw === null ? null : normalize(raw);
+      const fs = filesystem();
+      if (!directory || !fs) {
+        trace({ operation: 'ensureDirectory', decoded: raw !== null, fs: !!fs });
+        return ERROR_NOT_FOUND;
       }
-      const directory = readWidePath(module, path);
-      if (!directory || !ALLOWED_DIRECTORIES.has(directory)) return 2;
       try {
-        const runtime =
-          /** @type {{ FS?: { mkdirTree(path: string): void } }} */ (
-            globalThis
-          );
-        if (!runtime.FS) return 2;
-        runtime.FS.mkdirTree(directory);
+        fs.mkdirTree(directory);
+        trace({ operation: 'ensureDirectory', depth: directory.split('/').length, result: 0 });
         return 0;
       } catch (error) {
-        return typeof error === 'object'
+        const errno = typeof error === 'object'
           && error !== null
           && 'errno' in error
           && typeof error.errno === 'number'
           ? error.errno
-          : 5;
+          : ERROR_NOT_FOUND;
+        trace({ operation: 'ensureDirectory', result: errno });
+        return errno;
       }
+    };
+
+    /**
+     * @param {number} path Wildcard such as `Templates/Skills/*`.
+     * @param {number} out Zeroed list header: entries at +0, count at +8.
+     * @param {number} flags Which entry kinds the caller wants.
+     */
+    const findFiles = (path, out, flags) => {
+      const bytes = module.HEAPU8;
+      const raw = readWide(module, path);
+      const pattern = raw === null ? null : normalize(raw);
+      const fs = filesystem();
+      if (!bytes || !pattern || !fs || out <= 0 || (out & 3) !== 0) {
+        trace({
+          operation: 'findFiles',
+          heap: !!bytes,
+          decoded: raw !== null,
+          accepted: pattern !== null,
+          fs: !!fs,
+          aligned: out > 0 && (out & 3) === 0,
+        });
+        return 0;
+      }
+
+      const cut = pattern.lastIndexOf('/');
+      const directory = cut < 0 ? '.' : pattern.slice(0, cut);
+      const glob = cut < 0 ? pattern : pattern.slice(cut + 1);
+      /** @type {string[]} */
+      let names;
+      let listed = -1;
+      try {
+        listed = fs.readdir(directory).length;
+        names = matchingEntries(fs, directory, globToRegExp(glob), flags);
+      } catch (error) {
+        trace({
+          operation: 'findFiles',
+          depth: directory.split('/').length,
+          listed,
+          failed: error instanceof Error ? error.name : 'unknown',
+        });
+        return 0;
+      }
+      if (names.length === 0) {
+        trace({ operation: 'findFiles', flags, listed, matched: 0 });
+        return 0;
+      }
+
+      const malloc = exports()?.malloc;
+      if (typeof malloc !== 'function') {
+        trace({ operation: 'findFiles', flags, listed, matched: names.length, malloc: false });
+        return 0;
+      }
+      const entries = malloc(names.length * RECORD_BYTES);
+      if (!entries) {
+        trace({ operation: 'findFiles', flags, listed, matched: names.length, allocated: false });
+        return 0;
+      }
+
+      // malloc can grow memory, so every view is taken after it returns.
+      const heap = module.HEAPU8;
+      if (!heap) return 0;
+      heap.fill(0, entries, entries + names.length * RECORD_BYTES);
+      names.forEach((name, index) => {
+        writeWide(
+          module,
+          entries + index * RECORD_BYTES + RECORD_NAME_OFFSET,
+          name,
+          NAME_LIMIT,
+        );
+      });
+      const words = new Uint32Array(heap.buffer);
+      words[out >>> 2] = entries;
+      words[(out >>> 2) + 2] = names.length;
+      trace({
+        operation: 'findFiles',
+        flags,
+        listed,
+        matched: names.length,
+        published: true,
+      });
+      return 0;
+    };
+
+    /**
+     * @param {number} path A directory entry name from findFiles.
+     * @param {number} destination
+     * @param {number} limit
+     */
+    const fileBaseName = (path, destination, limit) => {
+      const raw = readWide(module, path);
+      if (raw === null) return 0;
+      const name = internalPath(raw);
+      const written = writeWide(
+        module,
+        destination,
+        name,
+        Math.min(limit, PATH_LIMIT),
+      );
+      trace({ operation: 'fileBaseName', length: name.length, written });
+      return written ? 1 : 0;
+    };
+
+    /**
+     * The client's own delete is `assert("not implemented")` followed by
+     * `unreachable`, so this is the difference between deleting a build and
+     * aborting the client. Its caller treats a non-zero result as success.
+     *
+     * @param {number} path
+     */
+    const deleteFile = (path) => {
+      const raw = readWide(module, path);
+      const file = raw === null ? null : normalize(raw);
+      const fs = filesystem();
+      if (!file || !fs) {
+        trace({ operation: 'deleteFile', decoded: raw !== null, fs: !!fs });
+        return 0;
+      }
+      try {
+        fs.unlink(file);
+        trace({ operation: 'deleteFile', deleted: true });
+        return 1;
+      } catch (error) {
+        trace({
+          operation: 'deleteFile',
+          deleted: false,
+          failed: error instanceof Error ? error.name : 'unknown',
+        });
+        return 0;
+      }
+    };
+
+    /**
+     * `File::Open` mode 1 is meant to open an existing file, but in this build
+     * it opens `O_RDWR | O_CREAT` like the write mode — so the client's own
+     * "is this name taken?" probe creates the file it is testing for and every
+     * rename is refused. Answer the question without touching the file.
+     *
+     * An undecidable path answers "taken", which refuses a rename rather than
+     * silently overwriting a template.
+     *
+     * @param {number} path
+     */
+    const fileExists = (path) => {
+      const raw = readWide(module, path);
+      const file = raw === null ? null : normalize(raw);
+      const fs = filesystem();
+      if (!file || !fs) {
+        trace({ operation: 'fileExists', decoded: raw !== null, fs: !!fs });
+        return 1;
+      }
+      const exists = fs.analyzePath(file).exists;
+      trace({ operation: 'fileExists', exists });
+      return exists ? 1 : 0;
+    };
+
+    trace({ operation: 'installed' });
+
+    env.__syscall_newfstatat = function (dirfd, path, buffer, flags) {
+      if (dirfd === ENSURE_DIRECTORY) return ensureDirectory(path);
+      if (dirfd === FIND_FILES) return findFiles(path, buffer, flags);
+      if (dirfd === FILE_BASE_NAME) return fileBaseName(path, buffer, flags);
+      if (dirfd === DELETE_FILE) return deleteFile(path);
+      if (dirfd === FILE_EXISTS) return fileExists(path);
+      return carrier.call(this, dirfd, path, buffer, flags);
     };
   };
 })();

--- a/src/tools/template-save-recertify.ts
+++ b/src/tools/template-save-recertify.ts
@@ -1,0 +1,73 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  formatBuildEntry,
+  inspectTemplateSaveCandidate,
+} from "../main/core/template-save-recert.js";
+import { defaultGuildWarsProfile } from "./toolbox-doctor.js";
+
+const USAGE =
+  "usage: template:recertify [path/to/Gw.jspi.wasm]"
+  + " [--emit-ts] [--expect-certified]\n";
+
+function defaultArtifact(): string {
+  return path.join(
+    defaultGuildWarsProfile(),
+    "game",
+    "artifacts",
+    "Gw.jspi.wasm",
+  );
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2).filter((argument) => argument !== "--");
+  const emitTypeScript = argv.includes("--emit-ts");
+  const expectCertified = argv.includes("--expect-certified");
+  const positional = argv.filter((argument) => !argument.startsWith("--"));
+  if (positional.length > 1) {
+    process.stderr.write(USAGE);
+    process.exitCode = 2;
+    return;
+  }
+
+  const filename = positional[0] ?? defaultArtifact();
+  let input: Uint8Array;
+  try {
+    input = await readFile(filename);
+  } catch {
+    process.stderr.write(`template:recertify: cannot read ${filename}\n`);
+    process.stderr.write(USAGE);
+    process.exitCode = 2;
+    return;
+  }
+
+  const report = inspectTemplateSaveCandidate(input);
+  process.stdout.write(`${JSON.stringify(report)}\n`);
+
+  // Paste-ready entry goes to stderr so stdout stays machine-parseable. The
+  // 23-byte delete-file body is the one value nobody should retype by hand: a
+  // wrong byte fails as "not the expected stub", which reads exactly like the
+  // build having genuinely changed.
+  if (emitTypeScript && report.entry) {
+    process.stderr.write(`\n${formatBuildEntry(report.entry)}\n`);
+  }
+
+  if (report.status === "failed") {
+    process.exitCode = 1;
+    return;
+  }
+  if (expectCertified && report.matchesCertifiedEntry !== true) {
+    process.stderr.write(
+      "template:recertify: derived entry does not match the certified one\n",
+    );
+    process.exitCode = 1;
+  }
+}
+
+if (
+  process.argv[1]
+  && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+) {
+  await main();
+}

--- a/tests/release/wasm-host.test.mjs
+++ b/tests/release/wasm-host.test.mjs
@@ -113,15 +113,91 @@ test("template saving uses one exact-build derived WASM and a restricted mkdir b
     "utf8",
   );
 
-  assert.match(transform, /callOffset: 0x365a23/);
-  assert.match(transform, /1883197770cc74fe48d308f097359a08/);
+  assert.match(transform, /b0319704f3072d6948a66026a35af5eb/);
+  assert.match(transform, /68c6e09cec0f6992058a44a5617ca9ea/);
   assert.match(transform, /WebAssembly\.validate\(output\)/);
+  assert.match(transform, /unsupported input/);
+  assert.match(transform, /is not the expected stub/);
+  assert.match(transform, /call site signature mismatch/);
   assert.match(runtime, /prepareTemplateSaveClient/);
-  assert.match(bridge, /BRIDGE_SENTINEL = 1/);
-  assert.match(bridge, /Templates\/Skills/);
-  assert.match(bridge, /Templates\/Equipment/);
+
+  // The derived module and the host agree on the dirfd markers by hand. If the
+  // two copies ever drift, every bridged call silently becomes a real stat.
+  const markers = (source) =>
+    [...source.matchAll(/-70_?00(\d)/g)].map((found) => found[1]);
+  assert.deepEqual(markers(transform), ["1", "2", "3", "4", "5"]);
+  assert.deepEqual(markers(bridge), ["1", "2", "3", "4", "5"]);
+
+  assert.match(bridge, /__syscall_newfstatat/);
   assert.match(bridge, /mkdirTree\(directory\)/);
+  // The listing block is freed by the client, so it must be its own allocation.
+  assert.match(bridge, /exports\(\)\?\.malloc/);
   assert.doesNotMatch(bridge, /gwNative|ipc|fetch\s*\(/i);
+});
+
+test("a new client build can be re-certified without hand-derivation", async () => {
+  const recert = await readFile(
+    path.join(root, "src/main/core/template-save-recert.ts"),
+    "utf8",
+  );
+  const cli = await readFile(
+    path.join(root, "src/tools/template-save-recertify.ts"),
+    "utf8",
+  );
+  const manifest = JSON.parse(
+    await readFile(path.join(root, "package.json"), "utf8"),
+  );
+
+  // The regression mode recertify.md makes step 0: prove the tool reproduces
+  // today's certified entry before pointing it at a new build.
+  assert.match(cli, /--expect-certified/);
+  assert.match(recert, /compareToCertified/);
+  assert.equal(
+    manifest.scripts["template:recertify"],
+    "pnpm build && node build/tools/template-save-recertify.js",
+  );
+
+  // Derivation must stay shape-based. A remembered index would defeat the point.
+  assert.match(recert, /caller-set intersection|callers\(/);
+  assert.doesNotMatch(recert, /localFunction: \d+/);
+
+  // Every ambiguity is a finding, never a best guess.
+  assert.match(recert, /expected exactly one/);
+  assert.match(recert, /expected exactly 2 template scans/);
+});
+
+test("the WASM section codec has exactly one home", async () => {
+  const shared = await readFile(
+    path.join(root, "src/main/core/wasm-binary.ts"),
+    "utf8",
+  );
+  assert.match(shared, /export function splitSections/);
+  assert.match(shared, /export function parseCode/);
+  // `Buffer.prototype.slice` aliases, so a transform that sliced its input
+  // would rewrite the caller's bytes. Every slice here must copy.
+  assert.match(shared, /function copyRange/);
+  assert.doesNotMatch(shared, /bodies\.push\(bytes\.slice/);
+
+  for (const file of [
+    "src/main/core/toolbox-transform.ts",
+    "src/main/core/template-save-compat.ts",
+    "src/main/core/template-save-recert.ts",
+  ]) {
+    const source = await readFile(path.join(root, file), "utf8");
+    assert.match(source, /from "\.\/wasm-binary\.js"/, `${file} must share the codec`);
+    for (const primitive of [
+      "splitSections",
+      "parseCode",
+      "encodeCode",
+      "readUleb",
+    ]) {
+      assert.doesNotMatch(
+        source,
+        new RegExp(`^function ${primitive}\\(`, "m"),
+        `${file} redefines ${primitive}`,
+      );
+    }
+  }
 });
 
 test("saved-file recovery defers IndexedDB deletion until before renderer startup", async () => {

--- a/tests/unit/template-filesystem-trace.test.ts
+++ b/tests/unit/template-filesystem-trace.test.ts
@@ -47,7 +47,7 @@ function fixture(search = "?template-fs-trace=1", openResult = 17) {
   const window = {} as {
     gwInstallTemplateFilesystemTrace?: (options: {
       imports: typeof imports;
-      module: { HEAPU8: Uint8Array; HEAPU32: Uint32Array };
+      module: { HEAPU8: Uint8Array };
     }) => void;
     gwTemplateFilesystemTrace?: () => ReadonlyArray<Record<string, unknown>>;
   };
@@ -76,7 +76,9 @@ function fixture(search = "?template-fs-trace=1", openResult = 17) {
     HEAPU32,
     imports,
     logs,
-    module: { HEAPU8, HEAPU32 },
+    // The generated glue publishes only `Module.HEAPU8`; the trace has to
+    // derive anything wider itself, so the fixture must not hand it more.
+    module: { HEAPU8 },
     openat,
     fdWrite,
     window,

--- a/tests/unit/template-save-compat.test.ts
+++ b/tests/unit/template-save-compat.test.ts
@@ -22,94 +22,181 @@ function section(id: number, body: number[]): number[] {
   return [id, ...uleb(body.length), ...body];
 }
 
-function fixture(): { bytes: Uint8Array; callOffset: number } {
-  const type = section(1, [1, 0x60, 2, 0x7f, 0x7f, 1, 0x7f]);
-  const importBody = [
+/** The width LLVM uses for call targets, which the transform patches in place. */
+function paddedCall(index: number): number[] {
+  const bytes = [0x10];
+  for (let position = 0; position < 5; position += 1) {
+    bytes.push((index & 0x7f) | (position === 4 ? 0 : 0x80));
+    index >>>= 7;
+  }
+  return bytes;
+}
+
+const STUB_BODY = [0x00, 0x41, 0x02, 0x0b];
+const CALL_OFFSET = 5;
+
+/**
+ * One carrier import, one `i32.const 2` stub, and one caller that reaches it
+ * through a padded call — the shape the production entry certifies.
+ */
+function fixture(): Uint8Array {
+  const types = section(1, [
     2,
-    1, 109, 1, 97, 0, 0,
-    1, 109, 1, 98, 0, 0,
-  ];
-  const imports = section(2, importBody);
-  const functions = section(3, [1, 0]);
-  const body = [0, 0x20, 0, 0x20, 1, 0x10, 0, 0x0b];
-  const code = section(10, [1, ...uleb(body.length), ...body]);
-  const bytes = Uint8Array.from([
+    0x60, 2, 0x7f, 0x7f, 1, 0x7f,
+    0x60, 4, 0x7f, 0x7f, 0x7f, 0x7f, 1, 0x7f,
+  ]);
+  const imports = section(2, [1, 1, 109, 1, 97, 0, 1]);
+  const functions = section(3, [2, 0, 0]);
+  const exports = section(7, [
+    1,
+    6, ...[..."caller"].map((character) => character.charCodeAt(0)),
+    0, 2,
+  ]);
+  const caller = [0x00, 0x20, 0x00, 0x20, 0x01, ...paddedCall(1), 0x0b];
+  const code = section(10, [
+    2,
+    ...uleb(STUB_BODY.length),
+    ...STUB_BODY,
+    ...uleb(caller.length),
+    ...caller,
+  ]);
+  return Uint8Array.from([
     0, 97, 115, 109, 1, 0, 0, 0,
-    ...type,
+    ...types,
     ...imports,
     ...functions,
+    ...exports,
     ...code,
   ]);
-  const callOffset = bytes.findIndex(
-    (byte, index) => byte === 0x10 && bytes[index + 1] === 0,
-  );
-  return { bytes, callOffset };
 }
 
 function hash(bytes: Uint8Array): string {
   return createHash("sha256").update(bytes).digest("hex");
 }
 
-function certifiedFixture(): {
-  input: Uint8Array;
-  build: KnownTemplateSaveBuild;
-} {
-  const { bytes: input, callOffset } = fixture();
-  const expectedCall = [0x10, 0];
-  const replacementCall = [0x10, 1];
-  const expectedOutput = input.slice();
-  expectedOutput.set(replacementCall, callOffset);
+function draft(input: Uint8Array): KnownTemplateSaveBuild {
   return {
-    input,
-    build: {
-      sha256: hash(input),
-      outputSha256: hash(expectedOutput),
-      callOffset,
-      expectedCall,
-      replacementCall,
-    },
+    sha256: hash(input),
+    outputSha256: "0".repeat(64),
+    importCount: 1,
+    carrierImport: 0,
+    bridges: [
+      {
+        kind: "ensureDirectory",
+        stubFunction: 0,
+        stubBody: STUB_BODY,
+        callSites: [{ localFunction: 1, bodyOffset: CALL_OFFSET }],
+      },
+    ],
   };
 }
 
+/** Learn the derived hash the way a new client build would be certified. */
+function certify(input: Uint8Array): KnownTemplateSaveBuild {
+  const build = draft(input);
+  try {
+    rewriteTemplateSaveWasm(input, build);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "";
+    const found = /unexpected output ([0-9a-f]{64})/.exec(message);
+    if (found) return { ...build, outputSha256: found[1]! };
+  }
+  return assert.fail("fixture did not produce a derived module");
+}
+
 describe("template-save WASM compatibility transform", () => {
-  it("rewrites only the certified call target and remains valid", () => {
-    const { input, build } = certifiedFixture();
-    const output = rewriteTemplateSaveWasm(input, build);
+  it("routes the certified call site to the host behind a dirfd marker", () => {
+    const input = fixture();
+    const output = rewriteTemplateSaveWasm(input, certify(input));
     assert.equal(WebAssembly.validate(output), true);
-    assert.deepEqual(
-      Array.from(output.slice(build.callOffset, build.callOffset + 2)),
-      [0x10, 1],
-    );
-    assert.deepEqual(
-      Array.from(input.slice(build.callOffset, build.callOffset + 2)),
-      [0x10, 0],
-    );
+
+    const seen: number[][] = [];
+    const instance = new WebAssembly.Instance(new WebAssembly.Module(output), {
+      m: {
+        a: (...args: number[]) => {
+          seen.push(args);
+          return 0;
+        },
+      },
+    });
+    const caller = instance.exports.caller as (
+      path: number,
+      recursive: number,
+    ) => number;
+
+    assert.equal(caller(0x1234, 1), 0);
+    assert.deepEqual(seen, [[-70001, 0x1234, 0, 1]]);
   });
 
-  it("rejects hash, signature, and expected-output drift", () => {
-    const { input, build } = certifiedFixture();
+  it("keeps the stub itself intact so uncertified callers are unaffected", () => {
+    const input = fixture();
+    const output = rewriteTemplateSaveWasm(input, certify(input));
+    const stubbed = new WebAssembly.Instance(new WebAssembly.Module(output), {
+      m: { a: () => assert.fail("the stub must not reach the host") },
+    });
+    // Nothing else calls it here, but the body must still be the original
+    // `i32.const 2` so the model paths that use it keep today's behaviour.
+    assert.ok(stubbed instanceof WebAssembly.Instance);
+    assert.ok(output.join(",").includes(STUB_BODY.join(",")));
+  });
+
+  it("rejects input, stub, call-site, and derived-output drift", () => {
+    const input = fixture();
+    const build = certify(input);
     assert.throws(
       () => rewriteTemplateSaveWasm(input, { ...build, sha256: "0".repeat(64) }),
       /unsupported input/,
     );
     assert.throws(
-      () => rewriteTemplateSaveWasm(input, {
-        ...build,
-        expectedCall: [0x10, 9],
-      }),
-      /call signature mismatch/,
+      () =>
+        rewriteTemplateSaveWasm(input, {
+          ...build,
+          bridges: [{ ...build.bridges[0]!, stubBody: [0x00, 0x41, 0x09, 0x0b] }],
+        }),
+      /is not the expected stub/,
     );
     assert.throws(
-      () => rewriteTemplateSaveWasm(input, {
-        ...build,
-        outputSha256: "0".repeat(64),
-      }),
+      () =>
+        rewriteTemplateSaveWasm(input, {
+          ...build,
+          bridges: [
+            {
+              ...build.bridges[0]!,
+              callSites: [{ localFunction: 1, bodyOffset: CALL_OFFSET + 1 }],
+            },
+          ],
+        }),
+      /call site signature mismatch/,
+    );
+    assert.throws(
+      () =>
+        rewriteTemplateSaveWasm(input, {
+          ...build,
+          outputSha256: "0".repeat(64),
+        }),
       /unexpected output/,
     );
   });
 
+  // `Buffer.prototype.slice` returns a view, so a transform that sliced its
+  // input and then wrote into a body would corrupt the caller's copy. Every
+  // caller here reads the artifact with `readFile`, which yields a Buffer.
+  it("never writes into the caller's input, Buffer or not", () => {
+    const input = fixture();
+    const build = certify(input);
+    const asBuffer = Buffer.from(input);
+    const before = hash(new Uint8Array(asBuffer));
+    rewriteTemplateSaveWasm(asBuffer, build);
+    assert.equal(hash(new Uint8Array(asBuffer)), before);
+
+    const asArray = fixture();
+    const arrayBefore = hash(asArray);
+    rewriteTemplateSaveWasm(asArray, build);
+    assert.equal(hash(asArray), arrayBefore);
+  });
+
   it("leaves unknown future client builds canonical", () => {
-    const input = fixture().bytes;
+    const input = fixture();
     assert.equal(applyTemplateSaveCompatibility(input), input);
   });
 });

--- a/tests/unit/template-save-compatibility.test.ts
+++ b/tests/unit/template-save-compatibility.test.ts
@@ -11,45 +11,119 @@ const source = await readFile(
   "utf8",
 );
 
-function fixture() {
-  const memory = new ArrayBuffer(2048);
+const ENSURE_DIRECTORY = -70001;
+const FIND_FILES = -70002;
+const FILE_BASE_NAME = -70003;
+const DELETE_FILE = -70004;
+const FILE_EXISTS = -70005;
+const RECORD_BYTES = 544;
+const WANT_FILES = 17;
+const WANT_DIRECTORIES = 18;
+const RECORD_NAME_OFFSET = 24;
+
+type Bridge = (
+  dirfd: number,
+  path: number,
+  buffer: number,
+  flags: number,
+) => number;
+
+function fixture(tree: Record<string, string[]> = {}, search = "") {
+  const memory = new ArrayBuffer(65536);
   const HEAPU8 = new Uint8Array(memory);
-  const directories: string[] = [];
-  const statCalls: number[][] = [];
+  const made: string[] = [];
+  const removed: string[] = [];
+  const carrierCalls: number[][] = [];
+  let next = 0x4000;
   const imports = {
     env: {
-      __syscall_stat64(...args: number[]) {
-        statCalls.push(args);
+      __syscall_newfstatat(...args: number[]) {
+        carrierCalls.push(args);
         return 19;
       },
     },
   };
-  const window = {} as {
-    gwInstallTemplateSaveCompatibility?: (
-      value: typeof imports,
-      module: { HEAPU8: Uint8Array },
-    ) => void;
+  const FS = {
+    readdir(directory: string) {
+      const entries = tree[directory];
+      if (!entries) throw new Error(`ENOENT ${directory}`);
+      return [".", "..", ...entries];
+    },
+    stat(value: string) {
+      if (value.endsWith("/broken")) return { mode: 0 };
+      return { mode: value.endsWith("/sub") ? 2 : 1 };
+    },
+    isFile(mode: number) {
+      if (mode === 0) throw new Error("unreadable");
+      return mode === 1;
+    },
+    isDir(mode: number) {
+      if (mode === 0) throw new Error("unreadable");
+      return mode === 2;
+    },
+    mkdirTree(value: string) {
+      made.push(value);
+    },
+    analyzePath(value: string) {
+      const cut = value.lastIndexOf("/");
+      return { exists: (tree[value.slice(0, cut)] ?? []).includes(value.slice(cut + 1)) };
+    },
+    unlink(value: string) {
+      if (value.includes("missing")) throw new Error("ENOENT");
+      removed.push(value);
+    },
   };
+  const window = {} as {
+    gwInstallTemplateSaveCompatibility?: (options: {
+      imports: typeof imports;
+      module: { HEAPU8: Uint8Array };
+      exports: () => { malloc(bytes: number): number };
+    }) => void;
+  };
+  const logs: string[] = [];
   const context = {
     ArrayBuffer,
-    Set,
+    Math,
+    RegExp,
     String,
+    URL,
     Uint16Array,
+    Uint32Array,
     Uint8Array,
-    window,
-    FS: {
-      mkdirTree(value: string) {
-        directories.push(value);
+    console: {
+      info(...values: unknown[]) {
+        logs.push(values.map(String).join(" "));
       },
     },
+    location: { href: `gw://app/${search}` },
+    setTimeout,
+    window,
+    FS,
   };
   Object.assign(context, { globalThis: context });
   vm.runInNewContext(source, context);
-  window.gwInstallTemplateSaveCompatibility?.(imports, { HEAPU8 });
-  return { directories, HEAPU8, imports, statCalls };
+  window.gwInstallTemplateSaveCompatibility?.({
+    imports,
+    module: { HEAPU8 },
+    exports: () => ({
+      malloc(bytes: number) {
+        const pointer = next;
+        next += bytes + 8;
+        return pointer;
+      },
+    }),
+  });
+  return {
+    bridge: imports.env.__syscall_newfstatat as unknown as Bridge,
+    carrierCalls,
+    HEAPU8,
+    logs,
+    made,
+    removed,
+  };
 }
 
-function writeWideString(heap: Uint8Array, pointer: number, value: string) {
+function writeWide(heap: Uint8Array, pointer: number, value: string) {
   const wide = new Uint16Array(heap.buffer);
   const start = pointer >>> 1;
   for (let index = 0; index < value.length; index += 1) {
@@ -58,31 +132,268 @@ function writeWideString(heap: Uint8Array, pointer: number, value: string) {
   wide[start + value.length] = 0;
 }
 
-test("passes ordinary stat calls through unchanged", () => {
+function readWide(heap: Uint8Array, pointer: number) {
+  const wide = new Uint16Array(heap.buffer);
+  let index = pointer >>> 1;
+  let value = "";
+  while (wide[index]) {
+    value += String.fromCharCode(wide[index]!);
+    index += 1;
+  }
+  return value;
+}
+
+test("passes ordinary stat calls through untouched", () => {
   const value = fixture();
-  assert.equal(value.imports.env.__syscall_stat64(40, 80), 19);
-  assert.deepEqual(value.statCalls, [[40, 80]]);
-  assert.deepEqual(value.directories, []);
+  assert.equal(value.bridge(-100, 64, 128, 0), 19);
+  assert.deepEqual(value.carrierCalls, [[-100, 64, 128, 0]]);
+  assert.deepEqual(value.made, []);
 });
 
-test("creates only the marked Skills and Equipment directories", () => {
+// `_wsplitpath` keeps the separator that terminates the directory component
+// and `_wmakepath` puts it back, so this is the shape the client passes.
+test("creates the directory the client asks for, separator and all", () => {
   const value = fixture();
-  writeWideString(value.HEAPU8, 64, String.raw`Templates\Skills`);
-  assert.equal(value.imports.env.__syscall_stat64(64, 1), 0);
-  writeWideString(value.HEAPU8, 128, "app:/Templates/Equipment");
-  assert.equal(value.imports.env.__syscall_stat64(128, 1), 0);
-  assert.deepEqual(value.directories, [
+  writeWide(value.HEAPU8, 64, "Templates/Skills/");
+  assert.equal(value.bridge(ENSURE_DIRECTORY, 64, 0, 1), 0);
+  writeWide(value.HEAPU8, 256, "app:/Templates\\Equipment\\");
+  assert.equal(value.bridge(ENSURE_DIRECTORY, 256, 0, 1), 0);
+  writeWide(value.HEAPU8, 512, "Screens/");
+  assert.equal(value.bridge(ENSURE_DIRECTORY, 512, 0, 1), 0);
+  assert.deepEqual(value.made, [
     "Templates/Skills",
     "Templates/Equipment",
+    "Screens",
   ]);
-  assert.deepEqual(value.statCalls, []);
+  assert.deepEqual(value.carrierCalls, []);
 });
 
-test("rejects marked paths outside the two template directories", () => {
+test("refuses to leave the mount", () => {
   const value = fixture();
-  writeWideString(value.HEAPU8, 64, "../Templates/Skills");
-  assert.notEqual(value.imports.env.__syscall_stat64(64, 1), 0);
-  writeWideString(value.HEAPU8, 128, "Templates/Skills/Nested");
-  assert.notEqual(value.imports.env.__syscall_stat64(128, 1), 0);
-  assert.deepEqual(value.directories, []);
+  for (const escape of ["../Templates", "Templates/../../etc", ""]) {
+    writeWide(value.HEAPU8, 64, escape);
+    assert.notEqual(value.bridge(ENSURE_DIRECTORY, 64, 0, 1), 0);
+  }
+  assert.deepEqual(value.made, []);
+});
+
+// A run of separators is redundant, not a traversal. The client produces one on
+// every file operation against a listed template, so rejecting it broke delete
+// and, with it, the second half of rename.
+test("collapses the client's doubled separator instead of rejecting it", () => {
+  const value = fixture();
+  writeWide(value.HEAPU8, 64, "Templates/Skills/\\");
+  assert.equal(value.bridge(ENSURE_DIRECTORY, 64, 0, 1), 0);
+  assert.deepEqual(value.made, ["Templates/Skills"]);
+
+  writeWide(value.HEAPU8, 64, "Templates/Skills/\\Sub\\Deep.txt");
+  assert.equal(value.bridge(DELETE_FILE, 64, 0, 0), 1);
+  assert.deepEqual(value.removed, ["Templates/Skills/Sub/Deep.txt"]);
+});
+
+test("lists the files a wildcard matches, sorted, and hands over a block", () => {
+  const value = fixture({
+    "Templates/Skills": ["Zealot.txt", "Test.txt", "notes.md"],
+  });
+  writeWide(value.HEAPU8, 64, "Templates/Skills/*.txt");
+  const out = 1024;
+  assert.equal(value.bridge(FIND_FILES, 64, out, WANT_FILES), 0);
+
+  const words = new Uint32Array(value.HEAPU8.buffer);
+  const entries = words[out >>> 2]!;
+  assert.equal(words[(out >>> 2) + 2], 2);
+  assert.ok(entries > 0);
+  // `notes.md` is excluded by the pattern; the client asks for `*.txt`.
+  assert.deepEqual(
+    [0, 1].map((index) =>
+      readWide(
+        value.HEAPU8,
+        entries + index * RECORD_BYTES + RECORD_NAME_OFFSET,
+      ),
+    ),
+    ["Test.txt", "Zealot.txt"],
+  );
+  // The 24-byte header the client strides over is left zeroed.
+  assert.deepEqual(
+    Array.from(value.HEAPU8.slice(entries, entries + RECORD_NAME_OFFSET)),
+    Array.from<number>({ length: RECORD_NAME_OFFSET }).fill(0),
+  );
+});
+
+test("honours the wildcard instead of listing the whole directory", () => {
+  const value = fixture({
+    "Templates/Skills": ["gw000.jpg", "gw001.jpg", "readme.txt"],
+  });
+  writeWide(value.HEAPU8, 64, "Templates/Skills/gw???.jpg");
+  const out = 1024;
+  value.bridge(FIND_FILES, 64, out, WANT_FILES);
+  const words = new Uint32Array(value.HEAPU8.buffer);
+  assert.equal(words[(out >>> 2) + 2], 2);
+});
+
+test("leaves the list empty for a missing or unreadable directory", () => {
+  const value = fixture({ "Templates/Skills": ["broken"] });
+  const words = () => new Uint32Array(value.HEAPU8.buffer);
+
+  writeWide(value.HEAPU8, 64, "Templates/Equipment/*");
+  assert.equal(value.bridge(FIND_FILES, 64, 1024, WANT_FILES), 0);
+  assert.equal(words()[1024 >>> 2], 0);
+  assert.equal(words()[(1024 >>> 2) + 2], 0);
+
+  // An entry the mount cannot describe is skipped, not fatal to the listing.
+  writeWide(value.HEAPU8, 64, "Templates/Skills/*");
+  assert.equal(value.bridge(FIND_FILES, 64, 2048, WANT_FILES), 0);
+  assert.equal(words()[(2048 >>> 2) + 2], 0);
+});
+
+test("stays silent unless the trace is explicitly requested", () => {
+  const quiet = fixture({ "Templates/Skills": ["Test.txt"] });
+  writeWide(quiet.HEAPU8, 64, "Templates/Skills/*.txt");
+  quiet.bridge(FIND_FILES, 64, 1024, WANT_FILES);
+  assert.deepEqual(quiet.logs, []);
+
+  const traced = fixture(
+    { "Templates/Skills": ["Test.txt"] },
+    "?template-fs-trace=1",
+  );
+  writeWide(traced.HEAPU8, 64, "Templates/Skills/*.txt");
+  traced.bridge(FIND_FILES, 64, 1024, WANT_FILES);
+  assert.match(traced.logs[0]!, /"operation":"installed"/);
+  assert.match(traced.logs[1]!, /"listed":3,"matched":1,"published":true/);
+  // Counts and outcomes only: no filename, path, or content.
+  assert.doesNotMatch(traced.logs.join(" "), /Test|Templates|Skills/);
+});
+
+// The client keys a template on its path below the type directory, in Windows
+// form with a leading separator, and its list filter matches that prefix. A
+// bare name is registered but never listed.
+test("hands back the client's internal template path", () => {
+  const value = fixture();
+  writeWide(value.HEAPU8, 64, "Test.txt");
+  assert.equal(value.bridge(FILE_BASE_NAME, 64, 256, 260), 1);
+  assert.equal(readWide(value.HEAPU8, 256), String.raw`\Test`);
+
+  writeWide(value.HEAPU8, 64, "Sub/Nested.txt");
+  assert.equal(value.bridge(FILE_BASE_NAME, 64, 256, 260), 1);
+  assert.equal(readWide(value.HEAPU8, 256), String.raw`\Sub\Nested`);
+
+  writeWide(value.HEAPU8, 64, "noextension");
+  assert.equal(value.bridge(FILE_BASE_NAME, 64, 256, 260), 1);
+  assert.equal(readWide(value.HEAPU8, 256), String.raw`\noextension`);
+});
+
+// `Path::RemoveExtension` in this build drops the last character of the name
+// along with the extension, so the name must reach it already bare.
+test("keeps the last character the client's own trimmer would eat", () => {
+  const value = fixture();
+  for (const [file, expected] of [
+    ["Two.Dots.txt", String.raw`\Two.Dots`],
+    ["Sub/.hidden", String.raw`\Sub\.hidden`],
+    ["trailing.", String.raw`\trailing`],
+  ] as const) {
+    writeWide(value.HEAPU8, 64, file);
+    assert.equal(value.bridge(FILE_BASE_NAME, 64, 256, 260), 1);
+    assert.equal(readWide(value.HEAPU8, 256), expected);
+  }
+});
+
+test("truncates a display name to the destination the client offered", () => {
+  const value = fixture();
+  writeWide(value.HEAPU8, 64, "AbcdefghijName.txt");
+  assert.equal(value.bridge(FILE_BASE_NAME, 64, 256, 5), 1);
+  // Four characters plus the terminator, the separator among them.
+  assert.equal(readWide(value.HEAPU8, 256), String.raw`\Abc`);
+});
+
+// The two template scans differ only in this flag: `*.txt` is asked for with
+// files and `*` with directories. Answering both with files fills the
+// subdirectory list with phantom folders named after the templates.
+test("separates the file and directory requests by flag", () => {
+  const tree = { "Templates/Skills": ["Test.txt", "sub"] };
+  const count = (flags: number) => {
+    const value = fixture(tree);
+    writeWide(value.HEAPU8, 64, "Templates/Skills/*");
+    value.bridge(FIND_FILES, 64, 1024, flags);
+    const words = new Uint32Array(value.HEAPU8.buffer);
+    const entries = words[1024 >>> 2]!;
+    return {
+      total: words[(1024 >>> 2) + 2],
+      first: entries
+        ? readWide(value.HEAPU8, entries + RECORD_NAME_OFFSET)
+        : null,
+    };
+  };
+  assert.deepEqual(count(WANT_FILES), { total: 1, first: "Test.txt" });
+  assert.deepEqual(count(WANT_DIRECTORIES), { total: 1, first: "sub" });
+});
+
+// The client's own delete is `assert("not implemented")` + `unreachable`, and
+// its caller reads a non-zero result as success.
+test("deletes a template and reports the outcome the caller expects", () => {
+  const value = fixture();
+  // The shape the client actually builds: its type directory joined with `/`
+  // onto a record name that already starts with `\`.
+  writeWide(value.HEAPU8, 64, "Templates/Skills/\\Test.txt");
+  assert.equal(value.bridge(DELETE_FILE, 64, 0, 0), 1);
+  assert.deepEqual(value.removed, ["Templates/Skills/Test.txt"]);
+
+  writeWide(value.HEAPU8, 64, "Templates/Skills/missing.txt");
+  assert.equal(value.bridge(DELETE_FILE, 64, 0, 0), 0);
+
+  writeWide(value.HEAPU8, 64, "../escape.txt");
+  assert.equal(value.bridge(DELETE_FILE, 64, 0, 0), 0);
+  assert.deepEqual(value.removed, ["Templates/Skills/Test.txt"]);
+});
+
+// `File::Open` mode 1 opens O_RDWR|O_CREAT in this build, so the client's own
+// "is this name taken?" probe creates the file it is testing for and refuses
+// every rename. The host answers without touching the file.
+test("answers whether a file exists without creating it", () => {
+  const value = fixture({ "Templates/Skills": ["Taken.txt"] });
+  writeWide(value.HEAPU8, 64, "Templates/Skills/\\Taken.txt");
+  assert.equal(value.bridge(FILE_EXISTS, 64, 0, 0), 1);
+
+  writeWide(value.HEAPU8, 64, "Templates/Skills/\\Fresh.txt");
+  assert.equal(value.bridge(FILE_EXISTS, 64, 0, 0), 0);
+
+  // An undecidable path refuses the rename rather than overwriting a template.
+  writeWide(value.HEAPU8, 64, "../escape.txt");
+  assert.equal(value.bridge(FILE_EXISTS, 64, 0, 0), 1);
+
+  assert.deepEqual(value.removed, []);
+  assert.deepEqual(value.made, []);
+});
+
+// Every path shape the client is known to emit, from
+// internal/upstream/client-internals.md. Four of the ten rounds it took to fix
+// issue #5 were the same mistake: a fixture that used a cleaner input than the
+// client actually produces. `_wsplitpath` keeps the separator that ends a
+// directory, `_wmakepath` joins with `/`, and record names already start with
+// `\` — so a doubled separator reaches every file operation on a listed
+// template.
+const CLIENT_PATH_SHAPES = [
+  { emitted: "Templates/Skills/", resolves: "Templates/Skills", why: "directory, trailing separator kept by _wsplitpath" },
+  { emitted: "Templates\\Equipment\\", resolves: "Templates/Equipment", why: "same, Windows separators" },
+  { emitted: "app:/Templates/Skills/", resolves: "Templates/Skills", why: "mount prefix" },
+  { emitted: "Screens/", resolves: "Screens", why: "screenshot directory" },
+  { emitted: "Templates/Skills/*", resolves: "Templates/Skills/*", why: "directory enumeration pattern" },
+  { emitted: "Templates/Skills/*.txt", resolves: "Templates/Skills/*.txt", why: "file enumeration pattern" },
+  { emitted: "Templates/Skills/\\Test.txt", resolves: "Templates/Skills/Test.txt", why: "type directory joined onto a record name that already starts with a separator" },
+  { emitted: "Templates/Skills/\\Sub\\Nested.txt", resolves: "Templates/Skills/Sub/Nested.txt", why: "the same, one subdirectory down" },
+] as const;
+
+test("accepts every path shape the client actually emits", () => {
+  const value = fixture();
+  for (const shape of CLIENT_PATH_SHAPES) {
+    writeWide(value.HEAPU8, 64, shape.emitted);
+    assert.equal(
+      value.bridge(ENSURE_DIRECTORY, 64, 0, 1),
+      0,
+      `rejected ${JSON.stringify(shape.emitted)} — ${shape.why}`,
+    );
+  }
+  assert.deepEqual(
+    value.made,
+    CLIENT_PATH_SHAPES.map((shape) => shape.resolves),
+  );
 });

--- a/tests/unit/template-save-recert.test.ts
+++ b/tests/unit/template-save-recert.test.ts
@@ -1,0 +1,432 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { describe, it } from "node:test";
+import {
+  compareToCertified,
+  deriveTemplateSaveBuild,
+  draftTemplateSaveBuild,
+  formatBuildEntry,
+  inspectTemplateSaveCandidate,
+} from "../../src/main/core/template-save-recert.js";
+import { defaultGuildWarsProfile } from "../../src/tools/toolbox-doctor.js";
+
+function uleb(value: number): number[] {
+  const out: number[] = [];
+  do {
+    const byte = value & 0x7f;
+    value >>>= 7;
+    out.push(value === 0 ? byte : byte | 0x80);
+  } while (value !== 0);
+  return out;
+}
+
+function sleb(value: number): number[] {
+  const out: number[] = [];
+  for (;;) {
+    const byte = value & 0x7f;
+    value >>= 7;
+    const sign = (byte & 0x40) !== 0;
+    if ((value === 0 && !sign) || (value === -1 && sign)) {
+      out.push(byte);
+      return out;
+    }
+    out.push(byte | 0x80);
+  }
+}
+
+function section(id: number, body: number[]): number[] {
+  return [id, ...uleb(body.length), ...body];
+}
+
+const IMPORTS = 2;
+const CARRIER = 0;
+const ASSERT_HOOK = 1;
+
+/** The padded encoding the transform repoints in place. */
+function callIndex(index: number): number[] {
+  const bytes = [0x10];
+  for (let position = 0; position < 5; position += 1) {
+    bytes.push((index & 0x7f) | (position === 4 ? 0 : 0x80));
+    index >>>= 7;
+  }
+  return bytes;
+}
+
+function call(local: number): number[] {
+  return callIndex(IMPORTS + local);
+}
+
+/** The canonical encoding, which a repoint could not overwrite in place. */
+function canonicalCall(local: number): number[] {
+  return [0x10, ...uleb(IMPORTS + local)];
+}
+
+function constant(value: number): number[] {
+  return [0x41, ...sleb(value)];
+}
+
+const DATA_BASE = 1024;
+const MESSAGE = "not implemented";
+const FILE = "../../../../Base/Os/Emscripten/Exe/EmscriptenExeFile.cpp";
+const MESSAGE_AT = DATA_BASE;
+const FILE_AT = DATA_BASE + MESSAGE.length + 1;
+const LINE = 840;
+
+// Types, in the order the type section declares them.
+const T_CREATE = 0; // (i32,i32)->i32
+const T_FIND = 1; // (i32,i32,i32)->()
+const T_NAME = 2; // (i32 x6)->i32
+const T_DELETE = 3; // (i32)->i32
+const T_OPEN = 4; // (i32,i32,i32)->i32
+const T_VOID = 5; // ()->()
+const T_CARRIER = 6; // (i32,i32,i32,i32)->i32, the shape the forwarders call
+
+const CREATE_BODY = [0x00, 0x41, 0x02, 0x0b];
+const FIND_BODY = [0x00, 0x0b];
+const NAME_BODY = [0x00, 0x41, 0x00, 0x0b];
+
+interface Local {
+  type: number;
+  body: number[];
+}
+
+interface Options {
+  /** A second create-directory stub that is also called several times. */
+  ambiguousCreate?: boolean;
+  /** A third function calling both find-files and entry-name. */
+  thirdScan?: boolean;
+  /** Encode the write function's probe call canonically. */
+  canonicalProbe?: boolean;
+  /** A second function calling File::Open with modes 1 and 2. */
+  secondOpenPair?: boolean;
+}
+
+/**
+ * A module carrying every shape the locators look for, plus a decoy for each,
+ * plus the callers that produce the real intersections. Local indices are
+ * assigned in declaration order and referenced through `at`.
+ */
+function build(options: Options = {}): {
+  bytes: Uint8Array;
+  at: Record<string, number>;
+} {
+  const locals: Local[] = [];
+  const at: Record<string, number> = {};
+  const add = (name: string, type: number, body: number[]) => {
+    at[name] = locals.length;
+    locals.push({ type, body });
+    return at[name]!;
+  };
+
+  const createStub = add("createStub", T_CREATE, CREATE_BODY);
+  const findStub = add("findStub", T_FIND, FIND_BODY);
+  const nameStub = add("nameStub", T_NAME, NAME_BODY);
+  const assertHandler = add("assertHandler", T_FIND, [
+    0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02,
+    ...callIndex(ASSERT_HOOK), 0x1a, 0x0b,
+  ]);
+  const deleteStub = add("deleteStub", T_DELETE, [
+    0x00,
+    ...constant(MESSAGE_AT),
+    ...constant(FILE_AT),
+    ...constant(LINE),
+    ...call(assertHandler),
+    0x00, 0x0b,
+  ]);
+  const fileOpen = add("fileOpen", T_OPEN, NAME_BODY.slice(0, 3).concat(0x0b));
+
+  // Decoys: same shape, no callers.
+  add("findDecoy", T_FIND, FIND_BODY);
+  add("nameDecoy", T_NAME, NAME_BODY);
+  add("createDecoy", T_CREATE, CREATE_BODY);
+  add("deleteDecoy", T_DELETE, [
+    0x00,
+    ...constant(MESSAGE_AT),
+    ...constant(FILE_AT),
+    ...constant(LINE),
+    ...call(assertHandler),
+    0x00, 0x0b,
+  ]);
+
+  const scanBody = [
+    0x00,
+    ...constant(0), ...constant(0), ...constant(0), ...call(findStub),
+    ...Array.from({ length: 6 }, () => constant(0)).flat(),
+    ...call(nameStub), 0x1a,
+    0x0b,
+  ];
+  add("scanA", T_VOID, scanBody);
+  add("scanB", T_VOID, scanBody);
+
+  const sinkBody = [
+    0x00,
+    ...constant(0), ...constant(0), ...call(createStub), 0x1a,
+    ...constant(0), ...constant(0), ...constant(0), ...call(findStub),
+    0x0b,
+  ];
+  add("sinkA", T_VOID, sinkBody);
+  add("sinkB", T_VOID, sinkBody);
+
+  const probeCall = options.canonicalProbe
+    ? canonicalCall(fileOpen)
+    : call(fileOpen);
+  add("writeFn", T_VOID, [
+    0x00,
+    ...constant(0), ...constant(0), ...call(createStub), 0x1a,
+    ...constant(0), ...constant(1), ...constant(0), ...probeCall, 0x1a,
+    ...constant(0), ...constant(2), ...constant(0), ...call(fileOpen), 0x1a,
+    0x0b,
+  ]);
+
+  // Callers the locators must exclude: they touch one stub only.
+  add("loginAlike", T_VOID, [
+    0x00, ...constant(0), ...constant(0), ...call(createStub), 0x1a, 0x0b,
+  ]);
+  add("frameAlike", T_VOID, [
+    0x00, ...constant(0), ...constant(0), ...constant(0), ...call(findStub), 0x0b,
+  ]);
+  const modelBody = [
+    0x00,
+    ...Array.from({ length: 6 }, () => constant(0)).flat(),
+    ...call(nameStub), 0x1a, 0x0b,
+  ];
+  add("modelA", T_VOID, modelBody);
+  add("modelB", T_VOID, modelBody);
+
+  add("deleteCaller", T_VOID, [
+    0x00, ...constant(0), ...call(deleteStub), 0x1a, 0x0b,
+  ]);
+
+  // Assert-handler lookalikes: same shape and hook, one caller each.
+  const lookalikeA = add("lookalikeA", T_FIND, [
+    0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02,
+    ...callIndex(ASSERT_HOOK), 0x1a, 0x0b,
+  ]);
+  const lookalikeB = add("lookalikeB", T_FIND, [
+    0x00, 0x20, 0x00, 0x20, 0x01, 0x20, 0x02,
+    ...callIndex(ASSERT_HOOK), 0x1a, 0x0b,
+  ]);
+  const callThree = (target: number) => [
+    0x00, ...constant(0), ...constant(0), ...constant(0), ...call(target), 0x0b,
+  ];
+  add("lookalikeCallerA", T_VOID, callThree(lookalikeA));
+  add("lookalikeCallerB", T_VOID, callThree(lookalikeB));
+
+  if (options.ambiguousCreate) {
+    const rival = add("createRival", T_CREATE, CREATE_BODY);
+    for (let index = 0; index < 3; index += 1) {
+      add(`createRivalCaller${index}`, T_VOID, [
+        0x00, ...constant(0), ...constant(0), ...call(rival), 0x1a, 0x0b,
+      ]);
+    }
+  }
+  if (options.thirdScan) add("scanC", T_VOID, scanBody);
+  if (options.secondOpenPair) {
+    add("secondOpenPair", T_VOID, [
+      0x00,
+      ...constant(0), ...constant(0), ...call(createStub), 0x1a,
+      ...constant(0), ...constant(1), ...constant(0), ...call(fileOpen), 0x1a,
+      ...constant(0), ...constant(2), ...constant(0), ...call(fileOpen), 0x1a,
+      0x0b,
+    ]);
+  }
+
+  // The assert handler must dominate its lookalikes by a wide margin, the way
+  // it does in the real client (7274 callers against one).
+  for (let index = 0; index < 150; index += 1) {
+    add(`assertCaller${index}`, T_VOID, callThree(assertHandler));
+  }
+
+  const types = section(1, [
+    7,
+    0x60, 2, 0x7f, 0x7f, 1, 0x7f,
+    0x60, 3, 0x7f, 0x7f, 0x7f, 0,
+    0x60, 6, ...Array.from({ length: 6 }, () => 0x7f), 1, 0x7f,
+    0x60, 1, 0x7f, 1, 0x7f,
+    0x60, 3, 0x7f, 0x7f, 0x7f, 1, 0x7f,
+    0x60, 0, 0,
+    0x60, 4, 0x7f, 0x7f, 0x7f, 0x7f, 1, 0x7f,
+  ]);
+  const name = (value: string) => [
+    value.length, ...[...value].map((character) => character.charCodeAt(0)),
+  ];
+  const imports = section(2, [
+    2,
+    ...name("env"), ...name("__syscall_newfstatat"), 0x00, T_CARRIER,
+    ...name("env"), ...name("emscripten_asm_const_int"), 0x00, T_OPEN,
+  ]);
+  const memory = section(5, [1, 0x00, 1]);
+  const functions = section(3, [
+    ...uleb(locals.length),
+    ...locals.flatMap((local) => uleb(local.type)),
+  ]);
+  const code = section(10, [
+    ...uleb(locals.length),
+    ...locals.flatMap((local) => [...uleb(local.body.length), ...local.body]),
+  ]);
+  const payload = [
+    ...[...MESSAGE].map((character) => character.charCodeAt(0)), 0,
+    ...[...FILE].map((character) => character.charCodeAt(0)), 0,
+  ];
+  const data = section(11, [
+    1, 0x00, 0x41, ...sleb(DATA_BASE), 0x0b, ...uleb(payload.length), ...payload,
+  ]);
+
+  return {
+    bytes: Uint8Array.from([
+      0, 97, 115, 109, 1, 0, 0, 0,
+      ...types, ...imports, ...functions, ...memory, ...code, ...data,
+    ]),
+    at,
+  };
+}
+
+describe("template-save re-certification", () => {
+  it("builds a valid fixture module", () => {
+    assert.equal(WebAssembly.validate(build().bytes), true);
+  });
+
+  it("derives every target and call site past its decoys", () => {
+    const { bytes, at } = build();
+    const entry = draftTemplateSaveBuild(bytes);
+
+    assert.equal(entry.importCount, IMPORTS);
+    assert.equal(entry.carrierImport, CARRIER);
+
+    const bridge = (kind: string) =>
+      entry.bridges.find((value) => value.kind === kind)!;
+    assert.equal(bridge("ensureDirectory").stubFunction, at.createStub);
+    assert.equal(bridge("findFiles").stubFunction, at.findStub);
+    assert.equal(bridge("fileBaseName").stubFunction, at.nameStub);
+    assert.equal(bridge("deleteFile").stubFunction, at.deleteStub);
+    assert.equal(bridge("fileExists").stubFunction, at.fileOpen);
+
+    // The decoys share the shape and must not be chosen.
+    for (const decoy of ["createDecoy", "findDecoy", "nameDecoy", "deleteDecoy"]) {
+      assert.ok(
+        entry.bridges.every((value) => value.stubFunction !== at[decoy]),
+        `${decoy} was selected`,
+      );
+    }
+
+    const callers = (kind: string) =>
+      bridge(kind).callSites.map((site) => site.localFunction).sort((a, b) => a - b);
+    assert.deepEqual(
+      callers("ensureDirectory"),
+      [at.writeFn, at.sinkA, at.sinkB].sort((a, b) => a! - b!),
+    );
+    assert.deepEqual(
+      callers("findFiles"),
+      [at.scanA, at.scanB, at.sinkA, at.sinkB].sort((a, b) => a! - b!),
+    );
+    assert.deepEqual(callers("fileBaseName"), [at.scanA, at.scanB]);
+    assert.deepEqual(callers("deleteFile"), [at.deleteCaller]);
+
+    // Only the probe, never the write call that follows it in the same body.
+    assert.deepEqual(callers("fileExists"), [at.writeFn]);
+    assert.equal(bridge("fileExists").callSites.length, 1);
+  });
+
+  it("excludes the callers that must keep the original behaviour", () => {
+    const { bytes, at } = build();
+    const entry = draftTemplateSaveBuild(bytes);
+    const touched = new Set(
+      entry.bridges.flatMap((bridge) =>
+        bridge.callSites.map((site) => site.localFunction)),
+    );
+    for (const excluded of ["loginAlike", "frameAlike", "modelA", "modelB"]) {
+      assert.ok(!touched.has(at[excluded]!), `${excluded} was repointed`);
+    }
+  });
+
+  it("reads the delete stub's own assertion rather than guessing", () => {
+    const report = inspectTemplateSaveCandidate(build().bytes);
+    assert.equal(report.status, "derived");
+    assert.deepEqual(report.deleteAssertion, {
+      message: MESSAGE,
+      file: FILE,
+      line: LINE,
+    });
+    assert.equal(report.targets.assertHandler?.localFunction, build().at.assertHandler);
+  });
+
+  it("round-trips the derived entry through the production transform", () => {
+    const { bytes } = build();
+    const entry = deriveTemplateSaveBuild(bytes);
+    assert.match(entry.outputSha256, /^[0-9a-f]{64}$/);
+    assert.match(formatBuildEntry(entry), /kind: "ensureDirectory" as const/);
+    // No certified entry exists for a synthetic module.
+    assert.deepEqual(compareToCertified(entry), [
+      `no certified entry for ${entry.sha256}`,
+    ]);
+  });
+
+  it("reports a build with no create-directory stub as not applicable", () => {
+    // The "ArenaNet fixed it" signal: nothing returns i32.const 2.
+    const patched = build().bytes.slice();
+    const marker = CREATE_BODY;
+    for (let at = 0; at + marker.length <= patched.length; at += 1) {
+      if (marker.every((value, offset) => patched[at + offset] === value)) {
+        patched[at + 2] = 0x03; // `i32.const 3` — no create-directory shape left
+      }
+    }
+    const report = inspectTemplateSaveCandidate(patched);
+    assert.equal(report.status, "not-applicable");
+    assert.match(report.diagnostics.join(" "), /no create-directory stub/);
+  });
+
+  it("keeps the negative fixtures valid, so the throw is the locator's", () => {
+    for (const options of [
+      { ambiguousCreate: true },
+      { thirdScan: true },
+      { secondOpenPair: true },
+      { canonicalProbe: true },
+    ]) {
+      assert.equal(
+        WebAssembly.validate(build(options).bytes),
+        true,
+        `${JSON.stringify(options)} produced an invalid module`,
+      );
+    }
+  });
+
+  it("refuses to guess when a predicate matches more than once", () => {
+    assert.throws(
+      () => draftTemplateSaveBuild(build({ ambiguousCreate: true }).bytes),
+      /expected exactly one create-directory stub, found 2/,
+    );
+    assert.throws(
+      () => draftTemplateSaveBuild(build({ thirdScan: true }).bytes),
+      /expected exactly 2 template scans/,
+    );
+    assert.throws(
+      () => draftTemplateSaveBuild(build({ secondOpenPair: true }).bytes),
+      /expected exactly one File::Open probe\/write pair/,
+    );
+  });
+
+  // A canonically encoded call is invisible to the needle scan, so the site is
+  // simply not found. The cardinality checks are what turn that into an error
+  // instead of a silently incomplete rewrite.
+  it("fails loudly when a call site is not padded to the repointable width", () => {
+    assert.throws(
+      () => draftTemplateSaveBuild(build({ canonicalProbe: true }).bytes),
+      /File::Open probe\/write pair/,
+    );
+  });
+
+  // The real proof. The client artifact is gitignored and absent in CI, so this
+  // runs wherever the game is installed and skips cleanly elsewhere.
+  it("reproduces the checked-in certified entry", async (t) => {
+    const artifact = process.env.GW_CLIENT_WASM
+      ?? path.join(defaultGuildWarsProfile(), "game", "artifacts", "Gw.jspi.wasm");
+    const bytes = await readFile(artifact).catch(() => null);
+    if (!bytes) {
+      return t.skip(
+        `no client WASM at ${artifact}; set GW_CLIENT_WASM to point at one`,
+      );
+    }
+    assert.deepEqual(compareToCertified(deriveTemplateSaveBuild(bytes)), []);
+  });
+});

--- a/tests/unit/wasm-binary.test.ts
+++ b/tests/unit/wasm-binary.test.ts
@@ -1,0 +1,112 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  concat,
+  countFunctionImports,
+  encodeCode,
+  encodeIndexVector,
+  encodeSection,
+  functionImportIndex,
+  paddedIndex,
+  parseCode,
+  parseIndexVector,
+  parseTypes,
+  readSleb,
+  readUleb,
+  sectionById,
+  sleb,
+  splitSections,
+  uleb,
+  valueTypeName,
+  WASM_HEADER,
+} from "../../src/main/core/wasm-binary.js";
+
+function bytes(...values: number[]): Uint8Array {
+  return Uint8Array.from(values);
+}
+
+describe("wasm binary codec", () => {
+  it("round-trips unsigned LEB128", () => {
+    for (const value of [0, 1, 63, 64, 127, 128, 624, 17_819, 1_131_422]) {
+      assert.equal(readUleb(uleb(value), { offset: 0 }), value);
+    }
+    assert.deepEqual(Array.from(uleb(207)), [0xcf, 0x01]);
+    assert.throws(() => uleb(-1), /invalid unsigned value/);
+  });
+
+  it("round-trips signed LEB128, including the client's dirfd markers", () => {
+    for (const value of [0, 1, -1, 63, -64, 128, -70_001, -70_005]) {
+      assert.equal(readSleb(sleb(value), { offset: 0 }), value);
+    }
+    // The marker the derived module actually carries.
+    assert.deepEqual(Array.from(sleb(-70_001)), [0x8f, 0xdd, 0x7b]);
+  });
+
+  // LLVM emits relocatable call targets at a fixed five bytes, which is what
+  // lets a repoint overwrite a call without changing any body length.
+  it("emits fixed-width indices and refuses ones that do not fit", () => {
+    assert.equal(paddedIndex(0).byteLength, 5);
+    assert.equal(paddedIndex(17_819).byteLength, 5);
+    assert.deepEqual(Array.from(paddedIndex(17_819)), [0x9b, 0x8b, 0x81, 0x80, 0x00]);
+    assert.equal(readUleb(paddedIndex(17_819), { offset: 0 }), 17_819);
+    assert.throws(() => paddedIndex(2 ** 32), /padded call width/);
+    assert.throws(() => paddedIndex(-1), /padded call width/);
+  });
+
+  it("refuses an oversized LEB rather than truncating it", () => {
+    assert.throws(
+      () => readUleb(bytes(0x80, 0x80, 0x80, 0x80, 0x80, 0x01), { offset: 0 }),
+      /oversized LEB128/,
+    );
+    assert.throws(() => readUleb(bytes(0x80), { offset: 0 }), /truncated LEB128/);
+  });
+
+  it("round-trips sections", () => {
+    const body = bytes(1, 2, 3, 4);
+    const module = concat(WASM_HEADER, encodeSection({ id: 7, body }));
+    const sections = splitSections(module);
+    assert.equal(sections.length, 1);
+    assert.deepEqual(Array.from(sectionById(sections, 7)), [1, 2, 3, 4]);
+    assert.throws(() => sectionById(sections, 3), /missing section 3/);
+    assert.throws(() => splitSections(bytes(0, 1, 2)), /invalid WebAssembly header/);
+  });
+
+  it("round-trips code bodies and index vectors", () => {
+    const bodies = [bytes(0x00, 0x0b), bytes(0x00, 0x41, 0x02, 0x0b)];
+    assert.deepEqual(
+      parseCode(encodeCode(bodies)).map((body) => Array.from(body)),
+      bodies.map((body) => Array.from(body)),
+    );
+    const indices = [0, 5, 200, 17_600];
+    assert.deepEqual(parseIndexVector(encodeIndexVector(indices)), indices);
+  });
+
+  it("parses function types by resolved signature", () => {
+    // (i32,i32)->i32 and (i32,i32,i32)->()
+    const section = bytes(
+      2,
+      0x60, 2, 0x7f, 0x7f, 1, 0x7f,
+      0x60, 3, 0x7f, 0x7f, 0x7f, 0,
+    );
+    const types = parseTypes(section);
+    assert.deepEqual(types[0], { params: [0x7f, 0x7f], results: [0x7f] });
+    assert.deepEqual(types[1], { params: [0x7f, 0x7f, 0x7f], results: [] });
+    assert.equal(valueTypeName(0x7f), "i32");
+    assert.equal(valueTypeName(0x70), "0x70");
+  });
+
+  it("counts and names function imports, skipping the other kinds", () => {
+    const name = (value: string) =>
+      concat(uleb(value.length), new TextEncoder().encode(value));
+    const importSection = concat(
+      uleb(3),
+      name("env"), name("first"), bytes(0x00), uleb(4),
+      name("env"), name("memory"), bytes(0x02), bytes(0x00), uleb(1),
+      name("env"), name("__syscall_newfstatat"), bytes(0x00), uleb(6),
+    );
+    assert.equal(countFunctionImports(importSection), 2);
+    assert.equal(functionImportIndex(importSection, "first"), 0);
+    assert.equal(functionImportIndex(importSection, "__syscall_newfstatat"), 1);
+    assert.equal(functionImportIndex(importSection, "absent"), null);
+  });
+});


### PR DESCRIPTION
Closes #5.

Saving a build failed. So did listing, loading, renaming and deleting one — and screenshots and chat logs, which nobody had connected to it. The cause is not in this repo: **six independent defects in ArenaNet's published WebAssembly client**, four unimplemented `Base/Os` routines and two implemented-but-wrong ones.

| # | Function | Defect |
|---|---|---|
| 1 | create directory | returns error 2 unconditionally |
| 2 | find files | empty body — every directory reads as empty |
| 3 | entry name | writes nothing — the scan registers uninitialised stack |
| 4 | delete file | `assert("not implemented")` + `unreachable` — the client aborts |
| 5 | `Path::RemoveExtension` | removes the extension *and* the character before it |
| 6 | `File::Open` mode 1 | carries `O_CREAT`, so the rename probe creates the file it tests for |

None is reachable from JavaScript: the module imports no `mkdir`, `getdents` or `unlink`, and the client never reaches a syscall we could answer. The derived module therefore appends five forwarders and repoints the template, chat-log and screenshot call sites at them, routed through the existing `__syscall_newfstatat` import behind dirfd markers no real call can produce. Appending keeps every existing function index valid and leaves the stub bodies intact, so uncertified callers — the model paths, `ActDlgLogin`, `FrApi` — keep exactly today's behaviour.

## Client-update insurance

Every number in `TEMPLATE_SAVE_BUILDS` — five function indices, eleven call-site byte offsets, four exact stub bodies, two hashes — belongs to build `b0319704…`. ArenaNet updates the client automatically. When that happens the transform correctly refuses, the app falls back to the official module, and templates silently revert to broken.

`pnpm template:recertify` re-derives the whole table from a new client by shape — body bytes, resolved signatures, and caller-set intersection — in about a second, and **refuses rather than guessing** when a locator finds the wrong number of candidates. It reproduces the checked-in entry exactly:

```
$ pnpm template:recertify -- --expect-certified   # exit 0
assert handler 103 chosen with 7274 callers (runner-up 1)
template scans 9527, 9528
directory sinks 11525, 12214
File::Open probe at +201, write at +226
```

It recovers **indices, not semantics** — all six defects above were semantic findings. `internal/upstream/recertify.md` says so prominently and keeps the manual procedure.

## Two defects found in our own code while building it

- **`Buffer.prototype.slice` returns a view.** `splitSections` and `parseCode` were handing out aliases into the caller's input, and both transforms write into the bodies they get back. Every caller reads the artifact with `readFile`, so the production transform was mutating its own input — harmless today only because the buffer is discarded immediately. Fixed at the codec level with a regression test.
- **A dead overflow guard** in `paddedIndex`: `>>>` truncates to 32 bits, so the trailing bound check could never fire.

## Commits

1. `refactor:` give the WASM section codec one home — 8 primitives were duplicated across two transforms. Byte-provable via the pinned `outputSha256`; builds and passes on its own.
2. `fix:` the CRUD cycle, the re-certifier, and `internal/upstream/`.

## Testing

Four of the ten rounds this took were the same mistake — **fixtures cleaner than the client's real output**. The tests now carry a corpus of every path shape the client is known to emit, including the doubled separator `Templates/Skills/\Test.txt`, sourced from `client-internals.md`. The re-certifier's synthetic fixture carries a decoy for every shape plus four negative fixtures, each asserting a *specific* refusal and each asserted to be otherwise valid — so the throw is the locator refusing, not a malformed module.

| Suite | Result |
|---|---|
| `pnpm check` | 153 unit pass |
| `pnpm test:release` | 32 pass |
| `pnpm test:integration` | 10 pass |
| `pnpm test:electron` | 32 passed, 1 skipped |
| `pnpm package` + `test:packaged` | pass |
| `template:recertify --expect-certified` | exit 0 against the real client |

Plus the live cycle by hand: save, list, load, rename, delete, restart, screenshot, equipment templates.

## Not in scope

`internal/upstream/upstream-defects.md` is written to be sent to ArenaNet as-is — filing it is a separate step. A user-facing warning in Settings when the client build is uncertified is deliberately left out; the `wasm.templateSaveCompatible` gauge already makes it visible in any `.gwdiag`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
