### PR TITLE
Record game-client crash reasons and guide reporting

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -246,6 +246,21 @@ known patterns, so treat it as strong rather than absolute. The export is an
 ordinary ZIP you can open and read before attaching it. GitHub issues are
 public, so review the bug form’s privacy notice as well.
 
+## If the game crashes
+
+When the running game client stops unexpectedly, the launcher screen returns
+with **Retry** and **Report a Problem…**. Retry starts the client again; a
+single crash is usually transient.
+
+If the client crashes again in the same app run, the message changes to say
+so and leads with reporting: **Report a Problem…** on the launcher is the
+same flow as **Help → Report a Problem…** — it exports the diagnostics
+archive (which includes the crashed session and the reason class of the
+crash) and offers to open the GitHub bug form. What the archive does and does
+not contain is described under [Report a problem](#report-a-problem).
+
+The crash count resets when you quit and reopen the app.
+
 ## Recovery behavior
 
 - If startup cannot reach ArenaNet, the previous verified client is restored

--- a/src/main/core/enhancement-builds.ts
+++ b/src/main/core/enhancement-builds.ts
@@ -139,7 +139,10 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] = Object.freez
   Object.freeze({
     sha256: "9ee332604a9b2adbdfa1a8ab217f4fd1dac58b01a2443e037bc5bd11f279d094",
     programId: 1,
-    buildId: 38771,
+    // The client behind this hash identifies itself as build 38797 at runtime
+    // (diagnostics build.info); the entry previously carried the baseline's
+    // 38771 by mistake.
+    buildId: 38797,
     hookFunction: 446,
     hookParams: Object.freeze(["i32"] as const),
     hookResults: Object.freeze([] as const),

--- a/src/main/core/sockets.ts
+++ b/src/main/core/sockets.ts
@@ -194,7 +194,7 @@ export class SocketManager {
       entry.opened = true;
       this.metrics?.count("socket.opened");
       this.metrics?.observe("socket.connect", (Date.now() - entry.openedAt) * 1_000);
-      this.emit(ownerId, { type: "open", socketId: id });
+      this.emit(ownerId, { type: "open", socketId: id, port: parsed.port });
     });
 
     socket.on("data", (buf) => {

--- a/src/main/diagnostic-report.ts
+++ b/src/main/diagnostic-report.ts
@@ -116,6 +116,11 @@ export async function previousAbnormalSession(
       record.name === "uncaught.exception" ||
       record.name === "uncaught exception" ||
       record.name === "quit.cleanupFailed" ||
+      // A game-client abort or non-zero exit is a crash even when the app
+      // itself then quits cleanly; without these the crashed session
+      // exported as "normal".
+      record.name === "wasm.abort" ||
+      record.name === "wasm.exit" ||
       (record.name === "renderer.processGone" && record.level === "error"),
   );
   if (final.name === "quit.cleanupCompleted" && !abnormal) return null;

--- a/src/main/diagnostics.ts
+++ b/src/main/diagnostics.ts
@@ -538,9 +538,42 @@ export function recordRendererMilestone(
     ? Math.max(0, Math.round(rendererTimestampUs + rendererClockOffsetUs))
     : recorder.timestampUs();
   recorder.setLatest(`milestone.${name}Us`, timestampUs);
-  if (name === "build.info" && fields) {
+  if (name === "build.info" && fields && "programId" in fields) {
     recorder.setLatest("client.programId", fields.programId);
     recorder.setLatest("client.buildId", fields.buildId);
+  }
+  if (name === "wasm.abort") {
+    // IPC validation guarantees these fields for this name; a call without
+    // them is unreachable and recording a reasonless abort would be a lie.
+    if (!fields || !("reasonKind" in fields)) return;
+    // The run-scoped crash tally the loading overlay reads back through
+    // diagnostics.current() to decide first-crash vs repeated-crash copy.
+    // The renderer records one crash per client launch, so this counts
+    // launches that crashed, not abort re-entries.
+    recorder.count("wasm.crashes");
+    recordEvent(
+      {
+        k: "wasm.abort",
+        clockSynchronized: rendererClockSynchronized,
+        reasonKind: fields.reasonKind,
+        fingerprint: asRendererFingerprint(fields.fingerprint),
+      },
+      { timestampUs },
+    );
+    return;
+  }
+  if (name === "wasm.exit") {
+    if (!fields || !("code" in fields)) return;
+    recorder.count("wasm.crashes");
+    recordEvent(
+      {
+        k: "wasm.exit",
+        clockSynchronized: rendererClockSynchronized,
+        code: fields.code,
+      },
+      { timestampUs },
+    );
+    return;
   }
   recordEvent(
     { k: name, clockSynchronized: rendererClockSynchronized },

--- a/src/main/diagnostics/schema.ts
+++ b/src/main/diagnostics/schema.ts
@@ -13,11 +13,12 @@ import {
   isDigest,
   type Digest,
 } from "../../shared/digest.js";
-import type {
-  DiagnosticFields,
-  DiagnosticLevel,
-  DiagnosticScalar,
-  DiagnosticSubsystem,
+import {
+  WASM_ABORT_REASON_KINDS,
+  type DiagnosticFields,
+  type DiagnosticLevel,
+  type DiagnosticScalar,
+  type DiagnosticSubsystem,
 } from "../../shared/diagnostics.js";
 import { AppError, isErrorCode, type ErrorCode } from "../../shared/errors.js";
 import {
@@ -28,6 +29,7 @@ import {
   isProxyRoute,
   type ProxyRoute,
 } from "../core/proxy-routes.js";
+import { ALLOWED_PORTS } from "../core/allowlists.js";
 
 /**
  * The one runtime and compile-time schema for app-authored diagnostic events.
@@ -82,7 +84,7 @@ export function asRendererFingerprint(value: string): RendererFingerprint {
   }
   return value as RendererFingerprint;
 }
-const isRendererFingerprint: FieldGuard<RendererFingerprint> = (
+export const isRendererFingerprint: FieldGuard<RendererFingerprint> = (
   value,
 ): value is RendererFingerprint =>
   typeof value === "string" && RENDERER_FINGERPRINT.test(value);
@@ -891,7 +893,9 @@ export const DIAGNOSTIC_EVENT_SCHEMA = {
   "socket.open": {
     subsystem: "socket",
     level: "info",
-    fields: { socketId: finiteNumber },
+    // The port is the closed production allowlist, so a reset on the game
+    // connection (6112) is distinguishable from patch/web traffic (80/443).
+    fields: { socketId: finiteNumber, port: literal([...ALLOWED_PORTS]) },
   },
   "socket.close": {
     subsystem: "socket",
@@ -1127,10 +1131,23 @@ export const DIAGNOSTIC_EVENT_SCHEMA = {
     level: "info",
     fields: { clockSynchronized: boolean },
   },
+  // The two milestones that are also failures. The abort argument collapses
+  // in the renderer into a closed reason kind plus a non-text fingerprint, so
+  // the export can name the failing native operation class without carrying
+  // prose; a non-zero exit carries only the client's own numeric code.
   "wasm.abort": {
     subsystem: "renderer",
-    level: "info",
-    fields: { clockSynchronized: boolean },
+    level: "error",
+    fields: {
+      clockSynchronized: boolean,
+      reasonKind: literal(WASM_ABORT_REASON_KINDS),
+      fingerprint: isRendererFingerprint,
+    },
+  },
+  "wasm.exit": {
+    subsystem: "renderer",
+    level: "error",
+    fields: { clockSynchronized: boolean, code: finiteNumber },
   },
 } as const satisfies Readonly<Record<string, EventSpec>>;
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -23,11 +23,13 @@ import type {
   RendererMetrics,
   RendererMilestone,
   RendererMilestoneFields,
+  WasmAbortReasonKind,
 } from "../shared/diagnostics.js";
 import {
   isRendererFrameBatch,
   isRendererMetrics,
   RENDERER_MILESTONES,
+  WASM_ABORT_REASON_KINDS,
 } from "../shared/diagnostics.js";
 import { DEFAULT_SETTINGS, EXTERNAL_URLS, IPC } from "../shared/contracts.js";
 import { isDigest } from "../shared/digest.js";
@@ -60,6 +62,7 @@ import {
   recordClockOffset,
   startDnsResolveSpan,
 } from "./diagnostics.js";
+import { isRendererFingerprint } from "./diagnostics/schema.js";
 import { gamePaths } from "./paths.js";
 import { isCanonicalRendererUrl } from "./core/renderer-trust.js";
 import { enhancementSelectionChanged } from "./enhancement-policy.js";
@@ -84,6 +87,7 @@ export interface IpcContext {
   checkAppUpdates: () => Promise<void>;
   restartAndInstallUpdate: (win: BrowserWindow) => Promise<void>;
   getClientSession: () => ClientSession;
+  exportProblemReport: (win: BrowserWindow) => Promise<void>;
   acquireSteamToken: (
     parent: BrowserWindow,
     record: (event: SteamAcquireEvent) => void,
@@ -330,43 +334,60 @@ interface ParsedMilestone {
 const asMilestone: Parser<ParsedMilestone> = (args) => {
   exact(args, 3);
   const [name, rendererTimestampUs, fields] = args;
-  const record = fields as Record<string, unknown> | undefined;
-  const recordIsObject =
-    record !== undefined
-    && record !== null
-    && typeof record === "object"
-    && !Array.isArray(record);
-  const exactBuildInfoFields =
-    recordIsObject
-    && Object.keys(record).length === 2
-    && Object.hasOwn(record, "programId")
-    && Object.hasOwn(record, "buildId");
-  const milestoneFields =
-    recordIsObject &&
-    exactBuildInfoFields &&
-    (typeof record.programId === "string" || typeof record.programId === "number") &&
-    (typeof record.buildId === "string" || typeof record.buildId === "number")
-      ? {
-          programId: record.programId as string | number,
-          buildId: record.buildId as string | number,
-        }
-      : undefined;
   if (
     typeof name !== "string" ||
     !RENDERER_MILESTONES.includes(name as RendererMilestone) ||
     typeof rendererTimestampUs !== "number" ||
     !Number.isFinite(rendererTimestampUs) ||
     rendererTimestampUs < 0 ||
-    rendererTimestampUs > Number.MAX_SAFE_INTEGER ||
-    (name === "build.info" && !milestoneFields) ||
-    (name !== "build.info" && fields !== undefined) ||
-    (milestoneFields &&
-      [milestoneFields.programId, milestoneFields.buildId].some(
-        (value) =>
-          (typeof value === "string" && value.length > 128) ||
-          (typeof value === "number" && (!Number.isSafeInteger(value) || value < 0)),
-      ))
+    rendererTimestampUs > Number.MAX_SAFE_INTEGER
   ) {
+    throw new ValidationError("invalid renderer milestone");
+  }
+  const record = fields as Record<string, unknown> | undefined;
+  const recordIsObject =
+    record !== undefined
+    && record !== null
+    && typeof record === "object"
+    && !Array.isArray(record);
+  let milestoneFields: RendererMilestoneFields | undefined;
+  if (name === "build.info") {
+    const valid =
+      recordIsObject
+      && Object.keys(record).length === 2
+      && (typeof record.programId === "string" || typeof record.programId === "number")
+      && (typeof record.buildId === "string" || typeof record.buildId === "number")
+      && [record.programId, record.buildId].every(
+        (value) =>
+          (typeof value === "string" && value.length <= 128) ||
+          (typeof value === "number" && Number.isSafeInteger(value) && value >= 0),
+      );
+    if (!valid) throw new ValidationError("invalid renderer milestone");
+    milestoneFields = {
+      programId: record.programId as string | number,
+      buildId: record.buildId as string | number,
+    };
+  } else if (name === "wasm.abort") {
+    const valid =
+      recordIsObject
+      && Object.keys(record).length === 2
+      && typeof record.reasonKind === "string"
+      && (WASM_ABORT_REASON_KINDS as readonly string[]).includes(record.reasonKind)
+      && isRendererFingerprint(record.fingerprint);
+    if (!valid) throw new ValidationError("invalid renderer milestone");
+    milestoneFields = {
+      reasonKind: record.reasonKind as WasmAbortReasonKind,
+      fingerprint: record.fingerprint as string,
+    };
+  } else if (name === "wasm.exit") {
+    const valid =
+      recordIsObject
+      && Object.keys(record).length === 1
+      && typeof record.code === "number"
+      && Number.isSafeInteger(record.code);
+    if (!valid) throw new ValidationError("invalid renderer milestone");
+    milestoneFields = { code: record.code as number };
+  } else if (fields !== undefined) {
     throw new ValidationError("invalid renderer milestone");
   }
   return {
@@ -721,6 +742,10 @@ export function registerIpcHandlers(ctx: IpcContext): {
     ),
 
     diagnosticsCurrent: channel(nothing, () => diagnosticSummary()),
+
+    diagnosticsExportReport: channel(nothing, async (win) => {
+      await ctx.exportProblemReport(win);
+    }),
 
     appOpenExternal: channel(asExternalLinkKind, async (_win, kind) => {
       await shell.openExternal(EXTERNAL_URLS[kind]);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -183,7 +183,7 @@ function buildSocketManager(): SocketManager {
   return new SocketManager(
     (ownerId, event) => {
       if (event.type === "open") {
-        logEvent({ k: "socket.open", socketId: event.socketId });
+        logEvent({ k: "socket.open", socketId: event.socketId, port: event.port });
       } else if (event.type === "close") {
         logEvent({
           k: "socket.close",
@@ -543,6 +543,8 @@ if (primaryInstance) void app.whenReady().then(async () => {
       compatibility: clientRuntime.compatibility,
       healthToken: clientRuntime.healthToken,
     }),
+    exportProblemReport: (win) =>
+      exportProblemReport(win, () => exportDiagnosticsForWindow(win)),
     acquireSteamToken: (parent, record) =>
       acquireSteamToken(STEAM_OAUTH, { parent, record }),
   });

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -425,10 +425,16 @@ export async function resetGameInput(win: BrowserWindow): Promise<void> {
   await sendRendererCommand(win, { type: "input.reset" });
 }
 
+let problemReportInFlight = false;
+
 export async function exportProblemReport(
   win: BrowserWindow,
   exportDiagnostics: () => Promise<string>,
 ): Promise<void> {
+  // One report flow at a time, whichever surface asked: a second invocation
+  // while the save dialog is up would stack sheets and run two exports.
+  if (problemReportInFlight) return;
+  problemReportInFlight = true;
   try {
     const saved = await exportDiagnostics();
     if (!saved) return;
@@ -451,6 +457,8 @@ export async function exportProblemReport(
       "Report export failed",
       error instanceof Error ? error.message : String(error),
     );
+  } finally {
+    problemReportInFlight = false;
   }
 }
 

--- a/src/preload/preload.body.cjs
+++ b/src/preload/preload.body.cjs
@@ -194,6 +194,7 @@ const api = {
         fields,
       ),
     current: () => ipcRenderer.invoke(IPC.diagnosticsCurrent),
+    exportReport: () => ipcRenderer.invoke(IPC.diagnosticsExportReport),
   },
   app: {
     openExternal: (kind) => ipcRenderer.invoke(IPC.appOpenExternal, kind),

--- a/src/renderer/failure-messages.ts
+++ b/src/renderer/failure-messages.ts
@@ -160,6 +160,42 @@ export function suggestReport(code: string): boolean {
 const REPORT_HINT = 'You can retry, or choose Help → Report a Problem.';
 
 /**
+ * The running game client died (Emscripten abort, or exit with a non-zero
+ * code). One crash is usually transient; from the second crash in the same
+ * app run the sentence stops promising that a retry will fix it and leads
+ * with the report, because a repeating crash is the case a diagnostics
+ * bundle exists for.
+ */
+export interface ClientCrashPresentation {
+  label: string;
+  detail: string;
+  reportButton: string;
+  retryButton: string;
+}
+
+const CRASH_RETRY = 'Retry';
+const CRASH_REPORT = 'Report a Problem…';
+
+export function clientCrashPresentation(
+  crashCount: number,
+): ClientCrashPresentation {
+  const repeated = crashCount >= 2;
+  return {
+    label: repeated
+      ? 'The game client keeps stopping unexpectedly.'
+      : 'The game client stopped unexpectedly.',
+    detail: repeated
+      ? 'Retrying alone may not fix this. Choose Report a Problem to export '
+        + 'diagnostics and open the bug form — the report shows what stopped, '
+        + 'not your account or chat.'
+      : 'This is usually temporary — choose Retry to start it again. '
+        + 'If it keeps happening, choose Report a Problem.',
+    reportButton: CRASH_REPORT,
+    retryButton: CRASH_RETRY,
+  };
+}
+
+/**
  * The quiet second line under a failure: the report hint when the fault may
  * be ours, and always the raw code — it costs the player nothing and makes
  * every bug report specific.

--- a/src/renderer/gw-native.d.ts
+++ b/src/renderer/gw-native.d.ts
@@ -38,6 +38,8 @@ declare global {
     set(message: string, fraction: number | null, detail?: string): void;
     fail(message: string, detail?: string): void;
     failFilesystem(): void;
+    /** The running game client crashed; count is per app run. */
+    failCrash(crashCount: number): void;
     done(): void;
     waitForClient(): Promise<boolean>;
   }

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -84,7 +84,7 @@ type GwGameModule = {
   ): void;
   handleFatalReadError(): void;
   setBuildInfo(
-    info: import('../shared/diagnostics.js').RendererMilestoneFields,
+    info: import('../shared/diagnostics.js').RendererMilestoneFieldsByName['build.info'],
   ): void;
   isMobile: boolean;
   requestFullScreen(): void;
@@ -177,14 +177,33 @@ const LOG_LINES = 400;
 const logBuf: string[] = [];
 let gameWasmInstance: WebAssembly.Instance | null = null;
 let gameWasmModule: WebAssembly.Module | null = null;
+let crashRecorded = false;
+
+/**
+ * How many client launches have crashed this app run. Main's flight recorder
+ * owns the tally (it survives the location.reload() a Retry performs and
+ * dies with the process), so the renderer records the crash first and then
+ * reads the count back — browser storage is deliberately not used anywhere
+ * in this app. A count that cannot be read degrades to the first-crash
+ * presentation, never worse than showing no count at all.
+ */
+async function escalateRepeatedCrash(): Promise<void> {
+  const { counters } = await native().diagnostics.current();
+  const count = counters['wasm.crashes'] || 0;
+  if (count > 1) window.gwLoading?.failCrash(count);
+}
 let disposeSocketHost = () => {};
 const native = () => window.gwNative;
-const milestone = (
-  name: import('../shared/diagnostics.js').RendererMilestone,
-  fields?: import('../shared/diagnostics.js').RendererMilestoneFields,
+const milestone = <
+  N extends import('../shared/diagnostics.js').RendererMilestone,
+>(
+  name: N,
+  ...fields: N extends keyof import('../shared/diagnostics.js').RendererMilestoneFieldsByName
+    ? [import('../shared/diagnostics.js').RendererMilestoneFieldsByName[N]]
+    : []
 ) => {
   void native().diagnostics
-    .recordRendererMilestone(name, performance.now() * 1000, fields)
+    .recordRendererMilestone(name, performance.now() * 1000, fields[0])
     .catch(() => {});
 };
 
@@ -628,9 +647,30 @@ Module = {
     }
   },
   onAbort(reason) {
-    milestone('wasm.abort');
     log('[err] WASM aborted:', reason);
-    window.gwLoading?.fail('The game client stopped unexpectedly.');
+    // Emscripten can abort more than once while unwinding; only the first
+    // call presents and records — a repeat would reset the escalated copy
+    // back to first-crash and steal focus again. The prose never crosses
+    // IPC — it collapses into the closed reason vocabulary plus a
+    // fingerprint.
+    if (crashRecorded) return;
+    crashRecorded = true;
+    // The overlay first, with the first-crash presentation; the recorded
+    // count upgrades it below once main has counted this crash.
+    window.gwLoading?.failCrash(1);
+    void (async () => {
+      const { classifyWasmAbortReason, wasmAbortFingerprint } =
+        await import('./wasm-abort-reason.js');
+      await native().diagnostics.recordRendererMilestone(
+        'wasm.abort',
+        performance.now() * 1000,
+        {
+          reasonKind: classifyWasmAbortReason(reason),
+          fingerprint: wasmAbortFingerprint(reason),
+        },
+      );
+      await escalateRepeatedCrash();
+    })().catch(() => {});
   },
   onExit(code) {
     log('WASM exited:', code);
@@ -642,7 +682,25 @@ Module = {
         );
       });
     } else {
-      window.gwLoading?.fail('The game client stopped unexpectedly.');
+      // An abort that unwinds into a non-zero exit was already presented and
+      // counted by onAbort; re-running this branch would reset the copy to
+      // first-crash and count the same death twice.
+      if (crashRecorded) return;
+      crashRecorded = true;
+      window.gwLoading?.failCrash(1);
+      void (async () => {
+        // `code` is declared unknown at the Module boundary; anything the
+        // glue passes that is not a plain integer records as the -1 the
+        // schema can still account for.
+        const exitCode =
+          typeof code === 'number' && Number.isSafeInteger(code) ? code : -1;
+        await native().diagnostics.recordRendererMilestone(
+          'wasm.exit',
+          performance.now() * 1000,
+          { code: exitCode },
+        );
+        await escalateRepeatedCrash();
+      })().catch(() => {});
     }
   },
 };

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -74,6 +74,9 @@
         </div>
         <div id="loading-detail"></div>
       </div>
+      <!-- Shown only after a game-client crash; loading.ts writes the label.
+           Left of Retry so the primary action keeps the rightmost spot. -->
+      <button type="button" id="loading-report" hidden>Report a Problem…</button>
       <button type="button" id="loading-retry" hidden>Retry</button>
     </div>
 

--- a/src/renderer/loading.css
+++ b/src/renderer/loading.css
@@ -125,18 +125,25 @@
    is visible so the dock never shows two states at once. */
 #loading-boot { flex:1; min-width:0; display:flex; align-items:center;
                 justify-content:space-between; gap:20px; }
-#loading-retry { min-height:38px; padding:8px 22px; border:1px solid #7a4b38;
+#loading-retry,
+#loading-report { min-height:38px; padding:8px 22px; border:1px solid #7a4b38;
                  border-radius:6px; color:#eee3c9; background:#201a14e8;
                  font:inherit; cursor:default;
                  transition:transform .1s ease-out; }
-#loading-retry:hover { border-color:#e07a40; background:#2b2117f2; }
+#loading-retry:hover,
+#loading-report:hover:not(:disabled) { border-color:#e07a40;
+                                       background:#2b2117f2; }
 /* Response on pointer-down, not on release: every dock control presses. */
 #loading-retry:active,
+#loading-report:active:not(:disabled),
 .data-choice-option:active,
 .data-download-actions button:active:not(:disabled),
 .client-compat-actions button:active:not(:disabled) { transform:scale(.97); }
-#loading-retry:focus-visible { outline:2px solid #ff9d66; outline-offset:2px; }
-#loading-retry[hidden] { display:none; }
+#loading-retry:focus-visible,
+#loading-report:focus-visible { outline:2px solid #ff9d66; outline-offset:2px; }
+#loading-retry[hidden],
+#loading-report[hidden] { display:none; }
+#loading-report:disabled { opacity:.6; }
 #loading-dock:has(#data-choice:not([hidden])) #loading-boot,
 #loading-dock:has(#client-compat:not([hidden])) #loading-boot,
 #loading-dock:has(#data-download:not([hidden])) #loading-boot { display:none; }

--- a/src/renderer/loading.ts
+++ b/src/renderer/loading.ts
@@ -40,12 +40,31 @@ window.gwLoading = (function (): LoadingController {
   const root = el('loading'), bar = el('loading-bar'), fill = el('loading-fill');
   const label = el('loading-label'), detail = el('loading-detail');
   const retry = el('loading-retry') as HTMLButtonElement;
+  const report = el('loading-report') as HTMLButtonElement;
   let recovery: 'client' | 'filesystem' = 'client';
+  // Bumped by every state change so failCrash's async copy upgrade can tell
+  // it has been overtaken — e.g. by a Retry already in progress.
+  let stateGeneration = 0;
 
   function setBar(frac: number | null) {
     if (frac === null) { bar.classList.add('busy'); return; }
     bar.classList.remove('busy');
     fill.style.width = Math.max(0, Math.min(1, frac)) * 100 + '%';
+  }
+
+  /** The shared red failure frame; every fail* variant starts from it. */
+  function showFailureFrame(text: string, sub: string) {
+    stateGeneration += 1;
+    root.style.display = '';
+    root.classList.remove('gone');
+    label.textContent = text;
+    label.classList.add('error');
+    detail.textContent = sub;
+    retry.hidden = false;
+    report.hidden = true;
+    bar.classList.remove('busy');
+    fill.style.width = '100%';
+    fill.style.background = '#b8452f';
   }
 
   function finish() {
@@ -58,42 +77,54 @@ window.gwLoading = (function (): LoadingController {
   const api: LoadingController = {
     set(text, frac, sub) {
       recovery = 'client';
+      stateGeneration += 1;
       label.textContent = text;
       label.classList.remove('error');
       detail.textContent = sub || '';
       retry.hidden = true;
       retry.textContent = 'Retry';
+      report.hidden = true;
       setBar(frac);
     },
 
     fail(text, failDetail) {
       recovery = 'client';
-      root.style.display = '';
-      root.classList.remove('gone');
-      label.textContent = text;
-      label.classList.add('error');
-      detail.textContent =
-        failDetail ?? 'You can retry, or choose Help → Report a Problem.';
-      retry.hidden = false;
+      showFailureFrame(
+        text,
+        failDetail ?? 'You can retry, or choose Help → Report a Problem.',
+      );
       retry.textContent = 'Retry';
-      bar.classList.remove('busy');
-      fill.style.width = '100%';
-      fill.style.background = '#b8452f';
     },
 
     failFilesystem() {
       recovery = 'filesystem';
-      root.style.display = '';
-      root.classList.remove('gone');
-      label.textContent = 'Saved game files could not be opened.';
-      label.classList.add('error');
-      detail.textContent =
-        'Reset the local Guild Wars files to continue. Downloaded game data and your saved login are kept.';
-      retry.hidden = false;
+      showFailureFrame(
+        'Saved game files could not be opened.',
+        'Reset the local Guild Wars files to continue. Downloaded game data and your saved login are kept.',
+      );
       retry.textContent = 'Reset Saved Files…';
-      bar.classList.remove('busy');
-      fill.style.width = '100%';
-      fill.style.background = '#b8452f';
+    },
+
+    failCrash(crashCount) {
+      // The synchronous frame first: the overlay must appear even if module
+      // loading is broken. The crash copy then upgrades it in place.
+      api.fail('The game client stopped unexpectedly.');
+      const generation = stateGeneration;
+      void import('./failure-messages.js')
+        .then(({ clientCrashPresentation }) => {
+          // A later state — a Retry in progress, another failure — owns the
+          // panel now; upgrading it would repaint stale crash copy over it.
+          if (generation !== stateGeneration) return;
+          const crash = clientCrashPresentation(crashCount);
+          label.textContent = crash.label;
+          detail.textContent = crash.detail;
+          retry.textContent = crash.retryButton;
+          report.textContent = crash.reportButton;
+          report.hidden = false;
+          // After the live-region sentence, not instead of it.
+          setTimeout(() => retry.focus(), 0);
+        })
+        .catch(() => {});
     },
 
     done() {
@@ -198,6 +229,16 @@ window.gwLoading = (function (): LoadingController {
     } finally {
       retry.disabled = false;
     }
+  });
+
+  // Main owns the whole report flow — save dialog, export, follow-up dialog,
+  // and its own failure dialog — so there is nothing to render here beyond
+  // preventing a second dialog while one is up.
+  report.addEventListener('click', () => {
+    report.disabled = true;
+    void window.gwNative.diagnostics.exportReport()
+      .catch(() => {})
+      .finally(() => { report.disabled = false; });
   });
 
   // Project links are enum-selected so the renderer never invents arbitrary URLs.

--- a/src/renderer/wasm-abort-reason.ts
+++ b/src/renderer/wasm-abort-reason.ts
@@ -1,0 +1,57 @@
+// The renderer-side collapse of an Emscripten abort: prose in, closed
+// vocabulary plus non-text fingerprint out. This is the only shape allowed to
+// cross IPC — the abort message itself stays in this process.
+import type { WasmAbortReasonKind } from '../shared/diagnostics.js';
+
+/**
+ * Ordered from most to least specific: an assertion message may also contain
+ * the word "memory", and an OOM message mentions enlarging memory, so the
+ * narrow shapes must win before the broad ones.
+ */
+export function classifyWasmAbortReason(reason: unknown): WasmAbortReasonKind {
+  if (reason === undefined || reason === null || reason === '') {
+    return 'unspecified';
+  }
+  const text = (
+    reason instanceof Error ? `${reason.name}: ${reason.message}` : String(reason)
+  ).toLowerCase();
+  if (text.includes('assert')) return 'assertion';
+  if (
+    text.includes('signature mismatch')
+    || text.includes('null function')
+    || text.includes('table index')
+  ) {
+    return 'indirectCall';
+  }
+  if (text.includes('out of bounds')) return 'memoryBounds';
+  if (text.includes('unreachable')) return 'unreachable';
+  if (text.includes('stack overflow') || text.includes('call stack')) {
+    return 'stackOverflow';
+  }
+  if (
+    text.includes('oom')
+    || text.includes('enlarge memory')
+    || text.includes('allocation failed')
+  ) {
+    return 'oom';
+  }
+  if (text.includes('native code called abort')) return 'nativeAbort';
+  return 'other';
+}
+
+/**
+ * FNV-1a over the abort text, the same non-text fingerprint renderer events
+ * carry: identical causes cluster across sessions and machines while the
+ * message itself stays on the machine it happened on.
+ */
+export function wasmAbortFingerprint(reason: unknown): string {
+  const input = reason instanceof Error
+    ? `${reason.name}:${reason.stack || reason.message}`
+    : String(reason);
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < input.length; index++) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -113,6 +113,8 @@ export interface CacheInfo {
 export interface SocketOpenedEvent {
   type: "open";
   socketId: number;
+  /** Destination port from the closed allowlist; never a host name. */
+  port: number;
 }
 
 export interface SocketDataEvent {
@@ -524,6 +526,7 @@ export const IPC = {
   diagnosticsRendererFrames: "gw:diagnostics:rendererFrames",
   diagnosticsRendererMilestone: "gw:diagnostics:rendererMilestone",
   diagnosticsCurrent: "gw:diagnostics:current",
+  diagnosticsExportReport: "gw:diagnostics:exportReport",
   appOpenExternal: "gw:app:openExternal",
   appRevealPath: "gw:app:revealPath",
   appRequestQuit: "gw:app:requestQuit",
@@ -661,6 +664,12 @@ export interface GwNativeApi {
       fields?: RendererMilestoneFields,
     ): Promise<void>;
     current(): Promise<DiagnosticSummary>;
+    /**
+     * The Help-menu "Report a Problem" flow, launched from the renderer. Main
+     * owns everything — save dialog, export, the bug-report follow-up dialog
+     * and its own failure dialog — and nothing crosses back.
+     */
+    exportReport(): Promise<void>;
   };
   app: {
     openExternal(kind: ExternalLinkKind): Promise<void>;

--- a/src/shared/diagnostics.ts
+++ b/src/shared/diagnostics.ts
@@ -194,13 +194,38 @@ export const RENDERER_MILESTONES = [
   "build.info",
   "snapshot.fatalRead",
   "wasm.abort",
+  "wasm.exit",
 ] as const;
 
 export type RendererMilestone = (typeof RENDERER_MILESTONES)[number];
-export interface RendererMilestoneFields {
-  programId: string | number;
-  buildId: string | number;
+
+/**
+ * The closed vocabulary a WASM abort collapses into before crossing IPC. The
+ * Emscripten abort argument is prose and never leaves the renderer; each kind
+ * names a distinct native failure shape, so the export can say *what class* of
+ * operation died without carrying text.
+ */
+export const WASM_ABORT_REASON_KINDS = [
+  "assertion",
+  "indirectCall",
+  "memoryBounds",
+  "unreachable",
+  "stackOverflow",
+  "oom",
+  "nativeAbort",
+  "unspecified",
+  "other",
+] as const;
+export type WasmAbortReasonKind = (typeof WASM_ABORT_REASON_KINDS)[number];
+
+export interface RendererMilestoneFieldsByName {
+  "build.info": { programId: string | number; buildId: string | number };
+  "wasm.abort": { reasonKind: WasmAbortReasonKind; fingerprint: string };
+  /** A non-zero client exit: the other way the running game dies. */
+  "wasm.exit": { code: number };
 }
+export type RendererMilestoneFields =
+  RendererMilestoneFieldsByName[keyof RendererMilestoneFieldsByName];
 
 export interface DiagnosticHistogramSummary {
   count: number;

--- a/tests/electron/diagnostics.spec.ts
+++ b/tests/electron/diagnostics.spec.ts
@@ -498,6 +498,53 @@ test.describe("diagnostics", () => {
     }
   });
 
+  test("a crashed client offers reporting from the launcher", async () => {
+    const fixture = await launchOffline("gw-crash-panel-e2e-");
+    const saveRoot = await mkdtemp(path.join(tmpdir(), "gw-crash-export-"));
+    const target = path.join(saveRoot, "crash-report.zip");
+    try {
+      const { app, page } = fixture;
+      // Offline boot settles into its own generic failure first; the crash
+      // panel is driven on top of that settled state, as a real mid-game
+      // abort would be.
+      await expect(page.locator("#loading-retry")).toBeVisible();
+      await page.evaluate(() => window.gwLoading.failCrash(1));
+      await expect(page.locator("#loading-label")).toHaveText(
+        /stopped unexpectedly/,
+      );
+      await expect(page.locator("#loading-retry")).toBeVisible();
+      await expect(page.locator("#loading-report")).toBeVisible();
+
+      // The second crash of the run escalates the copy, not the actions.
+      await page.evaluate(() => window.gwLoading.failCrash(2));
+      await expect(page.locator("#loading-label")).toHaveText(/keeps stopping/);
+      await expect(page.locator("#loading-report")).toBeVisible();
+
+      // The launcher button drives the same main-owned flow as the Help menu:
+      // save dialog, export, follow-up dialog ("Done" is response 2).
+      await app.evaluate(({ dialog }, filePath) => {
+        dialog.showSaveDialog = async () => ({ canceled: false, filePath });
+        dialog.showMessageBox = async () => ({
+          response: 2,
+          checkboxChecked: false,
+        });
+      }, target);
+      await page.click("#loading-report");
+      await expect
+        .poll(async () => (await stat(target).catch(() => null))?.size ?? 0)
+        .toBeGreaterThan(0);
+
+      // A subsequent progress state clears the crash actions.
+      await page.evaluate(() => {
+        window.gwLoading.set("Checking the game client", null);
+      });
+      await expect(page.locator("#loading-report")).toBeHidden();
+    } finally {
+      await closeOffline(fixture);
+      await rm(saveRoot, { recursive: true, force: true });
+    }
+  });
+
   test("exports a bounded, redacted report with prior crash context", async () => {
     const previousSessionId = randomUUID();
     const fixture = await launchOffline(

--- a/tests/electron/sandbox.spec.ts
+++ b/tests/electron/sandbox.spec.ts
@@ -65,6 +65,7 @@ test.describe("sandbox boundary", () => {
         diagnosticsKeys: [
           "clockSync",
           "current",
+          "exportReport",
           "recordClockOffset",
           "recordGraphics",
           "recordRendererFrames",

--- a/tests/release/preload-behaviour.test.ts
+++ b/tests/release/preload-behaviour.test.ts
@@ -225,6 +225,11 @@ const INVOCATIONS: Invocation[] = [
     channel: IPC.diagnosticsRendererMilestone,
   },
   { path: "diagnostics.current", args: [], channel: IPC.diagnosticsCurrent },
+  {
+    path: "diagnostics.exportReport",
+    args: [],
+    channel: IPC.diagnosticsExportReport,
+  },
   { path: "app.openExternal", args: ["support"], channel: IPC.appOpenExternal },
   { path: "app.reveal", args: ["gameData"], channel: IPC.appRevealPath },
   { path: "app.requestQuit", args: [], channel: IPC.appRequestQuit },

--- a/tests/unit/diagnostic-report.test.ts
+++ b/tests/unit/diagnostic-report.test.ts
@@ -67,6 +67,60 @@ describe("diagnostic report", () => {
     }
   });
 
+  it("treats a game-client abort as abnormal even after a clean app quit", async () => {
+    // The app quitting cleanly used to make the whole session read as normal,
+    // which hid exactly the sessions a crash report needs.
+    const directory = await mkdtemp(path.join(tmpdir(), "gw-report-"));
+    const currentSessionId = randomUUID();
+    const crashedSessionId = randomUUID();
+    try {
+      await writeFile(
+        path.join(directory, `session-${crashedSessionId}.jsonl`),
+        [
+          event(1, "info", "diagnostics.started"),
+          event(2, "error", "wasm.abort"),
+          event(3, "info", "quit.cleanupCompleted"),
+        ].join("\n"),
+      );
+      const previous = await previousAbnormalSession(directory, currentSessionId);
+      assert.equal(previous?.abnormalReason, "wasm.abort");
+      assert.equal(previous?.finalEventName, "quit.cleanupCompleted");
+
+      // The other way the running client dies is a non-zero exit; the
+      // detection is name-based, so a newer crash record wins the reason.
+      await writeFile(
+        path.join(directory, `session-${crashedSessionId}.jsonl`),
+        [
+          event(1, "info", "diagnostics.started"),
+          event(2, "error", "wasm.exit"),
+          event(3, "info", "quit.cleanupCompleted"),
+        ].join("\n"),
+      );
+      const exited = await previousAbnormalSession(directory, currentSessionId);
+      assert.equal(exited?.abnormalReason, "wasm.exit");
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("reports no abnormal session when the previous run was clean", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "gw-report-"));
+    const currentSessionId = randomUUID();
+    const cleanSessionId = randomUUID();
+    try {
+      await writeFile(
+        path.join(directory, `session-${cleanSessionId}.jsonl`),
+        [
+          event(1, "info", "diagnostics.started"),
+          event(2, "info", "quit.cleanupCompleted"),
+        ].join("\n"),
+      );
+      assert.equal(await previousAbnormalSession(directory, currentSessionId), null);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
   it("derives startup, capture, and performance fields from canonical data", () => {
     const summary: DiagnosticSummary = {
       sessionId: "summary-session",

--- a/tests/unit/diagnostic-schema.test.ts
+++ b/tests/unit/diagnostic-schema.test.ts
@@ -91,12 +91,15 @@ describe("diagnosticEventRecord", () => {
   it("keeps the socket event name closed and the payload declared", () => {
     // `socket.${event.type}` was a templated name whose error branch carried
     // libuv's message; both parts are now fields of a fixed name.
-    assert.deepEqual(diagnosticEventRecord({ k: "socket.open", socketId: 4 }), {
-      subsystem: "socket",
-      level: "info",
-      name: "socket.open",
-      fields: { socketId: 4 },
-    });
+    assert.deepEqual(
+      diagnosticEventRecord({ k: "socket.open", socketId: 4, port: 6112 }),
+      {
+        subsystem: "socket",
+        level: "info",
+        name: "socket.open",
+        fields: { socketId: 4, port: 6112 },
+      },
+    );
     assert.deepEqual(
       diagnosticEventRecord({ k: "socket.close", socketId: 4, reason: "owner" }),
       {

--- a/tests/unit/export-detector-rejects-undeclared-event-fields.test.ts
+++ b/tests/unit/export-detector-rejects-undeclared-event-fields.test.ts
@@ -181,7 +181,9 @@ describe("export detector", () => {
   });
 
   it("skips the blank lines a JSONL document ends with", () => {
-    const result = inspectEventLog(`${recorded({ k: "socket.open", socketId: 1 })}\n\n`);
+    const result = inspectEventLog(
+      `${recorded({ k: "socket.open", socketId: 1, port: 6112 })}\n\n`,
+    );
     assert.equal(result.records, 1);
   });
 });

--- a/tests/unit/failure-codes-become-sentences-in-the-renderer.test.ts
+++ b/tests/unit/failure-codes-become-sentences-in-the-renderer.test.ts
@@ -7,6 +7,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  clientCrashPresentation,
   describeDownloadFailure as download,
   describeLaunchFailure as launch,
   describeNotice,
@@ -141,5 +142,26 @@ describe("renderer failure messages", () => {
       failureDetail(),
       "You can retry, or choose Help → Report a Problem.",
     );
+  });
+  it("stops promising a retry once the client crashes twice in one run", () => {
+    const first = clientCrashPresentation(1);
+    const repeated = clientCrashPresentation(2);
+    for (const crash of [first, repeated]) {
+      for (const text of [crash.label, crash.detail, crash.retryButton, crash.reportButton]) {
+        assert.ok(text.length > 0, "crash presentation has empty prose");
+      }
+    }
+    // The first crash reads as transient; the repeat leads with the report.
+    assert.match(first.detail, /usually temporary/);
+    assert.match(repeated.label, /keeps stopping/);
+    assert.match(repeated.detail, /^Retrying alone may not fix this/);
+    // The privacy half-sentence the player needs before agreeing to export.
+    assert.match(repeated.detail, /not your account or chat/);
+    // Buttons are identical across counts: escalation changes the words, not
+    // the actions.
+    assert.equal(first.retryButton, repeated.retryButton);
+    assert.equal(first.reportButton, repeated.reportButton);
+    // An unreadable count degrades to the first-crash presentation.
+    assert.deepEqual(clientCrashPresentation(0), first);
   });
 });

--- a/tests/unit/local-client-verifier.test.ts
+++ b/tests/unit/local-client-verifier.test.ts
@@ -70,7 +70,15 @@ function valid(): LocalClientVerification {
     baselineFingerprint: LOCAL_CLIENT_BASELINE_FINGERPRINT,
     officialSha256: TEMPLATE.sha256,
     templateSaveBuild: TEMPLATE,
-    enhancementBuild: ENHANCEMENT,
+    // What deriveEnhancementBuild actually emits: the relocated layout under
+    // the baseline's own buildId, because a locally verified client cannot
+    // prove its build number. The first manifest entry carried the same id as
+    // the baseline until the baseline was corrected to the build its client
+    // self-reports, which is what this spread now makes explicit.
+    enhancementBuild: {
+      ...ENHANCEMENT,
+      buildId: ENHANCEMENT_BUILDS[ENHANCEMENT_BUILDS.length - 1]!.buildId,
+    },
     reasons: [],
   };
 }

--- a/tests/unit/no-game-traffic-is-uploaded.test.ts
+++ b/tests/unit/no-game-traffic-is-uploaded.test.ts
@@ -15,9 +15,10 @@
 //     are the complete set of destinations the app can open.
 //  2. What the recorder is told about a socket cannot contain the bytes. The
 //     manager publishes payloads to exactly one consumer — the game — and the
-//     three socket events the diagnostics schema declares carry an id, a close
-//     reason and a failure code. A record that carries anything else stops the
-//     export instead of being scrubbed on the way out.
+//     three socket events the diagnostics schema declares carry an id, an
+//     allowlisted destination port, a close reason and a failure code. A
+//     record that carries anything else stops the export instead of being
+//     scrubbed on the way out.
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import type { SocketEvent } from "../../src/shared/contracts.ts";
@@ -197,7 +198,9 @@ describe("no game traffic is uploaded: what the recorder may hear", () => {
     // its element type from the first branch, so a socket event that stopped
     // matching the schema would have been widened away instead of rejected.
     const recorded: DiagnosticEvent[] = events.flatMap((event): DiagnosticEvent[] => {
-      if (event.type === "open") return [{ k: "socket.open", socketId: event.socketId }];
+      if (event.type === "open") {
+        return [{ k: "socket.open", socketId: event.socketId, port: event.port }];
+      }
       if (event.type === "close") {
         return [
           { k: "socket.close", socketId: event.socketId, reason: event.reason },
@@ -249,13 +252,13 @@ describe("no game traffic is uploaded: what the recorder may hear", () => {
         fields,
       });
 
-    assert.doesNotThrow(() => inspectEventLog(line({ socketId: 1 })));
+    assert.doesNotThrow(() => inspectEventLog(line({ socketId: 1, port: 6112 })));
     assert.throws(
-      () => inspectEventLog(line({ socketId: 1, bytes: "QUNDT1VOVA==" })),
+      () => inspectEventLog(line({ socketId: 1, port: 6112, bytes: "QUNDT1VOVA==" })),
       /carries undeclared field bytes/,
     );
     assert.throws(
-      () => inspectEventLog(line({ socketId: 1, payload: [65, 66, 67] })),
+      () => inspectEventLog(line({ socketId: 1, port: 6112, payload: [65, 66, 67] })),
       /undeclared field payload/,
     );
   });

--- a/tests/unit/socket-events-carry-no-error-text.test.ts
+++ b/tests/unit/socket-events-carry-no-error-text.test.ts
@@ -87,7 +87,7 @@ describe("socket events carry no error text", () => {
     socket.emit("error", refused);
 
     assert.deepEqual(events, [
-      { type: "open", socketId: 1 },
+      { type: "open", socketId: 1, port: 6112 },
       { type: "error", socketId: 1, code: "refused" },
       { type: "close", socketId: 1, reason: "error" },
     ]);

--- a/tests/unit/socket-host.test.ts
+++ b/tests/unit/socket-host.test.ts
@@ -73,8 +73,8 @@ describe("renderer socket host", () => {
     native.connects[0]!(11);
     native.connects[1]!(12);
     await turn();
-    native.emit({ type: "open", socketId: 12 });
-    native.emit({ type: "open", socketId: 11 });
+    native.emit({ type: "open", socketId: 12, port: 6112 });
+    native.emit({ type: "open", socketId: 11, port: 6112 });
     native.emit({ type: "data", socketId: 11, data: new Uint8Array([7]) });
     assert.deepEqual(opened, ["two", "one"]);
     assert.equal(socketOpened, 2);
@@ -117,7 +117,7 @@ describe("renderer socket host", () => {
 
     native.connects[0]!(31);
     await turn();
-    native.emit({ type: "open", socketId: 31 });
+    native.emit({ type: "open", socketId: 31, port: 6112 });
     const backing = new Uint8Array(1024);
     backing.set([2, 3, 4, 5], 100);
     await socket.send(backing.subarray(100, 104));
@@ -158,7 +158,7 @@ describe("renderer socket host", () => {
     };
     native.connects[1]!(41);
     await turn();
-    native.emit({ type: "open", socketId: 41 });
+    native.emit({ type: "open", socketId: 41, port: 6112 });
     assert.equal(secondOpened, 1);
     assert.equal(secondClosed, 0);
     host.dispose();

--- a/tests/unit/wasm-abort-reason.test.ts
+++ b/tests/unit/wasm-abort-reason.test.ts
@@ -1,0 +1,104 @@
+// A WASM abort is the one failure the flight recorder used to see only as a
+// timestamp: the Emscripten abort argument is prose, and prose may not cross
+// IPC or enter the export. What crosses instead is a closed reason kind plus
+// an FNV-1a fingerprint. These tests pin the two halves of that bargain:
+// every reason collapses into the declared vocabulary, and every fingerprint
+// the renderer can produce is one the boundary validator accepts.
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  classifyWasmAbortReason,
+  wasmAbortFingerprint,
+} from "../../src/renderer/wasm-abort-reason.ts";
+import { WASM_ABORT_REASON_KINDS } from "../../src/shared/diagnostics.ts";
+import {
+  asRendererFingerprint,
+  diagnosticEventRecord,
+} from "../../src/main/diagnostics/schema.ts";
+
+describe("wasm abort reasons collapse into the closed vocabulary", () => {
+  it("names the failure class of each known Emscripten abort shape", () => {
+    const cases: [unknown, string][] = [
+      ["Aborted(Assertion failed: agent->type == kAgentLiving)", "assertion"],
+      ["RuntimeError: null function or function signature mismatch", "indirectCall"],
+      ["RuntimeError: table index is out of bounds", "indirectCall"],
+      ["RuntimeError: memory access out of bounds", "memoryBounds"],
+      ["RuntimeError: unreachable", "unreachable"],
+      ["RangeError: Maximum call stack size exceeded", "stackOverflow"],
+      ["Aborted(OOM)", "oom"],
+      ["Cannot enlarge memory arrays to size 2147483648", "oom"],
+      ["Aborted(native code called abort())", "nativeAbort"],
+      [undefined, "unspecified"],
+      [null, "unspecified"],
+      ["", "unspecified"],
+      ["something entirely new", "other"],
+    ];
+    for (const [reason, expected] of cases) {
+      assert.equal(classifyWasmAbortReason(reason), expected, String(reason));
+    }
+  });
+
+  it("classifies an Error by its name and message", () => {
+    const trap = new WebAssembly.RuntimeError("unreachable");
+    assert.equal(classifyWasmAbortReason(trap), "unreachable");
+  });
+
+  it("never invents a kind outside the declared union", () => {
+    const inputs = [
+      undefined,
+      42,
+      {},
+      new Error("x"),
+      "ASSERTION FAILED IN UPPERCASE",
+    ];
+    const declared: readonly string[] = WASM_ABORT_REASON_KINDS;
+    for (const input of inputs) {
+      assert.equal(declared.includes(classifyWasmAbortReason(input)), true);
+    }
+  });
+});
+
+describe("wasm abort fingerprints", () => {
+  it("always satisfy the boundary validator, whatever the reason was", () => {
+    const inputs = [
+      undefined,
+      "",
+      "Aborted(Assertion failed)",
+      new Error("boom"),
+      "☃".repeat(10_000),
+    ];
+    for (const input of inputs) {
+      // Throws if the shape ever drifts from the declared 8-hex form.
+      asRendererFingerprint(wasmAbortFingerprint(input));
+    }
+  });
+
+  it("cluster identical causes and separate different ones", () => {
+    const a = wasmAbortFingerprint("Aborted(Assertion failed: x)");
+    assert.equal(a, wasmAbortFingerprint("Aborted(Assertion failed: x)"));
+    assert.notEqual(a, wasmAbortFingerprint("Aborted(Assertion failed: y)"));
+  });
+});
+
+describe("the recorded abort event", () => {
+  it("is an error-level renderer event carrying kind and fingerprint", () => {
+    assert.deepEqual(
+      diagnosticEventRecord({
+        k: "wasm.abort",
+        clockSynchronized: true,
+        reasonKind: "indirectCall",
+        fingerprint: asRendererFingerprint(wasmAbortFingerprint("x")),
+      }),
+      {
+        subsystem: "renderer",
+        level: "error",
+        name: "wasm.abort",
+        fields: {
+          clockSynchronized: true,
+          reasonKind: "indirectCall",
+          fingerprint: wasmAbortFingerprint("x"),
+        },
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- collapse the Emscripten abort argument into a closed reason vocabulary (`assertion`, `indirectCall`, `memoryBounds`, `unreachable`, `stackOverflow`, `oom`, `nativeAbort`, `unspecified`, `other`) plus an 8-hex FNV fingerprint, recorded on the `wasm.abort` event at level `error`; the prose never leaves the renderer
- record a non-zero client exit as a new `wasm.exit` event carrying the code, and count both crash shapes in a run-scoped `wasm.crashes` tally
- treat `wasm.abort` / `wasm.exit` as abnormal in previous-session detection, so a run that crashed mid-game but quit cleanly no longer exports as normal
- add the allowlisted destination port (6112/80/443) to `socket.open`, making game-connection resets distinguishable from patch/web traffic
- show a crash panel on the launcher after the client dies: **Retry** plus **Report a Problem…** (a new `diagnosticsExportReport` invoke channel into the existing main-owned export flow, now guarded against re-entry), with copy that escalates once a run crashes repeatedly
- correct the current enhancement manifest entry to the build its client self-reports (38797; it carried the 38771 baseline id by mistake)

## Why

The #46 diagnostics show 9–10 abort/relaunch cycles per session across two consecutive runs, and the bundle cannot say why: the abort reason was dropped in the renderer, the crashed session exported as "normal", `report.json` showed `errorCount: 0`, and socket resets could not be attributed to the game connection. Players also had no visible path from the crash to a report — the export lived only in the Help menu.

With this change the next bundle names the failing native operation class directly (e.g. `indirectCall` would implicate the enhancement hook on the new client build), identical causes cluster across machines via the fingerprint without exporting text, and the player standing in front of a crash is one click from a redacted report and the bug form.

## User impact

After a crash the launcher returns with Retry and Report a Problem…; a second crash in the same app run changes the message to lead with reporting. The exported archive labels crashed sessions and carries the reason class. No new data leaves the machine: the reason is a closed vocabulary, the fingerprint is non-text, and the port field is the closed production allowlist.

## Validation

- `pnpm typecheck`, `pnpm lint`
- `pnpm test:unit` (592), `pnpm test:policy` (124), `pnpm test:release` (21), `pnpm test:integration` (20)
- `pnpm test:electron` diagnostics + sandbox suites (14), including a new end-to-end spec driving the crash panel and exporting through the new channel
- new unit coverage: abort-reason classification and fingerprint↔boundary-validator invariant, crash-copy escalation, abnormal-session detection for both crash shapes

Refs #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)