### PR TITLE
Add bounded tester snapshot builds

### DIFF
--- a/.github/ISSUE_TEMPLATE/preview-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/preview-feedback.yml
@@ -1,0 +1,73 @@
+name: Preview feedback
+description: Report results from a temporary tester snapshot.
+title: "[Snapshot]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for testing a snapshot. Snapshots are temporary and unsupported, so the exact tag is required to connect your report to its source.
+
+        GitHub issues are public. Diagnostics stay on your Mac unless you explicitly attach them. The app excludes credentials, account identifiers, packet contents, HTTP bodies, headers, cookies, filesystem paths, and crash dumps from a `.gwdiag`.
+  - type: input
+    id: snapshot
+    attributes:
+      label: Snapshot tag and commit
+      description: Copy both values from the snapshot release page.
+      placeholder: snapshot-42-f45f762 — f45f7629e9d31d5456ef3387e154a88f53750e84
+    validations:
+      required: true
+  - type: input
+    id: macos
+    attributes:
+      label: macOS version
+      placeholder: macOS 15.5
+    validations:
+      required: true
+  - type: input
+    id: hardware
+    attributes:
+      label: Mac hardware
+      placeholder: M2 Pro Mac mini
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. …
+        2. …
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: dropdown
+    id: versioned-release
+    attributes:
+      label: Does this happen on the latest versioned release?
+      options:
+        - No — this is a snapshot regression
+        - Yes — it also happens on the latest versioned release
+        - I have not compared them
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Diagnostics (optional)
+      description: If you choose to share a `.gwdiag`, Control-click it in Finder, choose **Compress**, then drag the resulting `.zip` here. GitHub does not accept `.gwdiag` directly.
+      placeholder: Drag the .zip file here, or leave this blank.
+    validations:
+      required: false

