### PR TITLE
fix: keep camera rotation smooth in small windows

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -518,7 +518,18 @@ pointer lock. `input.js` owns the canvas input listeners and accepts validated
 touch settings from the settings owner; it does not persist settings itself. One
 held-input registry releases keys, buttons, and touches when focus or native UI
 consumes an input release. Pointer lock uses a virtual cursor and recycles a
-held drag at canvas edges so camera rotation does not stall.
+held drag so camera rotation does not stall.
+
+That recycle is rare by construction. The client keeps integrating mouse moves
+whose coordinates fall outside the canvas, so a held right-drag is free to roam
+sixteen canvases before the host releases the button, re-anchors at center, and
+presses again — several camera revolutions apart at any window size. Stopping at
+the canvas edge instead, as the host first did, made the recycle rate inversely
+proportional to the window: a 941px canvas recycled on about every third mouse
+move against every twenty-fifth on an 1866px one. Both halves of that cost the
+smaller window: the released button interrupts the client's drag, and until the
+leftover delta was spent in the same task rather than the next animation frame,
+each recycle also froze the camera for a frame.
 
 The client identifies a key by `KeyboardEvent.key`, so its held-key state is
 character state, not physical state. macOS makes Option a text modifier, which

--- a/src/renderer/input.js
+++ b/src/renderer/input.js
@@ -1,5 +1,17 @@
 // Renderer-owned game input. The Emscripten host installs this once before its
 // glue loads; native interruptions all converge on releaseAll().
+
+// Canvases a held drag may wander from the one it started on. The client keeps
+// integrating mouse moves whose coordinates fall outside the canvas, so a drag
+// need not stop at the edge — it only needs to stop somewhere, or the
+// coordinates of a long drag grow without limit. Sixteen of them put a
+// re-anchor several camera revolutions apart at any window size.
+const POINTER_ROAM = 16;
+
+// Re-anchors a single mouse move may spend before the leftover delta is
+// dropped. Four cross a drag's whole range; further is a teleport, not a drag.
+const MAX_POINTER_REGRABS = 4;
+
 /**
  * @param {{
  *   canvas: HTMLCanvasElement,
@@ -55,10 +67,6 @@ export const installGameInput = ({
   /** @type {{ x: number, y: number } | null} */
   let virtualCursor = null;
   let pointerWanted = false;
-  let resettingPointer = false;
-  let pendingPointerX = 0;
-  let pendingPointerY = 0;
-  let pointerResetFrame = 0;
   let releasing = false;
   let wheelRemainder = 0;
   let wheelDirection = 0;
