### PR TITLE
Keep the cause of a Keychain refusal and a failed update check

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -153,6 +153,11 @@ multi-release format because its native numeric comparison cannot represent
 this project's SemVer preview suffixes. It publishes one discriminated
 `AppUpdateState`: `idle`, `checking`, `up-to-date`, `downloading`, `ready`, or
 `failed` with a closed reason. The renderer receives no network text or URL.
+A check left without a readable answer — `offline`, `timeout`, or `unreadable`,
+whether the body never parsed or parsed into something that is not a releases
+list — also records `appUpdate.requestFailed` naming which request lost it, the
+releases list or one release's own feed, beside the same closed reason. An
+error behind the fault is redacted and logged, never recorded.
 `lastUpdateCheckAt` is persisted by main after a catalog check completes.
 
 A ready update is offered nonmodally. Restart is explicit; choosing Later lets
@@ -208,7 +213,13 @@ Development use distinct service names and labels. The boundary uses
 `kSecUseDataProtectionKeychain`, `WhenUnlockedThisDeviceOnly`, and a fresh
 noninteractive `LAContext` for every operation. A read failure never deletes or
 replaces an item; the failure is recorded without credential content and the
-game prompts again.
+game prompts again. The native module classifies a refusal, and
+`KeychainJsonStore` keeps that classification on the error it raises:
+`keychain_locked` for an item the Keychain would only release with user
+interaction, `keychain_unentitled` for a process with no application identifier
+for the access group, and the secret's own `*_unavailable` code otherwise. The
+underlying rejection is logged by classification and error name only and never
+becomes an exported field.
 
 Unpackaged development, ordinary local packages, and explicit packaged smokes
 use `VolatileNativeKeychain`, so no unstable identity can claim a provisioned

--- a/src/main/app-updater.ts
+++ b/src/main/app-updater.ts
@@ -11,6 +11,14 @@ import {
   parseReleaseVersion,
   type ReleaseVersion,
 } from "../shared/release.js";
+import { redactDiagnosticText } from "./diagnostics/text-scan.js";
+
+/**
+ * Which of the two requests a check makes was the one that lost its answer.
+ * The state a check publishes says only what went wrong, and the same reason
+ * reads very differently for the releases list than for one release's feed.
+ */
+export type AppUpdateStage = "releases" | "feed";
 
 const API_URL =
   `https://api.github.com/repos/${RELEASE_REPO}/releases?per_page=100`;
@@ -46,6 +54,11 @@ export interface AppUpdaterOptions {
   timeoutMs?: number;
   rememberCheckedAt: (checkedAt: number) => Promise<void>;
   publish: (state: AppUpdateState) => void;
+  /**
+   * Keeps the cause of a discarded transport or parse fault. Injected rather
+   * than recorded here, so this class stays constructible without Electron.
+   */
+  recordFailure: (stage: AppUpdateStage, reason: AppUpdateErrorCode) => void;
 }
 
 export class AppUpdater {
@@ -165,9 +178,13 @@ export class AppUpdater {
           signal: controller.signal,
           headers: { accept: "application/vnd.github+json" },
         });
-      } catch {
+      } catch (error) {
         await this.failAndRemember(
-          controller.signal.aborted ? "timeout" : "offline",
+          this.noteFailure(
+            "releases",
+            controller.signal.aborted ? "timeout" : "offline",
+            error,
+          ),
         );
         return;
       }