--- a/.github/workflows/macos-verify.yml
+++ b/.github/workflows/macos-verify.yml
@@ -1,0 +1,99 @@
+name: Reusable macOS verification
+
+on:
+  workflow_call:
+    inputs:
+      artifact-name:
+        description: Empty disables packaging handoff.
+        required: false
+        type: string
+        default: ""
+      artifact-retention-days:
+        required: false
+        type: number
+        default: 1
+      dependency-review:
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: macos-15
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - name: Review dependency changes
+        if: inputs.dependency-review
+        uses: actions/dependency-review-action@cc4f6536e38d1126c5e3b0683d469a14f23bfea4 # v3.1.5
+        with:
+          fail-on-severity: high
+      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 11.13.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "24"
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm audit --audit-level=high
+      - run: pnpm verify
+
+      - name: Prepare tested package
+        if: inputs.artifact-name != ''
+        id: package
+        run: |
+          app_count="$(find out -name 'Guild Wars.app' -type d | wc -l | tr -d ' ')"
+          if [ "$app_count" != "1" ]; then
+            echo "Expected exactly one packaged app, found $app_count." >&2
+            exit 1
+          fi
+          app="$(find out -name 'Guild Wars.app' -type d -print -quit)"
+          codesign --verify --deep --strict --verbose=2 "$app"
+          signature="$(codesign -dv --verbose=4 "$app" 2>&1)"
+          echo "$signature"
+          echo "$signature" | grep -E "Signature=adhoc|TeamIdentifier=not set"
+
+          short="${GITHUB_SHA:0:7}"
+          mkdir distribution
+          archive="$PWD/distribution/Guild-Wars-$short-macOS-arm64.zip"
+          sbom="$PWD/distribution/Guild-Wars-$short-macOS-arm64.spdx.json"
+          ditto -c -k --sequesterRsrc --keepParent "$app" "$archive"
+          printf '%s\n' "$GITHUB_SHA" > distribution/SOURCE_COMMIT.txt
+          echo "app=$app" >> "$GITHUB_OUTPUT"
+          echo "archive=$archive" >> "$GITHUB_OUTPUT"
+          echo "sbom=$sbom" >> "$GITHUB_OUTPUT"
+
+      - name: Generate package SBOM
+        if: inputs.artifact-name != ''
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
+        with:
+          path: ${{ steps.package.outputs.app }}
+          format: spdx-json
+          output-file: ${{ steps.package.outputs.sbom }}
+          upload-artifact: false
+          upload-release-assets: false
+
+      - name: Finalize package checksums
+        if: inputs.artifact-name != ''
+        run: |
+          (
+            cd distribution
+            shasum -a 256 ./*.zip ./*.spdx.json SOURCE_COMMIT.txt > SHA256SUMS.txt
+            shasum -a 256 -c SHA256SUMS.txt
+          )
+
+      - name: Upload tested package
+        if: inputs.artifact-name != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: distribution/*
+          if-no-files-found: error
+          retention-days: ${{ inputs.artifact-retention-days }}
+          compression-level: 0

--- a/.github/workflows/main-snapshot.yml
+++ b/.github/workflows/main-snapshot.yml
@@ -1,0 +1,34 @@
+name: Main snapshot
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: main-snapshot
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    uses: ./.github/workflows/macos-verify.yml
+    with:
+      artifact-name: snapshot-assets-${{ github.run_id }}
+      artifact-retention-days: 1
+
+  publish:
+    needs: verify
+    permissions:
+      actions: read
+      artifact-metadata: write
+      attestations: write
+      contents: write
+      id-token: write
+    uses: ./.github/workflows/publish-snapshot.yml
+    with:
+      artifact-name: snapshot-assets-${{ github.run_id }}
+      commit-sha: ${{ github.sha }}
+      run-number: ${{ github.run_number }}
+      require-current-main: true

--- a/.github/workflows/pr-package.yml
+++ b/.github/workflows/pr-package.yml
@@ -1,0 +1,19 @@
+name: PR package
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-package-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    uses: ./.github/workflows/macos-verify.yml
+    with:
+      artifact-name: ${{ format('gwonmac-pr-{0}-{1}', github.event.pull_request.number, github.sha) }}
+      artifact-retention-days: 3
+      dependency-review: true

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,0 +1,172 @@
+name: Publish tester snapshot
+
+on:
+  workflow_call:
+    inputs:
+      artifact-name:
+        required: true
+        type: string
+      commit-sha:
+        required: true
+        type: string
+      run-number:
+        required: true
+        type: number
+      require-current-main:
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      artifact-metadata: write
+      attestations: write
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "24"
+      - name: Receive tested package
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: ${{ inputs.artifact-name }}
+          path: snapshot-assets
+
+      - name: Verify package handoff
+        id: assets
+        env:
+          COMMIT_SHA: ${{ inputs.commit-sha }}
+          GH_TOKEN: ${{ github.token }}
+          REQUIRE_CURRENT_MAIN: ${{ inputs.require-current-main }}
+          RUN_NUMBER: ${{ inputs.run-number }}
+        run: |
+          if ! [[ "$COMMIT_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Invalid snapshot commit: $COMMIT_SHA" >&2
+            exit 1
+          fi
+          if [ "$REQUIRE_CURRENT_MAIN" = "true" ]; then
+            current="$(gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/main" --jq '.object.sha')"
+            if [ "$current" != "$COMMIT_SHA" ]; then
+              echo "publish=false" >> "$GITHUB_OUTPUT"
+              echo "A newer main commit exists; skipping stale snapshot $COMMIT_SHA."
+              exit 0
+            fi
+          fi
+
+          archive_count="$(find snapshot-assets -type f -name '*.zip' | wc -l | tr -d ' ')"
+          sbom_count="$(find snapshot-assets -type f -name '*.spdx.json' | wc -l | tr -d ' ')"
+          test "$archive_count" = "1"
+          test "$sbom_count" = "1"
+          archive="$(find snapshot-assets -type f -name '*.zip' -print -quit)"
+          sbom="$(find snapshot-assets -type f -name '*.spdx.json' -print -quit)"
+          checksum="snapshot-assets/SHA256SUMS.txt"
+          source_commit="snapshot-assets/SOURCE_COMMIT.txt"
+          test -f "$checksum"
+          test -f "$source_commit"
+          test "$(tr -d '\n' < "$source_commit")" = "$COMMIT_SHA"
+          (
+            cd snapshot-assets
+            shasum -a 256 -c SHA256SUMS.txt
+          )
+
+          existing="$(gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+            --jq ".[] | select(.prerelease == true and (.tag_name | test(\"^snapshot-[1-9][0-9]*-[0-9a-f]{7,40}$\")) and .target_commitish == \"$COMMIT_SHA\") | .tag_name" \
+            | head -n 1)"
+          if [ -n "$existing" ]; then
+            echo "publish=false" >> "$GITHUB_OUTPUT"
+            echo "Snapshot $existing already publishes $COMMIT_SHA."
+            exit 0
+          fi
+
+          previous="$(gh api "repos/$GITHUB_REPOSITORY/releases?per_page=100" \
+            --jq ".[] | select(.prerelease == true and (.tag_name | test(\"^snapshot-[1-9][0-9]*-[0-9a-f]{7,40}$\")) and .target_commitish != \"$COMMIT_SHA\") | .target_commitish" \
+            | head -n 1)"
+          if [ -z "$previous" ]; then
+            previous="$(gh api "repos/$GITHUB_REPOSITORY/commits/$COMMIT_SHA" --jq '.parents[0].sha // empty')"
+          fi
+
+          short="${COMMIT_SHA:0:7}"
+          tag="snapshot-$RUN_NUMBER-$short"
+          echo "publish=true" >> "$GITHUB_OUTPUT"
+          echo "archive=$archive" >> "$GITHUB_OUTPUT"
+          echo "sbom=$sbom" >> "$GITHUB_OUTPUT"
+          echo "checksum=$checksum" >> "$GITHUB_OUTPUT"
+          echo "source_commit=$source_commit" >> "$GITHUB_OUTPUT"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "short=$short" >> "$GITHUB_OUTPUT"
+          echo "previous=$previous" >> "$GITHUB_OUTPUT"
+
+      - name: Attest snapshot provenance
+        if: steps.assets.outputs.publish == 'true'
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4
+        with:
+          subject-path: ${{ steps.assets.outputs.archive }}
+
+      - name: Attest snapshot SBOM
+        if: steps.assets.outputs.publish == 'true'
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4
+        with:
+          subject-path: ${{ steps.assets.outputs.archive }}
+          sbom-path: ${{ steps.assets.outputs.sbom }}
+
+      - name: Publish immutable snapshot prerelease
+        if: steps.assets.outputs.publish == 'true'
+        env:
+          ARCHIVE: ${{ steps.assets.outputs.archive }}
+          CHECKSUM: ${{ steps.assets.outputs.checksum }}
+          COMMIT_SHA: ${{ inputs.commit-sha }}
+          GH_TOKEN: ${{ github.token }}
+          PREVIOUS: ${{ steps.assets.outputs.previous }}
+          SBOM: ${{ steps.assets.outputs.sbom }}
+          SHORT: ${{ steps.assets.outputs.short }}
+          SOURCE_COMMIT: ${{ steps.assets.outputs.source_commit }}
+          TAG: ${{ steps.assets.outputs.tag }}
+        run: |
+          compare="https://github.com/$GITHUB_REPOSITORY/commit/$COMMIT_SHA"
+          if [ -n "$PREVIOUS" ]; then
+            compare="https://github.com/$GITHUB_REPOSITORY/compare/$PREVIOUS...$COMMIT_SHA"
+          fi
+          feedback="https://github.com/$GITHUB_REPOSITORY/issues/new?template=preview-feedback.yml"
+          notes="$(cat <<EOF
+          > [!WARNING]
+          > This is an unsupported tester snapshot. Back up important data and
+          > expect bugs.
+
+          Commit: [\`$COMMIT_SHA\`](https://github.com/$GITHUB_REPOSITORY/commit/$COMMIT_SHA)
+
+          Changes: [$PREVIOUS…$SHORT]($compare)
+
+          This build is ad-hoc signed, not notarized by Apple. Follow the install
+          guide for the one-time per-app approval; do not disable Gatekeeper.
+
+          Snapshots are temporary: only the newest three are retained, and all
+          but the newest expire after 14 days. [Report preview feedback]($feedback)
+          and include snapshot \`$TAG\`. Diagnostics remain local unless you
+          explicitly attach the exported file.
+          EOF
+          )"
+          gh release create "$TAG" "$ARCHIVE" "$CHECKSUM" "$SBOM" "$SOURCE_COMMIT" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target "$COMMIT_SHA" \
+            --title "Tester snapshot $SHORT" \
+            --prerelease \
+            --latest=false \
+            --notes "$notes"
+
+      - name: Prune expired snapshots
+        if: steps.assets.outputs.publish == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          node --import ./scripts/ts-hook.mjs --experimental-strip-types \
+            scripts/snapshot-retention.ts \
+            --repo "$GITHUB_REPOSITORY" \
+            --apply

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,27 +15,27 @@ concurrency:
 
 jobs:
   verify:
-    runs-on: macos-15
-    timeout-minutes: 45
-    steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
-        with:
-          persist-credentials: false
-      - name: Review dependency changes
-        if: github.event_name == 'pull_request'
-        uses: actions/dependency-review-action@cc4f6536e38d1126c5e3b0683d469a14f23bfea4 # v3.1.5
-        with:
-          fail-on-severity: high
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
-        with:
-          version: 11.13.1
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: "24"
-          cache: pnpm
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm audit --audit-level=high
-      - run: pnpm verify
+    uses: ./.github/workflows/macos-verify.yml
+    with:
+      artifact-name: ${{ github.event_name == 'pull_request' && format('gwonmac-pr-{0}-{1}', github.event.number, github.sha) || github.event_name == 'push' && format('snapshot-assets-{0}', github.run_id) || '' }}
+      artifact-retention-days: ${{ github.event_name == 'pull_request' && 3 || 1 }}
+      dependency-review: ${{ github.event_name == 'pull_request' }}
+
+  snapshot:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: verify
+    permissions:
+      actions: read
+      artifact-metadata: write
+      attestations: write
+      contents: write
+      id-token: write
+    uses: ./.github/workflows/publish-snapshot.yml
+    with:
+      artifact-name: snapshot-assets-${{ github.run_id }}
+      commit-sha: ${{ github.sha }}
+      run-number: ${{ github.run_number }}
+      require-current-main: true
 
   release-build:
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,44 +1,23 @@
-name: macOS
+name: Versioned release
 
 on:
-  push:
-    branches: [main]
-  pull_request:
   workflow_dispatch:
 
 permissions:
   contents: read
 
 concurrency:
-  group: macos-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  group: versioned-release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   verify:
     uses: ./.github/workflows/macos-verify.yml
     with:
-      artifact-name: ${{ github.event_name == 'pull_request' && format('gwonmac-pr-{0}-{1}', github.event.number, github.sha) || github.event_name == 'push' && format('snapshot-assets-{0}', github.run_id) || '' }}
-      artifact-retention-days: ${{ github.event_name == 'pull_request' && 3 || 1 }}
-      dependency-review: ${{ github.event_name == 'pull_request' }}
-
-  snapshot:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: verify
-    permissions:
-      actions: read
-      artifact-metadata: write
-      attestations: write
-      contents: write
-      id-token: write
-    uses: ./.github/workflows/publish-snapshot.yml
-    with:
-      artifact-name: snapshot-assets-${{ github.run_id }}
-      commit-sha: ${{ github.sha }}
-      run-number: ${{ github.run_number }}
-      require-current-main: true
+      artifact-name: ""
 
   release-build:
-    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     needs: verify
     runs-on: macos-15
     timeout-minutes: 45
@@ -205,7 +184,7 @@ jobs:
           compression-level: 0
 
   release:
-    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     needs: release-build
     runs-on: macos-15
     timeout-minutes: 10

--- a/.github/workflows/tester-build.yml
+++ b/.github/workflows/tester-build.yml
@@ -1,0 +1,32 @@
+name: Tester build
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tester-build-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  verify:
+    uses: ./.github/workflows/macos-verify.yml
+    with:
+      artifact-name: snapshot-assets-${{ github.run_id }}
+      artifact-retention-days: 1
+
+  publish:
+    needs: verify
+    permissions:
+      actions: read
+      artifact-metadata: write
+      attestations: write
+      contents: write
+      id-token: write
+    uses: ./.github/workflows/publish-snapshot.yml
+    with:
+      artifact-name: snapshot-assets-${{ github.run_id }}
+      commit-sha: ${{ github.sha }}
+      run-number: ${{ github.run_number }}

--- a/README.md
+++ b/README.md
@@ -131,6 +131,22 @@ Releases are cut from `main` by manual dispatch of the macOS workflow. The
 workflow verifies one ad-hoc signed package, generates checksums and an SPDX
 SBOM, attests that exact ZIP, and publishes those same tested files.
 
+### Test snapshots
+
+Every verified push to `main` publishes a temporary
+[`snapshot-*` prerelease](https://github.com/Mat4m0/gwonmac/releases) for
+players who want to test the newest changes. A maintainer can publish the same
+kind of snapshot from another repository branch with the **Tester build**
+workflow. Snapshots are unsupported, never offered by the website or in-app
+release check, and are bounded: only the newest three remain, while every
+snapshot except the newest expires after fourteen days.
+
+Pull requests keep their packaged app as a GitHub Actions artifact for three
+days. Those artifacts require a signed-in GitHub account; snapshot prereleases
+use ordinary public download links. Report results with the
+[preview feedback form](https://github.com/Mat4m0/gwonmac/issues/new?template=preview-feedback.yml);
+diagnostics remain local unless you explicitly attach the exported file.
+
 ## Diagnostics
 
 The app keeps a bounded, local-only flight recorder — startup and frame

--- a/apps/website/app/utils/release-download.ts
+++ b/apps/website/app/utils/release-download.ts
@@ -18,9 +18,10 @@ import {
 } from "../../../../src/shared/release.ts";
 
 export const RELEASES_FALLBACK_URL = EXTERNAL_URLS.releases;
-// Enough entries to see past a run of prereleases. `per_page=1` returned the
-// newest release of any channel, which is regularly a prerelease.
-const API_URL = `https://api.github.com/repos/${RELEASE_REPO}/releases?per_page=20`;
+// Snapshot tags are not release versions and are ignored below. Fetch the API
+// maximum so a temporarily failed snapshot-pruning run cannot hide the latest
+// valid versioned release behind a page of snapshots.
+const API_URL = `https://api.github.com/repos/${RELEASE_REPO}/releases?per_page=100`;
 
 type WebsiteReleaseChannel = "stable" | "preview";
 

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -34,6 +34,13 @@ Nothing about the number implies an automatic update. Updating is manual, and
 the app checks for a newer release only when asked — see
 [Updates](user-guide.md#updates).
 
+Temporary `snapshot-<run>-<commit>` prereleases are tester builds, not
+application versions. Their tags deliberately do not parse as one of the
+version shapes above, so neither the website nor the in-app release check
+offers them. They remain available as public downloads on GitHub while their
+bounded retention window is open; pull-request packages instead live as
+signed-in-only GitHub Actions artifacts for three days.
+
 Versions published before this scheme, including the public alpha
 `0.0.1-alpha.1`, used a plain `0.x` number and are older than everything above.
 The macOS bundle also carries a `CFBundleVersion` derived from the release

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "enhancements:visual": "pnpm build && node --import ./scripts/ts-hook.mjs --experimental-strip-types scripts/enhancements-visual.ts",
     "enhancements:transform": "pnpm build && node build/tools/enhancement-transform.js",
     "template:recertify": "pnpm build && node build/tools/template-save-recertify.js",
+    "snapshot:prune": "node --import ./scripts/ts-hook.mjs --experimental-strip-types scripts/snapshot-retention.ts",
     "test:website": "pnpm --filter gw-website typecheck && pnpm --filter gw-website generate && pnpm --filter gw-website build && node --import ./scripts/ts-hook.mjs --experimental-strip-types tests/website-smoke.ts",
     "check": "pnpm typecheck && pnpm lint && pnpm check:links && pnpm test:unit && pnpm test:policy",
     "test": "pnpm build && pnpm test:unit && pnpm test:integration && pnpm test:electron",

--- a/scripts/snapshot-retention.ts
+++ b/scripts/snapshot-retention.ts
@@ -1,0 +1,159 @@
+import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+
+const SNAPSHOT_TAG = /^snapshot-[1-9][0-9]*-[0-9a-f]{7,40}$/;
+const MAX_SNAPSHOTS = 3;
+const MAX_AGE_MS = 14 * 24 * 60 * 60 * 1_000;
+
+export interface SnapshotRelease {
+  readonly id: number;
+  readonly tagName: string;
+  readonly publishedAt: string;
+  readonly draft: boolean;
+  readonly prerelease: boolean;
+}
+
+export interface SnapshotRemoval {
+  readonly release: SnapshotRelease;
+  readonly reason: "expired" | "overflow";
+}
+
+export interface SnapshotRetentionPlan {
+  readonly keep: readonly SnapshotRelease[];
+  readonly remove: readonly SnapshotRemoval[];
+}
+
+function publishedTime(release: SnapshotRelease): number | null {
+  const value = Date.parse(release.publishedAt);
+  return Number.isFinite(value) ? value : null;
+}
+
+/**
+ * Plans deletion only for the exact immutable snapshot namespace. Versioned
+ * releases, drafts, ordinary prereleases, and malformed snapshot-like tags are
+ * outside this function's authority and can never appear in `remove`.
+ */
+export function planSnapshotRetention(
+  releases: readonly SnapshotRelease[],
+  now = Date.now(),
+): SnapshotRetentionPlan {
+  const snapshots = releases
+    .filter(
+      (release) =>
+        !release.draft
+        && release.prerelease
+        && SNAPSHOT_TAG.test(release.tagName)
+        && publishedTime(release) !== null,
+    )
+    .sort((left, right) => {
+      const byTime = publishedTime(right)! - publishedTime(left)!;
+      return byTime || right.tagName.localeCompare(left.tagName);
+    });
+
+  const keep: SnapshotRelease[] = [];
+  const remove: SnapshotRemoval[] = [];
+  for (const [index, release] of snapshots.entries()) {
+    const age = Math.max(0, now - publishedTime(release)!);
+    if (index >= MAX_SNAPSHOTS) {
+      remove.push({ release, reason: "overflow" });
+    } else if (index > 0 && age > MAX_AGE_MS) {
+      remove.push({ release, reason: "expired" });
+    } else {
+      // The newest snapshot is retained even after fourteen quiet days.
+      keep.push(release);
+    }
+  }
+  return { keep, remove };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function releaseFromApi(value: unknown): SnapshotRelease | null {
+  if (!isRecord(value)) return null;
+  const {
+    id,
+    tag_name: tagName,
+    published_at: publishedAt,
+    draft,
+    prerelease,
+  } = value;
+  return typeof id === "number"
+    && Number.isSafeInteger(id)
+    && typeof tagName === "string"
+    && typeof publishedAt === "string"
+    && typeof draft === "boolean"
+    && typeof prerelease === "boolean"
+    ? { id, tagName, publishedAt, draft, prerelease }
+    : null;
+}
+
+function repositoryArgument(args: readonly string[]): string {
+  const index = args.indexOf("--repo");
+  const value = index >= 0 ? args[index + 1] : undefined;
+  if (!value || !/^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/.test(value)) {
+    throw new Error("--repo must be an owner/repository name");
+  }
+  return value;
+}
+
+function github(args: readonly string[]): string {
+  return execFileSync("gh", args, { encoding: "utf8", stdio: ["ignore", "pipe", "inherit"] });
+}
+
+function listReleases(repository: string): SnapshotRelease[] {
+  const pages: unknown = JSON.parse(
+    github([
+      "api",
+      `repos/${repository}/releases?per_page=100`,
+      "--paginate",
+      "--slurp",
+    ]),
+  );
+  if (!Array.isArray(pages)) throw new Error("GitHub returned no release pages");
+  return pages.flatMap((page) =>
+    Array.isArray(page)
+      ? page.map(releaseFromApi).filter((release) => release !== null)
+      : [],
+  );
+}
+
+function removeRelease(repository: string, release: SnapshotRelease): void {
+  github([
+    "api",
+    "--method",
+    "DELETE",
+    `repos/${repository}/releases/${release.id}`,
+  ]);
+  github([
+    "api",
+    "--method",
+    "DELETE",
+    `repos/${repository}/git/refs/tags/${release.tagName}`,
+  ]);
+}
+
+function main(args: readonly string[]): void {
+  const repository = repositoryArgument(args);
+  const apply = args.includes("--apply");
+  const plan = planSnapshotRetention(listReleases(repository));
+  for (const removal of plan.remove) {
+    console.log(
+      `${apply ? "delete" : "would delete"} ${removal.release.tagName} (${removal.reason})`,
+    );
+    if (apply) removeRelease(repository, removal.release);
+  }
+  console.log(
+    `${apply ? "retained" : "would retain"} ${plan.keep.length} snapshot(s)`,
+  );
+}
+
+if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : "snapshot cleanup failed");
+    process.exitCode = 1;
+  }
+}

