### PR TITLE
Fix shutdown from the in-game close button

### DIFF
--- a/src/renderer/client-exit.ts
+++ b/src/renderer/client-exit.ts
@@ -1,0 +1,109 @@
+// ArenaNet's client does not exit its Emscripten runtime when the player uses
+// the in-game X. Its exported main-loop callback performs the client's cleanup,
+// stops scheduling itself, and resolves successfully. `Module.onExit` therefore
+// never runs even though the client has finished.
+//
+// Own only that missing edge. `emscripten_async_call` is still ArenaNet's
+// scheduler for every other callback. The main loop is identified by function
+// identity against both the exported function and its table entry — the same
+// identity Emscripten's JSPI glue uses before wrapping the callback with
+// `WebAssembly.promising`. If a future client changes that contract, this
+// adapter delegates unchanged instead of guessing.
+
+type WasmCallback = (...args: number[]) => unknown;
+type PromisingCallback = (...args: number[]) => Promise<unknown>;
+type AsyncCall = (callback: number, argument: number, milliseconds: number) => void;
+
+export type ClientExitImports = WebAssembly.Imports & {
+  env?: WebAssembly.ModuleImports & {
+    emscripten_async_call?: AsyncCall;
+  };
+};
+
+interface ClientInstance {
+  readonly exports: WebAssembly.Exports;
+}
+
+interface ClientExitOptions {
+  readonly imports: ClientExitImports;
+  readonly instance: () => ClientInstance | null;
+  readonly onExit: () => void | Promise<void>;
+  readonly onFailure: (error: unknown) => void;
+  readonly log: (...values: unknown[]) => void;
+  readonly requestFrame?: (callback: FrameRequestCallback) => number;
+  readonly promising?: (callback: WasmCallback) => PromisingCallback;
+}
+
+export function installClientExit(options: ClientExitOptions): void {
+  const { env } = options.imports;
+  const original = env?.emscripten_async_call;
+  if (!env || typeof original !== "function") {
+    options.log("[warn] no emscripten_async_call import — clean client exit unavailable");
+    return;
+  }
+
+  const requestFrame =
+    options.requestFrame ?? globalThis.requestAnimationFrame.bind(globalThis);
+  const promising =
+    options.promising
+    ?? (callback =>
+      (
+        WebAssembly as typeof WebAssembly & {
+          promising(value: WasmCallback): PromisingCallback;
+        }
+      ).promising(callback));
+
+  let mainLoop: WasmCallback | null = null;
+  let promisingMainLoop: PromisingCallback | null = null;
+  let scheduleGeneration = 0;
+  let settled = false;
+
+  const fail = (error: unknown): void => {
+    if (settled) return;
+    settled = true;
+    options.onFailure(error);
+  };
+
+  env.emscripten_async_call = (callback, argument, milliseconds) => {
+    const instance = options.instance();
+    const table = instance?.exports.__indirect_function_table;
+    const exportedMainLoop = instance?.exports.EmscriptenExeThreadMainLoop;
+    const tableCallback =
+      table instanceof WebAssembly.Table ? table.get(callback) : null;
+
+    if (
+      milliseconds >= 0
+      || typeof exportedMainLoop !== "function"
+      || tableCallback !== exportedMainLoop
+    ) {
+      original(callback, argument, milliseconds);
+      return;
+    }
+
+    if (settled) return;
+    const callableMainLoop = exportedMainLoop as WasmCallback;
+    if (mainLoop !== callableMainLoop) {
+      mainLoop = callableMainLoop;
+      promisingMainLoop = promising(callableMainLoop);
+    }
+
+    const generation = ++scheduleGeneration;
+    requestFrame(() => {
+      const run = promisingMainLoop;
+      if (!run) {
+        fail(new Error("clean client exit lost the main-loop callback"));
+        return;
+      }
+      void run(argument).then(
+        () => {
+          // A running tick schedules the next generation before it resolves.
+          // The client's termination tick completes its cleanup and does not.
+          if (settled || generation !== scheduleGeneration) return;
+          settled = true;
+          void Promise.resolve(options.onExit()).catch(options.onFailure);
+        },
+        fail,
+      );
+    });
+  };
+}

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -13,6 +13,9 @@
  * them declares is still an error here.
  */
 type GwClientImports = Parameters<
