### PR TITLE
Optimize snapshot loading bursts

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -105,7 +105,11 @@ Chromium's derived network cache is cleared at startup; otherwise it duplicates
 hundreds of megabytes of already-resident native chunks. This does not remove
 or redownload the canonical chunk store. `image.fileSize` stays synchronous
 because the snapshot metadata is obtained before the Emscripten glue is
-appended.
+appended. Adjacent demand chunks already queued in the same renderer turn share
+one bounded range request and are split back into compact cache entries; the
+eight-request ceiling continues to count chunks, not HTTP requests. A
+multi-chunk `image.cacheAsync` queues its whole range so the same scheduler can
+use all eight slots while demand retains priority over queued prefetch.
 
 Download concurrency is capped at eight. This is a conduct constraint as well
 as a performance setting: every installation uses the public client access key

--- a/src/main/diagnostics.ts
+++ b/src/main/diagnostics.ts
@@ -315,6 +315,7 @@ export function recordRendererMetrics(value: RendererMetrics): void {
   recorder.count("renderer.presentationFailures", value.presentationFailures);
   recorder.count("snapshot.reads", value.snapshotReads);
   recorder.count("snapshot.bytes", value.snapshotBytes);
+  recorder.count("snapshot.readsFromMemory", value.snapshotMemoryReads);
   recorder.count("cache.memoryHits", value.memoryHits);
   recorder.count("cache.nativeHits", value.nativeHits);
   recorder.count("cache.coalesced", value.coalesced);

--- a/src/renderer/diagnostics.ts
+++ b/src/renderer/diagnostics.ts
@@ -112,6 +112,7 @@
     snapshotTotalUs: 0,
     snapshotMinUs: 0,
     snapshotMaxUs: 0,
+    snapshotMemoryReads: 0,
     memoryHits: 0,
     nativeHits: 0,
     coalesced: 0,
@@ -345,11 +346,12 @@
       announceCapture('Performance problem marked.');
     },
     event: recordEvent,
