### PR TITLE
Deliver the certificate feed, so a recovery can arrive as data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ is meant to inherit the dead ends rather than walk back into them.
 | ------------------------- | ------------------------------------------------------------- |
 | `src/main/main.ts`        | composition root, ArenaNet client update, app state           |
 | `src/main/core/`          | chunks, manifest, DNS, sockets, settings                      |
-| `src/main/certification/` | the official -> template-save -> Enhancement chain: certified tables, both transforms, the isolated proof, the Enhancement switches, the certificate feed |
+| `src/main/certification/` | the official -> template-save -> Enhancement chain: certified tables, both transforms, the isolated proof, the Enhancement switches, the certificate feed and its delivery |
 | `certificates/`           | the pinned certificate-feed public key and its key ceremony    |
 | `src/main/protocol.ts`    | secure `gw://app` routing and snapshot ranges                 |
 | `src/main/ipc.ts`         | validated native capability handlers                          |
@@ -192,7 +192,16 @@ is meant to inherit the dead ends rather than walk back into them.
   `sequence`; the bundled snapshot is not, because it is derived from tables
   compiled into the signed application.
   `certificates/public-key.txt` holds a placeholder, which means no
-  remote feed is trusted at all. `docs/wasm-host.md` owns the mechanism.
+  remote feed is trusted at all — and no request is made either. A feed is
+  fetched as two release assets on the same host the updater already reads,
+  on the update check's own trigger and behind the same consent switch; there
+  is no second scheduler and no second egress destination. A verified feed is
+  stored in the profile as one versioned record carrying the exact bytes and
+  signature, re-verified by the same path at every launch, and deleted rather
+  than partially read when it no longer holds. The governing feed is consulted
+  only where the shipped tables answer `uncertified`, so a feed widens where a
+  certificate may come from and can never withdraw one.
+  `docs/wasm-host.md` owns the mechanism.
 - The app makes no network request the user was not plainly told about.
   `autoCheckUpdates` (default `true`, declared as one pre-checked line at first
   run and in Settings → Updates) performs one release check at launch, then at
@@ -201,7 +210,10 @@ is meant to inherit the dead ends rather than walk back into them.
   exception, including the one on an unrecognised client build; switched off,
   a launch reaches github.com zero times, forever. `src/main/app-updater.ts` is the only
   caller of the releases API and the single owner of discovery, feed
-  validation, download, ready, and install state. Only an official package
+  validation, download, ready, and install state. The certificate feed's two
+  asset requests are the only other reads from this project's releases; they
+  fire on the same trigger, behind the same switch, and decide nothing about
+  installing anything. Only an official package
   carrying the release marker may reach Squirrel.Mac. Stable installs never
   receive previews; a preview may advance to stable. A ready update waits for
   an explicit or ordinary restart. ArenaNet client updates remain separate and

--- a/certificates/README.md
+++ b/certificates/README.md
@@ -61,6 +61,25 @@ a machine that builds anything.
 4. Destroy every copy of the private half outside the signing environment,
    including the file written in step 1 and the machine's shell history.
 
+## What a signed feed is published as
+
+Two assets on the release the application resolves as current:
+
+| Asset                       | Content                                          |
+| --------------------------- | ------------------------------------------------ |
+| `certificate-feed.json`     | the exact canonical document the signature covers |
+| `certificate-feed.json.sig` | base64 of the 64-byte detached Ed25519 signature  |
+
+`pnpm build` writes the document the shipped tables derive to
+`build/certificates/feed.json`; a published feed is that document with a
+`sequence` higher than any feed already released. Sign the bytes, not a
+re-serialised copy of them — the parser accepts exactly one spelling, and a
+signature that covers a different one verifies against nothing.
+
+Replacing those two assets on an existing release is the whole of what it takes
+to reach installations. No application release is involved, which is the point:
+recovery arrives as data.
+
 ## Rotation and loss
 
 There is no revocation list and no second pinned key, deliberately: a second key

--- a/docs/content-pipeline.md
+++ b/docs/content-pipeline.md
@@ -101,6 +101,16 @@ six-hour spacing. `autoCheckUpdates` defaults on and is declared plainly at
 first run and in Settings; switched off, a launch reaches github.com zero
 times.
 
+That one trigger asks for two things. `main.ts` calls the updater and
+`src/main/certification/certificate-feed-delivery.ts` from the same place, so
+the certificate feed inherits the schedule, the deferral behind a game socket
+and the consent switch instead of acquiring its own. The feed's request is two
+GETs for release assets published at
+`releases/latest/download/` — the same host and redirect chain the updater's own
+asset requests follow, so there is no second egress destination — and the
+application adds nothing to either: no body, no header, no query, no credential.
+`docs/wasm-host.md` owns what arrives and what it is allowed to do.
+
 Only a packaged macOS build whose generated `distribution-channel.json` names
 `release` may update. The marker has the exact shape
 `{ schema: 1, repository, channel }`; capabilities are derived from that closed

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -291,6 +291,15 @@ the app contacts GitHub only when you choose **Check for Updates** — on the
 loading screen, in the application menu, on a client-compatibility notice, or
 under **Settings → Updates**. Turning it back on immediately checks once.
 
+A check asks GitHub for two things: whether a newer version of the app exists,
+and whether the project has published a newer compatibility record for Guild
+Wars client builds. The second is how an ArenaNet update that would otherwise
+switch template saving off can be repaired without you installing anything. It
+is a signed list of hashes and nothing else — no program and no instruction —
+and the app still re-derives every claim against the client on your machine
+before anything switches back on. Neither request sends anything about you or
+your installation.
+
 An eligible update downloads in the background. When it is ready, choose
 **Restart to Update** or choose Later and let it install on the next ordinary
 restart. Restarting while Guild Wars is connected asks before disconnecting.

--- a/docs/wasm-host.md
+++ b/docs/wasm-host.md
@@ -269,6 +269,47 @@ candidate must be strictly newer to replace the feed in hand, so a captured
 older feed replayed at the application cannot withdraw a certificate it already
 holds.
 
+### How a feed arrives
+
+`src/main/certification/certificate-feed-delivery.ts` owns where a feed is
+fetched from, how a verified one is stored, and which of the feeds in hand
+governs a session.
+
+A check is two GETs — `certificate-feed.json` and `certificate-feed.json.sig`,
+published as assets on the current release and addressed through
+`latestReleaseAssetUrl`. It is the same host and redirect chain the updater's
+own asset requests already follow, so the feed adds no egress destination, and
+the application adds nothing to either request: no body, no header, no query, no
+credential.
+`tests/unit/no-game-traffic-is-uploaded.test.ts` executes that.
+
+There is no second scheduler. `main.ts` triggers the delivery from the same
+place it triggers the release check — at launch, on the periodic tick that
+`periodicCheckDue` gates, when the player switches automatic checks on, and when
+they press **Check for Updates** — so one predicate governs both and
+`docs/content-pipeline.md` owns it. With no pinned key the module makes no
+request at all: refusing an answer to a question already decided would spend a
+connection for nothing.
+
+A verified feed is stored in the profile at `game/certificate-feed.json` as one
+versioned record holding the exact bytes and the exact detached signature. That
+record is verified by the same code path as a fresh fetch at every launch, so a
+file edited on this machine is refused and rotating the pin retroactively
+refuses everything the old key signed — there is no weaker rule for a feed that
+is already ours. A record the application does not fully understand is deleted
+rather than partially read, and the bundled snapshot governs.
+
+The governing feed is read once per certification pass. A build the shipped
+tables already certify is unaffected: the feed is consulted only where the
+answer would otherwise be `uncertified`, and what it proposes still has to
+survive `certificate-feed-proof.ts` against the client bytes. So a feed can
+widen where a certificate comes from and can never withdraw one.
+
+`.gwdiag` carries `certificateFeed.source`, `certificateFeed.sequence`,
+`certificateFeed.outcome` and `certificateFeed.lastSuccessAt`, which is what
+makes a stuck feed visible rather than silent — `outcome` is a closed
+vocabulary naming exactly what stopped the last check.
+
 ## Enhancement instrumentation
 
 The official `Gw.jspi.wasm` remains canonical. A session with the Enhancement

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -73,6 +73,10 @@ const config: ForgeConfig = {
       "LICENSE",
       "THIRD-PARTY-NOTICES.md",
       "src/renderer/fonts/COPYING-QUALITYPE",
+      // The certificate feed's pinned key. It ships inside the bundle so the
+      // code signature seals it: the one decision about whom a fetched feed
+      // may come from must not be editable without breaking the signature.
+      "certificates/public-key.txt",
     ],
     ...(distributionSigning ? { osxSign: distributionSigning } : {}),
     ...(releaseNotarization ? { osxNotarize: releaseNotarization } : {}),

--- a/scripts/release-manifest.ts
+++ b/scripts/release-manifest.ts
@@ -1,7 +1,7 @@
 import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import { RELEASE_REPO } from "../src/shared/contracts.js";
