### PR TITLE
Keep tester snapshots out of the official Keychain identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,10 +126,12 @@ not only happy paths.
   inspection. Do not write docs or UI that tell a player to verify the origin.
   `docs/internals.md` owns the reasoning; `tests/electron/steam-acquire.spec.ts`
   pins the presentation.
-- Unpackaged development and explicitly marked ad-hoc test builds set
-  Chromium's `use-mock-keychain` switch before ready. Official Developer ID
-  packages use Chromium's real Keychain-backed provider. All builds clear
-  browser cookies at startup and quit.
+- Every package without the official release marker, plus unpackaged
+  development and explicitly marked release smoke tests, sets Chromium's
+  `use-mock-keychain` switch before ready. This keeps an unstable ad-hoc code
+  identity from claiming the official app's Safe Storage Keychain item.
+  Official Developer ID packages use Chromium's real Keychain-backed provider.
+  All builds clear browser cookies at startup and quit.
 - The app makes no network request the user was not plainly told about.
   `autoCheckUpdates` (default `true`, declared as one pre-checked line at first
   run and in Settings → Updates) performs one release check per launch and

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -193,12 +193,14 @@ shop.initialize/inAppPurchase
 The generated glue requires all three credential methods. They cross a narrow
 IPC boundary to one native `CredentialsStore`, which writes encrypted
 `credentials.bin` atomically with mode `0600`. Official Developer ID packages
-let Electron `safeStorage` use its macOS Keychain-backed provider. Unpackaged
-development and the explicit packaged-test switch use Chromium's local mock
-provider to avoid recurring prompts from an unstable identity. An unreadable
-ciphertext is never deleted by a read; the failure is recorded without
-credential content and the game prompts again. A later explicit save atomically
-replaces it.
+let Electron `safeStorage` use its macOS Keychain-backed provider. Every
+package without the official release marker, unpackaged development, and the
+explicit release-smoke switch use Chromium's local mock provider. The decision
+is made before Electron becomes ready: allowing an ad-hoc package to create the
+same Safe Storage item binds it to an unstable code identity, after which macOS
+repeatedly challenges the official application. An unreadable ciphertext is
+never deleted by a read; the failure is recorded without credential content and
+the game prompts again. A later explicit save atomically replaces it.
 Browser cookies are cleared at startup and quit. Persistent IDBFS client
 preferences and the dedicated saved-login file remain intact.
 Steam is advertised as a federated provider; Apple and Google are not. The

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -29,6 +29,13 @@ development mock provider to macOS Keychain-backed protection. An existing
 preview installation may ask you to sign in once; its old encrypted file is
 preserved rather than silently deleted.
 
+Tester snapshots published before this boundary was enforced could create a
+**Guild Wars Reforged Safe Storage** item under their temporary ad-hoc identity.
+If macOS repeatedly asks the official application to access that item, choose
+**Always Allow**. If the prompt returns on a later launch, quit the application,
+delete only that named item in Keychain Access, and launch again. You will need
+to sign in once; downloaded game data and launcher settings are unaffected.
+
 The app then:
 
 1. checks the official game client;
@@ -137,12 +144,13 @@ centered on the primary display instead of opening off-screen. Choose **View →
 Reset Window Size and Position** for an immediate window-only reset.
 
 Guild Wars' **Remember Password** checkbox controls saved login. The password
-is encrypted in an owner-only local file and is not placed in macOS Keychain,
-so the application does not show a Keychain prompt. Because unsigned builds
-use Chromium's local mock encryption provider, this is weaker than Keychain:
-software running as your macOS user may be able to recover it. Leave
-**Remember Password** off if that tradeoff is not acceptable. Browser cookies
-are cleared at startup and quit.
+is encrypted in an owner-only local file rather than stored as a Keychain
+password. Official releases protect that file's encryption key with macOS
+Keychain; tester snapshots use Chromium's local mock provider so their unstable
+code identity cannot cause authorization prompts in a later official release.
+The snapshot protection is weaker: software running as your macOS user may be
+able to recover the password. Leave **Remember Password** off if that tradeoff
+is not acceptable. Browser cookies are cleared at startup and quit.
 
 ## Signing in with Steam
 
@@ -175,8 +183,9 @@ You only do this once per machine. The sign-in is remembered in an encrypted,
 owner-only local file and replayed on later launches, so no Steam window appears
 again until it expires or you sign out. It carries the same tradeoff as the saved
 password above: it is not in macOS Keychain, and on an unsigned build software
-running as your macOS user may be able to recover it. If the file cannot be read,
-or the sign-in has expired or been revoked, you are simply returned to the login
+running as your macOS user may be able to recover it. The official application
+protects the file's encryption key with Keychain. If the file cannot be read, or
+the sign-in has expired or been revoked, you are simply returned to the login
 screen — the application does not fail to start.
 
 If an explicit sign-in fails for a reason other than you closing the window, a

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -75,14 +75,17 @@ import { sendRendererCommand } from "./renderer-commands.js";
 import { STEAM_OAUTH } from "./core/steam-oauth.js";
 import { acquireSteamToken } from "./steam-acquire.js";
 