@@ -182,13 +199,15 @@ export class AppUpdater {
       let body: unknown;
       try {
         body = await response.json();
-      } catch {
-        await this.failAndRemember("unreadable");
+      } catch (error) {
+        await this.failAndRemember(
+          this.noteFailure("releases", "unreadable", error),
+        );
         return;
       }
       const candidates = parseCandidates(body, current);
       if (candidates === null) {
-        await this.failAndRemember("unreadable");
+        await this.failAndRemember(this.noteFailure("releases", "unreadable"));
         return;
       }
       const latest = candidates[0] ?? null;
@@ -249,16 +268,22 @@ export class AppUpdater {
     let response: Response;
     try {
       response = await this.fetchImpl(manifestUrl, { signal });
-    } catch {
-      return { reason: signal.aborted ? "timeout" : "offline" };
+    } catch (error) {
+      return {
+        reason: this.noteFailure(
+          "feed",
+          signal.aborted ? "timeout" : "offline",
+          error,
+        ),
+      };
     }
     if (isRateLimited(response)) return { reason: "rate-limited" };
     if (!response.ok) return { reason: "server" };
     let body: unknown;
     try {
       body = await response.json();
-    } catch {
-      return { reason: "unreadable" };
+    } catch (error) {
+      return { reason: this.noteFailure("feed", "unreadable", error) };
     }
     return validManifest(
       body,
@@ -268,6 +293,25 @@ export class AppUpdater {
     )
       ? { url: manifestUrl }
       : { reason: "feed-invalid" };
+  }
+
+  /**
+   * The one place a fault that stops a check is kept rather than dropped. The
+   * stage and reason are bounded and reach diagnostics; an error is text this
+   * process did not author, so it is redacted and goes no further than the
+   * console. A body that parses as JSON but is not the document expected
+   * raises none, and every stage still names itself.
+   */
+  private noteFailure(
+    stage: AppUpdateStage,
+    reason: AppUpdateErrorCode,
+    error?: unknown,
+  ): AppUpdateErrorCode {
+    this.options.recordFailure(stage, reason);
+    const summary = `Update check failed at ${stage}: ${reason}`;
+    if (error === undefined) console.warn(summary);
+    else console.warn(summary, redactDiagnosticText(String(error)));
+    return reason;
   }
 
   private async remember(checkedAt: number): Promise<void> {

--- a/src/main/core/keychain-store.ts
+++ b/src/main/core/keychain-store.ts
@@ -1,5 +1,24 @@
-import { AppError } from "../../shared/errors.js";
+import { AppError, type ErrorCode } from "../../shared/errors.js";
 import type { NativeKeychain, SecretSlot } from "./native-keychain.js";
+
+/**
+ * The refusals the native module classifies, keyed by the identifier it puts
+ * on its rejection. A `Map` rather than an object literal: the lookup runs on
+ * a `code` this process did not write, and `Object.prototype` members would
+ * otherwise answer it.
+ */
+const NATIVE_REFUSALS = new Map<string, ErrorCode>([
+  ["interaction_not_allowed", "keychain_locked"],
+  ["missing_entitlement", "keychain_unentitled"],
+]);
+
+function nativeRefusal(error: unknown): ErrorCode | null {
+  if (typeof error !== "object" || error === null || !("code" in error)) {
+    return null;
+  }
+  const { code } = error;
+  return typeof code === "string" ? NATIVE_REFUSALS.get(code) ?? null : null;
+}
 
 export interface KeychainSecret<T> {
   parse(value: unknown): T;
@@ -59,8 +78,22 @@ export class KeychainJsonStore<T> {
   private async native<R>(operation: () => Promise<R>): Promise<R> {
     try {
       return await operation();
-    } catch {
-      throw this.secret.unavailable();
+    } catch (error) {
+      const refusal = nativeRefusal(error);
+      // This module is below the diagnostics redactor and cannot reach it, so
+      // the rejection is logged as the two bounded parts of it: how the
+      // Keychain refused, and what kind of thing was thrown. Its message and
+      // stack are text this process did not author and stay on the error.
+      console.warn(
+        "Keychain operation failed",
+        this.slot,
+        refusal ?? "unclassified",
+        error instanceof Error ? error.name : typeof error,
+      );
+      if (refusal === null) throw this.secret.unavailable();
+      throw new AppError(refusal, "the Keychain refused this secret", {
+        cause: error,
+      });
     }
   }
 

--- a/src/main/diagnostics/schema.ts
+++ b/src/main/diagnostics/schema.ts
@@ -27,6 +27,7 @@ import {
   formatReleaseVersion,
   parseReleaseVersion,
 } from "../../shared/release.js";
+import type { AppUpdateStage } from "../app-updater.js";
 import {
   isProxyRoute,
   type ProxyRoute,
@@ -152,6 +153,10 @@ const appUpdateErrorCode = literal([
   "feed-invalid",
   "download-failed",
 ] as const satisfies readonly AppUpdateErrorCode[]);
+const appUpdateStage = literal([
+  "releases",
+  "feed",
+] as const satisfies readonly AppUpdateStage[]);
 const closeReason = literal([
   "requested",
   "peer",
@@ -293,6 +298,14 @@ export const DIAGNOSTIC_EVENT_SCHEMA = {
     subsystem: "app",
     level: "error",
     fields: { reason: appUpdateErrorCode },
+  },
+  // The published state names the reason but not the request it came from, and
+  // "offline" against the releases list is a different report from "offline"
+  // against one release's own feed.
+  "appUpdate.requestFailed": {
+    subsystem: "app",
+    level: "warn",
+    fields: { stage: appUpdateStage, reason: appUpdateErrorCode },
   },
   "orphanTemps.swept": {
     subsystem: "app",
@@ -558,17 +571,17 @@ export const DIAGNOSTIC_EVENT_SCHEMA = {
   "credentials.loadFailed": {
     subsystem: "credentials",
     level: "error",
-    fields: none,
+    fields: { code },
   },
   "credentials.saveFailed": {
     subsystem: "credentials",
     level: "error",
-    fields: none,
+    fields: { code },
   },
   "credentials.clearFailed": {
     subsystem: "credentials",
     level: "error",
-    fields: none,
+    fields: { code },
   },
   "steam.tokenRequested": {
     subsystem: "steam",

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -648,7 +648,7 @@ export function registerIpcHandlers(ctx: IpcContext): {
       try {
         return await secretOperation(() => credentials.load());
       } catch (error) {
-        logEvent({ k: "credentials.loadFailed" });
+        logEvent({ k: "credentials.loadFailed", code: errorCode(error) });
         throw error;
       }
     }),
@@ -661,7 +661,7 @@ export function registerIpcHandlers(ctx: IpcContext): {
         try {
           await secretOperation(() => credentials.save(value));
         } catch (error) {
-          logEvent({ k: "credentials.saveFailed" });
+          logEvent({ k: "credentials.saveFailed", code: errorCode(error) });
           throw error;
         }
       },
@@ -671,7 +671,7 @@ export function registerIpcHandlers(ctx: IpcContext): {
       try {
         await secretOperation(() => credentials.clear());
       } catch (error) {
-        logEvent({ k: "credentials.clearFailed" });
+        logEvent({ k: "credentials.clearFailed", code: errorCode(error) });
         throw error;
       }
     }),

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -468,6 +468,9 @@ if (primaryInstance) void app.whenReady().then(async () => {
     rememberCheckedAt: async (lastUpdateCheckAt) => {
       await updateAppSettings({ lastUpdateCheckAt });
     },
+    recordFailure: (stage, reason) => {
+      logEvent({ k: "appUpdate.requestFailed", stage, reason });
+    },
     publish: (state) => {
       if (state.phase === "failed") {
         logEvent({ k: "appUpdate.failed", reason: state.reason });

--- a/src/renderer/failure-messages.ts
+++ b/src/renderer/failure-messages.ts
@@ -138,12 +138,17 @@ export function describeSteamRefusal(
  * Whether the failure is worth a bug report. Network and disk conditions are
  * the player's to fix — suggesting "Report a Problem" for them blames the app
  * for the Wi-Fi. Anything else might genuinely be ours.
+ *
+ * A locked Keychain belongs here for the same reason and `keychain_unentitled`
+ * deliberately does not: that one says the installed application is signed
+ * wrongly, which no player can fix and we want to hear about.
  */
 const PLAYER_SIDE: ReadonlySet<string> = new Set<ErrorCode>([
   'net_offline',
   'http_status',
   'disk_full',
   'not_ready',
+  'keychain_locked',
   'chunk_offline',
   'dns_failed',
   'dns_timeout',

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -42,6 +42,15 @@ export const ERROR_CODES = [
   "hash_format",
   "hash_mismatch",
   "http_status",
+  /** The Data Protection Keychain refused an item it would only release with
+   * user interaction. The secret is intact and readable once the device is
+   * unlocked, so this is not the same fault as a store that cannot be
+   * reached at all. */
+  "keychain_locked",
+  /** The Keychain refused because the running process carries no application
+   * identifier for the item's access group. Nothing the build does at runtime
+   * recovers from that; only a re-signed one does. */
+  "keychain_unentitled",
   "manifest_chunks",
   "manifest_cycle",
   "manifest_directories",

--- a/tests/unit/app-updater.test.ts
+++ b/tests/unit/app-updater.test.ts
@@ -5,8 +5,12 @@ import {
   PERIODIC_CHECK_DUE_MS,
   PERIODIC_CHECK_TICK_MS,
   periodicCheckDue,
+  type AppUpdateStage,
 } from "../../src/main/app-updater.ts";
-import type { AppUpdateState } from "../../src/shared/contracts.ts";
+import type {
+  AppUpdateErrorCode,
+  AppUpdateState,
+} from "../../src/shared/contracts.ts";
 
 const repo = "https://github.com/Mat4m0/gwonmac";
 const releaseApi =
@@ -71,6 +75,7 @@ function fixture(options: {
   const states: AppUpdateState[] = [];
   const remembered: number[] = [];
   const feeds: string[] = [];
+  const failures: { stage: AppUpdateStage; reason: AppUpdateErrorCode }[] = [];
   let nativeChecks = 0;
   let installs = 0;
   const updater = new AppUpdater({
@@ -98,12 +103,14 @@ function fixture(options: {
       remembered.push(value);
     },
     publish: (state) => states.push(state),
+    recordFailure: (stage, reason) => failures.push({ stage, reason }),
   });
   return {
     updater,
     states,
     remembered,
     feeds,
+    failures,
     nativeChecks: () => nativeChecks,
     installs: () => installs,
   };
@@ -275,6 +282,65 @@ describe("application updater", () => {
       lastCheckedAt: "1970-01-01T00:00:01.234Z",
       reason: "offline",
     });
+    assert.deepEqual(f.failures, [{ stage: "releases", reason: "offline" }]);
+  });
+
+  it("records which request lost its answer, not only that one did", async () => {
+    // The published state cannot say where a fault happened, so a check that
+    // reached GitHub and lost the release's own feed would otherwise read
+    // exactly like one that never reached GitHub at all.
+    const f = fixture({
+      fetch: async (input) => isReleaseApiRequest(input)
+        ? response([release("2026.7.0-beta.2")])
+        : new Response("<html>not json</html>", {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    });
+
+    await f.updater.check();
+
+    assert.deepEqual(f.failures, [{ stage: "feed", reason: "unreadable" }]);
+    assert.equal(f.updater.getState().phase, "failed");
+    assert.equal(f.nativeChecks(), 0);
+  });
+
+  it("records an unreadable releases list against the releases request", async () => {
+    const f = fixture({
+      fetch: async () => new Response("<html>not json</html>", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    });
+
+    await f.updater.check();
+
+    assert.deepEqual(f.failures, [{ stage: "releases", reason: "unreadable" }]);
+  });
+
+  it("names the request behind a body that parses but is not a releases list", async () => {
+    const f = fixture({ fetch: async () => response({ message: "nope" }) });
+
+    await f.updater.check();
+
+    const state = f.updater.getState();
+    assert.equal(state.phase === "failed" && state.reason, "unreadable");
+    assert.deepEqual(f.failures, [{ stage: "releases", reason: "unreadable" }]);
+  });
+
+  it("keeps a rejected feed apart from a rejected release list", async () => {
+    const f = fixture({
+      fetch: async (input) => {
+        if (isReleaseApiRequest(input)) {
+          return response([release("2026.7.0-beta.2")]);
+        }
+        throw new Error("offline");
+      },
+    });
+
+    await f.updater.check();
+
+    assert.deepEqual(f.failures, [{ stage: "feed", reason: "offline" }]);
   });
 
   it("classifies a stalled release feed as a timeout", async () => {
@@ -300,6 +366,7 @@ describe("application updater", () => {
       lastCheckedAt: "1970-01-01T00:00:01.234Z",
       reason: "timeout",
     });
+    assert.deepEqual(f.failures, [{ stage: "feed", reason: "timeout" }]);
   });
 
   it("does not duplicate work while downloading or ready", async () => {

--- a/tests/unit/failure-codes-become-sentences-in-the-renderer.test.ts
+++ b/tests/unit/failure-codes-become-sentences-in-the-renderer.test.ts
@@ -143,6 +143,22 @@ describe("renderer failure messages", () => {
       "You can retry, or choose Help → Report a Problem.",
     );
   });
+
+  it("tells a locked Keychain apart from a build that may not use one", () => {
+    // Unlocking is the player's to do; a missing entitlement is a signing
+    // fault in what we shipped, and the two must not share one answer.
+    assert.equal(suggestReport("keychain_locked"), false);
+    assert.doesNotMatch(failureDetail("keychain_locked"), /Report a Problem/);
+    assert.equal(suggestReport("keychain_unentitled"), true);
+    assert.match(failureDetail("keychain_unentitled"), /Report a Problem/);
+    // Neither reaches a transfer surface, so both take its honest default
+    // rather than a sentence invented for a screen that never shows them.
+    for (const code of ["keychain_locked", "keychain_unentitled"] as const) {
+      assert.equal(launch(code), launch("unknown"));
+      assert.equal(download(code), download("unknown"));
+    }
+  });
+
   it("stops promising a retry once the client crashes twice in one run", () => {
     const first = clientCrashPresentation(1);
     const repeated = clientCrashPresentation(2);

--- a/tests/unit/keychain-store.test.ts
+++ b/tests/unit/keychain-store.test.ts
@@ -62,6 +62,52 @@ describe("KeychainJsonStore", () => {
     assert.deepEqual(trace, ["save:start", "clear"]);
   });
 
+  it("keeps the native classification of a refusal instead of collapsing it", async () => {
+    // The native module is the only thing that can tell a locked Keychain from
+    // an unsigned build, and a diagnostics reader is the one who needs it.
+    for (const [nativeCode, expected] of [
+      ["interaction_not_allowed", "keychain_locked"],
+      ["missing_entitlement", "keychain_unentitled"],
+      // An unclassified rejection, and one whose `code` is an identifier this
+      // process does not own, both keep the secret's own code.
+      ["unavailable", "credentials_unavailable"],
+      ["toString", "credentials_unavailable"],
+    ] as const) {
+      const rejection = Object.assign(new Error("Keychain operation unavailable"), {
+        code: nativeCode,
+      });
+      const keychain: NativeKeychain = {
+        load: async () => {
+          throw rejection;
+        },
+        save: async () => {
+          throw rejection;
+        },
+        clear: async () => {
+          throw rejection;
+        },
+      };
+      const store = new KeychainJsonStore("arenaNetCredentials", keychain, secret);
+      for (const operation of [
+        () => store.load(),
+        () => store.save({ value: "secret" }),
+        () => store.clear(),
+      ]) {
+        await assert.rejects(operation(), (error: unknown) => {
+          assert.ok(error instanceof AppError);
+          assert.equal(error.code, expected);
+          // A classified refusal keeps the rejection it came from; the code
+          // is the published part and the cause never becomes one.
+          assert.equal(
+            error.cause,
+            expected === "credentials_unavailable" ? undefined : rejection,
+          );
+          return true;
+        });
+      }
+    }
+  });
+
   it("zeroes native save buffers on success and failure", async () => {
     for (const fail of [false, true]) {
       let captured: Buffer | undefined;


### PR DESCRIPTION
Part 2/7 of the quality stack (#62). Base: `q01-forbidden-symlinks`.

## What this ships to users

Failure sentences that say the true thing. A Keychain that is merely locked now tells the player it is theirs to unlock; a wrongly signed build now asks for a problem report instead of pretending the store is broken. A failed update check records **which** request failed and **why**, so a `.gwdiag` export answers the question instead of a back-and-forth.

## What changed

- `src/shared/errors.ts` — two new members of the closed `ERROR_CODES` union: `keychain_locked`, `keychain_unentitled`, each with the rationale in the file's style.
- `src/main/core/keychain-store.ts` — `native()` no longer swallows the rejection. The native module's classification (computed in `keychain.mm` and previously discarded one layer up) maps onto the new codes via a `Map` (so `Object.prototype` members cannot answer a lookup on a code this process did not write), the original error rides along as `cause`, and the bounded parts are logged.
- Diagnostics — `credentials.loadFailed/saveFailed/clearFailed` gain the existing `code` field; new `appUpdate.requestFailed { stage, reason }` event, with `stage` pinned against the updater's type by `satisfies`.
- `src/main/app-updater.ts` — one private `noteFailure(stage, reason, error)` records the bounded pair and logs the redacted cause; the four catch sites stay one expression each. Recording is injected (`recordFailure` option) so the class stays constructible without Electron.
- `src/renderer/failure-messages.ts` — `keychain_locked` joins the player-side set; `keychain_unentitled` deliberately does not (a signing fault we want reported).

## Review focus

- The `PLAYER_SIDE` membership decision — it encodes who can fix what.
- The schema additions: codes only, no free text; the free-text rejection policy test still holds.

## Verification

- New unit case: all three store operations × four rejection shapes, asserting both code and preserved `cause`.
- Updater tests extended: failure recording asserted on the existing transport-failure cases plus three new ones.
- Sentence test pins report-advice for both new codes. `pnpm check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