+  typeof import('./client-exit.js').installClientExit
+>[0]['imports'] &
+  Parameters<
   typeof import('./gl-program-cache.js').installGlProgramCache
 >[0]['imports'] &
   Parameters<
@@ -259,6 +262,7 @@ let gamepadImportsAvailable = false;
 // glue and cannot await. Reading `host` before boot() assigns it is a
 // TypeError, not a silently skipped installation.
 let host: typeof import('./graphics.js') &
+  typeof import('./client-exit.js') &
   typeof import('./gl-program-cache.js') &
   typeof import('./filesystem.js') &
   typeof import('./input.js') &
@@ -324,6 +328,13 @@ Module = {
 
   // Take over instantiation so the EGL imports can be patched first.
   instantiateWasm(imports, success) {
+    host.installClientExit({
+      imports,
+      instance: () => gameWasmInstance,
+      onExit: () => Module.onExit(0),
+      onFailure: (error) => Module.onAbort(error),
+      log,
+    });
     host.installTemplateSaveCompatibility({
       imports,
       module: Module,
@@ -788,6 +799,7 @@ function loadGlue() {
     const [
       { unavailablePlatformCapabilities },
       { createSocketHost },
+      clientExit,
       graphics,
       glProgramCache,
       filesystem,
@@ -798,6 +810,7 @@ function loadGlue() {
     ] = await Promise.all([
       import('./platform-capabilities.js'),
       import('./socket-host.js'),
+      import('./client-exit.js'),
       import('./graphics.js'),
       import('./gl-program-cache.js'),
       import('./filesystem.js'),
@@ -807,6 +820,7 @@ function loadGlue() {
       import('./client-health.js'),
     ]);
     host = {
+      ...clientExit,
       ...graphics,
       ...glProgramCache,
       ...filesystem,

--- a/tests/policy/source-wasm-host.test.ts
+++ b/tests/policy/source-wasm-host.test.ts
@@ -382,10 +382,16 @@ test("the served module, not requested settings, decides whether Enhancement imp
   assert.doesNotMatch(initialized, /init\.nativeCursor/u);
 });
 
-test("a clean WASM process exit closes the host application", async () => {
+test("a completed client main loop closes the host application", async () => {
   const harness = await readFile(
     path.join(root, "src/renderer/harness.ts"),
     "utf8",
+  );
+  assert.match(harness, /host\.installClientExit\(\{/);
+  assert.ok(
+    harness.indexOf("host.installClientExit({")
+      < harness.indexOf("WebAssembly.instantiateStreaming("),
+    "the clean-exit adapter must wrap imports before instantiation",
   );
   assert.match(harness, /onExit\(code\)/);
   assert.match(harness, /code === 0[\s\S]*native\(\)\.app\.requestQuit\(\)/);

--- a/tests/unit/client-exit.test.ts
+++ b/tests/unit/client-exit.test.ts
@@ -1,0 +1,207 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  installClientExit,
+  type ClientExitImports,
+} from "../../src/renderer/client-exit.js";
+
+type Callback = (...args: number[]) => unknown;
+
+function uleb(value: number): number[] {
+  const bytes: number[] = [];
+  do {
+    let byte = value & 0x7f;
+    value >>>= 7;
+    if (value) byte |= 0x80;
+    bytes.push(byte);
+  } while (value);
+  return bytes;
+}
+
+function section(id: number, body: number[]): number[] {
+  return [id, ...uleb(body.length), ...body];
+}
+
+function realMainLoopInstance(): WebAssembly.Instance {
+  const loopName = [
+    ...new TextEncoder().encode("EmscriptenExeThreadMainLoop"),
+  ];
+  const tableName = [
+    ...new TextEncoder().encode("__indirect_function_table"),
+  ];
+  const bytes = Uint8Array.from([
+    0, 97, 115, 109, 1, 0, 0, 0,
+    ...section(1, [1, 0x60, 1, 0x7f, 0]),
+    ...section(3, [1, 0]),
+    ...section(4, [1, 0x70, 1, 1, 1]),
+    ...section(7, [
+      2,
+      ...uleb(loopName.length), ...loopName, 0, 0,
+      ...uleb(tableName.length), ...tableName, 1, 0,
+    ]),
+    ...section(9, [1, 0, 0x41, 0, 0x0b, 1, 0]),
+    ...section(10, [1, 2, 0, 0x0b]),
+  ]);
+  return new WebAssembly.Instance(new WebAssembly.Module(bytes));
+}
+
+function fixture() {
+  const frames: FrameRequestCallback[] = [];
+  const delegated: number[][] = [];
+  const failures: unknown[] = [];
+  let exits = 0;
+  let mainLoop: Callback = () => undefined;
+  const table = new WebAssembly.Table({
+    element: "anyfunc",
+    initial: 2,
+  });
+  // Node cannot put an ordinary JavaScript function in a funcref table. The
+  // installer only relies on reference identity, so this fixture supplies the
+  // same WebAssembly-shaped exports through a narrow test table.
+  const tableView = {
+    get(index: number): Callback | null {
+      return index === 1 ? mainLoop : null;
+    },
+  };
+  const imports: ClientExitImports = {
+    env: {
+      emscripten_async_call: (...args) => {
+        delegated.push(args);
+      },
+    },
+  };
+  const instance = {
+    exports: {
+      EmscriptenExeThreadMainLoop: mainLoop,
+      __indirect_function_table: table,
+    },
+  };
+  Object.defineProperty(table, "get", {
+    value: tableView.get.bind(tableView),
+  });
+  installClientExit({
+    imports,
+    instance: () => instance,
+    onExit: () => {
+      exits += 1;
+    },
+    onFailure: (error) => failures.push(error),
+    log: () => undefined,
+    requestFrame: (callback) => {
+      frames.push(callback);
+      return frames.length;
+    },
+    promising: (callback) => async (...args) => callback(...args),
+  });
+  return {
+    delegated,
+    failures,
+    frames,
+    imports,
+    setMainLoop(callback: Callback) {
+      mainLoop = callback;
+      instance.exports.EmscriptenExeThreadMainLoop = callback;
+    },
+    get exits() {
+      return exits;
+    },
+  };
+}
+
+async function runFrame(value: ReturnType<typeof fixture>): Promise<void> {
+  const frame = value.frames.shift();
+  assert.ok(frame, "no animation frame was scheduled");
+  frame(0);
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("client clean-exit adapter", () => {
+  it("recognizes the real exported function stored in a WebAssembly table", async () => {
+    const instance = realMainLoopInstance();
+    const frames: FrameRequestCallback[] = [];
+    let exits = 0;
+    const imports: ClientExitImports = {
+      env: { emscripten_async_call: () => assert.fail("unexpected delegation") },
+    };
+    installClientExit({
+      imports,
+      instance: () => instance,
+      onExit: () => {
+        exits += 1;
+      },
+      onFailure: (error) => {
+        assert.fail(error instanceof Error ? error : String(error));
+      },
+      log: () => undefined,
+      requestFrame: (callback) => {
+        frames.push(callback);
+        return frames.length;
+      },
+      promising: (callback) => async (...args) => callback(...args),
+    });
+
+    imports.env!.emscripten_async_call!(0, 0, -1);
+    const frame = frames.shift();
+    assert.ok(frame);
+    frame(0);
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.equal(exits, 1);
+  });
+
+  it("delegates timers and callbacks that are not the exported main loop", () => {
+    const value = fixture();
+    value.imports.env!.emscripten_async_call!(1, 7, 10);
+    value.imports.env!.emscripten_async_call!(0, 8, -1);
+    assert.deepEqual(value.delegated, [
+      [1, 7, 10],
+      [0, 8, -1],
+    ]);
+    assert.equal(value.frames.length, 0);
+  });
+
+  it("keeps running while the main loop schedules a successor", async () => {
+    const value = fixture();
+    let ticks = 0;
+    value.setMainLoop(() => {
+      ticks += 1;
+      if (ticks < 2) {
+        value.imports.env!.emscripten_async_call!(1, 0, -1);
+      }
+    });
+
+    value.imports.env!.emscripten_async_call!(1, 0, -1);
+    await runFrame(value);
+    assert.equal(value.exits, 0);
+    assert.equal(value.frames.length, 1);
+
+    await runFrame(value);
+    assert.equal(value.exits, 1);
+    assert.equal(value.failures.length, 0);
+  });
+
+  it("reports a successful final tick as one clean exit", async () => {
+    const value = fixture();
+    value.setMainLoop(() => undefined);
+
+    value.imports.env!.emscripten_async_call!(1, 0, -1);
+    await runFrame(value);
+    assert.equal(value.exits, 1);
+
+    value.imports.env!.emscripten_async_call!(1, 0, -1);
+    assert.equal(value.frames.length, 0);
+    assert.equal(value.exits, 1);
+  });
+
+  it("reports a rejected main-loop tick as a failure, not a clean exit", async () => {
+    const value = fixture();
+    const failure = new Error("main loop failed");
+    value.setMainLoop(() => Promise.reject(failure));
+
+    value.imports.env!.emscripten_async_call!(1, 0, -1);
+    await runFrame(value);
+    assert.deepEqual(value.failures, [failure]);
+    assert.equal(value.exits, 0);
+  });
+});

--- a/tests/unit/renderer-host-modules-merge-without-collision.test.ts
+++ b/tests/unit/renderer-host-modules-merge-without-collision.test.ts
@@ -1,5 +1,5 @@
-// P6.5 turned the six `window.gwInstall*` globals into ESM exports, and
-// harness.ts's boot() merges the six module namespaces into one `host` object
+// P6.5 turned the `window.gwInstall*` globals into ESM exports, and harness.ts's
+// boot() merges the module namespaces into one `host` object
 // it calls from `instantiateWasm` and `loadGlue`. A merge is silent about a
 // collision: two modules exporting the same name would leave one installer
 // unreachable, and the harness would install a graphics adapter or a
@@ -12,7 +12,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { WASM_BRIDGE_MARKERS } from "../../src/shared/contracts.ts";
 
-// Five of the six import cleanly with no page at all;
+// All but template-save compatibility import cleanly with no page at all;
 // template-save-compatibility.js reads the bridge markers as it is imported,
 // which is why boot() imports it after the preload rather than before.
 Object.assign(globalThis, {
@@ -25,6 +25,7 @@ Object.assign(globalThis, {
 });
 
 const namespaces = await Promise.all([
+  import("../../src/renderer/client-exit.js"),
   import("../../src/renderer/graphics.js"),
   import("../../src/renderer/gl-program-cache.js"),
   import("../../src/renderer/filesystem.js"),
@@ -42,12 +43,13 @@ test("every host module exports exactly one installer", () => {
   }
 });
 
-test("merging the six host modules loses no installer", () => {
+test("merging the host modules loses no installer", () => {
   const names = namespaces.flatMap((namespace) => Object.keys(namespace));
   assert.equal(new Set(names).size, names.length, "two modules share a name");
 
   const host = Object.assign({}, ...namespaces) as Record<string, unknown>;
   assert.deepEqual(Object.keys(host).sort(), [
+    "installClientExit",
     "installGameFilesystem",
     "installGameInput",
     "installGlProgramCache",


### PR DESCRIPTION
## Summary

- detect when the official client’s exported main loop completes without scheduling another frame
- route that clean completion through the existing `Module.onExit(0)` and native application quit path
- leave timers and unrelated Emscripten callbacks unchanged
- add focused unit and source-policy regression coverage

## Root cause

Guild Wars’ in-game X completes the client’s cleanup and stops scheduling its WASM main loop, but the generated Emscripten runtime is configured to remain alive. As a result, `Module.onExit` never runs and Electron keeps displaying the final frozen frame.

The adapter identifies only the exported `EmscriptenExeThreadMainLoop` by exact function identity. A successful tick that schedules no successor is treated as the missing clean-exit edge; changed or unrelated callbacks continue through the original scheduler.

## Player impact

Clicking Guild Wars’ own top-right X now closes the macOS application cleanly instead of requiring Force Quit.

## Validation

- `pnpm check` — 563 unit tests and 117 policy tests passed
- `pnpm build`
- launched the cached real client, clicked the game-rendered top-right X, and observed the Electron application close within the assertion window
