### PR TITLE
State what every module owns at the top of it

### DIFF
--- a/src/main/app-updater.ts
+++ b/src/main/app-updater.ts
@@ -1,3 +1,19 @@
+/**
+ * The single owner of application updates: discovery, feed validation,
+ * download, ready, and install.
+ *
+ * It is also the only caller of the releases API in this project, which is what
+ * makes the consent promise checkable rather than merely stated — with
+ * automatic checks off there is no second code path that could still reach
+ * github.com. `periodicCheckDue` holds every gate on an automatic check and is
+ * pure, so the gates are provable without running a timer; an open game socket
+ * defers a check because a Squirrel download must not compete with live game
+ * traffic.
+ *
+ * Only a package carrying the release marker may reach Squirrel.Mac. A stable
+ * install is never offered a preview, a preview may advance to stable, and a
+ * ready update waits for a restart rather than taking one.
+ */
 import type {
   AppUpdateErrorCode,
   AppUpdateState,

--- a/src/main/client-certification.ts
+++ b/src/main/client-certification.ts
@@ -1,3 +1,18 @@
+/**
+ * Which of the three certification states an ArenaNet client build is in.
+ *
+ * The two transforms are chained but keyed by **different** hashes:
+ * template-save by the official build's hash, Enhancement by the hash of what the
+ * template-save transform *produces*. Certification can therefore succeed at
+ * step one and fail at step two — templates saved, cursor gone — and that is
+ * the normal intermediate during a recertification, because the transform that
+ * breaks saving gets fixed before the one that draws a pointer.
+ *
+ * This is the single owner of that answer: the launcher notice, the settings
+ * status, the diagnostics gauges and `enhancements:doctor` all ask here, so the
+ * intermediate state has one name and one user-facing sentence rather than
+ * being reassembled from two independent gauges at each surface.
+ */
 import type { ClientCertification } from "./core/client-module.js";
 import {
   findTemplateSaveBuild,
@@ -9,21 +24,6 @@ import {
 } from "./core/enhancement-builds.js";
 import type { LocalClientVerification } from "./core/local-client-verifier.js";
 
-/**
- * Which of the three certification states an ArenaNet client build is in.
- *
- * The two transforms are chained but keyed by **different** hashes:
- * template-save by the official build's hash, Enhancement by the hash of what the
- * template-save transform *produces*. Certification can therefore succeed at
- * step one and fail at step two — templates saved, cursor gone — and that is
- * the normal intermediate during a recertification, because the transform that
- * breaks saving gets fixed before the one that draws a pointer.
- *
- * Before this module the two answers were two independent gauges that nothing
- * composed, so the intermediate state had no name and no user-facing sentence.
- * This is the single owner: every consumer (the launcher notice, the settings
- * status, the diagnostics gauges, and `enhancements:doctor`) asks here.
- */
 export type { ClientCertification } from "./core/client-module.js";
 
 /**

--- a/src/main/client-runtime.ts
+++ b/src/main/client-runtime.ts
@@ -1,3 +1,22 @@
+/**
+ * The client generation state machine: look for an update, download it, decide
+ * what the resulting build may be transformed into, and publish exactly one
+ * active client.
+ *
+ * `clientReady` is the only thing in the application permitted to publish
+ * progress `phase: "ready"`. That phase means the main process has an active
+ * client, which nothing outside this runtime can know; published early, the
+ * renderer reads snapshot metadata before a client exists, sees size 0, and
+ * streams the whole game over the network.
+ *
+ * Every operation that moves a generation directory holds one lock for the
+ * whole of its work. Update, candidate confirmation and crash rollback all
+ * rename the same trees, and two of them interleaving at an await lets one
+ * rename away a tree the other is still reading.
+ *
+ * Certification is consumed, not re-derived: the runtime asks once which state
+ * a build is in and carries that one answer through preparation.
+ */
 import { net } from "electron";
 import type {
   ClientCompatibility,

--- a/src/main/core/access-key.ts
+++ b/src/main/core/access-key.ts
@@ -1,3 +1,15 @@
+/**
+ * The fixed identity and limits every request to ArenaNet's patch service
+ * carries.
+ *
+ * `ACCESS_KEY` identifies the official Guild Wars client, not a player and not
+ * an installation; it is public, and the policy tests exempt this one
+ * UUID-shaped value so that every other one still fails. The honest user agent,
+ * the eight-job ceiling and the request timeout are conduct toward shared
+ * production infrastructure, not tuning knobs to be raised when a download
+ * feels slow. `FATAL_HTTP` is the set that no amount of backoff can help, so
+ * retrying those is a defect rather than politeness.
+ */
 export const ACCESS_KEY = "2043FE79-F32D-4FD7-8C27-0D47231C4F03";
 export const PATCH_ROOT = "https://patching.1.arenanetworks.com";
 export const UA = "gwonmac (Guild Wars interoperability client)";

--- a/src/main/core/active-client.ts
+++ b/src/main/core/active-client.ts
@@ -1,3 +1,14 @@
+/**
+ * The one holder of the client the rest of main is allowed to serve.
+ *
+ * Every publication takes the next generation number, and a caller holding a
+ * stale one cannot write through it: `replaceSnapshot` refuses unless the
+ * generation still matches, so work that an update superseded cannot reach back
+ * and edit the client that replaced it. Published values are frozen, so a
+ * holder of an `ActiveClient` reads one fixed picture rather than a moving one.
+ *
+ * The slot records what is current and decides nothing about readiness.
+ */
 import type { SnapshotMetadata } from "../../shared/contracts.js";
 import type { ChunkStore } from "./chunk-store.js";
 import type { KnownEnhancementBuild } from "./enhancement-builds.js";

--- a/src/main/core/allowlists.ts
+++ b/src/main/core/allowlists.ts
@@ -1,3 +1,17 @@
+/**
+ * What a game connection is allowed to reach: three ports, public IPv4 unicast,
+ * and the ArenaNet domain suffixes.
+ *
+ * Every rule here is a refusal. Loopback, link-local, RFC1918, carrier-grade
+ * NAT, this-network and multicast are all excluded, so a hostile or confused
+ * destination cannot turn the main process into a scanner of the player's own
+ * network. Suffix matching is anchored on a dot, so `notarenanetworks.com` is
+ * not a match for `arenanetworks.com`.
+ *
+ * These are the game-infrastructure rules. Web services are allowlisted
+ * separately in `proxy-routes.ts`; the two lists grant different things and
+ * must not be merged into one.
+ */
 import { AllowlistError, ValidationError } from "../../shared/errors.js";
 
 export const ALLOWED_PORTS = new Set([6112, 80, 443]);

--- a/src/main/core/async-pool.ts
+++ b/src/main/core/async-pool.ts
@@ -1,3 +1,13 @@
+/**
+ * Bounded concurrency over a fixed list, and nothing else: at most `jobs`
+ * workers, each claiming the next index, `stopped()` consulted before every
+ * item so a cancelled download stops claiming work instead of draining the
+ * queue.
+ *
+ * There is no result collection, no ordering guarantee and no retry. A
+ * rejection escapes through `Promise.all` while sibling workers are still
+ * running, so callers that need those workers to stop pass `stopped`.
+ */
 export async function mapPool<T>(
   items: readonly T[],
   jobs: number,

--- a/src/main/core/atomic-file.ts
+++ b/src/main/core/atomic-file.ts
@@ -1,3 +1,14 @@
+/**
+ * The only way this process replaces a file whose half-written state a reader
+ * could otherwise observe: temp file, fsync, rename, fsync the directory.
+ *
+ * Nothing here overwrites in place and nothing here is best-effort. A failed
+ * write unlinks its own temp file and rethrows, so the target keeps its previous
+ * contents rather than acquiring part of the new ones. Temp names carry the
+ * writing pid, which is what lets the sweep tell a dead process's debris from a
+ * live process's in-flight write; no other code collects them, because chunk
+ * pruning deliberately ignores names that are not content hashes.
+ */
 import { randomBytes } from "node:crypto";
 import { mkdir, open, readdir, rename, unlink } from "node:fs/promises";
 import { dirname, join } from "node:path";

--- a/src/main/core/chunk-cache.ts
+++ b/src/main/core/chunk-cache.ts
@@ -1,3 +1,13 @@
+/**
+ * Reclaims cache space by deleting content-addressed chunks that neither the
+ * serving client nor the generation it can roll back to references.
+ *
+ * The keep set is the union of both manifests, so pruning after an update never
+ * destroys the rollback it was supposed to preserve. Anything that is not a
+ * regular file with a content-hash name is left alone: directories, temp files
+ * and unrecognised names are not this module's to judge. A missing rollback
+ * manifest is absence and prunes nothing extra; a corrupt one is an error.
+ */
 import { readdir, readFile, stat, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import { mapPool } from "./async-pool.js";

--- a/src/main/core/chunk-format.ts
+++ b/src/main/core/chunk-format.ts
@@ -1,3 +1,14 @@
+/**
+ * What makes a chunk a chunk: which digest a hash length implies, that the
+ * bytes hash to the name they were fetched under, and that a decoded chunk is
+ * exactly the length the manifest declared.
+ *
+ * Decompression is bounded before it starts rather than checked afterwards —
+ * that bound is what stops a corrupt or hostile gzip chunk from expanding into
+ * memory, and a length that merely differs from the manifest's is a failure
+ * rather than a short read. Every path that accepts chunk bytes goes through
+ * here, so no caller gets to invent its own idea of a valid chunk.
+ */
 import { createHash } from "node:crypto";
 import { gunzip } from "node:zlib";
 import { AppError } from "../../shared/errors.js";

--- a/src/main/core/chunk-store.ts
+++ b/src/main/core/chunk-store.ts
@@ -1,3 +1,18 @@
+/**
+ * The resident chunk cache and the scheduler in front of it: what is on disk,
+ * what is being fetched, and in which order.
+ *
+ * Concurrent readers of one content hash share a single in-flight promise, so a
+ * chunk is never fetched twice at once, and every arriving chunk is hash-
+ * verified before it is written — a wrong index or a corrupt response costs a
+ * wasted fetch and never a wrong byte. Demand reads outrank queued prefetch and
+ * the combined concurrency ceiling is ArenaNet's; do not raise it to make a
+ * download feel faster.
+ *
+ * Local write failures that no retry can fix are separated from transport
+ * faults here, because a full disk and an unreachable host need different
+ * things from the player.
+ */
 import { readFile, readdir, stat, statfs, unlink } from "node:fs/promises";
 import { join } from "node:path";
 import type { PrefetchProgress } from "../../shared/contracts.js";

--- a/src/main/core/client-compatibility.ts
+++ b/src/main/core/client-compatibility.ts
@@ -1,3 +1,18 @@
+/**
+ * Crash-loop protection across an ArenaNet client update: the marker files and
+ * the directory swap that let a launch tell "this generation has never survived
+ * a run" from "this generation works".
+ *
+ * A candidate is marked before it is served and confirmed only after the client
+ * has actually run. A launch that finds an unconfirmed marker rolls the
+ * previous generation back and records the rejected fingerprint, so the same
+ * broken download is not fetched and served again. The rejection is made
+ * durable before either directory moves: repeating the swap after a crash is
+ * safe, re-trying the candidate that caused the crash is not.
+ *
+ * Rejection is scoped to the host version that recorded it, so a fixed app is
+ * allowed to try a generation an older one refused.
+ */
 import { readFile, rename, rm, stat } from "node:fs/promises";
 import path from "node:path";
 import { isDigest } from "../../shared/digest.js";

--- a/src/main/core/client-fingerprint.ts
+++ b/src/main/core/client-fingerprint.ts
@@ -1,3 +1,17 @@
+/**
+ * Canonical identity of one complete published client generation.
+ *
+ * The identity is the chunking parameters plus, per file, its name, size and
+ * chunk hash list — never where the bytes came from, when they were fetched, or
+ * the order the manifest happened to list them in. Sorting here is what makes
+ * that order irrelevant. Two manifests that would produce byte-identical
+ * artifacts must fingerprint the same, or update rollback and the certification
+ * tables both begin lying.
+ *
+ * A freshly downloaded manifest and a legacy manifest being sealed both pass
+ * through this one function; callers do not get a second serialization or
+ * hashing policy.
+ */
 import { createHash } from "node:crypto";
 import { asDigest, type Digest } from "../../shared/digest.js";
 
@@ -7,13 +21,6 @@ export interface FingerprintedClientFile {
   readonly chunkHashes: readonly string[];
 }
 
-/**
- * Canonical identity of one complete published client generation.
- *
- * Both a freshly downloaded manifest and a legacy manifest being sealed pass
- * through this function. Sorting here makes file order irrelevant; callers do
- * not get a second serialization or hashing policy.
- */
 export function fingerprintClientGeneration(options: {
   compression: string;
   chunkSize: number;

--- a/src/main/core/client-module.ts
+++ b/src/main/core/client-module.ts
@@ -1,3 +1,16 @@
+/**
+ * Chooses the one WebAssembly module a launch serves, and owns the rule that
+ * the choice is a chain and not a menu: official then template-save then
+ * optional Enhancement, each stage taking the previous stage's output as its
+ * input.
+ *
+ * A derived module is served only when its whole ancestry is certified against
+ * the exact official hash in hand. Every refusal degrades by one step and
+ * deletes the cache entries it may no longer serve, so a derivative can never
+ * be handed to a client it was not derived from. The compatibility state
+ * returned here is the state the rest of the app reports; nothing recomputes
+ * it downstream.
+ */
 import {
   type ClientCompatibilityState,
   enhancementCapabilitiesRequested,

--- a/src/main/core/credentials.ts
+++ b/src/main/core/credentials.ts
@@ -1,3 +1,16 @@
+/**
+ * The ArenaNet saved login: its shape rule and its one Keychain slot.
+ *
+ * `parseCredentials` is what the IPC boundary runs on whatever the renderer
+ * sent and what runs again on whatever came back out of the Keychain, so a
+ * value becomes `StoredCredentials` exactly one way. It is written for this
+ * payload alone and must not be widened to admit another secret's shape; the
+ * Steam token supplies its own validator to the same `KeychainJsonStore`.
+ *
+ * Neither field may reach a log, a diagnostic export, browser storage or a
+ * profile file. This module hands them to the Keychain and to the caller that
+ * asked, and nowhere else.
+ */
 import type { StoredCredentials } from "../../shared/contracts.js";
 import { AppError } from "../../shared/errors.js";
 import type { NativeKeychain } from "./native-keychain.js";

--- a/src/main/core/derived-wasm.ts
+++ b/src/main/core/derived-wasm.ts
@@ -1,9 +1,3 @@
-import { createHash } from "node:crypto";
-import { createReadStream } from "node:fs";
-import { mkdir, readFile, rm, stat } from "node:fs/promises";
-import path from "node:path";
-import { writeAtomic, writeAtomicJson } from "./atomic-file.js";
-
 /**
  * The shared lifecycle behind every derived WebAssembly module we publish: hash
  * the base, reuse a cache entry only when it still describes exactly this
@@ -14,7 +8,17 @@ import { writeAtomic, writeAtomicJson } from "./atomic-file.js";
  * The cache root belongs to one transform outright. A rebuild empties it, so a
  * client update or an ABI bump cannot leave ~8 MB of dead derived modules
  * behind for every build the machine has ever seen.
+ *
+ * Nothing here returns a module it has not just hashed. An entry that fails any
+ * part of its own description is a miss rather than a repair, and a transform
+ * that throws leaves the last good publication where it is.
  */
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { mkdir, readFile, rm, stat } from "node:fs/promises";
+import path from "node:path";
+import { writeAtomic, writeAtomicJson } from "./atomic-file.js";
+
 export interface DerivedWasmCache {
   /** sha256 of the module the transform consumes. Keys the cache entry. */
   inputSha256: string;

--- a/src/main/core/dns.ts
+++ b/src/main/core/dns.ts
@@ -1,3 +1,17 @@
+/**
+ * Name resolution for game infrastructure, and the reason it does not simply
+ * call the system resolver.
+ *
+ * A name is refused before any query is sent if it is not on the allowlist, and
+ * an IP literal is refused outright so this cannot be used to launder an
+ * address past the domain check. `geodc.arenanetworks.com` answers with the
+ * datacenter sentinel `0.0.1.2`, which some resolvers drop as bogus; the
+ * hand-built UDP query exists to read that answer verbatim, not to route around
+ * a slow resolver.
+ *
+ * Every attempt that failed is accumulated and reported together, because
+ * "DNS failed" without the list of resolvers tried is not diagnosable.
+ */
 import { createSocket } from "node:dgram";
 import { promises as dns } from "node:dns";
 import { randomBytes } from "node:crypto";

--- a/src/main/core/enhancement-builds.ts
+++ b/src/main/core/enhancement-builds.ts
@@ -1,3 +1,18 @@
+/**
+ * The certified Enhancement support table: per known client hash, the memory
+ * layout the companion kernel reads, the UI message IDs that dirty the party
+ * graph, and the output hash of every capability profile derived from it.
+ *
+ * Entries are matched by exact input hash and by nothing else. Every offset
+ * here was measured against one build, so there is no nearest match, no
+ * inheritance between entries and no default: a client with no entry gets no
+ * Enhancement rather than a plausible guess.
+ *
+ * The order of `ENHANCEMENT_*_LAYOUT_FIELDS` is the config ABI — the kernel
+ * decodes those words positionally. Reordering or inserting a field changes
+ * what the kernel reads and invalidates every `outputSha256` in the table, so
+ * the two must be edited together or not at all.
+ */
 import {
   enhancementCapabilityProfile,
   enhancementConfigWordActive,

--- a/src/main/core/enhancement-transform.ts
+++ b/src/main/core/enhancement-transform.ts
@@ -1,3 +1,22 @@
+/**
+ * The Enhancement transform: given one exact certified build, appends the hook
+ * dispatch machinery to its WebAssembly and reserves the table slot the
+ * companion kernel is installed into.
+ *
+ * The input hash is checked against the build entry before a byte is read, and
+ * every hook's function signature is re-verified against the certified one, so
+ * a table entry that has gone stale fails loudly instead of producing a module
+ * that traps at runtime. Capability selection is exact — three booleans, no
+ * extra keys, and a profile that has no certified output hash is refused rather
+ * than derived.
+ *
+ * Hook ordering is part of the output identity, not an implementation detail:
+ * it determines relocated function indices and therefore the resulting bytes,
+ * so no capability selection may inherit another's ordering.
+ *
+ * `inspectEnhancementCandidate` is the read-only half. It reports what a module
+ * looks like and certifies nothing.
+ */
 import { createHash } from "node:crypto";
 import {
   enhancementCapabilityProfile,

--- a/src/main/core/keychain-store.ts
+++ b/src/main/core/keychain-store.ts
@@ -1,3 +1,17 @@
+/**
+ * One validated JSON secret in one fixed native Keychain slot: the single
+ * mechanism underneath every persistent secret this app keeps.
+ *
+ * Each secret supplies its own validator and its own error codes, so a second
+ * secret never means widening the first one's shape rule. A slot is serialized
+ * by its own lock, so a load cannot observe the half-written state of a save it
+ * raced. The decoded secret's buffer is zeroed on every path out, success and
+ * failure alike.
+ *
+ * This module sits below the diagnostics redactor and cannot reach it, so it
+ * never logs a value, a message or a stack — only the slot, the classified
+ * refusal, and the kind of thing that was thrown.
+ */
 import { AppError, type ErrorCode } from "../../shared/errors.js";
 import { Mutex } from "./mutex.js";
 import type { NativeKeychain, SecretSlot } from "./native-keychain.js";

--- a/src/main/core/legacy-secret-cleanup.ts
+++ b/src/main/core/legacy-secret-cleanup.ts
@@ -1,3 +1,14 @@
+/**
+ * Deletes the two retired Safe Storage ciphertext files, and does nothing else
+ * to a profile.
+ *
+ * The filenames are a closed list and the removal is not recursive, so this
+ * cannot widen into a profile reset. Nothing here reads, parses, migrates or
+ * backs up what it deletes: the secrets live in the Data Protection Keychain
+ * now, and the old ciphertext is not a source to recover from. Failures are
+ * collected and returned rather than thrown, because a file that will not
+ * delete must not stop a launch.
+ */
 import path from "node:path";
 
 const LEGACY_SECRET_FILES = ["credentials.bin", "steam-session.bin"] as const;

--- a/src/main/core/local-client-verifier.ts
+++ b/src/main/core/local-client-verifier.ts
@@ -1,3 +1,23 @@
+/**
+ * The structural proof that decides whether an unrecognised official client may
+ * still be transformed, and what it may be transformed for.
+ *
+ * Pure: it reads the bytes it is handed and nothing else — no profile state, no
+ * filesystem, no caching. The utility-process host owns all of that, which is
+ * what allows this to run inside a bounded isolated process.
+ *
+ * The two answers are not symmetric and must not be merged. Template save is
+ * shape-verifiable, so a client whose affected call sites still match is
+ * accepted by proof. Enhancement execution is exact-build only, because a
+ * matching address delta is not evidence about hook semantics or layout; an
+ * unrecognised client reports `enhancement-layout-changed` rather than being
+ * given the benefit of the doubt.
+ *
+ * `isLocalClientVerification` re-validates every field of a result that crossed
+ * a process boundary or came back off disk. A verifier ABI or baseline change
+ * makes every older result unreadable, so an app update can never inherit a
+ * decision made by verifier code it no longer contains.
+ */
 import { createHash } from "node:crypto";
 import { ENHANCEMENT_CAPABILITY_PROFILES } from "../../shared/contracts.js";
 import {

--- a/src/main/core/manifest.ts
+++ b/src/main/core/manifest.ts
@@ -1,3 +1,17 @@
+/**
+ * The parser for an ArenaNet patch manifest, which is treated as hostile input.
+ *
+ * Every bound here — name length, reserved names, directory and file counts,
+ * total chunk references, chunk size — exists because flat `parentIndex`-linked
+ * lists arrive over the network and are turned into filesystem-shaped paths. A
+ * name carrying a separator or a NUL, a parent cycle, a duplicate path, a chunk
+ * count that disagrees with the declared size, or one hash claiming two lengths
+ * is a refusal and never something to normalise: a manifest that parses here is
+ * one whose paths may be joined onto a real directory.
+ *
+ * Construction either yields a fully validated manifest or throws. There is no
+ * partially trusted intermediate state for a caller to observe.
+ */
 import { AppError } from "../../shared/errors.js";
 import { parseContentHash } from "./chunk-format.js";
 

--- a/src/main/core/native-keychain.ts
+++ b/src/main/core/native-keychain.ts
@@ -1,3 +1,14 @@
+/**
+ * The interface every persistent secret talks to, and the closed set of slots
+ * it may name.
+ *
+ * `SecretSlot` is a union rather than a string, so a new persistent secret is a
+ * deliberate edit here instead of an ad-hoc item appearing in a player's
+ * Keychain. `VolatileNativeKeychain` is the implementation for builds with no
+ * provisioned signing identity: secrets live in memory and are lost at quit.
+ * It is not a fallback an entitled build may drop to, and no file, encrypted
+ * blob or mock-Keychain implementation stands beside it as one.
+ */
 export const SECRET_SLOTS = ["arenaNetCredentials", "steamSession"] as const;
 
 export type SecretSlot = (typeof SECRET_SLOTS)[number];

--- a/src/main/core/patch-client.ts
+++ b/src/main/core/patch-client.ts
@@ -1,3 +1,20 @@
+/**
+ * Talks to ArenaNet's patch service: fetch the manifest, work out what this
+ * installation is missing, download and verify it, and publish the result as a
+ * new client generation.
+ *
+ * Publication is staged and marked as a candidate, never written over the
+ * generation currently in use, so a launch that never completes can be rolled
+ * back. Nothing is published that has not been hash-verified against the
+ * manifest that named it.
+ *
+ * This class reports download progress and nothing more. `"ready"` is excluded
+ * from its `emit` signature at the type level because the launcher reads that
+ * phase as "the main process has an active client", which only `ClientRuntime`
+ * can know; announcing it from here let the renderer read snapshot metadata
+ * before a client existed, receive size 0, and stream the whole game over the
+ * network instead.
+ */
 import {
   copyFile,
   link,

--- a/src/main/core/patch-transport.ts
+++ b/src/main/core/patch-transport.ts
@@ -1,3 +1,15 @@
+/**
+ * The bounded HTTP transport every patch-service request goes through: one
+ * timeout, one abort composition, one redirect policy, one response ceiling and
+ * one backoff schedule, so manifest and chunk downloads cannot drift apart.
+ *
+ * Bytes are counted as they stream and a declared length over the ceiling is
+ * refused before the body is read, so an unbounded or lying response is never
+ * buffered first and judged second. Redirects are `manual` and a 3xx is fatal:
+ * the patch service is addressed by a fixed root, and a redirect out of it is
+ * not a route to follow. Retries are exponential and exist for transport
+ * faults; the statuses that no retry can fix throw on the first answer.
+ */
 import { AppError, HttpStatusError } from "../../shared/errors.js";
 import { FATAL_HTTP } from "./access-key.js";
 

--- a/src/main/core/paths.ts
+++ b/src/main/core/paths.ts
@@ -1,7 +1,3 @@
-import path from "node:path";
-import type { CLIENT_ARTIFACTS } from "./access-key.js";
-import { clientGenerationPaths } from "./client-compatibility.js";
-
 /**
  * Every filesystem path this application constructs, in one place.
  *
@@ -15,6 +11,10 @@ import { clientGenerationPaths } from "./client-compatibility.js";
  * and so the pinning test can execute it. The Electron-rooted entry point is
  * `src/main/paths.ts`.
  */
+import path from "node:path";
+import type { CLIENT_ARTIFACTS } from "./access-key.js";
+import { clientGenerationPaths } from "./client-compatibility.js";
+
 export interface GamePaths {
   userData: string;
   settings: string;

--- a/src/main/core/proxy-routes.ts
+++ b/src/main/core/proxy-routes.ts
@@ -1,3 +1,18 @@
+/**
+ * The five web-service hosts `gw://app` may proxy to, and the rules that stop a
+ * response from leading anywhere else.
+ *
+ * The route set is closed and its keys are the type, so diagnostics can name a
+ * failing route without introducing an open string. An unrecognised route fails
+ * closed instead of being forwarded. A redirect is rewritten only if it stays
+ * on the same allowlisted host over https, on the default port, with no
+ * credentials in the URL; anything else is refused rather than followed. Cookie
+ * headers are identified here so the proxy can drop them — login state belongs
+ * in the native secret slots, never in Chromium's cookie store.
+ *
+ * These are web services. Game infrastructure is allowlisted separately in
+ * `allowlists.ts`, and the two lists do not merge.
+ */
 import { AppError, AllowlistError } from "../../shared/errors.js";
 
 export const PROXY_ROUTES = {

--- a/src/main/core/published-client.ts
+++ b/src/main/core/published-client.ts
@@ -1,3 +1,18 @@
+/**
+ * The manifest describing an installed client generation, and the proof that
+ * the files sitting beside it are still the ones it names.
+ *
+ * The fingerprint is recomputed while parsing, so a manifest whose recorded
+ * identity disagrees with its own contents is rejected before anything acts on
+ * it: editing this file cannot certify a substituted artifact. Artifacts and
+ * fingerprint travel together — one without the other is incomplete integrity
+ * metadata, not a half-finished upgrade to accept.
+ *
+ * Verification re-reads the artifacts and hashes them chunk by chunk. `false`
+ * means the files are wrong; `null` means the manifest predates artifact
+ * integrity entirely, which is a different answer and must not be collapsed
+ * into the first.
+ */
 import { createHash } from "node:crypto";
 import { open, readFile } from "node:fs/promises";
 import { isDigest } from "../../shared/digest.js";

--- a/src/main/core/ranges.ts
+++ b/src/main/core/ranges.ts
@@ -1,3 +1,14 @@
+/**
+ * HTTP byte ranges for the virtual snapshot: parsing, clamping, and the one
+ * refusal that matters.
+ *
+ * `Gw.snapshot` is assembled on demand from cached chunks and has no whole-file
+ * representation to fall back to, so `requireSnapshotRange` treats a missing or
+ * unsatisfiable Range as an error rather than serving the entire multi-gigabyte
+ * resource. `assertSafeRead` bounds offset and length against the real size
+ * before any read is attempted, so a malformed request cannot become an
+ * out-of-bounds read.
+ */
 import { AppError, ValidationError } from "../../shared/errors.js";
 
 const RANGE_RE = /^bytes=(\d*)-(\d*)$/;

--- a/src/main/core/renderer-trust.ts
+++ b/src/main/core/renderer-trust.ts
@@ -1,3 +1,13 @@
+/**
+ * What counts as the renderer document: two paths under `gw://app`, with no
+ * port, credentials, query or fragment.
+ *
+ * Callers decide from this whether a navigation is the application itself, so
+ * it answers yes or no and never repairs a URL into an acceptable one. There is
+ * nothing to allow in a query string — launch configuration reaches the
+ * renderer through `RENDERER_INIT_ARGUMENT`, which is what keeps this boundary
+ * from having to know what any individual setting means.
+ */
 const TRUSTED_PATHS = new Set(["/", "/index.html"]);
 
 /**

--- a/src/main/core/settings.ts
+++ b/src/main/core/settings.ts
@@ -1,3 +1,18 @@
+/**
+ * The settings file: its shape rule, its recovery behaviour, and nothing about
+ * what any individual setting means.
+ *
+ * Unknown fields are ignored and unknown types refused, so an older profile
+ * keeps every value it had while a malformed one cannot slip past the type. A
+ * format version this build does not recognise is refused rather than
+ * reinterpreted; the file is then moved aside intact and defaults are used, so
+ * an unreadable profile costs a player their preferences and never their
+ * downloaded game data.
+ *
+ * `parseSettingsPatch` rejects an unknown key outright instead of dropping it,
+ * because a silently ignored key is indistinguishable to the renderer from a
+ * setting that did not stick.
+ */
 import { readdir, readFile, rename, unlink } from "node:fs/promises";
 import { basename, dirname, join } from "node:path";
 import {

--- a/src/main/core/snapshot.ts
+++ b/src/main/core/snapshot.ts
@@ -1,3 +1,15 @@
+/**
+ * The resident-chunk bitmap and the snapshot index published beside a client
+ * generation.
+ *
+ * The bitmap is the compact answer to "is chunk N already on disk" for a
+ * snapshot with hundreds of thousands of chunks. It is packed and read only
+ * here, so no caller indexes the bytes itself and no caller has to know the bit
+ * order. An index outside the chunk count is dropped rather than growing the
+ * map, and a stored bitmap of the wrong length is fitted to the chunk count
+ * instead of being trusted — the cost of a mis-sized index is chunks that look
+ * absent and get fetched again, which must never become an out-of-range read.
+ */
 import type { SnapshotMetadata } from "../../shared/contracts.js";
 import { writeAtomicJson } from "./atomic-file.js";
 

--- a/src/main/core/sockets.ts
+++ b/src/main/core/sockets.ts
@@ -1,4 +1,20 @@
-// Main-process TCP ownership: public unicast only, ports 6112/80/443.
+/**
+ * Main-process TCP ownership: public unicast only, ports 6112/80/443.
+ *
+ * The renderer never holds a handle. It holds a socket id, and every operation
+ * on that id is re-checked against the owner it was opened under, so one
+ * renderer generation cannot read, write to, or close another's connection.
+ * Owner teardown closes what that owner opened and nothing else.
+ *
+ * The per-socket and per-owner queue ceilings are the backpressure boundary: a
+ * client that writes faster than the network drains is refused rather than
+ * allowed to grow main-process memory without limit. Sockets are counted per
+ * owner for the same reason.
+ *
+ * Nothing about a destination or a libuv failure escapes as text. Addresses stay
+ * inside this module and errors collapse into the closed contract vocabulary
+ * before they are published.
+ */
 import net from "node:net";
 import type {
   SocketCloseReason,

--- a/src/main/core/steam-oauth.ts
+++ b/src/main/core/steam-oauth.ts
@@ -1,3 +1,16 @@
+/**
+ * The Steam sign-in flow as data and pure predicates: the authorize URL, the
+ * set of URLs the window may load, and the one redirect that ends an attempt.
+ *
+ * Nothing here opens a window, stores a token, or imports Electron. That is
+ * what lets the same rules run offline against a fixture server, so every
+ * decision this file makes is testable without a live Steam account.
+ *
+ * Both predicates fail closed and neither repairs its input. Recognising the
+ * redirect and extracting the token are deliberately one operation, so no
+ * caller can accept a matching nonce that arrived from the wrong host, port,
+ * scheme or path.
+ */
 import { randomUUID } from "node:crypto";
 
 /**

--- a/src/main/core/steam-session.ts
+++ b/src/main/core/steam-session.ts
@@ -1,3 +1,16 @@
+/**
+ * The Steam token's three concerns in one module: what a storable session looks
+ * like, the one slot it lives in, and which token a launch is given.
+ *
+ * There are exactly two sources — the stored session while it is still good,
+ * and a token a sign-in just produced. No third source exists at any tier; in
+ * particular no environment variable seeds this in any build, and
+ * `tests/policy/source-saved-login-surface.test.ts` scans for one.
+ *
+ * Nothing here imports Electron and nothing here logs. What happened on the way
+ * to an answer comes back as notes for the caller to record, so the audit trail
+ * is a value a test can assert on, and no note ever carries the token.
+ */
 import type { SteamRefusalReason } from "../../shared/contracts.js";
 import { AppError, errorCode, type ErrorCode } from "../../shared/errors.js";
 import type { NativeKeychain } from "./native-keychain.js";

--- a/src/main/core/template-save-compat.ts
+++ b/src/main/core/template-save-compat.ts
@@ -1,16 +1,18 @@
-// ArenaNet's Emscripten port ships four unimplemented `Base/Os` file routines.
-// Creating a directory always fails with error 2, so a build cannot be saved.
-// Enumerating a directory does nothing and deriving a name from an entry writes
-// nothing, so "Load from Skills Template" stays empty. Deleting a file is
-// `assert("not implemented")` followed by `unreachable`, so removing or renaming
-// a build aborts the client.
-//
-// None of that can be repaired from JavaScript alone: the client never reaches
-// a syscall, and the module imports no `mkdir`, `getdents`, or `unlink`. So one
-// derived module, accepted only for an exact official hash, appends forwarders
-// and repoints the template, chat-log, and screenshot call sites at them. Each
-// forwarder hands the stub's arguments to `__syscall_newfstatat` behind a dirfd
-// that no real call can produce, where the renderer answers it.
+/**
+ * ArenaNet's Emscripten port ships four unimplemented `Base/Os` file routines.
+ * Creating a directory always fails with error 2, so a build cannot be saved.
+ * Enumerating a directory does nothing and deriving a name from an entry writes
+ * nothing, so "Load from Skills Template" stays empty. Deleting a file is
+ * `assert("not implemented")` followed by `unreachable`, so removing or renaming
+ * a build aborts the client.
+ *
+ * None of that can be repaired from JavaScript alone: the client never reaches
+ * a syscall, and the module imports no `mkdir`, `getdents`, or `unlink`. So one
+ * derived module, accepted only for an exact official hash, appends forwarders
+ * and repoints the template, chat-log, and screenshot call sites at them. Each
+ * forwarder hands the stub's arguments to `__syscall_newfstatat` behind a dirfd
+ * that no real call can produce, where the renderer answers it.
+ */
 import { createHash } from "node:crypto";
 // The dirfd markers are canonical in src/shared because the renderer half needs
 // the same values and cannot import from here; the generated preload carries

--- a/src/main/core/template-save-verifier.ts
+++ b/src/main/core/template-save-verifier.ts
@@ -1,23 +1,25 @@
-// Re-derive a `KnownTemplateSaveBuild` entry from a client WASM, by shape
-// rather than by remembered index.
-//
-// The launcher runs this logic in a disposable utility process when ArenaNet
-// publishes an unknown client hash. Developer tooling imports the same
-// implementation, so a manual report and the production decision cannot drift.
-//
-// Every number in the certified table belongs to one exact build, and ArenaNet
-// updates the client automatically. Recovering them by hand takes hours; this
-// recovers them in seconds and hands the result to the production transform for
-// validation. It removes the index-recovery work, not the semantic work — see
-// internal/upstream/recertify.md, which still owns re-measuring what the path
-// helpers actually do.
-//
-// Two measured facts make this cheap. Byte-scanning for the six-byte padded
-// `call` needle locates every call site with no false positives, so no
-// whole-module instruction decoder is needed. And caller-set intersection
-// identifies every target, so source-file attribution is not needed either —
-// which is just as well, because the most important call site here references
-// no source string at all.
+/**
+ * Re-derive a `KnownTemplateSaveBuild` entry from a client WASM, by shape
+ * rather than by remembered index.
+ *
+ * The launcher runs this logic in a disposable utility process when ArenaNet
+ * publishes an unknown client hash. Developer tooling imports the same
+ * implementation, so a manual report and the production decision cannot drift.
+ *
+ * Every number in the certified table belongs to one exact build, and ArenaNet
+ * updates the client automatically. Recovering them by hand takes hours; this
+ * recovers them in seconds and hands the result to the production transform for
+ * validation. It removes the index-recovery work, not the semantic work — see
+ * internal/upstream/recertify.md, which still owns re-measuring what the path
+ * helpers actually do.
+ *
+ * Two measured facts make this cheap. Byte-scanning for the six-byte padded
+ * `call` needle locates every call site with no false positives, so no
+ * whole-module instruction decoder is needed. And caller-set intersection
+ * identifies every target, so source-file attribution is not needed either —
+ * which is just as well, because the most important call site here references
+ * no source string at all.
+ */
 import { createHash } from "node:crypto";
 import {
   countFunctionImports,

--- a/src/main/core/wasm-binary.ts
+++ b/src/main/core/wasm-binary.ts
@@ -1,10 +1,12 @@
-// WebAssembly section codec shared by everything that rewrites or inspects
-// ArenaNet's client: the Enhancement transform, the template-save compatibility
-// transform, and the re-certifier that re-derives a build entry.
-//
-// Callers keep their own domain-prefixed `fail()` for their own invariants;
-// everything here throws `wasm: …` so a structural fault is distinguishable
-// from a policy one.
+/**
+ * WebAssembly section codec shared by everything that rewrites or inspects
+ * ArenaNet's client: the Enhancement transform, the template-save compatibility
+ * transform, and the re-certifier that re-derives a build entry.
+ *
+ * Callers keep their own domain-prefixed `fail()` for their own invariants;
+ * everything here throws `wasm: …` so a structural fault is distinguishable
+ * from a policy one.
+ */
 
 export interface Section {
   id: number;

--- a/src/main/core/window-state.ts
+++ b/src/main/core/window-state.ts
@@ -1,3 +1,18 @@
+/**
+ * The persisted window placement: what counts as a valid one, and how a stored
+ * one is fitted back onto the displays that exist right now.
+ *
+ * `mode` is three values and minimized is not among them — a window is never
+ * restored into a state the player cannot see. Placement is re-validated
+ * against the current work areas on every restore, so a window last seen on a
+ * monitor that is now unplugged is centred on the primary display instead of
+ * opening off-screen, while one that still overlaps a display keeps its
+ * position clamped inside that display's work area.
+ *
+ * A file this build cannot read is deleted and reported rather than
+ * reinterpreted: failing to restore a window must never mean failing to open
+ * one.
+ */
 import { readFile, unlink } from "node:fs/promises";
 import { AppError } from "../../shared/errors.js";
 import { writeAtomicJson } from "./atomic-file.js";

--- a/src/main/diagnostics.ts
+++ b/src/main/diagnostics.ts
@@ -1,12 +1,3 @@
-import type { DiagnosticSummary } from "../shared/diagnostics.js";
-import {
-  activeCaptureLevel,
-  discardTrace,
-  stopDiagnosticCapture,
-} from "./diagnostics/capture.js";
-import { recorder, sweepDiagnosticsDirectory } from "./diagnostics/recorder.js";
-import { startSampling, stopSampling } from "./diagnostics/samplers.js";
-
 /**
  * The diagnostics subsystem's one entry point, and the composition of its
  * parts: the recorder under `./diagnostics/`, the capture session, the OS
@@ -15,6 +6,14 @@ import { startSampling, stopSampling } from "./diagnostics/samplers.js";
  * The rest of the main process imports diagnostics from here and nowhere else,
  * so which module owns a given piece of state stays an internal question.
  */
+import type { DiagnosticSummary } from "../shared/diagnostics.js";
+import {
+  activeCaptureLevel,
+  discardTrace,
+  stopDiagnosticCapture,
+} from "./diagnostics/capture.js";
+import { recorder, sweepDiagnosticsDirectory } from "./diagnostics/recorder.js";
+import { startSampling, stopSampling } from "./diagnostics/samplers.js";
 
 export {
   count,

--- a/src/main/diagnostics/capture.ts
+++ b/src/main/diagnostics/capture.ts
@@ -1,3 +1,13 @@
+/**
+ * The capture session: its level, its deadline, and the raw Chromium trace it
+ * may leave on disk.
+ *
+ * The active level is what the rest of the subsystem asks before recording
+ * anything a capture pays for, and the level the export declares is a second
+ * value on purpose — it survives the stop so an export after the fact still
+ * describes the capture it is exporting. Both are owned here; nothing else
+ * assigns them.
+ */
 import { rm, stat } from "node:fs/promises";
 import path from "node:path";
 import { contentTracing } from "electron";
@@ -11,17 +21,6 @@ import {
 import type { CaptureMetadata } from "./flight-recorder.js";
 import { logEvent, recorder } from "./recorder.js";
 import { resetEventLoopWindow } from "./samplers.js";
-
-/**
- * The capture session: its level, its deadline, and the raw Chromium trace it
- * may leave on disk.
- *
- * The active level is what the rest of the subsystem asks before recording
- * anything a capture pays for, and the level the export declares is a second
- * value on purpose — it survives the stop so an export after the fact still
- * describes the capture it is exporting. Both are owned here; nothing else
- * assigns them.
- */
 
 let captureLevel: 0 | 1 | 2 = 0;
 let recordedLevel: 0 | 1 | 2 = 0;

--- a/src/main/diagnostics/detector.ts
+++ b/src/main/diagnostics/detector.ts
@@ -1,10 +1,3 @@
-import { AppError } from "../../shared/errors.js";
-import {
-  DIAGNOSTIC_EVENT_SCHEMA,
-  diagnosticEventSpec,
-  type DiagnosticEventName,
-} from "./schema.js";
-
 /**
  * Independent structural certification for `events.jsonl`.
  *
@@ -14,6 +7,12 @@ import {
  * fields, and declared values. Unknown events and fields are export failures;
  * there is no open-field counter or fallback path.
  */
+import { AppError } from "../../shared/errors.js";
+import {
+  DIAGNOSTIC_EVENT_SCHEMA,
+  diagnosticEventSpec,
+  type DiagnosticEventName,
+} from "./schema.js";
 
 type Guard<T> = (value: unknown) => value is T;
 

--- a/src/main/diagnostics/export.ts
+++ b/src/main/diagnostics/export.ts
@@ -1,3 +1,11 @@
+/**
+ * The `.gwdiag` report: what goes in it, which tier of protection covers each
+ * document, and the staging that makes the archive appear whole or not at all.
+ *
+ * Nothing is written before the detector has passed over the event log, and
+ * the log is written byte for byte as the detector saw it — a reader can
+ * reproduce the manifest's counts from the file in the archive.
+ */
 import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { createReadStream } from "node:fs";
@@ -32,15 +40,6 @@ import {
   redactDiagnosticText as redactText,
   redactTraceStream,
 } from "./text-scan.js";
-
-/**
- * The `.gwdiag` report: what goes in it, which tier of protection covers each
- * document, and the staging that makes the archive appear whole or not at all.
- *
- * Nothing is written before the detector has passed over the event log, and
- * the log is written byte for byte as the detector saw it — a reader can
- * reproduce the manifest's counts from the file in the archive.
- */
 
 const execFileAsync = promisify(execFile);
 

--- a/src/main/diagnostics/flight-recorder.ts
+++ b/src/main/diagnostics/flight-recorder.ts
@@ -1,3 +1,17 @@
+/**
+ * The recorder itself: the bounded JSONL of events, the counters, gauges and
+ * histograms, and the binary frame log beside them.
+ *
+ * Every store here is bounded before it is written to — a file count, a byte
+ * ceiling per file, an event ceiling in memory, a byte ceiling on frames — so a
+ * session that misbehaves for hours costs a fixed amount of disk instead of
+ * filling the profile. Overflow is counted and reported rather than silently
+ * dropped, because a summary that omits how much it omitted is not evidence.
+ *
+ * `LogRecord.name` is an open string only because it is the *reader's* type:
+ * a previous session's file may have been written by an older format. Nothing
+ * this build records is open — producers are typed by the closed schema.
+ */
 import { randomUUID } from "node:crypto";
 import {
   appendFile,

--- a/src/main/diagnostics/recorder.ts
+++ b/src/main/diagnostics/recorder.ts
@@ -1,9 +1,3 @@
-import { readdir, rm } from "node:fs/promises";
-import path from "node:path";
-import { gamePaths } from "../paths.js";
-import { FlightRecorder } from "./flight-recorder.js";
-import type { DiagnosticEvent } from "./schema.js";
-
 /**
  * The one main-process flight recorder, and the only writes into it.
  *
@@ -11,6 +5,11 @@ import type { DiagnosticEvent } from "./schema.js";
  * rather than holding a recorder of its own, so a second recorder — with its
  * own session id, its own ring, and its own JSONL — cannot exist.
  */
+import { readdir, rm } from "node:fs/promises";
+import path from "node:path";
+import { gamePaths } from "../paths.js";
+import { FlightRecorder } from "./flight-recorder.js";
+import type { DiagnosticEvent } from "./schema.js";
 
 export const recorder = new FlightRecorder();
 

--- a/src/main/diagnostics/renderer.ts
+++ b/src/main/diagnostics/renderer.ts
@@ -1,3 +1,11 @@
+/**
+ * Everything the renderer reports, translated into recorder state.
+ *
+ * The renderer measures the frame loop, the game's reads and sockets, and its
+ * own milestones; main owns the recorder. This is the one place the two meet,
+ * so a renderer-reported value cannot reach the recorder by another route and
+ * arrive under a different name.
+ */
 import {
   ENHANCEMENT_CAPABILITY_PROFILES,
   type EnhancementCapabilityProfile,
@@ -14,15 +22,6 @@ import {
 import { activeCaptureLevel } from "./capture.js";
 import { logEvent, recordEvent, recorder } from "./recorder.js";
 import { asRendererFingerprint } from "./schema.js";
-
-/**
- * Everything the renderer reports, translated into recorder state.
- *
- * The renderer measures the frame loop, the game's reads and sockets, and its
- * own milestones; main owns the recorder. This is the one place the two meet,
- * so a renderer-reported value cannot reach the recorder by another route and
- * arrive under a different name.
- */
 
 let graphics: GraphicsDiagnostics | null = null;
 let rendererClockOffsetUs = 0;

--- a/src/main/diagnostics/report.ts
+++ b/src/main/diagnostics/report.ts
@@ -1,3 +1,16 @@
+/**
+ * Reading sessions back: the one parser for a session's JSONL, and the summary
+ * document an export carries.
+ *
+ * A process killed between a write and its newline leaves one incomplete final
+ * record, and that is ordinary — it costs the reader that record and nothing
+ * else. Interior corruption is not tolerated the same way. Both the current
+ * session's export and the previous session's report come through the same
+ * parser, so one cannot be lenient while the other throws.
+ *
+ * The report is derived entirely from records and counters. It quotes no
+ * message text and reaches for no source outside what was already recorded.
+ */
 import { readFile, readdir, stat } from "node:fs/promises";
 import path from "node:path";
 import type {

--- a/src/main/diagnostics/samplers.ts
+++ b/src/main/diagnostics/samplers.ts
@@ -1,10 +1,3 @@
-import { arch, cpus, platform, release, totalmem } from "node:os";
-import { monitorEventLoopDelay, performance } from "node:perf_hooks";
-import { app, powerMonitor, screen } from "electron";
-import { runtimeVersions } from "./flight-recorder.js";
-import { logEvent, recorder } from "./recorder.js";
-import { asAppVersion } from "./schema.js";
-
 /**
  * What this process observes about the machine it runs on: the main process's
  * own CPU and memory, Chromium's per-process metrics, event-loop delay, the
@@ -15,6 +8,12 @@ import { asAppVersion } from "./schema.js";
  * so a report covers the launch that produced it, and the detailed sample is a
  * multiple of that interval rather than a second timer.
  */
+import { arch, cpus, platform, release, totalmem } from "node:os";
+import { monitorEventLoopDelay, performance } from "node:perf_hooks";
+import { app, powerMonitor, screen } from "electron";
+import { runtimeVersions } from "./flight-recorder.js";
+import { logEvent, recorder } from "./recorder.js";
+import { asAppVersion } from "./schema.js";
 
 const SAMPLE_INTERVAL_MS = 1_000;
 const PROCESS_SAMPLE_INTERVAL = 5;

--- a/src/main/diagnostics/schema.ts
+++ b/src/main/diagnostics/schema.ts
@@ -1,3 +1,11 @@
+/**
+ * The one runtime and compile-time schema for app-authored diagnostic events.
+ *
+ * Event names, subsystem/level ownership, field names, and field validators
+ * live together. Producers receive the type derived from this value, and the
+ * export detector executes these exact validators. There is no permissive
+ * fallback: if an event is absent here, it cannot be recorded or exported.
+ */
 import {
   ENHANCEMENT_CAPABILITY_PROFILES,
   EVENT_CHANNELS,
@@ -33,15 +41,6 @@ import {
   type ProxyRoute,
 } from "../core/proxy-routes.js";
 import { ALLOWED_PORTS } from "../core/allowlists.js";
-
-/**
- * The one runtime and compile-time schema for app-authored diagnostic events.
- *
- * Event names, subsystem/level ownership, field names, and field validators
- * live together. Producers receive the type derived from this value, and the
- * export detector executes these exact validators. There is no permissive
- * fallback: if an event is absent here, it cannot be recorded or exported.
- */
 
 export type FieldGuard<T extends DiagnosticScalar> = (
   value: unknown,

--- a/src/main/diagnostics/spans.ts
+++ b/src/main/diagnostics/spans.ts
@@ -1,11 +1,3 @@
-import { randomUUID } from "node:crypto";
-import type { Digest } from "../../shared/digest.js";
-import type { ErrorCode } from "../../shared/errors.js";
-import type { ProxyRoute } from "../core/proxy-routes.js";
-import { activeCaptureLevel } from "./capture.js";
-import { recordEvent, recorder } from "./recorder.js";
-import type { DiagnosticEvent } from "./schema.js";
-
 /**
  * The bounded operations worth timing, each one begin/end pair declared here.
  *
@@ -14,6 +6,13 @@ import type { DiagnosticEvent } from "./schema.js";
  * `end` is ignored — so an unbalanced pair cannot reach the recorder and a
  * histogram cannot be fed a duration no event accounts for.
  */
+import { randomUUID } from "node:crypto";
+import type { Digest } from "../../shared/digest.js";
+import type { ErrorCode } from "../../shared/errors.js";
+import type { ProxyRoute } from "../core/proxy-routes.js";
+import { activeCaptureLevel } from "./capture.js";
+import { recordEvent, recorder } from "./recorder.js";
+import type { DiagnosticEvent } from "./schema.js";
 
 export interface ClosedDiagnosticSpan<End> {
   readonly traceId: string;

--- a/src/main/diagnostics/text-scan.ts
+++ b/src/main/diagnostics/text-scan.ts
@@ -1,5 +1,3 @@
-import { homedir } from "node:os";
-
 /**
  * The pattern scanner for text this application did **not** author.
  *
@@ -13,6 +11,7 @@ import { homedir } from "node:os";
  * unit test could reach it because that module resolves Electron paths at
  * import time.
  */
+import { homedir } from "node:os";
 
 /**
  * An absolute path. The lookbehind is **negative** so that a path at index 0

--- a/src/main/enhancement-policy.ts
+++ b/src/main/enhancement-policy.ts
@@ -1,3 +1,18 @@
+/**
+ * The two developer-only Enhancement switches, resolved once, and the rule that
+ * decides when a tool change needs a relaunch.
+ *
+ * Both switches are read from the environment and both are refused in a
+ * packaged application, so no shipped build can be talked into automation
+ * capabilities or a developer example by the environment it was started in.
+ * They stay independent on purpose: automation grants input and IPC
+ * capabilities, the program chooses which example is installed, and neither
+ * implies the other.
+ *
+ * `enhancementSelectionChanged` exists because the client module is chosen
+ * before the renderer exists. A selection the running session cannot honour
+ * makes the settings write and the relaunch one action rather than two.
+ */
 import { app } from "electron";
 import {
   ENHANCEMENTS,

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1,3 +1,18 @@
+/**
+ * Every native capability the renderer may ask for, and the boundary that
+ * decides whether it may have it.
+ *
+ * A channel exists only as a parser paired with a handler, checked against
+ * `InvokeChannel`, so a channel with no handler and a handler with no channel
+ * are both build failures and nothing can be registered that takes its
+ * arguments unvalidated. The sender is re-checked on every call — the owned
+ * window, its main frame, the canonical renderer URL — because a page that
+ * navigated away is no longer the renderer the capability was granted to.
+ *
+ * Transport, not policy. What a socket, a secret, a setting or a chunk means is
+ * decided behind these handlers; this file validates arguments, names the
+ * subsystem that answers, and returns codes rather than inventing prose.
+ */
 import { BrowserWindow, dialog, ipcMain, shell, app } from "electron";
 import { statfs, writeFile } from "node:fs/promises";
 import type {

--- a/src/main/lifecycle.ts
+++ b/src/main/lifecycle.ts
@@ -1,3 +1,17 @@
+/**
+ * Quit ordering: the registry of cleanup tasks and the one pass that runs them.
+ *
+ * Tasks run in reverse registration order, so a subsystem is torn down before
+ * whatever it was built on. The pass runs at most once and cannot be re-entered
+ * by a second quit request, and a task that throws is recorded and stepped over
+ * rather than abandoning the tasks behind it — a socket left open because a
+ * settings write failed is exactly the quit that strands a process. Diagnostics
+ * are flushed last, once every task has had its chance to record something.
+ *
+ * Sandbox enabling lives here for the same reason: it is the other thing that
+ * must happen at a fixed point in the application's life, before `ready` or not
+ * at all.
+ */
 import { app } from "electron";
 import { errorCode } from "../shared/errors.js";
 import { flushDiagnostics, logEvent } from "./diagnostics.js";

--- a/src/main/local-client-verifier-host.ts
+++ b/src/main/local-client-verifier-host.ts
@@ -1,3 +1,17 @@
+/**
+ * Runs the local client proof and owns everything the proof itself may not:
+ * the bounded child process, the timeout, and the derived on-disk cache.
+ *
+ * The child gets the module path and the hash it must match, and nothing else.
+ * A result is accepted only if it survives `isLocalClientVerification` against
+ * that same hash, whether it arrived over the message port or came back out of
+ * the cache — a cache file is untrusted input, not a shortcut past the check.
+ * Its checksum catches ordinary corruption; the boundary check is what makes an
+ * edited one useless.
+ *
+ * The timeout is the reason for the process at all: a client this app did not
+ * produce must not be able to hang a launch by hanging the verifier.
+ */
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";

--- a/src/main/local-client-verifier-process.ts
+++ b/src/main/local-client-verifier-process.ts
@@ -1,3 +1,16 @@
+/**
+ * The utility process the local client proof runs inside: read the module,
+ * confirm it is the one that was asked for, verify it, answer once.
+ *
+ * Isolation is the whole point. The verifier walks a multi-megabyte module this
+ * project did not produce, so it runs where a crash or a runaway loop costs the
+ * launch nothing. The host owns the timeout and the caching; this process holds
+ * no state and writes no files.
+ *
+ * Every refusal is its own exit code, and no message is posted unless the
+ * result also passes the boundary check, so the parent never has to interpret a
+ * partial answer.
+ */
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,3 +1,14 @@
+/**
+ * The composition root: it constructs the subsystems, wires them to one
+ * another, and owns the order in which a launch happens.
+ *
+ * Nothing here implements a behaviour. Every rule this file appears to make —
+ * what a setting is, when an update may be checked, which module is served,
+ * which secrets are available — belongs to the module it hands the work to, and
+ * a decision that starts growing here belongs somewhere else. What main owns is
+ * sequence and lifetime: the single-instance lock, the work that must precede
+ * `ready`, the profile location, and what is registered to run at quit.
+ */
 import {
   app,
   autoUpdater,

--- a/src/main/native-keychain.ts
+++ b/src/main/native-keychain.ts
@@ -1,3 +1,13 @@
+/**
+ * Finding and loading the native Keychain addon, kept apart from every rule
+ * about what a secret is.
+ *
+ * A packaged build resolves it inside `app.asar.unpacked` because a `.node`
+ * binary cannot be loaded from within an archive. What comes back is
+ * shape-checked before it is returned, so a missing, stale or mismatched addon
+ * fails here with a type error instead of at the first attempt to read a
+ * player's saved password.
+ */
 import { createRequire } from "node:module";
 import path from "node:path";
 import type { NativeKeychain } from "./core/native-keychain.js";

--- a/src/main/paths.ts
+++ b/src/main/paths.ts
@@ -1,3 +1,12 @@
+/**
+ * The Electron-rooted entry to the path table.
+ *
+ * Which paths exist is decided in `./core/paths.ts`, which stays Electron-free
+ * so it can be executed by a test and imported from `src/main/core/**`. This
+ * module adds only what needs `app`: the per-user data root, the compiled
+ * renderer directory, and the preload. Nothing here invents a path that the
+ * core table does not already own.
+ */
 import { app } from "electron";
 import path from "node:path";
 import { gamePaths as resolveGamePaths } from "./core/paths.js";

--- a/src/main/problem-report.ts
+++ b/src/main/problem-report.ts
@@ -1,10 +1,3 @@
-import { dialog, shell, type BrowserWindow } from "electron";
-import { EXTERNAL_URLS } from "../shared/contracts.js";
-import { errorCode } from "../shared/errors.js";
-import { logEvent } from "./diagnostics.js";
-import { resetGameInput } from "./renderer-commands.js";
-import type { WindowHost } from "./window.js";
-
 /**
  * What a player does when something goes wrong: choose between exporting what
  * the recorder already holds and recording the problem as it happens, then be
@@ -14,6 +7,12 @@ import type { WindowHost } from "./window.js";
  * notice — arrives here, so the choice, the prose about what the archive
  * contains, and the one-at-a-time rule are stated once.
  */
+import { dialog, shell, type BrowserWindow } from "electron";
+import { EXTERNAL_URLS } from "../shared/contracts.js";
+import { errorCode } from "../shared/errors.js";
+import { logEvent } from "./diagnostics.js";
+import { resetGameInput } from "./renderer-commands.js";
+import type { WindowHost } from "./window.js";
 
 const BUG_REPORT_URL =
   `${EXTERNAL_URLS.github}/issues/new?template=bug-report.yml`;

--- a/src/main/protocol.ts
+++ b/src/main/protocol.ts
@@ -1,3 +1,18 @@
+/**
+ * The `gw://app` scheme: the renderer's own documents, the virtual
+ * `Gw.snapshot` assembled from cached chunks, and the fail-closed proxy to the
+ * allowlisted web services.
+ *
+ * Every filesystem path is resolved and then proved to still be under its root,
+ * so a traversal, an encoded separator or an embedded NUL cannot reach a file
+ * outside it. The snapshot is served from ranges only. Exactly two shared
+ * modules are reachable from `src/shared`, named here rather than inferred, and
+ * a route the proxy does not recognise is refused rather than forwarded.
+ *
+ * The response headers, including the CSP, are attached here for everything
+ * this scheme serves, so no individual handler can serve a document without
+ * them.
+ */
 import { app, protocol, net } from "electron";
 import { createReadStream } from "node:fs";
 import { stat } from "node:fs/promises";

--- a/src/main/renderer-commands.ts
+++ b/src/main/renderer-commands.ts
@@ -1,3 +1,13 @@
+/**
+ * Main→renderer commands, and the single owner of "which window is the
+ * renderer".
+ *
+ * Commands are typed values, never JavaScript source built by interpolation,
+ * and the window they may address is the one `renderer-trust.ts` recognises —
+ * the same rule `ipc.ts` applies to traffic coming the other way, so the two
+ * directions cannot drift into different ideas of what the renderer is. Only
+ * the renderer a command was sent to may complete it.
+ */
 import { BrowserWindow, ipcMain } from "electron";
 import {
   IPC,
@@ -6,13 +16,6 @@ import {
   type RendererCommandOutcome,
 } from "../shared/contracts.js";
 import { isCanonicalRendererUrl } from "./core/renderer-trust.js";
-
-/**
- * Main→renderer commands, and the single owner of "which window is the
- * renderer". `diagnostics.ts` used to answer that question itself with
- * `getURL().startsWith("gw://app")` — looser than the check `ipc.ts` applies to
- * traffic coming the other way — and built the command as JavaScript source.
- */
 
 interface Pending {
   webContentsId: number;

--- a/src/main/steam-acquire.ts
+++ b/src/main/steam-acquire.ts
@@ -1,3 +1,25 @@
+/**
+ * Open a hardened window the main process owns, run the Steam OAuth2 implicit
+ * flow in it, and return the access token it yields.
+ *
+ * The window matches or beats the game window's posture: its own
+ * in-memory session partition, no preload and no Node, deny-by-default
+ * permission and download handlers, no popups and no webviews, and top-level
+ * navigation confined to the fail-closed allowlist derived from `config`.
+ * Chromium owns subframe and resource isolation; neither can deliver the
+ * top-level redirect. That redirect is intercepted *before it is fetched*, its
+ * `state` is checked against the value generated for this attempt, and the
+ * window and its whole partition are destroyed the moment sign-in ends —
+ * success, refusal, or cancellation alike.
+ *
+ * Sign-in never renders in the game renderer, and this window is never the
+ * place a player is told to verify an origin: it is a sheet, so it draws no
+ * title bar and shows no URL. The allowlist and the sandbox controls above are
+ * what confine it.
+ *
+ * Never throws into the caller: a player whose sign-in failed belongs back at
+ * the client's login screen, not looking at an unhandled rejection.
+ */
 import { BrowserWindow, session, type Session } from "electron";
 import { randomUUID } from "node:crypto";
 import type { SteamRefusalReason } from "../shared/contracts.js";
@@ -36,23 +58,6 @@ export interface SteamAcquireOptions {
 
 const SIGN_IN_CLEANUP_DEADLINE_MS = 5_000;
 
-/**
- * Open a hardened window the main process owns, run the Steam OAuth2 implicit
- * flow in it, and return the access token it yields.
- *
- * The window matches or beats the game window's posture: its own
- * in-memory session partition, no preload and no Node, deny-by-default
- * permission and download handlers, no popups and no webviews, and top-level
- * navigation confined to the fail-closed allowlist derived from `config`.
- * Chromium owns subframe and resource isolation; neither can deliver the
- * top-level redirect. That redirect is intercepted *before it is fetched*, its
- * `state` is checked against the value generated for this attempt, and the
- * window and its whole partition are destroyed the moment sign-in ends —
- * success, refusal, or cancellation alike.
- *
- * Never throws into the caller: a player whose sign-in failed belongs back at
- * the client's login screen, not looking at an unhandled rejection.
- */
 /**
  * Build the partition and the window together, so a failure to construct either
  * is one thing the caller can catch. Separated out because everything here runs

--- a/src/main/window-menu.ts
+++ b/src/main/window-menu.ts
@@ -1,3 +1,12 @@
+/**
+ * The application menu, which is the whole keyboard-and-mouse surface of this
+ * application outside the game itself.
+ *
+ * Item ids are the contract the Electron specs click through, so an item keeps
+ * its id when it moves between submenus. Every item that opens a sheet or takes
+ * focus clears game input first: the game never sees the key that opened it
+ * released.
+ */
 import {
   app,
   dialog,
@@ -12,16 +21,6 @@ import { reportProblem } from "./problem-report.js";
 import { resetGameInput, sendRendererCommand } from "./renderer-commands.js";
 import { isDevBuild } from "./protocol.js";
 import type { WindowHost } from "./window.js";
-
-/**
- * The application menu, which is the whole keyboard-and-mouse surface of this
- * application outside the game itself.
- *
- * Item ids are the contract the Electron specs click through, so an item keeps
- * its id when it moves between submenus. Every item that opens a sheet or takes
- * focus clears game input first: the game never sees the key that opened it
- * released.
- */
 
 const USER_GUIDE_URL = `${EXTERNAL_URLS.github}/blob/main/docs/user-guide.md`;
 

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -1,3 +1,11 @@
+/**
+ * The game window: its creation, the navigation and permission handlers bound
+ * to it, and the owner-only state persisted beneath it.
+ *
+ * `window-menu.ts` and `problem-report.ts` own the surfaces that act on the
+ * window, so every transition of window state is written here and a menu
+ * handler can only ask for one.
+ */
 import {
   app,
   BrowserWindow,
@@ -30,15 +38,6 @@ import { isCanonicalRendererUrl } from "./core/renderer-trust.js";
 import { isQuitting } from "./lifecycle.js";
 import { gamePaths, preloadPath } from "./paths.js";
 import { installApplicationMenu } from "./window-menu.js";
-
-/**
- * The game window: its creation, the navigation and permission handlers bound
- * to it, and the owner-only state persisted beneath it.
- *
- * `window-menu.ts` and `problem-report.ts` own the surfaces that act on the
- * window, so every transition of window state is written here and a menu
- * handler can only ask for one.
- */
 
 // Tests launch the app dozens of times; without this they steal keyboard focus
 // on every launch. Focus-dependent specs leave the flag unset.

--- a/src/renderer/client-compatibility-notice.ts
+++ b/src/renderer/client-compatibility-notice.ts
@@ -1,9 +1,11 @@
-// What the player is told about the client build this session is running.
-//
-// The pure report below owns every compatibility sentence. The concrete DOM
-// binding at the end renders that same report in the launcher and Settings and
-// owns the notice acknowledgement. Certification gaps require a new release;
-// a runtime preparation failure is retryable and says so.
+/**
+ * What the player is told about the client build this session is running.
+ *
+ * The pure report below owns every compatibility sentence. The concrete DOM
+ * binding at the end renders that same report in the launcher and Settings and
+ * owns the notice acknowledgement. Certification gaps require a new release;
+ * a runtime preparation failure is retryable and says so.
+ */
 
 import type {
   ClientCompatibility,

--- a/src/renderer/client-exit.ts
+++ b/src/renderer/client-exit.ts
@@ -1,14 +1,16 @@
-// ArenaNet's client does not exit its Emscripten runtime when the player uses
-// the in-game X. Its exported main-loop callback performs the client's cleanup,
-// stops scheduling itself, and resolves successfully. `Module.onExit` therefore
-// never runs even though the client has finished.
-//
-// Own only that missing edge. `emscripten_async_call` is still ArenaNet's
-// scheduler for every other callback. The main loop is identified by function
-// identity against both the exported function and its table entry — the same
-// identity Emscripten's JSPI glue uses before wrapping the callback with
-// `WebAssembly.promising`. If a future client changes that contract, this
-// adapter delegates unchanged instead of guessing.
+/**
+ * ArenaNet's client does not exit its Emscripten runtime when the player uses
+ * the in-game X. Its exported main-loop callback performs the client's cleanup,
+ * stops scheduling itself, and resolves successfully. `Module.onExit` therefore
+ * never runs even though the client has finished.
+ *
+ * Own only that missing edge. `emscripten_async_call` is still ArenaNet's
+ * scheduler for every other callback. The main loop is identified by function
+ * identity against both the exported function and its table entry — the same
+ * identity Emscripten's JSPI glue uses before wrapping the callback with
+ * `WebAssembly.promising`. If a future client changes that contract, this
+ * adapter delegates unchanged instead of guessing.
+ */
 
 type WasmCallback = (...args: number[]) => unknown;
 type PromisingCallback = (...args: number[]) => Promise<unknown>;

--- a/src/renderer/client-health.ts
+++ b/src/renderer/client-health.ts
@@ -1,7 +1,9 @@
-// Confirms a newly published client only after the renderer has shown a frame
-// and opened a game socket. The main-process operation is idempotent, but IPC
-// or filesystem failures can be transient, so this controller makes a small,
-// bounded number of attempts instead of latching the first rejection forever.
+/**
+ * Confirms a newly published client only after the renderer has shown a frame
+ * and opened a game socket. The main-process operation is idempotent, but IPC
+ * or filesystem failures can be transient, so this controller makes a small,
+ * bounded number of attempts instead of latching the first rejection forever.
+ */
 
 import type { ClientHealthToken } from '../shared/contracts.js';
 

--- a/src/renderer/commands.ts
+++ b/src/renderer/commands.ts
@@ -1,10 +1,12 @@
-// The renderer's single subscriber to main→renderer commands. The main process
-// used to reach in with `executeJavaScript` and a string of source it had built
-// by interpolation; it now sends typed events, and this is the one place that
-// turns them into renderer actions.
-//
-// index.html loads this as a classic script, so the file carries no top-level
-// import or export and names the contracts through type-only `import(…)`.
+/**
+ * The renderer's single subscriber to main→renderer commands. The main process
+ * used to reach in with `executeJavaScript` and a string of source it had built
+ * by interpolation; it now sends typed events, and this is the one place that
+ * turns them into renderer actions.
+ *
+ * index.html loads this as a classic script, so the file carries no top-level
+ * import or export and names the contracts through type-only `import(…)`.
+ */
 (() => {
   'use strict';
 

--- a/src/renderer/companion-observer.ts
+++ b/src/renderer/companion-observer.ts
@@ -1,3 +1,16 @@
+/**
+ * The per-frame read of the companion kernel's shared memory, and the only
+ * place that decides how often it happens.
+ *
+ * One direction only: the kernel writes, this reads, and nothing here writes
+ * back into the module. A snapshot that fails its own validity check is counted
+ * and skipped rather than partly believed, so a torn or stale write costs one
+ * frame of readout and never a wrong number on screen.
+ *
+ * The consumers — cursor, readout, toolbox — are passed in and any of them may
+ * be absent, because which ones exist was decided when the module was derived
+ * and is not something to rediscover per frame.
+ */
 import {
   type CompanionToolboxState,
   readChangedCompanionToolbox,

--- a/src/renderer/companion-snapshot.ts
+++ b/src/renderer/companion-snapshot.ts
@@ -1,3 +1,19 @@
+/**
+ * The decoders for the three fixed-layout records the companion kernel
+ * publishes into shared memory: the game snapshot, the cursor, and the toolbox
+ * state.
+ *
+ * Shared memory is untrusted input here. Every record is checked against its
+ * magic, its ABI and its declared size, and each field is re-validated against
+ * the property the kernel claims to have enforced — coordinates for finiteness
+ * and range, agent types against the accepted bit patterns, flags against the
+ * known set. A decoder that agreed with the writer by construction would be
+ * evidence of nothing.
+ *
+ * The `*_ABI` and `*_BYTES` constants are the contract with the kernel. A
+ * layout change has to move both sides, so a mismatched pair decodes to a
+ * refusal instead of to plausible numbers.
+ */
 export const COMPANION_SNAPSHOT_ABI = 1;
 export const COMPANION_SNAPSHOT_BYTES = 64;
 

--- a/src/renderer/diagnostics.ts
+++ b/src/renderer/diagnostics.ts
@@ -1,8 +1,10 @@
-// Cheap renderer-side aggregation. Hot paths only mutate numbers; one bounded
-// batch crosses IPC every two seconds.
-//
-// index.html loads this as a classic script, so the file carries no top-level
-// import or export and names the contracts through type-only `import(…)`.
+/**
+ * Cheap renderer-side aggregation. Hot paths only mutate numbers; one bounded
+ * batch crosses IPC every two seconds.
+ *
+ * index.html loads this as a classic script, so the file carries no top-level
+ * import or export and names the contracts through type-only `import(…)`.
+ */
 (function () {
   'use strict';
 

--- a/src/renderer/enhancement-cursor.ts
+++ b/src/renderer/enhancement-cursor.ts
@@ -1,3 +1,14 @@
+/**
+ * Turns the cursor bitmap the kernel publishes into a CSS cursor.
+ *
+ * The authoring grid is fixed at 32x32 because Chromium silently drops a custom
+ * cursor larger than that; Retina crispness comes from the 2x candidate of the
+ * same `image-set`, never from a bigger grid. The images are data URLs because
+ * the CSP governs cursor images through `img-src`, which bars `blob:`.
+ *
+ * The cache is bounded on purpose. Drag cursors are composed at runtime, so an
+ * unbounded map would grow with every distinct pointer the game ever draws.
+ */
 import {
   readCompanionCursorHeader,
   readCompanionCursorPixels,

--- a/src/renderer/enhancement-manifest.ts
+++ b/src/renderer/enhancement-manifest.ts
@@ -1,3 +1,15 @@
+/**
+ * Reads the fixed evidence section the Enhancement transform wrote into the
+ * derived module, and refuses anything that is not exactly what this build
+ * expects.
+ *
+ * This is the renderer's proof that the module it was handed came from the
+ * transform this build ships. The ABI, the capability set, the hooks and the
+ * whole config-word vector must match, with exact key sets rather than
+ * supersets, and a field that is merely present is not accepted. Installing
+ * hooks against a layout derived from a different client is how a game gets
+ * corrupted memory rather than an error message.
+ */
 import {
   enhancementCapabilitiesRequested,
   ENHANCEMENT_CONFIG_WORD_COUNT,

--- a/src/renderer/enhancement-settings.ts
+++ b/src/renderer/enhancement-settings.ts
@@ -1,11 +1,13 @@
-// The Enhancement registry reaches the renderer through gwNative.init. This module
-// owns only the Settings-pane surface and the words it needs; it is not a
-// general settings framework. The first-run gate deliberately carries no tool
-// checkboxes: the defaults are right for a first launch, and Settings is where
-// a player who has formed an opinion changes them.
-//
-// index.html loads this as a classic script, so the file carries no top-level
-// import or export and names the contracts through type-only `import(…)`.
+/**
+ * The Enhancement registry reaches the renderer through gwNative.init. This module
+ * owns only the Settings-pane surface and the words it needs; it is not a
+ * general settings framework. The first-run gate deliberately carries no tool
+ * checkboxes: the defaults are right for a first launch, and Settings is where
+ * a player who has formed an opinion changes them.
+ *
+ * index.html loads this as a classic script, so the file carries no top-level
+ * import or export and names the contracts through type-only `import(…)`.
+ */
 
 (function () {
   type AppSettings = import('../shared/contracts.js').AppSettings;

--- a/src/renderer/enhancements.ts
+++ b/src/renderer/enhancements.ts
@@ -1,3 +1,17 @@
+/**
+ * Installs the companion kernel into the running client: verifies the exports
+ * it needs, allocates its shared memory, hands it the manifest's config, and
+ * starts the observer.
+ *
+ * All or nothing. Every precondition is checked before anything is allocated,
+ * and any failure afterwards releases everything this installation took before
+ * rethrowing, so there is no state where some hooks are live and others are
+ * not. A module that carries no decodable manifest, or that lacks an export the
+ * kernel needs, gets no kernel at all rather than a partial one.
+ *
+ * What a failed installation costs the launch is the harness's decision, not
+ * this module's.
+ */
 import {
   enhancementCapabilitiesFor,
   enhancementCapabilityProfile,

--- a/src/renderer/failure-messages.ts
+++ b/src/renderer/failure-messages.ts
@@ -1,15 +1,17 @@
-// The one place a failure becomes a sentence.
-//
-// The main process sends codes and never prose: it cannot see the UI, its
-// strings cannot be tested against what the player actually reads, and free
-// text on a channel is what let an error message reach the diagnostics export
-// in the first place. So every user-facing failure sentence is written here,
-// beside the surface that shows it, and a unit test executes this file.
-//
-// The maps are deliberately partial. Most of the catalogue names a fault in
-// something the player cannot act on, and inventing fifty sentences to say
-// "it broke" fifty ways would be worse than one honest default. A code earns
-// an entry only when it changes what the player should *do*.
+/**
+ * The one place a failure becomes a sentence.
+ *
+ * The main process sends codes and never prose: it cannot see the UI, its
+ * strings cannot be tested against what the player actually reads, and free
+ * text on a channel is what let an error message reach the diagnostics export
+ * in the first place. So every user-facing failure sentence is written here,
+ * beside the surface that shows it, and a unit test executes this file.
+ *
+ * The maps are deliberately partial. Most of the catalogue names a fault in
+ * something the player cannot act on, and inventing fifty sentences to say
+ * "it broke" fifty ways would be worse than one honest default. A code earns
+ * an entry only when it changes what the player should *do*.
+ */
 
 import type { NoticeCode, SteamRefusalReason } from '../shared/contracts.js';
 import type { ErrorCode } from '../shared/errors.js';

--- a/src/renderer/filesystem.ts
+++ b/src/renderer/filesystem.ts
@@ -1,8 +1,10 @@
-// ArenaNet's Emscripten client mounts IDBFS at app:, but it does so from
-// main() after preRun. The WASM can open and write files but has no mkdir
-// import, and it leaves the process working directory at the ephemeral MEMFS
-// root. Own the mount once, before main(), so every relative game file is
-// durable and the required template directories already exist.
+/**
+ * ArenaNet's Emscripten client mounts IDBFS at app:, but it does so from
+ * main() after preRun. The WASM can open and write files but has no mkdir
+ * import, and it leaves the process working directory at the ephemeral MEMFS
+ * root. Own the mount once, before main(), so every relative game file is
+ * durable and the required template directories already exist.
+ */
 const MOUNT = 'app:';
 const DEPENDENCY = 'gw-persistent-filesystem';
 const SYNC_TIMEOUT_MS = 30_000;

--- a/src/renderer/gl-program-cache.ts
+++ b/src/renderer/gl-program-cache.ts
@@ -1,12 +1,14 @@
-// ArenaNet's client uses KHR_parallel_shader_compile and polls
-// glGetProgramiv(program, COMPLETION_STATUS_KHR) in a loop while a program
-// compiles asynchronously. Chromium cannot answer that from its client-side
-// cache, so every poll flushes the command buffer and waits on the GPU
-// process. A recon session measured 36,713 polls against roughly 250 programs.
-//
-// Completion is the only thing memoized, and only once it reads true, and only
-// while the host has seen the program created and not deleted. Everything else
-// is passed through, including enums this file does not know about.
+/**
+ * ArenaNet's client uses KHR_parallel_shader_compile and polls
+ * glGetProgramiv(program, COMPLETION_STATUS_KHR) in a loop while a program
+ * compiles asynchronously. Chromium cannot answer that from its client-side
+ * cache, so every poll flushes the command buffer and waits on the GPU
+ * process. A recon session measured 36,713 polls against roughly 250 programs.
+ *
+ * Completion is the only thing memoized, and only once it reads true, and only
+ * while the host has seen the program created and not deleted. Everything else
+ * is passed through, including enums this file does not know about.
+ */
 const COMPLETION_STATUS_KHR = 0x91b1;
 const GL_TRUE = 1;
 

--- a/src/renderer/graphics.ts
+++ b/src/renderer/graphics.ts
@@ -1,6 +1,8 @@
-// ArenaNet's EGL adapter. The generated client owns context creation and canvas
-// sizing; this module only supplies the OffscreenCanvas presentation path and
-// the selected render density.
+/**
+ * ArenaNet's EGL adapter. The generated client owns context creation and canvas
+ * sizing; this module only supplies the OffscreenCanvas presentation path and
+ * the selected render density.
+ */
 
 let diagnosticsFrame = 0;
 

--- a/src/renderer/gw-native.d.ts
+++ b/src/renderer/gw-native.d.ts
@@ -1,3 +1,13 @@
+/**
+ * The renderer's global surface: `window.gwNative`, the controllers the host
+ * installs alongside it, and the shape of `Module` as this application uses it.
+ *
+ * Declarations only. Everything named here is implemented elsewhere — in the
+ * preload, in the harness, or by ArenaNet's generated glue — so this file
+ * changes nothing at runtime. It exists so the renderer's classic scripts are
+ * checked against one description of that surface rather than against each
+ * other's assumptions.
+ */
 import type {
   AppSettings,
   AppSettingsPatch,

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -1,10 +1,12 @@
-// Host for Gw.jspi.wasm inside the Electron renderer. Platform services are
-// injected on Module; privileged work goes through window.gwNative.
-//
-// index.html loads this as a classic script, and it must stay one: a top-level
-// import or export would make this an ES module, and the redeclaration below
-// only works between two `var`s in the same global script. Every type here is
-// therefore named through type-only `import(…)`.
+/**
+ * Host for Gw.jspi.wasm inside the Electron renderer. Platform services are
+ * injected on Module; privileged work goes through window.gwNative.
+ *
+ * index.html loads this as a classic script, and it must stay one: a top-level
+ * import or export would make this an ES module, and the redeclaration below
+ * only works between two `var`s in the same global script. Every type here is
+ * therefore named through type-only `import(…)`.
+ */
 
 /**
  * The generated glue's import object. Four renderer modules patch or read it,

--- a/src/renderer/image-source.ts
+++ b/src/renderer/image-source.ts
@@ -1,11 +1,13 @@
-// The snapshot image behind `Module.image`: metadata, a byte-budgeted LRU over
-// renderer memory, native residency, request coalescing, range assembly, and
-// the eight-request scheduler that lets a demand read overtake prefetch work.
-//
-// harness.js owned all of this until P6.2 and now owns only the wiring: the
-// HTTP range fetch, the WASM heap write, and the console helpers over stats().
-// Nothing here touches `window`, `fetch` or `Module`, which is what makes the
-// algorithms testable.
+/**
+ * The snapshot image behind `Module.image`: metadata, a byte-budgeted LRU over
+ * renderer memory, native residency, request coalescing, range assembly, and
+ * the eight-request scheduler that lets a demand read overtake prefetch work.
+ *
+ * harness.js owned all of this until P6.2 and now owns only the wiring: the
+ * HTTP range fetch, the WASM heap write, and the console helpers over stats().
+ * Nothing here touches `window`, `fetch` or `Module`, which is what makes the
+ * algorithms testable.
+ */
 
 import type { SnapshotMetadata } from '../shared/contracts.js';
 

--- a/src/renderer/input.ts
+++ b/src/renderer/input.ts
@@ -1,5 +1,7 @@
-// Renderer-owned game input. The Emscripten host installs this once before its
-// glue loads; native interruptions all converge on releaseAll().
+/**
+ * Renderer-owned game input. The Emscripten host installs this once before its
+ * glue loads; native interruptions all converge on releaseAll().
+ */
 
 // Canvases a held drag may wander from the one it started on. The client keeps
 // integrating mouse moves whose coordinates fall outside the canvas, so a drag

--- a/src/renderer/loading.ts
+++ b/src/renderer/loading.ts
@@ -1,8 +1,10 @@
-// Loading screen: owns everything the user sees before the canvas appears.
-// Progress comes from the main-process updater via gwNative, not HTTP polling.
-//
-// index.html loads this as a classic script, so the file carries no top-level
-// import or export and names the contracts through type-only `import(…)`.
+/**
+ * Loading screen: owns everything the user sees before the canvas appears.
+ * Progress comes from the main-process updater via gwNative, not HTTP polling.
+ *
+ * index.html loads this as a classic script, so the file carries no top-level
+ * import or export and names the contracts through type-only `import(…)`.
+ */
 
 window.gwAutomation = (function (): EnhancementAutomation {
   let stage = 'renderer.loading';

--- a/src/renderer/platform-capabilities.ts
+++ b/src/renderer/platform-capabilities.ts
@@ -1,7 +1,9 @@
-// ArenaNet's current glue has two defective absence guards: ad playback falls
-// through after reporting failure, and shop purchase dereferences Module.shop
-// before checking it. Keep only those two namespaces, with explicit unavailable
-// semantics. Properly guarded optional namespaces are intentionally absent.
+/**
+ * ArenaNet's current glue has two defective absence guards: ad playback falls
+ * through after reporting failure, and shop purchase dereferences Module.shop
+ * before checking it. Keep only those two namespaces, with explicit unavailable
+ * semantics. Properly guarded optional namespaces are intentionally absent.
+ */
 
 /**
  * The shop namespace ArenaNet's glue expects to find. The four callbacks are

--- a/src/renderer/progress-display.ts
+++ b/src/renderer/progress-display.ts
@@ -1,3 +1,14 @@
+/**
+ * The two throttled readouts on the loading screen: the minutes-remaining
+ * estimate and the detail line under the bar.
+ *
+ * Both exist because progress arrives on every chunk completion, in bursts, and
+ * a number rewritten that often is unreadable even while it is correct. Neither
+ * smooths the underlying values — the rate is already smoothed where it is
+ * computed — they decide only when a changed value is allowed to reach the
+ * screen, and a value that stops being available is shown immediately rather
+ * than left stale.
+ */
 import type { DownloadActivity } from "../shared/contracts.js";
 
 /**

--- a/src/renderer/settings.ts
+++ b/src/renderer/settings.ts
@@ -1,8 +1,10 @@
-// One owner for launcher strategy, full-download presentation, and Settings.
-// Cache residency is the download-progress truth; dataStrategy is only intent.
-//
-// index.html loads this as a classic script, so the file carries no top-level
-// import or export and names the contracts through type-only `import(…)`.
+/**
+ * One owner for launcher strategy, full-download presentation, and Settings.
+ * Cache residency is the download-progress truth; dataStrategy is only intent.
+ *
+ * index.html loads this as a classic script, so the file carries no top-level
+ * import or export and names the contracts through type-only `import(…)`.
+ */
 
 (function () {
   type AppSettings = import('../shared/contracts.js').AppSettings;

--- a/src/renderer/socket-host.ts
+++ b/src/renderer/socket-host.ts
@@ -1,3 +1,14 @@
+/**
+ * The renderer half of the game's TCP: one object per connection carrying the
+ * three callbacks ArenaNet's glue assigns, multiplexed over the single native
+ * event stream.
+ *
+ * The main process owns the handles, the destination checks and the
+ * backpressure; this owns the demultiplexing and nothing else. An event that
+ * arrives for a socket the caller has not finished creating is queued rather
+ * than dropped — the connect round trip can complete first — and is delivered
+ * in arrival order once the object exists.
+ */
 import type { GwNativeApi, SocketEvent } from '../shared/contracts.js';
 
 // The bridge's own socket surface, named rather than restated: this host is the

--- a/src/renderer/template-filesystem-trace.ts
+++ b/src/renderer/template-filesystem-trace.ts
@@ -1,3 +1,16 @@
+/**
+ * A development-only trace of the file syscalls the client makes while saving
+ * or loading a template.
+ *
+ * It wraps the WASM imports in order to watch them and passes every call
+ * through unchanged: it answers nothing, repairs nothing, and alters no result.
+ * Events are bounded and go to the developer console alone — nothing here
+ * reaches the flight recorder, because the paths, descriptors and flags it
+ * records are precisely what a diagnostics export may not contain.
+ *
+ * Installed only when the launch argument says so, which no packaged build
+ * sets.
+ */
 const EVENT_LIMIT = 128;
 const TRACE_PREFIX = '[template-fs-trace]';
 

--- a/src/renderer/template-save-compatibility.ts
+++ b/src/renderer/template-save-compatibility.ts
@@ -1,15 +1,17 @@
-// Host half of the derived-client bridge in src/main/core/template-save-compat.ts.
-//
-// Four `Base/Os` file routines ship unimplemented in ArenaNet's Emscripten
-// build: creating a directory always fails, enumerating one does nothing,
-// deriving a name from an entry writes nothing, and deleting a file aborts the
-// client. A fifth is implemented but wrong — opening a file to test whether it
-// exists creates it. The derived module forwards all five to
-// `__syscall_newfstatat` behind dirfd markers that no real call produces, and
-// they are answered here against the mounted IDBFS.
-// Not a mirror any more: the canonical values reach this sandboxed renderer
-// module through the generated preload, so the transform that writes the
-// markers into the module and the code that answers them cannot disagree.
+/**
+ * Host half of the derived-client bridge in src/main/core/template-save-compat.ts.
+ *
+ * Four `Base/Os` file routines ship unimplemented in ArenaNet's Emscripten
+ * build: creating a directory always fails, enumerating one does nothing,
+ * deriving a name from an entry writes nothing, and deleting a file aborts the
+ * client. A fifth is implemented but wrong — opening a file to test whether it
+ * exists creates it. The derived module forwards all five to
+ * `__syscall_newfstatat` behind dirfd markers that no real call produces, and
+ * they are answered here against the mounted IDBFS.
+ * Not a mirror any more: the canonical values reach this sandboxed renderer
+ * module through the generated preload, so the transform that writes the
+ * markers into the module and the code that answers them cannot disagree.
+ */
 const {
   ensureDirectory: ENSURE_DIRECTORY,
   findFiles: FIND_FILES,

--- a/src/renderer/toolbox-foundation.ts
+++ b/src/renderer/toolbox-foundation.ts
@@ -1,3 +1,14 @@
+/**
+ * The Tools overlay: the HUD chip and the panel behind it, drawn above the game
+ * canvas.
+ *
+ * It renders the state it is handed and asks the game for nothing. There is
+ * deliberately no widget registry, plugin surface or layout engine behind it —
+ * a second tool can introduce one when it exists and needs it.
+ *
+ * The overlay is chrome, so it owns only its own pixels: every click that is
+ * not on Tools chrome still belongs to the game.
+ */
 type ToolboxState = Readonly<{
   status: string;
   playerChatCount?: number;

--- a/src/renderer/update-action.ts
+++ b/src/renderer/update-action.ts
@@ -1,3 +1,15 @@
+/**
+ * The update control as a player meets it: what the button says, what pressing
+ * it does, and the sentence underneath.
+ *
+ * Every update failure becomes prose here. The main process sends a code; the
+ * words live beside the surface that shows them, where a test can execute them
+ * and where free text cannot escape onto a channel and into a diagnostics
+ * export.
+ *
+ * The action's state machine is pure and kept apart from the DOM binding, so
+ * what the button does is testable without a window.
+ */
 import type {
   AppUpdateErrorCode,
   AppUpdateState,

--- a/src/renderer/wasm-abort-reason.ts
+++ b/src/renderer/wasm-abort-reason.ts
@@ -1,6 +1,8 @@
-// The renderer-side collapse of an Emscripten abort: prose in, closed
-// vocabulary plus non-text fingerprint out. This is the only shape allowed to
-// cross IPC — the abort message itself stays in this process.
+/**
+ * The renderer-side collapse of an Emscripten abort: prose in, closed
+ * vocabulary plus non-text fingerprint out. This is the only shape allowed to
+ * cross IPC — the abort message itself stays in this process.
+ */
 import type { WasmAbortReasonKind } from '../shared/diagnostics.js';
 
 /**

--- a/src/shared/automation.ts
+++ b/src/shared/automation.ts
@@ -1,3 +1,11 @@
+/**
+ * The closed set of commands the developer automation harness may issue.
+ *
+ * Two capture controls and nothing else. The list is a union rather than an
+ * open string so an automation build cannot reach a capability by naming it,
+ * and it lives in `shared` because both sides of the harness must agree on the
+ * spelling — not because the surface is meant to grow.
+ */
 export const AUTOMATION_COMMAND = Object.freeze({
   startLevel1Capture: "diagnostics:start-level-1",
   stopCapture: "diagnostics:stop",

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -1,3 +1,19 @@
+/**
+ * The canonical contracts between main, the preload and the renderer: the IPC
+ * channels, the settings, the progress and socket shapes, the Enhancement
+ * capability profiles, and the closed vocabularies each side validates against.
+ *
+ * These are types and frozen values only. Nothing here has behaviour, imports
+ * Electron, or touches a filesystem, which is what lets both processes and the
+ * generated preload share one definition rather than three copies that agree
+ * until they do not.
+ *
+ * The closed unions are the load-bearing part. A channel, a notice, a refusal
+ * or a capability profile exists only if it is listed here, so adding one is a
+ * deliberate edit that the compiler then demands both sides honour. Codes cross
+ * these boundaries; the sentence a player reads is written in the renderer,
+ * where it can be tested against what is actually shown.
+ */
 import type {
   DiagnosticSummary,
   RendererFrameBatch,

--- a/src/shared/diagnostics.ts
+++ b/src/shared/diagnostics.ts
@@ -1,3 +1,17 @@
+/**
+ * The vocabulary main and the renderer share when they talk about measurements:
+ * levels, subsystems, histogram buckets, the renderer's metrics and milestones,
+ * and the summary and report shapes an export carries.
+ *
+ * Every one of them is a closed union. A renderer failure crosses IPC as an
+ * allow-listed name plus non-text fingerprints, never as console output, and a
+ * metric that is not named here has no way to reach the recorder at all.
+ *
+ * The bucket boundaries are part of the contract, not a tuning constant: two
+ * sessions can only be compared if their histograms were bucketed identically,
+ * so changing them makes existing exports incomparable rather than merely
+ * differently shaped.
+ */
 export type DiagnosticLevel = "debug" | "info" | "warn" | "error";
 
 export type DiagnosticSubsystem =

--- a/src/shared/digest.ts
+++ b/src/shared/digest.ts
@@ -1,3 +1,15 @@
+/**
+ * A SHA-256 digest as a type the compiler can keep apart from any other string.
+ *
+ * The brand is the point. Digests identify bytes and are safe to record; prose
+ * quotes paths, hostnames and manifest entries and is not. Making them
+ * different types means the diagnostics schema can accept one and reject the
+ * other at compile time, instead of relying on every producer to remember which
+ * of its strings was which.
+ *
+ * A `Digest` is created only by `asDigest`, and only from a lower-case 64-hex
+ * string. There is no cast that skips the check.
+ */
 import { AppError } from "./errors.js";
 
 /** A lower-case SHA-256 digest. It can identify bytes; it can never be prose. */

--- a/src/shared/distribution-channel.ts
+++ b/src/shared/distribution-channel.ts
@@ -1,3 +1,19 @@
+/**
+ * The three provisioned distribution channels and what each is allowed to do.
+ *
+ * Their distinct bundle IDs are what give them mutually isolated Data
+ * Protection Keychain groups, so this table decides which secrets an
+ * installation can even reach. The marker is configuration and not
+ * authorization: the host bundle ID, the application-identifier entitlement and
+ * the provisioning profile are what actually grant access, and
+ * `parseDistributionMarker` refuses anything that is not exactly one of the
+ * three — a marker with an extra key, a foreign repository, or an unknown
+ * channel yields `null`, and `null` means volatile secrets and no automatic
+ * updates.
+ *
+ * There is no fourth channel and no way to synthesise one. Adding a channel
+ * means provisioning a bundle ID, not editing a string here.
+ */
 import { APPLE_TEAM_ID, RELEASE_REPO } from "./project-identity.js";
 
 export { APPLE_TEAM_ID } from "./project-identity.js";

--- a/src/shared/progress.ts
+++ b/src/shared/progress.ts
@@ -1,3 +1,15 @@
+/**
+ * The shape of download progress and the arithmetic every surface derives from
+ * it: the initial value, the estimate, and the smoothed rate.
+ *
+ * A rate is computed once, here, so the launcher, the Dock and the diagnostics
+ * gauges cannot disagree about how fast a download is going. Chunk completions
+ * arrive in bursts, so the average is time-weighted and samples are committed
+ * at most twice a second — an instantaneous rate over a millisecond interval is
+ * an arithmetically correct number that tells the player nothing true.
+ *
+ * Nothing here formats a sentence or knows what a phase is called on screen.
+ */
 import type {
   DownloadActivity,
   DownloadProgress,

--- a/src/shared/project-identity.ts
+++ b/src/shared/project-identity.ts
@@ -1,2 +1,13 @@
+/**
+ * The two identifiers that name this project to services outside it: the GitHub
+ * repository releases are read from, and the Apple Team ID its bundles are
+ * signed under.
+ *
+ * They live alone, with no imports, because build scripts, the packaging
+ * configuration, the updater and the distribution channels all need them and
+ * none of those may become the place the others read them from. Changing either
+ * changes which releases an installation trusts and which Keychain groups its
+ * secrets belong to.
+ */
 export const RELEASE_REPO = "Mat4m0/gwonmac";
 export const APPLE_TEAM_ID = "9NN976MFZ4";

--- a/src/shared/release.ts
+++ b/src/shared/release.ts
@@ -1,16 +1,18 @@
-// One parse, one comparison, one channel policy for this project's releases.
-//
-// Three places currently answer "is that version newer than this one, and may
-// it be offered?" and they disagree: the update/mismatch check in main, the
-// website's download resolver, and the release workflow's own tag validation.
-// A disagreement here is user-visible — an install told it is up to date when
-// it is not, or a download button pointing at a prerelease.
-//
-// SemVer only. The versioning *scheme* (CalVer semantics in SemVer syntax) is a
-// product decision owned by scripts/macos-version.ts and the release workflow;
-// nothing in this file knows what a year or a month is. It knows the shapes
-// .github/workflows/release.yml actually publishes: `X.Y.Z`, optionally
-// `-alpha.N` / `-beta.N` / `-rc.N`, optionally tag-prefixed with `v`.
+/**
+ * One parse, one comparison, one channel policy for this project's releases.
+ *
+ * Three places currently answer "is that version newer than this one, and may
+ * it be offered?" and they disagree: the update/mismatch check in main, the
+ * website's download resolver, and the release workflow's own tag validation.
+ * A disagreement here is user-visible — an install told it is up to date when
+ * it is not, or a download button pointing at a prerelease.
+ *
+ * SemVer only. The versioning *scheme* (CalVer semantics in SemVer syntax) is a
+ * product decision owned by scripts/macos-version.ts and the release workflow;
+ * nothing in this file knows what a year or a month is. It knows the shapes
+ * .github/workflows/release.yml actually publishes: `X.Y.Z`, optionally
+ * `-alpha.N` / `-beta.N` / `-rc.N`, optionally tag-prefixed with `v`.
+ */
 
 export type ReleaseChannel = "alpha" | "beta" | "rc" | "stable";
 

--- a/src/tools/diagnostics/attribute-frames.ts
+++ b/src/tools/diagnostics/attribute-frames.ts
@@ -1,13 +1,23 @@
+/**
+ * `pnpm diagnostics:attribute-frames`: attributes long visible-frame gaps in a
+ * Level 1 capture to what the main process was doing around them.
+ *
+ * Level 1 is where gains are judged, because Level 2 traces are
+ * profiler-contaminated — but until this, a Level 1 stall could be seen and not
+ * explained. The join runs against main-process timestamps because the main
+ * process keeps running while the renderer is frozen, so its clock is the
+ * reliable side.
+ *
+ * A gap it cannot account for is reported as uninstrumented rather than
+ * assigned to the nearest event. Continuous per-sample telemetry is excluded
+ * from consideration outright: something that is always happening explains
+ * nothing.
+ */
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { withCapture } from "./common.js";
 
-// Level 2 traces locate causes but are profiler-contaminated, so gains are
-// judged at Level 1 — where until now a stall could not be attributed at all.
-// This joins visible-frame gaps to the main-process events that surround them.
-// The main process keeps running while the renderer is frozen, so its
-// timestamps are the reliable side of the join.
 const DEFAULT_THRESHOLD_US = 100_000;
 const CORRELATION_US = 1_500_000;
 const BLOCKED_MAIN_US = 200_000;

--- a/src/tools/diagnostics/attribute-stalls.ts
+++ b/src/tools/diagnostics/attribute-stalls.ts
@@ -1,3 +1,15 @@
+/**
+ * `pnpm diagnostics:attribute-stalls`: locates long frame gaps inside a Level 2
+ * Chromium trace and names the stack that was running through them.
+ *
+ * This is the causal tool and it is not the measurement tool. The trace it
+ * reads is profiler-contaminated, so its durations may not be quoted as
+ * evidence of a gain — it answers where the time went, and Level 1 answers how
+ * much time there was.
+ *
+ * A capture with no trace-aligned frame marks says so and stops, rather than
+ * attributing stalls to whatever else the trace happened to contain.
+ */
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";

--- a/src/tools/diagnostics/common.ts
+++ b/src/tools/diagnostics/common.ts
@@ -1,3 +1,17 @@
+/**
+ * What every `.gwdiag` reader needs: unpacking one into a temporary directory,
+ * parsing its documents, and the validation each command runs before it prints
+ * a number.
+ *
+ * A capture is opened here and nowhere else, so the tools cannot disagree about
+ * what a valid archive is, and the temporary directory is removed even when the
+ * caller throws. Validation is separate from reading on purpose: a capture with
+ * warnings is still readable, and a command decides for itself whether to
+ * refuse or to print them alongside its output.
+ *
+ * These are developer tools. They read exports; nothing here produces one, and
+ * nothing here reaches into a running application.
+ */
 import { execFile } from "node:child_process";
 import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";

--- a/src/tools/diagnostics/compare.ts
+++ b/src/tools/diagnostics/compare.ts
@@ -1,3 +1,12 @@
+/**
+ * `pnpm diagnostics:compare`: two captures side by side.
+ *
+ * The comparison is only as good as the pairing, so the mismatches that make
+ * two captures incomparable — a different application version, a different
+ * capture level, a profiler-contaminated arm — are reported as warnings before
+ * any figure is shown. Level 2 traces locate causes but do not establish gains;
+ * a comparison drawn from them is a lead, not a result.
+ */
 import { resolve } from "node:path";
 import type { Capture } from "./common.js";
 import {

--- a/src/tools/diagnostics/summarize.ts
+++ b/src/tools/diagnostics/summarize.ts
@@ -1,3 +1,13 @@
+/**
+ * `pnpm diagnostics:summarize`: the readable account of one capture — startup
+ * milestones, frame and read percentiles, cache behaviour, socket volume.
+ *
+ * Presentation only. Every number is read from the export's own summary and
+ * counters; nothing here recomputes a statistic or infers one the recorder did
+ * not measure. Validation warnings are printed rather than suppressed, because
+ * a percentile from an incomplete capture is worth less than the knowledge that
+ * it was incomplete.
+ */
 import { resolve } from "node:path";
 import { withCapture, validateCapture } from "./common.js";
 

--- a/src/tools/diagnostics/validate.ts
+++ b/src/tools/diagnostics/validate.ts
@@ -1,3 +1,11 @@
+/**
+ * `pnpm diagnostics:validate`: says whether one `.gwdiag` is internally
+ * consistent, and exits non-zero when it is not.
+ *
+ * Argument handling and one call into the shared reader. The rules it enforces
+ * belong to `common.ts`; this file owns the command's usage line and its exit
+ * codes, so no rule is stated twice.
+ */
 import { resolve } from "node:path";
 import { withCapture, validateCapture } from "./common.js";
 

--- a/src/tools/enhancement-doctor.ts
+++ b/src/tools/enhancement-doctor.ts
@@ -1,3 +1,16 @@
+/**
+ * `pnpm enhancements:doctor`: reports why Enhancement is or is not running on
+ * this machine, before anyone starts guessing.
+ *
+ * It reads the real profile — the installed client, its published manifest, the
+ * derived cache, the settings file — and reports what it found. It repairs
+ * nothing, downloads nothing and writes nothing, so running it can never be the
+ * reason a subsequent launch behaves differently.
+ *
+ * Certification is asked of `client-certification.ts` rather than re-derived
+ * here, so the doctor and the launch cannot disagree about what state a build
+ * is in.
+ */
 import { createHash } from "node:crypto";
 import { readdir, readFile, stat } from "node:fs/promises";
 import { homedir } from "node:os";

--- a/src/tools/enhancement-recertify.ts
+++ b/src/tools/enhancement-recertify.ts
@@ -1,3 +1,17 @@
+/**
+ * `pnpm enhancements:recertify`: derives a candidate Enhancement build entry
+ * from a client this repository does not yet know, and prints the evidence
+ * behind it.
+ *
+ * It proposes; a human certifies. The output is a draft table entry plus the
+ * structural findings that produced it, and every output hash is obtained by
+ * actually running the transform rather than by prediction. Nothing here edits
+ * the shipped tables — an entry becomes certified when a person reads the
+ * evidence and commits it.
+ *
+ * It recovers indices, not semantics. What the hooked functions mean still has
+ * to be re-measured; `internal/upstream/recertify.md` owns that work.
+ */
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/src/tools/enhancement-structural-evidence.ts
+++ b/src/tools/enhancement-structural-evidence.ts
@@ -1,3 +1,16 @@
+/**
+ * The structural analysis behind a recertification: what a client module's own
+ * shape says about where the Enhancement hooks belong.
+ *
+ * Every answer is evidence with a status attached, never a conclusion.
+ * `candidate` means one location survived all the anchors; `ambiguous` means
+ * several did and a human must choose; `unavailable` names the specific reason
+ * the analysis could not run. A single best guess is deliberately not offered —
+ * silently picking one of two candidates is how a wrong hook gets certified.
+ *
+ * The analysis is bounded: oversized inputs, unsupported module shapes and
+ * exceeded work limits are reported as failures rather than pursued.
+ */
 import { createHash } from "node:crypto";
 import {
   parseCode,

--- a/src/tools/enhancement-transform.ts
+++ b/src/tools/enhancement-transform.ts
@@ -1,3 +1,17 @@
+/**
+ * `pnpm enhancements:transform`: runs the Enhancement transform over one client
+ * module on the command line, for inspecting the derived bytes outside a
+ * launch.
+ *
+ * It emits one fixed profile. The other certified profiles are selected through
+ * the application path that owns their cache identity, and reproducing that
+ * selection here would be a second place where a capability set decides which
+ * output is correct.
+ *
+ * The transform, the build lookup and the expected output hash all come from
+ * the application's own modules, so this command cannot produce bytes a launch
+ * would not.
+ */
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
@@ -12,9 +26,6 @@ import {
   ENHANCEMENT_TRANSFORM_ABI,
 } from "../shared/contracts.js";
 
-// This developer command emits the fixed foundation derivative: native cursor
-// plus Toolbox. Other exact profiles are selected by settings or live-program
-// intent through the application path that owns their cache identity.
 const FOUNDATION_CAPABILITIES = ENHANCEMENT_CAPABILITY_PROFILES.cursorToolbox;
 
 const [inputPath, outputPath] = process.argv.slice(2).filter((arg) => arg !== "--");

--- a/src/tools/template-save-recert.ts
+++ b/src/tools/template-save-recert.ts
@@ -1,3 +1,15 @@
+/**
+ * The template-save recertification report: run the shape-based derivation over
+ * a client module and say how the result differs from the entry in the table.
+ *
+ * The derivation itself belongs to `template-save-verifier.ts` and is
+ * re-exported rather than reimplemented, so the manual report and the
+ * production decision cannot drift. What this file owns is the comparison and
+ * the shape of its output.
+ *
+ * An empty difference list means the checked-in entry is still exact. A
+ * non-empty one is a finding for a human to read, never an entry to apply.
+ */
 import {
   analyzeTemplateSaveCandidate,
 } from "../main/core/template-save-verifier.js";

--- a/src/tools/template-save-recertify.ts
+++ b/src/tools/template-save-recertify.ts
@@ -1,3 +1,13 @@
+/**
+ * `pnpm template:recertify`: the command around the template-save
+ * recertification report.
+ *
+ * Argument parsing, locating the installed client, printing, and the exit code
+ * — nothing else. It uses the same production locator the application does, so
+ * the module it inspects is the module a launch would serve. `--expect-certified`
+ * turns a difference into a non-zero exit, which is what makes this usable as a
+ * check rather than only as a report.
+ */
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";

--- a/tests/policy/source-module-headers.test.ts
+++ b/tests/policy/source-module-headers.test.ts
@@ -1,0 +1,96 @@
+// Reads repository text, and says so in its filename. A module that opens on
+// its import block tells a reader what it uses and never what it owns, so the
+// first question about any file — what is mine, and what do I refuse? — could
+// only be answered by reading the whole file and inferring. That inference is
+// how two modules end up owning the same invariant.
+//
+// The rule is deliberately about presence, not content: a test cannot tell a
+// truthful header from a plausible one. What it can do is make the absence of
+// one a build failure rather than something a reviewer has to notice.
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+const SOURCE = /^src\/.+\.(?:m|c)?ts$/u;
+
+// Files that genuinely cannot carry a header, each with the reason. It is
+// empty, and the staleness assertion below keeps it that way: an entry that
+// stops being needed fails rather than lingering as permission nobody rechecks.
+//
+// `src/preload/preload.body.cjs` is not here because it is not in scope. It is
+// CommonJS — the sandbox loader executes no ESM preload graph — and it does
+// carry its own header; `scripts/generate-preload.ts`, which splices the
+// canonical constants above it, carries the header for the generated file.
+const KNOWN_UNHEADERED: { reason: string; files: string[] }[] = [];
+
+const excused = new Map(
+  KNOWN_UNHEADERED.flatMap(({ reason, files }) => files.map((file) => [file, reason])),
+);
+
+// Enumerated from git rather than from a literal list, because the file added
+// tomorrow is the one this test exists to catch. Untracked files that are not
+// ignored count too, so an escape is caught in the working tree that created it
+// rather than one commit later.
+const sources = execFileSync(
+  "git",
+  ["ls-files", "--cached", "--others", "--exclude-standard"],
+  { cwd: root, encoding: "utf8" },
+)
+  .split("\n")
+  .filter((file) => SOURCE.test(file))
+  .filter((file) => existsSync(path.join(root, file)));
+
+const MINIMUM_HEADER_LINES = 2;
+
+/**
+ * The leading block doc comment's content lines, or `null` when the file does
+ * not open with one.
+ *
+ * Anchored at offset zero: a header below the imports is not a header, because
+ * a reader who has already read the imports has stopped asking. `/*` is not
+ * accepted either — the doc form is what an editor surfaces and what the rest
+ * of the repository uses, and two spellings would be two conventions.
+ */
+function headerLines(text: string): string[] | null {
+  if (!text.startsWith("/**")) return null;
+  const end = text.indexOf("*/");
+  if (end < 0) return null;
+  return text
+    .slice("/**".length, end)
+    .split("\n")
+    .map((line) => line.replace(/^\s*\*?/u, "").trim())
+    .filter((line) => line.length > 0);
+}
+
+test("every source module opens with a block doc comment", () => {
+  const bare = sources
+    .filter((file) => !excused.has(file))
+    .filter((file) => {
+      const lines = headerLines(readFileSync(path.join(root, file), "utf8"));
+      return lines === null || lines.length < MINIMUM_HEADER_LINES;
+    });
+  assert.deepEqual(
+    bare,
+    [],
+    `${bare.length} module(s) start with no leading doc comment of at least ` +
+      `${MINIMUM_HEADER_LINES} lines saying what they own: ${bare.join(", ")}`,
+  );
+});
+
+test("every KNOWN_UNHEADERED entry still names a file that still lacks one", () => {
+  const stale = [...excused.keys()].filter((file) => {
+    if (!sources.includes(file)) return true;
+    const lines = headerLines(readFileSync(path.join(root, file), "utf8"));
+    return lines !== null && lines.length >= MINIMUM_HEADER_LINES;
+  });
+  assert.deepEqual(
+    stale,
+    [],
+    `KNOWN_UNHEADERED is out of date; delete these entries: ${stale.join(", ")}`,
+  );
+});


### PR DESCRIPTION
Part 7/7 of the quality stack (#62). Base: `q06-kernel-safety`.

## What changed

Every source module now opens with a doc comment stating what it owns and what it refuses — and a policy test makes the absence of one a build failure rather than something a reviewer has to notice.

- Headers written for every file under `src/` that lacked one (~110 modules across main, core, shared, renderer, tools). The bar is the repo's own best headers: constraints and ownership, nothing a filename could generate. Existing `//` headers were converted to the `/** */` doc form so the repository has one spelling.
- `tests/policy/source-module-headers.test.ts`: sources enumerated from git including untracked-but-not-ignored files (so tomorrow's file is caught in the working tree that created it), anchored at byte zero (a header below the imports is not a header), minimum two content lines. The exemption list is empty, and a staleness assertion keeps it honest — an entry that stops being needed fails the build.
- `preload.body.cjs` carries its own header; the generator that splices it (`scripts/generate-preload.ts`) documents the generated file.

## Review focus

- Spot-check headers in the areas you know best. The test can force presence, not truth — a wrong ownership claim is the review's to catch.

## Verification

- `pnpm check` green, including the new policy test over the full tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
