### PR TITLE
Record the Enhancement install lifecycle in crash diagnostics

### DIFF
--- a/src/main/diagnostics.ts
+++ b/src/main/diagnostics.ts
@@ -24,10 +24,12 @@ import {
   screen,
   type BrowserWindow,
 } from "electron";
-import type {
-  AppSettings,
-  GraphicsDiagnostics,
-  RendererCommand,
+import {
+  ENHANCEMENT_CAPABILITY_PROFILES,
+  type AppSettings,
+  type EnhancementCapabilityProfile,
+  type GraphicsDiagnostics,
+  type RendererCommand,
 } from "../shared/contracts.js";
 import { errorCode, type ErrorCode } from "../shared/errors.js";
 import type {
@@ -570,6 +572,38 @@ export function recordRendererMilestone(
         k: "wasm.exit",
         clockSynchronized: rendererClockSynchronized,
         code: fields.code,
+      },
+      { timestampUs },
+    );
+    return;
+  }
+  if (name === "enhancement.installed") {
+    if (!fields || !("capabilityProfile" in fields)) return;
+    // IPC validated the shape; membership in the closed profile vocabulary is
+    // this recorder's gate. An unknown profile is dropped, not recorded.
+    const profile = fields.capabilityProfile;
+    if (!Object.hasOwn(ENHANCEMENT_CAPABILITY_PROFILES, profile)) return;
+    recordEvent(
+      {
+        k: "enhancement.installed",
+        clockSynchronized: rendererClockSynchronized,
+        companionAbi: fields.companionAbi,
+        installation: fields.installation,
+        capabilityProfile: profile as EnhancementCapabilityProfile,
+      },
+      { timestampUs },
+    );
+    return;
+  }
+  if (name === "enhancement.uninstalled") {
+    if (!fields || !("installation" in fields) || "capabilityProfile" in fields) {
+      return;
+    }
+    recordEvent(
+      {
+        k: "enhancement.uninstalled",
+        clockSynchronized: rendererClockSynchronized,
+        installation: fields.installation,
       },
       { timestampUs },
     );

--- a/src/main/diagnostics/schema.ts
+++ b/src/main/diagnostics/schema.ts
@@ -1,7 +1,9 @@
 import {
+  ENHANCEMENT_CAPABILITY_PROFILES,
   EVENT_CHANNELS,
   IPC,
   type AppUpdateErrorCode,
+  type EnhancementCapabilityProfile,
   type EventChannel,
   type InvokeChannel,
   type RendererCommand,
@@ -1148,6 +1150,34 @@ export const DIAGNOSTIC_EVENT_SCHEMA = {
     subsystem: "renderer",
     level: "error",
     fields: { clockSynchronized: boolean, code: finiteNumber },
+  },
+  // The renderer's Enhancement installation lifecycle. `clientPrepared` above
+  // says a transformed module was served; only these say whether the hook was
+  // actually live in the game's call path — the first fact a wasm.abort
+  // triage needs.
+  "enhancement.installed": {
+    subsystem: "renderer",
+    level: "info",
+    fields: {
+      clockSynchronized: boolean,
+      companionAbi: finiteNumber,
+      installation: finiteNumber,
+      capabilityProfile: literal(
+        Object.keys(
+          ENHANCEMENT_CAPABILITY_PROFILES,
+        ) as EnhancementCapabilityProfile[],
+      ),
+    },
+  },
+  "enhancement.installFailed": {
+    subsystem: "renderer",
+    level: "warn",
+    fields: { clockSynchronized: boolean },
+  },
+  "enhancement.uninstalled": {
+    subsystem: "renderer",
+    level: "info",
+    fields: { clockSynchronized: boolean, installation: finiteNumber },
   },
 } as const satisfies Readonly<Record<string, EventSpec>>;
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -387,6 +387,33 @@ const asMilestone: Parser<ParsedMilestone> = (args) => {
       && Number.isSafeInteger(record.code);
     if (!valid) throw new ValidationError("invalid renderer milestone");
     milestoneFields = { code: record.code as number };
+  } else if (name === "enhancement.installed") {
+    const valid =
+      recordIsObject
+      && Object.keys(record).length === 3
+      && typeof record.companionAbi === "number"
+      && Number.isSafeInteger(record.companionAbi)
+      && record.companionAbi >= 0
+      && typeof record.installation === "number"
+      && Number.isSafeInteger(record.installation)
+      && record.installation >= 1
+      && typeof record.capabilityProfile === "string"
+      && record.capabilityProfile.length <= 32;
+    if (!valid) throw new ValidationError("invalid renderer milestone");
+    milestoneFields = {
+      companionAbi: record.companionAbi as number,
+      installation: record.installation as number,
+      capabilityProfile: record.capabilityProfile as string,
+    };
+  } else if (name === "enhancement.uninstalled") {
+    const valid =
+      recordIsObject
+      && Object.keys(record).length === 1
+      && typeof record.installation === "number"
+      && Number.isSafeInteger(record.installation)
+      && record.installation >= 1;
+    if (!valid) throw new ValidationError("invalid renderer milestone");
+    milestoneFields = { installation: record.installation as number };
   } else if (fields !== undefined) {
     throw new ValidationError("invalid renderer milestone");
   }

--- a/src/renderer/enhancements.ts
+++ b/src/renderer/enhancements.ts
@@ -1,5 +1,6 @@
 import {
   enhancementCapabilitiesFor,
+  enhancementCapabilityProfile,
   type EnhancementProgram,
   type EnhancementSelection,
 } from "../shared/contracts.js";
@@ -17,6 +18,10 @@ import {
   recordCompanionLifecycle,
 } from "./companion-observer.js";
 import { decodeEnhancementManifest } from "./enhancement-manifest.js";
+import type {
+  RendererMilestone,
+  RendererMilestoneFields,
+} from "../shared/diagnostics.js";
 
 const ENHANCEMENT_FEATURE_NATIVE_CURSOR = 1 << 0;
 const ENHANCEMENT_FEATURE_TARGET_READOUT = 1 << 1;
@@ -24,6 +29,20 @@ const ENHANCEMENT_FEATURE_TOOLBOX_FOUNDATION = 1 << 2;
 const COMPANION_ABI = 6;
 const COMPANION_RUNTIME_BYTES = 65_536;
 let companionInstallations = 0;
+
+/**
+ * The renderer half of the Enhancement crash story: whether the hook was live
+ * when a later wasm.abort fires. Best-effort by design — telemetry must never
+ * fail an installation.
+ */
+const recordMilestone = (
+  name: RendererMilestone,
+  fields?: RendererMilestoneFields,
+) => {
+  void window.gwNative.diagnostics
+    .recordRendererMilestone(name, performance.now() * 1000, fields)
+    .catch(() => {});
+};
 
 function percentile95(samples: readonly number[]): number {
   if (samples.length === 0) return 0;
@@ -144,6 +163,7 @@ export async function installEnhancements(
     const state = Object.freeze({ status: "unsupported" } as const);
     recordCompanionLifecycle(state);
     if (publishObserverState) window.gwCompanionState = state;
+    recordMilestone("enhancement.installFailed");
     return null;
   }
 
@@ -183,6 +203,7 @@ export async function installEnhancements(
   let installedCallback: CallableFunction | null = null;
   let installedRuntime: object | null = null;
   let cleaned = false;
+  let telemetryInstalled = false;
   const cleanup = () => {
     if (cleaned) return;
     cleaned = true;
@@ -206,6 +227,14 @@ export async function installEnhancements(
     if (runtimePointer) free(runtimePointer);
     if (window.gwCompanionRuntime === installedRuntime) {
       window.gwCompanionRuntime = null;
+    }
+    // Only a completed installation records a withdrawal; a rollback after a
+    // failed install records enhancement.installFailed instead.
+    if (telemetryInstalled) {
+      telemetryInstalled = false;
+      recordMilestone("enhancement.uninstalled", {
+        installation: companionInstallations,
+      });
     }
   };
   try {
@@ -501,9 +530,19 @@ export async function installEnhancements(
       `[enhancement] installed for client build ${manifest.buildId}; ` +
       `companion ABI ${COMPANION_ABI} ${kernelSha256.slice(0, 12)}`,
     );
+    const capabilityProfile = enhancementCapabilityProfile(capabilities);
+    if (capabilityProfile !== null) {
+      telemetryInstalled = true;
+      recordMilestone("enhancement.installed", {
+        companionAbi: COMPANION_ABI,
+        installation,
+        capabilityProfile,
+      });
+    }
     return runtime;
   } catch (error) {
     cleanup();
+    recordMilestone("enhancement.installFailed");
     if (publishObserverState) {
       window.gwCompanionState = Object.freeze({
         status: "error",

--- a/src/shared/diagnostics.ts
+++ b/src/shared/diagnostics.ts
@@ -195,6 +195,13 @@ export const RENDERER_MILESTONES = [
   "snapshot.fatalRead",
   "wasm.abort",
   "wasm.exit",
+  // The renderer half of the Enhancement story: whether our code was actually
+  // live in the game's call path. Main records that a transformed module was
+  // *prepared*; only these say the hook was installed, refused, or withdrawn —
+  // the first question a wasm.abort triage asks.
+  "enhancement.installed",
+  "enhancement.installFailed",
+  "enhancement.uninstalled",
 ] as const;
 
 export type RendererMilestone = (typeof RENDERER_MILESTONES)[number];
@@ -223,6 +230,17 @@ export interface RendererMilestoneFieldsByName {
   "wasm.abort": { reasonKind: WasmAbortReasonKind; fingerprint: string };
   /** A non-zero client exit: the other way the running game dies. */
   "wasm.exit": { code: number };
+  /**
+   * The hook went live. `capabilityProfile` is the closed profile vocabulary
+   * from contracts — typed as string here because contracts imports this file;
+   * the recorder's schema enforces membership.
+   */
+  "enhancement.installed": {
+    companionAbi: number;
+    installation: number;
+    capabilityProfile: string;
+  };
+  "enhancement.uninstalled": { installation: number };
 }
 export type RendererMilestoneFields =
   RendererMilestoneFieldsByName[keyof RendererMilestoneFieldsByName];

--- a/tests/packaged-enhancement-runtime.ts
+++ b/tests/packaged-enhancement-runtime.ts
@@ -7,6 +7,7 @@ import { existsSync } from "node:fs";
 import {
   mkdir,
   mkdtemp,
+  readdir,
   readFile,
   rm,
   stat,
@@ -810,6 +811,61 @@ async function assertTargetReadoutLifecycle() {
       state: undefined,
       tableEmpty: true,
     });
+
+    // The crash-triage timeline: installation and withdrawal are recorded
+    // events beside wasm.abort, so an exported log can say whether the hook
+    // was live. Poll, because the recorder flushes asynchronously.
+    const telemetryDeadline = Date.now() + 10_000;
+    let lifecycle: { name: string; fields: Record<string, unknown> }[] = [];
+    while (Date.now() < telemetryDeadline) {
+      const events: { name?: string; fields?: Record<string, unknown> }[] = [];
+      for (const file of (await readdir(path.join(fixture.userData, "diagnostics"))
+        .catch(() => [] as string[]))
+        .filter((name) => name.endsWith(".jsonl"))) {
+        const text = await readFile(
+          path.join(fixture.userData, "diagnostics", file),
+          "utf8",
+        );
+        for (const entry of text.split("\n")) {
+          if (!entry) continue;
+          try {
+            events.push(JSON.parse(entry));
+          } catch {
+            continue;
+          }
+        }
+      }
+      lifecycle = events
+        .filter((event) =>
+          event.name === "enhancement.installed"
+          || event.name === "enhancement.uninstalled")
+        .map((event) => ({ name: event.name ?? "", fields: event.fields ?? {} }));
+      if (lifecycle.length >= 2) break;
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+    assert.deepEqual(
+      lifecycle.map(({ name, fields }) => ({
+        name,
+        companionAbi: fields.companionAbi,
+        capabilityProfile: fields.capabilityProfile,
+        installation: fields.installation,
+      })),
+      [
+        {
+          name: "enhancement.installed",
+          companionAbi: 6,
+          capabilityProfile: "target",
+          installation: 1,
+        },
+        {
+          name: "enhancement.uninstalled",
+          companionAbi: undefined,
+          capabilityProfile: undefined,
+          installation: 1,
+        },
+      ],
+      "the packaged install lifecycle did not reach the diagnostics log",
+    );
     assert.ok(
       resources.some(
         (url) => new URL(url).pathname === "/companion-kernel.wasm",

--- a/tests/unit/export-detector-rejects-undeclared-event-fields.test.ts
+++ b/tests/unit/export-detector-rejects-undeclared-event-fields.test.ts
@@ -69,6 +69,15 @@ describe("export detector", () => {
       { k: "proxy.requestFailed", route: "account", code: "http_status" },
       { k: "socket.close", socketId: 7, reason: "peer" },
       { k: "socket.error", socketId: 7, code: "refused" },
+      {
+        k: "enhancement.installed",
+        clockSynchronized: true,
+        companionAbi: 6,
+        installation: 1,
+        capabilityProfile: "cursor",
+      },
+      { k: "enhancement.installFailed", clockSynchronized: false },
+      { k: "enhancement.uninstalled", clockSynchronized: true, installation: 1 },
     ];
     const result = inspectEventLog(events.map(recorded).join("\n"));
     assert.equal(result.records, events.length);
@@ -104,6 +113,17 @@ describe("export detector", () => {
     rejects(
       line({ name: "client.candidatePromoted" }, { fingerprint: "not-a-digest" }),
       /client\.candidatePromoted\.fingerprint is not a declared value/,
+    );
+    // The capability profile is the closed vocabulary from contracts, not a
+    // renderer-supplied string.
+    rejects(
+      line({ name: "enhancement.installed" }, {
+        clockSynchronized: true,
+        companionAbi: 6,
+        installation: 1,
+        capabilityProfile: "everything",
+      }),
+      /enhancement\.installed\.capabilityProfile is not a declared value/,
     );
   });
 


### PR DESCRIPTION
## Why

#48 gave crash logs a closed abort vocabulary, and #49 shipped the cursor riding a transformed game module — but the timeline between them had a gap: `enhancement.clientPrepared` says a derived module was *served*, while nothing recorded whether the renderer actually *installed* the hook. A `wasm.abort` could not be triaged into "our code was live" vs. "install failed closed, the crash is the client's" — the exact distinction that separated real enhancement bugs from innocent crashes during development.

## What

Three renderer milestones, carried through every layer of the existing pipeline (shared vocabulary → strict per-name IPC validation → recorder branch → schema'd event):

- **`enhancement.installed { companionAbi, installation, capabilityProfile }`** — the hook went live. `capabilityProfile` is the closed `cursor | target | cursorTarget | cursorToolbox` vocabulary from contracts; the schema's `literal` guard plus its compile-time no-free-text proof enforce membership, and the recorder drops unknown values rather than recording them.
- **`enhancement.installFailed`** — fail-closed validation refusals and install-time rollbacks (fields-free; prose stays in the console).
- **`enhancement.uninstalled { installation }`** — teardown/pagehide withdrawal, guarded so a rollback after a failed install does not record a phantom uninstall.

Telemetry is best-effort by design (`.catch(() => {})`) — it can never fail or delay an installation.

## Tests

- Detector unit cases: the three events accepted through the schema; an out-of-vocabulary `capabilityProfile` rejected.
- Packaged lifecycle: reads the real diagnostics JSONL after install + pagehide and requires the exact `installed → uninstalled` sequence with correct fields.
- Full chain green: 634 unit, 127 policy, kernel ABI + reproducibility, 29 integration, 21 release, 96 Electron (1 opt-in skip), package, packaged smoke + Enhancement runtime.

## Review focus

- `src/main/ipc.ts` — the two new `asMilestone` validation branches (strictness parity with `wasm.abort`/`build.info`).
- `src/main/diagnostics.ts` — recorder branches and the drop-not-record gate for unknown profiles.
- The `enhancement.uninstalled` guard in `src/renderer/enhancements.ts` cleanup ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)