### PR TITLE
Fix the signed Keychain test's Steam expectations

### DIFF
--- a/tests/signed-keychain-runtime.ts
+++ b/tests/signed-keychain-runtime.ts
@@ -43,6 +43,11 @@ const credentials = {
   username: "signed-runtime@example.invalid",
   password: "synthetic-signed-runtime-secret",
 };
+// The only Steam-token writer is the main process's own interactive OAuth
+// flow. The renderer's `steam.store` is the client's expiry storeback, and
+// against an empty keychain it must be ignored — so this synthetic session is
+// expected to be *refused*, proving a renderer cannot plant a Steam credential
+// in the signed app.
 const steamSession = {
   token: "synthetic-signed-runtime-steam-token",
   expiry: Date.now() + 86_400_000,
@@ -149,8 +154,6 @@ type SecretAction =
   | "save-and-load"
   | "load"
   | "clear-and-load"
-  | "clear-credentials-and-load"
-  | "save-credentials-and-load"
   | "clear-steam-and-load";
 
 async function useSecrets(
@@ -183,15 +186,9 @@ async function useSecrets(
           await api.credentials.save(value.credentials);
           await api.steam.store(value.steam.token, value.steam.expiry);
         }
-        if (next === "save-credentials-and-load") {
-          await api.credentials.save(value.credentials);
-        }
         if (next === "clear-and-load") {
           await api.credentials.clear();
           await api.steam.clear();
-        }
-        if (next === "clear-credentials-and-load") {
-          await api.credentials.clear();
         }
         if (next === "clear-steam-and-load") await api.steam.clear();
         return {
@@ -220,12 +217,13 @@ try {
   createdSyntheticItem = true;
   assert.deepEqual(
     await useSecrets(sourceApp, "save-and-load"),
-    { credentials, steam: { token: steamSession.token } },
+    { credentials, steam: { token: null } },
+    "the renderer storeback planted a Steam token in an empty keychain",
   );
   assert.deepEqual(
     await useSecrets(sourceApp, "load"),
-    { credentials, steam: { token: steamSession.token } },
-    "the signed app did not retain both secrets across relaunch",
+    { credentials, steam: { token: null } },
+    "the signed app did not retain the credentials across relaunch",
   );
 
   const movedApp = path.join(
@@ -237,7 +235,7 @@ try {
   await execFileAsync("ditto", [sourceApp, movedApp]);
   assert.deepEqual(
     await useSecrets(movedApp, "load"),
-    { credentials, steam: { token: steamSession.token } },
+    { credentials, steam: { token: null } },
     "moving the signed app changed its Keychain identity",
   );
 
@@ -265,23 +263,14 @@ try {
   await execFileAsync("codesign", ["--verify", "--deep", "--strict", upgradedApp]);
   assert.deepEqual(
     await useSecrets(upgradedApp, "load"),
-    { credentials, steam: { token: steamSession.token } },
-    "a newly signed build could not read the existing Keychain items",
+    { credentials, steam: { token: null } },
+    "a newly signed build could not read the existing Keychain item",
   );
 
   assert.deepEqual(
-    await useSecrets(upgradedApp, "clear-credentials-and-load"),
-    { credentials: null, steam: { token: steamSession.token } },
-    "clearing credentials also cleared the independent Steam session",
-  );
-  assert.deepEqual(
-    await useSecrets(upgradedApp, "save-credentials-and-load"),
-    { credentials, steam: { token: steamSession.token } },
-  );
-  assert.deepEqual(
     await useSecrets(upgradedApp, "clear-steam-and-load"),
     { credentials, steam: { token: null } },
-    "clearing the Steam session also cleared independent credentials",
+    "clearing the Steam session slot also cleared independent credentials",
   );
   assert.deepEqual(
     await useSecrets(upgradedApp, "clear-and-load"),
@@ -310,7 +299,7 @@ try {
     "chunk-sentinel",
   );
   console.log(
-    `signed ${channel} Data Protection Keychain survived relaunch, move, and upgrade`,
+    `signed ${channel} Data Protection Keychain survived relaunch, move, and upgrade; the renderer storeback never planted a Steam token`,
   );
 } finally {
   if (createdSyntheticItem) {


### PR DESCRIPTION
## Why the release is red

Every Versioned release run since #44 fails deterministically at the `save-and-load` step of `tests/signed-keychain-runtime.ts`: credentials round-trip, but the Steam token comes back `null`.

The test seeded its synthetic Steam session through `gwNative.steam.store`. That surface is the client's expiry **storeback** (`refreshSteamExpiry`): by deliberate design it only tightens the expiry of a token *already in the Keychain* and returns `ignored` for everything else — the client's storeback value may be a session-resume token that must never overwrite (or plant) a credential. The only writer of a new Steam token is the main process's own interactive OAuth flow, so a renderer can never seed one. The test asserted an impossible outcome, and today's release run was simply the first time the release pipeline executed it.

`plans/keychain.md` (signed release-candidate tests, step 5) had called for seeding through a main-process test harness; that harness was never built, and the test reached for the renderer storeback instead.

## What this changes

Test only — production semantics are intentional and stay untouched:

- **`save-and-load` now expects the storeback to be refused** (`steam: { token: null }`), turning the step into a positive security proof: a renderer cannot plant a Steam credential in the signed app.
- **Credentials continuity is unchanged**: save, relaunch, move via `ditto`, re-sign/upgrade, legacy-file retirement, and profile-preservation checks all still run. They exercise the same native Keychain module, access group, and channel identity that protect the `steamSession` slot.
- **`clear-steam-and-load` is kept** as the one-direction independence proof (clearing the Steam slot must not touch credentials). `clear-credentials-and-load` and `save-credentials-and-load` are dropped — without a storable token they only duplicated `save-and-load`/`clear-and-load`.

Steam save/load/clear semantics remain covered by `tests/unit/steam-session.test.ts` through the `SteamSessionReader` seam.

## Verification

- `tsc -p tsconfig.tests.json` — clean
- `eslint tests/signed-keychain-runtime.ts` — clean
- `pnpm test:policy` — all pass (pins the release-pipeline wiring)
- The test itself only runs against a signed app on CI; the release/sign-preview run of this PR's merge is the end-to-end proof.

## Not in this PR

- The Main snapshot workflow additionally fails because the `snapshot-signing` GitHub environment's secrets come through empty (also since #44). That is a repo-settings fix, not a code change.
- A main-process seeding harness for true end-to-end Steam-slot continuity (per `plans/keychain.md`) is a design decision worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)