### PR TITLE
Generate the inputs nobody thought of, and report what the tests reach

### DIFF
--- a/.github/workflows/macos-verify.yml
+++ b/.github/workflows/macos-verify.yml
@@ -63,6 +63,20 @@ jobs:
       - run: pnpm audit --audit-level=high
       - run: pnpm verify
 
+      # Written by the unit suite inside `pnpm verify`, so this costs a run of
+      # nothing. It is a report and not a gate: there is no threshold, and a
+      # verified commit stays verified whatever the number says. Uploaded even
+      # when the run failed, because a drop in what the tests reach is often
+      # what explains the failure.
+      - name: Upload unit coverage
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: unit-coverage-${{ github.run_id }}-${{ github.run_attempt }}
+          path: coverage/lcov.info
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: Upload Electron failure evidence
         if: failure()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ forge-dist/
 *.tsbuildinfo
 playwright-report/
 test-results/
+# The unit suite's coverage report. A measurement of the run that produced it,
+# never an input to the next one.
+coverage/
 .eslintcache
 
 # Local git worktrees checked out inside the repository.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,14 @@ is meant to inherit the dead ends rather than walk back into them.
 - Concurrent chunk reads share one promise per content hash.
 - Renderer and native download schedulers cap ArenaNet concurrency at eight.
   Demand work outranks queued prefetch; do not raise the ceiling.
+  `ARENANET_REQUEST_CEILING` in `src/shared/contracts.ts` is the one
+  declaration all three schedulers import, and
+  `tests/unit/the-download-schedulers-share-one-ceiling.test.ts` refuses a
+  second. A renderer module may import a `src/shared` *value*, but only from
+  the named allowlist `RENDERER_SHARED_MODULES` in `src/main/protocol.ts`,
+  which is what serves `build/shared` under `gw://app/shared/`. A value import
+  of anything else 404s at runtime, and neither the type checker, the linter
+  nor the unit tests catch it.
 - Snapshot constants can use fixed-width, non-canonical LEB128. Analysis tools
   must decode values rather than byte-match a canonical encoding.
 - `geodc.arenanetworks.com` can return the datacenter sentinel `0.0.1.2`; raw
@@ -252,6 +260,11 @@ pnpm test:packaged
 `pnpm test:policy` holds the repository invariants that need no build: import
 boundaries, lint coverage, action pinning, fuses, font licensing, forbidden
 artifacts, and documentation links.
+
+`pnpm test:unit` also writes `coverage/lcov.info`, and CI keeps it as a build
+artifact. It is a report: there is no threshold and no commit fails on it. What
+it is for is the question a passing suite cannot answer — which failure paths
+nothing exercises.
 
 `pnpm verify` runs that gate end to end, and CI runs it on every pull request.
 The website is not part of it: `apps/website` has its own path-filtered

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "typecheck": "tsc --noEmit && tsc -p tsconfig.renderer.json --noEmit && tsc -p tsconfig.tests.json",
     "lint": "eslint .",
     "check:links": "node --import ./scripts/ts-hook.mjs --experimental-strip-types scripts/check-markdown-links.ts",
-    "test:unit": "node --import ./scripts/ts-hook.mjs --experimental-strip-types --test --test-timeout=60000 tests/unit/*.ts",
+    "test:unit": "mkdir -p coverage && node --import ./scripts/ts-hook.mjs --experimental-strip-types --test --test-timeout=60000 --experimental-test-coverage --test-coverage-include='src/**' --test-reporter=spec --test-reporter-destination=stdout --test-reporter=lcov --test-reporter-destination=coverage/lcov.info tests/unit/*.ts",
     "test:integration": "node --import ./scripts/ts-hook.mjs --experimental-strip-types --test --test-timeout=60000 tests/integration/*.ts",
     "test:electron": "playwright test --config=tests/electron/playwright.config.ts",
     "test:packaged": "node --import ./scripts/ts-hook.mjs --experimental-strip-types tests/packaged-smoke.ts && node --import ./scripts/ts-hook.mjs --experimental-strip-types tests/packaged-enhancement-runtime.ts",

--- a/src/main/core/access-key.ts
+++ b/src/main/core/access-key.ts
@@ -4,11 +4,15 @@
  *
  * `ACCESS_KEY` identifies the official Guild Wars client, not a player and not
  * an installation; it is public, and the policy tests exempt this one
- * UUID-shaped value so that every other one still fails. The honest user agent,
- * the eight-job ceiling and the request timeout are conduct toward shared
- * production infrastructure, not tuning knobs to be raised when a download
- * feels slow. `FATAL_HTTP` is the set that no amount of backoff can help, so
- * retrying those is a defect rather than politeness.
+ * UUID-shaped value so that every other one still fails. The honest user agent
+ * and the request timeout are conduct toward shared production infrastructure,
+ * not tuning knobs to be raised when a download feels slow. `FATAL_HTTP` is the
+ * set that no amount of backoff can help, so retrying those is a defect rather
+ * than politeness.
+ *
+ * The ceiling on requests in flight is not here: the renderer's scheduler
+ * spends the same budget and cannot import from src/main, so
+ * `ARENANET_REQUEST_CEILING` in src/shared/contracts.ts owns it for both.
  */
 export const ACCESS_KEY = "2043FE79-F32D-4FD7-8C27-0D47231C4F03";
 export const PATCH_ROOT = "https://patching.1.arenanetworks.com";
