### PR TITLE
Serialize settings and Keychain writes through the one Mutex

### DIFF
--- a/src/main/client-runtime.ts
+++ b/src/main/client-runtime.ts
@@ -88,7 +88,13 @@ interface ClientRuntimeOptions {
 
 export class ClientRuntime {
   private readonly activeSlot = new ActiveClientSlot();
-  /** Held by every operation that moves a generation directory. */
+  /**
+   * Held by every operation that moves a generation directory. `update`,
+   * candidate confirmation and crash rollback all rename `artifacts`,
+   * `artifacts.previous` and `artifacts.failed`, and two of them interleaving
+   * at an `await` lets one observe — or rename away — a tree the other had
+   * half moved. The full download stays outside it.
+   */
   private readonly generationLock = new Mutex();
   private progressValue: DownloadProgress = { ...INITIAL_PROGRESS };
   private saveTouchedTimer: ReturnType<typeof setInterval> | null = null;

--- a/src/main/core/keychain-store.ts
+++ b/src/main/core/keychain-store.ts
@@ -1,4 +1,5 @@
 import { AppError, type ErrorCode } from "../../shared/errors.js";
+import { Mutex } from "./mutex.js";
 import type { NativeKeychain, SecretSlot } from "./native-keychain.js";
 
 /**
@@ -28,7 +29,8 @@ export interface KeychainSecret<T> {
 
 /** One validated JSON secret in one fixed native Keychain slot. */
 export class KeychainJsonStore<T> {
-  private tail: Promise<void> = Promise.resolve();
+  /** One slot, so a load must not read what an unfinished save is replacing. */
+  private readonly slotLock = new Mutex();
   private readonly slot: SecretSlot;
   private readonly keychain: NativeKeychain;
   private readonly secret: KeychainSecret<T>;
@@ -44,7 +46,7 @@ export class KeychainJsonStore<T> {
   }
 
   load(): Promise<T | null> {
-    return this.enqueue(async () => {
+    return this.slotLock.run(async () => {
       const bytes = await this.native(() => this.keychain.load(this.slot));
       if (!bytes) return null;
       try {
@@ -61,7 +63,7 @@ export class KeychainJsonStore<T> {
 
   async save(value: unknown): Promise<void> {
     const cleaned = this.secret.parse(value);
-    await this.enqueue(async () => {
+    await this.slotLock.run(async () => {
       const bytes = Buffer.from(JSON.stringify(cleaned), "utf8");
       try {
         await this.native(() => this.keychain.save(this.slot, bytes));
@@ -72,7 +74,9 @@ export class KeychainJsonStore<T> {
   }
 
   clear(): Promise<void> {
-    return this.enqueue(() => this.native(() => this.keychain.clear(this.slot)));
+    return this.slotLock.run(() =>
+      this.native(() => this.keychain.clear(this.slot)),
+    );
   }
 
   private async native<R>(operation: () => Promise<R>): Promise<R> {
@@ -95,14 +99,5 @@ export class KeychainJsonStore<T> {
         cause: error,
       });
     }
-  }
-
-  private enqueue<R>(operation: () => Promise<R>): Promise<R> {
-    const result = this.tail.then(operation, operation);
-    this.tail = result.then(
-      () => undefined,
-      () => undefined,
-    );
-    return result;
   }
 }

--- a/src/main/core/mutex.ts
+++ b/src/main/core/mutex.ts
@@ -1,13 +1,9 @@
 /**
- * Serialises the operations that move generation directories.
+ * Runs queued operations one at a time, in the order they were queued.
  *
- * `update`, candidate confirmation and crash rollback all rename
- * `artifacts`, `artifacts.previous` and `artifacts.failed`. Nothing in the
- * process stopped two of them from interleaving at an `await`, so one could
- * observe — or rename away — a tree the other had half moved.
- *
- * Take this only for operations that move a directory. Reads and the full
- * download must stay concurrent with everything else.
+ * Take one for work a concurrent caller could catch half done: a directory
+ * moved aside, a read-modify-write, a rewritten Keychain slot. Work that
+ * tolerates interleaving stays outside it and keeps its concurrency.
  */
 export class Mutex {
   private tail: Promise<unknown> = Promise.resolve();
@@ -23,5 +19,17 @@ export class Mutex {
     const next = this.tail.then(fn, fn);
     this.tail = next;
     return next;
+  }
+
+  /**
+   * Settles when everything queued at the time of the read has finished, and
+   * only that; anything queued afterwards is not waited for. A failed operation
+   * is the caller's business, not the drain's, so this never rejects.
+   */
+  get settled(): Promise<void> {
+    return this.tail.then(
+      () => undefined,
+      () => undefined,
+    );
   }
 }

--- a/src/main/core/steam-session.ts
+++ b/src/main/core/steam-session.ts
@@ -2,6 +2,7 @@ import type { SteamRefusalReason } from "../../shared/contracts.js";
 import { AppError, errorCode, type ErrorCode } from "../../shared/errors.js";
 import type { NativeKeychain } from "./native-keychain.js";
 import { KeychainJsonStore, type KeychainSecret } from "./keychain-store.js";
+import { Mutex } from "./mutex.js";
 
 /**
  * The Steam OAuth access token that authenticates a Steam login, and when it
@@ -298,7 +299,7 @@ export async function refreshSteamExpiry(
  * invariant without putting Electron knowledge in this module.
  */
 export class SteamSessionCoordinator {
-  private tail: Promise<void> = Promise.resolve();
+  private readonly sessionLock = new Mutex();
   private interactiveResolution: Promise<SteamResolution> | null = null;
   private readonly store: SteamSessionReader;
 
@@ -308,11 +309,13 @@ export class SteamSessionCoordinator {
 
   resolve(options: SteamResolutionOptions): Promise<SteamResolution> {
     if (options.silent) {
-      return this.enqueue(() => resolveSteamToken(this.store, options));
+      return this.sessionLock.run(() => resolveSteamToken(this.store, options));
     }
     if (this.interactiveResolution) return this.interactiveResolution;
 
-    const pending = this.enqueue(() => resolveSteamToken(this.store, options));
+    const pending = this.sessionLock.run(() =>
+      resolveSteamToken(this.store, options),
+    );
     const joined = pending.finally(() => {
       if (this.interactiveResolution === joined) {
         this.interactiveResolution = null;
@@ -323,23 +326,16 @@ export class SteamSessionCoordinator {
   }
 
   refresh(token: string, expiry: number | null): Promise<SteamStorebackOutcome> {
-    return this.enqueue(() => refreshSteamExpiry(this.store, token, expiry));
+    return this.sessionLock.run(() =>
+      refreshSteamExpiry(this.store, token, expiry),
+    );
   }
 
   clear(): Promise<void> {
-    return this.enqueue(() => this.store.clear());
+    return this.sessionLock.run(() => this.store.clear());
   }
 
   settled(): Promise<void> {
-    return this.tail;
-  }
-
-  private enqueue<T>(operation: () => Promise<T>): Promise<T> {
-    const result = this.tail.then(operation, operation);
-    this.tail = result.then(
-      () => undefined,
-      () => undefined,
-    );
-    return result;
+    return this.sessionLock.settled;
   }
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -25,6 +25,7 @@ import { errorCode } from "../shared/errors.js";
 import { EMPTY_PREFETCH, INITIAL_PROGRESS } from "../shared/progress.js";
 import { AUTOMATION_COMMAND } from "../shared/automation.js";
 import { ClientRuntime } from "./client-runtime.js";
+import { Mutex } from "./core/mutex.js";
 import { loadSettings, saveSettings } from "./core/settings.js";
 import { SocketManager } from "./core/sockets.js";
 import {
@@ -133,7 +134,8 @@ const HOST_VERSION = (() => {
 })();
 
 const prefetch: PrefetchProgress = { ...EMPTY_PREFETCH };
-let settingsWrite: Promise<void> = Promise.resolve();
+/** Every settings write is a read-modify-write of one file. */
+const settingsLock = new Mutex();
 let appUpdaterController: AppUpdater | null = null;
 let updateRestartInFlight: Promise<void> | null = null;
 let secondInstanceRequested = false;
@@ -154,7 +156,7 @@ function revealMainWindow(): void {
 }
 
 function updateAppSettings(patch: AppSettingsPatch): Promise<AppSettings> {
-  const operation = settingsWrite.then(async () => {
+  return settingsLock.run(async () => {
     const settingsPath = gamePaths().settings;
     const current = await loadSettings(settingsPath);
     const saved = await saveSettings(settingsPath, { ...current, ...patch });
@@ -167,22 +169,12 @@ function updateAppSettings(patch: AppSettingsPatch): Promise<AppSettings> {
     }
     return saved;
   });
-  settingsWrite = operation.then(
-    () => undefined,
-    () => undefined,
-  );
-  return operation;
 }
 
 function resetAppSettings(): Promise<AppSettings> {
-  const operation = settingsWrite.then(() =>
+  return settingsLock.run(() =>
     saveSettings(gamePaths().settings, { ...DEFAULT_SETTINGS }),
   );
-  settingsWrite = operation.then(
-    () => undefined,
-    () => undefined,
-  );
-  return operation;
 }
 
 function buildSocketManager(): SocketManager {

--- a/tests/unit/mutex.test.ts
+++ b/tests/unit/mutex.test.ts
@@ -5,6 +5,8 @@ import { join } from "node:path";
 import { setTimeout as sleep } from "node:timers/promises";
 import { after, describe, it } from "node:test";
 import { Mutex } from "../../src/main/core/mutex.js";
+import { loadSettings, saveSettings } from "../../src/main/core/settings.js";
+import type { AppSettings, AppSettingsPatch } from "../../src/shared/contracts.js";
 
 const scratchDirs: string[] = [];
 
@@ -162,5 +164,101 @@ describe("generation mutex", () => {
     // Queue order, not completion order: task 0 sleeps longest and still runs
     // first.
     assert.deepEqual(finished, [0, 1, 2, 3]);
+  });
+});
+
+describe("queue drain", () => {
+  it("waits for the work already queued, failure included", async () => {
+    const lock = new Mutex();
+    let release!: () => void;
+    const held = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+
+    const failing = lock.run(async () => {
+      await held;
+      throw new Error("keychain write refused");
+    });
+    let drained = false;
+    const drain = lock.settled.then(() => {
+      drained = true;
+    });
+
+    await sleep(0);
+    assert.equal(drained, false);
+    release();
+    await assert.rejects(failing, /keychain write refused/);
+    // Quit waits for the write to stop touching the slot, not for it to have
+    // succeeded: a drain that rejected would take the shutdown path down with
+    // an error its caller has already been given.
+    await drain;
+    assert.equal(drained, true);
+  });
+});
+
+/**
+ * The shape every settings write in `main.ts` has: read the file, merge a
+ * patch, write the whole object back. `holdMs` stands in for the work between
+ * the read and the write, and decides which of two unserialised patches lands
+ * last rather than leaving that to the filesystem.
+ */
+function patchSettings(
+  path: string,
+  patch: AppSettingsPatch,
+  holdMs: number,
+): () => Promise<AppSettings> {
+  return async () => {
+    const current = await loadSettings(path);
+    await sleep(holdMs);
+    return saveSettings(path, { ...current, ...patch });
+  };
+}
+
+describe("settings write queue", () => {
+  it("keeps both patches when the writes are serialised", async () => {
+    const path = join(await scratch(), "settings.json");
+    const lock = new Mutex();
+
+    await Promise.all([
+      lock.run(patchSettings(path, { renderScale: 1 }, 40)),
+      lock.run(patchSettings(path, { showDiagnostics: true }, 0)),
+    ]);
+
+    const settings = await loadSettings(path);
+    assert.equal(settings.renderScale, 1);
+    assert.equal(settings.showDiagnostics, true);
+  });
+
+  it("drops a patch when the same writes are not serialised", async () => {
+    const path = join(await scratch(), "settings.json");
+
+    // The same two patches without the lock. Both read before either writes,
+    // so the slower one merges onto a value that never carried the faster
+    // one's field and then writes the whole object over it. A player who
+    // toggles two settings in the same moment keeps one of them.
+    await Promise.all([
+      patchSettings(path, { renderScale: 1 }, 40)(),
+      patchSettings(path, { showDiagnostics: true }, 0)(),
+    ]);
+
+    const settings = await loadSettings(path);
+    assert.equal(settings.renderScale, 1);
+    assert.equal(settings.showDiagnostics, false);
+  });
+
+  it("writes the next patch after a write fails", async () => {
+    const path = join(await scratch(), "settings.json");
+    const lock = new Mutex();
+
+    const failed = lock.run(async () => {
+      throw new Error("settings volume is read-only");
+    });
+    const queued = lock.run(patchSettings(path, { renderScale: 1.5 }, 0));
+
+    await assert.rejects(failed, /read-only/);
+    await queued;
+    // A refused write costs its own caller an error and nothing more; the
+    // queue behind it is not the place that failure is allowed to land.
+    assert.equal((await loadSettings(path)).renderScale, 1.5);
   });
 });


### PR DESCRIPTION
Part 3/7 of the quality stack (#62). Base: `q02-error-causes`.

## What changed

Three hand-rolled promise-chain serializers implemented the same idea in three places: `main.ts` (`settingsWrite`), `KeychainJsonStore.enqueue`, and the Steam session store. All three now use the one existing `Mutex`; the hand-rolled chains are deleted.

- `Mutex` gains a `settled` drain: resolves when everything queued at the time of the read has finished, and never rejects — quit waits for a write to stop touching its slot, not for it to have succeeded. The Steam session store's quit-drain runs through it.
- The generation-specific constraint text that used to live on the `Mutex` class doc moved to the `generationLock` field in `client-runtime.ts`, where it is about that lock; the class doc now states the general contract.

## Review focus

- Rejection semantics: a failed operation must not wedge the queue, and the drain must not reject on a failed write. Both are pinned by the new tests rather than assumed.

## Verification

- ~100 lines of new `Mutex` tests, including a drain-across-failure case and FIFO ordering under contention. `pnpm check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
