### PR TITLE
Make every signed-release assertion runnable off CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,81 +221,21 @@ jobs:
             --issuer "$APPLE_API_ISSUER_ID"
           xcrun stapler staple -v "$dmg"
 
+      # Every assertion this makes lives in scripts/verify-signed-app.ts, so a
+      # release that fails one can be reproduced against the same package on a
+      # developer's machine instead of only by cutting another release.
       - name: Verify Apple distribution identity and tickets
+        env:
+          GW_SIGNED_CHANNEL: release
         run: |
-          app="$(find out -name 'Guild Wars Reforged.app' -type d -print -quit)"
-          dmg="$(find out/make -type f -name '*.dmg' -print -quit)"
-          test -n "$app"
-          test -n "$dmg"
-          codesign --verify --deep --strict --verbose=2 "$app"
-          signature="$(codesign -dv --verbose=4 "$app" 2>&1)"
-          echo "$signature"
-          echo "$signature" | grep "Authority=Developer ID Application"
-          echo "$signature" | grep "TeamIdentifier=9NN976MFZ4"
-          echo "$signature" | grep "Runtime Version"
-          echo "$signature" | grep "Timestamp="
-          test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' \
-            "$app/Contents/Info.plist")" = "io.github.mat4m0.gwonmac"
-          cmp "$APPLE_PROVISIONING_PROFILE" \
-            "$app/Contents/embedded.provisionprofile"
-          codesign -d --entitlements :- "$app" > "$RUNNER_TEMP/app-entitlements.plist"
-          plutil -convert json -o "$RUNNER_TEMP/app-entitlements.json" \
-            "$RUNNER_TEMP/app-entitlements.plist"
-          node -e '
-            const value = require(process.argv[1]);
-            const expected = {
-              "com.apple.application-identifier": "9NN976MFZ4.io.github.mat4m0.gwonmac",
-              "com.apple.developer.team-identifier": "9NN976MFZ4",
-              "com.apple.security.cs.allow-jit": true,
-            };
-            require("node:assert/strict").deepEqual(value, expected);
-          ' "$RUNNER_TEMP/app-entitlements.json"
-          helper_count=0
-          plugin_helper_count=0
-          while IFS= read -r -d '' helper; do
-            ((helper_count += 1))
-            if [[ "$helper" == *"(Plugin)"* ]]; then
-              ((plugin_helper_count += 1))
-            fi
-            entitlements="$RUNNER_TEMP/$(basename "$helper").plist"
-            json="$entitlements.json"
-            codesign -d --entitlements :- "$helper" > "$entitlements"
-            plutil -convert json -o "$json" "$entitlements"
-            node -e '
-              const value = require(process.argv[1]);
-              const plugin = process.argv[2].includes("(Plugin)");
-              const allowed = new Set([
-                "com.apple.security.cs.allow-jit",
-                ...(plugin ? [
-                  "com.apple.security.cs.allow-unsigned-executable-memory",
-                  "com.apple.security.cs.disable-library-validation",
-                ] : []),
-              ]);
-              const keys = Object.keys(value);
-              if (keys.some((key) => !allowed.has(key))) process.exit(1);
-              if ([...allowed].some((key) => value[key] !== true)) process.exit(1);
-            ' "$json" "$helper"
-            helper_signature="$(codesign -dv --verbose=4 "$helper" 2>&1)"
-            echo "$helper_signature" | grep "TeamIdentifier=9NN976MFZ4"
-            echo "$helper_signature" | grep "Runtime Version"
-            echo "$helper_signature" | grep "Timestamp="
-          done < <(find "$app/Contents/Frameworks" -name '*Helper*.app' -print0)
-          test "$helper_count" -eq 4
-          test "$plugin_helper_count" -eq 1
-          xcrun stapler validate -v "$app"
-          spctl --assess --type execute --verbose=4 "$app"
-          codesign --verify --verbose=2 "$dmg"
-          dmg_signature="$(codesign -dv --verbose=4 "$dmg" 2>&1)"
-          echo "$dmg_signature" | grep "Authority=Developer ID Application"
-          echo "$dmg_signature" | grep "TeamIdentifier=9NN976MFZ4"
-          echo "$dmg_signature" | grep "Timestamp="
-          xcrun stapler validate -v "$dmg"
-          spctl --assess --type open \
-            --context context:primary-signature --verbose=4 "$dmg"
+          pnpm verify:signed-app \
+            "$(find out -name 'Guild Wars Reforged.app' -type d -print -quit)" \
+            "$(find out/make -type f -name '*.dmg' -print -quit)"
 
       - name: Prepare immutable release assets
         id: assets
         env:
+          GW_SIGNED_CHANNEL: release
           VERSION: ${{ steps.version.outputs.version }}
           TAG: ${{ steps.version.outputs.tag }}
         run: |
@@ -318,9 +258,7 @@ jobs:
             "$VERSION" "$TAG" "$(basename "$zip")" "$published_at" "$manifest"
           unzip_dir="$RUNNER_TEMP/unzipped-release"
           ditto -x -k "$zip" "$unzip_dir"
-          extracted="$unzip_dir/Guild Wars Reforged.app"
-          codesign --verify --deep --strict --verbose=2 "$extracted"
-          xcrun stapler validate -v "$extracted"
+          pnpm verify:signed-app "$unzip_dir/Guild Wars Reforged.app"
           sbom="$asset_dir/Guild-Wars-Reforged-$VERSION-macOS-arm64.spdx.json"
           checksum="$asset_dir/SHA256SUMS.txt"
           {

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -79,6 +79,12 @@ lifetime. It blocks below two years and warns below five. After signing, it
 compares the embedded profile byte-for-byte and checks the top-level app's
 exact three entitlements.
 
+Those post-signing checks are `scripts/verify-signed-app.ts` rather than
+workflow text, so the release path is reproducible off CI:
+`pnpm verify:signed-app` runs every one of them against a notarized
+application, and its optional second argument against the disk image that
+carries it. The script's header states what it needs.
+
 ## Identity correction and saved-login rollout
 
 `2026.7.0-beta.2` was the first Developer ID package, but it inherited the

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "test:electron": "playwright test --config=tests/electron/playwright.config.ts",
     "test:packaged": "node --import ./scripts/ts-hook.mjs --experimental-strip-types tests/packaged-smoke.ts && node --import ./scripts/ts-hook.mjs --experimental-strip-types tests/packaged-enhancement-runtime.ts",
     "test:signed-keychain": "node --import ./scripts/ts-hook.mjs --experimental-strip-types tests/signed-keychain-runtime.ts",
+    "verify:signed-app": "node --import ./scripts/ts-hook.mjs --experimental-strip-types scripts/verify-signed-app.ts",
     "test:policy": "node --import ./scripts/ts-hook.mjs --experimental-strip-types --test --test-timeout=60000 tests/policy/*.ts",
     "test:release": "node --import ./scripts/ts-hook.mjs --experimental-strip-types --test --test-timeout=60000 tests/release/*.ts",
     "enhancements:live": "pnpm build && node --import ./scripts/ts-hook.mjs --experimental-strip-types scripts/enhancements-live.ts",

--- a/scripts/apple-signing.ts
+++ b/scripts/apple-signing.ts
@@ -112,6 +112,48 @@ export function ignoreRedundantSigningTarget(filePath: string): boolean {
   );
 }
 