+    // This is per readAsync. The cache() counters below are per chunk, so
+    // mixing them would produce a ratio with two different denominators.
     snapshot(durationUs, bytes, source) {
       observe(metrics, 'snapshot', durationUs, 'snapshotReads');
       metrics.snapshotBytes += bytes;
-      if (source === 'memory') metrics.memoryHits++;
-      else if (source === 'native') metrics.nativeHits++;
+      if (source === 'memory') metrics.snapshotMemoryReads++;
       traceMark('gw.snapshot.resolve');
     },
     cache(source) {

--- a/src/renderer/graphics.ts
+++ b/src/renderer/graphics.ts
@@ -4,6 +4,48 @@
 
 let diagnosticsFrame = 0;
 
+interface StaticContextFacts {
+  renderer: string;
+  vendor: string;
+  samples: number;
+  antialias: boolean;
+}
+
+// These values are fixed for a WebGL context. Re-reading them after every
+// client-owned resize can flush the command buffer and synchronously wait on
+// the GPU process, so retain them only for that context's lifetime.
+const staticContextFacts = new WeakMap<
+  WebGLRenderingContext | WebGL2RenderingContext,
+  StaticContextFacts
+>();
+
+function contextFacts(
+  gl: WebGLRenderingContext | WebGL2RenderingContext,
+): StaticContextFacts {
+  const cached = staticContextFacts.get(gl);
+  if (cached) return cached;
+  const debugInfo = gl.getExtension('WEBGL_debug_renderer_info');
+  const renderer: unknown = debugInfo
+    ? gl.getParameter(debugInfo.UNMASKED_RENDERER_WEBGL)
+    : 'unknown';
+  const vendor: unknown = debugInfo
+    ? gl.getParameter(debugInfo.UNMASKED_VENDOR_WEBGL)
+    : 'unknown';
+  const facts = {
+    renderer: String(renderer),
+    vendor: String(vendor),
+    samples: Number(gl.getParameter(gl.SAMPLES) || 0),
+    antialias: !!gl.getContextAttributes()?.antialias,
+  };
+  staticContextFacts.set(gl, facts);
+  return facts;
+}
+
+function forgetContextFacts(canvas: OffscreenCanvas) {
+  const gl = canvas.getContext('webgl2') || canvas.getContext('webgl');
+  if (gl) staticContextFacts.delete(gl);
+}
+
 /**
  * The visible canvas, carrying the two things this module attaches to it: the
  * OffscreenCanvas the client renders into and the bitmaprenderer context that
@@ -25,16 +67,9 @@ function scheduleDiagnostics(
   diagnosticsFrame = requestAnimationFrame(async () => {
     try {
       const gl = offscreen.getContext('webgl2') || offscreen.getContext('webgl');
-      const dbg = gl && gl.getExtension('WEBGL_debug_renderer_info');
-      // `getParameter` is declared `any`, so both are pinned to `unknown` and
-      // stringified below rather than trusted.
-      const renderer: unknown = dbg
-        ? gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL)
-        : (gl ? 'unknown' : 'none');
-      const vendor: unknown = dbg
-        ? gl.getParameter(dbg.UNMASKED_VENDOR_WEBGL)
-        : (gl ? 'unknown' : 'none');
-      const attributes = gl?.getContextAttributes();
+      const { renderer, vendor, samples, antialias } = gl
+        ? contextFacts(gl)
+        : { renderer: 'none', vendor: 'none', samples: 0, antialias: false };
       await window.gwNative.diagnostics.recordGraphics({
         userAgent: navigator.userAgent,
         jspi: 'Suspending' in WebAssembly,
@@ -43,12 +78,12 @@ function scheduleDiagnostics(
               ? 'WebGL2'
               : 'WebGL')
           : 'none',
-        renderer: String(renderer),
-        vendor: String(vendor),
+        renderer,
+        vendor,
         hardwareAcceleration:
           renderer !== 'unknown' &&
           renderer !== 'none' &&
-          !/swiftshader|llvmpipe|software/i.test(String(renderer)),
+          !/swiftshader|llvmpipe|software/i.test(renderer),
         canvasWidth: visible.width,
         canvasHeight: visible.height,
         offscreenWidth: offscreen.width,
@@ -57,8 +92,8 @@ function scheduleDiagnostics(
         drawingBufferHeight: gl?.drawingBufferHeight || 0,
         devicePixelRatio: window.devicePixelRatio || 1,
         renderScale,
-        antialias: !!attributes?.antialias,
-        samples: gl ? Number(gl.getParameter(gl.SAMPLES) || 0) : 0,
+        antialias,
+        samples,
       });
       window.dispatchEvent(new globalThis.Event('gw:graphics-resized'));
     } catch (error) {
@@ -97,6 +132,7 @@ export const installGraphics = (options: {
       visible.offscreen = new OffscreenCanvas(visible.width, visible.height);
       visible.offscreen.addEventListener('webglcontextlost', (event) => {
         event.preventDefault();
+        forgetContextFacts(visible.offscreen!);
         performance.mark('gw.graphics.context-lost');
         // Program objects do not survive the context; anything memoized
         // about them has to go with it.
@@ -105,6 +141,7 @@ export const installGraphics = (options: {
         void window.gwDiagnostics?.flush();
       });
       visible.offscreen.addEventListener('webglcontextrestored', () => {
+        forgetContextFacts(visible.offscreen!);
         performance.mark('gw.graphics.context-restored');
         window.dispatchEvent(new globalThis.Event('gw:graphics-context-reset'));
         window.gwDiagnostics?.event('graphics.contextRestored');

--- a/src/renderer/image-source.ts
+++ b/src/renderer/image-source.ts
@@ -141,6 +141,7 @@ export function createImageSource({
   const prefetchQueue: ChunkTask[] = [];
   let activeDemand = 0;
   let activePrefetch = 0;
+  let drainScheduled = false;
   let stopped = false;
 
   const handles = new Set<number>();
@@ -198,36 +199,86 @@ export function createImageSource({
     diagnostics?.scheduler('promotion');
   }
 
+  function takeDemandBatch(capacity: number): ChunkTask[] {
+    const first = demandQueue.shift();
+    if (!first) return [];
+    const tasks = [first];
+    while (tasks.length < Math.min(capacity, MAX_CHUNK_REQUESTS)) {
+      const nextIndex = tasks[tasks.length - 1]!.index + 1;
+      const queuedIndex = demandQueue.findIndex((task) => task.index === nextIndex);
+      if (queuedIndex < 0) break;
+      const [next] = demandQueue.splice(queuedIndex, 1);
+      tasks.push(next!);
+    }
+    return tasks;
+  }
+
+  function startChunkTasks(tasks: ChunkTask[]) {
+    const priority = tasks[0]!.priority;
+    for (const task of tasks) task.state = 'active';
+    if (priority === 'demand') activeDemand += tasks.length;
+    else activePrefetch += tasks.length;
+
+    const firstIndex = tasks[0]!.index;
+    const lastIndex = tasks[tasks.length - 1]!.index;
+    const start = firstIndex * chunkSize;
+    const end = Math.min((lastIndex + 1) * chunkSize, size);
+    void fetchRange(start, end - start, priority).then((buf) => {
+      if (buf.length !== end - start) {
+        throw new Error(`snapshot range ${start}+${end - start}: received ${buf.length}`);
+      }
+      for (const task of tasks) {
+        const chunkStart = task.index * chunkSize;
+        const length = Math.min(chunkStart + chunkSize, size) - chunkStart;
+        const offset = chunkStart - start;
+        // A subarray would keep the whole batched response alive after sibling
+        // chunks were evicted and make the byte-budgeted LRU undercount memory.
+        const chunk = tasks.length === 1
+          ? buf
+          : buf.slice(offset, offset + length);
+        cachePut(task.index, chunk);
+        markResident(task.index);
+        stats.fromNative++;
+        diagnostics?.cache('native');
+        task.resolve(chunk);
+      }
+    }).catch((error) => {
+      lastError = error instanceof Error ? error.message : String(error);
+      for (const task of tasks) task.reject(error);
+    }).finally(() => {
+      for (const task of tasks) inflight.delete(task.index);
+      if (priority === 'demand') activeDemand -= tasks.length;
+      else activePrefetch -= tasks.length;
+      drainChunkQueue();
+    });
+  }
+
   function drainChunkQueue() {
     while (activeDemand + activePrefetch < MAX_CHUNK_REQUESTS) {
-      const task = demandQueue.shift() || prefetchQueue.shift();
+      const capacity = MAX_CHUNK_REQUESTS - activeDemand - activePrefetch;
+      const demand = takeDemandBatch(capacity);
+      if (demand.length) {
+        startChunkTasks(demand);
+        continue;
+      }
+      const task = prefetchQueue.shift();
       if (!task) return;
-      if (stopped && task.priority === 'prefetch') {
+      if (stopped) {
         task.reject(new Error('background download stopped'));
         inflight.delete(task.index);
         continue;
       }
-      task.state = 'active';
-      if (task.priority === 'demand') activeDemand++;
-      else activePrefetch++;
-      const start = task.index * chunkSize;
-      const length = Math.min(start + chunkSize, size) - start;
-      void fetchRange(start, length, task.priority).then((buf) => {
-        cachePut(task.index, buf);
-        markResident(task.index);
-        stats.fromNative++;
-        diagnostics?.cache('native');
-        task.resolve(buf);
-      }).catch((error) => {
-        lastError = error instanceof Error ? error.message : String(error);
-        task.reject(error);
-      }).finally(() => {
-        inflight.delete(task.index);
-        if (task.priority === 'demand') activeDemand--;
-        else activePrefetch--;
-        drainChunkQueue();
-      });
+      startChunkTasks([task]);
     }
+  }
+
+  function scheduleChunkDrain() {
+    if (drainScheduled) return;
+    drainScheduled = true;
+    queueMicrotask(() => {
+      drainScheduled = false;
+      drainChunkQueue();
+    });
   }
 
   function chunkBytes(i: number, priority: Priority): Promise<Uint8Array> {
@@ -252,7 +303,7 @@ export function createImageSource({
     const task: ChunkTask = { index: i, priority, state: 'queued', promise, resolve, reject };
     inflight.set(i, task);
     (priority === 'demand' ? demandQueue : prefetchQueue).push(task);
-    drainChunkQueue();
+    scheduleChunkDrain();
     return promise;
   }
 
@@ -268,10 +319,12 @@ export function createImageSource({
     last: number,
     progress: ((bytes: number) => void) | undefined,
   ) {
-    for (let i = first; i <= last; i++) {
-      const buf = await chunkBytes(i, 'prefetch');
-      if (progress) progress(buf.length);
-    }
+    await Promise.all(
+      Array.from({ length: last - first + 1 }, (_, n) =>
+        chunkBytes(first + n, 'prefetch').then((buf) => {
+          if (progress) progress(buf.length);
+        })),
+    );
   }
 
   function assembleRange(
@@ -313,7 +366,8 @@ export function createImageSource({
     burstTimer = setTimeout(() => {
       burstTimer = null;
       if (burstBytes > BURST_LOG_BYTES) {
-        log(`image: read ${(burstBytes / 1048576).toFixed(1)}MB (mem ${stats.fromMemory}, ` +
+        log(`image: completed ${(burstBytes / 1048576).toFixed(1)}MB read burst ` +
+            `(mem ${stats.fromMemory}, ` +
             `native ${stats.fromNative} chunks)`);
       }
       burstBytes = 0;

--- a/src/shared/diagnostics.ts
+++ b/src/shared/diagnostics.ts
@@ -103,6 +103,7 @@ const RENDERER_METRIC_FIELDS = {
     "snapshotTotalUs",
     "snapshotMinUs",
     "snapshotMaxUs",
+    "snapshotMemoryReads",
     "memoryHits",
     "nativeHits",
     "coalesced",
@@ -349,6 +350,7 @@ export function isRendererMetrics(value: unknown): value is RendererMetrics {
     "swapCount",
     "snapshotReads",
     "snapshotBytes",
+    "snapshotMemoryReads",
     "memoryHits",
     "nativeHits",
     "coalesced",
@@ -389,6 +391,7 @@ export function isRendererMetrics(value: unknown): value is RendererMetrics {
     counters.every((key) => Number.isSafeInteger(record[key])) &&
     (record.rafOver50 as number) <= (record.rafOver33 as number) &&
     (record.rafOver33 as number) <= (record.rafCount as number) &&
+    (record.snapshotMemoryReads as number) <= (record.snapshotReads as number) &&
     (record.presentationFailures as number) <= (record.swapCount as number)
   );
 }

--- a/src/tools/diagnostics/summarize.ts
+++ b/src/tools/diagnostics/summarize.ts
@@ -21,7 +21,8 @@ if (!input) {
       (c[sum] ?? 0) / Math.max(1, c[samples] ?? 0);
     const cacheTotal =
       (c["cache.memoryHits"] ?? 0) +
-      (c["cache.nativeHits"] ?? 0);
+      (c["cache.nativeHits"] ?? 0) +
+      (c["cache.coalesced"] ?? 0);
 
     console.log(`Session       ${manifest.sessionId}`);
     console.log(`App           ${manifest.applicationVersion}`);
@@ -104,7 +105,9 @@ if (!input) {
     console.log(`  initial cache     ${summary.latest["cache.initialResidentChunks"] ?? 0} / ${summary.latest["cache.totalChunks"] ?? 0} chunks`);
     console.log(`  reads / bytes    ${c["snapshot.reads"] ?? 0} / ${c["snapshot.bytes"] ?? 0}`);
     console.log(`  read p95/max     ${milliseconds(h["snapshot.rendererRead"]?.p95Us)} / ${milliseconds(h["snapshot.rendererRead"]?.maxUs)}`);
-    console.log(`  memory hit ratio ${ratio(c["cache.memoryHits"] ?? 0, cacheTotal)}`);
+    console.log(`  reads from memory ${ratio(c["snapshot.readsFromMemory"] ?? 0, c["snapshot.reads"] ?? 0)} of reads`);
+    console.log(`  chunks from memory ${ratio(c["cache.memoryHits"] ?? 0, cacheTotal)} of chunk resolutions`);
+    console.log(`  read amplification ${multiple(c["protocol.snapshotBytes"] ?? 0, c["snapshot.bytes"] ?? 0)} (bytes served / bytes read)`);
     console.log(`  disk p95         ${milliseconds(h["cache.diskRead"]?.p95Us)}`);
     console.log(
       `  demand queue p95 ${milliseconds(

--- a/tests/unit/diagnostics.test.ts
+++ b/tests/unit/diagnostics.test.ts
@@ -50,6 +50,7 @@ function metrics(): RendererMetrics {
     snapshotTotalUs: 20_000,
     snapshotMinUs: 5_000,
     snapshotMaxUs: 15_000,
+    snapshotMemoryReads: 1,
     memoryHits: 1,
     nativeHits: 1,
     coalesced: 0,
@@ -119,6 +120,10 @@ describe("renderer diagnostics boundary", () => {
     delete missing.swapCount;
     assert.equal(isRendererMetrics(missing), false);
     assert.equal(isRendererMetrics({ ...metrics(), snapshotBytes: -1 }), false);
+    assert.equal(
+      isRendererMetrics({ ...metrics(), snapshotMemoryReads: 3 }),
+      false,
+    );
     assert.equal(isRendererMetrics({ ...metrics(), rafMaxUs: Number.NaN }), false);
     assert.equal(
       isRendererMetrics({ ...metrics(), socketCompactBytes: 64 * 1024 * 1024 }),

--- a/tests/unit/graphics.test.ts
+++ b/tests/unit/graphics.test.ts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { installGraphics } from "../../src/renderer/graphics.js";
+
+test("graphics diagnostics read immutable context facts only once", async () => {
+  const animationFrames: FrameRequestCallback[] = [];
+  const reports: unknown[] = [];
+  const parameterCalls: number[] = [];
+  let attributeCalls = 0;
+  const contextListeners = new Map<string, (event: { preventDefault(): void }) => void>();
+
+  const gl = {
+    SAMPLES: 3,
+    drawingBufferWidth: 1280,
+    drawingBufferHeight: 720,
+    getExtension: () => ({
+      UNMASKED_RENDERER_WEBGL: 1,
+      UNMASKED_VENDOR_WEBGL: 2,
+    }),
+    getParameter: (parameter: number) => {
+      parameterCalls.push(parameter);
+      if (parameter === 1) return "renderer";
+      if (parameter === 2) return "vendor";
+      return 0;
+    },
+    getContextAttributes: () => {
+      attributeCalls++;
+      return { antialias: false };
+    },
+  };
+
+  class FakeOffscreenCanvas {
+    readonly width: number;
+    readonly height: number;
+    constructor(width: number, height: number) {
+      this.width = width;
+      this.height = height;
+    }
+    addEventListener(
+      name: string,
+      listener: (event: { preventDefault(): void }) => void,
+    ) {
+      contextListeners.set(name, listener);
+    }
+    getContext(kind: string) {
+      return kind === "webgl2" ? gl : null;
+    }
+  }
+
+  class FakeCanvas {
+    width = 1280;
+    height = 720;
+    offscreen?: FakeOffscreenCanvas;
+    context?: { transferFromImageBitmap(): void } | null;
+    getContext(kind: string) {
+      if (kind !== "bitmaprenderer") return null;
+      return { transferFromImageBitmap() {} };
+    }
+  }
+
+  Object.assign(globalThis, {
+    HTMLCanvasElement: FakeCanvas,
+    OffscreenCanvas: FakeOffscreenCanvas,
+    requestAnimationFrame: (callback: FrameRequestCallback) => {
+      animationFrames.push(callback);
+      return animationFrames.length;
+    },
+    cancelAnimationFrame: () => {},
+    window: {
+      gwNative: {
+        diagnostics: {
+          recordGraphics: async (report: unknown) => {
+            reports.push(report);
+          },
+        },
+      },
+      dispatchEvent: () => true,
+    },
+  });
+
+  const canvas = new FakeCanvas();
+  const env = {
+    eglCreateContext: () => 1,
+    eglSwapBuffers: () => 1,
+  };
+  const module = { canvas };
+  installGraphics({
+    env: env as unknown as Parameters<typeof installGraphics>[0]["env"],
+    module: module as unknown as Parameters<typeof installGraphics>[0]["module"],
+    renderScale: () => 1,
+    firstFrame: () => {},
+    log: () => {},
+  });
+
+  env.eglCreateContext();
+  await animationFrames.shift()!(0);
+  env.eglCreateContext();
+  await animationFrames.shift()!(0);
+
+  assert.equal(reports.length, 2, "resize diagnostics still publish twice");
+  assert.deepEqual(
+    parameterCalls,
+    [1, 2, 3],
+    "renderer, vendor, and sample count are context-lifetime facts",
+  );
+  assert.equal(attributeCalls, 1, "context creation attributes are fixed too");
+
+  contextListeners.get("webglcontextlost")!({ preventDefault() {} });
+  env.eglCreateContext();
+  await animationFrames.shift()!(0);
+  assert.deepEqual(parameterCalls, [1, 2, 3, 1, 2, 3]);
+  assert.equal(attributeCalls, 2, "a restored context is measured afresh");
+});

--- a/tests/unit/image-source.test.ts
+++ b/tests/unit/image-source.test.ts
@@ -170,41 +170,82 @@ describe("renderer image source", () => {
     source.stop();
   });
 
-  it("shares the eight-request ceiling between demand and prefetch work", async () => {
+  it("batches adjacent queued demand chunks without fetching across a gap", async () => {
+    const { image, source, transport, heap, handle } = makeSource({
+      size: 64 * 5,
+      chunkSize: 64,
+    });
+
+    const first = image.readAsync(handle, 0, null, 0, 16);
+    const adjacent = image.readAsync(handle, 64, null, 64, 16);
+    const afterGap = image.readAsync(handle, 3 * 64, null, 128, 16);
+    await turn();
+
+    assert.equal(transport.requests.length, 2);
+    assert.deepEqual(
+      transport.requests.map(({ start, length, priority }) => ({
+        start,
+        length,
+        priority,
+      })),
+      [
+        { start: 0, length: 128, priority: "demand" },
+        { start: 3 * 64, length: 64, priority: "demand" },
+      ],
+    );
+    assert.equal(source.state().activeDemand, 3, "the ceiling counts chunks");
+
+    transport.serveImmediately();
+    await Promise.all([first, adjacent, afterGap]);
+    assert.deepEqual(heap.subarray(0, 16), snapshotBytes(0, 16));
+    assert.deepEqual(heap.subarray(64, 80), snapshotBytes(64, 16));
+    assert.deepEqual(heap.subarray(128, 144), snapshotBytes(3 * 64, 16));
+    assert.equal(source.stats().fromNative, 3);
+    source.stop();
+  });
+
+  it("counts batched demand chunks toward the shared eight-chunk ceiling", async () => {
     const { image, source, transport, handle } = makeSource({
       size: 64 * 16,
       chunkSize: 64,
     });
 
-    // Four prefetches take four of the eight slots.
+    // All work is queued in one turn. Demand overtakes prefetch, and its six
+    // adjacent chunks share one range request while still consuming six slots.
     for (let chunk = 0; chunk < 4; chunk++) {
       void image.cacheAsync(handle, chunk * 64, 1, () => {}).catch(() => {});
     }
-    // Six demand reads compete for the four that are left.
     const reads = Array.from({ length: 6 }, (_, n) =>
       image.readAsync(handle, (4 + n) * 64, null, 0, 16));
     await turn();
 
-    assert.equal(transport.requests.length, 8, "the ceiling counts both priorities");
+    assert.equal(transport.requests.length, 3);
+    assert.deepEqual(
+      {
+        start: transport.requests[0]!.start,
+        length: transport.requests[0]!.length,
+        priority: transport.requests[0]!.priority,
+      },
+      { start: 4 * 64, length: 6 * 64, priority: "demand" },
+    );
     assert.deepEqual(source.state(), {
       memoryCacheBytes: 0,
       memoryCacheChunks: 0,
       pendingChunks: 10,
-      activeDemand: 4,
-      activePrefetch: 4,
-      queuedDemand: 2,
-      queuedPrefetch: 0,
+      activeDemand: 6,
+      activePrefetch: 2,
+      queuedDemand: 0,
+      queuedPrefetch: 2,
     });
 
-    // A prefetch finishing hands its slot to a queued demand read, not to more
-    // prefetch work.
+    // Completing one range releases all six logical demand slots. The queued
+    // prefetch chunks can then start, but total active chunks never exceeds 8.
     transport.serve(0);
     await turn();
-    assert.equal(transport.requests.length, 9);
-    assert.deepEqual(transport.issued()[8], { start: 8 * 64, priority: "demand" });
-    assert.equal(source.state().activeDemand, 5);
-    assert.equal(source.state().activePrefetch, 3);
-    assert.equal(source.state().queuedDemand, 1);
+    assert.equal(transport.requests.length, 5);
+    assert.equal(source.state().activeDemand, 0);
+    assert.equal(source.state().activePrefetch, 4);
+    assert.equal(source.state().queuedPrefetch, 0);
 
     transport.serveImmediately();
     await Promise.all(reads);
@@ -238,12 +279,13 @@ describe("renderer image source", () => {
     source.stop();
   });
 
-  it("holds the eight-request ceiling, and releases a slot when a request completes", async () => {
+  it("runs one multi-chunk cacheAsync eight-wide and reports every chunk", async () => {
     const { image, source, transport } = makeSource({ size: 64 * 12, chunkSize: 64 });
 
-    for (let chunk = 0; chunk < 12; chunk++) {
-      void image.cacheAsync(1, chunk * 64, 1, () => {}).catch(() => {});
-    }
+    const progress: number[] = [];
+    const prefetch = image.cacheAsync(1, 0, 64 * 12, (bytes) => {
+      progress.push(bytes);
+    });
     await turn();
 
     assert.equal(transport.requests.length, 8);
@@ -263,6 +305,10 @@ describe("renderer image source", () => {
     assert.equal(transport.requests.length, 9);
     assert.equal(source.state().activePrefetch, 8);
     assert.equal(source.state().queuedPrefetch, 3);
+    transport.serveImmediately();
+    await prefetch;
+    assert.equal(progress.length, 12);
+    assert.equal(progress.reduce((sum, bytes) => sum + bytes, 0), 64 * 12);
     source.stop();
   });
 
@@ -342,7 +388,7 @@ describe("renderer image source", () => {
     source.stop();
   });
 
-  it("does not dead-end after eight simultaneous failures", async () => {
+  it("releases every slot after a batched failure", async () => {
     const { image, source, transport, heap, handle } = makeSource({
       size: 64 * 12,
       chunkSize: 64,
@@ -352,25 +398,49 @@ describe("renderer image source", () => {
     const reads = Array.from({ length: 12 }, (_, chunk) =>
       image.readAsync(handle, chunk * 64, null, 0, 16));
     await turn();
-    assert.equal(transport.requests.length, 8);
+    assert.equal(transport.requests.length, 1);
+    assert.equal(transport.requests[0]!.length, 8 * 64);
     assert.equal(source.state().queuedDemand, 4);
 
-    // Every slot fails. If a failure kept its slot the scheduler would be
-    // permanently full and the four queued chunks would never be requested.
-    for (let index = 0; index < 8; index++) {
-      transport.fail(index, `Game data download failed (HTTP 50${index}).`);
-      await assert.rejects(reads[index]!, new RegExp(`HTTP 50${index}`));
-    }
+    // One failed range rejects its eight affected chunks and releases all
+    // eight logical slots, allowing the remaining batch to run.
+    transport.fail(0, "Game data download failed (HTTP 503).");
+    const failed = await Promise.allSettled(reads.slice(0, 8));
+    assert.ok(failed.every((result) => result.status === "rejected"));
     await turn();
 
-    assert.equal(transport.requests.length, 12, "the queued chunks got the freed slots");
+    assert.equal(transport.requests.length, 2, "the queued chunks got the freed slots");
+    assert.equal(transport.requests[1]!.start, 8 * 64);
+    assert.equal(transport.requests[1]!.length, 4 * 64);
     assert.equal(source.state().activeDemand, 4);
     assert.equal(source.state().queuedDemand, 0);
-    assert.equal(source.lastError(), "Game data download failed (HTTP 507).");
+    assert.equal(source.lastError(), "Game data download failed (HTTP 503).");
 
     transport.serveImmediately();
     await Promise.all(reads.slice(8));
     assert.deepEqual(heap.subarray(0, 16), snapshotBytes(11 * 64, 16));
+    source.stop();
+  });
+
+  it("rejects every affected chunk when a batched response is truncated", async () => {
+    const { image, source, transport, handle } = makeSource({
+      size: 128,
+      chunkSize: 64,
+      bytesFor: (start, length) => snapshotBytes(start, length - 1),
+    });
+
+    const reads = [
+      image.readAsync(handle, 0, null, 0, 16),
+      image.readAsync(handle, 64, null, 64, 16),
+    ];
+    await turn();
+    assert.equal(transport.requests.length, 1);
+
+    transport.serve(0);
+    await assert.rejects(Promise.all(reads), /received 127/);
+    await turn();
+    assert.equal(source.state().activeDemand, 0);
+    assert.equal(source.state().pendingChunks, 0);
     source.stop();
   });
 
@@ -384,24 +454,22 @@ describe("renderer image source", () => {
 
     await image.readAsync(handle, 12, null, 0, 20);
     assert.deepEqual(heap.subarray(0, 20), snapshotBytes(12, 20));
-    assert.deepEqual(transport.issued(), [
-      { start: 0, priority: "demand" },
-      { start: 16, priority: "demand" },
-    ]);
+    assert.deepEqual(transport.issued(), [{ start: 0, priority: "demand" }]);
+    assert.equal(transport.requests[0]!.length, 32);
 
     // Into the tail: chunk 1 is already resident, chunk 2 is 8 bytes long.
     await image.readAsync(handle, 30, null, 64, 10);
     assert.deepEqual(heap.subarray(64, 74), snapshotBytes(30, 10));
-    assert.equal(transport.requests.length, 3);
+    assert.equal(transport.requests.length, 2);
     assert.deepEqual(
-      { start: transport.requests[2]!.start, length: transport.requests[2]!.length },
+      { start: transport.requests[1]!.start, length: transport.requests[1]!.length },
       { start: 32, length: 8 },
     );
 
     // Wholly inside one cached chunk: no transport at all.
     await image.readAsync(handle, 20, null, 128, 4);
     assert.deepEqual(heap.subarray(128, 132), snapshotBytes(20, 4));
-    assert.equal(transport.requests.length, 3);
+    assert.equal(transport.requests.length, 2);
     assert.equal(source.stats().reads, 3);
     assert.ok(source.stats().fromMemory >= 1);
     source.stop();


### PR DESCRIPTION
## What changed

- Batch adjacent queued demand chunks into one bounded snapshot range request while preserving the eight-chunk ceiling.
- Let one multi-chunk `image.cacheAsync` use the existing scheduler's full concurrency, with demand still outranking queued prefetch.
- Split batched responses into compact LRU entries and reject truncated responses atomically.
- Cache immutable WebGL context facts for each context lifetime.
- Separate per-read memory diagnostics from per-chunk cache diagnostics and report read amplification correctly.
- Update the internal behavior documentation and clarify that the console line marks a completed read burst.

## Why

Zone loading issued many fixed-cost custom-protocol round trips, while `cacheAsync` fetched a multi-chunk range serially. The game suspends through JSPI while missing snapshot chunks are resolved, so those avoidable round trips appeared as loading hitches.

The change keeps native ownership and the existing ArenaNet concurrency ceiling intact. It adds no cache, public bridge, alternate transport, or compatibility path.

## Impact

In one clean Level 1 comparison, snapshot read p95 fell from 25 ms to 12 ms and frame p99 fell from 41 ms to 22.5 ms. Native chunk reads were grouped into fewer protocol requests. Targeted Level 2 attribution indicates that the remaining long loading frames are primarily inside the official client's synchronous decompression and CRC work, rather than host disk, queue, GPU, or presentation work.

Single-run frame differences are not treated as proof on their own; request grouping and reduced read latency are the direct evidence.

## Verification

- [x] `pnpm check`
- [x] `pnpm build`
- [x] `pnpm test:integration`
- [x] Live Level 1 and targeted Level 2 diagnostics on client build 38771
- [x] No game binaries, credentials, diagnostics, or private traffic were added
- [x] Updated `docs/internals.md`
