### PR TITLE
Stop Option-held keys from sticking the client's movement

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -387,6 +387,20 @@ held-input registry releases keys, buttons, and touches when focus or native UI
 consumes an input release. Pointer lock uses a virtual cursor and recycles a
 held drag at canvas edges so camera rotation does not stall.
 
+The client identifies a key by `KeyboardEvent.key`, so its held-key state is
+character state, not physical state. macOS makes Option a text modifier, which
+rewrites that character for as long as Option is held: `W` arrives as `∑` on a
+US layout, and as a bound character on others — a German Option+L is `@`, which
+the client reads as the `2` key. A press and its release therefore disagree
+whenever Option is held across only one of them, and the key the client believes
+is down never comes up. The input host reads the OS layout map, restates the
+event with the unmodified character of `event.code`, and stops the rewritten
+original so the client sees exactly one event per physical transition. Text
+fields are restated too, because the client relays their key events to the
+canvas; only propagation is stopped, so the field still types the composed
+character. Command is different — macOS withholds the release entirely — and
+that stays handled by releasing every non-modifier key when Command comes up.
+
 ## Diagnostics
 
 Every event uses an integer monotonic microsecond timestamp, sequence number,

--- a/src/renderer/gw-native.d.ts
+++ b/src/renderer/gw-native.d.ts
@@ -5,6 +5,15 @@ import type {
 } from "../shared/diagnostics.js";
 
 declare global {
+  // Keyboard Map API: Chromium ships it, TypeScript's DOM library does not.
+  interface Keyboard extends EventTarget {
+    getLayoutMap(): Promise<ReadonlyMap<string, string>>;
+  }
+
+  interface Navigator {
+    readonly keyboard?: Keyboard;
+  }
+
   interface GameInputDiagnostics {
     event(name: string, value?: unknown): void;
   }

--- a/src/renderer/input.js
+++ b/src/renderer/input.js
@@ -183,6 +183,78 @@
       }));
     };
 