-// Ad-hoc builds have no stable code identity, so Chromium's profile encryption
-// repeatedly asks for access to "<app> Safe Storage". The mock provider avoids
-// that OS prompt. The same provider encrypts the owner-only saved-login file;
-// this is intentionally weaker than a signed app's stable Keychain identity.
+// Anything without the official release marker has no stable Developer ID
+// identity. If it touches Chromium's real provider, macOS binds "<app> Safe
+// Storage" to that ad-hoc build and repeatedly challenges the later official
+// app. Select the mock provider before ready for every such build. The explicit
+// switch lets packaged release smoke tests avoid an interactive prompt too.
+// This is intentionally weaker than an official package's Keychain protection.
 if (
   process.platform === "darwin"
   && (
     !app.isPackaged
+    || !hasOfficialReleaseMarker()
     || app.commandLine.hasSwitch("gw-adhoc-test-keychain")
   )
 ) {
@@ -234,10 +237,7 @@ function sendToRenderer(channel: string, value: unknown): void {
   }
 }
 
-function officialUpdaterCapable(): boolean {
-  if (!app.isPackaged) {
-    return process.env.GW_TEST_OFFICIAL_UPDATER === "1";
-  }
+function hasOfficialReleaseMarker(): boolean {
   if (process.platform !== "darwin") return false;
   try {
     const marker = JSON.parse(
@@ -253,6 +253,13 @@ function officialUpdaterCapable(): boolean {
   } catch {
     return false;
   }
+}
+
+function officialUpdaterCapable(): boolean {
+  if (!app.isPackaged) {
+    return process.env.GW_TEST_OFFICIAL_UPDATER === "1";
+  }
+  return hasOfficialReleaseMarker();
 }
 
 async function ensureDirs(): Promise<void> {

--- a/tests/packaged-enhancement-runtime.ts
+++ b/tests/packaged-enhancement-runtime.ts
@@ -271,7 +271,9 @@ async function launchPackaged(
     packagedExecutable,
     [
       `--user-data-dir=${userData}`,
-      "--gw-adhoc-test-keychain",
+      ...(process.env.GW_EXPECT_OFFICIAL_UPDATER === "1"
+        ? ["--gw-adhoc-test-keychain"]
+        : []),
       `--remote-debugging-port=${port}`,
       "--remote-debugging-address=127.0.0.1",
     ],

--- a/tests/packaged-smoke.ts
+++ b/tests/packaged-smoke.ts
@@ -155,10 +155,14 @@ await writeFile(
 );
 const diagnostics = path.join(userData, "diagnostics");
 const output: string[] = [];
-const child = spawn(executable, [
+const launchArguments = [
   `--user-data-dir=${userData}`,
-  "--gw-adhoc-test-keychain",
-], {
+  // An ordinary ad-hoc package must select mock storage from the absence of the
+  // official marker. The signed release smoke still needs this explicit CI-only
+  // escape hatch because its real provider would open an interactive prompt.
+  ...(expectsOfficialUpdater ? ["--gw-adhoc-test-keychain"] : []),
+];
+const child = spawn(executable, launchArguments, {
   cwd: root,
   env: { ...process.env, GW_OFFLINE_SHELL: "1", ELECTRON_ENABLE_LOGGING: "1" },
   stdio: ["ignore", "pipe", "pipe"],

--- a/tests/policy/source-saved-login-surface.test.ts
+++ b/tests/policy/source-saved-login-surface.test.ts
@@ -84,13 +84,26 @@ test("no build seeds the Steam token from the environment", () => {
   );
 });
 
-test("only development and explicit ad-hoc tests enable mock keychain", () => {
+test("every non-official build enables mock keychain before ready", () => {
   // Ordering, not existence: `appendSwitch` after `whenReady` is a silent
   // no-op, and the symptom is an OS keychain prompt on a user's machine.
   const main = read("src/main/main.ts");
+  const packagedSmoke = read("tests/packaged-smoke.ts");
+  const packagedEnhancement = read("tests/packaged-enhancement-runtime.ts");
   assert.match(main, /appendSwitch\("use-mock-keychain"\)/);
   assert.match(main, /!app\.isPackaged/);
+  assert.match(main, /\|\| !hasOfficialReleaseMarker\(\)/);
   assert.match(main, /hasSwitch\("gw-adhoc-test-keychain"\)/);
+  assert.match(
+    main,
+    /function officialUpdaterCapable\(\)[\s\S]*return hasOfficialReleaseMarker\(\)/,
+  );
+  for (const smoke of [packagedSmoke, packagedEnhancement]) {
+    assert.match(
+      smoke,
+      /GW_EXPECT_OFFICIAL_UPDATER[\s\S]*\? \["--gw-adhoc-test-keychain"\][\s\S]*: \[\]/,
+    );
+  }
   assert.match(main, /clearStorageData\(\{ storages: \["cookies"\] \}\)/);
   assert.ok(
     main.indexOf('appendSwitch("use-mock-keychain")') <


### PR DESCRIPTION
## Summary
- select Chromium mock storage before ready for every package without the official release marker
- keep real macOS Keychain protection for Developer ID releases
- make ordinary packaged smokes prove the automatic ad-hoc path instead of supplying the override
- document the exact remediation for users whose older snapshot already created a stale Safe Storage item

## Root cause
An older ad-hoc tester package created Guild Wars Reforged Safe Storage while running from an App Translocation path. The official notarized application then inherited that item under a different code identity, so macOS correctly displayed repeated authorization prompts.

## Verification
- pnpm verify
- packaged smoke without the ad-hoc test switch
- pointer-lock focus check repeated 5/5 after one unrelated transient full-suite failure
- git diff --check