### PR TITLE
fix: keep camera rotation alive when dragging left

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -531,6 +531,19 @@ smaller window: the released button interrupts the client's drag, and until the
 leftover delta was spent in the same task rather than the next animation frame,
 each recycle also froze the camera for a frame.
 
+That roam runs outward only. The client integrates a move whose coordinates sit
+past the far edge of the canvas, but ignores one whose client coordinates are
+negative, and resumes only once they come back — so the near side of the budget
+is bounded by the window edge rather than by the sixteen canvases. Without that
+bound a canvas flush against the window, which is how the game canvas is laid
+out, spent half a canvas of leftward travel inside the window and the remaining
+sixteen in a range the client discards: rotating right ran indefinitely while
+rotating left froze after one flick and stayed frozen, because the re-anchor
+that would have restored it sits sixteen canvases beyond where a hand ever
+drags. Bounded at the window edge, the near side recycles about every half
+canvas of travel — far more often than the far side, and the cost of keeping
+every coordinate in the range the client accepts.
+
 The client identifies a key by `KeyboardEvent.key`, so its held-key state is
 character state, not physical state. macOS makes Option a text modifier, which
 rewrites that character for as long as Option is held: `W` arrives as `∑` on a

--- a/src/renderer/input.ts
+++ b/src/renderer/input.ts
@@ -7,7 +7,9 @@ import type { AppSettings } from '../shared/contracts.js';
 // integrating mouse moves whose coordinates fall outside the canvas, so a drag
 // need not stop at the edge — it only needs to stop somewhere, or the
 // coordinates of a long drag grow without limit. Sixteen of them put a
-// re-anchor several camera revolutions apart at any window size.
+// re-anchor several camera revolutions apart at any window size. Only outward:
+// the window edge bounds the near side, because the client ignores a move whose
+// client coordinates are negative.
 const POINTER_ROAM = 16;
 
 // Re-anchors a single mouse move may spend before the leftover delta is
@@ -526,16 +528,25 @@ export const installGameInput = ({
     const rect = canvas.getBoundingClientRect();
     const roamX = rect.width * POINTER_ROAM;
     const roamY = rect.height * POINTER_ROAM;
+    // Roam is free past the far edges and worthless past the near ones: the
+    // client stops integrating a drag whose client coordinates go negative, and
+    // resumes only once they come back. A canvas flush against the window — this
+    // one fills it — therefore has sixteen canvases of room rightward and half a
+    // canvas leftward, which is why rotating right ran forever while rotating
+    // left froze within one flick and stayed frozen: the re-anchor that would
+    // have rescued it is sixteen canvases further out than a hand ever drags.
+    const nearX = Math.max(-roamX, -rect.left);
+    const nearY = Math.max(-roamY, -rect.top);
     let restX = movementX;
     let restY = movementY;
     // Each re-anchor buys another budget, so a bounded few consume any delta a
     // hand can produce. The bound also ends the loop on a zero-area canvas.
     for (let regrab = 0; ; regrab += 1) {
       const stepX =
-        Math.max(-roamX, Math.min(rect.width + roamX, virtualCursor.x + restX)) -
+        Math.max(nearX, Math.min(rect.width + roamX, virtualCursor.x + restX)) -
         virtualCursor.x;
       const stepY =
-        Math.max(-roamY, Math.min(rect.height + roamY, virtualCursor.y + restY)) -
+        Math.max(nearY, Math.min(rect.height + roamY, virtualCursor.y + restY)) -
         virtualCursor.y;
       virtualCursor.x += stepX;
       virtualCursor.y += stepY;


### PR DESCRIPTION
## What changed

Rotating the camera right ran indefinitely; rotating left froze after roughly one flick of the mouse and stayed frozen no matter how far you kept dragging.

A held right-drag steers the client from absolute coordinates, so `input.ts` runs a virtual cursor and lets it roam sixteen canvases past the edge before releasing the button, re-anchoring at center and pressing again. That budget was symmetric. The client's tolerance is not: it keeps integrating moves whose coordinates sit past the far edge, and ignores any whose client coordinates are negative.

The game canvas fills the window, so from a press near the middle only half a canvas of leftward travel lands inside the window — the remaining sixteen land in a range the client discards. The re-anchor that would have restored the drag sits sixteen canvases beyond where a hand ever drags, so the freeze was permanent for the life of the gesture.

This bounds the near side of the roam at the window edge, leaving the far side untouched:

```ts
const nearX = Math.max(-roamX, -rect.left);
const nearY = Math.max(-roamY, -rect.top);
```

Every coordinate the host sends now stays in the range the client accepts.

## Reviewer notes

- **The tradeoff is real and worth a look.** The far side still has sixteen canvases and effectively never recycles; the near side now recycles about every half canvas of travel. Each recycle is the mouseup/mousedown pair that briefly interrupts the client's drag — the cost `POINTER_ROAM` was introduced to make rare (accdc3d). Left rotation is continuous where it used to be dead, but it is not as smooth as right. Making both directions symmetric means re-anchoring the press far out in positive coordinates instead of at canvas center, which presses outside the canvas and needs validating on its own; that is deliberately not in this PR.
- **No new test.** The existing camera-drag e2e tests fake the canvas rect at `box.x + 95`, so their client coordinates never go negative and their expectations are unchanged (`max(-64, -95)` is still `-64`). Covering this case needs the canvas flush at x=0 and a Playwright mouse move to a negative viewport coordinate — worth adding, but I did not want to land a test I had not actually run.
- `docs/internals.md` gains the near-side bound, since the paragraph on roam described a symmetric budget.

## Verification

Measured against the running client at a 1364px canvas, by recording every synthetic event the client received during held drags:

- The host fed `clientX` from **-4613 to +10683** across two drags, tracking `movementX` exactly at every step, with **zero re-anchors** — so the host was never what stopped, and it was still faithfully reporting mouse motion at -4613 while the camera was frozen.
- The client rotated from coordinates as far out as **+10683**, about seven canvases past the right edge, and ignored everything below 0. One drag swept left from +10683 down through 0 rotating normally, then died exactly where the coordinates went negative.

Commands:

- `pnpm typecheck` — clean
- `pnpm lint` — clean
- `pnpm check:links` — clean
- Electron e2e not run (needs a build); the four camera-drag specs in `tests/electron/input.spec.ts` are unaffected by construction, as noted above.

- [ ] I ran the relevant automated tests.
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [x] I updated documentation when behavior or an invariant changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)