### PR TITLE
State and enforce the companion kernel's memory-safety invariants

### DIFF
--- a/src/companion-kernel/abi.rs
+++ b/src/companion-kernel/abi.rs
@@ -1,3 +1,15 @@
+//! The shared wire format: the configuration the host installs, the three
+//! snapshots the kernel publishes, and the constants both sides compare
+//! against. Declarations only — no logic and no unsafe code.
+//!
+//! Every published type is `repr(C)` and none of them contains a pointer, so a
+//! snapshot is meaningful to a reader that only knows the byte layout. The
+//! size assertions at the end of the file pin the exact byte counts the
+//! renderer decodes: a field added, widened, or reordered fails the build
+//! instead of silently shifting every value after it. Those same sizes are
+//! what `companion_init` measures the host's regions against, so the
+//! assertions are also the reason a bounds check here is a bounds check there.
+
 use core::mem::size_of;
 
 pub(crate) const SNAPSHOT_BYTES: u32 = size_of::<Snapshot>() as u32;

--- a/src/companion-kernel/cursor.rs
+++ b/src/companion-kernel/cursor.rs
@@ -1,3 +1,20 @@
+//! The cursor observer and the sole writer of the cursor region. It reads the
+//! game's active cursor art, its texture handle chain, and its colour buffer,
+//! and republishes a 32x32 RGBA bitmap when the identity it derives changes.
+//!
+//! The invariant is the crate's: every step of the handle chase goes through
+//! `memory.rs`, so a cursor the game has not committed, a texture that is not
+//! 32x32, or a chain that no longer resolves ends the read at `None` instead of
+//! loading past the heap. The only address this file writes is `POINTER`, the
+//! host region `companion_init` validated.
+//!
+//! `publish` and `tick` write through `POINTER`, so each requires an
+//! `initialize` from a `FEATURE_NATIVE_CURSOR` init; every one of their call
+//! sites sits behind that flag, and `initialize` itself writes only the region
+//! it is handed. `event_count` and `mark_dirty` reach the statics below and
+//! nothing else, so they carry no precondition and are reachable without the
+//! flag.
+
 use core::ptr::write_volatile;
 
 use crate::abi::*;
