### PR TITLE
Prepare 2026.7.0-beta.1 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "guild-wars",
   "productName": "Guild Wars",
-  "version": "2026.7.0-alpha.1",
+  "version": "2026.7.0-beta.1",
   "private": true,
   "packageManager": "pnpm@11.13.1",
   "type": "module",


### PR DESCRIPTION
## What changed

- advances the single release version in `package.json` from `2026.7.0-alpha.1` to `2026.7.0-beta.1`
- produces macOS `CFBundleShortVersionString` `2026.7.0` and monotonic `CFBundleVersion` `2607.0.31`
- leaves release notes, tags, and bundle metadata derived from that one canonical version

## Why

The merged beta foundation is ready for a beta release cut. This intentionally changes only the canonical release version; the existing workflow derives the tag, prerelease status, artifact names, bundle versions, checksums, SBOM, attestations, and generated release notes.

## Player and developer impact

Once merged and published, this becomes the `v2026.7.0-beta.1` prerelease. Stable-download surfaces will continue to ignore prereleases, while existing prerelease installs can be offered the newer beta when they explicitly check.

## Validation

- [x] release version mapping: `2026.7.0` / `2607.0.31`
- [x] `pnpm check`: typecheck, lint, link checks, 474 unit tests, 111 policy tests
- [x] `pnpm test:release`: 21 tests
- [x] 20 integration tests
- [x] Electron suite: 50 passed, 1 intentional live-network skip; four local timing/focus failures all passed on immediate isolated rerun
- [x] macOS arm64 beta package built and ad-hoc signature verification passed
- [x] `pnpm test:packaged` passed in the required local-app launch environment, including renderer/IPC and Toolbox lifecycle smoke tests
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [x] Documentation did not need updating because release behavior and invariants are unchanged.

## Release handoff after merge

The release workflow requires a successful ArenaNet client canary on `main`. No successful `main` canary exists yet, so run that workflow after this PR merges and publish only after it is green.
