### PR TITLE
Give an investigation a shape and every setting its reason

### DIFF
--- a/.github/workflows/client-canary.yml
+++ b/.github/workflows/client-canary.yml
@@ -1,3 +1,5 @@
+# ArenaNet ships client builds on no schedule this project can see, and every
+# certified index belongs to one exact build: this is what notices the change.
 name: ArenaNet client canary
 
 on:

--- a/.github/workflows/macos-verify.yml
+++ b/.github/workflows/macos-verify.yml
@@ -1,3 +1,5 @@
+# The one definition of "verified" that every shipping path calls, so nothing
+# reaches a tester or a release having passed a weaker gate than a review does.
 name: Reusable macOS verification
 
 on:

--- a/.github/workflows/main-snapshot.yml
+++ b/.github/workflows/main-snapshot.yml
@@ -1,3 +1,5 @@
+# Signing and publishing run on every commit to main rather than once per
+# release, where a broken step would be discovered under the most time pressure.
 name: Main snapshot
 
 on:

--- a/.github/workflows/pr-package.yml
+++ b/.github/workflows/pr-package.yml
@@ -1,3 +1,5 @@
+# A reviewer gets the packaged application and not only a green tick; three days
+# is long enough to run it and short enough that unmerged builds do not pile up.
 name: PR package
 
 on:

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,3 +1,5 @@
+# Split from signing so the permission to write releases and attestations sits
+# in one job at the end of the chain, reachable by nothing that builds or signs.
 name: Publish tester snapshot
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,5 @@
+# The only path to a public versioned release: dispatched by hand, refused off
+# main, and gated on the approval environment holding the Developer ID material.
 name: Versioned release
 
 on:

--- a/.github/workflows/sign-preview.yml
+++ b/.github/workflows/sign-preview.yml
@@ -1,3 +1,5 @@
+# Its own workflow so the Preview signing material stays inside one protected
+# environment, and so the commit being signed is an input rather than implied.
 name: Sign verified Preview package
 
 on:

--- a/.github/workflows/tester-build.yml
+++ b/.github/workflows/tester-build.yml
@@ -1,3 +1,5 @@
+# A build for testers names its exact commit and waits for a human approval;
+# nothing else here signs a Preview from a revision somebody chose.
 name: Tester build
 
 on:

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,3 +1,5 @@
+# The website is outside pnpm verify, so this is the only thing that checks it;
+# the path filter keeps application-only commits off a run with nothing to do.
 name: Website
 
 on:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,15 @@ not only happy paths.
 Every module under `src/` opens with a comment stating what it owns and what it
 refuses to own; `tests/policy/source-module-headers.test.ts` fails a build that
 is missing one. Comments elsewhere state the constraint the code cannot show,
