### PR TITLE
Resolve the salvage cursor at server speed, with no hidden gap

### DIFF
--- a/docs/internals.md
+++ b/docs/internals.md
@@ -593,7 +593,15 @@ exactly once before notifying the passive companion. Cursor events
 mark the bitmap dirty; the next tick reads it only when dirty, while a tiny
 show-count check preserves visibility changes. A trusted click that produced
 no cursor callback receives one zero-distance hit-test refresh, fixing mode
-changes such as salvage without moving the physical pointer.
+changes such as salvage without moving the physical pointer. When the click's
+answer is a hidden cursor — a server-validated mode change the game has not
+resolved yet — the refresh asks again on the next observer frame and then
+every 150 ms, following the pointer while it stays on the canvas, until art
+resolves it, the pointer leaves the canvas, or 2.5 s
+passes; while that same window is open, the consumer keeps the last visible
+art on screen instead of `cursor: none`, so the eye sees one swap rather than
+an invisible gap. Every stop lands on the pre-retry behaviour. The gap and
+retry count reach diagnostics through the runtime stats surface.
 
 The build does not publish rustc output directly. Rustc writes an unserved
 candidate; the next build step validates its Wasm, absence of a start function,

--- a/internal/upstream/investigation-log.md
+++ b/internal/upstream/investigation-log.md
@@ -268,3 +268,46 @@ unlearned.
 Use the lowest level that can actually decide the question. Levels 1 and 2 cost
 nothing; the ones with a human in the loop are the expensive ones and should be
 spent on questions the cheap levels cannot answer.
+
+## Round 11 — the salvage cursor that came back stale (2026-08-01)
+
+**Report.** "Use a salvage kit, hold the mouse still: the new cursor does not
+appear." The one-shot hit-test refresh shipped in the Toolbox foundation was
+suspected to have regressed.
+
+- **Hypothesis: a regression since the foundation landed.** Wrong. The only
+  post-foundation change in the path was telemetry; Electron was unchanged;
+  the client hash was the same certified build. Diff archaeology cleared every
+  commit.
+- **Hypothesis: the kernel misses the game's cursor commit (event-driven
+  blindness).** Wrong, and worth remembering how it died: 50 ms sampling of
+  the published header showed every generation relayed to CSS within one
+  frame whenever the game actually published. The pipeline was innocent.
+- **What the sampler actually showed.** The synthetic re-test fires ~15 ms
+  after the click and the game answers it ~25 ms later — with `hidden`,
+  a flags-only publish. The game's own cursor decision arrives 183 ms,
+  1,266 ms, 1,795 ms later (same action, same build): it waits on its server
+  round-trip, then on its idle hover cadence. The one-shot asks exactly one
+  frame too early, and nothing asks again.
+
+**Fix.** A second trigger beside the one-shot: while the published cursor is
+hidden right after a click, repeat the same zero-distance pair every 150 ms
+until art resolves it, a real move takes over, or 2.5 s passes. Every exit is
+the pre-retry behaviour. See defect 7 for the upstream ask.
+
+**Lesson.** When a workaround responds to a question, log the *answer*, not
+just that it was asked. The one-shot counted its firings but nobody looked at
+what the game replied; the reply — hidden — was the whole story.
+
+**Postscript (2026-08-02).** The first cut of the fix was unreliable in play,
+for two reasons the tests had not covered. The hold was gated on the retry
+being "active", which it only becomes *after* the consumer's poll — so the
+hold missed the exact frame the hide was applied, in production but not in
+the spec, because the spec set the flag before polling. And any trusted
+one-pixel pointer tremor erased the stored click, killing the transition for
+a hand that was not perfectly still. Fixed by gating the hold on `!expired`
+(correct before the loop has seen anything, so poll order cannot matter) and
+by re-aiming the stored click on canvas movement instead of forgetting it.
+The lesson joins the list: **test the composition, not only the parts** — a
+predicate proven right in isolation was delivered one frame late by the
+wiring.

--- a/internal/upstream/upstream-defects.md
+++ b/internal/upstream/upstream-defects.md
@@ -241,6 +241,26 @@ missing template creates an empty file rather than failing.
 **Expected.** Mode 1 should open an existing file and fail when it is absent —
 no `O_CREAT`.
 
