### PR TITLE
Prove the release path without publishing anything

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,16 @@ name: Versioned release
 
 on:
   workflow_dispatch:
+    inputs:
+      dry_run:
+        # Proves the whole release path — the same build, signing,
+        # notarization, stapling, and verification a release runs — without
+        # creating a tag, a release, or an attestation. It gates the publish
+        # job alone, so a passing dry run is evidence about the real path
+        # rather than about a second one.
+        description: Build and verify the release, then publish nothing.
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -290,6 +300,30 @@ jobs:
             shasum -a 256 -c SHA256SUMS.txt
           )
 
+      # A dry run publishes nothing, so this is the only account it leaves of
+      # what it built and what the verification covered.
+      - name: Summarize built and verified assets
+        env:
+          ASSET_DIR: ${{ steps.assets.outputs.asset_dir }}
+          DRY_RUN: ${{ inputs.dry_run }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          outcome="built, signed, notarized, stapled, and verified"
+          if [ "$DRY_RUN" = "true" ]; then
+            headline="Dry run of $TAG: $outcome. Nothing published."
+          else
+            headline="$TAG: $outcome."
+          fi
+          {
+            echo "### Release assets"
+            echo
+            echo "$headline"
+            echo
+            echo '```'
+            cat "$ASSET_DIR/SHA256SUMS.txt"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Retain debug symbols
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -326,8 +360,11 @@ jobs:
             rm -f "$APPLE_PROFILE_PLIST"
           fi
 
+  # Every step below tags, attests, uploads, or publishes, and this is the only
+  # job holding the write permissions to do it. A dry run skips the job whole;
+  # nothing above it is conditional.
   release:
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main' && !inputs.dry_run
     needs: release-build
     runs-on: macos-15
     timeout-minutes: 15

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -303,6 +303,27 @@ test("release workflow publishes one tested, attested package version", () => {
     releasePublish,
     /actions\/checkout|pnpm install|pnpm make|pnpm test/,
   );
+
+  // A dry run is only evidence about the real release if it is the real
+  // release minus its publishing: the flag is read once, by the job that tags,
+  // attests, and uploads, and no step that builds or verifies may consult it.
+  // What the run produced is recorded where a skipped release cannot record
+  // it.
+  assert.match(workflow, /workflow_dispatch:\n {4}inputs:\n {6}dry_run:/);
+  assert.match(
+    workflow,
+    /description: Build and verify the release, then publish nothing\.\n {8}default: false\n {8}type: boolean/,
+  );
+  assert.match(
+    releasePublish,
+    /release:\n {4}if: github\.ref == 'refs\/heads\/main' && !inputs\.dry_run/,
+  );
+  assert.equal(workflow.match(/if: [^\n]*dry_run/gu)?.length, 1);
+  assert.match(
+    releaseBuild,
+    /name: Summarize built and verified assets[\s\S]*?cat "\$ASSET_DIR\/SHA256SUMS\.txt"[\s\S]*?>> "\$GITHUB_STEP_SUMMARY"/,
+  );
+
   assert.match(workflow, /--prerelease --latest=false/);
   assert.match(
     workflow,


### PR DESCRIPTION
## What ships

A `dry_run` input on the release workflow: build, sign, notarize, staple, and verify exactly as a real release would — publish nothing. The job summary reports artifact names, hashes, and verification outcomes. The one path that had no insurance now has a full rehearsal.

## What changed

- One path, not two: every build and verification step runs unconditionally; only the job that tags, attests, and uploads gates on the flag. The summary step reads the flag solely to label its report.
- A policy test enforces that shape — a future step that builds or verifies conditionally on `dry_run` fails `pnpm test:policy`, so the rehearsal can never drift from the real thing.

## Review focus

Confirm the conditional covers exactly the publish surface (tag, attestation, upload) and nothing upstream of it.

## Verification

`set -o pipefail; pnpm check` green; all release-pipeline policy tests pass. Not dispatched — the YAML shape plus the policy test are the reviewable evidence.
