### PR TITLE
Add a silent six-hour background update re-check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,10 +146,11 @@ not only happy paths.
   closed intent is what makes unsupported package states unrepresentable.
 - The app makes no network request the user was not plainly told about.
   `autoCheckUpdates` (default `true`, declared as one pre-checked line at first
-  run and in Settings → Updates) performs one release check per launch and
-  governs **every** automatic check without exception, including the one on an
-  unrecognised client build; switched off, a launch reaches github.com zero
-  times, forever. `src/main/app-updater.ts` is the only
+  run and in Settings → Updates) performs one release check at launch, then at
+  most one every six hours while the app stays open — never while a game
+  connection is open — and governs **every** automatic check without
+  exception, including the one on an unrecognised client build; switched off,
+  a launch reaches github.com zero times, forever. `src/main/app-updater.ts` is the only
   caller of the releases API and the single owner of discovery, feed
   validation, download, ready, and install state. Only an official package
   carrying the release marker may reach Squirrel.Mac. Stable installs never

--- a/README.md
+++ b/README.md
@@ -56,9 +56,10 @@ mid-download with _Play Now Instead_.
   Protection Keychain in provisioned Release, Preview, and signed Development
   builds. Each channel is isolated. Source and ad-hoc builds keep saved login
   only in memory for that process.