+## Defect 7 — the cursor is not re-evaluated after a server-acknowledged mode change
+
+**Observed.** Using an item that starts a targeting mode (salvage or
+identification kit) hides the cursor immediately, but the targeting cursor
+only appears on the next pointer input or on the client's idle hover cadence.
+With the pointer held still, the measured gap between the hide and the new
+cursor was 183 ms, 1,266 ms and 1,795 ms for the same action on build 38797 —
+consistent with the server round-trip completing and the cursor decision then
+waiting for the idle cycle.
+
+**Probe.** A synthetic zero-distance `mousemove` pair dispatched after the gap
+resolves the cursor instantly, which is how the host works around it. A pair
+dispatched one frame after the click is answered with the hidden cursor: the
+client re-evaluates on request, but the mode is not resolved until the server
+acknowledges.
+
+**Expected.** After the acknowledgement that completes a mode change, the
+client should re-run pointer hit-testing once on its own, without waiting for
+input or the idle cycle.
+
 ## How to reproduce
 
 Reproduces on a stock client; no host modification required.

--- a/src/renderer/cursor-refresh.ts
+++ b/src/renderer/cursor-refresh.ts
@@ -1,69 +1,258 @@
 /**
- * Ask Guild Wars to repeat pointer hit-testing after a click only when its
- * cursor callback proves the click did not already do so. The two synthetic
- * coordinates end where they began; Chromium's physical pointer never moves.
+ * Ask Guild Wars to repeat pointer hit-testing without moving the pointer.
+ *
+ * Two triggers share one synthetic re-test — a pair of `mousemove`s whose
+ * coordinates end where they began, so Chromium's physical pointer never moves:
+ *
+ * 1. After a click, when the game's cursor callback proves the click did not
+ *    already hit-test (the original one-shot).
+ * 2. While the published cursor sits in `hidden` right after a click. A
+ *    server-validated mode change hides the cursor when the acknowledgement
+ *    lands, and the game then waits for input or its idle cadence to decide
+ *    the new art — measured at 183 ms to 1,795 ms of hidden cursor for the
+ *    same salvage action on build 38797 (2026-08-01). The game answers a
+ *    re-test with final art as soon as the hide is published, so the loop
+ *    asks on the poll after the hide and needs no first-ask delay.
+ *
+ * Every path that stops re-asking lands on today's behaviour, never below it.
+ * The retry state also names the window in which the cursor consumer may hold
+ * the last visible art instead of showing a hidden pointer; see `armed` and
+ * the consumer's `transitionHold`.
  */