@@ -264,10 +272,6 @@ export const installGameInput = ({
   function releasePointer() {
     pointerWanted = false;
     virtualCursor = null;
-    resettingPointer = false;
-    pendingPointerX = 0;
-    pendingPointerY = 0;
-    cancelAnimationFrame(pointerResetFrame);
     canvas.classList.remove('cursor-hidden');
     if (document.pointerLockElement === canvas) document.exitPointerLock();
   }
@@ -521,49 +525,39 @@ export const installGameInput = ({
     finishTouch('touchcancel', touch);
   }, true);
 
+  // The client steers from absolute coordinates, so a held right-drag eventually
+  // runs out of the room a re-anchor gives it. Release and re-press at center
+  // while the physical button stays held, then spend the rest of the delta in
+  // the same tick — deferring the remainder to the next animation frame froze
+  // the camera for that frame.
   /** @param {number} movementX @param {number} movementY */
   const sendDelta = (movementX, movementY) => {
     if (!virtualCursor) return;
     const rect = canvas.getBoundingClientRect();
-    const nextX = virtualCursor.x + movementX;
-    const nextY = virtualCursor.y + movementY;
-    if (
-      nextX >= 0 &&
-      nextX <= rect.width &&
-      nextY >= 0 &&
-      nextY <= rect.height
-    ) {
-      virtualCursor.x = nextX;
-      virtualCursor.y = nextY;
-      sendMouse('mousemove', rect, currentButtons(), 0, movementX, movementY);
-      return;
+    const roamX = rect.width * POINTER_ROAM;
+    const roamY = rect.height * POINTER_ROAM;
+    let restX = movementX;
+    let restY = movementY;
+    // Each re-anchor buys another budget, so a bounded few consume any delta a
+    // hand can produce. The bound also ends the loop on a zero-area canvas.
+    for (let regrab = 0; ; regrab += 1) {
+      const stepX =
+        Math.max(-roamX, Math.min(rect.width + roamX, virtualCursor.x + restX)) -
+        virtualCursor.x;
+      const stepY =
+        Math.max(-roamY, Math.min(rect.height + roamY, virtualCursor.y + restY)) -
+        virtualCursor.y;
+      virtualCursor.x += stepX;
+      virtualCursor.y += stepY;
+      const buttons = currentButtons();
+      sendMouse('mousemove', rect, buttons, 0, stepX, stepY);
+      restX -= stepX;
+      restY -= stepY;
+      if ((!restX && !restY) || regrab === MAX_POINTER_REGRABS) return;
+      sendMouse('mouseup', rect, buttons & ~2, 2, 0, 0);
+      virtualCursor = { x: rect.width / 2, y: rect.height / 2 };
+      sendMouse('mousedown', rect, buttons, 2, 0, 0);
     }
-    const stepX =
-      Math.max(0, Math.min(rect.width, nextX)) - virtualCursor.x;
-    const stepY =
-      Math.max(0, Math.min(rect.height, nextY)) - virtualCursor.y;
-    virtualCursor.x += stepX;
-    virtualCursor.y += stepY;
-    const buttons = currentButtons();
-    sendMouse('mousemove', rect, buttons, 0, stepX, stepY);
-    pendingPointerX += movementX - stepX;
-    pendingPointerY += movementY - stepY;
-    if (resettingPointer) return;
-    resettingPointer = true;
-    // The client steers from absolute coordinates. Re-grab at center while
-    // the physical button remains held, then replay the unconsumed delta.
-    sendMouse('mouseup', rect, buttons & ~2, 2, 0, 0);
-    virtualCursor = { x: rect.width / 2, y: rect.height / 2 };
-    sendMouse('mousedown', rect, buttons, 2, 0, 0);
-    pointerResetFrame = requestAnimationFrame(() => {
-      resettingPointer = false;
-      if (document.pointerLockElement !== canvas || !virtualCursor) return;
-      const replayX = pendingPointerX;
-      const replayY = pendingPointerY;
-      pendingPointerX = 0;
-      pendingPointerY = 0;
-      if (replayX || replayY) sendDelta(replayX, replayY);
-    });
   };
 
   canvas.addEventListener('mousedown', (event) => {
@@ -574,9 +568,6 @@ export const installGameInput = ({
       y: event.clientY - rect.top,
     };
     pointerWanted = true;
-    resettingPointer = false;
-    pendingPointerX = 0;
-    pendingPointerY = 0;
     if (document.pointerLockElement === canvas) return;
     try {
       const request = canvas.requestPointerLock();
@@ -610,12 +601,7 @@ export const installGameInput = ({
     ) return;
     event.stopImmediatePropagation();
     event.preventDefault();
-    if (resettingPointer) {
-      pendingPointerX += event.movementX;
-      pendingPointerY += event.movementY;
-    } else {
-      sendDelta(event.movementX, event.movementY);
-    }
+    sendDelta(event.movementX, event.movementY);
   }, true);
 
   document.addEventListener('mouseup', (event) => {

--- a/tests/electron/input.spec.mjs
+++ b/tests/electron/input.spec.mjs
@@ -534,48 +534,79 @@ test.describe("renderer input", () => {
     }
   });
 
-  test("recycles a held camera drag instead of stalling at an edge", async () => {
+  // A held drag re-anchors only after POINTER_ROAM canvases of travel, so these
+  // tests report a deliberately tiny canvas: it brings that budget within a
+  // mouse move the fixture window can hold. Four pixels of canvas at 95 from the
+  // window's own left edge means 64 pixels of roam either side of it.
+  const CAMERA_CANVAS = 4;
+  const CAMERA_ROAM = CAMERA_CANVAS * 16;
+
+  // The press sits two pixels below the reported top so the drag starts inside
+  // the budget on both axes; every move in these tests is horizontal.
+  const CAMERA_Y = 2;
+
+  /** Watches what the client receives, from a right-drag pressed at box.x+100. */
+  const watchCameraDrag = async (page, box) => {
+    await page.evaluate(({ x, y, size }) => {
+      const gameCanvas = globalThis.document.getElementById("canvas");
+      globalThis.document.getElementById("loading").classList.add("gone");
+      globalThis.__cameraEvents = [];
+      // Microtasks queued by a listener drain only once the task dispatching it
+      // ends, so a shared count is an exact witness that these events were
+      // delivered without yielding to the event loop between them.
+      globalThis.__cameraDrains = 0;
+      globalThis.__cameraTasks = [];
+      for (const type of ["mousemove", "mouseup", "mousedown"]) {
+        gameCanvas.addEventListener(type, (event) => {
+          if (!event.isTrusted) {
+            globalThis.__cameraTasks.push(globalThis.__cameraDrains);
+            globalThis.queueMicrotask(() => {
+              globalThis.__cameraDrains += 1;
+            });
+            globalThis.__cameraEvents.push({
+              type,
+              button: event.button,
+              buttons: event.buttons,
+              clientX: event.clientX,
+              movementX: event.movementX,
+            });
+          }
+        });
+      }
+      gameCanvas.getBoundingClientRect = () =>
+        new globalThis.DOMRect(x + 95, y, size, size);
+      Object.defineProperty(globalThis.document, "pointerLockElement", {
+        configurable: true,
+        value: gameCanvas,
+      });
+      globalThis.document.exitPointerLock = () => {
+        Object.defineProperty(globalThis.document, "pointerLockElement", {
+          configurable: true,
+          value: null,
+        });
+      };
+      gameCanvas.focus();
+    }, { x: box.x, y: box.y, size: CAMERA_CANVAS });
+
+    await page.mouse.move(box.x + 100, box.y + CAMERA_Y);
+    await page.mouse.down({ button: "right" });
+  };
+
+  test("carries a held camera drag past the edge of the canvas", async () => {
     const fixture = await launchOffline("gw-pointer-edge-e2e-");
     try {
       const { page } = fixture;
       await startGameInput(page);
       const canvas = page.locator("#canvas");
       const box = await canvas.boundingBox();
-      await page.evaluate(({ x, y, width, height }) => {
-        const gameCanvas = globalThis.document.getElementById("canvas");
-        globalThis.document.getElementById("loading").classList.add("gone");
-        globalThis.__cameraEvents = [];
-        for (const type of ["mousemove", "mouseup", "mousedown"]) {
-          gameCanvas.addEventListener(type, (event) => {
-            if (!event.isTrusted) {
-              globalThis.__cameraEvents.push({
-                type,
-                button: event.button,
-                buttons: event.buttons,
-                clientX: event.clientX,
-                movementX: event.movementX,
-              });
-            }
-          });
-        }
-        gameCanvas.getBoundingClientRect = () =>
-          new globalThis.DOMRect(x + 95, y, width, height);
-        Object.defineProperty(globalThis.document, "pointerLockElement", {
-          configurable: true,
-          value: gameCanvas,
-        });
-        globalThis.document.exitPointerLock = () => {
-          Object.defineProperty(globalThis.document, "pointerLockElement", {
-            configurable: true,
-            value: null,
-          });
-        };
-        gameCanvas.focus();
-      }, box);
+      await watchCameraDrag(page, box);
 
-      await page.mouse.move(box.x + 100, box.y + 100);
-      await page.mouse.down({ button: "right" });
-      await page.mouse.move(box.x + 80, box.y + 100);
+      // Both moves leave the cursor well outside a four-pixel canvas. The client
+      // keeps integrating them there, so stopping at the edge to re-anchor buys
+      // nothing and costs a released button — which a small window pays on about
+      // every third move, and is why it rotated worse than a large one.
+      await page.mouse.move(box.x + 80, box.y + CAMERA_Y);
+      await page.mouse.move(box.x + 60, box.y + CAMERA_Y);
       await expect
         .poll(() => page.evaluate(() => globalThis.__cameraEvents))
         .toEqual([
@@ -583,41 +614,72 @@ test.describe("renderer input", () => {
             type: "mousemove",
             button: 0,
             buttons: 2,
-            clientX: box.x + 95,
-            movementX: -5,
+            clientX: box.x + 95 - 15,
+            movementX: -20,
+          },
+          {
+            type: "mousemove",
+            button: 0,
+            buttons: 2,
+            clientX: box.x + 95 - 35,
+            movementX: -20,
+          },
+        ]);
+      await page.mouse.up({ button: "right" });
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
+  test("recycles a held camera drag once it roams past its budget", async () => {
+    const fixture = await launchOffline("gw-pointer-roam-e2e-");
+    try {
+      const { page } = fixture;
+      await startGameInput(page);
+      const canvas = page.locator("#canvas");
+      const box = await canvas.boundingBox();
+      await watchCameraDrag(page, box);
+
+      // Eighty left of a press five into the canvas overruns the budget by 11.
+      await page.mouse.move(box.x + 20, box.y + CAMERA_Y);
+      await expect
+        .poll(() => page.evaluate(() => globalThis.__cameraEvents))
+        .toEqual([
+          {
+            type: "mousemove",
+            button: 0,
+            buttons: 2,
+            clientX: box.x + 95 - CAMERA_ROAM,
+            movementX: -(CAMERA_ROAM + 5),
           },
           {
             type: "mouseup",
             button: 2,
             buttons: 0,
-            clientX: box.x + 95,
+            clientX: box.x + 95 - CAMERA_ROAM,
             movementX: 0,
           },
           {
             type: "mousedown",
             button: 2,
             buttons: 2,
-            clientX: box.x + 95 + box.width / 2,
+            clientX: box.x + 95 + CAMERA_CANVAS / 2,
             movementX: 0,
           },
           {
             type: "mousemove",
             button: 0,
             buttons: 2,
-            clientX: box.x + 95 + box.width / 2 - 15,
-            movementX: -15,
+            clientX: box.x + 95 + CAMERA_CANVAS / 2 - 11,
+            movementX: -11,
           },
         ]);
-      await page.mouse.move(box.x + 70, box.y + 100);
+      // The recycled drag has to reach the client in the task that produced it.
+      // Replaying the leftover delta from a later animation frame satisfies
+      // every assertion above and still freezes the camera for that frame.
       await expect
-        .poll(() => page.evaluate(() => globalThis.__cameraEvents.at(-1)))
-        .toEqual({
-          type: "mousemove",
-          button: 0,
-          buttons: 2,
-          clientX: box.x + 95 + box.width / 2 - 25,
-          movementX: -10,
-        });
+        .poll(() => page.evaluate(() => globalThis.__cameraTasks))
+        .toEqual([0, 0, 0, 0]);
       await page.mouse.up({ button: "right" });
     } finally {
       await closeOffline(fixture);


### PR DESCRIPTION
Right-drag camera rotation felt clunky on a 13" laptop screen and clean on a 4K monitor. The cause was window size, not the display.

## Cause

The host steers the client with a virtual cursor, because the client reads absolute coordinates rather than raw deltas. That cursor was clamped to the canvas rect, so every time it reached an edge the host released the right button, re-anchored at center and pressed again. Measured with the drag instrumented:

| canvas | re-anchors/s |
| --- | --- |
| 941x767 | 20-38 |
| 1866x1234 | 0-3 |

The rate is inversely proportional to window size — a small window recycled on about every third mouse move. Each recycle cost twice over: the released button interrupts the client's drag, and the leftover delta was replayed from a `requestAnimationFrame` callback while every move in between was swallowed, freezing the camera for a frame.

The clamp turned out to buy nothing. Driving the client with synthetic events that run thousands of pixels past the canvas edge, it keeps integrating them and rotating normally — it does not need the coordinates to stay inside the canvas.

## Change

- A held drag may roam `POINTER_ROAM` (16) canvases before re-anchoring, instead of stopping at the edge. That puts a re-anchor several camera revolutions apart at any window size.
- When a recycle does happen, the leftover delta is spent in the task that produced it. This deletes `resettingPointer`, `pendingPointerX/Y` and `pointerResetFrame` along with the deferral.

Measured after the change, on a 655px-wide canvas: 0 re-anchors per second, `gap p50` steady at 16.7ms, and the stutter is gone.

## Tests

Both new tests were confirmed to fail against the pre-fix code:

- `carries a held camera drag past the edge of the canvas` — pins the bug itself: moves that leave the canvas produce plain moves and no button churn.
- `recycles a held camera drag once it roams past its budget` — the rare recycle still emits the correct sequence, and a microtask-drain counter witnesses that all four events reach the client without yielding to the event loop. The previous assertion only pinned the event *order*, which the frame deferral never changed, so it passed either way.

`pnpm lint`, `pnpm typecheck`, `pnpm check:links`, 474 unit tests, and the full 12-test Electron input spec all pass. Verified by hand in the running client on both displays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)