### PR TITLE
Refuse an already-shipped release version before building

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,28 @@ jobs:
           echo "tag=v$version" >> "$GITHUB_OUTPUT"
           echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
 
+      # The same refusal the release job enforces before publishing, moved
+      # ahead of the build so a forgotten version bump fails in seconds, not
+      # after signing and notarization. This job's read-only token cannot see
+      # draft releases, so a resumable draft passes through here and is
+      # verified by the release job's own check.
+      - name: Refuse a version that already shipped
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            if [ "$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
+              --json isDraft --jq '.isDraft')" != "true" ]; then
+              echo "Release $TAG is already published; bump the version in package.json." >&2
+              exit 1
+            fi
+            echo "Draft release $TAG exists; this run will resume it."
+          elif gh api "repos/$GITHUB_REPOSITORY/git/ref/tags/$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG exists without a resumable draft release." >&2
+            exit 1
+          fi
+
       - run: pnpm install --frozen-lockfile
 
       - name: Import Developer ID and notarization credentials
@@ -401,8 +423,11 @@ jobs:
           sbom="$(find release-assets -maxdepth 1 -type f -name '*.spdx.json' -print -quit)"
           echo "sbom=$sbom" >> "$GITHUB_OUTPUT"
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            test "$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
-              --json isDraft --jq '.isDraft')" = "true"
+            if [ "$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
+              --json isDraft --jq '.isDraft')" != "true" ]; then
+              echo "Release $TAG is already published; bump the version in package.json." >&2
+              exit 1
+            fi
             test "$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
               --json isPrerelease --jq '.isPrerelease')" = "$PRERELEASE"
             test "$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -233,6 +233,10 @@ test("release workflow publishes one tested, attested package version", () => {
   assert.match(workflow, /persist-credentials: false/);
   assert.match(workflow, /require\('\.\/package\.json'\)\.version/);
   assert.match(workflow, /git\/ref\/tags\/\$TAG/);
+  assert.match(
+    workflow,
+    /name: Refuse a version that already shipped[\s\S]*?already published; bump the version in package\.json[\s\S]*?- run: pnpm install --frozen-lockfile/,
+  );
   assert.doesNotMatch(workflow, /pnpm version|date -u/);
   assert.match(
     workflow,
@@ -289,7 +293,7 @@ test("release workflow publishes one tested, attested package version", () => {
     /if \[ "\$prerelease" = "false" \]; then\s+test "\$SIGNED_BETA_UPDATE_PROVEN" = "true"/,
   );
   assert.match(workflow, /--draft --generate-notes/);
-  assert.match(workflow, /--json isDraft --jq '\.isDraft'\)" = "true"/);
+  assert.match(workflow, /--json isDraft --jq '\.isDraft'\)" != "true"/);
   assert.match(
     workflow,
     /--json targetCommitish --jq '\.targetCommitish'\)" = "\$GITHUB_SHA"/,


### PR DESCRIPTION
## Why

Today's release dispatch reused `2026.7.0-beta.2` (already published July 30). The run built, signed, notarized, and stapled the entire package — about ten minutes — before the release job's resume logic hit a bare `test` against the published release's `isDraft` flag and exited 1 with no message.

## What this changes

- **New early guard in `release-build`**, right after "Resolve release version" and before `pnpm install`: if the tag is already a published release, fail immediately with `Release $TAG is already published; bump the version in package.json.` An orphan tag (no resumable draft) also fails here with the same message the release job uses. A forgotten bump now costs seconds, not a full signing run.
- **Resume path preserved**: the build job's token is `contents: read`, which cannot see draft releases, so a resumable draft passes through the early guard untouched and is still verified by the release job's authoritative check.
- **The late check now explains itself**: the silent `test ... isDraft = "true"` became an `if` with the same error message, so a late collision (or race) is no longer a debugging session.
- **Policy pin**: `source-release-pipeline.test.ts` now asserts the early guard exists ahead of the install/build step, and the existing `isDraft` pin follows the new form.

## Verification

- `pnpm test:policy` — all pass
- `tsc -p tsconfig.tests.json`, `eslint` on the changed test — clean
- Workflow YAML parses

## After merging

Bump `version` in package.json to `2026.7.0-beta.3` and dispatch the release again — beta.2 is shipped and immutable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)