-never what the next line does.
+never what the next line does. Configuration that decides behaviour — the
+Electron fuses, the strictness flags, a workflow's reason to exist — carries the
+reason on the line it governs.
+
+An investigation that cost a wrong turn is recorded the same way: one round per
+hypothesis, what was built on it, the measurement that killed it, and the lesson
+it leaves. `internal/upstream/investigation-template.md` holds that shape and
+`internal/upstream/investigation-log.md` is the worked example. The next reader
+is meant to inherit the dead ends rather than walk back into them.
 
 ## Layout
 

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -153,16 +153,39 @@ const config: ForgeConfig = {
         path.resolve(resourcesPath, "../..", "MacOS", "Electron"),
         {
           version: FuseVersion.V1,
+          // Flipping a fuse edits the binary, which invalidates the signature
+          // the prebuilt Electron carries and Apple Silicon insists on having.
           resetAdHocDarwinSignature: arch === "arm64",
+          // A fuse this list has never heard of fails the package rather than
+          // taking whichever default a new Electron shipped it with.
           strictlyRequireAllFuses: true,
+          // A binary that runs arbitrary script on request runs it under this
+          // app's signature, and so with its Keychain access.
           [FuseV1Options.RunAsNode]: false,
+          // Chromium would otherwise create its own Safe Storage Keychain item
+          // beside the Data Protection items this app owns.
           [FuseV1Options.EnableCookieEncryption]: false,
+          // NODE_OPTIONS is read from the launching environment, before any
+          // check this app is in a position to make.
           [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,
+          // A debugger attached to main reads the ArenaNet credentials and the
+          // Steam token straight out of memory.
           [FuseV1Options.EnableNodeCliInspectArguments]: false,
+          // Gatekeeper checks the bundle seal at first launch; this checks the
+          // archive at every one.
           [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: true,
+          // Otherwise an app/ directory beside the archive is the fallback when
+          // app.asar is missing or unreadable, so removing the archive replaces
+          // it with code the check above never sees.
           [FuseV1Options.OnlyLoadAppFromAsar]: true,
+          // A browser-process-specific snapshot is a second code-bearing file,
+          // outside the archive the two fuses above account for.
           [FuseV1Options.LoadBrowserProcessSpecificV8Snapshot]: false,
+          // Everything the renderer loads arrives over gw://app, so file://
+          // pages have nothing here that extra privileges would serve.
           [FuseV1Options.GrantFileProtocolExtraPrivileges]: false,
+          // The game is WebAssembly: without trap handlers every heap access
+          // pays for an explicit bounds check.
           [FuseV1Options.WasmTrapHandlers]: true,
         },
       );

--- a/internal/upstream/README.md
+++ b/internal/upstream/README.md
@@ -27,6 +27,7 @@ hash, that routes the broken routines back into the host.
 | [host-bridge.md](host-bridge.md) | us | What we actually ship: the transform, the five markers, the bridge contract, and the invariants that must hold. |
 | [recertify.md](recertify.md) | us | The procedure when ArenaNet publishes a new client. Every index and offset below is build-specific. |
 | [investigation-log.md](investigation-log.md) | us | The chronology, including every wrong turn and what corrected it. Read this before re-deriving anything. |
+| [investigation-template.md](investigation-template.md) | us | The shape a round takes — hypothesis, what was built, the measurement that killed it, the lesson. Copy it to start the next log. |
 
 ## The build this describes
 

--- a/internal/upstream/investigation-template.md
+++ b/internal/upstream/investigation-template.md
@@ -1,0 +1,49 @@
+# Investigation log template
+
+The shape [investigation-log.md](investigation-log.md) is written in, extracted
+so the next investigation does not have to invent one. Copy the skeleton below
+into a new log, or as the next round of an existing one, and fill it in while
+the work happens — a round reconstructed afterwards keeps the answer and loses
+the wrong turn, which is the part worth writing down.
+
+## When a log is owed
+
+When the cause was not where the symptom pointed, an instrument lied, or a
+shipped fix had to be replaced. Work whose first hypothesis held needs a commit
+message, not a log.
+
+## The skeleton
+
+```md
+## Round N — wrong: the one-line claim
+
+**Hypothesis.** What was believed, in the terms that made it plausible.
+
+**Built.** What was written on the strength of it, named well enough that a
+later reader can tell which parts survived.
+
+**Wrong because** — the measurement that killed it, quoted. The number, the
+string, the trace line, not "this turned out to be incorrect".
+
+**Kept anyway.** Only when part of the wrong build stands on its own merits;
+say what those are without the hypothesis that produced it.
+
+**Lesson.** The rule that would have shortened the round, stated so it applies
+to work with nothing else in common with this bug.
+```
+
+A round that was right keeps the same headings and says so in its title. The
+ratio is part of the record.
+
+## What keeps it worth reading
+
+- A hypothesis retired without a measurement is still alive. Say what was run,
+  and prefer the cheapest level that could decide the question.
+- Name what the instrument could not see. Silence from a filtered trace is not
+  absence, and an instrument gets its own defects recorded like any other.
+- Date a round that lands long after the ones above it; every index, offset and
+  hash in these documents belongs to one client build.
+- Close a finished investigation with what we would do differently and the
+  verification ladder that ended up working, so the next one starts a level up.
+- Probes that read client memory, temporary tracers and one-off patches are
+  removed once they have answered. The log is where they persist.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,9 +6,17 @@
     "lib": ["ES2022"],
     "outDir": "build",
     "rootDir": "src",
+    // Every input this program reads crosses a boundary it does not control —
+    // IPC, the settings file, ArenaNet's manifests — where absence is normal.
     "strict": true,
+    // A renamed base member otherwise turns an override into a second method
+    // that nothing calls and nothing reports.
     "noImplicitOverride": true,
+    // Chunk tables, manifest rows and argv are indexed by values from outside
+    // the program, so a miss is a normal case rather than a defect.
     "noUncheckedIndexedAccess": true,
+    // An absent field and an explicit undefined are the same value after a JSON
+    // round trip and different values to every contract in src/shared.
     "exactOptionalPropertyTypes": true,
     "skipLibCheck": true,
     "esModuleInterop": true,

--- a/tsconfig.renderer.json
+++ b/tsconfig.renderer.json
@@ -40,7 +40,10 @@
     "moduleResolution": "Bundler",
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "types": [],
+    // tsconfig.json owns why each of these is on; src is one tree, and the half
+    // of it that compiles for Chromium is held to the same bar.
     "strict": true,
+    "noImplicitOverride": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,
     // `pnpm typecheck` overrides this back to --noEmit. Checking is not


### PR DESCRIPTION
## What ships

Two standing practices, both currently one-offs:

1. **Investigation logs become a template.** The `internal/upstream/` shape (Hypothesis / Built / Wrong because / Lesson) that carried the template-save and cursor investigations is now `internal/upstream/investigation-template.md`, linked from AGENTS.md, so the next investigation starts from the proven structure instead of reinventing it.
2. **Config that governs behavior states its reason on the line it governs.** Every Electron fuse in `forge.config.ts`, every non-default strictness flag in `tsconfig.json` / `tsconfig.renderer.json`, and the header of all nine workflow files now carry their one-line why.

## What changed

- Rationale comments only where a choice was made — no narration, no restating flag names in prose.
- `tsconfig.renderer.json` gained `noImplicitOverride`: the renderer was documented as "held to the same bar" as the main config, and this flag was the one place that claim was false. Making the config true beat weakening the comment.
- The `OnlyLoadAppFromAsar` rationale states the real bypass (the `app/` directory is Electron's *fallback* when `app.asar` is missing or unreadable — removing the archive swaps in code the integrity check never sees).

## Review focus

- Read each fuse rationale as a threat-model statement: is it the actual mechanism?
- `noImplicitOverride` in the renderer program — zero new errors, but worth a glance that nothing relied on silent overrides.

## Verification

`set -o pipefail; pnpm check` green — 130 tests, 0 failures.
