### PR TITLE
fix: preserve physical keyboard bindings

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -635,19 +635,26 @@ drags. Bounded at the window edge, the near side recycles about every half
 canvas of travel — far more often than the far side, and the cost of keeping
 every coordinate in the range the client accepts.
 
-The client identifies a key by `KeyboardEvent.key`, so its held-key state is
-character state, not physical state. macOS makes Option a text modifier, which
-rewrites that character for as long as Option is held: `W` arrives as `∑` on a
-US layout, and as a bound character on others — a German Option+L is `@`, which
-the client reads as the `2` key. A press and its release therefore disagree
-whenever Option is held across only one of them, and the key the client believes
-is down never comes up. The input host reads the OS layout map, restates the
-event with the unmodified character of `event.code`, and stops the rewritten
-original so the client sees exactly one event per physical transition. Text
-fields are restated too, because the client relays their key events to the
-canvas; only propagation is stopped, so the field still types the composed
-character. Command is different — macOS withholds the release entirely — and
-that stays handled by releasing every non-modifier key when Command comes up.
+The client identifies a binding by layout-dependent `KeyboardEvent.key` rather
+than physical `KeyboardEvent.code`. The input host converts every main-block
+letter, top-row digit, and ANSI punctuation position to its unique fixed
+unshifted US-layout character before the client sees it. A physical `KeyW` is
+therefore `w` to the client under QWERTY, AZERTY, and macOS's Option layer alike;
+bindings survive an input-source change, and a release cannot disagree with its
+press. ISO/JIS-only and numpad positions retain the official client's behavior:
+its key-only vocabulary has no proven collision-free physical identity for
+them. Their release still reuses the character recorded at press time, so a
+layout or modifier change during one hold cannot strand the key. The client's
+Controls screen receives the canonical character and does not relabel it when
+the input source changes.
+
+The host stops each replaced event and dispatches exactly one normalized key
+event in its place. Text fields are restated too, because the client relays
+their key events to the canvas; stopping propagation without preventing the
+default action lets the field type the layout-aware composed character while
+game input sees the physical identity. Command is different — macOS withholds
+the release entirely — and remains handled by releasing every non-modifier key
+when Command comes up.
 
 ## Diagnostics
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -94,8 +94,16 @@ Settings shows the backing resolution for the current window beside every
 scale. Compared with 1×, 1.5× renders 2.25 times as many pixels and 2× renders
 four times as many pixels.
 Right-drag always locks the pointer while steering the camera and restores it
-on release. **Controls** owns two independent GWonMac Tools choices. **Use the
-game's own cursor** is on by default: the host reads the cursor Guild Wars itself draws
+on release. Main-block letter, number-row, and punctuation bindings stay on the
+same physical keys when the macOS input source changes, while chat and other
+text fields continue to type the active layout. Extra ISO/JIS keys and the
+numeric keypad retain the official web client's layout behavior. The in-game
+Controls list shows the binding's stable reference character rather than
+relabeling it after an input-source change. A custom binding first saved by an
+older app build under a non-US input source may need to be rebound once; its
+stored character does not retain the physical position needed for migration.
+**Controls** owns two independent GWonMac Tools choices. **Use the game's own
+cursor** is on by default: the host reads the cursor Guild Wars itself draws
 out of your installed client and shows it over the game view; no cursor artwork
 ships with this app and none is downloaded. **Show target distance and range**
 is off by default and adds the selected target's distance and range band at the

