### PR TITLE
Fix client updates, stop the game streaming itself, and make the diagnostics tell the truth

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -62,6 +62,11 @@ not only happy paths.
 - `dataStrategy` is the only launcher-intent state. The renderer resolves it
   against cache residency before appending `Gw.jspi.js`; no game audio,
   networking, WebGL, or WASM may start behind the launcher.
+- Progress `phase: "ready"` means the main process has an active client, and
+  only `ClientRuntime.clientReady` may publish it. `PatchClient` reports
+  download progress and nothing else — its `emit` signature excludes `"ready"`.
+  A premature ready lets the renderer read snapshot metadata before a client
+  exists, receive size 0, and silently stream the whole game over the network.
 - Concurrent chunk reads share one promise per content hash.
 - Renderer and native download schedulers cap ArenaNet concurrency at eight.
   Demand work outranks queued prefetch; do not raise the ceiling.

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -296,6 +296,26 @@ visible canvas’s `bitmaprenderer`. The client remains the only canvas-size
 owner; the host supplies the selected render scale through Emscripten’s device
 pixel ratio import and mirrors client-requested sizes to the offscreen buffer.
 
+A second import patch memoizes asynchronous shader-compile completion. The
+client uses `KHR_parallel_shader_compile` and polls
+`glGetProgramiv(program, COMPLETION_STATUS_KHR)` in a loop; Chromium cannot
+answer that from its client-side cache, so every poll flushes the command
+buffer and waits on the GPU process. A recon session measured 36,713 polls
+against roughly 250 programs in seven minutes.
+
+Only completion is cached, and only once it reads true. False is the answer the
+client is polling for a change in, so freezing it would leave the client
+polling a program that never finishes; true is terminal until the next
+`glLinkProgram`, which clears the entry, as does losing the WebGL context. The
+cache tracks a program only while the host has seen it created and not deleted,
+so a recycled name starts cold and a name from before install is never
+recorded. Every other query passes through untouched, including
+`GL_VALIDATE_STATUS` — evaluated against current GL state rather than the
+program — and the link-derived pnames, which the client was measured asking
+exactly once per program. A missing import disables the whole patch rather than
+half of it, and the `gl.programQuery*` counters prove it is engaged against the
+downloaded client.
+
 The renderer also supplies focus, OSK fields, trusted-interaction audio resume,
 fullscreen, touch translation, trackpad-wheel normalization, and right-drag
 pointer lock. `input.js` owns the canvas input listeners and accepts validated
@@ -325,16 +345,51 @@ Level 0 is always active:
   distributions, merged without reducing them to averages;
 - event-loop and process samples;
 - cache/disk/network/protocol spans;
-- GPU, power, thermal, lifecycle, crash, and context-loss signals.
+- GPU, power, thermal, lifecycle, crash, and context-loss signals;
+- window focus, minimize, hide, and resize/move brackets, plus a per-batch
+  renderer `focused` flag.
+
+Window state is load-bearing for stall attribution. An unfocused, occluded, or
+mid-resize window stops being composited, which stops `requestAnimationFrame`
+with no CPU spent in any process — indistinguishable from a real freeze unless
+it is recorded. `document.hidden` reports none of that on macOS, so the main
+process records the transitions itself; it stays responsive while the renderer
+is frozen, which makes its timestamps the ones to line up against `frames.bin`.
+
+GPU process feature status is sampled at export, not at Electron ready: the GPU
+process does not exist when the recorder starts, and Chromium's
+pre-initialization answer reads as software rendering on a machine that is in
+fact running ANGLE on Metal. Sampling late also means that if the GPU process
+has died, “disabled” is the truth rather than an artefact.
+
+At launch the diagnostics directory keeps only `session-*.jsonl`; everything
+else is removed, including Chromium's `.<bundle-id>.XXXXXX` atomic-write
+temporaries, which a prefix-matching sweep could never reach.
 
 Level 1 adds fixed-width per-frame records. The renderer batches them; the main
 process writes `frames.bin` asynchronously with a 128 MB ceiling. Level 2 adds
 an argument-filtered Chromium trace with selected supported categories, a
 256 MB buffer, an 80% stop threshold, and a 120-second time limit.
+The trace is deleted at quit and by the launch sweep, deliberately not after an
+export: the recorded capture level stays at 2 for the rest of the session, so
+discarding it there would make a second export declare Level 2 with no trace and
+fail its own validation. Its size is recorded as `capture.traceBytes`. If a
+trace is ever lost, drop the broad `blink` category before reducing the buffer.
+A Level 2 capture whose manifest declares no `chromium-trace.json` fails
+validation instead of looking complete.
+
+Record Level 2 for fifteen to thirty seconds and stop immediately after the
+hitch. The buffer fills in roughly half a minute of heavy activity, and a trace
+that stops short of the export leaves the stalls after it unattributed.
+
 During Level 2 only, fixed-name `gw.frame.submit` and `gw.snapshot.resolve`
 User Timing marks place frame and snapshot boundaries directly on Chromium's
 trace clock. They carry no arguments and are cleared from the renderer's
-Performance Timeline immediately after emission.
+Performance Timeline immediately after emission. Under an active trace each
+mark costs about 114 µs — roughly 1.3% of a capture, and the third hottest leaf
+in it. That cost is `performance.mark` emitting an argument-filtered trace
+event; `performance.clearMarks` was measured at 0.3 µs and is not the lever.
+It is one more reason Level 2 locates causes but cannot establish gains.
 The existing main-to-renderer capture command path also owns a noninteractive
 recording indicator, elapsed timer, and problem-marker acknowledgement; it
 does not add a preload capability.
@@ -376,9 +431,18 @@ Event-loop delay uses reset five-second windows at 5 ms resolution. When
 `frames.bin` exists, the tools calculate exact visible-only frame percentiles,
 FPS, and stalls from its fixed-width records.
 
-Exports fail closed on credential-shaped content. Chromium net bodies, HTTP
-headers, account request bodies, TCP payloads, and crash dumps are never
-included. Crashpad is local-only and retains at most three dumps.
+`socket.rendererSettle` measures how long the renderer takes to settle a send
+promise, so it reports *renderer* stalls, not network latency: a frozen renderer
+cannot run the continuation. `socket.writeCallback` is the main-side write, and
+subtracting the two is what separates TCP backpressure from a renderer stall.
+
+Exports fail closed on credential-shaped content. Trace redaction is a single
+streaming pass with a 64 KB boundary overlap that asserts each chunk is a fixed
+point before writing it; a second read-back would re-run an idempotent
+redaction with a smaller overlap over a file that can reach a quarter of a
+gigabyte, and could not detect anything the first pass missed. Chromium net
+bodies, HTTP headers, account request bodies, TCP payloads, and crash dumps are
+never included. Crashpad is local-only and retains at most three dumps.
 
 The comparison tool warns about architecture, OS, app version, GPU renderer,
 render scale, canvas size, capture level, visibility, same-session and
@@ -393,6 +457,16 @@ reports CPU categories, hot leaves, hot complete stacks, and the longest
 overlapping renderer-thread trace events. Captures without the markers fail
 report the incompatibility instead of attempting cross-clock timestamp
 inference.
+
+`pnpm diagnostics:attribute-frames <capture.gwdiag> [threshold-ms]` is its
+Level 1 counterpart, and Level 1 is the level that can establish gains. It joins
+visible-frame gaps from `frames.bin` to the main-process events within a second
+and a half either side — the main process keeps running while the renderer is
+frozen, so its timestamps are the reliable side of the join. Each stall is
+attributed to composition loss when the window changed state, to the main
+process when its event loop actually blocked, and otherwise to the renderer.
+Captures recorded before window-state tracking say so rather than claiming the
+window was steady.
 
 ## Verification boundaries
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "diagnostics:summarize": "tsc && node build/tools/diagnostics/summarize.js",
     "diagnostics:compare": "tsc && node build/tools/diagnostics/compare.js",
     "diagnostics:attribute-stalls": "tsc && node build/tools/diagnostics/attribute-stalls.js",