-- **The app does not poll for updates.** It checks GitHub once per launch — a
-  default declared at first run that one checkbox turns off. Switched off, it
-  asks GitHub only when you press **Check for Updates**. A downloaded update is
+- **Updates check on a declared schedule, or not at all.** The app checks
+  GitHub at launch and about every six hours while it stays open — a default
+  declared at first run that one checkbox turns off. Switched off, it asks
+  GitHub only when you press **Check for Updates**. A downloaded update is
   offered as a restart and otherwise installs on the next restart. See
   [Updates](docs/user-guide.md#updates).
 

--- a/docs/internals.md
+++ b/docs/internals.md
@@ -126,10 +126,16 @@ or fails. There is no renderer-owned download or power state.
 ## This app's own updater
 
 `src/main/app-updater.ts` is the single update owner. It asks the bounded GitHub
-release list only after a manual request or the once-per-launch automatic check.
-`autoCheckUpdates` defaults on and is declared plainly at first run and in
-Settings; switched off, a launch reaches github.com zero times. There is no
-timer or polling loop.
+release list only after a manual request or an automatic check that `main.ts`
+schedules: one at launch, then a 30-minute tick that re-checks when
+`periodicCheckDue` says so — the build is update-capable, `autoCheckUpdates` is
+on, no game socket is open, and the recorded `lastUpdateCheckAt` is at least
+six hours old. The tick-plus-due-time shape survives sleep without a resume
+handler: a laptop waking past the boundary checks within half an hour. Failures
+also record `lastUpdateCheckAt`, so a failing environment retries at the same
+six-hour spacing. `autoCheckUpdates` defaults on and is declared plainly at
+first run and in Settings; switched off, a launch reaches github.com zero
+times.
 
 Only a packaged macOS build whose generated `distribution-channel.json` names
 `release` may update. The marker has the exact shape
@@ -996,7 +1002,8 @@ two that read _none_ today are recorded rather than quietly kept.
 | Game files come directly from ArenaNet and are verified before use | website FAQ, `README.md` | `tests/unit/manifest.test.ts`, `tests/unit/chunk-store.test.ts` (verify-on-read, unlink-and-refetch), `tests/unit/published-client.test.ts`; `tests/integration/updater.test.ts` for publication, corruption repair and rollback |
 | No telemetry, credentials, account identifiers, or game traffic are uploaded | website features list and FAQ | `tests/unit/no-game-traffic-is-uploaded.test.ts` — the test named for the claim: *refuses every destination that is not a public ArenaNet-shaped address* (loopback, private ranges, this project's own host, every port outside 6112/80/443), and *exports a socket's lifetime with no trace of what it carried*; `tests/unit/allowlists.test.ts` and `tests/unit/proxy-routes.test.ts` for the boundaries underneath it |
 | A `.gwdiag` never contains credentials, account identifiers, packet contents, or crash dumps | website FAQ, `docs/user-guide.md` | `tests/unit/diagnostic-schema-rejects-free-text.test.ts`, `tests/unit/export-detector-rejects-undeclared-event-fields.test.ts`, `tests/unit/socket-events-carry-no-error-text.test.ts`, `tests/unit/trace-scanner-catches-the-adversarial-corpus.test.ts`. Read *What the export actually guarantees* above for which tier covers which file |
-| With update checks switched off, the app makes no network request the player did not ask for | settings copy, `docs/user-guide.md` | `tests/electron/a-launch-checks-github-once-unless-opted-out.spec.ts` — the row's proof: it wraps the main process's `fetch` and counts exactly **one** api.github.com request across a launch with the defaults, then **zero** across a launch with the box unticked. `tests/unit/settings.test.ts`, `tests/unit/app-updater.test.ts`, and `tests/unit/update-action.test.ts` prove the constituents |
+| With update checks switched off, the app makes no network request the player did not ask for | settings copy, `docs/user-guide.md` | `tests/electron/a-launch-checks-github-once-unless-opted-out.spec.ts` — the row's proof: it wraps the main process's `fetch` and counts exactly **one** api.github.com request across a launch with the defaults, then **zero** across a launch with the box unticked. `tests/unit/settings.test.ts`, `tests/unit/app-updater.test.ts`, and `tests/unit/update-action.test.ts` prove the constituents, including `periodicCheckDue` — every gate on the background re-check and its cadence constants |
+| Automatic checks happen at launch and then at most every six hours, never while a game connection is open | settings copy, first-run line, `README.md`, `docs/user-guide.md` | `tests/unit/app-updater.test.ts` — the `periodicCheckDue` gates and the `PERIODIC_CHECK_TICK_MS`/`PERIODIC_CHECK_DUE_MS` constants; `tests/policy/source-release-pipeline.test.ts` pins that the tick in `main.ts` is wired through that one predicate |
 | The game's own cursor is on by default, is switchable off, and no artwork ships or is downloaded | settings copy, `docs/user-guide.md` | `tests/release/packaged-enhancement-surface.test.ts` — *the cursor ships on, and a player who switches it off stays off*; `tests/electron/enhancement-cursor.spec.ts` for what Chromium computes from a published cursor region; `tests/policy/forbidden-artifacts.test.ts` for what is tracked |
 | Releases are Developer ID signed, notarized, stapled, and the shipped fuses hold | website FAQ | `.github/workflows/release.yml` verifies the G2 fingerprint, profile identity, Team ID, timestamp, hardened runtime, exact three top-level entitlements, Gatekeeper and stapled tickets; `tests/signed-keychain-runtime.ts` proves the signed product retains a Data Protection Keychain item across relaunch, move, and a newly signed replacement; `tests/policy/source-release-pipeline.test.ts` pins that policy; `tests/packaged-smoke.ts` and `tests/policy/fuses.test.ts` verify package structure and fuses |
 | Render scale changes the real backing resolution | website, settings copy | `tests/electron/live.spec.ts` (opt-in live smoke) — the drawing buffer changes with the setting; `tests/electron/settings.spec.ts` for the resolutions shown beside each scale |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -283,12 +283,13 @@ The crash count resets when you quit and reopen the app.
 The first Developer ID release must be installed manually from its notarized
 DMG. Later official releases can update themselves.
 
-The app never polls. **Automatically check for and download app updates** is
-on by default — it performs one check per launch, and the first-run screen
-says so before the first one happens. Turn it off and the app contacts GitHub
-only when you choose **Check for Updates** — on the loading screen, in the
-application menu, on a client-compatibility notice, or under
-**Settings → Updates**. Turning it back on immediately checks once.
+The app checks on a declared schedule. **Automatically check for and download
+app updates** is on by default — it checks once at launch and then about every
+six hours while the app stays open, never while a game connection is open, and
+the first-run screen says so before the first check happens. Turn it off and
+the app contacts GitHub only when you choose **Check for Updates** — on the
+loading screen, in the application menu, on a client-compatibility notice, or
+under **Settings → Updates**. Turning it back on immediately checks once.
 
 An eligible update downloads in the background. When it is ready, choose
 **Restart to Update** or choose Later and let it install on the next ordinary

--- a/src/main/app-updater.ts
+++ b/src/main/app-updater.ts
@@ -309,6 +309,33 @@ export class AppUpdater {
   }
 }
 
+export const PERIODIC_CHECK_TICK_MS = 30 * 60 * 1000;
+export const PERIODIC_CHECK_DUE_MS = 6 * 60 * 60 * 1000;
+
+export interface PeriodicCheckInput {
+  capable: boolean;
+  autoCheckUpdates: boolean;
+  activeSockets: number;
+  lastUpdateCheckAt: number | null;
+  now: number;
+}
+
+/**
+ * Whether a scheduler tick becomes an automatic check. Pure by design:
+ * main.ts owns when ticks fire; this owns every gate, so the gates are
+ * provable without timers. An open game socket defers the check — a
+ * Squirrel zip download must not compete with live game traffic.
+ */
+export function periodicCheckDue(input: PeriodicCheckInput): boolean {
+  if (!input.capable || !input.autoCheckUpdates) return false;
+  if (input.activeSockets > 0) return false;
+  if (input.lastUpdateCheckAt === null) return true;
+  const elapsed = input.now - input.lastUpdateCheckAt;
+  // A recorded check far in the future means the clock moved backwards;
+  // waiting for it to become the past would suppress checks indefinitely.
+  return elapsed >= PERIODIC_CHECK_DUE_MS || -elapsed >= PERIODIC_CHECK_DUE_MS;
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -43,7 +43,11 @@ import {
 } from "./diagnostics.js";
 import type { AppPhase } from "./diagnostics/schema.js";
 import { emitSocketEvent, registerIpcHandlers } from "./ipc.js";
-import { AppUpdater } from "./app-updater.js";
+import {
+  AppUpdater,
+  PERIODIC_CHECK_TICK_MS,
+  periodicCheckDue,
+} from "./app-updater.js";
 import {
   enableSandboxBeforeReady,
   onAppQuit,
@@ -590,6 +594,27 @@ if (primaryInstance) void app.whenReady().then(async () => {
   if (settings.autoCheckUpdates) {
     void appUpdaterController.check();
   }
+  // A 30-minute tick with a six-hour due-time instead of a six-hour timer:
+  // a laptop waking past the boundary checks within half an hour, with no
+  // resume handler and no new diagnostic event. check() already coalesces,
+  // so a due tick during a download or a ready update is a no-op.
+  const periodicCheckTick = setInterval(() => {
+    void (async () => {
+      const current = await loadSettings(gamePaths().settings);
+      if (!periodicCheckDue({
+        capable: distribution.automaticUpdates,
+        autoCheckUpdates: current.autoCheckUpdates,
+        activeSockets: sockets.size(),
+        lastUpdateCheckAt: current.lastUpdateCheckAt,
+        now: Date.now(),
+      })) return;
+      void appUpdaterController?.check();
+    })().catch(() => {
+      // A periodic check is silent by contract; an unreadable settings file
+      // already surfaces on the next explicit settings read.
+    });
+  }, PERIODIC_CHECK_TICK_MS);
+  onAppQuit(() => clearInterval(periodicCheckTick));
   if (secondInstanceRequested) win.once("ready-to-show", revealMainWindow);
   if (ENHANCEMENT_AUTOMATION_ENABLED) {
     process.on("message", (message) => {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -90,7 +90,7 @@
         <p>
           <label>
             <input type="checkbox" id="data-choice-auto-updates" checked>
-            Check for app updates at launch — contacts GitHub once per start
+            Check for app updates — contacts GitHub at launch and about every six hours
           </label>
         </p>
         <p id="data-choice-error" role="status" hidden></p>
@@ -322,7 +322,7 @@
             <input type="checkbox" name="autoCheckUpdates">
             <span>Automatically check for and download app updates</span>
           </label>
-          <p class="settings-note">On by default: one check per launch. Turn this off and the app contacts GitHub only when you ask it to — including when it meets a game client build it does not recognise. Downloaded updates are installed when you restart.</p>
+          <p class="settings-note">On by default: one check at launch, then a quiet check about every six hours while the app stays open — never while a game connection is open. Turn this off and the app contacts GitHub only when you ask it to — including when it meets a game client build it does not recognise. Downloaded updates are installed when you restart.</p>
           <div class="settings-update-actions">
             <button type="button" id="settings-check-updates">
               Check for Updates

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -365,10 +365,11 @@ export interface AppSettings extends EnhancementSelection {
   showDiagnostics: boolean;
   dataStrategy: "quick" | "full" | null;
   /**
-   * Automatic release checks: one GitHub request per launch, on by default so
-   * players stay current, and declared plainly wherever the checkbox appears.
-   * `false` means this app makes no network request to GitHub unless the user
-   * asks for one — with no exceptions, including the check on an uncertified
+   * Automatic release checks: a GitHub request at launch, then at most one
+   * every six hours while the app stays open, on by default so players stay
+   * current, and declared plainly wherever the checkbox appears. `false`
+   * means this app makes no network request to GitHub unless the user asks
+   * for one — with no exceptions, including the check on an uncertified
    * client build. Opting out is one checkbox, honored forever.
    */
   autoCheckUpdates: boolean;

--- a/tests/electron/a-launch-checks-github-once-unless-opted-out.spec.ts
+++ b/tests/electron/a-launch-checks-github-once-unless-opted-out.spec.ts
@@ -1,11 +1,17 @@
 // The load-bearing network claim, executed rather than read.
 //
-// AGENTS.md, README.md, PRODUCT.md, docs/user-guide.md and the in-app settings
-// note all say the same thing: `autoCheckUpdates` is on by default and performs
-// one check per launch, and with it off a launch reaches github.com zero
+// AGENTS.md, README.md, docs/user-guide.md and the in-app settings note all
+// say the same thing: `autoCheckUpdates` is on by default and performs one
+// check at launch plus a background re-check no more than every six hours
+// while the app stays open, and with it off a launch reaches github.com zero
 // times. Until this spec existed the only proof was call sites read by hand,
 // and deleting the `if (settings.autoCheckUpdates)` gate in `main.ts` left
 // every suite green.
+//
+// The exact request counts below stay deterministic because the periodic
+// tick first fires thirty minutes in — far beyond any spec's lifetime.
+// Anyone who shortens `PERIODIC_CHECK_TICK_MS` or adds a test seam for it
+// must revisit every 0/1/2 count in this file.
 //
 // The two halves are two launches because they must be. The default-launch
 // check fires at startup, before any test hook can wrap the main process's

--- a/tests/electron/launcher.spec.ts
+++ b/tests/electron/launcher.spec.ts
@@ -36,7 +36,7 @@ test.describe("launcher recovery", () => {
       // only — a first launch must not ask about restarts.
       await expect(page.locator("#data-choice-auto-updates")).toBeChecked();
       await expect(page.locator("#data-choice")).toContainText(
-        "contacts GitHub once per start",
+        "about every six hours",
       );
       await expect(page.locator("#data-choice")).not.toContainText("cursor");
       await expect(page.locator("#data-choice")).not.toContainText("restart");

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -112,6 +112,10 @@ test("the host has one native automatic application replacement path", () => {
   assert.match(main, /packagedDistributionChannel\(\)/);
   assert.match(main, /capable: distribution\.automaticUpdates/);
   assert.match(main, /autoUpdater\.quitAndInstall\(\)/);
+  // The periodic re-check must run through the one audited predicate; a
+  // deleted tick or a bypassed gate stays green in unit tests, not here.
+  assert.match(main, /setInterval\([\s\S]{0,600}periodicCheckDue\(/);
+  assert.match(main, /PERIODIC_CHECK_TICK_MS/);
   assert.doesNotMatch(updater, /electron-updater|update-electron-app|Sparkle/);
   assert.deepEqual(json("package.json").dependencies ?? {}, {});
 });

--- a/tests/unit/app-updater.test.ts
+++ b/tests/unit/app-updater.test.ts
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { AppUpdater } from "../../src/main/app-updater.ts";
+import {
+  AppUpdater,
+  PERIODIC_CHECK_DUE_MS,
+  PERIODIC_CHECK_TICK_MS,
+  periodicCheckDue,
+} from "../../src/main/app-updater.ts";
 import type { AppUpdateState } from "../../src/shared/contracts.ts";
 
 const repo = "https://github.com/Mat4m0/gwonmac";
@@ -316,5 +321,74 @@ describe("application updater", () => {
       lastCheckedAt: "1970-01-01T00:00:01.234Z",
       reason: "feed-invalid",
     });
+  });
+});
+
+describe("periodic check policy", () => {
+  const stale = (overrides: Partial<Parameters<typeof periodicCheckDue>[0]> = {}) => ({
+    capable: true,
+    autoCheckUpdates: true,
+    activeSockets: 0,
+    lastUpdateCheckAt: 0,
+    now: PERIODIC_CHECK_DUE_MS,
+    ...overrides,
+  });
+
+  it("never ticks an update-incapable build", () => {
+    assert.equal(periodicCheckDue(stale({ capable: false })), false);
+    assert.equal(
+      periodicCheckDue(stale({ capable: false, lastUpdateCheckAt: null })),
+      false,
+    );
+  });
+
+  it("honors the opt-out at fire time, however stale the record", () => {
+    assert.equal(periodicCheckDue(stale({ autoCheckUpdates: false })), false);
+    assert.equal(
+      periodicCheckDue(
+        stale({ autoCheckUpdates: false, lastUpdateCheckAt: null }),
+      ),
+      false,
+    );
+  });
+
+  it("defers while a game connection is open, however stale the record", () => {
+    assert.equal(periodicCheckDue(stale({ activeSockets: 1 })), false);
+    assert.equal(
+      periodicCheckDue(stale({ activeSockets: 1, lastUpdateCheckAt: null })),
+      false,
+    );
+  });
+
+  it("checks immediately when no check has ever been recorded", () => {
+    assert.equal(periodicCheckDue(stale({ lastUpdateCheckAt: null })), true);
+  });
+
+  it("becomes due exactly at the six-hour boundary", () => {
+    assert.equal(
+      periodicCheckDue(stale({ now: PERIODIC_CHECK_DUE_MS - 1 })),
+      false,
+    );
+    assert.equal(periodicCheckDue(stale({ now: PERIODIC_CHECK_DUE_MS })), true);
+  });
+
+  it("recovers from a clock moved backwards instead of waiting it out", () => {
+    assert.equal(
+      periodicCheckDue(
+        stale({ lastUpdateCheckAt: PERIODIC_CHECK_DUE_MS * 2, now: 0 }),
+      ),
+      true,
+    );
+    assert.equal(
+      periodicCheckDue(stale({ lastUpdateCheckAt: 1, now: 0 })),
+      false,
+    );
+  });
+
+  it("keeps the declared cadence: 30-minute ticks against a six-hour window", () => {
+    assert.equal(PERIODIC_CHECK_TICK_MS, 30 * 60 * 1000);
+    assert.equal(PERIODIC_CHECK_DUE_MS, 6 * 60 * 60 * 1000);
+    // A tick coarser than the window would silently stretch the promise.
+    assert.ok(PERIODIC_CHECK_TICK_MS < PERIODIC_CHECK_DUE_MS);
   });
 });


### PR DESCRIPTION
## Why

An app left running for days never re-checks for releases, so those players linger on builds whose bugs are already fixed. Every other path was already covered: each launch checks, downloads are silent, and a ready update installs on any ordinary restart. This closes the one gap — with zero new UI and no nagging.

## What

- **`src/main/app-updater.ts`** — one exported pure predicate, `periodicCheckDue`, plus `PERIODIC_CHECK_TICK_MS` (30 min) and `PERIODIC_CHECK_DUE_MS` (6 h). The class is untouched.
- **`src/main/main.ts`** — a 30-minute tick after the startup check, wired through that predicate: update-capable build, `autoCheckUpdates` re-read from disk at fire time, no open game socket (a Squirrel zip download must not compete with live game traffic), and the persisted `lastUpdateCheckAt` at least six hours old — with a clock-moved-backwards escape. Tick-plus-due-time survives sleep without a resume handler or new diagnostic event; `check()`'s existing coalescing keeps downloads and notifications single. The interval is cleared via `onAppQuit`.

"One check per launch" was a declared, tested promise, so every claim moves with the behavior in the same change: first-run consent line, settings note, `contracts.ts` docstring, README, AGENTS.md, user guide, and the internals updater section plus its verification-boundaries table (one new row for the new promise).

## Kept invariants

- Opted out ⇒ **zero** GitHub requests, forever — stated and proven everywhere it was.
- No check while a game connection is open.
- A ready update still waits for an ordinary or explicit restart; no forced restarts.

## Testing

- 7 new unit tests pin every gate and both cadence constants, including `TICK < DUE` so the promise can't be silently stretched.
- `tests/policy/source-release-pipeline.test.ts` now pins that the tick runs through the one audited predicate — deleting the wiring can't stay green.
- The fetch-counting spec keeps its exact 0/1/2 assertions; its header now states the new promise and why the counts stay deterministic (first tick fires 30 minutes in, far beyond any spec's lifetime). `launcher.spec.ts` pins the new consent substring.
- Verified: stale-copy grep sweep clean, `pnpm check` green, `pnpm build` + the three affected Electron specs 18/18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)