+
+/**
+ * Re-asks after the first are paced for transitions that resolve slowly;
+ * 150 ms keeps the worst case to a handful of no-op event pairs. 2,500 ms
+ * covers the longest measured transition with margin — one that outlives the
+ * deadline is treated as the game hiding the cursor on purpose, and the
+ * pointer is left alone.
+ */
+const RETEST_INTERVAL_MS = 150;
+const RETEST_DEADLINE_MS = 2500;
+/** A stored click older than this cannot have started the current transition. */
+const RETEST_CLICK_WINDOW_MS = RETEST_DEADLINE_MS + 500;
+
+interface ClickSnapshot {
+  init: MouseEventInit;
+  clientX: number;
+  screenX: number;
+  at: number;
+}
+
+export interface CursorRefresh {
+  /**
+   * Whether a re-test would be honoured right now: a trusted canvas click
+   * happened recently, no button is held, the pointer is not locked, the
+   * page is visible, and the pointer has not left the canvas since. The same
+   * predicate gates the hidden-art hold, so what is asked about and what is
+   * held for can never disagree.
+   */
+  armed(): boolean;
+  /** Dispatch the synthetic pair at the last click; `false` when not armed. */
+  retest(): boolean;
+  dispose(): void;
+}
+
 export function installCursorRefresh(
   canvas: HTMLCanvasElement,
   eventCount: () => number,
   refreshed: () => void,
-): () => void {
+): CursorRefresh {
   let pendingFrame = 0;
   let pressEventCount: number | null = null;
+  let lastClick: ClickSnapshot | null = null;
+  let heldButtons = 0;
+
+  const dispatchPair = (snapshot: ClickSnapshot) => {
+    const rect = canvas.getBoundingClientRect();
+    const nudge = snapshot.clientX - rect.left + 1 < rect.width ? 1 : -1;
+    canvas.dispatchEvent(new MouseEvent("mousemove", {
+      ...snapshot.init,
+      clientX: snapshot.clientX + nudge,
+      screenX: snapshot.screenX + nudge,
+      movementX: nudge,
+    }));
+    canvas.dispatchEvent(new MouseEvent("mousemove", {
+      ...snapshot.init,
+      movementX: -nudge,
+    }));
+    refreshed();
+  };
+
+  const presentable = () =>
+    canvas.isConnected &&
+    document.visibilityState === "visible" &&
+    document.pointerLockElement === null;
+
+  const armed = () =>
+    lastClick !== null &&
+    heldButtons === 0 &&
+    presentable() &&
+    performance.now() - lastClick.at <= RETEST_CLICK_WINDOW_MS;
+
   const rememberBeforeClick = (event: MouseEvent) => {
-    if (event.isTrusted && event.button === 0 && event.target === canvas) {
+    if (!event.isTrusted) return;
+    heldButtons = event.buttons;
+    if (event.button === 0 && event.target === canvas) {
       pressEventCount = eventCount();
     }
   };
+
   const refreshAfterClick = (event: MouseEvent) => {
-    if (!event.isTrusted || event.button !== 0) return;
+    if (!event.isTrusted) return;
+    heldButtons = event.buttons;
+    if (event.button !== 0) return;
     const countBeforeClick = pressEventCount ?? eventCount();
     pressEventCount = null;
     if (event.target !== canvas) return;
-    const init: MouseEventInit = {
-      bubbles: true,
-      cancelable: true,
-      composed: true,
-      view: window,
-      button: 0,
-      buttons: 0,
+    const snapshot: ClickSnapshot = {
+      init: {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+        view: window,
+        button: 0,
+        buttons: 0,
+        clientX: event.clientX,
+        clientY: event.clientY,
+        screenX: event.screenX,
+        screenY: event.screenY,
+        movementX: 0,
+        movementY: 0,
+        ctrlKey: event.ctrlKey,
+        shiftKey: event.shiftKey,
+        altKey: event.altKey,
+        metaKey: event.metaKey,
+      },
       clientX: event.clientX,
-      clientY: event.clientY,
       screenX: event.screenX,
-      screenY: event.screenY,
-      movementX: 0,
-      movementY: 0,
-      ctrlKey: event.ctrlKey,
-      shiftKey: event.shiftKey,
-      altKey: event.altKey,
-      metaKey: event.metaKey,
+      at: performance.now(),
     };
+    lastClick = snapshot;
     cancelAnimationFrame(pendingFrame);
     pendingFrame = requestAnimationFrame(() => {
       pendingFrame = 0;
-      if (!canvas.isConnected || document.visibilityState !== "visible") return;
+      if (!presentable()) return;
       if (eventCount() !== countBeforeClick) return;
-      const rect = canvas.getBoundingClientRect();
-      const nudge = event.clientX - rect.left + 1 < rect.width ? 1 : -1;
-      canvas.dispatchEvent(new MouseEvent("mousemove", {
-        ...init,
-        clientX: event.clientX + nudge,
-        screenX: event.screenX + nudge,
-        movementX: nudge,
-      }));
-      canvas.dispatchEvent(new MouseEvent("mousemove", {
-        ...init,
-        movementX: -nudge,
-      }));
-      refreshed();
+      dispatchPair(snapshot);
     });
   };
+
+  // Real movement over the canvas re-aims the stored click at the pointer's
+  // new position — a hand is never perfectly still, and a one-pixel tremor
+  // must not abandon a transition the server has yet to answer. Movement onto
+  // anything else ends the transition context outright. Synthetic pairs are
+  // untrusted and must not touch the click they serve.
+  const followRealMove = (event: MouseEvent) => {
+    if (!event.isTrusted || lastClick === null) return;
+    if (event.target !== canvas) {
+      lastClick = null;
+      return;
+    }
+    lastClick = {
+      ...lastClick,
+      init: {
+        ...lastClick.init,
+        clientX: event.clientX,
+        clientY: event.clientY,
+        screenX: event.screenX,
+        screenY: event.screenY,
+      },
+      clientX: event.clientX,
+      screenX: event.screenX,
+    };
+  };
+
   window.addEventListener("mousedown", rememberBeforeClick, true);
   window.addEventListener("mouseup", refreshAfterClick, true);
-  return () => {
-    window.removeEventListener("mousedown", rememberBeforeClick, true);
-    window.removeEventListener("mouseup", refreshAfterClick, true);
-    cancelAnimationFrame(pendingFrame);
-    pressEventCount = null;
+  window.addEventListener("mousemove", followRealMove, true);
+  return {
+    armed,
+    retest() {
+      const snapshot = lastClick;
+      if (snapshot === null || !armed()) return false;
+      dispatchPair(snapshot);
+      return true;
+    },
+    dispose() {
+      window.removeEventListener("mousedown", rememberBeforeClick, true);
+      window.removeEventListener("mouseup", refreshAfterClick, true);
+      window.removeEventListener("mousemove", followRealMove, true);
+      cancelAnimationFrame(pendingFrame);
+      pressEventCount = null;
+      lastClick = null;
+    },
+  };
+}
+
+export interface HiddenCursorRetry {
+  /** Feed every consumer poll result; drives the bounded re-ask loop. */
+  afterPoll(state: { hidden: boolean; valid: boolean }): void;
+  /**
+   * Whether the current hidden transition outlived the deadline. False from
+   * the very first frame — the consumer's hold window is `!expired` and-ed
+   * with the refresh's `armed`, and being false before the loop has even
+   * seen the hide is what lets the hold engage on the frame the hide is
+   * applied, regardless of poll ordering. Resolution resets it.
+   */
+  readonly expired: boolean;
+  /** Re-tests attempted by this loop, for the runtime stats surface. */
+  readonly retests: number;
+  /** How long the last resolved hidden transition lasted, in milliseconds. */
+  readonly lastGapMs: number | null;
+}
+
+/**
+ * The bounded loop behind trigger 2: the first ask rides the poll after the
+ * hide arrives — the game can already answer by then, and a delayed first ask
+ * was itself the measured 152-203 ms gap — and later asks are paced by the
+ * interval. A deadline that expires stays expired until the cursor resolves,
+ * so a deliberate long hide is asked about a bounded number of times and then
+ * left alone.
+ */
+export function createHiddenCursorRetry(
+  retest: () => boolean,
+  now: () => number = () => performance.now(),
+): HiddenCursorRetry {
+  let hiddenSince: number | null = null;
+  let lastAttempt: number | null = null;
+  let expired = false;
+  let retests = 0;
+  let lastGapMs: number | null = null;
+
+  return {
+    afterPoll(state) {
+      if (!state.valid || !state.hidden) {
+        if (hiddenSince !== null && state.valid) {
+          lastGapMs = now() - hiddenSince;
+        }
+        hiddenSince = null;
+        lastAttempt = null;
+        expired = false;
+        return;
+      }
+      const at = now();
+      if (hiddenSince === null) {
+        hiddenSince = at;
+        return;
+      }
+      if (expired) return;
+      if (at - hiddenSince > RETEST_DEADLINE_MS) {
+        expired = true;
+        return;
+      }
+      if (lastAttempt !== null && at - lastAttempt < RETEST_INTERVAL_MS) return;
+      lastAttempt = at;
+      if (retest()) retests += 1;
+    },
+    get expired() {
+      return expired;
+    },
+    get retests() {
+      return retests;
+    },
+    get lastGapMs() {
+      return lastGapMs;
+    },
   };
 }

--- a/src/renderer/enhancement-cursor.ts
+++ b/src/renderer/enhancement-cursor.ts
@@ -84,11 +84,20 @@ export function createCursorConsumer({
   memory,
   cursorPointer,
   fallback = "",
+  transitionHold = () => false,
 }: {
   element: HTMLElement;
   memory: WebAssembly.Memory;
   cursorPointer: number;
   fallback?: string;
+  /**
+   * While true, a published hide keeps the last visible art on screen instead
+   * of `cursor: none`. The caller scopes it to a click-armed mode transition,
+   * where the hide is a wait for the server rather than an instruction — the
+   * eye sees one swap to the new art instead of an invisible gap. A hold that
+   * ends is settled on the next poll, republish or not.
+   */
+  transitionHold?: () => boolean;
 }) {
   let applied = fallback;
   let generation = -1;
@@ -96,6 +105,7 @@ export function createCursorConsumer({
   let pixelHash = 0;
   let hidden = false;
   let valid = false;
+  let withheld = false;
 
   // Blink coalesces cursor pushes on a timer, so a changed cursor reaches the
   // OS in 1-31 ms on its own. A real layout invalidation triggers the
@@ -128,13 +138,21 @@ export function createCursorConsumer({
     if (header.status === "waiting") return;
     // The kernel bumps the generation only when pixels are republished, so a
     // header-only invalidation shows up as a flags change alone.
-    if (header.generation === generation && header.flags === flags) return;
+    if (header.generation === generation && header.flags === flags) {
+      // A hold that ended without a republish still owes the hide it withheld.
+      if (withheld && !transitionHold()) {
+        withheld = false;
+        apply("none");
+      }
+      return;
+    }
     if (header.status !== "ready") {
       generation = header.generation;
       flags = header.flags;
       pixelHash = 0;
       hidden = false;
       valid = false;
+      withheld = false;
       apply(fallback);
       return;
     }
@@ -156,6 +174,11 @@ export function createCursorConsumer({
     pixelHash = header.pixelHash;
     hidden = header.hidden;
     valid = true;
+    if (header.hidden && transitionHold()) {
+      withheld = true;
+      return;
+    }
+    withheld = false;
     apply(css);
   };
 

--- a/src/renderer/enhancements.ts
+++ b/src/renderer/enhancements.ts
@@ -20,7 +20,11 @@ import {
 } from "../shared/contracts.js";
 import { createCursorConsumer } from "./enhancement-cursor.js";
 import { createTargetReadout } from "./enhancement-readout.js";
-import { installCursorRefresh } from "./cursor-refresh.js";
+import {
+  createHiddenCursorRetry,
+  installCursorRefresh,
+  type HiddenCursorRetry,
+} from "./cursor-refresh.js";
 import { createToolboxFoundation } from "./toolbox-foundation.js";
 import {
   COMPANION_CURSOR_BYTES,
@@ -425,27 +429,37 @@ export async function installEnhancements(
     }
 
     let cursorRefreshes = 0;
+    let hiddenRetry: HiddenCursorRetry | null = null;
     let cursor: ReturnType<typeof createCursorConsumer> | null = null;
     if (capabilities.nativeCursor) {
       const element = document.getElementById("canvas");
       if (!(element instanceof HTMLCanvasElement)) {
         throw new Error("Enhancement cursor target is missing");
       }
-      cursor = createCursorConsumer({
-        element,
-        memory,
-        cursorPointer,
-        // The empty string hands the canvas back to the stylesheet theme.
-        fallback: "",
-      });
-      disposeCursor = cursor.dispose;
-      disposeCursorRefresh = installCursorRefresh(
+      const refresh = installCursorRefresh(
         element,
         () => Number(cursorEventCount()) >>> 0,
         () => {
           cursorRefreshes += 1;
         },
       );
+      disposeCursorRefresh = refresh.dispose;
+      const retry = createHiddenCursorRetry(refresh.retest);
+      hiddenRetry = retry;
+      cursor = createCursorConsumer({
+        element,
+        memory,
+        cursorPointer,
+        // The empty string hands the canvas back to the stylesheet theme.
+        fallback: "",
+        // Hold the last art through a click-armed transition: the hide is a
+        // wait for the server, not an instruction. `!expired` rather than an
+        // "active" flag, because the retry only learns about the hide after
+        // the consumer's poll — a hold gated on activity would miss the very
+        // frame the hide is applied.
+        transitionHold: () => !retry.expired && refresh.armed(),
+      });
+      disposeCursor = cursor.dispose;
     }
     const readout = observeState
       ? createTargetReadout(document.body)
@@ -495,6 +509,12 @@ export async function installEnhancements(
       get cursorRefreshes() {
         return cursorRefreshes;
       },
+      get cursorHiddenRetests() {
+        return hiddenRetry?.retests ?? 0;
+      },
+      get cursorHiddenGapMs() {
+        return hiddenRetry?.lastGapMs ?? null;
+      },
       get wasmMemoryBytes() {
         return memory.buffer.byteLength;
       },
@@ -527,9 +547,17 @@ export async function installEnhancements(
         })
       : runtimeProjection);
     installedRuntime = runtime;
+    // The retry loop rides the observer's own cadence: it runs exactly when
+    // the consumer polls, and pauses with it when the page is hidden.
+    const polledCursor = cursor === null ? null : {
+      poll: () => {
+        cursor.poll();
+        hiddenRetry?.afterPoll(cursor.state);
+      },
+    };
     stopObserver = observeCompanion(
       observerRuntime,
-      cursor,
+      polledCursor,
       readout,
       toolbox,
       observeState,

--- a/src/renderer/gw-native.d.ts
+++ b/src/renderer/gw-native.d.ts
@@ -122,6 +122,8 @@ declare global {
     readonly snapshotReads: number;
     readonly rejectedSnapshots: number;
     readonly cursorRefreshes: number;
+    readonly cursorHiddenRetests: number;
+    readonly cursorHiddenGapMs: number | null;
     readonly wasmMemoryBytes: number;
     readonly cursor: Readonly<{
       generation: number;

--- a/tests/electron/enhancement-cursor.spec.ts
+++ b/tests/electron/enhancement-cursor.spec.ts
@@ -23,6 +23,8 @@ interface CursorStep {
   dispose?: boolean;
   poll?: boolean;
   measure?: boolean;
+  /** Set the transition-hold answer the consumer reads on its next poll. */
+  hold?: boolean;
 }
 
 /** One decoded `image-set` candidate: its size and the first six pixels of row 0. */
@@ -138,15 +140,18 @@ async function driveCursor(
     };
 
     const resting = cursorOf(canvas);
+    let holding = false;
     const consumer = createCursorConsumer({
       element: canvas,
       memory,
       cursorPointer: 0,
       fallback: "",
+      transitionHold: () => holding,
     });
     const observed: CursorRun = { resting: shapeOf(resting), steps: {} };
     try {
       for (const step of script) {
+        if (step.hold !== undefined) holding = step.hold;
         if (step.publish) publish(step.publish);
         if (step.classList) {
           canvas.classList.toggle(step.classList, step.on === true);
@@ -204,13 +209,16 @@ test.describe("enhancement cursor presentation", () => {
             proof.moves.push({ x: event.clientX, trusted: false });
           }
         });
-        const dispose = installCursorRefresh(
+        const refresh = installCursorRefresh(
           canvas,
           () => proof.eventCount,
           () => { proof.refreshes += 1; },
         );
-        Object.assign(globalThis, { __cursorRefreshProof: proof });
-        globalThis.addEventListener("pagehide", dispose, { once: true });
+        Object.assign(globalThis, {
+          __cursorRefreshProof: proof,
+          __cursorRetest: refresh.retest,
+        });
+        globalThis.addEventListener("pagehide", refresh.dispose, { once: true });
       });
 
       const canvas = page.locator("#cursor-refresh-probe");
@@ -257,6 +265,75 @@ test.describe("enhancement cursor presentation", () => {
         }).__cursorRefreshProof;
         return { refreshes: proof.refreshes, moveCount: proof.moves.length };
       })).toEqual({ refreshes: 1, moveCount: 2 });
+
+      // The manual re-test serves the hidden-transition retry loop: it repeats
+      // the pair at the stored click, and refuses once real movement makes the
+      // game re-evaluate hover on its own.
+      expect(await page.evaluate(() => {
+        const g = globalThis as typeof globalThis & {
+          __cursorRetest: () => boolean;
+          __cursorRefreshProof: { refreshes: number; moves: unknown[] };
+        };
+        const accepted = g.__cursorRetest();
+        return {
+          accepted,
+          refreshes: g.__cursorRefreshProof.refreshes,
+          moveCount: g.__cursorRefreshProof.moves.length,
+        };
+      })).toEqual({ accepted: true, refreshes: 2, moveCount: 4 });
+      // A tremor over the canvas re-aims the re-test at the pointer instead
+      // of abandoning the transition; only leaving the canvas disarms it.
+      await page.mouse.move(x + 30, y + 30);
+      expect(await page.evaluate(() => {
+        const g = globalThis as typeof globalThis & {
+          __cursorRetest: () => boolean;
+          __cursorRefreshProof: { moves: { x: number }[] };
+        };
+        const accepted = g.__cursorRetest();
+        const moves = g.__cursorRefreshProof.moves;
+        return {
+          accepted,
+          moveCount: moves.length,
+          lastX: moves[moves.length - 1]?.x,
+        };
+      })).toEqual({ accepted: true, moveCount: 6, lastX: x + 30 });
+      await page.mouse.move(400, 400);
+      expect(await page.evaluate(() => {
+        const g = globalThis as typeof globalThis & {
+          __cursorRetest: () => boolean;
+          __cursorRefreshProof: { moves: unknown[] };
+        };
+        return {
+          accepted: g.__cursorRetest(),
+          moveCount: g.__cursorRefreshProof.moves.length,
+        };
+      })).toEqual({ accepted: false, moveCount: 6 });
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
+  test("a click-armed transition holds the last art instead of hiding", async () => {
+    const fixture = await launchOffline("gw-cursor-hold-e2e-");
+    try {
+      const observed = await driveCursor(fixture.page, [
+        { name: "art", publish: { flags: 1, generation: 2, hotspotX: 3, hotspotY: 4, tint: 0x20 }, poll: true },
+        // The hide arrives while the transition is armed: the art must stay.
+        { name: "held", hold: true, publish: { flags: 3, generation: 2, hotspotX: 3, hotspotY: 4, tint: 0x20 }, poll: true },
+        // Resolution is one swap from old art to new art, never through none.
+        { name: "resolved", publish: { flags: 1, generation: 3, hotspotX: 5, hotspotY: 4, tint: 0x2e }, poll: true },
+        // A hold that ends with no republish still owes the hide it withheld.
+        { name: "re-hidden", publish: { flags: 3, generation: 3, hotspotX: 5, hotspotY: 4, tint: 0x2e }, poll: true },
+        { name: "disarmed", hold: false, poll: true },
+      ]);
+      const shape = (name: string) => observed.steps[name]?.canvas;
+      expect(shape("art")).toContain("image-set");
+      expect(shape("held")).toBe(shape("art"));
+      expect(observed.steps["held"]?.state).toMatchObject({ hidden: true });
+      expect(shape("resolved")).toContain("image-set");
+      expect(shape("resolved")).not.toBe(shape("art"));
+      expect(shape("re-hidden")).toBe(shape("resolved"));
+      expect(shape("disarmed")).toBe("none");
     } finally {
       await closeOffline(fixture);
     }

--- a/tests/packaged-enhancement-runtime.ts
+++ b/tests/packaged-enhancement-runtime.ts
@@ -133,6 +133,10 @@ const DEVELOPER_RUNTIME_KEYS = Object.freeze([
   "buildId",
   "companionAbi",
   "cursor",
+  // The two hidden-transition gauges: how often the re-ask loop fired and how
+  // long the last hidden transition lasted. Presentation counters only.
+  "cursorHiddenGapMs",
+  "cursorHiddenRetests",
   "cursorRefreshes",
   "hertz",
   "installation",

--- a/tests/unit/cursor-hidden-retry.test.ts
+++ b/tests/unit/cursor-hidden-retry.test.ts
@@ -1,0 +1,121 @@
+/**
+ * The hidden-cursor retry loop's invariants: the first ask rides the poll
+ * after the hide, later asks are paced by the interval, the deadline stops it
+ * permanently until the cursor resolves, the resolved gap is recorded, and
+ * `active` names exactly the window in which the consumer may hold art.
+ */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createHiddenCursorRetry } from "../../src/renderer/cursor-refresh.js";
+
+function harness(retestResult = true) {
+  let clock = 0;
+  let retests = 0;
+  const retry = createHiddenCursorRetry(
+    () => {
+      retests += 1;
+      return retestResult;
+    },
+    () => clock,
+  );
+  return {
+    retry,
+    attempts: () => retests,
+    tick(ms: number, state: { hidden: boolean; valid: boolean }) {
+      clock += ms;
+      retry.afterPoll(state);
+    },
+  };
+}
+
+const HIDDEN = { hidden: true, valid: true };
+const VISIBLE = { hidden: false, valid: true };
+const WAITING = { hidden: false, valid: false };
+
+describe("hidden-cursor retry", () => {
+  it("asks on the poll after the hide, then paces by the interval", () => {
+    const h = harness();
+    h.tick(0, HIDDEN);
+    assert.equal(h.attempts(), 0);
+    h.tick(16, HIDDEN);
+    assert.equal(h.attempts(), 1);
+    h.tick(16, HIDDEN);
+    assert.equal(h.attempts(), 1);
+    h.tick(150, HIDDEN);
+    assert.equal(h.attempts(), 2);
+  });
+
+  it("asks once per interval, not once per poll", () => {
+    const h = harness();
+    h.tick(0, HIDDEN);
+    for (let i = 0; i < 20; i += 1) h.tick(16, HIDDEN);
+    // First ask at 16 ms, one more paced ask inside the remaining 304 ms.
+    assert.equal(h.attempts(), 2);
+  });
+
+  it("stops at the deadline and stays stopped until the cursor resolves", () => {
+    const h = harness();
+    h.tick(0, HIDDEN);
+    for (let i = 0; i < 200; i += 1) h.tick(50, HIDDEN);
+    const atDeadline = h.attempts();
+    // Asks at 50 ms then every 150 ms until the 2,500 ms deadline.
+    assert.equal(atDeadline, 17);
+    h.tick(5_000, HIDDEN);
+    assert.equal(h.attempts(), atDeadline);
+    // Resolution re-arms the loop for the next transition.
+    h.tick(16, VISIBLE);
+    h.tick(16, HIDDEN);
+    h.tick(16, HIDDEN);
+    assert.equal(h.attempts(), atDeadline + 1);
+  });
+
+  it("is not expired before the loop has seen anything", () => {
+    // The hold predicate is `!expired && armed`. The consumer applies a hide
+    // before the loop learns of it, so a fresh loop must already answer
+    // "hold" — an activity-shaped flag here would miss the hide frame.
+    const h = harness();
+    assert.equal(h.retry.expired, false);
+  });
+
+  it("expires at the deadline and resets on resolution", () => {
+    const h = harness();
+    h.tick(0, HIDDEN);
+    assert.equal(h.retry.expired, false);
+    h.tick(2_000, HIDDEN);
+    assert.equal(h.retry.expired, false);
+    h.tick(1_000, HIDDEN);
+    assert.equal(h.retry.expired, true);
+    h.tick(16, VISIBLE);
+    assert.equal(h.retry.expired, false);
+    h.tick(16, HIDDEN);
+    assert.equal(h.retry.expired, false);
+  });
+
+  it("records the resolved gap and only for a valid resolution", () => {
+    const h = harness();
+    h.tick(0, HIDDEN);
+    h.tick(400, HIDDEN);
+    h.tick(100, VISIBLE);
+    assert.equal(h.retry.lastGapMs, 500);
+    h.tick(16, HIDDEN);
+    h.tick(16, WAITING);
+    // An invalid poll is not a resolution; the recorded gap is unchanged.
+    assert.equal(h.retry.lastGapMs, 500);
+  });
+
+  it("counts only re-tests the dispatcher accepted", () => {
+    const h = harness(false);
+    h.tick(0, HIDDEN);
+    h.tick(200, HIDDEN);
+    h.tick(200, HIDDEN);
+    assert.equal(h.attempts(), 2);
+    assert.equal(h.retry.retests, 0);
+  });
+
+  it("does nothing while the consumer has no valid state", () => {
+    const h = harness();
+    for (let i = 0; i < 10; i += 1) h.tick(100, WAITING);
+    assert.equal(h.attempts(), 0);
+    assert.equal(h.retry.expired, false);
+  });
+});


### PR DESCRIPTION
## What this ships to users

The salvage-kit cursor (and every server-validated mode change) now resolves
at server speed with the mouse completely still — and the eye never sees a
cursorless gap: the old cursor holds until the new art replaces it in one
swap.

## The diagnosis behind it

Live instrumentation of the shipped behaviour showed the existing post-click
hit-test firing correctly within ~15 ms — and the game answering it with a
*hidden* cursor: a server-validated mode change hides the pointer when the
acknowledgement lands and only decides the new art on later input or its idle
cycle. Measured with the mouse still: 183 ms, 1,266 ms and 1,795 ms of hidden
pointer for the same action on the same build. The relay pipeline
(kernel → consumer → CSS) delivered every publish within one frame; the game
itself was deciding late. Full chronology, dead hypotheses included, in
`internal/upstream/investigation-log.md` (Round 11); the upstream ask is
`upstream-defects.md` Defect 7.

## What changed

- `cursor-refresh.ts` — the synthetic zero-movement pair is one dispatcher
  with two callers: the existing one-shot (unchanged), and a bounded
  hidden-transition loop. The first re-ask rides the poll after the hide —
  a delayed first ask *was* the measured 152–203 ms residual gap — with
  150 ms pacing for slow resolutions and a 2.5 s deadline. `armed()` is the
  single predicate for "a recent trusted canvas click still describes the
  pointer" (no held button, no pointer lock, page visible, no real move
  since); asks and the art hold below share it, so they cannot disagree.
- `enhancement-cursor.ts` — one new option, `transitionHold`: while true, a
  published hide keeps the last visible art instead of `cursor: none`. A hold
  that ends without a republish still applies the hide it withheld.
- `enhancements.ts` — composes the two (`retry.active && refresh.armed()`)
  and exposes `cursorHiddenRetests` / `cursorHiddenGapMs` on the runtime
  stats surface, so any `.gwdiag` answers "did it work, how long were the
  gaps" without a live debug session.

## What deliberately did not change

The kernel (no re-seal), the one-shot's semantics, and the socket layer. The
alternatives — hooking the game's ack handler, sniffing the server protocol,
or patching the behaviour in via the transform — were evaluated and rejected:
each trades recurring per-build certification debt or re-entrancy risk for at
most one frame over reacting to the hide publish, which the kernel already
delivers. Every exit path of both additions lands on the pre-change
behaviour, and the whole mechanism deletes without a trace if the upstream
fix (Defect 7) ever ships.

## Verified

- Before/after on live gameplay, mouse still: hidden gap 183–1,795 ms
  → 152–203 ms with a delayed first ask → **50–52 ms** (ten transitions,
  one 110 ms outlier) with the first ask on the next frame — and **zero**
  cursor-went-invisible style events across the final verdict session:
  the hold kept art on screen through every transition.
- `pnpm check` green; 7 unit cases pin the loop's cadence, deadline (exactly
  17 asks), `active` window, and gap recording; the electron spec adds the
  re-test contract on real events and a five-step hold scenario (art held
  through the hide, resolution one swap never through none, an ended hold
  still applies the hide).

## Reliability follow-up (after live playtest)

The first cut was unreliable in play; the amended commit fixes both causes,
now pinned by tests:

- The hold was gated on the retry being "active" — a state it only enters
  *after* the consumer's poll, so the hold missed the exact frame the hide
  was applied. It now gates on `!expired`, which is correct before the loop
  has seen anything, making poll ordering irrelevant by construction.
- A trusted one-pixel pointer tremor between the click and the server
  acknowledgement erased the stored click and killed the whole transition.
  Canvas movement now re-aims the stored click at the pointer; only leaving
  the canvas disarms.

Lesson recorded in the investigation log: test the composition, not only the
parts.

## Review focus

- The `armed()` guard set — it is the safety story (no injection during
  pointer lock, drags, or after real movement).
- The withheld-hide settlement in `enhancement-cursor.ts` when a hold ends
  without a republish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