+    "diagnostics:attribute-frames": "tsc && node build/tools/diagnostics/attribute-frames.js",
     "verify": "pnpm lint && pnpm test && pnpm test:release && pnpm package && pnpm test:packaged"
   },
   "devDependencies": {

--- a/src/main/client-runtime.ts
+++ b/src/main/client-runtime.ts
@@ -5,6 +5,7 @@ import type {
   PrefetchProgress,
   SnapshotMetadata,
 } from "../shared/contracts.js";
+import { AppError } from "../shared/errors.js";
 import { INITIAL_PROGRESS } from "../shared/progress.js";
 import {
   ACCESS_KEY,
@@ -447,13 +448,16 @@ export class ClientRuntime {
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
+      // Identify the failure by code, so comparing sessions does not depend on
+      // matching English prose.
+      const code = error instanceof AppError ? error.code : null;
       try {
         await this.activatePublishedAndReady(
           "The game client update failed, so the previous client was restored.",
         );
-        log("update", "warn", "patch.updateFallback", { message });
+        log("update", "warn", "patch.updateFallback", { code, message });
         gauge("update.usingCachedClient", true);
-        updateSpan.end({ status: "cachedFallback", message }, "warn");
+        updateSpan.end({ status: "cachedFallback", code, message }, "warn");
         return;
       } catch (fallbackError) {
         log("update", "error", "patch.updateFailed", {

--- a/src/main/core/manifest.ts
+++ b/src/main/core/manifest.ts
@@ -80,10 +80,15 @@ export class Manifest {
       }
       return value;
     };
+    // The live service omits the field on flat entries by sending null, not by
+    // leaving it out. Rejecting that stopped every client update from applying.
     const validateParent = (value: unknown, kind: string): number => {
-      if (value === undefined) return 0;
+      if (value === undefined || value === null) return 0;
       if (!Number.isSafeInteger(value) || (value as number) < 0 || (value as number) >= dirs.length) {
-        throw new AppError("manifest_parent", `invalid ${kind} parent index`);
+        throw new AppError(
+          "manifest_parent",
+          `invalid ${kind} parent index ${JSON.stringify(value)} of ${dirs.length}`,
+        );
       }
       return value as number;
     };

--- a/src/main/core/patch-client.ts
+++ b/src/main/core/patch-client.ts
@@ -113,7 +113,18 @@ export class PatchClient {
     };
   }
 
-  private emit(p: DownloadProgress): void {
+  /**
+   * Download progress only. "ready" is not this class's to declare: the
+   * launcher treats it as "the main process has an active client", which is
+   * true only after ClientRuntime activates one. Emitting it here let the
+   * renderer read snapshot metadata while there was still no active client,
+   * get size 0, and silently stream the whole game over the network instead.
+   */
+  private emit(
+    p: DownloadProgress & {
+      phase: Exclude<DownloadProgress["phase"], "ready">;
+    },
+  ): void {
     this.onProgress?.(p);
   }
 
@@ -442,15 +453,6 @@ export class PatchClient {
       wanted.length === 0 &&
       (await this.snapshotIndexesMatch(snapshotEntry, mf))
     ) {
-      this.emit({
-        phase: "ready",
-        label: "Ready",
-        received: 0,
-        total: 0,
-        bytesPerSecond: 0,
-        secondsRemaining: null,
-        error: null,
-      });
       return {
         manifest: mf,
         fingerprint,
@@ -558,15 +560,6 @@ export class PatchClient {
       await rm(stage, { recursive: true, force: true });
     }
 
-    this.emit({
-      phase: "ready",
-      label: "Ready",
-      received: total,
-      total,
-      bytesPerSecond: 0,
-      secondsRemaining: null,
-      error: null,
-    });
     return {
       manifest: mf,
       fingerprint,

--- a/src/main/diagnostics.ts
+++ b/src/main/diagnostics.ts
@@ -194,7 +194,6 @@ export function recordGraphics(value: GraphicsDiagnostics): void {
 
 export function recordRendererMetrics(value: RendererMetrics): void {
   recorder.count("renderer.raf", value.rafCount);
-  recorder.count("renderer.rafOver16", value.rafOver16);
   recorder.count("renderer.rafOver33", value.rafOver33);
   recorder.count("renderer.rafOver50", value.rafOver50);
   recorder.count("renderer.swaps", value.swapCount);
@@ -204,11 +203,13 @@ export function recordRendererMetrics(value: RendererMetrics): void {
   recorder.count("cache.memoryHits", value.memoryHits);
   recorder.count("cache.nativeHits", value.nativeHits);
   recorder.count("cache.coalesced", value.coalesced);
+  recorder.count("gl.programQueryHits", value.glProgramQueryHits);
+  recorder.count("gl.programQueryMisses", value.glProgramQueryMisses);
   recorder.count("socket.rendererSendCalls", value.socketSendCalls);
   recorder.count("socket.rendererPayloadBytes", value.socketPayloadBytes);
-  recorder.count(
-    "socket.rendererSourceBackingBytes",
-    value.socketSourceBackingBytes,
+  recorder.setPeak(
+    "socket.rendererPeakSourceBackingBytes",
+    value.socketSourceBackingMaxBytes,
   );
   recorder.count("socket.rendererCompactBytes", value.socketCompactBytes);
   recorder.count("socket.rendererSettles", value.socketSettles);
@@ -311,6 +312,7 @@ export function recordRendererMetrics(value: RendererMetrics): void {
     value.inputToSubmitMaxUs,
   );
   recorder.setLatest("renderer.visible", value.visible);
+  recorder.setLatest("renderer.focused", value.focused);
   recorder.setLatest("renderer.memoryCacheBytes", value.memoryCacheBytes);
   recorder.setLatest("renderer.memoryCacheChunks", value.memoryCacheChunks);
   recorder.setLatest("renderer.pendingChunks", value.pendingChunks);
@@ -318,12 +320,6 @@ export function recordRendererMetrics(value: RendererMetrics): void {
   recorder.setLatest("snapshot.activePrefetch", value.activePrefetch);
   recorder.setLatest("snapshot.queuedDemand", value.queuedDemand);
   recorder.setLatest("snapshot.queuedPrefetch", value.queuedPrefetch);
-  recorder.setLatest(
-    "socket.sourceBackingRatio",
-    value.socketPayloadBytes
-      ? value.socketSourceBackingBytes / value.socketPayloadBytes
-      : 0,
-  );
   recorder.setPeak("renderer.peakMemoryCacheBytes", value.memoryCacheBytes);
   recorder.setPeak("renderer.peakPendingChunks", value.pendingChunks);
   recorder.setPeak(
@@ -381,7 +377,7 @@ export function recordRendererMetrics(value: RendererMetrics): void {
       queuedPrefetch: value.queuedPrefetch,
       socketSendCalls: value.socketSendCalls,
       socketPayloadBytes: value.socketPayloadBytes,
-      socketSourceBackingBytes: value.socketSourceBackingBytes,
+      socketSourceBackingMaxBytes: value.socketSourceBackingMaxBytes,
       socketCompactBytes: value.socketCompactBytes,
       socketSyncMaxUs: Math.round(value.socketSyncMaxUs),
       socketSettles: value.socketSettles,
@@ -446,7 +442,10 @@ async function stopTrace(): Promise<void> {
   try {
     await contentTracing.stopRecording(target);
     lastTracePath = target;
-    recorder.event("app", "info", "chromiumTrace.stopped");
+    // Size is the first thing anyone asks after an export goes wrong.
+    const bytes = await stat(target).then((info) => info.size, () => 0);
+    recorder.setLatest("capture.traceBytes", bytes);
+    recorder.event("app", "info", "chromiumTrace.stopped", { bytes });
   } catch (err) {
     recorder.event("app", "error", "chromiumTrace.stopFailed", {
       message: err instanceof Error ? err.message : String(err),
@@ -673,17 +672,35 @@ function sampleEventLoop(): void {
   eventLoopWindowStartedUs = sampledAtUs;
 }
 
+/**
+ * The recorder owns the diagnostics directory outright, and the only entries
+ * that must outlive a launch are earlier sessions' JSONL. A whitelist is the
+ * rule: prefix matching missed Chromium's `.<bundle-id>.XXXXXX` atomic-write
+ * temporaries, which left a truncated 111 MB trace behind for days.
+ */
+function staleDiagnosticEntries(names: string[]): string[] {
+  return names.filter((name) => !/^session-.+\.jsonl$/.test(name));
+}
+
+/**
+ * Sampled at export, not at ready: the GPU process does not exist when the
+ * recorder starts, so Chromium answers with pre-initialization defaults that
+ * read as software rendering. If the process has since died, "disabled" is
+ * then the truth, and that is exactly what the reader needs.
+ */
+async function gpuEnvironment(): Promise<Record<string, unknown>> {
+  return {
+    featureStatus: app.getGPUFeatureStatus(),
+    info: await app.getGPUInfo("basic").catch(() => null),
+  };
+}
+
 export async function startDiagnostics(): Promise<void> {
   crashReporter.start({ uploadToServer: false, compress: true });
   const diagnosticsDir = gamePaths().diagnostics;
-  const staleCaptures = (await readdir(diagnosticsDir).catch(() => []))
-    .filter(
-      (name) =>
-        name.startsWith("frames-") ||
-        name.startsWith("chromium-") ||
-        name.startsWith("export-"),
-    )
-    .map((name) => path.join(diagnosticsDir, name));
+  const staleCaptures = staleDiagnosticEntries(
+    await readdir(diagnosticsDir).catch(() => []),
+  ).map((name) => path.join(diagnosticsDir, name));
   await Promise.all(
     staleCaptures.map((file) => rm(file, { recursive: true, force: true })),
   );
@@ -720,8 +737,6 @@ export async function startDiagnostics(): Promise<void> {
     appVersion: app.getVersion(),
     versions: versions(),
     startedAt: recorder.startedWall,
-    gpuFeatureStatus: app.getGPUFeatureStatus(),
-    gpuInfo: await app.getGPUInfo("basic").catch(() => null),
   };
   recorder.event("app", "info", "diagnostics.started", {
     sessionId: recorder.sessionId,
@@ -755,12 +770,26 @@ export async function startDiagnostics(): Promise<void> {
   }, SAMPLE_INTERVAL_MS);
 }
 
+/**
+ * A Level 2 trace is tens to hundreds of megabytes. Remove it by the exact
+ * path we hold — never a glob, and never anything a session still needs.
+ */
+async function discardTrace(): Promise<void> {
+  if (!lastTracePath) return;
+  const target = lastTracePath;
+  lastTracePath = "";
+  await rm(target, { force: true }).catch(() => undefined);
+}
+
 export async function stopDiagnostics(): Promise<void> {
   if (sampler) clearInterval(sampler);
   sampler = null;
   eventLoop.disable();
   await stopDiagnosticCapture("shutdown");
   await recorder.flush();
+  // A session that is never exported still bounds itself at quit rather than
+  // waiting for the next launch to sweep.
+  await discardTrace();
 }
 
 export async function flushDiagnostics(): Promise<void> {
@@ -777,18 +806,6 @@ function assertRedacted(text: string): void {
   }
 }
 
-async function assertFileRedacted(file: string): Promise<void> {
-  const stream = createReadStream(file, { encoding: "utf8" });
-  let carry = "";
-  for await (const chunk of stream) {
-    const text = carry + chunk;
-    if (containsSensitiveText(text)) {
-      throw new Error("diagnostics trace failed redaction scan");
-    }
-    carry = text.slice(-4_096);
-  }
-}
-
 async function sanitizeTraceFile(source: string, target: string): Promise<void> {
   const input = createReadStream(source, {
     encoding: "utf8",
@@ -802,13 +819,19 @@ async function sanitizeTraceFile(source: string, target: string): Promise<void> 
       const split = Math.max(0, text.length - 64 * 1024);
       const ready = text.slice(0, split);
       carry = text.slice(split);
-      if (ready) await output.write(ready);
+      // Fail closed in the same pass. A second read-back could only re-run an
+      // idempotent redaction with a smaller boundary overlap than this one,
+      // over a file that can reach a quarter of a gigabyte.
+      if (ready) {
+        assertRedacted(ready);
+        await output.write(ready);
+      }
     }
+    assertRedacted(carry);
     await output.write(carry);
   } finally {
     await output.close();
   }
-  await assertFileRedacted(target);
 }
 
 export async function exportDiagnosticsZip(
@@ -933,7 +956,12 @@ export async function exportDiagnosticsZip(
       ...(previous ? { "previous-events.jsonl": previous.text } : {}),
       "histograms.json": JSON.stringify(summary.histograms, null, 2),
       "environment.json": JSON.stringify(
-        { ...environment, graphics, electronVersions: extras.electronVersions },
+        {
+          ...environment,
+          gpu: await gpuEnvironment(),
+          graphics,
+          electronVersions: extras.electronVersions,
+        },
         null,
         2,
       ),
@@ -954,6 +982,10 @@ export async function exportDiagnosticsZip(
     await execFileAsync("ditto", ["-c", "-k", "--sequesterRsrc", staging, zipPart]);
     await chmod(zipPart, 0o600);
     await rename(zipPart, zipPath);
+    // The trace deliberately survives the export. `recordedCaptureLevel` stays
+    // at 2 for the rest of the session, so discarding here would make a second
+    // export declare Level 2 with no trace and fail its own validation. Quit
+    // and the launch sweep are what bound it.
     return zipPath;
   } finally {
     await rm(staging, { recursive: true, force: true });

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -263,6 +263,24 @@ export function createMainWindow(host: WindowHost): BrowserWindow {
   win.on("enter-full-screen", persistMode);
   win.on("leave-full-screen", persistMode);
 
+  // A window that is unfocused, occluded, minimized, or mid-resize stops
+  // being composited, which stops requestAnimationFrame with no CPU spent
+  // anywhere. `document.hidden` does not report any of that on macOS, so
+  // without these a stall of that kind is indistinguishable from a real one.
+  // Main stays responsive while the renderer is frozen, so these timestamps
+  // are the reliable ones to line up against frames.bin.
+  win.on("focus", () => log("app", "info", "window.focused"));
+  win.on("blur", () => log("app", "info", "window.blurred"));
+  win.on("minimize", () => log("app", "info", "window.minimized"));
+  win.on("restore", () => log("app", "info", "window.restored"));
+  win.on("hide", () => log("app", "info", "window.hidden"));
+  win.on("show", () => log("app", "info", "window.shown"));
+  // Only the settled events. Electron emits `will-resize` and `will-move` once
+  // per step of a live drag, which would flood the bounded event ring and
+  // evict the very evidence these listeners exist to keep.
+  win.on("resized", () => log("app", "info", "window.resized"));
+  win.on("moved", () => log("app", "info", "window.moved"));
+
   win.webContents.setWindowOpenHandler(() => {
     log("app", "warn", "security.windowOpenBlocked");
     return { action: "deny" };

--- a/src/renderer/diagnostics.js
+++ b/src/renderer/diagnostics.js
@@ -52,11 +52,11 @@
   const fresh = () => ({
     intervalMs: 0,
     visible: !document.hidden,
+    focused: document.hasFocus(),
     rafCount: 0,
     rafTotalUs: 0,
     rafMinUs: 0,
     rafMaxUs: 0,
-    rafOver16: 0,
     rafOver33: 0,
     rafOver50: 0,
     swapCount: 0,
@@ -90,6 +90,8 @@
     memoryHits: 0,
     nativeHits: 0,
     coalesced: 0,
+    glProgramQueryHits: 0,
+    glProgramQueryMisses: 0,
     memoryCacheBytes: 0,
     memoryCacheChunks: 0,
     pendingChunks: 0,
@@ -101,7 +103,7 @@
     queuePromotions: 0,
     socketSendCalls: 0,
     socketPayloadBytes: 0,
-    socketSourceBackingBytes: 0,
+    socketSourceBackingMaxBytes: 0,
     socketCompactBytes: 0,
     socketSyncTotalUs: 0,
     socketSyncMinUs: 0,
@@ -241,7 +243,6 @@
     if (lastRaf) {
       const deltaUs = (now - lastRaf) * 1000;
       observe(metrics, 'raf', deltaUs);
-      if (deltaUs > 16667) metrics.rafOver16++;
       if (deltaUs > 33333) metrics.rafOver33++;
       if (deltaUs > 50000) metrics.rafOver50++;
     }
@@ -264,6 +265,7 @@
     frameData = [];
     batch.intervalMs = now - periodStarted;
     batch.visible = !document.hidden;
+    batch.focused = document.hasFocus();
     periodStarted = now;
     flushing = true;
     try {
@@ -326,14 +328,6 @@
       if (marker) marker.hidden = false;
       announceCapture('Performance problem marked.');
     },
-    /** @param {string} name @param {unknown} [fields] */
-    mark(name, fields) {
-      try {
-        performance.mark(`gw.${name}`, { detail: fields });
-      } catch {
-        performance.mark(`gw.${name}`);
-      }
-    },
     event: recordEvent,
     /**
      * @param {number} durationUs
@@ -352,6 +346,14 @@
       if (source === 'memory') metrics.memoryHits++;
       else if (source === 'native') metrics.nativeHits++;
       else if (source === 'coalesced') metrics.coalesced++;
+    },
+    // Proves the GL program-state cache is engaged against the live client:
+    // the glue is downloaded at runtime, so a renamed import would otherwise
+    // look identical to "the fix stopped helping".
+    /** @param {boolean} hit */
+    glProgramQuery(hit) {
+      if (hit) metrics.glProgramQueryHits++;
+      else metrics.glProgramQueryMisses++;
     },
     /** @param {'eviction' | 'promotion'} event */
     scheduler(event) {
@@ -379,9 +381,9 @@
         Number.MAX_SAFE_INTEGER,
         metrics.socketPayloadBytes + payloadBytes,
       );
-      metrics.socketSourceBackingBytes = Math.min(
-        Number.MAX_SAFE_INTEGER,
-        metrics.socketSourceBackingBytes + sourceBackingBytes,
+      metrics.socketSourceBackingMaxBytes = Math.max(
+        metrics.socketSourceBackingMaxBytes,
+        sourceBackingBytes,
       );
       metrics.socketCompactBytes = Math.min(
         Number.MAX_SAFE_INTEGER,

--- a/src/renderer/gl-program-cache.js
+++ b/src/renderer/gl-program-cache.js
@@ -1,0 +1,161 @@
+// ArenaNet's client uses KHR_parallel_shader_compile and polls
+// glGetProgramiv(program, COMPLETION_STATUS_KHR) in a loop while a program
+// compiles asynchronously. Chromium cannot answer that from its client-side
+// cache, so every poll flushes the command buffer and waits on the GPU
+// process. A recon session measured 36,713 polls against roughly 250 programs.
+//
+// Completion is the only thing memoized, and only once it reads true, and only
+// while the host has seen the program created and not deleted. Everything else
+// is passed through, including enums this file does not know about.
+(() => {
+  'use strict';
+
+  const COMPLETION_STATUS_KHR = 0x91b1;
+  const GL_TRUE = 1;
+
+  // Deliberately not cached, and each for its own reason:
+  //   LINK_STATUS and friends   the client asks each exactly once per program
+  //                             (measured: 690 queries, 0 repeats), so caching
+  //                             them buys nothing.
+  //   VALIDATE_STATUS (0x8B83)  evaluated against current GL state, not the
+  //                             program — no invalidation set can exist.
+  //   INFO_LOG_LENGTH (0x8B84)  rewritten by link and validate, and a stale
+  //                             log would hide link failures.
+  //   the *_MAX_LENGTH trio     already memoized on the program object by the
+  //                             generated glue; they never reach GL twice.
+
+  // A ceiling, not an LRU. Evicting would reintroduce the round trips this
+  // exists to remove; overflow degrades to pass-through, never to wrong.
+  const MAX_PROGRAMS = 1024;
+
+  /**
+   * @param {{
+   *   imports: { env?: Record<string, (...args: any[]) => any> },
+   *   module: { HEAPU8?: Uint8Array },
+   *   log(...values: unknown[]): void,
+   * }} options
+   */
+  window.gwInstallGlProgramCache = ({ imports, module, log }) => {
+    const env = imports.env;
+    const getProgramiv = env?.glGetProgramiv;
+    const createProgram = env?.glCreateProgram;
+    const linkProgram = env?.glLinkProgram;
+    const deleteProgram = env?.glDeleteProgram;
+    // All four or none. A read cache without its invalidators is a rendering
+    // bug, so there is no useful degraded mode between them.
+    if (
+      !env ||
+      typeof getProgramiv !== 'function' ||
+      typeof createProgram !== 'function' ||
+      typeof linkProgram !== 'function' ||
+      typeof deleteProgram !== 'function'
+    ) {
+      log('[warn] GL program state cache unavailable — imports left unpatched');
+      return;
+    }
+
+    // program name -> has completed. An entry exists exactly while the host has
+    // seen the name created and not deleted, so a recycled id starts cold and a
+    // name we never saw created passes through forever — which matters, because
+    // the glue's "program >= GL.counter" branch writes nothing at all, so
+    // recording the out-pointer there would capture whatever was in memory.
+    /** @type {Map<number, boolean>} */
+    const programs = new Map();
+
+    // Queries that still reach the client, by pname, so a hot one we do not
+    // cache stays visible after an ArenaNet client update.
+    /** @type {Map<number, number>} */
+    const passThrough = new Map();
+    /** @param {number} pname */
+    const countPassThrough = (pname) =>
+      passThrough.set(pname, (passThrough.get(pname) ?? 0) + 1);
+
+    /** @type {ArrayBufferLike | null} */
+    let backing = null;
+    /** @type {Int32Array | null} */
+    let words = null;
+    function heap() {
+      const bytes = module.HEAPU8;
+      if (!bytes) return null;
+      // Growth replaces the buffer, so identity is the whole check.
+      if (bytes.buffer !== backing) {
+        backing = bytes.buffer;
+        words = new Int32Array(bytes.buffer);
+      }
+      return words;
+    }
+
+    env.glCreateProgram = function (...args) {
+      const program = createProgram.apply(this, args);
+      if (typeof program === 'number' && program > 0 && programs.size < MAX_PROGRAMS) {
+        programs.set(program, false);
+      }
+      return program;
+    };
+
+    env.glLinkProgram = function (program, ...rest) {
+      // Relinking restarts the asynchronous compile, so completion is false
+      // again until the client observes otherwise.
+      if (programs.has(program)) programs.set(program, false);
+      return linkProgram.call(this, program, ...rest);
+    };
+
+    env.glDeleteProgram = function (program, ...rest) {
+      programs.delete(program);
+      return deleteProgram.call(this, program, ...rest);
+    };
+
+    env.glGetProgramiv = function (program, pname, p) {
+      if (pname !== COMPLETION_STATUS_KHR) {
+        countPassThrough(pname);
+        return getProgramiv.call(this, program, pname, p);
+      }
+      const completed = programs.get(program);
+      const words32 = heap();
+      const index = p >>> 2;
+      if (
+        completed === undefined ||
+        words32 === null ||
+        !p ||
+        (p & 3) !== 0 ||
+        index >= words32.length
+      ) {
+        // A completion poll we cannot serve is still a poll reaching the
+        // client; counting it keeps a storm against untracked programs visible.
+        countPassThrough(pname);
+        return getProgramiv.call(this, program, pname, p);
+      }
+      if (completed) {
+        words32[index] = GL_TRUE;
+        window.gwDiagnostics?.glProgramQuery(true);
+        return undefined;
+      }
+      getProgramiv.call(this, program, pname, p);
+      // Re-read through heap(): the underlying call can grow memory, which
+      // detaches the view the miss started with.
+      const after = heap();
+      // Only a true completion is recorded. False is the answer the client is
+      // polling for a change in, so freezing it would leave it polling a
+      // program that never finishes. True is terminal until the next
+      // glLinkProgram, which clears the entry.
+      if (after !== null && after[index] === GL_TRUE) programs.set(program, true);
+      window.gwDiagnostics?.glProgramQuery(false);
+      return undefined;
+    };
+
+    // Programs do not survive the context, so neither may their completion.
+    addEventListener('gw:graphics-context-reset', () => programs.clear());
+
+    // Which queries still reach the client, and how often. Read it with
+    // gwGlRecon() after a play session to re-check the allowlist against a
+    // freshly downloaded client.
+    window.gwGlRecon = () => ({
+      livePrograms: programs.size,
+      passThrough: Object.fromEntries(
+        [...passThrough]
+          .sort((left, right) => right[1] - left[1])
+          .map(([pname, count]) => [`0x${pname.toString(16).toUpperCase()}`, count]),
+      ),
+    });
+  };
+})();

--- a/src/renderer/graphics.js
+++ b/src/renderer/graphics.js
@@ -91,11 +91,15 @@
         visible.offscreen.addEventListener('webglcontextlost', (event) => {
           event.preventDefault();
           performance.mark('gw.graphics.context-lost');
+          // Program objects do not survive the context; anything memoized
+          // about them has to go with it.
+          window.dispatchEvent(new globalThis.Event('gw:graphics-context-reset'));
           window.gwDiagnostics?.event('graphics.contextLost');
           void window.gwDiagnostics?.flush();
         });
         visible.offscreen.addEventListener('webglcontextrestored', () => {
           performance.mark('gw.graphics.context-restored');
+          window.dispatchEvent(new globalThis.Event('gw:graphics-context-reset'));
           window.gwDiagnostics?.event('graphics.contextRestored');
           void window.gwDiagnostics?.flush();
         });

--- a/src/renderer/gw-native.d.ts
+++ b/src/renderer/gw-native.d.ts
@@ -42,7 +42,6 @@ declare global {
     captureStarted(level: 1 | 2): void;
     captureStopped(): void;
     problemMarked(): void;
-    mark(name: string, fields?: unknown): void;
     event(name: RendererEventName, value?: unknown): void;
     snapshot(
       durationUs: number,
@@ -50,6 +49,7 @@ declare global {
       source: "memory" | "native",
     ): void;
     cache(source: "memory" | "native" | "coalesced"): void;
+    glProgramQuery(hit: boolean): void;
     scheduler(event: "eviction" | "promotion"): void;
     socketSend(
       started: number,
@@ -147,6 +147,17 @@ declare global {
       },
       module: { HEAPU8?: Uint8Array },
     ): void;
+    gwInstallGlProgramCache(options: {
+      imports: {
+        env?: Record<string, (...args: unknown[]) => unknown>;
+      };
+      module: { HEAPU8?: Uint8Array };
+      log(...values: unknown[]): void;
+    }): void;
+    gwGlRecon?(): Readonly<{
+      livePrograms: number;
+      passThrough: Record<string, number>;
+    }>;
     gwTemplateFilesystemTrace?(): ReadonlyArray<Readonly<{
       sequence: number;
       operation: string;

--- a/src/renderer/harness.js
+++ b/src/renderer/harness.js
@@ -410,6 +410,7 @@ Module = {
       },
       log,
     });
+    window.gwInstallGlProgramCache({ imports, module: Module, log });
     const gamepadImports = [
       'emscripten_sample_gamepad_data',
       'emscripten_set_gamepadconnected_callback_on_thread',

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -293,6 +293,7 @@
 <script src="loading.js"></script>
 <script src="input.js"></script>
 <script src="graphics.js"></script>
+<script src="gl-program-cache.js"></script>
 <script src="filesystem.js"></script>
 <script src="template-save-compatibility.js"></script>
 <script src="template-filesystem-trace.js"></script>

--- a/src/shared/diagnostics.ts
+++ b/src/shared/diagnostics.ts
@@ -64,11 +64,13 @@ export const DIAGNOSTIC_BUCKETS_US = [
 export interface RendererMetrics {
   intervalMs: number;
   visible: boolean;
+  /** Window focus, which `visible` cannot report: an unfocused or occluded
+   * macOS window stops being composited while `document.hidden` stays false. */
+  focused: boolean;
   rafCount: number;
   rafTotalUs: number;
   rafMinUs: number;
   rafMaxUs: number;
-  rafOver16: number;
   rafOver33: number;
   rafOver50: number;
   swapCount: number;
@@ -102,6 +104,8 @@ export interface RendererMetrics {
   memoryHits: number;
   nativeHits: number;
   coalesced: number;
+  glProgramQueryHits: number;
+  glProgramQueryMisses: number;
   memoryCacheBytes: number;
   memoryCacheChunks: number;
   pendingChunks: number;
@@ -113,7 +117,7 @@ export interface RendererMetrics {
   queuePromotions: number;
   socketSendCalls: number;
   socketPayloadBytes: number;
-  socketSourceBackingBytes: number;
+  socketSourceBackingMaxBytes: number;
   socketCompactBytes: number;
   socketSyncTotalUs: number;
   socketSyncMinUs: number;
@@ -232,7 +236,6 @@ export function isRendererMetrics(value: unknown): value is RendererMetrics {
     "rafTotalUs",
     "rafMinUs",
     "rafMaxUs",
-    "rafOver16",
     "rafOver33",
     "rafOver50",
     "swapCount",
@@ -266,6 +269,8 @@ export function isRendererMetrics(value: unknown): value is RendererMetrics {
     "memoryHits",
     "nativeHits",
     "coalesced",
+    "glProgramQueryHits",
+    "glProgramQueryMisses",
     "memoryCacheBytes",
     "memoryCacheChunks",
     "pendingChunks",
@@ -277,7 +282,7 @@ export function isRendererMetrics(value: unknown): value is RendererMetrics {
     "queuePromotions",
     "socketSendCalls",
     "socketPayloadBytes",
-    "socketSourceBackingBytes",
+    "socketSourceBackingMaxBytes",
     "socketCompactBytes",
     "socketSyncTotalUs",
     "socketSyncMinUs",
@@ -295,6 +300,7 @@ export function isRendererMetrics(value: unknown): value is RendererMetrics {
   if (
     !(
       typeof record.visible === "boolean" &&
+      typeof record.focused === "boolean" &&
       numeric.every(
         (key) =>
           typeof record[key] === "number" &&
@@ -364,8 +370,6 @@ export function isRendererMetrics(value: unknown): value is RendererMetrics {
   }
   if (
     record.socketCompactBytes !== record.socketPayloadBytes ||
-    (record.socketSourceBackingBytes as number) <
-      (record.socketPayloadBytes as number) ||
     !record.socketSendEvents.every((_item, index, events) => {
       if (index % 7 !== 0) return true;
       return events[index + 4]! >= events[index + 3]! &&
@@ -390,7 +394,6 @@ export function isRendererMetrics(value: unknown): value is RendererMetrics {
   };
   const counters = [
     "rafCount",
-    "rafOver16",
     "rafOver33",
     "rafOver50",
     "swapCount",
@@ -399,6 +402,8 @@ export function isRendererMetrics(value: unknown): value is RendererMetrics {
     "memoryHits",
     "nativeHits",
     "coalesced",
+    "glProgramQueryHits",
+    "glProgramQueryMisses",
     "memoryCacheBytes",
     "memoryCacheChunks",
     "pendingChunks",
@@ -410,7 +415,7 @@ export function isRendererMetrics(value: unknown): value is RendererMetrics {
     "queuePromotions",
     "socketSendCalls",
     "socketPayloadBytes",
-    "socketSourceBackingBytes",
+    "socketSourceBackingMaxBytes",
     "socketCompactBytes",
     "socketSettles",
     "inputToSubmitCount",
@@ -433,8 +438,7 @@ export function isRendererMetrics(value: unknown): value is RendererMetrics {
     bounded("inputToSubmit") &&
     counters.every((key) => Number.isSafeInteger(record[key])) &&
     (record.rafOver50 as number) <= (record.rafOver33 as number) &&
-    (record.rafOver33 as number) <= (record.rafOver16 as number) &&
-    (record.rafOver16 as number) <= (record.rafCount as number) &&
+    (record.rafOver33 as number) <= (record.rafCount as number) &&
     (record.presentationFailures as number) <= (record.swapCount as number)
   );
 }

--- a/src/tools/diagnostics/attribute-frames.ts
+++ b/src/tools/diagnostics/attribute-frames.ts
@@ -1,0 +1,225 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { withCapture } from "./common.js";
+
+// Level 2 traces locate causes but are profiler-contaminated, so gains are
+// judged at Level 1 — where until now a stall could not be attributed at all.
+// This joins visible-frame gaps to the main-process events that surround them.
+// The main process keeps running while the renderer is frozen, so its
+// timestamps are the reliable side of the join.
+const DEFAULT_THRESHOLD_US = 100_000;
+const CORRELATION_US = 1_500_000;
+const BLOCKED_MAIN_US = 200_000;
+
+// Per-sample telemetry, emitted continuously and never the reason for a stall.
+const NOISE =
+  /^(process\.(chromium|main)|eventLoop\.sample|socket\.rendererSend|renderer\.metrics|read\.(begin|end)|clock\.synchronized)$/;
+const WINDOW_STATE = /^window\./;
+
+export type StallCause =
+  | "composition"
+  | "mainProcess"
+  | "renderer"
+  | "uninstrumented";
+
+export interface FrameStall {
+  startUs: number;
+  endUs: number;
+  durationUs: number;
+  cause: StallCause;
+  windowEvents: string[];
+  events: string[];
+  mainLoopMaxUs: number;
+}
+
+export interface FrameStallReport {
+  visibleFrames: number;
+  thresholdUs: number;
+  instrumented: boolean;
+  stalls: FrameStall[];
+}
+
+interface RecorderEvent {
+  tsUs: number;
+  name: string;
+  fields?: Record<string, unknown> | null;
+}
+
+/** Visible-frame timestamps, in the order `frames.bin` records them. */
+export function visibleFrameTimestamps(bytes: Uint8Array): number[] {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const format = new TextDecoder("ascii").decode(bytes.subarray(0, 8));
+  if (bytes.byteLength < 16 || format !== "GWFRAME1") {
+    throw new Error("frames.bin header is invalid");
+  }
+  const stride = view.getUint32(8, true);
+  if (stride !== 7 || (bytes.byteLength - 16) % (stride * 8) !== 0) {
+    throw new Error("frames.bin stride or length is invalid");
+  }
+  const records = (bytes.byteLength - 16) / (stride * 8);
+  const timestamps: number[] = [];
+  for (let record = 0; record < records; record++) {
+    const base = 16 + record * stride * 8;
+    if (view.getFloat64(base + 6 * 8, true) === 0) continue;
+    timestamps.push(view.getFloat64(base, true));
+  }
+  return timestamps;
+}
+
+export function parseRecorderEvents(text: string): RecorderEvent[] {
+  const events: RecorderEvent[] = [];
+  for (const line of text.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const value = JSON.parse(line) as RecorderEvent;
+      if (typeof value?.tsUs === "number" && typeof value?.name === "string") {
+        events.push(value);
+      }
+    } catch {
+      // A torn final line is normal in a rolled log.
+    }
+  }
+  return events;
+}
+
+export function attributeFrameStalls(
+  frames: Uint8Array,
+  events: RecorderEvent[],
+  options: { thresholdUs?: number; instrumented?: boolean } = {},
+): FrameStallReport {
+  const thresholdUs = options.thresholdUs ?? DEFAULT_THRESHOLD_US;
+  if (!Number.isFinite(thresholdUs) || thresholdUs <= 0) {
+    throw new Error("stall threshold must be a positive number");
+  }
+  const instrumented = options.instrumented ?? false;
+  const timestamps = visibleFrameTimestamps(frames);
+  const stalls: FrameStall[] = [];
+
+  for (let index = 1; index < timestamps.length; index++) {
+    const startUs = timestamps[index - 1]!;
+    const endUs = timestamps[index]!;
+    const durationUs = endUs - startUs;
+    if (durationUs <= thresholdUs) continue;
+    const near = events.filter(
+      (event) =>
+        event.tsUs > startUs - CORRELATION_US &&
+        event.tsUs < endUs + CORRELATION_US,
+    );
+    const windowEvents = near
+      .filter((event) => WINDOW_STATE.test(event.name))
+      .map((event) => `${event.name}@${(event.tsUs / 1e6).toFixed(2)}s`);
+    const mainLoopMaxUs = near
+      .filter((event) => event.name === "eventLoop.sample")
+      .reduce((worst, event) => {
+        const value = Number(event.fields?.maxUs ?? 0);
+        return Number.isFinite(value) ? Math.max(worst, value) : worst;
+      }, 0);
+    stalls.push({
+      startUs,
+      endUs,
+      durationUs,
+      // Order matters: a window that stopped being composited explains a stall
+      // that looks identical to a real one, so it is checked first.
+      cause: !instrumented
+        ? "uninstrumented"
+        : windowEvents.length
+          ? "composition"
+          : mainLoopMaxUs > BLOCKED_MAIN_US
+            ? "mainProcess"
+            : "renderer",
+      windowEvents,
+      events: near
+        .filter(
+          (event) => !NOISE.test(event.name) && !WINDOW_STATE.test(event.name),
+        )
+        .map((event) => `${event.name}@${(event.tsUs / 1e6).toFixed(2)}s`),
+      mainLoopMaxUs,
+    });
+  }
+  return {
+    visibleFrames: timestamps.length,
+    thresholdUs,
+    instrumented,
+    stalls,
+  };
+}
+
+const EXPLANATION: Record<StallCause, string> = {
+  composition:
+    "the window stopped being composited — measurement artifact, not a game stall",
+  mainProcess: "the main process was blocked",
+  renderer: "the renderer stalled with nothing else busy",
+  uninstrumented: "this capture predates window-state recording",
+};
+
+function milliseconds(valueUs: number): string {
+  return `${(valueUs / 1000).toFixed(1)} ms`;
+}
+
+function printReport(report: FrameStallReport): void {
+  console.log(`Visible frames ${report.visibleFrames}`);
+  console.log(`Threshold      ${milliseconds(report.thresholdUs)}`);
+  console.log(`Stalls         ${report.stalls.length}`);
+  if (!report.instrumented) {
+    console.log(
+      "Window state   not recorded in this capture; causes are inconclusive.",
+    );
+  }
+  for (const stall of report.stalls) {
+    console.log("");
+    console.log(
+      `Stall ${milliseconds(stall.durationUs)} at ${(stall.startUs / 1e6).toFixed(2)}s`,
+    );
+    console.log(`  cause        ${stall.cause} — ${EXPLANATION[stall.cause]}`);
+    if (stall.windowEvents.length) {
+      console.log(`  window       ${stall.windowEvents.join(", ")}`);
+    }
+    console.log(`  main loop max ${milliseconds(stall.mainLoopMaxUs)}`);
+    for (const event of stall.events.slice(0, 8)) {
+      console.log(`  event        ${event}`);
+    }
+    if (stall.events.length > 8) {
+      console.log(`  … ${stall.events.length - 8} more nearby events`);
+    }
+  }
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(path.resolve(process.argv[1])).href
+) {
+  const input = process.argv[2];
+  if (!input) {
+    console.error(
+      "usage: pnpm diagnostics:attribute-frames <capture.gwdiag> [threshold-ms]",
+    );
+    process.exitCode = 2;
+  } else {
+    const thresholdMs =
+      process.argv[3] === undefined
+        ? DEFAULT_THRESHOLD_US / 1000
+        : Number(process.argv[3]);
+    if (!Number.isFinite(thresholdMs) || thresholdMs <= 0) {
+      throw new Error("threshold-ms must be a positive number");
+    }
+    await withCapture(input, async (capture, root) => {
+      if (!capture.manifest.includedFiles.includes("frames.bin")) {
+        throw new Error("frame attribution requires a Level 1 or 2 capture");
+      }
+      printReport(
+        attributeFrameStalls(
+          new Uint8Array(await readFile(path.join(root, "frames.bin"))),
+          parseRecorderEvents(
+            await readFile(path.join(root, "events.jsonl"), "utf8"),
+          ),
+          {
+            thresholdUs: thresholdMs * 1000,
+            instrumented:
+              capture.summary.latest["renderer.focused"] !== undefined,
+          },
+        ),
+      );
+    });
+  }
+}

--- a/src/tools/diagnostics/common.ts
+++ b/src/tools/diagnostics/common.ts
@@ -318,6 +318,14 @@ export function validateCapture(capture: Capture): string[] {
       errors.push(`manifest does not declare ${file}`);
     }
   }
+  if (
+    capture.manifest.captureLevel === 2 &&
+    !capture.manifest.includedFiles.includes("chromium-trace.json")
+  ) {
+    // A failed startRecording or stopRecording drops the trace silently while
+    // the manifest still claims Level 2, so the export looks complete.
+    errors.push("Level 2 capture has no Chromium trace");
+  }
   if (capture.summary.droppedEvents > 0) {
     errors.push(`${capture.summary.droppedEvents} flight-recorder events were dropped`);
   }

--- a/src/tools/diagnostics/compare.ts
+++ b/src/tools/diagnostics/compare.ts
@@ -192,7 +192,6 @@ function compare(before: Capture, after: Capture): void {
   console.log("\nSocket bytes             before       after");
   for (const [label, metric] of [
     ["logical payload", "socket.rendererPayloadBytes"],
-    ["source backing", "socket.rendererSourceBackingBytes"],
     ["compact payload", "socket.rendererCompactBytes"],
     ["IPC payload", "socket.ipcPayloadBytes"],
     ["IPC backing", "socket.ipcBackingBytes"],

--- a/src/tools/diagnostics/summarize.ts
+++ b/src/tools/diagnostics/summarize.ts
@@ -25,7 +25,12 @@ if (!input) {
 
     console.log(`Session       ${manifest.sessionId}`);
     console.log(`App           ${manifest.applicationVersion}`);
-    console.log(`Client build  ${String(summary.latest["client.buildId"] ?? "unknown")}`);
+    console.log(
+      `Client build  ${String(summary.latest["client.buildId"] ?? "unknown")}` +
+        (summary.latest["update.usingCachedClient"]
+          ? " (UPDATE FAILED — running the cached client)"
+          : ""),
+    );
     console.log(`Capture       level ${manifest.captureLevel}`);
     console.log(
       `Trace impact  ${manifest.profilerContaminated ? "profiler-contaminated" : "clean"}`,
@@ -114,17 +119,19 @@ if (!input) {
     console.log("");
     console.log("Socket");
     const socketPayload = c["socket.rendererPayloadBytes"] ?? 0;
-    const sourceBacking = c["socket.rendererSourceBackingBytes"] ?? 0;
+    const sourceBacking = Number(
+      summary.latest["socket.rendererPeakSourceBackingBytes"] ?? 0,
+    );
     const compactBytes = c["socket.rendererCompactBytes"] ?? 0;
     const ipcPayload = c["socket.ipcPayloadBytes"] ?? 0;
     const ipcBacking = c["socket.ipcBackingBytes"] ?? 0;
     console.log(
       `  sends / bytes    ${c["socket.rendererSendCalls"] ?? 0} / ${socketPayload}`,
     );
-    console.log(
-      `  source / compact ${sourceBacking} / ${compactBytes} bytes ` +
-        `(${multiple(sourceBacking, socketPayload)} source-to-payload)`,
-    );
+    console.log(`  compact payload  ${compactBytes} bytes`);
+    // Session-scoped, unlike every other value here: one WASM heap, proving
+    // the view was compacted rather than copied wholesale.
+    console.log(`  peak view backing ${sourceBacking} bytes (whole session)`);
     console.log(
       `  IPC payload/backing ${ipcPayload} / ${ipcBacking} bytes ` +
         `(${multiple(ipcBacking, ipcPayload)} backing-to-payload)`,

--- a/tests/electron/app.spec.mjs
+++ b/tests/electron/app.spec.mjs
@@ -44,6 +44,9 @@ test.describe("Electron application", () => {
     try {
       const page = await app.firstWindow({ timeout: 30_000 });
       await page.waitForLoadState("domcontentloaded");
+      // The socket host arrives behind a dynamic import, so it is not present
+      // at domcontentloaded. Wait for the capability instead of racing it.
+      await page.waitForFunction(() => window.Module?.socket !== undefined);
       await page.evaluate(async () => {
         const sock = window.Module.socket.connect("127.0.0.1:6112");
         await new Promise((resolve, reject) => {

--- a/tests/electron/app.spec.mjs
+++ b/tests/electron/app.spec.mjs
@@ -287,9 +287,9 @@ test.describe("Electron application", () => {
       expect(externalAfter - externalBefore).toBeLessThan(16 * 1024 * 1024);
       expect(result.summary.counters["socket.rendererSendCalls"]).toBe(20);
       expect(result.summary.counters["socket.rendererPayloadBytes"]).toBe(420);
-      expect(result.summary.counters["socket.rendererSourceBackingBytes"]).toBe(
-        20 * 64 * 1024 * 1024,
-      );
+      expect(
+        result.summary.latest["socket.rendererPeakSourceBackingBytes"],
+      ).toBe(64 * 1024 * 1024);
       expect(result.summary.counters["socket.rendererCompactBytes"]).toBe(420);
       expect(result.summary.counters["socket.ipcPayloadBytes"]).toBe(420);
       expect(result.summary.counters["socket.ipcBackingBytes"]).toBe(420);

--- a/tests/electron/client-compatibility.spec.mjs
+++ b/tests/electron/client-compatibility.spec.mjs
@@ -100,6 +100,53 @@ test.describe("client compatibility", () => {
         visibleRestored: true,
         offscreen: [64, 64],
       });
+      // The cache is a separate renderer script; prove index.html loads it,
+      // that an incomplete program is never frozen, and that a completed one
+      // stops costing a round trip.
+      expect(
+        await fixture.page.evaluate(() => {
+          // Installing a second cache into the live page would otherwise
+          // overwrite gwGlRecon and bump the session's real query counters.
+          const realRecon = window.gwGlRecon;
+          const realDiagnostics = window.gwDiagnostics;
+          window.gwDiagnostics = { ...realDiagnostics, glProgramQuery: () => {} };
+          const module = { HEAPU8: new Uint8Array(new ArrayBuffer(1024)) };
+          const calls = [];
+          let answer = 0;
+          const env = {
+            glGetProgramiv: (program, pname, p) => {
+              calls.push(pname);
+              new Int32Array(module.HEAPU8.buffer)[p >>> 2] = answer;
+            },
+            glCreateProgram: () => 1,
+            glLinkProgram: () => undefined,
+            glDeleteProgram: () => undefined,
+          };
+          window.gwInstallGlProgramCache({
+            imports: { env },
+            module,
+            log: () => undefined,
+          });
+          const read = (pname) => {
+            env.glGetProgramiv(1, pname, 64);
+            return new Int32Array(module.HEAPU8.buffer)[16];
+          };
+          env.glCreateProgram();
+          const polling = [read(0x91b1), read(0x91b1)];
+          answer = 1;
+          const completed = read(0x91b1);
+          answer = 0;
+          const held = read(0x91b1);
+          window.gwGlRecon = realRecon;
+          window.gwDiagnostics = realDiagnostics;
+          return { polling, completed, held, calls: calls.length };
+        }),
+      ).toEqual({
+        polling: [0, 0],
+        completed: 1,
+        held: 1,
+        calls: 3,
+      });
       expect(await pathExists(path.join(artifacts, ".candidate.json"))).toBe(true);
       await fixture.page.evaluate(async () => {
         const socket = window.Module.socket.connect("127.0.0.1:6112");

--- a/tests/electron/diagnostics.spec.mjs
+++ b/tests/electron/diagnostics.spec.mjs
@@ -183,6 +183,15 @@ test.describe("diagnostics", () => {
             .join("\n"),
           { mode: 0o600 },
         );
+        // Chromium's atomic-write temporary for an interrupted trace, and an
+        // old-format log. Neither matches a capture-file prefix, so both used
+        // to survive every launch — one of them at 111 MB.
+        await writeFile(
+          path.join(directory, ".com.gwdevhub.guildwars.mpNbZp"),
+          '{"traceEvents":[',
+          { mode: 0o600 },
+        );
+        await writeFile(path.join(directory, "session-13880.log"), "legacy");
       },
     );
     const diagnosticRoot = await mkdtemp(path.join(tmpdir(), "gwdiag-e2e-"));
@@ -276,6 +285,27 @@ test.describe("diagnostics", () => {
       expect(events).toContain("[redacted-path]");
       expect(events).toContain("[redacted-email]");
       expect(events).toContain("performance.problemmarked");
+
+      const environment = JSON.parse(
+        await readFile(path.join(extracted, "environment.json"), "utf8"),
+      );
+      // Sampled at export, so it agrees with the renderer's own probe instead
+      // of reporting the pre-initialization defaults from before ready.
+      if (environment.graphics?.hardwareAcceleration === true) {
+        expect(environment.gpu.featureStatus.gpu_compositing).not.toBe(
+          "disabled_software",
+        );
+      }
+
+      // The directory keeps session logs and nothing else — including the
+      // seeded atomic-write temporary and the legacy log.
+      const remaining = await readdir(path.join(fixture.userData, "diagnostics"));
+      expect(remaining).toContain(`session-${previousSessionId}.jsonl`);
+      expect(remaining).not.toContain(".com.gwdevhub.guildwars.mpNbZp");
+      expect(remaining).not.toContain("session-13880.log");
+      // A Level 1 capture's frames-<session>.bin is still live here; only the
+      // Chromium trace is discarded once the export exists.
+      expect(remaining.filter((name) => name.startsWith("chromium-"))).toEqual([]);
 
       const validated = await execFileAsync(process.execPath, [
         path.join(root, "build/tools/diagnostics/validate.js"),

--- a/tests/electron/launcher.spec.mjs
+++ b/tests/electron/launcher.spec.mjs
@@ -98,6 +98,12 @@ test.describe("launcher recovery", () => {
           );
         });
       }, size);
+      // The first boot may still be resolving its data strategy when the
+      // handler above is installed, and its call would otherwise be counted
+      // alongside the reload's. Only the reload is under test.
+      await app.evaluate(() => {
+        globalThis.__fullGameVerificationCalls = 0;
+      });
       await page.reload();
 
       await expect(page.locator("#data-download")).toBeVisible();

--- a/tests/electron/launcher.spec.mjs
+++ b/tests/electron/launcher.spec.mjs
@@ -78,6 +78,11 @@ test.describe("launcher recovery", () => {
     });
     try {
       const { app, page } = fixture;
+      // The first boot parks on the strategy choice, because it resolves with
+      // the default settings and therefore never runs a Full Game
+      // verification. Waiting for it leaves the reload as the only boot that
+      // can call downloadAll, which is what the count below asserts.
+      await expect(page.locator("#data-choice")).toBeVisible();
       await page.evaluate(() =>
         window.gwNative.settings.set({ dataStrategy: "full" }),
       );
@@ -98,12 +103,6 @@ test.describe("launcher recovery", () => {
           );
         });
       }, size);
-      // The first boot may still be resolving its data strategy when the
-      // handler above is installed, and its call would otherwise be counted
-      // alongside the reload's. Only the reload is under test.
-      await app.evaluate(() => {
-        globalThis.__fullGameVerificationCalls = 0;
-      });
       await page.reload();
 
       await expect(page.locator("#data-download")).toBeVisible();

--- a/tests/integration/updater.test.mjs
+++ b/tests/integration/updater.test.mjs
@@ -89,15 +89,22 @@ describe("integration: patch updater", () => {
         : { status: 404, body: new Uint8Array() };
     };
 
+    // "ready" means the main process has an active client, which only
+    // ClientRuntime can know. A premature one here let the renderer read
+    // snapshot metadata before a client existed and stream the whole game.
+    const phases = [];
     const client = new PatchClient({
       artifactsDir: artifacts,
       chunksDir: chunks,
       patchRoot: rootUrl,
       fetch: fetchFixture,
+      onProgress: (p) => phases.push(p.phase),
     });
 
     const initial = await client.update();
     assert.equal(initial.published, true);
+    assert.ok(phases.length > 0, "the downloader reported no progress at all");
+    assert.deepEqual(phases.filter((phase) => phase === "ready"), []);
     assert.equal(initial.candidate, false);
     assert.equal((await readFile(join(artifacts, "Gw.jspi.js"))).toString(), js.toString());
     assert.equal((await stat(join(artifacts, "Gw.jspi.wasm"))).size, wasm.length);
@@ -112,9 +119,12 @@ describe("integration: patch updater", () => {
         fetches += 1;
         return fetchFixture(url);
       },
+      onProgress: (p) => phases.push(p.phase),
     });
     await client2.update();
     assert.equal(fetches, 1);
+    // The up-to-date fast path is the one that used to announce readiness.
+    assert.deepEqual(phases.filter((phase) => phase === "ready"), []);
 
     // A changed upstream client remains a candidate until it submits a frame.
     const versionEntry = manifestFiles.find((file) => file.name === "version.json");

--- a/tests/release/wasm-host.test.mjs
+++ b/tests/release/wasm-host.test.mjs
@@ -99,6 +99,42 @@ test("template file tracing is explicit, bounded, and attached only at the impor
   assert.doesNotMatch(trace, /WebAssembly\.(?:Module|Instance)\.prototype/);
 });
 
+test("the GL program cache memoizes only shader-completion state, and only once it is true", async () => {
+  const cache = await readFile(
+    path.join(root, "src/renderer/gl-program-cache.js"),
+    "utf8",
+  );
+  const harness = await readFile(path.join(root, "src/renderer/harness.js"), "utf8");
+  const graphics = await readFile(path.join(root, "src/renderer/graphics.js"), "utf8");
+
+  // KHR_parallel_shader_compile completion, and nothing else.
+  assert.match(cache, /COMPLETION_STATUS_KHR = 0x91b1/);
+
+  // The complete invalidator set, plus the context-loss edge.
+  assert.match(cache, /glCreateProgram/);
+  assert.match(cache, /glLinkProgram/);
+  assert.match(cache, /glDeleteProgram/);
+  assert.match(cache, /'gw:graphics-context-reset'/);
+  assert.match(graphics, /'gw:graphics-context-reset'/);
+  assert.match(harness, /gwInstallGlProgramCache/);
+
+  // Only a true completion is recorded. Freezing false would make the client
+  // poll a program that never finishes.
+  assert.match(cache, /=== GL_TRUE\) programs\.set\(program, true\)/);
+
+  const code = cache.replace(/\/\/.*$/gm, "");
+  // VALIDATE_STATUS depends on current GL state, so no invalidation set can
+  // exist for it; the rest either change outside link, are already memoized by
+  // the generated glue, or were measured at one query per program.
+  for (const forbidden of [/0x8b82/i, /0x8b83/i, /0x8b84/i, /0x8b85/i, /0x8b80/i, /0x8b86/i, /0x8b89/i, /0x8a36/i]) {
+    assert.doesNotMatch(code, forbidden);
+  }
+  // Reading glGetError clears the flag, and useProgram issues no round trip.
+  assert.doesNotMatch(code, /glGetError|glUseProgram|glGetShaderiv/);
+  assert.doesNotMatch(cache, /gwNative|ipc|fetch\s*\(/i);
+  assert.doesNotMatch(cache, /WebAssembly\.(?:Module|Instance)\.prototype/);
+});
+
 test("template saving uses one exact-build derived WASM and a restricted mkdir bridge", async () => {
   const transform = await readFile(
     path.join(root, "src/main/core/template-save-compat.ts"),

--- a/tests/unit/diagnostics.test.ts
+++ b/tests/unit/diagnostics.test.ts
@@ -13,11 +13,11 @@ function metrics(): RendererMetrics {
   return {
     intervalMs: 2000,
     visible: true,
+    focused: true,
     rafCount: 120,
     rafTotalUs: 2_000_000,
     rafMinUs: 16_000,
     rafMaxUs: 17_000,
-    rafOver16: 4,
     rafOver33: 0,
     rafOver50: 0,
     swapCount: 120,
@@ -51,6 +51,8 @@ function metrics(): RendererMetrics {
     memoryHits: 1,
     nativeHits: 1,
     coalesced: 0,
+    glProgramQueryHits: 0,
+    glProgramQueryMisses: 0,
     memoryCacheBytes: 1024,
     memoryCacheChunks: 1,
     pendingChunks: 0,
@@ -62,7 +64,7 @@ function metrics(): RendererMetrics {
     queuePromotions: 0,
     socketSendCalls: 1,
     socketPayloadBytes: 21,
-    socketSourceBackingBytes: 64 * 1024 * 1024,
+    socketSourceBackingMaxBytes: 64 * 1024 * 1024,
     socketCompactBytes: 21,
     socketSyncTotalUs: 90,
     socketSyncMinUs: 90,
@@ -226,6 +228,50 @@ describe("capture validation", () => {
     assert.deepEqual(validateCapture(capture), []);
     capture.summary.droppedEvents = 2;
     assert.match(validateCapture(capture).join("\n"), /2 flight-recorder events/);
+  });
+
+  it("refuses to call a Level 2 capture complete without its Chromium trace", () => {
+    const capture: Capture = {
+      manifest: {
+        formatVersion: 1,
+        applicationVersion: "1.0.0",
+        sessionId: "session",
+        captureLevel: 2,
+        exportedAt: new Date(0).toISOString(),
+        droppedEventCount: 0,
+        includedFiles: [
+          "manifest.json",
+          "summary.json",
+          "events.jsonl",
+          "histograms.json",
+          "environment.json",
+          "settings-redacted.json",
+        ],
+        redaction: "passed",
+        profilerContaminated: false,
+      },
+      summary: {
+        sessionId: "session",
+        uptimeMs: 1000,
+        captureLevel: 2,
+        droppedEvents: 0,
+        counters: {},
+        histograms: {},
+        latest: {},
+      },
+      environment: {},
+    };
+    assert.match(
+      validateCapture(capture).join("\n"),
+      /Level 2 capture has no Chromium trace/,
+    );
+    capture.manifest.includedFiles.push("chromium-trace.json");
+    assert.deepEqual(validateCapture(capture), []);
+    // A capture that never asked for a trace is not missing one.
+    capture.manifest.includedFiles.pop();
+    capture.manifest.captureLevel = 1;
+    capture.summary.captureLevel = 1;
+    assert.deepEqual(validateCapture(capture), []);
   });
 
   it("validates the machine-readable report without requiring it in old captures", () => {

--- a/tests/unit/frame-attribution.test.ts
+++ b/tests/unit/frame-attribution.test.ts
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  attributeFrameStalls,
+  parseRecorderEvents,
+  visibleFrameTimestamps,
+} from "../../src/tools/diagnostics/attribute-frames.ts";
+
+/** Build a GWFRAME1 buffer from [timestampUs, visible] pairs. */
+function frames(rows: Array<[number, number]>): Uint8Array {
+  const bytes = new Uint8Array(16 + rows.length * 7 * 8);
+  bytes.set(new TextEncoder().encode("GWFRAME1"));
+  const view = new DataView(bytes.buffer);
+  view.setUint32(8, 7, true);
+  rows.forEach(([timestampUs, visible], record) => {
+    const base = 16 + record * 7 * 8;
+    view.setFloat64(base, timestampUs, true);
+    view.setFloat64(base + 6 * 8, visible, true);
+  });
+  return bytes;
+}
+
+describe("frame attribution", () => {
+  it("reads only visible records and rejects a bad header", () => {
+    assert.deepEqual(
+      visibleFrameTimestamps(
+        frames([
+          [1_000, 1],
+          [17_000, 0],
+          [33_000, 1],
+        ]),
+      ),
+      [1_000, 33_000],
+    );
+    assert.throws(
+      () => visibleFrameTimestamps(new Uint8Array(16)),
+      /header is invalid/,
+    );
+  });
+
+  it("blames composition loss when the window changed state", () => {
+    const report = attributeFrameStalls(
+      frames([
+        [1_000_000, 1],
+        [1_400_000, 1],
+      ]),
+      parseRecorderEvents(
+        [
+          JSON.stringify({ tsUs: 1_100_000, name: "window.blurred" }),
+          JSON.stringify({ tsUs: 1_100_000, name: "process.main", fields: {} }),
+        ].join("\n"),
+      ),
+      { thresholdUs: 100_000, instrumented: true },
+    );
+    assert.equal(report.stalls.length, 1);
+    assert.equal(report.stalls[0]?.cause, "composition");
+    assert.deepEqual(report.stalls[0]?.windowEvents, ["window.blurred@1.10s"]);
+    // Per-sample telemetry is never offered as an explanation.
+    assert.deepEqual(report.stalls[0]?.events, []);
+  });
+
+  it("blames the main process only when its event loop actually blocked", () => {
+    const blocked = attributeFrameStalls(
+      frames([
+        [1_000_000, 1],
+        [1_400_000, 1],
+      ]),
+      parseRecorderEvents(
+        JSON.stringify({
+          tsUs: 1_200_000,
+          name: "eventLoop.sample",
+          fields: { maxUs: 300_000 },
+        }),
+      ),
+      { thresholdUs: 100_000, instrumented: true },
+    );
+    assert.equal(blocked.stalls[0]?.cause, "mainProcess");
+    assert.equal(blocked.stalls[0]?.mainLoopMaxUs, 300_000);
+
+    const idle = attributeFrameStalls(
+      frames([
+        [1_000_000, 1],
+        [1_400_000, 1],
+      ]),
+      parseRecorderEvents(
+        [
+          JSON.stringify({
+            tsUs: 1_200_000,
+            name: "eventLoop.sample",
+            fields: { maxUs: 26_000 },
+          }),
+          JSON.stringify({
+            tsUs: 1_050_000,
+            name: "socket.error",
+            fields: { message: "read ECONNRESET" },
+          }),
+        ].join("\n"),
+      ),
+      { thresholdUs: 100_000, instrumented: true },
+    );
+    assert.equal(idle.stalls[0]?.cause, "renderer");
+    assert.deepEqual(idle.stalls[0]?.events, ["socket.error@1.05s"]);
+  });
+
+  it("refuses to blame anything when the capture predates the instrumentation", () => {
+    const report = attributeFrameStalls(
+      frames([
+        [1_000_000, 1],
+        [1_400_000, 1],
+      ]),
+      [],
+      { thresholdUs: 100_000 },
+    );
+    assert.equal(report.instrumented, false);
+    assert.equal(report.stalls[0]?.cause, "uninstrumented");
+  });
+
+  it("ignores gaps under the threshold and events outside the window", () => {
+    const report = attributeFrameStalls(
+      frames([
+        [1_000_000, 1],
+        [1_016_000, 1],
+        [1_400_000, 1],
+      ]),
+      parseRecorderEvents(
+        [
+          // Three seconds before the stall: outside the correlation window.
+          JSON.stringify({ tsUs: 1_000_000 - 3_000_000, name: "window.blurred" }),
+          "{ this line is torn",
+        ].join("\n"),
+      ),
+      { thresholdUs: 100_000, instrumented: true },
+    );
+    assert.equal(report.stalls.length, 1);
+    assert.equal(report.stalls[0]?.durationUs, 384_000);
+    assert.equal(report.stalls[0]?.cause, "renderer");
+  });
+
+  it("rejects a non-positive threshold", () => {
+    assert.throws(
+      () => attributeFrameStalls(frames([[0, 1]]), [], { thresholdUs: 0 }),
+      /positive number/,
+    );
+  });
+});

--- a/tests/unit/gl-program-cache.test.ts
+++ b/tests/unit/gl-program-cache.test.ts
@@ -1,0 +1,334 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+import vm from "node:vm";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+const source = await readFile(
+  path.join(root, "src/renderer/gl-program-cache.js"),
+  "utf8",
+);
+
+const COMPLETION_STATUS = 0x91b1;
+const LINK_STATUS = 0x8b82;
+const ACTIVE_UNIFORMS = 0x8b86;
+const ACTIVE_ATTRIBUTES = 0x8b89;
+const ACTIVE_UNIFORM_BLOCKS = 0x8a36;
+const VALIDATE_STATUS = 0x8b83;
+const DELETE_STATUS = 0x8b80;
+const ATTACHED_SHADERS = 0x8b85;
+const INFO_LOG_LENGTH = 0x8b84;
+const ACTIVE_UNIFORM_MAX_LENGTH = 0x8b87;
+
+const OUT = 64;
+const GL_FALSE = 0;
+const GL_TRUE = 1;
+
+type GlEnv = {
+  glGetProgramiv: (program: number, pname: number, p: number) => void;
+  glCreateProgram: () => number;
+  glLinkProgram: (program: number) => void;
+  glDeleteProgram: (program: number) => void;
+};
+
+interface Fixture {
+  env: Partial<GlEnv>;
+  module: { HEAPU8: Uint8Array };
+  words: Int32Array;
+  /** Every (program, pname) pair that reached the underlying import. */
+  calls: Array<[number, number]>;
+  /** What the underlying import writes; change it to detect staleness. */
+  answer: { value: number; writes: boolean };
+  warnings: string[];
+  listeners: Map<string, Array<() => void>>;
+  reconOf(): { livePrograms: number; passThrough: Record<string, number> };
+  setHeap(bytes: Uint8Array): void;
+  recycle(id: number): void;
+}
+
+function fixture(options: { omit?: Array<keyof GlEnv> } = {}): Fixture {
+  const omit = new Set(options.omit ?? []);
+  const module = { HEAPU8: new Uint8Array(new ArrayBuffer(2048)) };
+  const calls: Array<[number, number]> = [];
+  const answer = { value: GL_TRUE, writes: true };
+  const warnings: string[] = [];
+  const listeners = new Map<string, Array<() => void>>();
+  let nextProgram = 1;
+  const queued: number[] = [];
+
+  const full: GlEnv = {
+    glGetProgramiv(program, pname, p) {
+      calls.push([program, pname]);
+      // The generated glue leaves params untouched on its error branches.
+      if (!answer.writes) return;
+      new Int32Array(module.HEAPU8.buffer)[p >>> 2] = answer.value;
+    },
+    glCreateProgram: () => queued.shift() ?? nextProgram++,
+    glLinkProgram: () => {},
+    glDeleteProgram: () => {},
+  };
+  const env: Partial<GlEnv> = {};
+  for (const name of Object.keys(full) as Array<keyof GlEnv>) {
+    if (!omit.has(name)) env[name] = full[name] as never;
+  }
+
+  const window = {
+    gwInstallGlProgramCache: undefined as
+      | ((options: {
+          imports: { env?: Partial<GlEnv> };
+          module: { HEAPU8: Uint8Array };
+          log(...values: unknown[]): void;
+        }) => void)
+      | undefined,
+    gwGlRecon: undefined as
+      | (() => { livePrograms: number; passThrough: Record<string, number> })
+      | undefined,
+    gwDiagnostics: undefined,
+    dispatchEvent: () => true,
+  };
+  const context = {
+    ArrayBuffer,
+    Int32Array,
+    Map,
+    Object,
+    Uint8Array,
+    window,
+    addEventListener(name: string, listener: () => void) {
+      const bucket = listeners.get(name) ?? [];
+      bucket.push(listener);
+      listeners.set(name, bucket);
+    },
+  };
+  Object.assign(context, { globalThis: context });
+  vm.runInNewContext(source, context);
+  window.gwInstallGlProgramCache?.({
+    imports: { env },
+    module,
+    log: (...values: unknown[]) => warnings.push(values.join(" ")),
+  });
+
+  return {
+    env,
+    module,
+    get words() {
+      return new Int32Array(module.HEAPU8.buffer);
+    },
+    calls,
+    answer,
+    warnings,
+    listeners,
+    reconOf: () => window.gwGlRecon?.() ?? { livePrograms: 0, passThrough: {} },
+    setHeap: (bytes) => {
+      module.HEAPU8 = bytes;
+    },
+    recycle: (id: number) => queued.push(id),
+  } as Fixture;
+}
+
+/** Query through the installed wrapper and return what landed in the heap. */
+function query(value: Fixture, program: number, pname: number): number {
+  value.env.glGetProgramiv?.(program, pname, OUT);
+  return value.words[OUT >>> 2] ?? 0;
+}
+
+test("a completed program is answered without another round trip", () => {
+  const value = fixture();
+  const program = value.env.glCreateProgram!();
+  assert.equal(query(value, program, COMPLETION_STATUS), GL_TRUE);
+  value.answer.value = 0xbad;
+  assert.equal(query(value, program, COMPLETION_STATUS), GL_TRUE);
+  assert.deepEqual(value.calls, [[program, COMPLETION_STATUS]]);
+});
+
+test("an incomplete program is never frozen, however often it is polled", () => {
+  // The client polls until this flips. Caching false would make it poll a
+  // program that never finishes — a hang, not a slow frame.
+  const value = fixture();
+  const program = value.env.glCreateProgram!();
+  value.answer.value = GL_FALSE;
+  for (let poll = 0; poll < 5; poll += 1) {
+    assert.equal(query(value, program, COMPLETION_STATUS), GL_FALSE);
+  }
+  assert.equal(value.calls.length, 5);
+
+  // The moment it completes, that is observed and then held.
+  value.answer.value = GL_TRUE;
+  assert.equal(query(value, program, COMPLETION_STATUS), GL_TRUE);
+  assert.equal(value.calls.length, 6);
+  assert.equal(query(value, program, COMPLETION_STATUS), GL_TRUE);
+  assert.equal(value.calls.length, 6);
+});
+
+test("relinking makes a completed program incomplete again", () => {
+  const value = fixture();
+  const first = value.env.glCreateProgram!();
+  const second = value.env.glCreateProgram!();
+  query(value, first, COMPLETION_STATUS);
+  query(value, second, COMPLETION_STATUS);
+  value.calls.length = 0;
+
+  value.env.glLinkProgram!(first);
+  value.answer.value = GL_FALSE;
+  assert.equal(query(value, first, COMPLETION_STATUS), GL_FALSE);
+  // The other program keeps its completion.
+  assert.equal(query(value, second, COMPLETION_STATUS), GL_TRUE);
+  assert.deepEqual(value.calls, [[first, COMPLETION_STATUS]]);
+});
+
+test("a recycled program name never inherits the deleted program's completion", () => {
+  const value = fixture();
+  const program = value.env.glCreateProgram!();
+  assert.equal(query(value, program, COMPLETION_STATUS), GL_TRUE);
+
+  value.env.glDeleteProgram!(program);
+  value.recycle(program);
+  assert.equal(value.env.glCreateProgram!(), program);
+
+  value.calls.length = 0;
+  value.answer.value = GL_FALSE;
+  assert.equal(query(value, program, COMPLETION_STATUS), GL_FALSE);
+  assert.deepEqual(value.calls, [[program, COMPLETION_STATUS]]);
+});
+
+test("a name the host never saw created always reaches the client", () => {
+  const value = fixture();
+  assert.equal(query(value, 42, COMPLETION_STATUS), GL_TRUE);
+  assert.equal(query(value, 42, COMPLETION_STATUS), GL_TRUE);
+  assert.equal(value.calls.length, 2);
+
+  // The glue's out-of-range branch writes nothing; recording the out-pointer
+  // there would capture whatever happened to be in memory.
+  value.words[OUT >>> 2] = 0xdead;
+  value.answer.writes = false;
+  assert.equal(query(value, 42, COMPLETION_STATUS), 0xdead);
+  assert.equal(value.calls.length, 3);
+});
+
+test("every pname except completion reaches the client every time", () => {
+  for (const pname of [
+    // Measured at exactly one query per program, so caching buys nothing.
+    LINK_STATUS,
+    ACTIVE_UNIFORMS,
+    ACTIVE_ATTRIBUTES,
+    ACTIVE_UNIFORM_BLOCKS,
+    // Unsafe or already memoized by the generated glue.
+    VALIDATE_STATUS,
+    DELETE_STATUS,
+    ATTACHED_SHADERS,
+    INFO_LOG_LENGTH,
+    ACTIVE_UNIFORM_MAX_LENGTH,
+    0x1234,
+  ]) {
+    const value = fixture();
+    const program = value.env.glCreateProgram!();
+    const label = `pname 0x${pname.toString(16)}`;
+    assert.equal(query(value, program, pname), GL_TRUE, label);
+    value.answer.value = 12;
+    assert.equal(query(value, program, pname), 12, label);
+    assert.equal(value.calls.length, 2, label);
+  }
+});
+
+test("null and misaligned out-pointers pass through and record nothing", () => {
+  const value = fixture();
+  const program = value.env.glCreateProgram!();
+  value.env.glGetProgramiv!(program, COMPLETION_STATUS, 0);
+  value.env.glGetProgramiv!(program, COMPLETION_STATUS, 3);
+  assert.equal(value.calls.length, 2);
+  assert.equal(query(value, program, COMPLETION_STATUS), GL_TRUE);
+  assert.equal(value.calls.length, 3);
+});
+
+test("losing the GL context drops every memoized program", () => {
+  const value = fixture();
+  const program = value.env.glCreateProgram!();
+  query(value, program, COMPLETION_STATUS);
+  assert.equal(value.reconOf().livePrograms, 1);
+
+  for (const listener of value.listeners.get("gw:graphics-context-reset") ?? []) {
+    listener();
+  }
+  assert.equal(value.reconOf().livePrograms, 0);
+
+  value.calls.length = 0;
+  value.answer.value = GL_FALSE;
+  assert.equal(query(value, program, COMPLETION_STATUS), GL_FALSE);
+  assert.deepEqual(value.calls, [[program, COMPLETION_STATUS]]);
+});
+
+test("a missing invalidator leaves every import untouched", () => {
+  const bare = fixture({
+    omit: ["glGetProgramiv", "glCreateProgram", "glLinkProgram", "glDeleteProgram"],
+  });
+  assert.equal(bare.warnings.length, 1);
+  assert.match(bare.warnings[0] ?? "", /\[warn\]/);
+
+  // The read is present but an invalidator is not: install nothing at all.
+  const partial = fixture({ omit: ["glLinkProgram"] });
+  assert.equal(partial.warnings.length, 1);
+  const program = partial.env.glCreateProgram!();
+  assert.equal(query(partial, program, COMPLETION_STATUS), GL_TRUE);
+  partial.answer.value = 55;
+  assert.equal(query(partial, program, COMPLETION_STATUS), 55);
+  assert.equal(partial.calls.length, 2);
+});
+
+test("programs beyond the ceiling stay correct by passing through", () => {
+  const value = fixture();
+  for (let index = 0; index < 1024; index += 1) value.env.glCreateProgram!();
+  const overflow = value.env.glCreateProgram!();
+  assert.equal(value.reconOf().livePrograms, 1024);
+
+  value.calls.length = 0;
+  assert.equal(query(value, overflow, COMPLETION_STATUS), GL_TRUE);
+  value.answer.value = 21;
+  assert.equal(query(value, overflow, COMPLETION_STATUS), 21);
+  assert.equal(value.calls.length, 2);
+});
+
+test("hits and misses both return the client's void result", () => {
+  const value = fixture();
+  const program = value.env.glCreateProgram!();
+  assert.equal(value.env.glGetProgramiv!(program, COMPLETION_STATUS, OUT), undefined);
+  assert.equal(value.env.glGetProgramiv!(program, COMPLETION_STATUS, OUT), undefined);
+  assert.equal(value.env.glGetProgramiv!(program, VALIDATE_STATUS, OUT), undefined);
+});
+
+test("a grown WASM heap is followed on both the miss and the hit", () => {
+  const value = fixture();
+  const program = value.env.glCreateProgram!();
+  assert.equal(query(value, program, COMPLETION_STATUS), GL_TRUE);
+
+  value.setHeap(new Uint8Array(new ArrayBuffer(8192)));
+  value.calls.length = 0;
+  assert.equal(query(value, program, COMPLETION_STATUS), GL_TRUE);
+  assert.deepEqual(value.calls, []);
+});
+
+test("reconnaissance counts the queries that still reach the client", () => {
+  const value = fixture();
+  const program = value.env.glCreateProgram!();
+  // Served from the cache after the first miss, so it never shows here.
+  query(value, program, COMPLETION_STATUS);
+  query(value, program, COMPLETION_STATUS);
+  query(value, program, VALIDATE_STATUS);
+  query(value, program, VALIDATE_STATUS);
+  query(value, program, INFO_LOG_LENGTH);
+  assert.deepEqual(value.reconOf().passThrough, {
+    "0x8B83": 2,
+    "0x8B84": 1,
+  });
+});
+
+test("completion polls the cache cannot serve stay visible", () => {
+  // Otherwise a poll storm against untracked programs is invisible in both the
+  // counters and the recon, which is exactly what they exist to reveal.
+  const value = fixture();
+  for (let poll = 0; poll < 3; poll += 1) query(value, 42, COMPLETION_STATUS);
+  const overflowSafe = value.env.glCreateProgram!();
+  value.env.glGetProgramiv!(overflowSafe, COMPLETION_STATUS, 3);
+  assert.deepEqual(value.reconOf().passThrough, { "0x91B1": 4 });
+  assert.equal(value.calls.length, 4);
+});

--- a/tests/unit/manifest.test.ts
+++ b/tests/unit/manifest.test.ts
@@ -86,8 +86,43 @@ describe("manifest", () => {
           directories: [{ name: "root" }],
           files: [{ name: "a", size: 1, chunkHashes: [hashA], parentIndex: 9 }],
         }),
-      (e: unknown) => e instanceof AppError && e.code === "manifest_parent",
+      (e: unknown) =>
+        e instanceof AppError &&
+        e.code === "manifest_parent" &&
+        // The offending index and the list length, so a failure is actionable
+        // from the diagnostics export alone.
+        e.message.includes("9") &&
+        e.message.includes("1"),
     );
+  });
+
+  it("treats an explicitly null parentIndex as the root", () => {
+    // The live patch service publishes a flat manifest whose entries all carry
+    // parentIndex: null. Rejecting it made every client update fall back to
+    // the cached client, silently, on every launch.
+    const mf = new Manifest({
+      compressionMode: "none",
+      chunkSize: 262144,
+      directories: [],
+      files: [
+        { name: "Gw.jspi.wasm", size: 4, chunkHashes: [hashA], parentIndex: null },
+        { name: "version.json", size: 4, chunkHashes: [hashB], parentIndex: null },
+      ],
+    });
+    assert.equal(mf.find("Gw.jspi.wasm"), "Gw.jspi.wasm");
+    assert.equal(mf.find("version.json"), "version.json");
+
+    // Directories take the same path, and theirs feeds the parent recursion
+    // and the duplicate-path check.
+    const nested = new Manifest({
+      compressionMode: "none",
+      chunkSize: 262144,
+      directories: [{ name: "pad", parentIndex: null }, { name: "client" }],
+      files: [
+        { name: "Gw.dat", size: 4, chunkHashes: [hashA], parentIndex: 1 },
+      ],
+    });
+    assert.equal(nested.find("Gw.dat"), "client/Gw.dat");
   });
 
   it("rejects unsafe names, duplicate paths, and invalid sizes", () => {

--- a/tsconfig.renderer.json
+++ b/tsconfig.renderer.json
@@ -17,6 +17,7 @@
     "src/renderer/gw-native.d.ts",
     "src/renderer/diagnostics.js",
     "src/renderer/filesystem.js",
+    "src/renderer/gl-program-cache.js",
     "src/renderer/graphics.js",
     "src/renderer/harness.js",
     "src/renderer/input.js",


### PR DESCRIPTION
## What this fixes

Started as "we still have stuttering". The frame percentiles turned out to be
the least of it.

| | before | after |
|---|---:|---:|
| network streamed per session | **558 MB** | 44 KB |
| snapshot reads | 0 | 2,140 |
| snapshot read p95 (renderer) | 100 ms | 0.1 ms |
| blocking GPU round-trips from completion polls | 36,713 | 0 |
| startup to first frame | 77 s | ~20 s |
| ArenaNet client updates | never applied | apply |

Frame pacing after: p50 16.7 ms, p95 17.7 ms, p99 19.5 ms; 97.1% of frames under
18 ms. Chromium's own frame reporter: 0.07% high-latency, 0% missing content.

### The big one

`PatchClient` announced `phase: "ready"` before `ClientRuntime` had activated a
client. The launcher reads that as "an active client exists", so the renderer
fetched snapshot metadata too early, got `size: 0` from a null chunk store, and
the client concluded it had no local data — streaming the whole game from
ArenaNet instead of reading the resident 4.2 GB snapshot. Latent for a long
time; a slow full-download phase used to hide the race.

Readiness now has exactly one source, enforced in the type system: reintroducing
the emit in `PatchClient` fails to compile.

### The second one

The live patch manifest sends `parentIndex: null`. `validateParent` handled
`undefined` but not `null`, so every launch silently fell back to the cached
client.

## What was measured and rejected

Recorded here so nobody re-tries them:

- **Readahead prefetch** — the chunk scheduler already saturates its 8-way ceiling.
- **Low-latency / direct canvas** — Chromium reports 0.76% compositor-affected frames. Nothing to win.
- **`glGetError` caching** — stateful; reading clears the flag.
- **Caching the link-derived pnames** — the client asks each exactly once per program (690 queries, 0 repeats).
- **A completion-FIFO pacer** — the worst stall is *one* rAF callback with no yields (95.8% of it in a single task). There is nothing to interleave.

What remains is the client's own work: zone loads (~264 ms parsing map data) and
first-use shader pipeline creation. Both are inside ArenaNet's WASM and cannot be
preempted from the host.

## Diagnostics

These made the export actively mislead its reader:

- GPU status was sampled before the GPU process existed — a machine on ANGLE/Metal reported `disabled_software` across the board.
- The directory sweep matched filename prefixes, so Chromium's atomic-write temporaries were unreachable; a truncated 111 MB trace had survived every launch for days.
- `rafOver16` fired on 56% of frames in a healthy 60 Hz session.
- `socketSourceBackingBytes` reached 36.8 GB across 101 sends by summing the WASM heap size.

Plus new window-state recording — an occluded macOS window stops compositing
with no CPU anywhere, which is indistinguishable from a real freeze unless
recorded — and `diagnostics:attribute-frames`, its consumer and the Level 1
counterpart to `attribute-stalls`.

## Verification

`pnpm verify` green end to end: lint, typecheck, 143 unit, integration, 31
Electron, 31 release, package, packaged smoke.

Two suites (`chunk-store`, `launcher`) are flaky under full-suite load and pass
consistently in isolation; that predates this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