@@ -18,7 +22,6 @@ export const PATCH_REQUEST_HEADERS: Readonly<Record<string, string>> = {
   "User-Agent": UA,
   "Accept-Encoding": "identity",
 };
-export const PREFETCH_JOBS = 8;
 export const PATCH_REQUEST_TIMEOUT_MS = 30_000;
 export const MAX_PATCH_MANIFEST_BYTES = 16 * 1024 * 1024;
 export const SNAPSHOT = "Gw.snapshot";

--- a/src/main/core/allowlists.ts
+++ b/src/main/core/allowlists.ts
@@ -3,10 +3,12 @@
  * and the ArenaNet domain suffixes.
  *
  * Every rule here is a refusal. Loopback, link-local, RFC1918, carrier-grade
- * NAT, this-network and multicast are all excluded, so a hostile or confused
- * destination cannot turn the main process into a scanner of the player's own
- * network. Suffix matching is anchored on a dot, so `notarenanetworks.com` is
- * not a match for `arenanetworks.com`.
+ * NAT, this-network, benchmarking and multicast are all excluded, so a hostile
+ * or confused destination cannot turn the main process into a scanner of the
+ * player's own network — and the address is matched as text before it is
+ * matched as a range, because a spelling the platform resolver reads
+ * differently is a way past every range below. Suffix matching is anchored on a
+ * dot, so `notarenanetworks.com` is not a match for `arenanetworks.com`.
  *
  * These are the game-infrastructure rules. Web services are allowlisted
  * separately in `proxy-routes.ts`; the two lists grant different things and
@@ -31,11 +33,22 @@ export function allowedName(
   return domains.some((d) => h === d || h.endsWith("." + d));
 }
 