--- a/src/renderer/gw-native.d.ts
+++ b/src/renderer/gw-native.d.ts
@@ -26,15 +26,6 @@ export interface AppSettingsNegativeTypeTest extends AppSettings {
 }
 
 declare global {
-  // Keyboard Map API: Chromium ships it, TypeScript's DOM library does not.
-  interface Keyboard extends EventTarget {
-    getLayoutMap(): Promise<ReadonlyMap<string, string>>;
-  }
-
-  interface Navigator {
-    readonly keyboard?: Keyboard;
-  }
-
   interface GameInputDiagnostics {
     event(name: string, value?: unknown): void;
   }

--- a/src/renderer/input.ts
+++ b/src/renderer/input.ts
@@ -16,6 +16,32 @@ const POINTER_ROAM = 16;
 // dropped. Four cross a drag's whole range; further is a teleport, not a drag.
 const MAX_POINTER_REGRABS = 4;
 
+// ArenaNet's web client identifies a binding by KeyboardEvent.key, which is a
+// character from the active keyboard layout. Give each main-block position a
+// unique stable US-layout character instead. `code` already is the browser's
+// physical identity; this map is only the vocabulary the client accepts for
+// non-alphanumeric ANSI positions. ISO/JIS extras and the numpad pass through:
+// the key-only client contract has no proven collision-free identity for them.
+const PHYSICAL_PUNCTUATION_KEYS: Readonly<Record<string, string>> = {
+  Backquote: '`',
+  Minus: '-',
+  Equal: '=',
+  BracketLeft: '[',
+  BracketRight: ']',
+  Backslash: '\\',
+  Semicolon: ';',
+  Quote: "'",
+  Comma: ',',
+  Period: '.',
+  Slash: '/',
+};
+
+const physicalKey = (code: string, fallback: string): string => {
+  if (/^Key[A-Z]$/.test(code)) return code.slice(3).toLowerCase();
+  if (/^Digit[0-9]$/.test(code)) return code.slice(5);
+  return PHYSICAL_PUNCTUATION_KEYS[code] ?? fallback;
+};
+
 /**
  * What a trusted press recorded, so the synthetic release can restate it
  * exactly. `target` is the node the press reached, which is where its release
@@ -195,54 +221,21 @@ export const installGameInput = ({
     }));
   };
 
-  // macOS treats Option as a text modifier, so a held Option rewrites
-  // KeyboardEvent.key: W arrives as "∑" on a US layout, and as an unrelated
-  // ASCII character ("@", "|") on others. ArenaNet's client identifies keys
-  // by that string, so an Option-held release never clears the key its press
-  // registered — holding Option to read merchant names while running left
-  // movement keys down for good. The physical key is in `code`; ask the OS
-  // what that key produces unmodified, and restate the event before the
-  // client (or our own held-key registry) sees it.
-  let layoutKeys = new Map<string, string>();
-  const readLayoutKeys = () => {
-    const layout = navigator.keyboard?.getLayoutMap?.();
-    if (!layout) {
-      log('[warn] keyboard layout unavailable; Option-held keys may stick');
-      return;
-    }
-    layout.then((map) => {
-      layoutKeys = new Map(map);
-    }).catch((error: unknown) => {
-      diagnostics?.event('keyboard.layoutFailed', error);
-      log(
-        '[warn] keyboard layout unreadable:',
-        error instanceof Error ? error.message : String(error),
-      );
-    });
-  };
-  readLayoutKeys();
-  // Chromium has no layout-change event, and switching input source does not
-  // reach the game while another window owns it. Re-reading on focus is the
-  // last moment before the new layout can produce a key.
-  window.addEventListener('focus', readLayoutKeys);
-
   /**
-   * Returns the key the client should see, having already re-dispatched a
-   * corrected event in place of a modifier-rewritten one.
+   * Returns the physical key identity the client should see, having already
+   * re-dispatched a corrected event in place of a layout-dependent one.
    */
-  const layoutKey = (event: KeyboardEvent) => {
+  const clientKey = (
+    event: KeyboardEvent,
+    key = physicalKey(event.code, event.key),
+  ) => {
     const target = event.target;
-    if (!event.altKey || !target) return event.key;
-    const key = layoutKeys.get(event.code);
-    if (!key || key.toUpperCase() === event.key.toUpperCase()) return event.key;
+    if (!target || key === event.key) return key;
     // One event per physical transition: the rewritten one must not also
-    // reach the client, or a layout whose Option layer produces a bound
-    // character presses that binding and never releases it — a German
-    // Option+L is "@", which the client reads as the 2 key going down.
-    // Text entry is restated too: the client's own OSK fields relay key
-    // events to the canvas, so they carry the same rewrite to the same
-    // state. Only propagation stops here, so the field still types the
-    // character the OS composed.
+    // reach the client. Text entry is restated too because the client's OSK
+    // fields relay key events to the canvas. Only propagation stops here, so
+    // the field still types the character the OS composed while game input
+    // receives the physical identity.
     event.stopImmediatePropagation();
     const restated = new globalThis.KeyboardEvent(event.type, {
       bubbles: true,
@@ -337,8 +330,9 @@ export const installGameInput = ({
 
   window.addEventListener('keydown', (event) => {
     if (!event.isTrusted) return;
-    const key = layoutKey(event);
-    if (event.repeat && heldKeys.has(event.code)) return;
+    const held = heldKeys.get(event.code);
+    const key = clientKey(event, event.repeat ? held?.key : undefined);
+    if (event.repeat && held) return;
     heldKeys.set(event.code, {
       target: event.target,
       key,
@@ -355,7 +349,7 @@ export const installGameInput = ({
   }, true);
   window.addEventListener('keyup', (event) => {
     if (!event.isTrusted) return;
-    layoutKey(event);
+    clientKey(event, heldKeys.get(event.code)?.key);
     heldKeys.delete(event.code);
     if (event.code === 'MetaLeft' || event.code === 'MetaRight') {
       releaseKeys((code) =>

--- a/tests/electron/input.spec.ts
+++ b/tests/electron/input.spec.ts
@@ -200,8 +200,8 @@ test.describe("renderer input", () => {
     }
   });
 
-  test("restates keys macOS rewrites while Option is held", async () => {
-    const fixture = await launchOffline("gw-option-key-e2e-");
+  test("uses physical main-block keys without changing typed text", async () => {
+    const fixture = await launchOffline("gw-physical-key-e2e-");
     try {
       const { page } = fixture;
       await startGameInput(page);
@@ -216,9 +216,8 @@ test.describe("renderer input", () => {
           window.addEventListener(
             type,
             (event) => {
-              if (event.code !== "KeyW") return;
               testWindow.__gameKeys.push(
-                `${event.type}:${event.key}:${event.keyCode}`,
+                `${event.type}:${event.code}:${event.key}:${event.keyCode}`,
               );
             },
             true,
@@ -227,47 +226,98 @@ test.describe("renderer input", () => {
         canvas.focus();
       });
 
-      // macOS reports the Option layer in `key` while leaving `code` alone, so
-      // a key pressed before Option is held is released as a different key.
+      // A layout changes `key`, but the physical `code` stays put. Changing
+      // layouts between a press and release must not strand the old key, and
+      // two physical positions that produce the same letter must stay distinct.
       const cdp = await fixture.app.context().newCDPSession(page);
-      const alt = 1;
-      const sendW = (
+      const sendKey = (
         type: "keyDown" | "keyUp",
+        code: string,
         key: string,
+        virtualKeyCode: number,
         modifiers = 0,
         text?: string,
+        repeat = false,
       ) =>
         cdp.send("Input.dispatchKeyEvent", {
           type,
           key,
-          code: "KeyW",
-          windowsVirtualKeyCode: 87,
-          nativeVirtualKeyCode: 87,
+          code,
+          windowsVirtualKeyCode: virtualKeyCode,
+          nativeVirtualKeyCode: virtualKeyCode,
           modifiers,
+          autoRepeat: repeat,
           ...(text === undefined ? {} : { text }),
         });
 
-      await sendW("keyDown", "w");
-      await sendW("keyUp", "∑", alt);
-      await sendW("keyDown", "∑", alt);
-      // The registry must hold the restated key, or the interruption path
-      // releases a key the client never saw pressed.
+      await sendKey("keyDown", "KeyW", "w", 87);
+      await sendKey("keyUp", "KeyW", "z", 90);
+      await sendKey("keyDown", "KeyW", "z", 90);
+      // The registry must hold the physical key, or interruption releases a
+      // key the client never saw pressed.
       await page.evaluate(() =>
         window.dispatchEvent(new globalThis.CustomEvent("gw:input-reset")),
       );
+      await sendKey("keyDown", "KeyZ", "w", 87);
+      await sendKey("keyUp", "KeyZ", "w", 87);
+
+      const characterCases = [
+        ["Digit1", "&", "1", 49],
+        ["Backquote", "§", "`", 192],
+        ["Minus", ")", "-", 189],
+        ["Equal", "´", "=", 187],
+        ["BracketLeft", "ü", "[", 219],
+        ["BracketRight", "+", "]", 221],
+        ["Backslash", "#", "\\", 220],
+        ["Semicolon", "ö", ";", 186],
+        ["Quote", "ä", "'", 222],
+        ["Comma", ";", ",", 188],
+        ["Period", ":", ".", 190],
+        ["Slash", "-", "/", 191],
+      ] as const;
+      for (const [code, layoutKey, , keyCode] of characterCases) {
+        await sendKey("keyDown", code, layoutKey, keyCode);
+        await sendKey("keyUp", code, layoutKey, keyCode);
+      }
+      await sendKey("keyDown", "KeyW", "∑", 87, 1);
+      await sendKey("keyUp", "KeyW", "∑", 87, 1);
+      // Unsupported positions keep the official client's character semantics,
+      // but a modifier or layout change during one hold must not strand them.
+      await sendKey("keyDown", "IntlBackslash", "<", 226);
+      await sendKey(
+        "keyDown",
+        "IntlBackslash",
+        "≤",
+        226,
+        1,
+        undefined,
+        true,
+      );
+      await sendKey("keyUp", "IntlBackslash", "≤", 226, 1);
 
       expect(
         await page.evaluate(() => (window as InputTestWindow).__gameKeys),
       ).toEqual([
-        "keydown:w:87",
-        "keyup:w:87",
-        "keydown:w:87",
-        "keyup:w:87",
+        "keydown:KeyW:w:87",
+        "keyup:KeyW:w:90",
+        "keydown:KeyW:w:90",
+        "keyup:KeyW:w:90",
+        "keydown:KeyZ:z:87",
+        "keyup:KeyZ:z:87",
+        ...characterCases.flatMap(([code, , canonicalKey, keyCode]) => [
+          `keydown:${code}:${canonicalKey}:${keyCode}`,
+          `keyup:${code}:${canonicalKey}:${keyCode}`,
+        ]),
+        "keydown:KeyW:w:87",
+        "keyup:KeyW:w:87",
+        "keydown:IntlBackslash:<:226",
+        "keydown:IntlBackslash:<:226",
+        "keyup:IntlBackslash:<:226",
       ]);
 
       // The client relays key events from its own text fields to the canvas,
-      // so a rewritten release strands a key there too. Restating must not
-      // cost the field the character the OS composed.
+      // so they need the physical identity too. Stopping propagation must not
+      // cost the field the layout-aware character the OS composed.
       await page.evaluate(() => {
         const text = globalThis.document.getElementById("osk-input-text");
         if (!(text instanceof globalThis.HTMLInputElement)) {
@@ -280,8 +330,8 @@ test.describe("renderer input", () => {
         text.value = "";
         text.focus();
       });
-      await sendW("keyDown", "∑", alt, "∑");
-      await sendW("keyUp", "w");
+      await sendKey("keyDown", "KeyW", "z", 90, 0, "z");
+      await sendKey("keyUp", "KeyW", "z", 90);
       expect(
         await page.evaluate(() => {
           const text = globalThis.document.getElementById("osk-input-text");
@@ -293,7 +343,10 @@ test.describe("renderer input", () => {
             typed: text.value,
           };
         }),
-      ).toEqual({ keys: ["keydown:w:87", "keyup:w:87"], typed: "∑" });
+      ).toEqual({
+        keys: ["keydown:KeyW:w:90", "keyup:KeyW:w:90"],
+        typed: "z",
+      });
     } finally {
       await closeOffline(fixture);
     }


### PR DESCRIPTION
## What changed

- normalize main-block letter, number-row, and ANSI punctuation input from `KeyboardEvent.code` into stable physical-key identities
- preserve the key recorded at keydown for repeat, keyup, and interruption paths
- keep chat and other text input layout-aware
- remove the asynchronous keyboard-layout cache and its ambient DOM typings
- document the intentional ISO/JIS, numpad, control-label, and legacy-binding boundaries

## Why

Guild Wars' native client binds gameplay controls by physical key position. The official web client instead consumes layout-dependent `KeyboardEvent.key`, so switching between layouts such as QWERTY, QWERTZ, or AZERTY moved gameplay controls and could produce mismatched press/release identities.

This fixes the reported main-block behavior without inventing colliding identities for ISO/JIS-only or numpad keys.

Fixes #40.

## User impact

Main-block gameplay bindings remain on the same physical keys when the macOS input source changes. Chat and other text fields continue to type characters from the active layout.

The in-game Controls screen still shows the stable reference character because that UI is drawn inside the official WASM client. Custom bindings saved by older builds under a non-US layout may require one one-time rebind.

## Verification

- `pnpm verify`
  - 563 unit tests
  - 117 policy tests
  - 20 integration tests
  - 21 release tests
  - 89 Electron tests
  - package creation
  - packaged application and Enhancement runtime smoke tests
- thermo-nuclear multi-agent maintainability review with final architecture, boundary, and test rechecks reporting no remaining blockers

The opt-in production-network live smoke remained skipped.