@@ -101,6 +118,11 @@ unsafe fn collect(layout: Layout) -> Result<State, u32> {
 // disturbing the last good pixels.
 unsafe fn publish(published: Published, source: Option<u32>) {
     let next = unsafe { SEQUENCE }.wrapping_add(2) & !1;
+    // SAFETY: `POINTER` holds the region `companion_init` accepted through
+    // `valid_region` for `FEATURE_NATIVE_CURSOR` — non-null, four-byte-aligned,
+    // and exactly `CURSOR_BYTES` inside linear memory, which cannot shrink. The
+    // indexed pixel writes stay inside it because `CURSOR_WORDS` is the length
+    // `CursorSnapshot::pixels` declares.
     let cursor = unsafe { POINTER as *mut CursorSnapshot };
     unsafe {
         write_volatile(&mut (*cursor).sequence, next.wrapping_sub(1));
@@ -185,6 +207,10 @@ pub(crate) unsafe fn initialize(pointer: u32) {
         DIRTY = true;
         EVENT_COUNT = 0;
     }
+    // SAFETY: `pointer` is the caller's validated `CURSOR_BYTES` region, and
+    // the header, the six reserved words, and `CURSOR_WORDS` pixels are the
+    // whole of `CursorSnapshot`. Zeroing it before the first publish is what
+    // keeps a reader from decoding whatever the game's allocator left behind.
     let cursor = pointer as *mut CursorSnapshot;
     unsafe {
         write_volatile(&mut (*cursor).generation, 0);

--- a/src/companion-kernel/lib.rs
+++ b/src/companion-kernel/lib.rs
@@ -1,4 +1,39 @@
+//! The companion kernel: the freestanding side module the renderer installs on
+//! the game's dispatch table. This file owns the exported ABI, the module's
+//! state, and the per-frame agent, target, and party observation. `memory.rs`
+//! owns every load from a game address, `abi.rs` the shared wire format, and
+//! `cursor.rs` and `toolbox.rs` each own the region they publish.
+//!
+//! The memory-safety invariant the whole crate maintains: the kernel reads the
+//! game heap only through `memory.rs`, so every read is bounds-checked against
+//! the live linear memory and every pointer chase answers `Option`; a game
+//! structure that is missing, torn, or hostile costs an observation and never
+//! an out-of-bounds access. The kernel writes to no address the game owns: its
+//! only stores go to the snapshot, cursor, and toolbox regions the host set
+//! aside for it and `companion_init` accepted through `valid_region`, and to
+//! its own module footprint. WebAssembly memory grows and never shrinks, so a
+//! region proven in bounds at init stays in bounds for every later frame, which
+//! is what lets the publishers hold a raw pointer across callbacks.
+//!
+//! The module state below is `static mut`, and stays so. The kernel imports no
+//! function at all — the build contract admits only memory, the base and stack
+//! globals, and a table — so nothing it calls can re-enter it, and it runs only
+//! on the game's callback thread. Every access is a by-value load or store of a
+//! `Copy` value; the crate never forms a reference to one, so there is no
+//! aliasing for a safe wrapper to rule out. A cell wrapper would need its own
+//! `unsafe impl Sync`, which claims more than these two facts prove.
+//!
+//! SAFETY policy for the crate. Two patterns repeat and carry no per-site
+//! comment: reading or writing one of these statics, justified above; and
+//! calling a `memory.rs` reader, or an `unsafe fn` here that does nothing but
+//! forward to them, justified by that module. In `cursor.rs` and `toolbox.rs`,
+//! an `unsafe fn` that reaches the module's published region additionally
+//! requires that its own `initialize` has run; each module header names the
+//! fns that carry no such precondition. Every other unsafe operation states its
+//! own justification.
+
 #![no_std]
+#![deny(unsafe_op_in_unsafe_fn)]
 
 use core::panic::PanicInfo;
 use core::ptr::{read_volatile, write_volatile};
@@ -410,8 +445,16 @@ pub(crate) unsafe fn collect_first_owned_hero(
     (count, first_id, first_agent)
 }
 
+// The odd sequence brackets the write: a reader that sees it discards the
+// frame rather than decoding a half-written one.
 unsafe fn publish(state: State) {
     let next = unsafe { SEQUENCE }.wrapping_add(2) & !1;
+    // SAFETY: every successful `companion_init` assigns `SNAPSHOT_PTR`, and it
+    // is null unless that init carried `FEATURE_TARGET_READOUT`. When the flag
+    // was set, `valid_region` proved a non-null, four-byte-aligned
+    // `SNAPSHOT_BYTES` region inside linear memory. What makes the store sound
+    // is that every caller of `publish` is gated on that same flag from that
+    // same init, and memory never shrinks, so the region is still there.
     let snapshot = unsafe { SNAPSHOT_PTR as *mut Snapshot };
     unsafe {
         write_volatile(&mut (*snapshot).sequence, next.wrapping_sub(1));
@@ -473,10 +516,17 @@ pub unsafe extern "C" fn companion_init(
     {
         return 0;
     }
+    // SAFETY: the guard above refused anything but a four-byte-aligned
+    // `config_ptr` with `CONFIG_BYTES` inside linear memory. `Layout` is a
+    // `repr(C)` block of `u32`, so every bit pattern the host can leave there
+    // is a valid value and the copy cannot observe an invalid one.
     let layout = unsafe { read_volatile(config_ptr as *const Layout) };
     if features & FEATURE_TOOLBOX_FOUNDATION != 0 && !valid_toolbox_messages(layout) {
         return 0;
     }
+    // SAFETY: each `initialize` takes the region its feature flag made
+    // `valid_region` demand, so the pointer it stores is non-null, aligned, and
+    // large enough for the snapshot it will publish.
     unsafe {
         SNAPSHOT_PTR = snapshot_ptr;
         LAYOUT = layout;

--- a/src/companion-kernel/memory.rs
+++ b/src/companion-kernel/memory.rs
@@ -1,3 +1,26 @@
+//! The one place this crate turns a game address into a load. Everything the
+//! kernel learns about the game heap arrives through these readers.
+//!
+//! Each reader proves `address .. address + size` lies inside the live linear
+//! memory before it loads, and answers `None` when it does not, so a torn or
+//! hostile heap costs a frame of observation rather than an out-of-bounds
+//! access. Every address is built with checked arithmetic: a sum that would
+//! wrap yields `None` instead of a small address that would pass the bounds
+//! test. `pointer` also rejects null and unaligned chased values, so a chased
+//! base is four-byte-aligned. Nothing here checks the field offsets added to
+//! it: natural alignment of the field loads is an assumption the certified
+//! build configuration discharges, by supplying real struct offsets that are
+//! multiples of the access width.
+//!
+//! The loads are volatile because the game writes these locations between
+//! callbacks and the compiler is told about neither the writer nor the memory;
+//! a cached or hoisted load would republish a stale frame.
+//!
+//! SAFETY: each reader dereferences an address in the imported game memory,
+//! which the Rust abstract machine does not know is an allocation. That is the
+//! whole of what makes them `unsafe`, and `contains` discharges it in every
+//! one, so the pattern is not annotated again below.
+
 use core::ptr::read_volatile;
 
 pub(crate) fn memory_bytes() -> u32 {

--- a/src/companion-kernel/toolbox.rs
+++ b/src/companion-kernel/toolbox.rs
@@ -1,3 +1,19 @@
+//! The Toolbox observer and the sole writer of the toolbox region. It holds the
+//! chat and cursor event counts, the first owned hero's identity, and the panel
+//! state observed through UI dispatch, and republishes only when one of them
+//! changes.
+//!
+//! The invariant is the crate's: the party walk reaches the game only through
+//! `resolve_game` and `collect_first_owned_hero`, both of which read via
+//! `memory.rs`, and the only address this file writes is `POINTER`, the host
+//! region `companion_init` validated. Neither pointer-shaped UI argument is
+//! ever retained or dereferenced: `observe_ui` compares `message` and `wparam`
+//! against configured values and stores nothing derived from them.
+//!
+//! Every `unsafe fn` below requires `initialize` to have run, which the
+//! `FEATURE_TOOLBOX_FOUNDATION` gate in `companion_dispatch` is what
+//! guarantees.
+
 use core::ptr::{read_volatile, write_volatile};
 
 use crate::abi::*;
@@ -33,6 +49,10 @@ fn is_party_dirty_message(layout: Layout, message: u32) -> bool {
 
 unsafe fn publish() {
     let next = unsafe { SEQUENCE }.wrapping_add(2) & !1;
+    // SAFETY: `POINTER` holds the region `companion_init` accepted through
+    // `valid_region` for `FEATURE_TOOLBOX_FOUNDATION` — non-null,
+    // four-byte-aligned, and exactly `TOOLBOX_BYTES` inside linear memory,
+    // which cannot shrink.
     let snapshot = unsafe { POINTER as *mut ToolboxSnapshot };
     let flags = if unsafe { FIRST_HERO_ID } != 0 {
         FLAG_HERO_AVAILABLE
@@ -66,6 +86,10 @@ pub(crate) unsafe fn initialize(pointer: u32) {
         PANEL_STATE = PANEL_UNKNOWN;
         PARTY_DIRTY = true;
     }
+    // SAFETY: `pointer` is the caller's validated `TOOLBOX_BYTES` region, so
+    // the last word this loop reaches is its final four bytes and the sum
+    // cannot overflow. Zeroing it before the first publish is what keeps a
+    // reader from decoding whatever the game's allocator left behind.
     for index in 0..TOOLBOX_BYTES / 4 {
         unsafe { write_volatile((pointer + index * 4) as *mut u32, 0) };
     }
@@ -146,6 +170,9 @@ pub(crate) unsafe fn observe_ui(layout: Layout, message: u32, wparam: u32) {
 
 pub(crate) unsafe fn publish_cursor_event() {
     let count = unsafe { cursor::event_count() };
+    // SAFETY: the same validated region `publish` writes. The published count
+    // is read back rather than mirrored in a static, so what the reader sees is
+    // the only thing this comparison can be wrong about.
     let published =
         unsafe { read_volatile(&(*(POINTER as *const ToolboxSnapshot)).cursor_event_count) };
     if count != published {


### PR DESCRIPTION
Part 6/7 of the quality stack (#62). Base: `q05-split-god-modules`.

## What changed

The companion kernel — the freestanding Wasm module that reads live game memory every frame — was the one part of the tree held to no documentation standard: ~138 unsafe operations, no `SAFETY:` comments, no module docs. Documentation and enforcement only; no logic changes.

- Every kernel file gains a `//!` header stating what it owns and the invariant it maintains. The crate-level statement: every game-heap read goes through `memory.rs`, bounds-checked against live linear memory, with pointer chases answering `Option` — a missing, torn, or hostile structure costs an observation, never an out-of-bounds access; the kernel writes only to the regions `companion_init` validated.
- `#![deny(unsafe_op_in_unsafe_fn)]` at crate level, made to compile.
- A stated crate SAFETY policy names the two routine patterns that carry no per-site comment (static accesses; forwarding to `memory.rs` readers) — every other unsafe operation now states its own justification.
- `static mut` stays, on an argued basis rather than by omission: the kernel imports no functions (nothing it calls can re-enter it), runs only on the game's callback thread, and every access is a by-value load/store of a `Copy` value with no references formed. A cell wrapper would need its own `unsafe impl Sync`, which claims more than those facts prove.

## Review focus

- Check the stated invariants against the code they describe — the headers are claims, and wrong claims are worse than none.

## Verification

- `pnpm build` (kernel compiles under the new deny), `node scripts/verify-companion-kernel.mjs` (byte-reproducibility holds), kernel seal + compiled-once unit tests, `pnpm check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