--- a/tests/policy/action-pinning.test.ts
+++ b/tests/policy/action-pinning.test.ts
@@ -18,7 +18,14 @@ const pinned = /^[^@\s]+\/[^@\s]+@[0-9a-f]{40}$/;
 test("every workflow action is pinned to a full commit SHA", () => {
   assert.deepEqual(
     workflows.sort(),
-    ["client-canary.yml", "release.yml", "website.yml"],
+    [
+      "client-canary.yml",
+      "macos-verify.yml",
+      "publish-snapshot.yml",
+      "release.yml",
+      "tester-build.yml",
+      "website.yml",
+    ],
     "a workflow was added or removed; confirm it is covered here",
   );
 

--- a/tests/policy/action-pinning.test.ts
+++ b/tests/policy/action-pinning.test.ts
@@ -21,6 +21,8 @@ test("every workflow action is pinned to a full commit SHA", () => {
     [
       "client-canary.yml",
       "macos-verify.yml",
+      "main-snapshot.yml",
+      "pr-package.yml",
       "publish-snapshot.yml",
       "release.yml",
       "tester-build.yml",

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -97,7 +97,9 @@ test("official releases have one honest ad-hoc signing path", () => {
 
 test("release workflow publishes one tested, attested package version", () => {
   const workflow = read(".github/workflows/release.yml");
-  assert.match(workflow, /runs-on: macos-15/);
+  const verification = read(".github/workflows/macos-verify.yml");
+  assert.match(workflow, /uses: \.\/\.github\/workflows\/macos-verify\.yml/);
+  assert.match(verification, /runs-on: macos-15/);
   assert.match(workflow, /persist-credentials: false/);
   assert.match(workflow, /require\('\.\/package\.json'\)\.version/);
   assert.match(workflow, /git\/ref\/tags\/\$TAG/);
@@ -109,12 +111,12 @@ test("release workflow publishes one tested, attested package version", () => {
   assert.match(workflow, /actions\/attest@/);
   assert.match(workflow, /sbom-path: \$\{\{ steps\.assets\.outputs\.sbom \}\}/);
   assert.match(workflow, /artifact-metadata: write/);
-  assert.match(workflow, /actions\/dependency-review-action@/);
+  assert.match(verification, /actions\/dependency-review-action@/);
   assert.ok(
-    workflow.indexOf("actions/dependency-review-action@") <
-      workflow.indexOf("pnpm install --frozen-lockfile"),
+    verification.indexOf("actions/dependency-review-action@") <
+      verification.indexOf("pnpm install --frozen-lockfile"),
   );
-  assert.match(workflow, /run: pnpm audit --audit-level=high/);
+  assert.match(verification, /run: pnpm audit --audit-level=high/);
   const releaseBuild = workflow.slice(
     workflow.indexOf("  release-build:"),
     workflow.indexOf("\n  release:"),
@@ -135,6 +137,108 @@ test("release workflow publishes one tested, attested package version", () => {
     /if \[ "\$PRERELEASE" = "true" \]; then[\s\S]*This is a prerelease build/,
   );
   assert.match(workflow, /gh release create "\$TAG" "\$ASSET" "\$CHECKSUM" "\$SBOM"/);
+});
+
+test("tester snapshots are verified, immutable, bounded, and isolated from releases", () => {
+  const entry = read(".github/workflows/release.yml");
+  const verification = read(".github/workflows/macos-verify.yml");
+  const publisher = read(".github/workflows/publish-snapshot.yml");
+  const manual = read(".github/workflows/tester-build.yml");
+  const retention = read("scripts/snapshot-retention.ts");
+  const feedback = read(".github/ISSUE_TEMPLATE/preview-feedback.yml");
+
+  // One read-only verification path owns PR, main, manual tester, and release
+  // gates. PR artifacts are short-lived and no publishing permission reaches
+  // that reusable workflow.
+  assert.match(verification, /workflow_call:/);
+  assert.match(verification, /permissions:\n {2}contents: read/);
+  assert.doesNotMatch(
+    verification,
+    /contents: write|attestations: write|id-token: write/,
+  );
+  assert.match(verification, /run: pnpm verify/);
+  assert.match(verification, /codesign --verify --deep --strict/);
+  assert.match(verification, /Signature=adhoc/);
+  assert.match(verification, /ditto -c -k --sequesterRsrc --keepParent/);
+  assert.match(verification, /format: spdx-json/);
+  assert.match(verification, /SOURCE_COMMIT\.txt/);
+  assert.match(verification, /shasum -a 256 -c SHA256SUMS\.txt/);
+  assert.match(verification, /retention-days: \$\{\{ inputs\.artifact-retention-days \}\}/);
+
+  assert.match(
+    entry,
+    /gwonmac-pr-\{0\}-\{1\}', github\.event\.number, github\.sha/,
+  );
+  assert.match(
+    entry,
+    /artifact-retention-days: \$\{\{ github\.event_name == 'pull_request' && 3 \|\| 1 \}\}/,
+  );
+  assert.match(entry, /dependency-review: \$\{\{ github\.event_name == 'pull_request' \}\}/);
+  assert.match(
+    entry,
+    /snapshot:\n {4}if: github\.event_name == 'push' && github\.ref == 'refs\/heads\/main'\n {4}needs: verify/,
+  );
+  assert.match(
+    entry,
+    /release-build:\n {4}if: github\.event_name == 'workflow_dispatch' && github\.ref == 'refs\/heads\/main'\n {4}needs: verify/,
+  );
+
+  // Tester dispatch is separate from the versioned release dispatch. Both
+  // snapshot callers publish only after the same verification job succeeds.
+  assert.match(manual, /name: Tester build[\s\S]*workflow_dispatch:/);
+  assert.doesNotMatch(manual, /schedule:|release-build|package\.json'\)\.version/);
+  assert.match(manual, /artifact-retention-days: 1/);
+  assert.match(manual, /publish:\n {4}needs: verify/);
+  assert.match(manual, /uses: \.\/\.github\/workflows\/publish-snapshot\.yml/);
+
+  // The handoff identity and checksums are checked before attestations and
+  // release creation. Cleanup runs last and uses an explicit apply switch.
+  const handoff = publisher.indexOf("- name: Verify package handoff");
+  const attest = publisher.indexOf("- name: Attest snapshot provenance");
+  const publish = publisher.indexOf("- name: Publish immutable snapshot prerelease");
+  const prune = publisher.indexOf("- name: Prune expired snapshots");
+  assert.ok(handoff < attest && attest < publish && publish < prune);
+  assert.match(publisher, /test "\$\(tr -d '\\n' < "\$source_commit"\)" = "\$COMMIT_SHA"/);
+  assert.match(publisher, /shasum -a 256 -c SHA256SUMS\.txt/);
+  assert.match(publisher, /tag="snapshot-\$RUN_NUMBER-\$short"/);
+  assert.match(
+    publisher,
+    /test\(\\"\^snapshot-\[1-9\]\[0-9\]\*-\[0-9a-f\]\{7,40\}\$\\"\)/,
+  );
+  assert.match(publisher, /--target "\$COMMIT_SHA"/);
+  assert.match(publisher, /--prerelease[\s\S]*--latest=false/);
+  assert.match(
+    publisher,
+    /gh release create "\$TAG" "\$ARCHIVE" "\$CHECKSUM" "\$SBOM" "\$SOURCE_COMMIT"/,
+  );
+  assert.match(publisher, /scripts\/snapshot-retention\.ts[\s\S]*--apply/);
+  assert.match(publisher, /only the newest three are retained/);
+  assert.match(publisher, /expire after 14 days/);
+  assert.match(publisher, /preview-feedback\.yml/);
+
+  // Cleanup's authority is the exact snapshot namespace. It deletes a selected
+  // release before its unique tag and cannot match any v* release.
+  assert.match(retention, /\/\^snapshot-\[1-9\]\[0-9\]\*-\[0-9a-f\]\{7,40\}\$\//);
+  assert.match(retention, /const MAX_SNAPSHOTS = 3/);
+  assert.match(retention, /const MAX_AGE_MS = 14 \* 24 \* 60 \* 60 \* 1_000/);
+  assert.ok(
+    retention.indexOf("repos/${repository}/releases/${release.id}") <
+      retention.indexOf("repos/${repository}/git/refs/tags/${release.tagName}"),
+  );
+  assert.match(retention, /const apply = args\.includes\("--apply"\)/);
+
+  for (const id of [
+    "snapshot",
+    "macos",
+    "hardware",
+    "reproduction",
+    "expected",
+    "actual",
+    "versioned-release",
+  ]) {
+    assert.match(feedback, new RegExp(`id: ${id}[\\s\\S]*?required: true`));
+  }
+  assert.match(feedback, /id: diagnostics[\s\S]*?required: false/);
 });
 
 test("the application ships with no runtime dependency to audit", () => {

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -140,7 +140,9 @@ test("release workflow publishes one tested, attested package version", () => {
 });
 
 test("tester snapshots are verified, immutable, bounded, and isolated from releases", () => {
-  const entry = read(".github/workflows/release.yml");
+  const release = read(".github/workflows/release.yml");
+  const pullRequest = read(".github/workflows/pr-package.yml");
+  const main = read(".github/workflows/main-snapshot.yml");
   const verification = read(".github/workflows/macos-verify.yml");
   const publisher = read(".github/workflows/publish-snapshot.yml");
   const manual = read(".github/workflows/tester-build.yml");
@@ -165,22 +167,32 @@ test("tester snapshots are verified, immutable, bounded, and isolated from relea
   assert.match(verification, /shasum -a 256 -c SHA256SUMS\.txt/);
   assert.match(verification, /retention-days: \$\{\{ inputs\.artifact-retention-days \}\}/);
 
+  assert.match(pullRequest, /on:\n {2}pull_request:/);
+  assert.doesNotMatch(pullRequest, /workflow_dispatch:|push:/);
   assert.match(
-    entry,
-    /gwonmac-pr-\{0\}-\{1\}', github\.event\.number, github\.sha/,
+    pullRequest,
+    /gwonmac-pr-\{0\}-\{1\}', github\.event\.pull_request\.number, github\.sha/,
   );
-  assert.match(
-    entry,
-    /artifact-retention-days: \$\{\{ github\.event_name == 'pull_request' && 3 \|\| 1 \}\}/,
+  assert.match(pullRequest, /artifact-retention-days: 3/);
+  assert.match(pullRequest, /dependency-review: true/);
+  assert.doesNotMatch(
+    pullRequest,
+    /contents: write|attestations: write|id-token: write/,
   );
-  assert.match(entry, /dependency-review: \$\{\{ github\.event_name == 'pull_request' \}\}/);
+
+  assert.match(main, /on:\n {2}push:\n {4}branches: \[main\]/);
+  assert.doesNotMatch(main, /pull_request:|workflow_dispatch:/);
+  assert.match(main, /artifact-retention-days: 1/);
   assert.match(
-    entry,
-    /snapshot:\n {4}if: github\.event_name == 'push' && github\.ref == 'refs\/heads\/main'\n {4}needs: verify/,
+    main,
+    /publish:\n {4}needs: verify[\s\S]*uses: \.\/\.github\/workflows\/publish-snapshot\.yml/,
   );
+
+  assert.match(release, /name: Versioned release[\s\S]*workflow_dispatch:/);
+  assert.doesNotMatch(release, /pull_request:|push:/);
   assert.match(
-    entry,
-    /release-build:\n {4}if: github\.event_name == 'workflow_dispatch' && github\.ref == 'refs\/heads\/main'\n {4}needs: verify/,
+    release,
+    /release-build:\n {4}if: github\.ref == 'refs\/heads\/main'\n {4}needs: verify/,
   );
 
   // Tester dispatch is separate from the versioned release dispatch. Both

--- a/tests/unit/snapshot-retention.test.ts
+++ b/tests/unit/snapshot-retention.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+  planSnapshotRetention,
+  type SnapshotRelease,
+} from "../../scripts/snapshot-retention.ts";
+
+const NOW = Date.parse("2026-07-27T12:00:00Z");
+const day = 24 * 60 * 60 * 1_000;
+
+function release(
+  sequence: number,
+  ageDays: number,
+  overrides: Partial<SnapshotRelease> = {},
+): SnapshotRelease {
+  return {
+    id: sequence,
+    tagName: `snapshot-${sequence}-abcdef${sequence}`,
+    publishedAt: new Date(NOW - ageDays * day).toISOString(),
+    draft: false,
+    prerelease: true,
+    ...overrides,
+  };
+}
+
+describe("snapshot retention", () => {
+  test("accepts an empty release history", () => {
+    assert.deepEqual(planSnapshotRetention([], NOW), { keep: [], remove: [] });
+  });
+
+  test("always keeps the newest snapshot, even after a quiet month", () => {
+    const newest = release(1, 30);
+    assert.deepEqual(planSnapshotRetention([newest], NOW), {
+      keep: [newest],
+      remove: [],
+    });
+  });
+
+  test("keeps three recent snapshots regardless of API ordering", () => {
+    const releases = [release(2, 2), release(1, 3), release(3, 1)];
+    assert.deepEqual(
+      planSnapshotRetention(releases, NOW).keep.map(({ id }) => id),
+      [3, 2, 1],
+    );
+  });
+
+  test("removes every snapshot beyond the newest three", () => {
+    const plan = planSnapshotRetention(
+      [release(1, 4), release(4, 1), release(2, 3), release(3, 2)],
+      NOW,
+    );
+    assert.deepEqual(plan.keep.map(({ id }) => id), [4, 3, 2]);
+    assert.deepEqual(
+      plan.remove.map(({ release: item, reason }) => [item.id, reason]),
+      [[1, "overflow"]],
+    );
+  });
+
+  test("expires the second and third snapshots after fourteen days", () => {
+    const plan = planSnapshotRetention(
+      [release(3, 15), release(1, 21), release(2, 18)],
+      NOW,
+    );
+    assert.deepEqual(plan.keep.map(({ id }) => id), [3]);
+    assert.deepEqual(
+      plan.remove.map(({ release: item, reason }) => [item.id, reason]),
+      [
+        [2, "expired"],
+        [1, "expired"],
+      ],
+    );
+  });
+
+  test("has no authority over versioned or malformed releases", () => {
+    const realRelease = release(1, 100, {
+      tagName: "v2026.7.0-beta.1",
+    });
+    const malformed = release(2, 100, {
+      tagName: "snapshot-latest",
+    });
+    const draft = release(3, 100, { draft: true });
+    const ordinaryPrerelease = release(4, 100, {
+      tagName: "preview-4-abcdef4",
+    });
+    assert.deepEqual(
+      planSnapshotRetention(
+        [realRelease, malformed, draft, ordinaryPrerelease],
+        NOW,
+      ),
+      { keep: [], remove: [] },
+    );
+  });
+});

--- a/tests/website-smoke.ts
+++ b/tests/website-smoke.ts
@@ -47,6 +47,16 @@ const PRERELEASE = {
   assets: [PRERELEASE_ARM64_ZIP],
 };
 const DRAFT = { ...STABLE, tag_name: "v0.0.5", draft: true };
+const SNAPSHOTS = Array.from({ length: 25 }, (_, index) => ({
+  tag_name: `snapshot-${index + 1}-abcdef${index % 10}`,
+  draft: false,
+  prerelease: true,
+  assets: [{
+    name: `Guild-Wars-abcdef${index % 10}-macOS-arm64.zip`,
+    browser_download_url:
+      `https://github.com/Mat4m0/gwonmac/releases/download/snapshot-${index + 1}/snapshot.zip`,
+  }],
+}));
 
 // The resolved download is the arm64 ZIP of the release, not its checksums.
 assert.equal(WEBSITE_RELEASE_CHANNEL, "preview");
@@ -65,6 +75,35 @@ assert.deepEqual(selectWebsiteDownload([PRERELEASE]), {
   url: PRERELEASE_ARM64_ZIP.browser_download_url,
   version: "0.0.4-alpha.1",
 });
+
+// Snapshots are public GitHub prereleases but never application versions. A
+// failed cleanup can put more than one old API page ahead of the beta without
+// changing the website's answer, whichever side of it GitHub returns them on.
+assert.deepEqual(selectWebsiteDownload([...SNAPSHOTS, PRERELEASE, STABLE]), {
+  url: PRERELEASE_ARM64_ZIP.browser_download_url,
+  version: "0.0.4-alpha.1",
+});
+assert.deepEqual(selectWebsiteDownload([PRERELEASE, STABLE, ...SNAPSHOTS]), {
+  url: PRERELEASE_ARM64_ZIP.browser_download_url,
+  version: "0.0.4-alpha.1",
+});
+assert.deepEqual(
+  selectWebsiteDownload([
+    {
+      ...SNAPSHOTS[0],
+      tag_name: "snapshot-latest",
+    },
+    {
+      ...SNAPSHOTS[1],
+      assets: [CHECKSUMS, SBOM],
+    },
+    PRERELEASE,
+  ]),
+  {
+    url: PRERELEASE_ARM64_ZIP.browser_download_url,
+    version: "0.0.4-alpha.1",
+  },
+);
 
 // Drafts are invisible to a logged-out visitor and are not offered either.
 assert.deepEqual(selectWebsiteDownload([DRAFT, PRERELEASE]), {
@@ -123,8 +162,10 @@ assert.equal(selectWebsiteDownload({ message: "API rate limit exceeded" }), null
 {
   const realFetch = globalThis.fetch;
   let calls = 0;
-  globalThis.fetch = async () => {
+  let requested = "";
+  globalThis.fetch = async (input) => {
     calls += 1;
+    requested = String(input);
     return new globalThis.Response(JSON.stringify([PRERELEASE, STABLE]), {
       headers: { "content-type": "application/json" },
     });
@@ -137,6 +178,10 @@ assert.equal(selectWebsiteDownload({ message: "API rate limit exceeded" }), null
       loadWebsiteDownload(),
     ]);
     assert.equal(calls, 1);
+    assert.equal(
+      requested,
+      "https://api.github.com/repos/Mat4m0/gwonmac/releases?per_page=100",
+    );
     for (const answer of answers) {
       assert.deepEqual(answer, {
         url: PRERELEASE_ARM64_ZIP.browser_download_url,


### PR DESCRIPTION
## What changed

- extract the existing macOS gate into one reusable, read-only verification workflow
- upload tested PR packages for three days
- publish immutable tester snapshot prereleases after successful `main` builds or manual tester dispatches
- attach the ARM64 ZIP, SHA-256 checksums, SPDX SBOM, exact source commit, and provenance/SBOM attestations
- retain at most three exact `snapshot-*` releases and expire all but the newest after 14 days
- keep versioned releases and the stable release dispatch isolated from snapshots
- add a required preview-feedback issue form and snapshot documentation
- make the website inspect 100 releases while continuing to ignore snapshots

## Why

Users need a quick way to test the latest verified build without waiting for a
versioned release. PR artifacts serve collaborators, while public bounded
snapshots serve testers without changing the website or in-app release channel.

No nightly job is added: successful `main` builds provide the feedback loop
without rebuilding unchanged commits.

## Safety and retention

The PR verification path remains read-only. Snapshot publishing receives write
and attestation permissions only after the reusable verification job succeeds.
Cleanup runs only after release publication and matches the exact immutable
snapshot tag grammar; `v*` releases are outside its authority.

## Validation

- `pnpm verify`
- `pnpm test:website`
- 488 unit tests
- 20 integration tests
- 55 Electron tests (1 live-network test skipped by design)
- release and packaged-runtime smoke tests
- strict ad-hoc signature verification of the packaged ARM64 app
- live read-only retention dry-run against `Mat4m0/gwonmac`