+/**
+ * The exact entitlement set the top-level application of `channel` may carry.
+ *
+ * The preflight holds the entitlements *file* to it and
+ * `scripts/verify-signed-app.ts` holds the *signed application* to it, so the
+ * two can never disagree about what was approved.
+ */
+export function approvedDistributionEntitlements(
+  channel: DistributionChannel,
+): Readonly<Record<string, unknown>> {
+  return {
+    "com.apple.security.cs.allow-jit": true,
+    "com.apple.application-identifier": applicationIdentifier(channel),
+    "com.apple.developer.team-identifier": APPLE_TEAM_ID,
+  };
+}
+
+/**
+ * Whether `actual` is exactly `expected` — an extra key is a mismatch, which is
+ * the whole point of an allowlist.
+ */
+export function matchesExactEntitlements(
+  actual: unknown,
+  expected: Readonly<Record<string, unknown>>,
+): boolean {
+  if (typeof actual !== "object" || actual === null || Array.isArray(actual)) {
+    return false;
+  }
+  const value = actual as Record<string, unknown>;
+  return (
+    Object.keys(value).length === Object.keys(expected).length
+    && Object.entries(expected).every(([key, entitlement]) => value[key] === entitlement)
+  );
+}
+
+/** The certificate common name, and so the signature Authority, `channel` signs with. */
+export function distributionAuthorityName(channel: DistributionChannel): string {
+  return DISTRIBUTION_CHANNEL_CONFIG[channel].signingKind === "developer-id"
+    ? "Developer ID Application:"
+    : "Apple Development:";
+}
+
 export function distributionOptionsForFile(
   channel: DistributionChannel,
   filePath: string,
@@ -149,17 +191,10 @@ export function validateAppleSigningEvidence(
     fail("signing identity must be its unique uppercase SHA-1 fingerprint");
   }
   const expectedApplicationIdentifier = applicationIdentifier(channel);
-  const entitlements = dictionary(evidence.entitlements, "entitlements file");
-  const expectedEntitlements: Record<string, unknown> = {
-    "com.apple.security.cs.allow-jit": true,
-    "com.apple.application-identifier": expectedApplicationIdentifier,
-    "com.apple.developer.team-identifier": APPLE_TEAM_ID,
-  };
   if (
-    JSON.stringify(Object.keys(entitlements).sort())
-      !== JSON.stringify(Object.keys(expectedEntitlements).sort())
-    || Object.entries(expectedEntitlements).some(
-      ([key, value]) => entitlements[key] !== value,
+    !matchesExactEntitlements(
+      evidence.entitlements,
+      approvedDistributionEntitlements(channel),
     )
   ) {
     fail(`${channel} entitlements are not the exact approved allowlist`);
@@ -184,11 +219,7 @@ export function validateAppleSigningEvidence(
     fail("provisioning profile is expired or has no valid expiry");
   }
 
-  const config = DISTRIBUTION_CHANNEL_CONFIG[channel];
-  const expectedCertificateName =
-    config.signingKind === "developer-id"
-      ? "Developer ID Application:"
-      : "Apple Development:";
+  const expectedCertificateName = distributionAuthorityName(channel);
   const authorizedFingerprints = new Set(
     evidence.certificates
       .filter(({ subject }) => subject.includes(`CN=${expectedCertificateName}`))

--- a/scripts/verify-signed-app.ts
+++ b/scripts/verify-signed-app.ts
@@ -1,0 +1,200 @@
+// Everything a release asserts about a signed package, in one command a
+// developer can run against a build sitting on their own disk.
+//
+//   GW_SIGNED_CHANNEL=release \
+//   APPLE_PROVISIONING_PROFILE=/path/outside/the/repo/gwonmac.provisionprofile \
+//   pnpm verify:signed-app \
+//     "out/Guild Wars Reforged-darwin-arm64/Guild Wars Reforged.app" \
+//     "out/make/Guild Wars Reforged.dmg"
+//
+// The disk image is optional because the ZIP the updater installs contains an
+// application and no image. Everything else is required, and the application
+// must already be notarized and stapled: the Gatekeeper assessment and the
+// ticket are part of what is proved, so an unnotarized build fails here rather
+// than passing a quieter version of the same check.
+//
+// It owns no expectation of its own. What an approved package looks like is
+// scripts/apple-signing.ts — the same table the signer is driven by — so a
+// signing change cannot leave the verifier agreeing with a rule that moved.
+// It refuses to build, sign, notarize, staple, or publish anything.
+import { spawnSync } from "node:child_process";
+import { readdirSync, readFileSync } from "node:fs";
+import path from "node:path";
+import {
+  approvedDistributionEntitlements,
+  distributionAuthorityName,
+  distributionOptionsForFile,
+  matchesExactEntitlements,
+} from "./apple-signing.ts";
+import {
+  APPLE_TEAM_ID,
+  DISTRIBUTION_CHANNEL_CONFIG,
+  isDistributionChannel,
+  type DistributionChannel,
+} from "../src/shared/distribution-channel.ts";
+
+// Electron ships four helper applications, and exactly one of them is the
+// Plugin helper — the only target allowed to disable library validation and
+// map unsigned executable memory. A fifth helper, or a second plugin, is
+// signing surface nobody approved.
+const HELPERS = 4;
+const PLUGIN_HELPERS = 1;
+
+function fail(message: string): never {
+  throw new Error(`Signed package verification failed: ${message}`);
+}
+
+function capture(command: string, args: readonly string[]): string {
+  const result = spawnSync(command, args, { encoding: "utf8" });
+  if (result.error) throw result.error;
+  // codesign, spctl and stapler report on stderr even when they succeed.
+  const output = `${result.stdout}${result.stderr}`;
+  if (result.status !== 0) {
+    fail(`${command} ${args.join(" ")} exited ${result.status}\n${output}`);
+  }
+  return output;
+}
+
+function expectSignature(target: string, required: readonly string[]): void {
+  const signature = capture("codesign", ["-dv", "--verbose=4", target]);
+  for (const needle of required) {
+    if (!signature.includes(needle)) {
+      fail(`${target} signature has no ${needle}\n${signature}`);
+    }
+  }
+}
+
+function signedEntitlements(target: string): unknown {
+  const signed = spawnSync("codesign", ["-d", "--entitlements", ":-", target]);
+  if (signed.error) throw signed.error;
+  if (signed.status !== 0) fail(`${target} has no readable entitlements`);
+  const converted = spawnSync(
+    "plutil",
+    ["-convert", "json", "-o", "-", "--", "-"],
+    { input: signed.stdout, encoding: "utf8" },
+  );
+  if (converted.status !== 0) {
+    fail(`${target} entitlements are not a property list`);
+  }
+  return JSON.parse(converted.stdout) as unknown;
+}
+
+function verifyHelpers(channel: DistributionChannel, application: string): void {
+  const frameworks = path.join(application, "Contents/Frameworks");
+  const helpers = readdirSync(frameworks)
+    .filter((entry) => entry.includes("Helper") && entry.endsWith(".app"))
+    .map((entry) => path.join(frameworks, entry));
+  const plugins = helpers.filter((helper) =>
+    helper.includes("Helper (Plugin).app"),
+  );
+  if (helpers.length !== HELPERS || plugins.length !== PLUGIN_HELPERS) {
+    fail(
+      `${application} carries ${helpers.length} helpers and ${plugins.length} `
+        + `plugin helpers, not ${HELPERS} and ${PLUGIN_HELPERS}`,
+    );
+  }
+  for (const helper of helpers) {
+    const approved = distributionOptionsForFile(channel, helper).entitlements;
+    if (!Array.isArray(approved)) {
+      fail(`${helper} is not signed as a helper application`);
+    }
+    const expected = Object.fromEntries(approved.map((key) => [key, true]));
+    if (!matchesExactEntitlements(signedEntitlements(helper), expected)) {
+      fail(`${helper} is not signed with exactly ${approved.join(", ")}`);
+    }
+    expectSignature(helper, [
+      `TeamIdentifier=${APPLE_TEAM_ID}`,
+      "Runtime Version",
+      "Timestamp=",
+    ]);
+  }
+}
+
+function verifyApplication(
+  channel: DistributionChannel,
+  application: string,
+  profile: string,
+): void {
+  capture("codesign", [
+    "--verify",
+    "--deep",
+    "--strict",
+    "--verbose=2",
+    application,
+  ]);
+  expectSignature(application, [
+    `Authority=${distributionAuthorityName(channel)}`,
+    `TeamIdentifier=${APPLE_TEAM_ID}`,
+    "Runtime Version",
+    "Timestamp=",
+  ]);
+  const bundleId = capture("/usr/libexec/PlistBuddy", [
+    "-c",
+    "Print :CFBundleIdentifier",
+    path.join(application, "Contents/Info.plist"),
+  ]).trim();
+  if (bundleId !== DISTRIBUTION_CHANNEL_CONFIG[channel].bundleId) {
+    fail(`${application} is ${bundleId}, which is not the ${channel} bundle`);
+  }
+  const embedded = readFileSync(
+    path.join(application, "Contents/embedded.provisionprofile"),
+  );
+  if (!embedded.equals(readFileSync(profile))) {
+    fail(`${application} embeds a provisioning profile other than ${profile}`);
+  }
+  if (
+    !matchesExactEntitlements(
+      signedEntitlements(application),
+      approvedDistributionEntitlements(channel),
+    )
+  ) {
+    fail(`${application} is not signed with the approved ${channel} entitlements`);
+  }
+  verifyHelpers(channel, application);
+  capture("xcrun", ["stapler", "validate", "-v", application]);
+  capture("spctl", ["--assess", "--type", "execute", "--verbose=4", application]);
+}
+
+function verifyDiskImage(channel: DistributionChannel, diskImage: string): void {
+  capture("codesign", ["--verify", "--verbose=2", diskImage]);
+  expectSignature(diskImage, [
+    `Authority=${distributionAuthorityName(channel)}`,
+    `TeamIdentifier=${APPLE_TEAM_ID}`,
+    "Timestamp=",
+  ]);
+  capture("xcrun", ["stapler", "validate", "-v", diskImage]);
+  // Gatekeeper assesses an image the way an opening user does, against the
+  // image's own signature rather than a quarantine record it has not got yet.
+  capture("spctl", [
+    "--assess",
+    "--type",
+    "open",
+    "--context",
+    "context:primary-signature",
+    "--verbose=4",
+    diskImage,
+  ]);
+}
+
+const args = process.argv.slice(2);
+const [application, diskImage] = args;
+const channel = process.env.GW_SIGNED_CHANNEL;
+const profile = process.env.APPLE_PROVISIONING_PROFILE;
+// Only an absent second argument means a package with no disk image. An empty
+// one is a caller whose lookup found nothing, and skipping the image
+// assertions for it would let a release pass by verifying less than it asked
+// to.
+if (
+  !application
+  || !isDistributionChannel(channel)
+  || !profile
+  || (args.length > 1 && !diskImage)
+) {
+  throw new Error(
+    "usage: GW_SIGNED_CHANNEL=<channel> APPLE_PROVISIONING_PROFILE=<profile> "
+      + "verify-signed-app <application> [<disk image>]",
+  );
+}
+verifyApplication(channel, application, profile);
+if (diskImage) verifyDiskImage(channel, diskImage);
+console.log(`Verified the signed ${channel} package at ${application}.`);

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -124,6 +124,7 @@ test("distribution channels use preflighted signing and a scoped marker", () => 
   const workflow = read(".github/workflows/release.yml");
   const forge = read("forge.config.ts");
   const signing = read("scripts/apple-signing.ts");
+  const verifier = read("scripts/verify-signed-app.ts");
   assert.match(workflow, /environment: release/);
   for (const secret of [
     "APPLE_DEVELOPER_ID_P12",
@@ -183,20 +184,39 @@ test("distribution channels use preflighted signing and a scoped marker", () => 
   assert.match(workflow, /xcrun notarytool submit/);
   assert.match(workflow, /xcrun stapler staple/);
   assert.match(workflow, /test "\$TEAM_ID" = "9NN976MFZ4"/);
-  assert.match(workflow, /TeamIdentifier=9NN976MFZ4/);
   assert.match(workflow, /7F9A56793C16683742AA7818FE65221A884FA108/);
-  assert.match(workflow, /embedded\.provisionprofile/);
   assert.match(workflow, /remaining <= 2 \* 365 \* 86400000/);
   assert.match(workflow, /remaining <= 5 \* 365 \* 86400000/);
   assert.match(
     workflow,
     /rm -f "\$APPLE_PROVISIONING_PROFILE"[\s\S]*rm -f "\$APPLE_PROFILE_PLIST"/,
   );
-  assert.match(workflow, /Timestamp=/);
-  assert.match(workflow, /test "\$helper_count" -eq 4/);
-  assert.match(workflow, /test "\$plugin_helper_count" -eq 1/);
-  assert.match(workflow, /spctl --assess --type execute/);
-  assert.match(workflow, /spctl --assess --type open/);
+
+  // The signed-package assertions are the script's, and the workflow's only
+  // job is to run it. A release path that can only be exercised by cutting a
+  // release is one nobody can reproduce when it breaks, so an assertion that
+  // creeps back inline fails here.
+  assert.match(script("verify:signed-app"), /scripts\/verify-signed-app\.ts/);
+  assert.match(workflow, /GW_SIGNED_CHANNEL: release\n {8}run: \|\n {10}pnpm verify:signed-app/);
+  assert.match(workflow, /pnpm verify:signed-app "\$unzip_dir\//);
+  assert.doesNotMatch(
+    workflow,
+    /codesign -dv|codesign --verify|codesign -d --entitlements|spctl|stapler validate/,
+  );
+  assert.match(verifier, /TeamIdentifier=\$\{APPLE_TEAM_ID\}/);
+  assert.match(verifier, /Authority=\$\{distributionAuthorityName\(channel\)\}/);
+  assert.match(verifier, /embedded\.provisionprofile/);
+  assert.match(verifier, /"Timestamp="/);
+  assert.match(verifier, /const HELPERS = 4/);
+  assert.match(verifier, /const PLUGIN_HELPERS = 1/);
+  assert.match(verifier, /"--assess", "--type", "execute"/);
+  assert.match(verifier, /"--assess",\s*"--type",\s*"open"/);
+  assert.match(verifier, /approvedDistributionEntitlements\(channel\)/);
+  assert.match(verifier, /distributionOptionsForFile\(channel, helper\)/);
+  // The workflow passes the disk image as a `find` result. An empty one is a
+  // lookup that found nothing, not a package without an image, so it must not
+  // resolve to the form that skips every disk image assertion.
+  assert.match(verifier, /args\.length > 1 && !diskImage/);
 });
 
 test("release entitlements are an exact three-key allowlist", () => {


### PR DESCRIPTION
## What ships

`scripts/verify-signed-app.ts`: every Gatekeeper / entitlement / helper-census / notarization assertion that previously lived only inline in `release.yml` — runnable locally against any signed `.app` (plus an optional disk image). A release path only exercised by CI is one nobody can reproduce when it breaks; now the exact assertions run on a laptop.

## What changed

- `release.yml`'s verification step became a bare `pnpm verify:signed-app` call — zero assertion logic remains inline, and a policy test pins the workflow to that shape so logic cannot creep back.
- Argument validation is strict where it matters: an *empty-string* disk-image argument (e.g. a `find` that matched nothing) is a usage error, not a silent skip of every DMG assertion. Only an *absent* argument means "package with no image." A policy test pins this too.
- The identity/entitlement expectations stay owned by `scripts/apple-signing.ts`; the script asserts against them rather than declaring a second copy.

## Review focus

- Assertion parity: diff the old inline step against the script — nothing dropped in the move.
- The empty-vs-absent argument distinction in the usage guard.

## Verification

`set -o pipefail; pnpm check` green (659 unit + 130 policy). Script exercised directly: empty second argument hits the usage error; single-argument form proceeds to the application assertions. No release cut, no notarization run.
