### PR TITLE
Fix release SBOM attestation path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -326,6 +326,11 @@ jobs:
             test -f SHA256SUMS.txt
             shasum -a 256 -c SHA256SUMS.txt
           )
+          sbom_count="$(find release-assets -maxdepth 1 -type f -name '*.spdx.json' |
+            wc -l | tr -d ' ')"
+          test "$sbom_count" = "1"
+          sbom="$(find release-assets -maxdepth 1 -type f -name '*.spdx.json' -print -quit)"
+          echo "sbom=$sbom" >> "$GITHUB_OUTPUT"
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             test "$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
               --json isDraft --jq '.isDraft')" = "true"
@@ -352,7 +357,7 @@ jobs:
         uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4
         with:
           subject-path: release-assets/*.zip
-          sbom-path: release-assets/*.spdx.json
+          sbom-path: ${{ steps.release-state.outputs.sbom }}
 
       - name: Attest DMG provenance
         if: steps.release-state.outputs.create == 'true'

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -181,7 +181,15 @@ test("release workflow publishes one tested, attested package version", () => {
   assert.match(workflow, /anchore\/sbom-action@/);
   assert.match(workflow, /format: spdx-json/);
   assert.match(workflow, /actions\/attest@/);
-  assert.match(workflow, /sbom-path: release-assets\/\*\.spdx\.json/);
+  assert.match(
+    workflow,
+    /id: release-state[\s\S]*echo "sbom=\$sbom" >> "\$GITHUB_OUTPUT"/,
+  );
+  assert.match(
+    workflow,
+    /sbom-path: \$\{\{ steps\.release-state\.outputs\.sbom \}\}/,
+  );
+  assert.doesNotMatch(workflow, /sbom-path: [^\n]*\*/);
   assert.match(workflow, /artifact-metadata: write/);
   assert.match(verification, /actions\/dependency-review-action@/);
   assert.ok(


### PR DESCRIPTION
## Summary
- resolve the single generated SPDX SBOM during release handoff
- pass its concrete path to the attestation action
- reject wildcard SBOM paths in policy coverage

## Root cause
The handoff artifact contained a valid SBOM and its checksum passed. The attestation action expands subject-path globs, but sbom-path expects one existing JSON file, so the wildcard was treated as a literal missing filename.

## Verification
- pnpm verify
- git diff --check