### PR TITLE
Forbid tracked symlinks that leave the repository

### DIFF
--- a/apps/website/dist
+++ b/apps/website/dist
@@ -1,1 +1,0 @@
-/Users/matthias/Git/games/gw_in_browser/apps/website/.output/public

--- a/tests/policy/forbidden-artifacts.test.ts
+++ b/tests/policy/forbidden-artifacts.test.ts
@@ -1,5 +1,6 @@
 // Repository-contents policy: no ArenaNet binary, generated output, credential,
-// diagnostic export or retired runtime is ever tracked in git.
+// diagnostic export or retired runtime is ever tracked in git, and every
+// tracked path stays inside the repository.
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
@@ -29,6 +30,26 @@ test("no downloaded game artifacts or generated output are tracked", () => {
   ];
   const hits = tracked.filter((file) => forbidden.some((pattern) => pattern.test(file)));
   assert.deepEqual(hits, []);
+});
+
+test("no tracked symlink resolves outside the repository", () => {
+  // A symlink is tracked as its target string, so a target above the root
+  // resolves to whatever happens to sit at that path on the machine that wrote
+  // it and dangles on every other clone. `tracked` cannot answer this: it drops
+  // dangling entries, which is exactly the state such a link is usually in.
+  const escaping = execFileSync("git", ["ls-files", "-s"], { cwd: root, encoding: "utf8" })
+    .split("\n")
+    .filter((line) => line.startsWith("120000 "))
+    .map((line) => line.slice(line.indexOf("\t") + 1))
+    .filter((file) => {
+      const link = execFileSync("git", ["cat-file", "blob", `:${file}`], {
+        cwd: root,
+        encoding: "utf8",
+      });
+      const target = path.resolve(root, path.dirname(file), link);
+      return target !== root && !target.startsWith(root + path.sep);
+    });
+  assert.deepEqual(escaping, []);
 });
 
 test("the application does not collect process-memory crash dumps", () => {


### PR DESCRIPTION
Part 1/7 of the quality stack (#62). Base: `main`.

## What changed

`apps/website/dist` was tracked as a symlink (git mode `120000`) whose target is an absolute path that only exists on one machine — on every other clone it dangles. It is deleted, and the class is now forbidden: `tests/policy/forbidden-artifacts.test.ts` gains a test asserting no tracked file is a symlink whose resolved target lies outside the repository root.

Nothing referenced the link: `forge.config.ts`, every workflow (including `website.yml`), `scripts/`, and the website's own config were checked. No `.gitignore` entry was added — the site builds into `.output`/`.nuxt`, both already ignored, and a directory-shaped `dist/` rule already exists.

## Review focus

- The test reads both the mode **and the target from the git index** (`git cat-file blob :<path>`), not from disk. That is deliberate: an escaping symlink that was staged and then removed from the working tree still fails with the offending path named, instead of crashing on a read of a missing file. In-repo relative symlinks stay legal.

## Verification

- `pnpm check` green (typecheck, lint, links, 646 unit, 128 policy).
- Probe run: a staged `escaping-probe -> /etc/hosts` fails the test naming exactly that path; a staged in-repo relative link passes. Both probes removed before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