+/**
+ * Four decimal groups and nothing else, matched before any range is consulted.
+ * `Number` accepted spellings that reach a refused address by another route: an
+ * empty group in `8.8.8.`, surrounding whitespace, `0x08.8.8.8`, and the leading
+ * zeros `inet_aton` reads as octal, where `012.0.0.1` is a public decimal 12
+ * here and 10.0.0.1 to whatever connects. IPv4-in-IPv6 is refused by this rule
+ * rather than by how the dots happen to divide, so the refusal survives an edit
+ * to the ranges below.
+ */
+const IPV4_TEXT = /^(0|[1-9]\d{0,2})\.(0|[1-9]\d{0,2})\.(0|[1-9]\d{0,2})\.(0|[1-9]\d{0,2})$/;
+
 export function isPublicIpv4(ip: string): boolean {
-  const p = ip.split(".");
-  if (p.length !== 4) return false;
-  const nums = p.map((x) => Number(x));
-  if (nums.some((n) => !Number.isInteger(n) || n < 0 || n > 255)) return false;
+  const groups = IPV4_TEXT.exec(ip);
+  if (!groups) return false;
+  const nums = groups.slice(1).map(Number);
+  if (nums.some((n) => n > 255)) return false;
   const [a, b] = nums as [number, number, number, number];
   if (a === 0) return false;
   if (a === 10) return false;
@@ -45,6 +58,9 @@ export function isPublicIpv4(ip: string): boolean {
   if (a === 192 && b === 168) return false;
   if (a === 100 && b >= 64 && b <= 127) return false;
   if (a === 192 && b === 0) return false;
+  // Benchmarking range: never routed, and a lab's test harness is the last
+  // thing a game connection should be able to reach.
+  if (a === 198 && (b === 18 || b === 19)) return false;
   if (a >= 224) return false;
   return true;
 }

--- a/src/main/core/chunk-store.ts
+++ b/src/main/core/chunk-store.ts
@@ -15,13 +15,15 @@
  */
 import { readFile, readdir, stat, statfs, unlink } from "node:fs/promises";
 import { join } from "node:path";
-import type { PrefetchProgress } from "../../shared/contracts.js";
+import {
+  ARENANET_REQUEST_CEILING,
+  type PrefetchProgress,
+} from "../../shared/contracts.js";
 import { AppError, type ErrorCode } from "../../shared/errors.js";
 import {
   DownloadRateAverage,
   secondsRemaining,
 } from "../../shared/progress.js";
-import { PREFETCH_JOBS } from "./access-key.js";
 import { mapPool } from "./async-pool.js";
 import { writeAtomicInDir, writeAtomicJson } from "./atomic-file.js";
 import { decodeChunk, verifyChunkHash } from "./chunk-format.js";
@@ -445,7 +447,7 @@ export class ChunkStore {
   }
 
   private drainFetchQueue(): void {
-    while (this.activeDemand + this.activePrefetch < PREFETCH_JOBS) {
+    while (this.activeDemand + this.activePrefetch < ARENANET_REQUEST_CEILING) {
       const task = this.demandQueue.shift() ?? this.prefetchQueue.shift();
       if (!task) break;
       if (task.priority === "prefetch" && this.stopFlag) {
@@ -558,7 +560,7 @@ export class ChunkStore {
 
   async prefetch(
     onProgress?: (p: PrefetchProgress) => void,
-    jobs = PREFETCH_JOBS,
+    jobs = ARENANET_REQUEST_CEILING,
   ): Promise<void> {
     if (!this.fetchFn) return;
     const want = await this.readBootChunks();
@@ -599,7 +601,7 @@ export class ChunkStore {
     jobs?: number;
     freeBytes?: () => Promise<number>;
   } = {}): Promise<boolean> {
-    const jobs = opts.jobs ?? PREFETCH_JOBS;
+    const jobs = opts.jobs ?? ARENANET_REQUEST_CEILING;
     this.stopFlag = false;
     await this.initializeResidency();
     const residentRepresentatives = new Map<string, number>();

--- a/src/main/core/patch-client.ts
+++ b/src/main/core/patch-client.ts
@@ -26,9 +26,10 @@ import {
   stat,
 } from "node:fs/promises";
 import { join } from "node:path";
-import type {
-  DownloadActivity,
-  DownloadProgress,
+import {
+  ARENANET_REQUEST_CEILING,
+  type DownloadActivity,
+  type DownloadProgress,
 } from "../../shared/contracts.js";
 import { AppError } from "../../shared/errors.js";
 import {
@@ -40,7 +41,6 @@ import {
   MAX_PATCH_MANIFEST_BYTES,
   PATCH_REQUEST_HEADERS,
   PATCH_ROOT,
-  PREFETCH_JOBS,
   REQUIRED_PATCH_FILES,
   SNAPSHOT,
 } from "./access-key.js";
@@ -113,7 +113,7 @@ export class PatchClient {
     this.chunksDir = opts.chunksDir;
     this.patchRoot = opts.patchRoot ?? PATCH_ROOT;
     this.fetchFn = opts.fetch;
-    this.jobs = opts.jobs ?? PREFETCH_JOBS;
+    this.jobs = opts.jobs ?? ARENANET_REQUEST_CEILING;
     this.onProgress = opts.onProgress;
     this.headers = { ...PATCH_REQUEST_HEADERS };
   }

--- a/src/renderer/image-source.ts
+++ b/src/renderer/image-source.ts
@@ -9,14 +9,18 @@
  * algorithms testable.
  */
 
-import type { SnapshotMetadata } from '../shared/contracts.js';
+// A runtime import, not a type-only one: src/main/protocol.ts serves
+// build/shared/contracts.js at gw://app/shared/contracts.js for exactly this.
+import {
+  ARENANET_REQUEST_CEILING,
+  type SnapshotMetadata,
+} from '../shared/contracts.js';
 
 // The chunk size the main process publishes; the fallback is the value the
 // harness has always substituted for a metadata document without one.
 const DEFAULT_CHUNK_SIZE = 262144;
 // Renderer memory is disposable; native chunk residency lives in the main process.
 const CHUNK_CACHE_MAX = 256 * 1024 * 1024;
-const MAX_CHUNK_REQUESTS = 8;
 // A read burst is summarised once it goes quiet, for the optional game console.
 const BURST_QUIET_MS = 400;
 const BURST_LOG_BYTES = 4 * 1024 * 1024;
@@ -208,7 +212,7 @@ export function createImageSource({
     const first = demandQueue.shift();
     if (!first) return [];
     const tasks = [first];
-    while (tasks.length < Math.min(capacity, MAX_CHUNK_REQUESTS)) {
+    while (tasks.length < Math.min(capacity, ARENANET_REQUEST_CEILING)) {
       const nextIndex = tasks[tasks.length - 1]!.index + 1;
       const queuedIndex = demandQueue.findIndex((task) => task.index === nextIndex);
       if (queuedIndex < 0) break;
@@ -260,8 +264,8 @@ export function createImageSource({
   }
 
   function drainChunkQueue() {
-    while (activeDemand + activePrefetch < MAX_CHUNK_REQUESTS) {
-      const capacity = MAX_CHUNK_REQUESTS - activeDemand - activePrefetch;
+    while (activeDemand + activePrefetch < ARENANET_REQUEST_CEILING) {
+      const capacity = ARENANET_REQUEST_CEILING - activeDemand - activePrefetch;
       const demand = takeDemandBatch(capacity);
       if (demand.length) {
         startChunkTasks(demand);

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -1,7 +1,8 @@
 /**
  * The canonical contracts between main, the preload and the renderer: the IPC
  * channels, the settings, the progress and socket shapes, the Enhancement
- * capability profiles, and the closed vocabularies each side validates against.
+ * capability profiles, the ceiling on requests in flight to ArenaNet, and the
+ * closed vocabularies each side validates against.
  *
  * These are types and frozen values only. Nothing here has behaviour, imports
  * Electron, or touches a filesystem, which is what lets both processes and the
@@ -34,6 +35,15 @@ export interface SnapshotMetadata {
   chunkHashes: string[];
   residentBits: Uint8Array;
 }
+
+/**
+ * Requests in flight to ArenaNet, summed over every scheduler this application
+ * runs: the main process chunk store and patch client, and the renderer's
+ * snapshot image reader. They spend one budget against infrastructure every
+ * installation shares, so lowering this is a decision and raising it is a
+ * defect.
+ */
+export const ARENANET_REQUEST_CEILING = 8;
 
 /**
  * Why a ready client is not simply "ready": the launch took a fallback the

--- a/tests/unit/allowlists.test.ts
+++ b/tests/unit/allowlists.test.ts
@@ -58,11 +58,45 @@ describe("allowlists", () => {
     ]) {
       assert.equal(isPublicIp(ip), false, ip);
     }
+    // Carrier-grade NAT and the benchmarking range are someone else's
+    // infrastructure, not a game server.
+    for (const ip of [
+      "100.64.0.0",
+      "100.127.255.255",
+      "198.18.0.1",
+      "198.19.255.255",
+    ]) {
+      assert.equal(isPublicIp(ip), false, ip);
+    }
+    // Spellings that reach a refused address by a route the range checks do
+    // not see: an empty group, whitespace, hex, octal-looking leading zeros,
+    // and a quad carried inside an IPv6 literal.
+    for (const ip of [
+      "8.8.8.",
+      ".8.8.8",
+      " 8.8.8.8",
+      "8.8.8.8 ",
+      "8.8.8.8\n",
+      "0x08.8.8.8",
+      "012.0.0.1",
+      "8.8.8.08",
+      "8.8.8.+8",
+      "8.8.8.8.8",
+      "::ffff:8.8.8.8",
+      "::ffff:198.18.0.1",
+      "64:ff9b::8.8.8.8",
+    ]) {
+      assert.equal(isPublicIp(ip), false, ip);
+    }
     for (const ip of [
       "8.8.8.8",
       "54.196.189.234",
       "172.15.0.1",
       "172.32.0.1",
+      "100.63.255.255",
+      "100.128.0.1",
+      "198.17.255.255",
+      "198.20.0.1",
     ]) {
       assert.equal(isPublicIp(ip), true, ip);
     }

--- a/tests/unit/the-binary-parsers-hold-against-a-seeded-corpus.test.ts
+++ b/tests/unit/the-binary-parsers-hold-against-a-seeded-corpus.test.ts
@@ -1,0 +1,408 @@
+// The four parsers that read bytes this project did not write: the chunk
+// format, the patch manifest, LEB128 as ArenaNet's snapshots actually spell it,
+// and the WebAssembly section walk. Their existing tests are hand-curated,
+// which means they cover the inputs someone thought of — and the interesting
+// input is by definition the one nobody thought of.
+//
+// So the corpus is generated, and the assertion is a property rather than an
+// expected value: every one of these either produces a result that satisfies
+// its own stated invariant, or refuses with this repository's error type. What
+// it must never do is return something almost right.
+//
+// The generator is seeded and the round counts are fixed, so a run here costs
+// the same on every machine and a failure names an exact case that reproduces.
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { describe, it } from "node:test";
+import { gzipSync } from "node:zlib";
+import { HASH_ALGOS } from "../../src/main/core/access-key.js";
+import {
+  decodeChunk,
+  parseContentHash,
+  verifyChunkHash,
+} from "../../src/main/core/chunk-format.js";
+import { Manifest } from "../../src/main/core/manifest.js";
+import {
+  concat,
+  encodeCode,
+  encodeIndexVector,
+  encodeSection,
+  paddedIndex,
+  parseCode,
+  parseIndexVector,
+  parseTypes,
+  readSleb,
+  readUleb,
+  sleb,
+  splitSections,
+  uleb,
+  WASM_HEADER,
+} from "../../src/main/core/wasm-binary.js";
+import { AppError } from "../../src/shared/errors.js";
+
+const ROUNDS = 200;
+
+/** One stream per target, so adding a target does not reshuffle the others. */
+function stream(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 0x1_0000_0000;
+  };
+}
+
+function below(next: () => number, bound: number): number {
+  return Math.floor(next() * bound);
+}
+
+function pick<T>(next: () => number, values: readonly T[]): T {
+  return values[below(next, values.length)]!;
+}
+
+function randomBytes(next: () => number, length: number): Uint8Array {
+  return Uint8Array.from({ length }, () => below(next, 256));
+}
+
+/** What was thrown, once it is known to be an `Error`. */
+function thrown(run: () => unknown, what: string): Error {
+  try {
+    run();
+  } catch (error) {
+    assert.ok(error instanceof Error, `${what} threw a non-Error`);
+    return error;
+  }
+  return assert.fail(`${what} did not refuse`);
+}
+
+describe("LEB128 as the snapshots spell it", () => {
+  /**
+   * The same value in a wider encoding, which the format permits and a
+   * generated snapshot constant really uses. A decoder that byte-matched a
+   * canonical encoding would read these as different values.
+   */
+  function padUleb(value: number, width: number): Uint8Array {
+    const out = new Uint8Array(width);
+    let rest = value;
+    for (let index = 0; index < width; index += 1) {
+      out[index] = (rest & 0x7f) | (index === width - 1 ? 0 : 0x80);
+      rest >>>= 7;
+    }
+    return out;
+  }
+
+  it("decodes every non-canonical width of the same unsigned value", () => {
+    const next = stream(0x1f2e_3d4c);
+    for (let round = 0; round < ROUNDS; round += 1) {
+      const value = below(next, 0x1_0000_0000);
+      const canonical = uleb(value);
+      assert.equal(readUleb(canonical, { offset: 0 }), value, `round ${round}`);
+      for (let width = canonical.byteLength; width <= 5; width += 1) {
+        assert.equal(
+          readUleb(padUleb(value, width), { offset: 0 }),
+          value,
+          `round ${round}, width ${width}`,
+        );
+      }
+      assert.equal(readUleb(paddedIndex(value), { offset: 0 }), value, `round ${round}`);
+    }
+  });
+
+  it("round-trips signed values and refuses what will not fit", () => {
+    const next = stream(0x2a3b_4c5d);
+    for (let round = 0; round < ROUNDS; round += 1) {
+      const value = below(next, 0x1_0000_0000) - 0x8000_0000;
+      assert.equal(readSleb(sleb(value), { offset: 0 }), value, `round ${round}`);
+
+      const truncated = Uint8Array.from(
+        { length: 1 + below(next, 4) },
+        () => 0x80 | below(next, 128),
+      );
+      assert.match(
+        thrown(() => readUleb(truncated, { offset: 0 }), `round ${round}`).message,
+        /^wasm: truncated LEB128$/u,
+      );
+
+      const oversized = Uint8Array.from(
+        { length: 6 + below(next, 4) },
+        () => 0x80 | below(next, 128),
+      );
+      assert.match(
+        thrown(() => readUleb(oversized, { offset: 0 }), `round ${round}`).message,
+        /^wasm: oversized LEB128$/u,
+      );
+    }
+  });
+});
+
+describe("the chunk format against generated input", () => {
+  const HASH_CHARACTERS = "0123456789abcdefABCDEFghz-_ ";
+
+  it("accepts exactly the digest shapes, and lower-cases what it accepts", () => {
+    const next = stream(0x3b4c_5d6e);
+    for (let round = 0; round < ROUNDS; round += 1) {
+      const length = pick(next, [0, 1, 31, 32, 33, 40, 41, 63, 64, 65]);
+      const candidate = Array.from(
+        { length },
+        () => HASH_CHARACTERS[below(next, HASH_CHARACTERS.length)]!,
+      ).join("");
+      const acceptable =
+        HASH_ALGOS[length] !== undefined && /^[0-9a-fA-F]+$/u.test(candidate);
+      if (acceptable) {
+        assert.equal(parseContentHash(candidate), candidate.toLowerCase(), candidate);
+      } else {
+        const error = thrown(() => parseContentHash(candidate), `round ${round}`);
+        assert.ok(error instanceof AppError, candidate);
+        assert.equal(error.code, "hash_format", candidate);
+      }
+    }
+  });
+
+  it("verifies a chunk against its own digest and no other", () => {
+    const next = stream(0x4c5d_6e7f);
+    for (let round = 0; round < ROUNDS; round += 1) {
+      const data = randomBytes(next, 1 + below(next, 64));
+      const algorithm = pick(next, ["md5", "sha1", "sha256"] as const);
+      const hash = createHash(algorithm).update(data).digest("hex");
+      verifyChunkHash(hash, data);
+
+      const at = below(next, hash.length);
+      const wrong =
+        hash.slice(0, at)
+        + (hash[at] === "0" ? "1" : "0")
+        + hash.slice(at + 1);
+      const error = thrown(() => verifyChunkHash(wrong, data), `round ${round}`);
+      assert.ok(error instanceof AppError, `round ${round}`);
+      assert.equal(error.code, "hash_mismatch", `round ${round}`);
+    }
+  });
+
+  it("never yields a decoded chunk of a length the manifest did not declare", async () => {
+    const next = stream(0x5d6e_7f80);
+    for (let round = 0; round < ROUNDS; round += 1) {
+      const data = randomBytes(next, 1 + below(next, 96));
+      const compressed = gzipSync(data);
+      assert.deepEqual(
+        await decodeChunk(compressed, "gzip", data.byteLength),
+        Buffer.from(data),
+        `round ${round}`,
+      );
+      assert.deepEqual(
+        await decodeChunk(data, "none", data.byteLength),
+        data,
+        `round ${round}`,
+      );
+
+      for (const [what, run] of [
+        ["an over-declared length", () => decodeChunk(compressed, "gzip", data.byteLength + 1)],
+        ["a truncated gzip", () => decodeChunk(compressed.subarray(0, compressed.byteLength - 1), "gzip", data.byteLength)],
+        ["raw bytes read as gzip", () => decodeChunk(data, "gzip", data.byteLength)],
+        ["a length disagreement", () => decodeChunk(data, "none", data.byteLength + 1)],
+      ] as const) {
+        await assert.rejects(
+          run,
+          (error: unknown) => error instanceof AppError,
+          `round ${round}: ${what}`,
+        );
+      }
+    }
+  });
+});
+
+describe("the patch manifest against generated input", () => {
+  // Each field is sound most of the time and hostile the rest of it. A manifest
+  // has eight or so independent fields, so drawing each one uniformly from a
+  // pool of mostly-hostile values would refuse every round — and a refusal
+  // proves nothing about the paths a caller is handed if nothing is ever
+  // handed over. Over this seed, 57 of the 200 rounds parse.
+  const HOSTILE_SHARE = 0.08;
+  const HOSTILE_NAMES = [
+    "..",
+    ".",
+    "",
+    "/etc",
+    "a/b",
+    "a\\b",
+    "a\0b",
+    "__proto__",
+    "prototype",
+    "constructor",
+    "n".repeat(256),
+  ];
+  const HOSTILE_SIZES = [0, -4, 4.5, "8", Number.MAX_SAFE_INTEGER];
+
+  function hostile<T>(next: () => number, values: readonly T[], sound: T): T {
+    return next() < HOSTILE_SHARE ? pick(next, values) : sound;
+  }
+
+  /**
+   * A parent under `ceiling`, or one of the spellings that must be refused. A
+   * self reference is in range and still a cycle, so it belongs with the
+   * out-of-range values rather than with the sound draws.
+   */
+  function parentIndex(
+    next: () => number,
+    index: number,
+    ceiling: number,
+  ): unknown {
+    return hostile(
+      next,
+      [-1, 1.5, "1", true, index, Number.MAX_SAFE_INTEGER],
+      ceiling === 0 ? pick(next, [undefined, null]) : pick(next, [undefined, null, below(next, ceiling)]),
+    );
+  }
+
+  function randomHash(next: () => number, length: number): string {
+    return Array.from({ length }, () => "0123456789abcdef"[below(next, 16)]!).join("");
+  }
+
+  it("either refuses, or yields paths that may be joined onto a real directory", () => {
+    const next = stream(0x6e7f_8091);
+    // Named against whatever the rounds below actually reach, rather than
+    // against the one key an author guessed at: any own property that was not
+    // there before is pollution, whichever hostile name carried it.
+    const untouched = Object.getOwnPropertyNames(Object.prototype);
+    let accepted = 0;
+    let paths = 0;
+    for (let round = 0; round < ROUNDS; round += 1) {
+      const chunkSize = hostile(next, [0, -1, 4.5, 1 << 25], pick(next, [4, 8]));
+      const directoryCount = below(next, 5);
+      const raw = {
+        compressionMode: hostile(next, ["brotli", 7, null], pick(next, ["none", "gzip"])),
+        chunkSize,
+        // A distinct sound name per index, so the rounds that refuse do so for
+        // the reason the round injected rather than for a duplicate path.
+        directories: Array.from({ length: directoryCount }, (_, index) => ({
+          name: hostile(next, HOSTILE_NAMES, `d${index}`),
+          parentIndex: parentIndex(next, index, index),
+        })),
+        files: Array.from({ length: below(next, 5) }, (_, index) => {
+          const size = hostile(next, HOSTILE_SIZES, 1 + below(next, 24));
+          const declared = Math.ceil(Number(size) / Number(chunkSize));
+          // Clamped, so a nonsensical size produces a manifest to refuse
+          // rather than a chunk list too large to build.
+          const count = Math.min(
+            8,
+            Math.max(0, Number.isSafeInteger(declared) ? declared : 1),
+          );
+          return {
+            name: hostile(next, HOSTILE_NAMES, `f${index}.dat`),
+            size,
+            chunkHashes: Array.from({ length: hostile(next, [count + 1, 0], count) }, () =>
+              randomHash(next, hostile(next, [31, 33, 0], pick(next, [32, 40, 64])))),
+            parentIndex: parentIndex(next, index, directoryCount),
+          };
+        }),
+      };
+
+      let manifest: Manifest;
+      try {
+        manifest = new Manifest(raw);
+      } catch (error) {
+        assert.ok(error instanceof AppError, `round ${round} refused with a foreign error`);
+        continue;
+      }
+
+      accepted += 1;
+      assert.equal(Object.getPrototypeOf(manifest.files), null, `round ${round}`);
+      for (const [path, entry] of Object.entries(manifest.files)) {
+        paths += 1;
+        const segments = path.split("/");
+        assert.ok(segments.length > 0 && segments.every((segment) =>
+          segment.length > 0
+          && segment.length <= 255
+          && segment !== "."
+          && segment !== ".."
+          && !segment.includes("\0")
+          && !segment.includes("\\")), `round ${round}: ${JSON.stringify(path)}`);
+        assert.equal(
+          entry.chunkHashes.length,
+          Math.ceil(entry.size / manifest.chunkSize),
+          `round ${round}: ${path}`,
+        );
+        for (const hash of entry.chunkHashes) {
+          assert.equal(hash, hash.toLowerCase(), `round ${round}: ${path}`);
+          assert.ok(HASH_ALGOS[hash.length], `round ${round}: ${path}`);
+        }
+      }
+    }
+    assert.deepEqual(Object.getOwnPropertyNames(Object.prototype), untouched);
+    // The generator is the part that rots. Without this, weighting it a little
+    // further toward hostile input would turn the whole round into a refusal
+    // check and nothing above it would ever run again.
+    assert.ok(accepted > ROUNDS / 4, `only ${accepted} of ${ROUNDS} manifests parsed`);
+    assert.ok(paths > ROUNDS / 4, `only ${paths} paths were produced`);
+  });
+});
+
+describe("the WebAssembly section walk against generated input", () => {
+  function randomModule(next: () => number): Uint8Array {
+    const sections = Array.from({ length: 1 + below(next, 6) }, () =>
+      encodeSection({
+        id: below(next, 13),
+        body: randomBytes(next, below(next, 40)),
+      }));
+    return concat(WASM_HEADER, ...sections);
+  }
+
+  it("re-encodes what it split, byte for byte", () => {
+    const next = stream(0x7f80_91a2);
+    for (let round = 0; round < ROUNDS; round += 1) {
+      const module = randomModule(next);
+      const sections = splitSections(module);
+      assert.deepEqual(
+        concat(WASM_HEADER, ...sections.map(encodeSection)),
+        module,
+        `round ${round}`,
+      );
+    }
+  });
+
+  it("round-trips index vectors and code bodies", () => {
+    const next = stream(0x8091_a2b3);
+    for (let round = 0; round < ROUNDS; round += 1) {
+      const indices = Array.from({ length: below(next, 12) }, () =>
+        below(next, 0x1_0000_0000));
+      assert.deepEqual(
+        parseIndexVector(encodeIndexVector(indices)),
+        indices,
+        `round ${round}`,
+      );
+
+      const bodies = Array.from({ length: below(next, 6) }, () =>
+        randomBytes(next, below(next, 24)));
+      assert.deepEqual(parseCode(encodeCode(bodies)), bodies, `round ${round}`);
+    }
+  });
+
+  it("refuses a corrupted module as a structural fault, never as a surprise", () => {
+    const next = stream(0x91a2_b3c4);
+    const parsers = [splitSections, parseTypes, parseIndexVector, parseCode];
+    for (let round = 0; round < ROUNDS; round += 1) {
+      const module = randomModule(next);
+      const at = below(next, module.byteLength);
+      const corrupted = Uint8Array.from(module);
+      corrupted[at] = (corrupted[at]! + 1 + below(next, 255)) & 0xff;
+
+      for (const parse of parsers) {
+        try {
+          parse(corrupted);
+        } catch (error) {
+          assert.ok(error instanceof Error, `round ${round}: ${parse.name}`);
+          assert.match(error.message, /^wasm: /u, `round ${round}: ${parse.name}`);
+        }
+      }
+
+      const noise = randomBytes(next, below(next, 64));
+      for (const parse of parsers) {
+        try {
+          parse(noise);
+        } catch (error) {
+          assert.ok(error instanceof Error, `round ${round}: ${parse.name}`);
+          assert.match(error.message, /^wasm: /u, `round ${round}: ${parse.name}`);
+        }
+      }
+    }
+  });
+});

--- a/tests/unit/the-download-schedulers-share-one-ceiling.test.ts
+++ b/tests/unit/the-download-schedulers-share-one-ceiling.test.ts
@@ -1,0 +1,80 @@
+// Three schedulers spend the ceiling on requests in flight to ArenaNet — the
+// chunk store and the patch client in the main process, the snapshot image
+// reader in the renderer — and they import one declaration. This is the scan
+// that keeps it one: a fourth const named for the same budget is what a reader
+// would take for the ceiling and what a scheduler would then spend twice.
+//
+// The renderer's import is the fragile half, and its second test is here for
+// that reason. `src/shared` reaches the renderer only through the named
+// allowlist in src/main/protocol.ts; a value import of a module outside it
+// typechecks, lints, passes every unit test, and 404s when the launcher runs.
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { ARENANET_REQUEST_CEILING } from "../../src/shared/contracts.js";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+const OWNER = "src/shared/contracts.ts";
+
+// Names such a ceiling plausibly takes, bound to the value it has. The name
+// half is deliberately broad, because what this must catch is the constant
+// someone declares next under whatever name reads naturally to them. The value
+// half keeps an unrelated bound of some other size out of it: a second copy of
+// *this* ceiling is 8, and a copy that is not 8 already disagrees with a
+// scheduler test that pins the behaviour.
+const CEILING_DECLARATION =
+  /^\s*(?:export\s+)?const\s+([A-Za-z0-9_]*(?:JOBS|REQUESTS|CONCURRENCY|CEILING|PARALLEL)[A-Za-z0-9_]*)\s*=\s*8\s*;/gmu;
+
+const sources = execFileSync(
+  "git",
+  ["ls-files", "--cached", "--others", "--exclude-standard", "src"],
+  { cwd: root, encoding: "utf8" },
+)
+  .split("\n")
+  .filter((file) => /^src\/.+\.(?:m|c)?ts$/u.test(file))
+  .filter((file) => existsSync(path.join(root, file)));
+
+const read = (file: string) => readFileSync(path.join(root, file), "utf8");
+
+test("no second declaration of the ceiling exists", () => {
+  const declarations = sources.flatMap((file) => {
+    const text = read(file);
+    return [...text.matchAll(CEILING_DECLARATION)].map((match) => ({
+      file,
+      name: match[1]!,
+    }));
+  });
+
+  assert.deepEqual(
+    declarations,
+    [{ file: OWNER, name: "ARENANET_REQUEST_CEILING" }],
+    "a second request ceiling was declared; the one above is the whole set",
+  );
+});
+
+test("the renderer's scheduler can load the module that declares it", () => {
+  const scheduler = read("src/renderer/image-source.ts");
+  assert.match(
+    scheduler,
+    /^import \{\n\s*ARENANET_REQUEST_CEILING,/mu,
+    "src/renderer/image-source.ts no longer imports the ceiling as a value",
+  );
+
+  const allowlist = /const RENDERER_SHARED_MODULES = new Set\(\[([^\]]*)\]\)/u
+    .exec(read("src/main/protocol.ts"));
+  assert.ok(allowlist, "src/main/protocol.ts no longer declares the allowlist");
+  assert.ok(
+    allowlist[1]!.includes('"contracts.js"'),
+    "gw://app/shared/contracts.js is no longer served to the renderer",
+  );
+});
+
+test("eight is what ArenaNet's shared infrastructure is owed", () => {
+  // Conduct toward infrastructure every installation shares, so lowering it is
+  // a decision and raising it is a defect.
+  assert.equal(ARENANET_REQUEST_CEILING, 8);
+});

--- a/tests/unit/the-glue-rewrites-exactly-the-allowlisted-routes.test.ts
+++ b/tests/unit/the-glue-rewrites-exactly-the-allowlisted-routes.test.ts
@@ -1,0 +1,39 @@
+// Two tables describe the same allowlist from opposite ends. src/main/core/
+// proxy-routes.ts decides which hosts `gw://app/<route>/…` may reach; the
+// renderer rewrites the client's same-origin API calls onto those paths, and
+// the labels it recognises are written out again in src/renderer/harness.ts
+// because the import boundary keeps the renderer out of src/main.
+//
+// Neither drift is loud. A label the renderer does not know leaves the call on
+// its original URL, where the proxy never sees it and the request fails as a
+// network error rather than as a refusal. A label the route table has since
+// dropped is rewritten into a `gw://app` path that fails closed, which is safe
+// and also indistinguishable from the feature never having worked.
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+import { PROXY_ROUTES } from "../../src/main/core/proxy-routes.js";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+const GLUE = "src/renderer/harness.ts";
+
+const PROXY_LABELS = /const PROXY_LABELS = new Set\(\[([^\]]*)\]\);/u;
+
+/**
+ * The renderer's label set is read out of its source rather than imported:
+ * harness.ts installs itself onto `window` and `Module` at import time, and a
+ * DOM-less test process has neither.
+ */
+function glueLabels(): string[] {
+  const text = readFileSync(path.join(root, GLUE), "utf8");
+  const match = PROXY_LABELS.exec(text);
+  assert.ok(match, `${GLUE} no longer declares a PROXY_LABELS set`);
+  return [...match[1]!.matchAll(/['"]([^'"]*)['"]/gu)].map((entry) => entry[1]!);
+}
+
+test("the renderer rewrites every allowlisted route and no other label", () => {
+  assert.deepEqual(glueLabels().sort(), Object.keys(PROXY_ROUTES).sort());
+});


### PR DESCRIPTION
## What ships

Three test upgrades with one theme — make the invisible visible:

1. **Coverage as a report, not a gate.** `pnpm test:unit` writes `coverage/lcov.info` and CI keeps it as an artifact. No threshold, no new failure mode; it answers the one question a passing suite cannot — which failure paths nothing exercises.
2. **Seeded property tests for the binary parsers** (`the-binary-parsers-hold-against-a-seeded-corpus.test.ts`): the chunk format, the patch manifest, non-canonical LEB128 widths, and the WebAssembly section walk are fed generated inputs and held to a property — parse to a value satisfying the invariant, or refuse with this repository's error type. Fixed seed and round counts: same cost everywhere, every failure names a reproducing case. The generator guards its own honesty — if weighted so far toward hostile input that the accept path stops running, the round fails.
3. **Cross-table invariants where two representations must agree.** The eight-request ceiling now has exactly one owner — `ARENANET_REQUEST_CEILING` in `src/shared/contracts.ts` — imported as a runtime value by the main-process schedulers *and* the renderer (via the `gw://app/shared/` allowlist route). A join test proves the single declaration, the renderer's value import, and the protocol allowlist entry together. Same treatment for the proxy route table vs. glue label derivation.

## What changed beyond the tests

- `src/main/core/access-key.ts` and `src/renderer/image-source.ts` lost their private copies of the ceiling.
- AGENTS.md previously recorded that a renderer module *cannot* value-import `src/shared` — that claim was false (the `RENDERER_SHARED_MODULES` allowlist already serves two such modules to the packaged renderer) and is now corrected to describe the real boundary: the shared route is a named allowlist, not an impossibility.
- Security rider: `isPublicIpv4` now also refuses IPv4-in-IPv6 forms, CGNAT (100.64/10), and the benchmarking range (198.18/15) — defense-in-depth with unit tests. (The Steam OAuth popup-denial assertion the same rider called for already exists in `steam-acquire.spec.ts` and needed nothing.)

## Review focus

- The ceiling move: renderer import path and the join test are the load-bearing parts.
- Pick one property test and check the property is the parser's real invariant, not a restatement of the implementation.

## Verification

`set -o pipefail; pnpm check` green — 672 unit + 136 policy tests. Coverage artifact wiring visible in `macos-verify.yml`.