+import { releaseAssetUrl } from "../src/shared/project-identity.js";
 import {
   formatReleaseVersion,
   parseReleaseVersion,
@@ -31,9 +31,7 @@ export function releaseManifest(options: {
   if (Number.isNaN(publishedAt.valueOf())) {
     throw new Error("release publication timestamp is invalid");
   }
-  const url =
-    `https://github.com/${RELEASE_REPO}/releases/download/`
-    + `${encodeURIComponent(options.tag)}/${encodeURIComponent(options.zipName)}`;
+  const url = releaseAssetUrl(options.tag, options.zipName);
   return `${JSON.stringify({
     url,
     name: `Guild Wars Reforged v${options.version}`,

--- a/src/main/app-updater.ts
+++ b/src/main/app-updater.ts
@@ -2,13 +2,18 @@
  * The single owner of application updates: discovery, feed validation,
  * download, ready, and install.
  *
- * It is also the only caller of the releases API in this project, which is what
- * makes the consent promise checkable rather than merely stated — with
- * automatic checks off there is no second code path that could still reach
- * github.com. `periodicCheckDue` holds every gate on an automatic check and is
- * pure, so the gates are provable without running a timer; an open game socket
- * defers a check because a Squirrel download must not compete with live game
- * traffic.
+ * It is also the only caller of the releases API in this project.
+ * `periodicCheckDue` holds every gate on an automatic check and is pure, so the
+ * gates are provable without running a timer; an open game socket defers a
+ * check because a Squirrel download must not compete with live game traffic.
+ *
+ * One other module reads from this project's releases:
+ * `certification/certificate-feed-delivery.ts` fetches two published assets.
+ * It does not ask the releases API, it makes no install decision, and it fires
+ * on this class's trigger rather than on one of its own — `main.ts` calls both
+ * from one place. The consent promise therefore stays checkable: the same
+ * predicate gates both, and with automatic checks off a launch reaches
+ * github.com zero times.
  *
  * Only a package carrying the release marker may reach Squirrel.Mac. A stable
  * install is never offered a preview, a preview may advance to stable, and a
@@ -19,6 +24,7 @@ import type {
   AppUpdateState,
 } from "../shared/contracts.js";
 import { RELEASE_REPO } from "../shared/contracts.js";
+import { releaseAssetUrl } from "../shared/project-identity.js";
 import {
   compareReleaseVersions,
   formatReleaseVersion,
@@ -430,10 +436,6 @@ function parseCandidates(
   }
   candidates.sort((a, b) => compareReleaseVersions(b.version, a.version));
   return candidates;
-}
-
-function releaseAssetUrl(tag: string, name: string): string {
-  return `https://github.com/${RELEASE_REPO}/releases/download/${encodeURIComponent(tag)}/${encodeURIComponent(name)}`;
 }
 
 function validManifest(

--- a/src/main/certification/certificate-feed-delivery.ts
+++ b/src/main/certification/certificate-feed-delivery.ts
@@ -1,0 +1,478 @@
+/**
+ * How a certificate feed reaches this installation and survives a restart:
+ * where it is fetched from, how a verified one is stored, and which of the
+ * feeds in hand governs this session.
+ *
+ * A check is two GETs at the release-asset address this project already
+ * downloads from — the document and its detached signature — and the
+ * application adds nothing to either request. No body, no header, no query, no
+ * credential, no identifier, no game-derived value. There is nothing in the ask
+ * for an installation to be recognised by, which is what keeps the feed inside
+ * the promise that no game traffic is uploaded rather than beside it.
+ *
+ * Nothing is believed on arrival. A candidate is verified under the pinned key
+ * before it is parsed, parsed before it is compared, and replaces the feed in
+ * hand only when its `sequence` is strictly greater. The stored record keeps
+ * the exact bytes and the exact signature, so a stored feed is verified by the
+ * same code path as a fresh one at every launch: a file edited on this machine
+ * is refused, and rotating the pin retroactively refuses everything the old key
+ * signed. There is deliberately no second, weaker rule for a feed that is
+ * already ours.
+ *
+ * The record states its own version and is read whole or not at all. One this
+ * application does not fully understand — a version it does not know, a field
+ * it cannot decode, a signature that no longer verifies — is deleted rather
+ * than partially read, and the snapshot compiled into the application governs.
+ * Falling back is always available because that snapshot needs nothing from
+ * disk.
+ *
+ * With no pinned key this module makes no request at all. A refused response
+ * and an ask never sent are the same trust decision, and only one of them
+ * costs the player a connection.
+ *
+ * It refuses to own what a feed *means*: it never decides that a certificate
+ * holds — `certificate-feed-proof.ts` does, against the client bytes — and it
+ * never decides when to run. The caller owns the schedule.
+ */
+import { readFile, rm } from "node:fs/promises";
+import { latestReleaseAssetUrl } from "../../shared/project-identity.js";
+import { AppError } from "../../shared/errors.js";
+import { writeAtomicJson } from "../core/atomic-file.js";
+import { readBoundedResponse } from "../core/patch-transport.js";
+import {
+  bundledCertificateFeed,
+  governingCertificateFeed,
+  MAX_CERTIFICATE_FEED_BYTES,
+  type CertificateFeed,
+} from "./certificate-feed.js";
+import {
+  certificateFeedTrust,
+  verifyFetchedCertificateFeed,
+  type CertificateFeedTrust,
+} from "./certificate-feed-trust.js";
+
+/** The two release assets a feed is published as. */
+export const CERTIFICATE_FEED_ASSET = "certificate-feed.json";
+export const CERTIFICATE_FEED_SIGNATURE_ASSET = "certificate-feed.json.sig";
+
+/**
+ * The stored record's own version, which is not the feed's. It changes when
+ * the *envelope* changes; a reader that does not know a version deletes the
+ * record rather than guessing which fields still mean what they used to.
+ */
+export const STORED_CERTIFICATE_FEED_RECORD = 1;
+
+const FETCH_TIMEOUT_MS = 5_000;
+// A detached Ed25519 signature is 64 bytes: 88 base64 characters and a newline.
+// The ceiling is generous enough for stray whitespace and nothing else.
+const MAX_SIGNATURE_BYTES = 128;
+
+/**
+ * Everything that can come of a check, as one closed vocabulary. It is the
+ * gauge a maintainer reads and the field the diagnostics schema declares, so a
+ * stuck feed names its own reason instead of being inferred from a silence.
+ */
+export const CERTIFICATE_FEED_OUTCOMES = [
+  /** Nothing stored and nothing fetched: the compiled-in snapshot governs. */
+  "bundled",
+  /** A stored feed verified and governs. */
+  "stored",
+  /** A stored record did not survive verification and was deleted. */
+  "discarded",
+  /** A fetched feed verified, was strictly newer, and was stored. */
+  "updated",
+  /** A fetched feed verified and was not newer than the feed in hand. */
+  "unchanged",
+  /** A fetched feed verified but could not be persisted, so it was not adopted. */
+  "unstored",
+  /** No key is pinned, so no request was made. The normal state of a clone. */
+  "unpinned",
+  /** A key is pinned and these bytes were not signed by it. */
+  "untrusted",
+  /** Signed by the pinned key and still not a feed this schema accepts. */
+  "malformed",
+  /** The current release publishes no feed. */
+  "absent",
+  "offline",
+  "timeout",
+  "server",
+] as const;
+
+export type CertificateFeedOutcome = (typeof CERTIFICATE_FEED_OUTCOMES)[number];
+
+/**
+ * Outcomes that mean a check produced no feed *and* something is wrong — as
+ * opposed to the ones that are a configured or ordinary state. Only these are
+ * worth a warning; a clone with no pinned key must not log one every launch.
+ */
+export const CERTIFICATE_FEED_REFUSALS: ReadonlySet<CertificateFeedOutcome> =
+  new Set<CertificateFeedOutcome>([
+    "discarded",
+    "unstored",
+    "untrusted",
+    "malformed",
+    "offline",
+    "timeout",
+    "server",
+  ]);
+
+export const CERTIFICATE_FEED_SOURCES = ["bundled", "stored"] as const;
+export type CertificateFeedSource = (typeof CERTIFICATE_FEED_SOURCES)[number];
+
+export interface CertificateFeedStatus {
+  readonly source: CertificateFeedSource;
+  /** The governing feed's sequence. It only ever increases. */
+  readonly sequence: number;
+  readonly outcome: CertificateFeedOutcome;
+  /** When the stored feed was fetched, or `null` if none was. */
+  readonly lastSuccessAt: number | null;
+}
+
+export interface CertificateFeedDeliveryOptions {
+  readonly storePath: string;
+  readonly pinnedKeyPath: string;
+  /**
+   * False makes `refresh` a no-op that reaches the network zero times. It
+   * carries the same answer as the automatic update check, so the consent
+   * promise stays one predicate rather than two that have to agree.
+   */
+  readonly enabled: boolean;
+  readonly fetch?: typeof fetch;
+  readonly now?: () => number;
+  readonly timeoutMs?: number;
+  readonly publish: (status: CertificateFeedStatus) => void;
+}
+
+interface StoredCertificateFeed {
+  readonly record: typeof STORED_CERTIFICATE_FEED_RECORD;
+  /** Base64 of the exact feed bytes. A signature is over bytes, not over text. */
+  readonly document: string;
+  readonly signature: string;
+  readonly fetchedAt: number;
+}
+
+type StoredRead =
+  | { readonly kind: "absent" }
+  | { readonly kind: "corrupt" }
+  | { readonly kind: "loaded"; readonly feed: CertificateFeed; readonly fetchedAt: number };
+
+type FetchedCandidate =
+  | {
+      readonly ok: true;
+      readonly document: Uint8Array;
+      readonly signature: Uint8Array;
+      readonly feed: CertificateFeed;
+    }
+  | { readonly ok: false; readonly outcome: CertificateFeedOutcome };
+
+/** The exact base64 of `value`, or `null` if it is spelled any other way. */
+function canonicalBase64(value: unknown): Uint8Array | null {
+  if (typeof value !== "string") return null;
+  const bytes = Buffer.from(value, "base64");
+  return bytes.toString("base64") === value ? bytes : null;
+}
+
+function storedRecord(value: unknown): {
+  document: Uint8Array;
+  signature: Uint8Array;
+  fetchedAt: number;
+} | null {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return null;
+  }
+  const record = value as Record<string, unknown>;
+  // Field-for-field, in both directions: an unknown field means the writer knew
+  // something this reader does not, which is exactly when guessing is wrong.
+  if (
+    Object.keys(record).sort().join(",")
+    !== "document,fetchedAt,record,signature"
+  ) return null;
+  if (record["record"] !== STORED_CERTIFICATE_FEED_RECORD) return null;
+  const fetchedAt = record["fetchedAt"];
+  if (
+    typeof fetchedAt !== "number"
+    || !Number.isSafeInteger(fetchedAt)
+    || fetchedAt < 0
+  ) return null;
+  const document = canonicalBase64(record["document"]);
+  const signature = canonicalBase64(record["signature"]);
+  if (document === null || signature === null) return null;
+  return { document, signature, fetchedAt };
+}
+
+/**
+ * A refusal the feed's own modules raised, in this module's vocabulary. The
+ * two codes are the whole distinction that matters: whether the bytes came
+ * from the key holder, or whether the key holder sent something unreadable.
+ */
+function refusalOutcome(error: unknown): CertificateFeedOutcome {
+  if (error instanceof AppError && error.code === "certificate_feed_format") {
+    return "malformed";
+  }
+  return "untrusted";
+}
+
+export class CertificateFeedDelivery {
+  private readonly options: CertificateFeedDeliveryOptions;
+  private readonly fetchImpl: typeof fetch;
+  private readonly now: () => number;
+  private readonly timeoutMs: number;
+  private governing: CertificateFeed = bundledCertificateFeed();
+  private sourceValue: CertificateFeedSource = "bundled";
+  private outcomeValue: CertificateFeedOutcome = "bundled";
+  private lastSuccessAt: number | null = null;
+  private trustValue: CertificateFeedTrust | "unreadable" | null = null;
+  private inFlight: Promise<void> | null = null;
+
+  constructor(options: CertificateFeedDeliveryOptions) {
+    this.options = options;
+    // Resolved at request time, exactly as the updater resolves it, so a test
+    // can prove the real main-process network boundary without a second
+    // transport existing in production.
+    this.fetchImpl = options.fetch
+      ?? ((input, init) => globalThis.fetch(input, init));
+    this.now = options.now ?? (() => Date.now());
+    this.timeoutMs = options.timeoutMs ?? FETCH_TIMEOUT_MS;
+  }
+
+  /** The feed every certification decision in this session is made against. */
+  get feed(): CertificateFeed {
+    return this.governing;
+  }
+
+  get status(): CertificateFeedStatus {
+    return {
+      source: this.sourceValue,
+      sequence: this.governing.sequence,
+      outcome: this.outcomeValue,
+      lastSuccessAt: this.lastSuccessAt,
+    };
+  }
+
+  /**
+   * Reads whatever a previous session stored. Runs before the first
+   * certification pass, because a feed that governs only after the launch it
+   * arrived on is a fact with two answers in one session.
+   */
+  async load(): Promise<void> {
+    const trust = await this.trust();
+    if (trust === "unreadable" || !trust.remote) {
+      // Nothing signed may be believed, so nothing stored may be. The record
+      // is deleted rather than carried as a file no code path can ever read.
+      await this.discardStore();
+      this.settle(trust === "unreadable" ? "untrusted" : "unpinned");
+      return;
+    }
+    const stored = await this.readStored(trust);
+    if (stored.kind === "absent") {
+      this.settle("bundled");
+      return;
+    }
+    if (stored.kind === "corrupt") {
+      await this.discardStore();
+      this.settle("discarded");
+      return;
+    }
+    this.lastSuccessAt = stored.fetchedAt;
+    // A stored feed an application release has since overtaken loses: the
+    // tables compiled into a signed application are the stronger claim.
+    const { feed, accepted } = governingCertificateFeed(
+      this.governing,
+      stored.feed,
+    );
+    this.governing = feed;
+    this.sourceValue = accepted ? "stored" : "bundled";
+    this.settle(accepted ? "stored" : "bundled");
+  }
+
+  /** Coalesced: a second caller joins the check already in flight. */
+  refresh(): Promise<void> {
+    if (!this.options.enabled) return Promise.resolve();
+    if (this.inFlight) return this.inFlight;
+    const operation = this.runRefresh().finally(() => {
+      if (this.inFlight === operation) this.inFlight = null;
+    });
+    this.inFlight = operation;
+    return operation;
+  }
+
+  private async runRefresh(): Promise<void> {
+    const candidate = await this.fetchCandidate();
+    if (!candidate.ok) {
+      this.settle(candidate.outcome);
+      return;
+    }
+    const { feed, accepted } = governingCertificateFeed(
+      this.governing,
+      candidate.feed,
+    );
+    if (!accepted) {
+      this.settle("unchanged");
+      return;
+    }
+    const fetchedAt = this.now();
+    try {
+      await writeAtomicJson(
+        this.options.storePath,
+        {
+          record: STORED_CERTIFICATE_FEED_RECORD,
+          document: Buffer.from(candidate.document).toString("base64"),
+          signature: Buffer.from(candidate.signature).toString("base64"),
+          fetchedAt,
+        } satisfies StoredCertificateFeed,
+        0o600,
+      );
+    } catch {
+      // Adopting a feed this session could not keep would make the certified
+      // set flicker between launches. The next check retries; nothing is lost
+      // but time, and a stuck `unstored` says which disk to look at.
+      this.settle("unstored");
+      return;
+    }
+    this.governing = feed;
+    this.sourceValue = "stored";
+    this.lastSuccessAt = fetchedAt;
+    this.settle("updated");
+  }
+
+  private settle(outcome: CertificateFeedOutcome): void {
+    this.outcomeValue = outcome;
+    this.options.publish(this.status);
+  }
+
+  private discardStore(): Promise<void> {
+    return rm(this.options.storePath, { force: true }).catch(() => undefined);
+  }
+
+  private async readStored(trust: CertificateFeedTrust): Promise<StoredRead> {
+    let text: string;
+    try {
+      text = await readFile(this.options.storePath, "utf8");
+    } catch {
+      return { kind: "absent" };
+    }
+    let document: unknown;
+    try {
+      document = JSON.parse(text) as unknown;
+    } catch {
+      return { kind: "corrupt" };
+    }
+    const record = storedRecord(document);
+    if (record === null) return { kind: "corrupt" };
+    try {
+      return {
+        kind: "loaded",
+        feed: verifyFetchedCertificateFeed(
+          trust,
+          record.document,
+          record.signature,
+        ),
+        fetchedAt: record.fetchedAt,
+      };
+    } catch {
+      return { kind: "corrupt" };
+    }
+  }
+
+  private async fetchCandidate(): Promise<FetchedCandidate> {
+    const trust = await this.trust();
+    if (trust === "unreadable") return { ok: false, outcome: "untrusted" };
+    // No pinned key, no request. Asking and then refusing the answer would
+    // spend a connection to reach a decision already made.
+    if (!trust.remote) return { ok: false, outcome: "unpinned" };
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
+    try {
+      const document = await this.get(
+        CERTIFICATE_FEED_ASSET,
+        MAX_CERTIFICATE_FEED_BYTES,
+        controller.signal,
+      );
+      if (!document.ok) return document;
+      const signature = await this.get(
+        CERTIFICATE_FEED_SIGNATURE_ASSET,
+        MAX_SIGNATURE_BYTES,
+        controller.signal,
+      );
+      if (!signature.ok) return signature;
+      const detached = canonicalBase64(
+        new TextDecoder().decode(signature.body).trim(),
+      );
+      if (detached === null) return { ok: false, outcome: "untrusted" };
+      try {
+        return {
+          ok: true,
+          document: document.body,
+          signature: detached,
+          feed: verifyFetchedCertificateFeed(trust, document.body, detached),
+        };
+      } catch (error) {
+        return { ok: false, outcome: refusalOutcome(error) };
+      }
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  private async get(
+    asset: string,
+    maxBytes: number,
+    signal: AbortSignal,
+  ): Promise<
+    { ok: true; body: Uint8Array } | { ok: false; outcome: CertificateFeedOutcome }
+  > {
+    let response: Response;
+    try {
+      response = await this.fetchImpl(latestReleaseAssetUrl(asset), {
+        method: "GET",
+        // Everything an installation could be recognised by is off. The ask
+        // carries the address and nothing this application added to it.
+        credentials: "omit",
+        cache: "no-store",
+        referrerPolicy: "no-referrer",
+        // The published address is a redirect into GitHub's release storage,
+        // the same chain the updater's own asset requests already follow.
+        redirect: "follow",
+        signal,
+      });
+    } catch {
+      return {
+        ok: false,
+        outcome: signal.aborted ? "timeout" : "offline",
+      };
+    }
+    if (response.status === 404) return { ok: false, outcome: "absent" };
+    if (!response.ok) return { ok: false, outcome: "server" };
+    try {
+      return { ok: true, body: await readBoundedResponse(response, maxBytes) };
+    } catch {
+      // Over the ceiling, or a body that stopped arriving. Neither is a feed.
+      return { ok: false, outcome: signal.aborted ? "timeout" : "offline" };
+    }
+  }
+
+  /**
+   * The pinned key, read once. A file that is neither the placeholder nor a
+   * canonical key line stays distinguishable from the deliberate placeholder:
+   * a mistyped pin reports `untrusted`, not the silent `unpinned` that a clone
+   * is supposed to be in.
+   */
+  private async trust(): Promise<CertificateFeedTrust | "unreadable"> {
+    if (this.trustValue !== null) return this.trustValue;
+    let pinned: string;
+    try {
+      pinned = await readFile(this.options.pinnedKeyPath, "utf8");
+    } catch {
+      // No key file at all is no pinned key, which is the placeholder's answer.
+      this.trustValue = { remote: false };
+      return this.trustValue;
+    }
+    try {
+      this.trustValue = certificateFeedTrust(pinned);
+    } catch {
+      this.trustValue = "unreadable";
+    }
+    return this.trustValue;
+  }
+}

--- a/src/main/certification/certificate-feed.ts
+++ b/src/main/certification/certificate-feed.ts
@@ -19,7 +19,9 @@
  * `KnownTemplateSaveBuild` plus `KnownEnhancementBuild`, the two records
  * `certifyClientBuild` already consumes, so a feed cannot describe a fact the
  * subsystem cannot use or omit one it needs. `certifiedBuildTablesFromFeed`
- * hands a parsed feed straight to that function as its `CertifiedBuildTables`.
+ * states that equivalence in the chain's own vocabulary; how a feed actually
+ * reaches a launch is one proved entry at a time, and `client-runtime.ts` owns
+ * that order.
  *
  * The parser treats its input as hostile and refuses rather than repairs:
  * unknown fields, absent fields, values outside their declared range, more
@@ -69,7 +71,8 @@ export const BUNDLED_CERTIFICATE_FEED_SEQUENCE = 1;
 // describes one client build, and every index the transforms use is a WASM
 // function or memory word. Nothing here may grow into an allocation an attacker
 // chooses.
-const MAX_FEED_BYTES = 256 * 1024;
+/** Exported so a transport stops reading at the size the parser would refuse. */
+export const MAX_CERTIFICATE_FEED_BYTES = 256 * 1024;
 const MAX_ENTRIES = 64;
 const MAX_BRIDGE_CALL_SITES = 64;
 const MAX_STUB_BODY_BYTES = 256;
@@ -398,8 +401,11 @@ function feedEntry(value: unknown, index: number): CertificateFeedEntry {
  */
 export function parseCertificateFeed(bytes: Uint8Array): CertificateFeed {
   if (bytes.byteLength === 0) refuse("no bytes");
-  if (bytes.byteLength > MAX_FEED_BYTES) {
-    refuse(`${bytes.byteLength} bytes exceeds the ${MAX_FEED_BYTES}-byte cap`);
+  if (bytes.byteLength > MAX_CERTIFICATE_FEED_BYTES) {
+    refuse(
+      `${bytes.byteLength} bytes exceeds the `
+        + `${MAX_CERTIFICATE_FEED_BYTES}-byte cap`,
+    );
   }
   // A byte-order mark is a second spelling of the same document, and a signature
   // is over bytes.
@@ -585,9 +591,17 @@ export function bundledCertificateFeed(): CertificateFeed {
 }
 
 /**
- * The two lookups `certifyClientBuild` takes, read out of a feed. This is the
- * whole of what a feed is for; there is no other way its contents reach a
- * launch decision.
+ * The two lookups `certifyClientBuild` takes, read out of a feed: what a feed's
+ * contents *mean* expressed in the vocabulary the rest of the chain already
+ * speaks, which is what makes "a feed answers exactly what the shipped tables
+ * answer" a statement that can be executed rather than argued.
+ *
+ * It is deliberately not how a feed reaches a launch. `client-runtime.ts` asks
+ * the shipped tables first and consults the feed only where they say nothing,
+ * one entry at a time and through `certificate-feed-proof.ts` — so a feed can
+ * widen where a certificate comes from and can never withdraw one. These
+ * tables would answer for a whole feed at once and take its word for the
+ * lookup; nothing hands them to a launch, and nothing should.
  */
 export function certifiedBuildTablesFromFeed(feed: CertificateFeed): CertifiedBuildTables {
   const byEnhancementInput = new Map<string, KnownEnhancementBuild>();

--- a/src/main/certification/local-client-verifier.ts
+++ b/src/main/certification/local-client-verifier.ts
@@ -53,12 +53,20 @@ declare const WebAssembly: {
  */
 export const LOCAL_CLIENT_VERIFIER_ABI = 3;
 
-export type LocalVerificationReason =
-  | "invalid-wasm"
-  | "template-shape-changed"
-  | "template-transform-failed"
-  | "enhancement-layout-changed"
-  | "enhancement-transform-failed";
+/**
+ * Declared as a list rather than a union so the boundary check below and the
+ * diagnostics schema can both execute it. A union nobody can enumerate gets
+ * restated wherever it has to be checked, and the restatements drift.
+ */
+export const LOCAL_VERIFICATION_REASONS = [
+  "invalid-wasm",
+  "template-shape-changed",
+  "template-transform-failed",
+  "enhancement-layout-changed",
+  "enhancement-transform-failed",
+] as const;
+
+export type LocalVerificationReason = (typeof LOCAL_VERIFICATION_REASONS)[number];
 
 export interface LocalClientVerification {
   readonly verifierAbi: number;
@@ -258,15 +266,9 @@ export function isLocalClientVerification(
     || result.officialSha256 !== officialSha256
     || !isDigest(result.officialSha256)
     || !Array.isArray(result.reasons)
-    || !result.reasons.every((reason) =>
+    || !result.reasons.every((reason): reason is LocalVerificationReason =>
       typeof reason === "string"
-      && [
-        "invalid-wasm",
-        "template-shape-changed",
-        "template-transform-failed",
-        "enhancement-layout-changed",
-        "enhancement-transform-failed",
-      ].includes(reason)
+      && (LOCAL_VERIFICATION_REASONS as readonly string[]).includes(reason)
     )
   ) {
     return false;

--- a/src/main/client-runtime.ts
+++ b/src/main/client-runtime.ts
@@ -15,9 +15,13 @@
  * rename away a tree the other is still reading.
  *
  * Certification is consumed, not re-derived: the runtime asks once which state
- * a build is in and carries that one answer through preparation.
+ * a build is in and carries that one answer through preparation. A certificate
+ * feed can only widen where that answer comes from, never what it is allowed to
+ * be — a feed entry has to survive the same transforms before it counts, and a
+ * build nothing certifies is served untouched exactly as before.
  */
 import { net } from "electron";
+import { readFile } from "node:fs/promises";
 import type {
   ClientCompatibility,
   ClientHealthToken,
@@ -39,6 +43,9 @@ import {
   certificationFromLocalVerification,
   certifyClientBuild,
 } from "./certification/client-certification.js";
+import type { CertificateFeed } from "./certification/certificate-feed.js";
+import { proveCertificateFeedEntry } from "./certification/certificate-feed-proof.js";
+import type { ClientCertification } from "./certification/client-module.js";
 import {
   PATCH_REQUEST_HEADERS,
   PATCH_REQUEST_TIMEOUT_MS,
@@ -101,6 +108,12 @@ interface ClientRuntimeOptions {
   cachedOnly: boolean;
   offlineShell: boolean;
   enhancementCapabilities: EnhancementCapabilities;
+  /**
+   * The feed governing this session, read per certification pass rather than
+   * captured: a check that lands mid-session must reach the next pass, and the
+   * delivery module is the one thing that knows which feed won.
+   */
+  certificateFeed: () => CertificateFeed;
   onProgress: (progress: DownloadProgress) => void;
   onPrefetch: (progress: PrefetchProgress) => void;
 }
@@ -205,6 +218,45 @@ export class ClientRuntime {
     });
   }
 
+  /**
+   * What the governing feed proposes for this build, once the transforms in
+   * this application have reproduced it — or `null`, which leaves the untouched
+   * official module and the isolated local proof exactly as they were.
+   *
+   * The proof runs here rather than in the isolated verifier because it is the
+   * same work `prepareClientModule` is about to do on the same bytes: the entry
+   * names the transform's inputs outright, so there is no structure to discover
+   * and no attacker-shaped parser to bound. What the isolated process exists
+   * for is the search, and a feed entry is the answer to it.
+   */
+  private async provedFeedCertification(
+    officialWasmPath: string,
+    officialSha256: string,
+  ): Promise<ClientCertification | null> {
+    const feed = this.options.certificateFeed();
+    const entry = feed.entries.get(officialSha256);
+    if (!entry) return null;
+    let official: Uint8Array;
+    try {
+      official = await readFile(officialWasmPath);
+    } catch (error) {
+      logEvent({ k: "certificateFeed.proofUnavailable", code: errorCode(error) });
+      return null;
+    }
+    const proof = proveCertificateFeedEntry(entry, official);
+    logEvent({
+      k: "certificateFeed.proved",
+      sequence: feed.sequence,
+      certification: proof.certification.state,
+    });
+    for (const reason of proof.withheld) {
+      logEvent({ k: "certificateFeed.withheld", reason });
+    }
+    return proof.certification.state === "uncertified"
+      ? null
+      : proof.certification;
+  }
+
   private async selectClientWasm(): Promise<{
     wasmPath: string;
     build: ActiveClient["enhancementBuild"];
@@ -228,6 +280,12 @@ export class ClientRuntime {
     }
 
     let certification = certifyClientBuild(officialSha256);
+    if (certification.state === "uncertified") {
+      certification = await this.provedFeedCertification(
+        officialWasm,
+        officialSha256,
+      ) ?? certification;
+    }
     if (certification.state === "uncertified") {
       const local = await verifyClientLocally({
         officialWasmPath: officialWasm,

--- a/src/main/core/paths.ts
+++ b/src/main/core/paths.ts
@@ -25,6 +25,7 @@ export interface GamePaths {
   previousArtifacts: string;
   rejectedClient: string;
   localClientVerification: string;
+  certificateFeed: string;
   compatibility: string;
   enhancements: string;
   chunks: string;
@@ -49,6 +50,7 @@ export function gamePaths(userData: string): GamePaths {
       game,
       "local-client-verification.json",
     ),
+    certificateFeed: path.join(game, "certificate-feed.json"),
     compatibility: path.join(game, "compatibility"),
     enhancements: path.join(game, "enhancements"),
     chunks: path.join(game, "chunks"),

--- a/src/main/diagnostics/schema.ts
+++ b/src/main/diagnostics/schema.ts
@@ -37,6 +37,11 @@ import {
 } from "../../shared/release.js";
 import type { AppUpdateStage } from "../app-updater.js";
 import {
+  CERTIFICATE_FEED_OUTCOMES,
+  CERTIFICATE_FEED_SOURCES,
+} from "../certification/certificate-feed-delivery.js";
+import { LOCAL_VERIFICATION_REASONS } from "../certification/local-client-verifier.js";
+import {
   isProxyRoute,
   type ProxyRoute,
 } from "../core/proxy-routes.js";
@@ -241,11 +246,14 @@ const thermalState = literal([
   "critical",
 ] as const);
 const localVerificationSource = literal(["cache", "process"] as const);
+const localVerificationReason = literal(LOCAL_VERIFICATION_REASONS);
 const buildCertification = literal([
   "certified",
   "template-only",
   "uncertified",
 ] as const);
+const certificateFeedOutcome = literal(CERTIFICATE_FEED_OUTCOMES);
+const certificateFeedSource = literal(CERTIFICATE_FEED_SOURCES);
 
 const none = {} as const;
 
@@ -743,6 +751,39 @@ export const DIAGNOSTIC_EVENT_SCHEMA = {
     subsystem: "wasm",
     level: "warn",
     fields: none,
+  },
+  // The certificate feed reports under `wasm` rather than `update` or
+  // `release`: it decides what a WebAssembly build may become, and nothing
+  // else. Where its bytes came from is transport, and transport is not what a
+  // reader of these events is looking for.
+  "certificateFeed.resolved": {
+    subsystem: "wasm",
+    level: "info",
+    fields: {
+      source: certificateFeedSource,
+      sequence: finiteNumber,
+      outcome: certificateFeedOutcome,
+    },
+  },
+  "certificateFeed.refused": {
+    subsystem: "wasm",
+    level: "warn",
+    fields: { outcome: certificateFeedOutcome },
+  },
+  "certificateFeed.proved": {
+    subsystem: "wasm",
+    level: "info",
+    fields: { sequence: finiteNumber, certification: buildCertification },
+  },
+  "certificateFeed.withheld": {
+    subsystem: "wasm",
+    level: "warn",
+    fields: { reason: localVerificationReason },
+  },
+  "certificateFeed.proofUnavailable": {
+    subsystem: "wasm",
+    level: "warn",
+    fields: { code },
   },
   "wasm.templateSavePrepareFailed": {
     subsystem: "wasm",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -61,6 +61,10 @@ import {
   periodicCheckDue,
 } from "./app-updater.js";
 import {
+  CertificateFeedDelivery,
+  CERTIFICATE_FEED_REFUSALS,
+} from "./certification/certificate-feed-delivery.js";
+import {
   enableSandboxBeforeReady,
   onAppQuit,
   runQuitCleanup,
@@ -147,6 +151,7 @@ const prefetch: PrefetchProgress = { ...EMPTY_PREFETCH };
 /** Every settings write is a read-modify-write of one file. */
 const settingsLock = new Mutex();
 let appUpdaterController: AppUpdater | null = null;
+let certificateFeedDelivery: CertificateFeedDelivery | null = null;
 let updateRestartInFlight: Promise<void> | null = null;
 let secondInstanceRequested = false;
 const INJECT_STARTUP_FAILURE =
@@ -165,20 +170,47 @@ function revealMainWindow(): void {
   win.focus();
 }
 
+/**
+ * The one "ask this project what is new" action, and the only thing that makes
+ * either request. A new application and a newer certificate feed are two
+ * answers to that one question — the second is how a recovery arrives as data
+ * rather than as an install — so they share a trigger, a schedule and a
+ * consent switch instead of acquiring a second of each.
+ */
+async function checkForProjectUpdates(): Promise<void> {
+  await Promise.allSettled([
+    appUpdaterController?.check() ?? Promise.resolve(),
+    certificateFeedDelivery?.refresh() ?? Promise.resolve(),
+  ]);
+}
+
 function updateAppSettings(patch: AppSettingsPatch): Promise<AppSettings> {
   return settingsLock.run(async () => {
     const settingsPath = gamePaths().settings;
     const current = await loadSettings(settingsPath);
     const saved = await saveSettings(settingsPath, { ...current, ...patch });
-    if (
-      !current.autoCheckUpdates
-      && saved.autoCheckUpdates
-      && appUpdaterController
-    ) {
-      void appUpdaterController.check();
+    if (!current.autoCheckUpdates && saved.autoCheckUpdates) {
+      void checkForProjectUpdates();
     }
     return saved;
   });
+}
+
+/**
+ * The pinned certificate-feed key. A packaged build reads it from the bundle's
+ * Resources, where the code signature seals it; an unpackaged one reads the
+ * committed file, which holds the placeholder.
+ *
+ * The unpackaged override is how the Electron suite exercises a signed feed
+ * with a keypair it generates per run, because the committed placeholder is a
+ * value it must not change. It is unreachable from a packaged build.
+ */
+function pinnedCertificateFeedKeyPath(): string {
+  if (app.isPackaged) return path.join(process.resourcesPath, "public-key.txt");
+  return (
+    process.env.GW_TEST_CERTIFICATE_FEED_KEY
+    ?? path.join(app.getAppPath(), "certificates", "public-key.txt")
+  );
 }
 
 function resetAppSettings(): Promise<AppSettings> {
@@ -447,12 +479,40 @@ if (primaryInstance) void app.whenReady().then(async () => {
   const profileMatches =
     !expectedUserData ||
     path.resolve(expectedUserData) === path.resolve(app.getPath("userData"));
+  certificateFeedDelivery = new CertificateFeedDelivery({
+    storePath: paths.certificateFeed,
+    pinnedKeyPath: pinnedCertificateFeedKeyPath(),
+    // The same answer that decides whether an automatic release check may
+    // reach the network. One predicate, so the two cannot disagree about what
+    // the player consented to.
+    enabled: distribution.automaticUpdates,
+    publish: (status) => {
+      gauge("certificateFeed.source", status.source);
+      gauge("certificateFeed.sequence", status.sequence);
+      gauge("certificateFeed.outcome", status.outcome);
+      gauge("certificateFeed.lastSuccessAt", status.lastSuccessAt);
+      if (CERTIFICATE_FEED_REFUSALS.has(status.outcome)) {
+        logEvent({ k: "certificateFeed.refused", outcome: status.outcome });
+      } else {
+        logEvent({
+          k: "certificateFeed.resolved",
+          source: status.source,
+          sequence: status.sequence,
+          outcome: status.outcome,
+        });
+      }
+    },
+  });
+  // Before the first certification pass: a feed that governs only after the
+  // launch it arrived on would answer one question two ways in one session.
+  await certificateFeedDelivery.load();
   const clientRuntime = new ClientRuntime({
     paths,
     hostVersion: HOST_VERSION,
     cachedOnly: process.env.GW_REQUIRE_CACHED_CLIENT === "1",
     offlineShell: process.env.GW_OFFLINE_SHELL === "1",
     enhancementCapabilities,
+    certificateFeed: () => certificateFeedDelivery!.feed,
     onProgress: setProgress,
     onPrefetch: setPrefetch,
   });
@@ -530,7 +590,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
     // reads it — a second, thrown answer would have been a second owner.
     retryClient: () => clientRuntime.requestUpdate(),
     getAppUpdateState: () => appUpdaterController!.getState(),
-    checkAppUpdates: () => appUpdaterController!.check(),
+    checkAppUpdates: () => checkForProjectUpdates(),
     restartAndInstallUpdate: (win) => {
       if (updateRestartInFlight) return updateRestartInFlight;
       const operation = (async () => {
@@ -597,7 +657,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
     enhancementProgram,
   ));
   if (settings.autoCheckUpdates) {
-    void appUpdaterController.check();
+    void checkForProjectUpdates();
   }
   // A 30-minute tick with a six-hour due-time instead of a six-hour timer:
   // a laptop waking past the boundary checks within half an hour, with no
@@ -613,7 +673,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
         lastUpdateCheckAt: current.lastUpdateCheckAt,
         now: Date.now(),
       })) return;
-      void appUpdaterController?.check();
+      void checkForProjectUpdates();
     })().catch(() => {
       // A periodic check is silent by contract; an unreadable settings file
       // already surfaces on the next explicit settings read.

--- a/src/shared/project-identity.ts
+++ b/src/shared/project-identity.ts
@@ -1,13 +1,36 @@
 /**
- * The two identifiers that name this project to services outside it: the GitHub
- * repository releases are read from, and the Apple Team ID its bundles are
- * signed under.
+ * The identifiers that name this project to services outside it — the GitHub
+ * repository releases are read from and the Apple Team ID its bundles are
+ * signed under — and the one address shape a published release asset is
+ * downloaded from.
  *
  * They live alone, with no imports, because build scripts, the packaging
- * configuration, the updater and the distribution channels all need them and
- * none of those may become the place the others read them from. Changing either
- * changes which releases an installation trusts and which Keychain groups its
- * secrets belong to.
+ * configuration, the updater, the certificate feed and the distribution
+ * channels all need them and none of those may become the place the others
+ * read them from. Changing any of them changes which releases an installation
+ * trusts, which Keychain group its secrets belong to, or where it goes for
+ * bytes.
+ *
+ * This module refuses to own what is downloaded, when, or whether the answer
+ * may be believed. It builds an address and makes no request.
  */
 export const RELEASE_REPO = "Mat4m0/gwonmac";
 export const APPLE_TEAM_ID = "9NN976MFZ4";
+
+/** One published release's asset, addressed by the tag it was published under. */
+export function releaseAssetUrl(tag: string, name: string): string {
+  return `https://github.com/${RELEASE_REPO}/releases/download/`
+    + `${encodeURIComponent(tag)}/${encodeURIComponent(name)}`;
+}
+
+/**
+ * The same asset on whichever release is current, with GitHub resolving which
+ * that is. It is how a document attached to a release can be replaced without
+ * shipping an application, and it is the same host, the same path prefix and
+ * the same redirect chain as `releaseAssetUrl` — one egress destination, not
+ * two.
+ */
+export function latestReleaseAssetUrl(name: string): string {
+  return `https://github.com/${RELEASE_REPO}/releases/latest/download/`
+    + `${encodeURIComponent(name)}`;
+}

--- a/tests/electron/certificate-feed.spec.ts
+++ b/tests/electron/certificate-feed.spec.ts
@@ -1,0 +1,321 @@
+// The certificate feed's delivery path, run inside the real application: the
+// pinned key it actually reads, the scheduler it actually shares, the profile
+// it actually writes, and the launch that actually reads it back.
+//
+// The key is generated per run and its private half never leaves this process.
+// The committed pin is the placeholder and must stay that way, so the app is
+// pointed at a key file of this spec's own through an override that exists only
+// in unpackaged builds.
+//
+// The feed served here is the application's own bundled snapshot restated at a
+// higher `sequence`. That is deliberate: a fixture written to agree would prove
+// that the fixture agrees. Restating the shipped tables proves the document the
+// build actually produces survives signing, transport, storage and a restart.
+//
+// What this spec does not do is certify a client. The offline fixture has no
+// ArenaNet build to certify, so `certificate-feed-proof.test.ts` owns whether a
+// proposal survives the transforms and this owns whether a proposal ever
+// reaches them.
+import { expect, test } from "@playwright/test";
+import { generateKeyPairSync, sign, type KeyObject } from "node:crypto";
+import { mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import {
+  closeOffline,
+  launchOfflineAt,
+  root,
+  type OfflineFixture,
+} from "./fixtures.mjs";
+
+const FEED_URL =
+  "https://github.com/Mat4m0/gwonmac/releases/latest/download/certificate-feed.json";
+const SIGNATURE_URL = `${FEED_URL}.sig`;
+
+interface ServedFeed {
+  readonly document: string;
+  readonly signature: string;
+}
+
+/**
+ * The bundled snapshot restated at `sequence`, signed by `privateKey`. The
+ * canonical document is `JSON.stringify(…, null, 2)` plus a newline, and a JSON
+ * round trip preserves the key order the serialiser wrote — which is what a
+ * signature covers.
+ */
+async function serve(
+  sequence: number,
+  privateKey: KeyObject,
+): Promise<ServedFeed> {
+  const bundled = JSON.parse(
+    await readFile(path.join(root, "build/certificates/feed.json"), "utf8"),
+  ) as Record<string, unknown>;
+  const document = `${JSON.stringify({ ...bundled, sequence }, null, 2)}\n`;
+  return {
+    document,
+    signature: Buffer.from(
+      sign(null, Buffer.from(document, "utf8"), privateKey),
+    ).toString("base64"),
+  };
+}
+
+function keypair(): { pinned: string; privateKey: KeyObject } {
+  const pair = generateKeyPairSync("ed25519");
+  const spki = pair.publicKey.export({ format: "der", type: "spki" });
+  return {
+    pinned: spki.subarray(spki.byteLength - 32).toString("base64"),
+    privateKey: pair.privateKey,
+  };
+}
+
+/**
+ * Answers the two feed addresses and GitHub's releases list; nothing else.
+ * Runs in the main process, wrapping the real `fetch` the delivery resolves at
+ * request time, so what is exercised is the production network boundary.
+ */
+function serveFeed(
+  _electron: unknown,
+  served: ServedFeed & { feedUrl: string; signatureUrl: string },
+): void {
+  const real = globalThis.fetch;
+  globalThis.fetch = (input, init) => {
+    const url =
+      typeof input === "string" || input instanceof URL ? String(input) : input.url;
+    if (url === served.feedUrl) {
+      return Promise.resolve(
+        new globalThis.Response(served.document, { status: 200 }),
+      );
+    }
+    if (url === served.signatureUrl) {
+      return Promise.resolve(
+        new globalThis.Response(served.signature, { status: 200 }),
+      );
+    }
+    if (url.startsWith("https://api.github.com/")) {
+      // A real-shaped answer so the release check finishes on its own path.
+      // No packet leaves this machine either way.
+      return Promise.resolve(
+        new globalThis.Response(JSON.stringify([]), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+      );
+    }
+    return real(input, init);
+  };
+}
+
+interface FeedGauges {
+  source?: unknown;
+  sequence?: unknown;
+  outcome?: unknown;
+  lastSuccessAt?: unknown;
+}
+
+function gauges(fixture: OfflineFixture): Promise<FeedGauges> {
+  return fixture.page.evaluate(async () => {
+    const latest = (await window.gwNative.diagnostics.current()).latest;
+    return {
+      source: latest["certificateFeed.source"],
+      sequence: latest["certificateFeed.sequence"],
+      outcome: latest["certificateFeed.outcome"],
+      lastSuccessAt: latest["certificateFeed.lastSuccessAt"],
+    };
+  });
+}
+
+/**
+ * A profile with automatic checks off, so a launch reaches the network zero
+ * times and every request this spec counts is one it asked for.
+ */
+async function profile(pinned: string): Promise<{
+  userData: string;
+  keyFile: string;
+  environment: Record<string, string>;
+}> {
+  const userData = await mkdtemp(path.join(tmpdir(), "gw-certificate-feed-e2e-"));
+  const keyFile = path.join(userData, "pinned-key.txt");
+  await writeFile(keyFile, `${pinned}\n`, { mode: 0o600 });
+  await writeFile(
+    path.join(userData, "settings.json"),
+    JSON.stringify({ autoCheckUpdates: false }),
+    { mode: 0o600 },
+  );
+  return {
+    userData,
+    keyFile,
+    environment: {
+      // Update-capable, which is the one predicate that lets either request
+      // happen at all.
+      GW_TEST_DISTRIBUTION_CHANNEL: "release",
+      GW_TEST_CERTIFICATE_FEED_KEY: keyFile,
+    },
+  };
+}
+
+test.describe("certificate feed delivery", () => {
+  test("a feed the pinned key signed governs the next launch", async () => {
+    const { pinned, privateKey } = keypair();
+    const { userData, environment } = await profile(pinned);
+    const served = await serve(2, privateKey);
+    const storePath = path.join(userData, "game", "certificate-feed.json");
+    let fixture = await launchOfflineAt(userData, environment);
+    try {
+      // Nothing stored yet, so the snapshot compiled into the app governs and
+      // the unrecognised-build behaviour is exactly today's.
+      await expect.poll(() => gauges(fixture)).toMatchObject({
+        source: "bundled",
+        sequence: 1,
+        outcome: "bundled",
+        lastSuccessAt: null,
+      });
+
+      await fixture.app.evaluate(serveFeed, {
+        ...served,
+        feedUrl: FEED_URL,
+        signatureUrl: SIGNATURE_URL,
+      });
+      // One press of the app's one "what is new?" control. The feed shares that
+      // trigger with the release check rather than owning a schedule.
+      await fixture.page.locator("#loading-update-check").click();
+
+      await expect.poll(() => gauges(fixture)).toMatchObject({
+        source: "stored",
+        sequence: 2,
+        outcome: "updated",
+      });
+      expect((await gauges(fixture)).lastSuccessAt).toEqual(expect.any(Number));
+      expect((await stat(storePath)).mode & 0o777).toBe(0o600);
+      expect(
+        (JSON.parse(await readFile(storePath, "utf8")) as { record: unknown }).record,
+      ).toBe(1);
+
+      await fixture.app.close();
+      fixture = await launchOfflineAt(userData, environment);
+
+      // The launch that matters: no request was made, and the feed the app
+      // certifies against is the fetched one.
+      await expect.poll(() => gauges(fixture)).toMatchObject({
+        source: "stored",
+        sequence: 2,
+        outcome: "stored",
+      });
+      expect((await stat(storePath)).mode & 0o777).toBe(0o600);
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
+  test("a forged feed changes nothing and is never stored", async () => {
+    const { pinned } = keypair();
+    const { userData, environment } = await profile(pinned);
+    // Signed correctly, by somebody who is not the key holder.
+    const served = await serve(9, keypair().privateKey);
+    const storePath = path.join(userData, "game", "certificate-feed.json");
+    const fixture = await launchOfflineAt(userData, environment);
+    try {
+      await fixture.app.evaluate(serveFeed, {
+        ...served,
+        feedUrl: FEED_URL,
+        signatureUrl: SIGNATURE_URL,
+      });
+      await fixture.page.locator("#loading-update-check").click();
+
+      await expect.poll(() => gauges(fixture)).toMatchObject({
+        source: "bundled",
+        sequence: 1,
+        outcome: "untrusted",
+        lastSuccessAt: null,
+      });
+      await expect(stat(storePath)).rejects.toThrow();
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
+  test("a stored feed the pin no longer covers is discarded, not partially read", async () => {
+    const { pinned, privateKey } = keypair();
+    const { userData, keyFile, environment } = await profile(pinned);
+    const served = await serve(7, privateKey);
+    const storePath = path.join(userData, "game", "certificate-feed.json");
+
+    let fixture = await launchOfflineAt(userData, environment);
+    try {
+      await fixture.app.evaluate(serveFeed, {
+        ...served,
+        feedUrl: FEED_URL,
+        signatureUrl: SIGNATURE_URL,
+      });
+      await fixture.page.locator("#loading-update-check").click();
+      await expect.poll(() => gauges(fixture)).toMatchObject({ sequence: 7 });
+      await fixture.app.close();
+
+      // The pin rotates, exactly as a key ceremony run after a suspected loss
+      // would rotate it. Everything the old key signed stops counting.
+      await writeFile(keyFile, `${keypair().pinned}\n`, { mode: 0o600 });
+      fixture = await launchOfflineAt(userData, environment);
+
+      await expect.poll(() => gauges(fixture)).toMatchObject({
+        source: "bundled",
+        sequence: 1,
+        outcome: "discarded",
+      });
+      await expect(stat(storePath)).rejects.toThrow();
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
+  test("no key pinned means no request and no stored feed", async () => {
+    const { userData, environment } = await profile(
+      "PLACEHOLDER-NO-REMOTE-FEED-TRUST",
+    );
+    const fixture = await launchOfflineAt(userData, environment);
+    try {
+      const counted = await fixture.app.evaluate(() => {
+        const holder = globalThis as typeof globalThis & { __feedRequests?: number };
+        holder.__feedRequests = 0;
+        const real = globalThis.fetch;
+        globalThis.fetch = (input, init) => {
+          const url =
+            typeof input === "string" || input instanceof URL
+              ? String(input)
+              : input.url;
+          if (url.includes("certificate-feed")) {
+            holder.__feedRequests = (holder.__feedRequests ?? 0) + 1;
+          }
+          if (url.startsWith("https://api.github.com/")) {
+            return Promise.resolve(
+              new globalThis.Response("[]", {
+                status: 200,
+                headers: { "content-type": "application/json" },
+              }),
+            );
+          }
+          return real(input, init);
+        };
+        return true;
+      });
+      expect(counted).toBe(true);
+      await fixture.page.locator("#loading-update-check").click();
+
+      await expect.poll(() => gauges(fixture)).toMatchObject({
+        source: "bundled",
+        sequence: 1,
+        outcome: "unpinned",
+      });
+      expect(
+        await fixture.app.evaluate(
+          () =>
+            (globalThis as typeof globalThis & { __feedRequests?: number })
+              .__feedRequests,
+        ),
+      ).toBe(0);
+      await expect(
+        stat(path.join(userData, "game", "certificate-feed.json")),
+      ).rejects.toThrow();
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+});

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -92,6 +92,17 @@ test("packaged releases carry the project and third-party license notices", () =
   assert.match(notices, /QT Friz Quad[\s\S]*SIL Open Font\s+License 1\.1/);
 });
 
+test("packaged releases carry the pinned certificate-feed key", () => {
+  // Read from the bundle's Resources at runtime, where the code signature
+  // seals it. Left out of the package, `certificateFeedTrust` would see no
+  // pinned key at all and every fetched feed would be refused — a failure that
+  // is safe, silent, and would survive a release.
+  assert.match(
+    read("forge.config.ts"),
+    /extraResource:[\s\S]*"certificates\/public-key\.txt"/,
+  );
+});
+
 // What the mapping produces is proved by executing it, in
 // tests/unit/every-release-raises-the-macos-build-number.test.ts. This is the
 // wiring: the packaged bundle takes its two numbers from that one function and

--- a/tests/unit/certificate-feed-delivery.test.ts
+++ b/tests/unit/certificate-feed-delivery.test.ts
@@ -1,0 +1,450 @@
+// Delivery, which is the half of the feed that touches a network and a disk.
+// What a feed *means* is proved next door in certificate-feed-proof.test.ts;
+// what is proved here is that a candidate has to earn its way in and a stored
+// one has to earn its way back.
+//
+// Every signature is made by a keypair generated in this process and destroyed
+// with it. No private key material exists in this repository, and
+// tests/policy/forbidden-artifacts.test.ts is what keeps that true.
+import assert from "node:assert/strict";
+import { generateKeyPairSync, sign, type KeyObject } from "node:crypto";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { after, describe, it } from "node:test";
+import {
+  CERTIFICATE_FEED_ASSET,
+  CERTIFICATE_FEED_SIGNATURE_ASSET,
+  CertificateFeedDelivery,
+  STORED_CERTIFICATE_FEED_RECORD,
+  type CertificateFeedStatus,
+} from "../../src/main/certification/certificate-feed-delivery.ts";
+import {
+  bundledCertificateFeed,
+  serializeCertificateFeed,
+} from "../../src/main/certification/certificate-feed.ts";
+import { CERTIFICATE_FEED_KEY_SENTINEL } from "../../src/main/certification/certificate-feed-trust.ts";
+import { latestReleaseAssetUrl } from "../../src/shared/project-identity.ts";
+
+const roots: string[] = [];
+
+after(async () => {
+  await Promise.all(
+    roots.map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+async function workspace(): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "gw-feed-delivery-"));
+  roots.push(root);
+  return root;
+}
+
+/** One throwaway signer, whose private half exists only for this process. */
+function signer(): { pinned: string; privateKey: KeyObject } {
+  const pair = generateKeyPairSync("ed25519");
+  const spki = pair.publicKey.export({ format: "der", type: "spki" });
+  return {
+    pinned: spki.subarray(spki.byteLength - 32).toString("base64"),
+    privateKey: pair.privateKey,
+  };
+}
+
+/** The shipped tables as a feed, restated at `sequence`. */
+function feedBytes(sequence: number): Uint8Array {
+  return serializeCertificateFeed({ ...bundledCertificateFeed(), sequence });
+}
+
+const BUNDLED_SEQUENCE = bundledCertificateFeed().sequence;
+
+/** A `Response` body detached from the view it was copied out of. */
+function body(bytes: Uint8Array): ArrayBuffer {
+  const copy = new ArrayBuffer(bytes.byteLength);
+  new Uint8Array(copy).set(bytes);
+  return copy;
+}
+
+interface Served {
+  readonly document?: Uint8Array;
+  readonly signature?: Uint8Array;
+  readonly status?: number;
+  readonly throws?: boolean;
+}
+
+interface Harness {
+  readonly storePath: string;
+  readonly pinnedKeyPath: string;
+  readonly requests: { url: string; init: RequestInit | undefined }[];
+  readonly published: CertificateFeedStatus[];
+  delivery(): CertificateFeedDelivery;
+}
+
+async function harness(options: {
+  pinned: string;
+  serve?: Served;
+  enabled?: boolean;
+  storePath?: string;
+}): Promise<Harness> {
+  const root = await workspace();
+  const pinnedKeyPath = path.join(root, "public-key.txt");
+  await writeFile(pinnedKeyPath, `${options.pinned}\n`);
+  const storePath = options.storePath ?? path.join(root, "certificate-feed.json");
+  const requests: { url: string; init: RequestInit | undefined }[] = [];
+  const published: CertificateFeedStatus[] = [];
+  const served = options.serve;
+  return {
+    storePath,
+    pinnedKeyPath,
+    requests,
+    published,
+    delivery: () =>
+      new CertificateFeedDelivery({
+        storePath,
+        pinnedKeyPath,
+        enabled: options.enabled ?? true,
+        now: () => 1_700_000_000_000,
+        publish: (status) => published.push(status),
+        fetch: async (input, init) => {
+          const url = String(input);
+          requests.push({ url, init });
+          if (served?.throws) throw new Error("no route to host");
+          const status = served?.status ?? 200;
+          const bytes = url.endsWith(CERTIFICATE_FEED_SIGNATURE_ASSET)
+            ? served?.signature
+            : served?.document;
+          return new Response(
+            status === 200 && bytes ? body(bytes) : null,
+            { status },
+          );
+        },
+      }),
+  };
+}
+
+function signed(
+  privateKey: KeyObject,
+  document: Uint8Array,
+): { document: Uint8Array; signature: Uint8Array } {
+  return {
+    document,
+    signature: new TextEncoder().encode(
+      `${Buffer.from(sign(null, document, privateKey)).toString("base64")}\n`,
+    ),
+  };
+}
+
+describe("a fetched certificate feed has to earn its way in", () => {
+  it("adopts and stores a feed the pinned key signed and whose sequence is newer", async () => {
+    const { pinned, privateKey } = signer();
+    const document = feedBytes(BUNDLED_SEQUENCE + 1);
+    const test = await harness({ pinned, serve: signed(privateKey, document) });
+    const delivery = test.delivery();
+
+    await delivery.load();
+    await delivery.refresh();
+
+    assert.deepEqual(delivery.status, {
+      source: "stored",
+      sequence: BUNDLED_SEQUENCE + 1,
+      outcome: "updated",
+      lastSuccessAt: 1_700_000_000_000,
+    });
+    assert.equal(delivery.feed.sequence, BUNDLED_SEQUENCE + 1);
+    assert.equal((await stat(test.storePath)).mode & 0o777, 0o600);
+    assert.deepEqual(
+      JSON.parse(await readFile(test.storePath, "utf8")) as unknown,
+      {
+        record: STORED_CERTIFICATE_FEED_RECORD,
+        document: Buffer.from(document).toString("base64"),
+        signature: Buffer.from(
+          sign(null, document, privateKey),
+        ).toString("base64"),
+        fetchedAt: 1_700_000_000_000,
+      },
+    );
+  });
+
+  it("refuses a feed another key signed and stores nothing", async () => {
+    const { pinned } = signer();
+    const forger = signer();
+    const document = feedBytes(BUNDLED_SEQUENCE + 9);
+    const test = await harness({
+      pinned,
+      serve: signed(forger.privateKey, document),
+    });
+    const delivery = test.delivery();
+
+    await delivery.load();
+    await delivery.refresh();
+
+    assert.equal(delivery.status.outcome, "untrusted");
+    assert.equal(delivery.feed.sequence, BUNDLED_SEQUENCE);
+    await assert.rejects(stat(test.storePath));
+  });
+
+  it("refuses a correctly signed feed that is not newer, and keeps the one in hand", async () => {
+    const { pinned, privateKey } = signer();
+    const test = await harness({
+      pinned,
+      serve: signed(privateKey, feedBytes(BUNDLED_SEQUENCE)),
+    });
+    const delivery = test.delivery();
+
+    await delivery.load();
+    await delivery.refresh();
+
+    assert.equal(delivery.status.outcome, "unchanged");
+    assert.equal(delivery.status.source, "bundled");
+    await assert.rejects(stat(test.storePath));
+  });
+
+  it("refuses bytes the key holder signed that are not a feed", async () => {
+    const { pinned, privateKey } = signer();
+    const test = await harness({
+      pinned,
+      serve: signed(privateKey, new TextEncoder().encode("{\"nope\":1}")),
+    });
+    const delivery = test.delivery();
+
+    await delivery.load();
+    await delivery.refresh();
+
+    assert.equal(delivery.status.outcome, "malformed");
+  });
+
+  it("names the transport fault that stopped a check", async () => {
+    const cases = [
+      [{ throws: true }, "offline"],
+      [{ status: 404 }, "absent"],
+      [{ status: 503 }, "server"],
+    ] as const;
+    for (const [serve, outcome] of cases) {
+      const { pinned } = signer();
+      const test = await harness({ pinned, serve });
+      const delivery = test.delivery();
+      await delivery.load();
+      await delivery.refresh();
+      assert.equal(delivery.status.outcome, outcome, JSON.stringify(serve));
+    }
+  });
+
+  it("does not adopt a feed it could not persist", async () => {
+    const { pinned, privateKey } = signer();
+    const root = await workspace();
+    const test = await harness({
+      pinned,
+      serve: signed(privateKey, feedBytes(BUNDLED_SEQUENCE + 1)),
+      // A directory in the store's place: the atomic write cannot land, and a
+      // feed that governs this launch and not the next one is worse than one
+      // that arrives a check later.
+      storePath: root,
+    });
+    const delivery = test.delivery();
+
+    await delivery.load();
+    await delivery.refresh();
+
+    assert.equal(delivery.status.outcome, "unstored");
+    assert.equal(delivery.feed.sequence, BUNDLED_SEQUENCE);
+  });
+});
+
+describe("a stored certificate feed has to earn its way back", () => {
+  async function store(
+    pinned: string,
+    privateKey: KeyObject,
+    sequence: number,
+  ): Promise<Harness> {
+    const document = feedBytes(sequence);
+    const test = await harness({ pinned, serve: signed(privateKey, document) });
+    const first = test.delivery();
+    await first.load();
+    await first.refresh();
+    assert.equal(first.status.outcome, "updated");
+    return test;
+  }
+
+  it("governs the next launch, verified by the same path as a fresh fetch", async () => {
+    const { pinned, privateKey } = signer();
+    const test = await store(pinned, privateKey, BUNDLED_SEQUENCE + 4);
+
+    const next = test.delivery();
+    await next.load();
+
+    assert.deepEqual(next.status, {
+      source: "stored",
+      sequence: BUNDLED_SEQUENCE + 4,
+      outcome: "stored",
+      lastSuccessAt: 1_700_000_000_000,
+    });
+    // Loading made no request: a stored feed is believed on its signature, not
+    // on having been fetched again.
+    assert.deepEqual(test.requests.map(({ url }) => url).slice(2), []);
+  });
+
+  it("discards a record whose bytes were edited on this machine", async () => {
+    const { pinned, privateKey } = signer();
+    const test = await store(pinned, privateKey, BUNDLED_SEQUENCE + 4);
+    const record = JSON.parse(
+      await readFile(test.storePath, "utf8"),
+    ) as Record<string, unknown>;
+    await writeFile(
+      test.storePath,
+      JSON.stringify({
+        ...record,
+        document: Buffer.from(feedBytes(BUNDLED_SEQUENCE + 5)).toString("base64"),
+      }),
+    );
+
+    const next = test.delivery();
+    await next.load();
+
+    assert.equal(next.status.outcome, "discarded");
+    assert.equal(next.feed.sequence, BUNDLED_SEQUENCE);
+    await assert.rejects(stat(test.storePath), "the refused record was kept");
+  });
+
+  it("discards a record it does not fully understand rather than reading part of it", async () => {
+    const { pinned, privateKey } = signer();
+    const base = await store(pinned, privateKey, BUNDLED_SEQUENCE + 4);
+    const good = JSON.parse(
+      await readFile(base.storePath, "utf8"),
+    ) as Record<string, unknown>;
+
+    const mangled: Record<string, unknown>[] = [
+      { ...good, record: STORED_CERTIFICATE_FEED_RECORD + 1 },
+      { ...good, sequence: 9 },
+      { ...good, fetchedAt: -1 },
+      { ...good, fetchedAt: 1.5 },
+      { ...good, document: `${String(good["document"])}=` },
+      Object.fromEntries(
+        Object.entries(good).filter(([key]) => key !== "signature"),
+      ),
+    ];
+    for (const value of mangled) {
+      const test = await harness({ pinned });
+      await writeFile(test.storePath, JSON.stringify(value));
+      const delivery = test.delivery();
+      await delivery.load();
+      assert.equal(
+        delivery.status.outcome,
+        "discarded",
+        JSON.stringify(value).slice(0, 80),
+      );
+      assert.equal(delivery.feed.sequence, BUNDLED_SEQUENCE);
+    }
+  });
+
+  it("is refused wholesale once the pin rotates, and the file is removed", async () => {
+    const { pinned, privateKey } = signer();
+    const test = await store(pinned, privateKey, BUNDLED_SEQUENCE + 4);
+    await writeFile(test.pinnedKeyPath, `${signer().pinned}\n`);
+
+    const next = test.delivery();
+    await next.load();
+
+    assert.equal(next.status.outcome, "discarded");
+    assert.equal(next.feed.sequence, BUNDLED_SEQUENCE);
+    await assert.rejects(stat(test.storePath));
+  });
+});
+
+describe("the pin decides whether a request happens at all", () => {
+  it("makes no request while the committed placeholder is the pin", async () => {
+    const test = await harness({ pinned: CERTIFICATE_FEED_KEY_SENTINEL });
+    const delivery = test.delivery();
+
+    await delivery.load();
+    await delivery.refresh();
+
+    assert.deepEqual(test.requests, []);
+    assert.deepEqual(delivery.status, {
+      source: "bundled",
+      sequence: BUNDLED_SEQUENCE,
+      outcome: "unpinned",
+      lastSuccessAt: null,
+    });
+  });
+
+  it("deletes a stored feed the placeholder can never believe again", async () => {
+    const { pinned, privateKey } = signer();
+    const document = feedBytes(BUNDLED_SEQUENCE + 2);
+    const test = await harness({ pinned, serve: signed(privateKey, document) });
+    const first = test.delivery();
+    await first.load();
+    await first.refresh();
+    await writeFile(test.pinnedKeyPath, `${CERTIFICATE_FEED_KEY_SENTINEL}\n`);
+
+    const next = test.delivery();
+    await next.load();
+
+    assert.equal(next.status.outcome, "unpinned");
+    await assert.rejects(stat(test.storePath));
+  });
+
+  it("reports a mistyped pin as untrusted rather than as the deliberate placeholder", async () => {
+    const test = await harness({ pinned: "not-a-key" });
+    const delivery = test.delivery();
+
+    await delivery.load();
+    await delivery.refresh();
+
+    assert.equal(delivery.status.outcome, "untrusted");
+    assert.deepEqual(test.requests, []);
+  });
+
+  it("makes no request when automatic checks are not this build's to make", async () => {
+    const { pinned, privateKey } = signer();
+    const test = await harness({
+      pinned,
+      serve: signed(privateKey, feedBytes(BUNDLED_SEQUENCE + 1)),
+      enabled: false,
+    });
+    const delivery = test.delivery();
+
+    await delivery.load();
+    await delivery.refresh();
+
+    assert.deepEqual(test.requests, []);
+    assert.equal(delivery.feed.sequence, BUNDLED_SEQUENCE);
+  });
+});
+
+describe("what a check publishes", () => {
+  it("publishes one status per resolution, and the sequence only moves forward", async () => {
+    const { pinned, privateKey } = signer();
+    const document = feedBytes(BUNDLED_SEQUENCE + 3);
+    const test = await harness({ pinned, serve: signed(privateKey, document) });
+    const delivery = test.delivery();
+
+    await delivery.load();
+    await delivery.refresh();
+    await delivery.refresh();
+
+    assert.deepEqual(
+      test.published.map(({ outcome, sequence }) => [outcome, sequence]),
+      [
+        ["bundled", BUNDLED_SEQUENCE],
+        ["updated", BUNDLED_SEQUENCE + 3],
+        ["unchanged", BUNDLED_SEQUENCE + 3],
+      ],
+    );
+  });
+
+  it("coalesces concurrent checks into one pair of requests", async () => {
+    const { pinned, privateKey } = signer();
+    const test = await harness({
+      pinned,
+      serve: signed(privateKey, feedBytes(BUNDLED_SEQUENCE + 1)),
+    });
+    const delivery = test.delivery();
+    await delivery.load();
+
+    await Promise.all([delivery.refresh(), delivery.refresh()]);
+
+    assert.deepEqual(test.requests.map(({ url }) => url), [
+      latestReleaseAssetUrl(CERTIFICATE_FEED_ASSET),
+      latestReleaseAssetUrl(CERTIFICATE_FEED_SIGNATURE_ASSET),
+    ]);
+  });
+});

--- a/tests/unit/no-game-traffic-is-uploaded.test.ts
+++ b/tests/unit/no-game-traffic-is-uploaded.test.ts
@@ -19,9 +19,25 @@
 //     allowlisted destination port, a close reason and a failure code. A
 //     record that carries anything else stops the export instead of being
 //     scrubbed on the way out.
+//
+// A third property joined the claim when the certificate feed gained a
+// delivery path: the app now fetches a document of its own from GitHub, and a
+// request is a place a fact about this installation could travel. The last
+// section holds that request to the same standard — it carries the address and
+// nothing this application added to it.
 import assert from "node:assert/strict";
-import { describe, it } from "node:test";
+import { generateKeyPairSync } from "node:crypto";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { after, describe, it } from "node:test";
 import type { SocketEvent } from "../../src/shared/contracts.ts";
+import {
+  CERTIFICATE_FEED_ASSET,
+  CERTIFICATE_FEED_SIGNATURE_ASSET,
+  CertificateFeedDelivery,
+} from "../../src/main/certification/certificate-feed-delivery.ts";
+import { latestReleaseAssetUrl } from "../../src/shared/project-identity.ts";
 import { allowedName, isAllowedPort } from "../../src/main/core/allowlists.ts";
 import { AppError } from "../../src/shared/errors.ts";
 import { inspectEventLog } from "../../src/main/diagnostics/detector.ts";
@@ -261,5 +277,97 @@ describe("no game traffic is uploaded: what the recorder may hear", () => {
       () => inspectEventLog(line({ socketId: 1, port: 6112, payload: [65, 66, 67] })),
       /undeclared field payload/,
     );
+  });
+});
+
+describe("no game traffic is uploaded: what the certificate feed asks for", () => {
+  const roots: string[] = [];
+  after(async () => {
+    await Promise.all(
+      roots.map((root) => rm(root, { recursive: true, force: true })),
+    );
+  });
+
+  /**
+   * A delivery whose pin is a throwaway public key, so requests happen at all,
+   * and whose fetch records the exact call rather than making one. The private
+   * half is discarded on the next line: nothing here needs to sign.
+   */
+  async function recorded(): Promise<{
+    delivery: CertificateFeedDelivery;
+    calls: { url: string; init: RequestInit | undefined }[];
+  }> {
+    const root = await mkdtemp(path.join(tmpdir(), "gw-feed-request-"));
+    roots.push(root);
+    const spki = generateKeyPairSync("ed25519").publicKey.export({
+      format: "der",
+      type: "spki",
+    });
+    const pinnedKeyPath = path.join(root, "public-key.txt");
+    await writeFile(pinnedKeyPath, spki.subarray(spki.byteLength - 32).toString("base64"));
+    const calls: { url: string; init: RequestInit | undefined }[] = [];
+    return {
+      calls,
+      delivery: new CertificateFeedDelivery({
+        storePath: path.join(root, "certificate-feed.json"),
+        pinnedKeyPath,
+        enabled: true,
+        publish: () => {},
+        fetch: async (input, init) => {
+          calls.push({ url: String(input), init });
+          return new Response(new Uint8Array(), { status: 200 });
+        },
+      }),
+    };
+  }
+
+  it("asks two fixed addresses derived from this project's repository", async () => {
+    const { delivery, calls } = await recorded();
+    await delivery.refresh();
+
+    assert.deepEqual(calls.map(({ url }) => url), [
+      latestReleaseAssetUrl(CERTIFICATE_FEED_ASSET),
+      latestReleaseAssetUrl(CERTIFICATE_FEED_SIGNATURE_ASSET),
+    ]);
+    for (const { url } of calls) {
+      const parsed = new URL(url);
+      // A query string and a fragment are the two places a value could be
+      // smuggled into an address that otherwise looks constant.
+      assert.equal(parsed.origin, "https://github.com");
+      assert.equal(parsed.search, "");
+      assert.equal(parsed.hash, "");
+      assert.equal(parsed.username, "");
+      assert.equal(parsed.password, "");
+    }
+  });
+
+  it("adds nothing to the request: no body, no header, no credential", async () => {
+    const { delivery, calls } = await recorded();
+    await delivery.refresh();
+
+    assert.equal(calls.length, 2);
+    for (const { init } of calls) {
+      assert.ok(init, "the request was made with no init at all");
+      assert.equal(init.method, "GET");
+      // A GET with a body would be the plainest way to upload something. The
+      // rest are the ways an installation could be recognised without one.
+      assert.equal(init.body, undefined);
+      assert.equal(init.headers, undefined);
+      assert.equal(init.credentials, "omit");
+      assert.equal(init.cache, "no-store");
+      assert.equal(init.referrerPolicy, "no-referrer");
+      assert.equal(init.referrer, undefined);
+      assert.equal(init.integrity, undefined);
+      // The transport's own keys are the only ones present, and none of them
+      // names a value this application chose.
+      assert.deepEqual(Object.keys(init).sort(), [
+        "cache",
+        "credentials",
+        "method",
+        "redirect",
+        "referrerPolicy",
+        "signal",
+      ]);
+    }
   });
 });

--- a/tests/unit/paths.test.ts
+++ b/tests/unit/paths.test.ts
@@ -32,6 +32,7 @@ describe("resolved profile paths", () => {
       previousArtifacts: `${root}/game/artifacts.previous`,
       rejectedClient: `${root}/game/rejected-client.json`,
       localClientVerification: `${root}/game/local-client-verification.json`,
+      certificateFeed: `${root}/game/certificate-feed.json`,
       compatibility: `${root}/game/compatibility`,
       enhancements: `${root}/game/enhancements`,
       chunks: `${root}/game/chunks`,


### PR DESCRIPTION
## What ships

The app fetches, verifies, stores, and applies the certificate feed. This is the user-facing half of the wave: after an ArenaNet patch, a certified recovery arrives as data — no app release, no user action.

## What changed

- Fetch reuses the updater's already-validated GitHub Releases host — no new egress destination — and rides the existing periodic-check scheduler rather than adding a second one. The `no-game-traffic-is-uploaded` policy family now covers the feed fetch.
- The verified feed persists as one versioned refuse-don't-reinterpret record; a corrupt or unverifiable store is discarded whole (fall back to bundled), never partially read. Sequence rules hold across all three sources: bundled vs stored vs fetched, newest verified wins, regressions never apply.
- A newer verified feed makes tools for a known build available on the next certification pass. Feed status (sequence, fetch outcome, last success) is visible in diagnostics, so a stuck feed is a readable fact instead of a mystery.
- Fail-closed UX unchanged: an unknown build still runs the official client unmodified.

## Review focus

- The storage path: nothing partially applies, and the bundled snapshot always remains the floor.
- The scheduler integration — confirm there's no second timer.

## Verification

`set -o pipefail; pnpm check` green. Electron E2E: stale/forged feed leaves features off; a valid newer feed signed with an ephemeral test key enables the certified path on next launch.