+    // macOS treats Option as a text modifier, so a held Option rewrites
+    // KeyboardEvent.key: W arrives as "∑" on a US layout, and as an unrelated
+    // ASCII character ("@", "|") on others. ArenaNet's client identifies keys
+    // by that string, so an Option-held release never clears the key its press
+    // registered — holding Option to read merchant names while running left
+    // movement keys down for good. The physical key is in `code`; ask the OS
+    // what that key produces unmodified, and restate the event before the
+    // client (or our own held-key registry) sees it.
+    /** @type {Map<string, string>} */
+    let layoutKeys = new Map();
+    const readLayoutKeys = () => {
+      const layout = navigator.keyboard?.getLayoutMap?.();
+      if (!layout) {
+        log('[warn] keyboard layout unavailable; Option-held keys may stick');
+        return;
+      }
+      layout.then((map) => {
+        layoutKeys = new Map(map);
+      }).catch((error) => {
+        diagnostics?.event('keyboard.layoutFailed', error);
+        log(
+          '[warn] keyboard layout unreadable:',
+          error instanceof Error ? error.message : String(error),
+        );
+      });
+    };
+    readLayoutKeys();
+    // Chromium has no layout-change event, and switching input source does not
+    // reach the game while another window owns it. Re-reading on focus is the
+    // last moment before the new layout can produce a key.
+    window.addEventListener('focus', readLayoutKeys);
+
+    /**
+     * Returns the key the client should see, having already re-dispatched a
+     * corrected event in place of a modifier-rewritten one.
+     * @param {KeyboardEvent} event
+     */
+    const layoutKey = (event) => {
+      const target = event.target;
+      if (!event.altKey || !target) return event.key;
+      const key = layoutKeys.get(event.code);
+      if (!key || key.toUpperCase() === event.key.toUpperCase()) return event.key;
+      // One event per physical transition: the rewritten one must not also
+      // reach the client, or a layout whose Option layer produces a bound
+      // character presses that binding and never releases it — a German
+      // Option+L is "@", which the client reads as the 2 key going down.
+      // Text entry is restated too: the client's own OSK fields relay key
+      // events to the canvas, so they carry the same rewrite to the same
+      // state. Only propagation stops here, so the field still types the
+      // character the OS composed.
+      event.stopImmediatePropagation();
+      const restated = new globalThis.KeyboardEvent(event.type, {
+        bubbles: true,
+        cancelable: true,
+        key,
+        code: event.code,
+        location: event.location,
+        repeat: event.repeat,
+        ctrlKey: event.ctrlKey,
+        shiftKey: event.shiftKey,
+        altKey: event.altKey,
+        metaKey: event.metaKey,
+      });
+      Object.defineProperties(restated, {
+        charCode: { value: event.charCode },
+        keyCode: { value: event.keyCode },
+        which: { value: event.which },
+      });
+      target.dispatchEvent(restated);
+      return key;
+    };
+
     function releasePointer() {
       pointerWanted = false;
       virtualCursor = null;
@@ -259,10 +331,12 @@
     }
 
     window.addEventListener('keydown', (event) => {
-      if (!event.isTrusted || (event.repeat && heldKeys.has(event.code))) return;
+      if (!event.isTrusted) return;
+      const key = layoutKey(event);
+      if (event.repeat && heldKeys.has(event.code)) return;
       heldKeys.set(event.code, {
         target: event.target,
-        key: event.key,
+        key,
         code: event.code,
         location: event.location,
         charCode: event.charCode,
@@ -276,6 +350,7 @@
     }, true);
     window.addEventListener('keyup', (event) => {
       if (!event.isTrusted) return;
+      layoutKey(event);
       heldKeys.delete(event.code);
       if (event.code === 'MetaLeft' || event.code === 'MetaRight') {
         releaseKeys((code) =>

--- a/tests/electron/input.spec.mjs
+++ b/tests/electron/input.spec.mjs
@@ -147,6 +147,84 @@ test.describe("renderer input", () => {
     }
   });
 
+  test("restates keys macOS rewrites while Option is held", async () => {
+    const fixture = await launchOffline("gw-option-key-e2e-");
+    try {
+      const { page } = fixture;
+      await startGameInput(page);
+      await page.evaluate(() => {
+        window.__gameKeys = [];
+        // Registered after the game input host, so anything it stops — the
+        // rewritten original — never arrives here or at the client.
+        for (const type of ["keydown", "keyup"]) {
+          window.addEventListener(
+            type,
+            (event) => {
+              if (event.code !== "KeyW") return;
+              window.__gameKeys.push(
+                `${event.type}:${event.key}:${event.keyCode}`,
+              );
+            },
+            true,
+          );
+        }
+        globalThis.document.getElementById("canvas").focus();
+      });
+
+      // macOS reports the Option layer in `key` while leaving `code` alone, so
+      // a key pressed before Option is held is released as a different key.
+      const cdp = await fixture.app.context().newCDPSession(page);
+      const alt = 1;
+      const sendW = (type, key, modifiers = 0, text = undefined) =>
+        cdp.send("Input.dispatchKeyEvent", {
+          type,
+          key,
+          code: "KeyW",
+          windowsVirtualKeyCode: 87,
+          nativeVirtualKeyCode: 87,
+          modifiers,
+          ...(text === undefined ? {} : { text }),
+        });
+
+      await sendW("keyDown", "w");
+      await sendW("keyUp", "∑", alt);
+      await sendW("keyDown", "∑", alt);
+      // The registry must hold the restated key, or the interruption path
+      // releases a key the client never saw pressed.
+      await page.evaluate(() =>
+        window.dispatchEvent(new globalThis.CustomEvent("gw:input-reset")),
+      );
+
+      expect(await page.evaluate(() => window.__gameKeys)).toEqual([
+        "keydown:w:87",
+        "keyup:w:87",
+        "keydown:w:87",
+        "keyup:w:87",
+      ]);
+
+      // The client relays key events from its own text fields to the canvas,
+      // so a rewritten release strands a key there too. Restating must not
+      // cost the field the character the OS composed.
+      await page.evaluate(() => {
+        window.__gameKeys = [];
+        const text = globalThis.document.getElementById("osk-input-text");
+        window.Module.oskActiveInput = text;
+        text.value = "";
+        text.focus();
+      });
+      await sendW("keyDown", "∑", alt, "∑");
+      await sendW("keyUp", "w");
+      expect(
+        await page.evaluate(() => ({
+          keys: window.__gameKeys,
+          typed: globalThis.document.getElementById("osk-input-text").value,
+        })),
+      ).toEqual({ keys: ["keydown:w:87", "keyup:w:87"], typed: "∑" });
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
   test("uses the native click count for double-tap compatibility", async () => {
     const fixture = await launchOffline("gw-double-click-e2e-");
     try {


### PR DESCRIPTION
Holding Option to read merchant names while running left the character in
permanent autorun. The keys were never stuck in our listeners — the client's own
key state was.

## Why

ArenaNet's client identifies a key by `KeyboardEvent.key`, the character, not by
`code`. Its table in `Gw.jspi.wasm` is 20-byte records of
`{ u32 keyId, char name[16] }` holding `" "`, `","`, `"Escape"`, `"A"`, `"@"`;
there is no `"KeyW"` or `"Space"` anywhere in the module. The client's held-key
state is therefore character state, not physical state.

macOS makes Option a text modifier, so the character changes while the physical
key does not:

| moment | `code` | key the client sees |
| --- | --- | --- |
| press W, running | `KeyW` | `w` — W goes down |
| hold Option for merchant names | | |
| release W | `KeyW` | `∑` — unknown; `w` never comes up |

The client keeps running until something else clears the key. Non-US layouts are
worse, because their Option layer produces characters the client *does* know: a
German Option+L is `@`, which shares key id `0x32` with `2`, so it presses the
client's 2 key and never releases it.

Our own interruption path was disarmed by the same rewrite. `releaseAll` replayed
the stored `∑`, and the registry deleted its entry on the rewritten keyup, so
blur could not always recover either.

## The fix

`input.js` reads the OS layout map — `navigator.keyboard.getLayoutMap()`, so
`code` resolves correctly on QWERTZ and AZERTY too — and when Option has
rewritten a key, stops the rewritten event and re-dispatches one carrying that
key's unmodified character. The client sees exactly one event per physical
transition, and the held-key registry stores the restated key, so the
blur/interrupt release now speaks the client's language.

Chromium has no layout-change event, so the map is re-read on window focus:
switching input source cannot reach the game while another window owns it.

Text fields are restated too. The client relays key events from its own OSK
fields to the canvas, carrying the same rewrite into the same state. Only
propagation is stopped, so the field still types the character the OS composed.

## What was checked and left alone

- **Shift** is safe, and the table proves it: both shift variants of a key share
  one id (`"2"`/`"@"` → `0x32`, `"-"`/`"_"` → `7`), so a press and release
  straddling Shift resolve to the same key.
- **Caps Lock and Control** do not rewrite `key` on macOS.
- **Command** is a different defect — macOS withholds the release entirely —
  already handled by releasing every non-modifier key when Command comes up.
- **Dead keys and IME** are asymmetric in the safe direction: unknown down,
  known up, so nothing strands.

## Verification

`tests/electron/input.spec.mjs` reproduces the macOS rewrite over CDP, the only
way to produce a trusted event whose `key` and `code` disagree. It fails on the
old code with the reported symptom (`keyup:∑:87` where the client needed
`keyup:w:87`) and covers the OSK route, asserting the field still receives `∑`
as text.

`pnpm check` 177/177 · `test:integration` 18/18 · `test:release` 35/35 ·
`test:electron` 36 passed, 1 skipped. Confirmed in the running game.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
