### PR TITLE
Fix official release packaged smoke expectation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,6 +134,8 @@ jobs:
         run: pnpm make
 
       - name: Smoke-test signed release candidate
+        env:
+          GW_EXPECT_OFFICIAL_UPDATER: "1"
         run: pnpm test:packaged
 
       - name: Notarize and staple DMG

--- a/tests/packaged-smoke.ts
+++ b/tests/packaged-smoke.ts
@@ -42,10 +42,14 @@ const executable = path.join(
 const execFileAsync = promisify(execFile);
 const resources = path.join(appBundle, "Contents/Resources");
 const asarPath = path.join(resources, "app.asar");
+const expectsOfficialUpdater =
+  process.env.GW_EXPECT_OFFICIAL_UPDATER === "1";
 assert.equal(
   existsSync(path.join(resources, "official-update.json")),
-  false,
-  "ordinary local packages must not carry the official updater capability",
+  expectsOfficialUpdater,
+  expectsOfficialUpdater
+    ? "an official release must carry the updater capability"
+    : "ordinary local packages must not carry the official updater capability",
 );
 const packageVersion = JSON.parse(
   await readFile(path.join(root, "package.json"), "utf8"),

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -173,7 +173,10 @@ test("release workflow publishes one tested, attested package version", () => {
   assert.match(workflow, /require\('\.\/package\.json'\)\.version/);
   assert.match(workflow, /git\/ref\/tags\/\$TAG/);
   assert.doesNotMatch(workflow, /pnpm version|date -u/);
-  assert.match(workflow, /name: Smoke-test signed release candidate[\s\S]*pnpm test:packaged/);
+  assert.match(
+    workflow,
+    /name: Smoke-test signed release candidate[\s\S]*?GW_EXPECT_OFFICIAL_UPDATER: "1"[\s\S]*?run: pnpm test:packaged/,
+  );
   assert.match(workflow, /shasum -a 256 -c SHA256SUMS\.txt/);
   assert.match(workflow, /anchore\/sbom-action@/);
   assert.match(workflow, /format: spdx-json/);


### PR DESCRIPTION
Summary:
- make the packaged smoke test assert the updater marker according to the expected package type
- declare the official updater expectation in the signed release smoke step
- pin that release wiring with a policy test

Verification:
- pnpm test:packaged
- focused release pipeline policy test
- pnpm typecheck
- pnpm lint
- pnpm verify