### PR TITLE
Notice an ArenaNet patch, and derive what it certifies

### DIFF
--- a/.github/workflows/client-recertification.yml
+++ b/.github/workflows/client-recertification.yml
@@ -1,0 +1,365 @@
+# ArenaNet ships client builds on no schedule this project can see, and every
+# certified index belongs to one exact build. The weekly canary proves the build
+# we know still runs; this notices a build we do not know, derives what can be
+# derived from it, and leaves a person a branch and an issue to finish.
+#
+# It carries no secret of any kind. The only credential it uses is the run's own
+# GITHUB_TOKEN, and the strongest thing it can do with that is propose a pull
+# request that the ordinary verification gate then has to pass.
+name: ArenaNet client recertification
+
+on:
+  schedule:
+    # A quarter hour is the resolution, not a deadline: scheduler jitter and a
+    # skipped tick are both acceptable, because the certified tables and the
+    # local structural proof already decide correctly without this workflow.
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: arenanet-client-recertification
+  cancel-in-progress: false
+
+jobs:
+  # One manifest fetch. No install, no build, no client bytes: the unchanged
+  # path is the one that runs ninety-six times a day, and it has to cost
+  # seconds. A scheduled run that cannot reach the patch service fails, and that
+  # visible failure is this workflow's heartbeat.
+  detect:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    outputs:
+      changed: ${{ steps.unproposed.outputs.changed }}
+      fingerprint: ${{ steps.published.outputs.fingerprint }}
+      recorded: ${{ steps.published.outputs.recorded }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+      # Node runs the detector directly, and no package manager is installed at
+      # all: `pnpm <script>` resolves this repository's dependency tree before
+      # the script starts, which is a thousand packages and an Electron binary
+      # for a script whose whole import graph is Node builtins. That install is
+      # the difference between a second and a minute, ninety-six times a day.
+      - name: Read the published client generation
+        id: published
+        run: node --import ./scripts/ts-hook.mjs --experimental-strip-types scripts/official-client.ts
+      # A generation already proposed is not news. Without this, every quarter
+      # hour of the human latency the proposal expects — close, reopen, review,
+      # merge — re-runs a forty-five minute macOS derivation and files another
+      # tracking issue, and the red runs bury the fetch-failure heartbeat.
+      - name: Skip a generation that is already proposed
+        id: unproposed
+        env:
+          CHANGED: ${{ steps.published.outputs.changed }}
+          FINGERPRINT: ${{ steps.published.outputs.fingerprint }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "$CHANGED" != "true" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          short="${FINGERPRINT:0:12}"
+          proposed=""
+          # The branch is asked for by ref rather than by name search: this
+          # endpoint takes a slash-bearing ref, and a 404 is the only answer
+          # that means "nobody has proposed this generation".
+          if gh api "repos/$GITHUB_REPOSITORY/git/ref/heads/client-recertification/$short" \
+            > /dev/null 2>&1; then
+            proposed="branch client-recertification/$short"
+          elif [ -n "$(gh issue list --state open --label client-recertification \
+            --search "$short in:title" --json number --jq '.[].number')" ]; then
+            proposed="an open tracking issue"
+          fi
+          if [ -n "$proposed" ]; then
+            echo "Generation $short is already proposed by $proposed."
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+      # The recorded generation is by definition the certified one, so an open
+      # issue naming it has been answered by whatever merged that record.
+      - name: Close tracking issues the certified generation resolves
+        if: steps.published.outputs.changed == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RECORDED: ${{ steps.published.outputs.recorded }}
+        run: |
+          gh issue list --state open --label client-recertification \
+            --search "${RECORDED:0:12} in:title" --json number --jq '.[].number' \
+            | while read -r number; do
+                gh issue close "$number" \
+                  --comment "The published client generation is certified on main."
+              done
+
+  # On change only, and on macOS because this is where the application is built
+  # and certified. It downloads the JSPI code artifacts — never Gw.snapshot —
+  # verifies every byte against the manifest chunk hash that named it, and runs
+  # the same certification command line a developer runs by hand.
+  derive:
+    needs: detect
+    if: needs.detect.outputs.changed == 'true'
+    runs-on: macos-15
+    timeout-minutes: 45
+    permissions:
+      contents: read
+    env:
+      EVIDENCE: ${{ runner.temp }}/evidence
+    outputs:
+      outcome: ${{ steps.derive.outputs.outcome }}
+      summary: ${{ steps.derive.outputs.summary }}
+      build: ${{ steps.derive.outputs.build }}
+      # The generation whose bytes this job actually downloaded and certified,
+      # which is what the branch, the record and the issue must all name.
+      fingerprint: ${{ steps.official.outputs.fingerprint }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          cache: pnpm
+      # The runner image's default toolchain is not this repository's. Installs
+      # the one rust-toolchain.toml names, with no version repeated here.
+      - name: Install the pinned Rust toolchain
+        run: rustup toolchain install
+      - run: pnpm install --frozen-lockfile
+      # `pnpm certification` is this build plus the command line below. They are
+      # split here so the kernel is compiled once for two invocations, and so
+      # build progress never lands in the machine-readable report.
+      - run: pnpm build
+      - name: Download the published client code artifacts
+        id: official
+        run: pnpm client:official --download "$RUNNER_TEMP/official"
+
+      # The path comes from the download rather than being spelled again here:
+      # a second spelling is a second thing to keep in step with where the
+      # artifacts actually land.
+      - name: Derive what the published build certifies
+        id: derive
+        env:
+          WASM: ${{ steps.official.outputs.wasm }}
+        run: |
+          mkdir -p "$EVIDENCE"
+          # Both reports are findings, so a refusal is an answer rather than the
+          # end of the run; the status inside the report decides the outcome.
+          set +e
+          node build/tools/certification.js template "$WASM" --emit-ts --write \
+            > "$EVIDENCE/template-save.json" 2> "$EVIDENCE/template-save.txt"
+          template_exit=$?
+          node build/tools/certification.js recertify "$WASM" \
+            > "$EVIDENCE/enhancement.json" 2> "$EVIDENCE/enhancement.txt"
+          set -e
+          status="$(jq -r '.status' "$EVIDENCE/template-save.json")"
+          # The report is printed before `--write` edits the authoring table, so
+          # the status alone cannot tell a derivation that landed from one that
+          # threw on the way to disk and would leave the branch claiming an
+          # entry it does not carry. Only the pair decides: a derived entry
+          # written exits 0, and an already-certified build is the refusal to
+          # write anything, which exits 1.
+          if [ "$status" = "derived" ] && [ "$template_exit" -eq 0 ]; then
+            outcome=ready
+            summary="template-save certificate auto-derived for a new build"
+          elif [ "$status" = "certified" ] && [ "$template_exit" -eq 1 ]; then
+            outcome=ready
+            summary="the WASM is already certified; only the published generation moved"
+          else
+            outcome=investigation
+            summary="the template-save layout could not be re-derived"
+          fi
+          {
+            echo "outcome=$outcome"
+            echo "summary=$summary"
+            echo "build=$(jq -r '.sha256' "$EVIDENCE/template-save.json")"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Record the derived generation and regenerate the candidate feed
+        if: steps.derive.outputs.outcome == 'ready'
+        env:
+          # The digest the download above produced, never a fresh fetch:
+          # ArenaNet may republish inside this job's window, and a refetched
+          # value would record a generation whose bytes nothing here certified —
+          # after which the detector reads published == recorded and hides the
+          # new build until the patch after it.
+          FINGERPRINT: ${{ steps.official.outputs.fingerprint }}
+        run: |
+          pnpm client:official --record "$FINGERPRINT"
+          node --import ./scripts/ts-hook.mjs --experimental-strip-types \
+            scripts/generate-certificate-feed.ts
+          cp build/certificates/feed.json "$EVIDENCE/candidate-feed.json"
+
+      # Scoped by path, so the branch can only ever carry the authoring table
+      # and the recorded generation. Nothing else this job wrote can travel.
+      - name: Collect the authoring change
+        if: always()
+        run: |
+          mkdir -p "$EVIDENCE"
+          git diff -- src/main/certification/template-save-compat.ts \
+            certificates/certified-client.json > "$EVIDENCE/tables.patch"
+          echo "$GITHUB_SHA" > "$EVIDENCE/SOURCE_COMMIT.txt"
+
+      # Evidence only. The client artifacts stay in the runner's temporary
+      # directory and are never an upload path: this project does not
+      # redistribute ArenaNet's binaries.
+      - name: Publish the derivation evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: client-recertification-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/evidence
+          retention-days: 30
+          if-no-files-found: error
+
+  # Stage one of publication: a branch and a proposal. Nothing here signs,
+  # releases, or merges, and the branch is worth nothing until the pull
+  # request's own `pnpm verify` gate passes on it.
+  publish:
+    needs: [detect, derive]
+    if: always() && needs.derive.result != 'skipped'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: write
+      issues: write
+      pull-requests: write
+    env:
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      # The one checkout in this repository that keeps its credentials: this job
+      # exists to push a branch. It builds nothing, installs nothing, and runs
+      # no code out of the artifact it downloads.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: true
+      - name: Receive the derivation evidence
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: client-recertification-${{ github.run_id }}-${{ github.run_attempt }}
+          path: evidence
+
+      - name: Push the recertification branch
+        id: branch
+        env:
+          # The generation the deriver downloaded, so the branch name, the
+          # recorded digest and the issue title are one value rather than three
+          # fetches of a service that may republish between them. It falls back
+          # to what the detector saw only when derivation never got that far,
+          # and an outcome of `ready` is proof that it did.
+          FINGERPRINT: ${{ needs.derive.outputs.fingerprint || needs.detect.outputs.fingerprint }}
+          OUTCOME: ${{ needs.derive.outputs.outcome }}
+        run: |
+          if ! [[ "$FINGERPRINT" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "Invalid client generation: $FINGERPRINT" >&2
+            exit 1
+          fi
+          # The patch was produced against this commit's tables; applying it to
+          # any other tree would silently propose a diff nobody derived.
+          test "$(tr -d '\n' < evidence/SOURCE_COMMIT.txt)" = "$GITHUB_SHA"
+          {
+            echo "branch=client-recertification/${FINGERPRINT:0:12}"
+            echo "short=${FINGERPRINT:0:12}"
+          } >> "$GITHUB_OUTPUT"
+          if [ "$OUTCOME" != "ready" ] || [ ! -s evidence/tables.patch ]; then
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "client-recertification/${FINGERPRINT:0:12}"
+          git apply evidence/tables.patch
+          git commit --all --message \
+            "Certify the ArenaNet client generation ${FINGERPRINT:0:12}"
+          git push --force-with-lease origin "client-recertification/${FINGERPRINT:0:12}"
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Propose the change
+        id: proposal
+        if: steps.branch.outputs.pushed == 'true'
+        # Repository policy may forbid an automated pull request. The branch is
+        # pushed either way and the issue below names it, so the work is never
+        # lost to a setting this workflow cannot read.
+        continue-on-error: true
+        env:
+          BRANCH: ${{ steps.branch.outputs.branch }}
+          BUILD: ${{ needs.derive.outputs.build }}
+          GH_TOKEN: ${{ github.token }}
+          SHORT: ${{ steps.branch.outputs.short }}
+          SUMMARY: ${{ needs.derive.outputs.summary }}
+        run: |
+          {
+            echo "Derived automatically from the client ArenaNet is publishing now."
+            echo
+            echo "- published WASM: \`$BUILD\`"
+            echo "- derivation: $SUMMARY"
+            echo "- evidence: $RUN_URL"
+            echo
+            echo "Nothing here is certified until this pull request's verification"
+            echo "gate passes. The Enhancement table is deliberately untouched: its"
+            echo "layout words are client-memory addresses no structural anchor"
+            echo "re-derives, so a person measures them or they do not ship."
+            echo
+            echo "**Close and reopen this pull request to start that gate.** GitHub"
+            echo "runs no workflow for a pull request opened by the run's own token,"
+            echo "and the alternative — a personal access token — is a secret this"
+            echo "workflow refuses to hold for a job that only ever proposes."
+          } > proposal.md
+          if gh pr create --base main --head "$BRANCH" \
+            --title "Certify the ArenaNet client generation $SHORT" \
+            --body-file proposal.md; then
+            echo "opened=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "opened=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open the tracking issue
+        env:
+          BRANCH: ${{ steps.branch.outputs.branch }}
+          BUILD: ${{ needs.derive.outputs.build }}
+          GH_TOKEN: ${{ github.token }}
+          OUTCOME: ${{ needs.derive.outputs.outcome }}
+          PROPOSED: ${{ steps.proposal.outputs.opened }}
+          PUSHED: ${{ steps.branch.outputs.pushed }}
+          SHORT: ${{ steps.branch.outputs.short }}
+          SUMMARY: ${{ needs.derive.outputs.summary }}
+        run: |
+          gh label create client-recertification --force --color 1d76db \
+            --description "An ArenaNet client build this repository has not certified"
+          if [ "$OUTCOME" = "ready" ]; then
+            title="ArenaNet client $SHORT: auto-derived, PR ready"
+          else
+            title="ArenaNet client $SHORT: layout changed, investigation needed"
+          fi
+          {
+            echo "Published client generation \`$SHORT\`, WASM \`$BUILD\`."
+            echo
+            echo "- outcome: $SUMMARY"
+            if [ "$PUSHED" = "true" ]; then
+              echo "- branch: \`$BRANCH\`"
+            else
+              echo "- branch: none pushed"
+            fi
+            if [ "$PROPOSED" = "true" ]; then
+              echo "- pull request: opened"
+            else
+              echo "- pull request: not opened; review the branch directly"
+            fi
+            echo "- evidence: $RUN_URL"
+            echo
+            echo "\`internal/upstream/recertify.md\` owns the investigation when the"
+            echo "structural proof refuses. This issue closes itself once the"
+            echo "recorded generation on main is the published one."
+          } > tracking.md
+          gh issue create --label client-recertification \
+            --title "$title" --body-file tracking.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ is meant to inherit the dead ends rather than walk back into them.
 | `src/main/main.ts`        | composition root, ArenaNet client update, app state           |
 | `src/main/core/`          | chunks, manifest, DNS, sockets, settings                      |
 | `src/main/certification/` | the official -> template-save -> Enhancement chain: certified tables, both transforms, the isolated proof, the Enhancement switches, the certificate feed and its delivery |
-| `certificates/`           | the pinned certificate-feed public key and its key ceremony    |
+| `certificates/`           | the pinned certificate-feed public key, its key ceremony, and the client generation this repository has certified |
 | `src/main/protocol.ts`    | secure `gw://app` routing and snapshot ranges                 |
 | `src/main/ipc.ts`         | validated native capability handlers                          |
 | `src/main/diagnostics.ts` | the diagnostics subsystem's one entry point                   |
@@ -328,9 +328,24 @@ official module. The
 `certified`, `template-only` (templates save, enhancement tools cannot load), or
 `uncertified` — and `wasm.templateSaveCompatible` is the older boolean
 derived from that same answer. `pnpm certification template` re-derives the
-template build entry with the same production locator.
+template build entry with the same production locator, and `--write` puts a
+derived entry into the authoring table so a patch-day branch and a developer's
+paste produce the same text. It never writes `ENHANCEMENT_BUILDS`: those layout
+words are client-memory addresses no structural anchor re-derives.
 `internal/upstream/recertify.md` owns investigation when the local proof
 refuses.
+
+`.github/workflows/client-recertification.yml` runs that derivation without
+being asked. Every quarter hour it fetches one patch manifest and compares the
+published JSPI code generation against `certificates/certified-client.json`;
+matching, it exits in about a second, and a scheduled run that cannot fetch
+fails loudly, which is the heartbeat. On a change it downloads the code
+artifacts — never `Gw.snapshot` — runs the same certification command line, and
+pushes a branch with a pull request and a tracking issue, or an issue alone when
+the layout stopped being derivable. It holds no secret, uploads evidence and
+never client bytes, and its branch is worth nothing until the pull request's
+`pnpm verify` gate passes on it. The recorded generation carries no authority;
+it decides only whether that job runs.
 
 For enhancement work, begin with `pnpm certification doctor`, use the offline layers in
 `docs/enhancement-development.md`, and finish with one scoped `enhancements:live`

--- a/certificates/README.md
+++ b/certificates/README.md
@@ -1,4 +1,10 @@
-# The certificate feed's pinned key
+# Certificates
+
+Two files: the key that decides whether a fetched certificate feed may be
+believed, and the record of which ArenaNet client generation this repository has
+already certified.
+
+## The feed's pinned key
 
 `public-key.txt` is the one place this application decides whether a certificate
 feed fetched from anywhere may be believed. Its committed content is the
@@ -23,7 +29,7 @@ with no structural anchor — so they are accepted only as an exact restatement 
 the table compiled into this application. So the worst a stolen key achieves is
 withholding a certificate. It cannot mint one.
 
-## What the file holds
+### What the file holds
 
 One line, and nothing else: the placeholder, or the base64 of a raw 32-byte
 Ed25519 public key — 43 base64 characters and one `=`. The algorithm is not
@@ -32,7 +38,7 @@ Ed25519 and wraps the raw key in its SPKI header. Anything that is neither the
 placeholder nor a canonical key line is a refusal, not a fall back to the
 placeholder: a mistyped key must be visible as a mistake.
 
-## The one-time key ceremony
+### The one-time key ceremony
 
 Run once, on a machine that is offline and stays offline for the duration. The
 private half must never exist in this repository, in a test, in a fixture, or on
@@ -61,7 +67,7 @@ a machine that builds anything.
 4. Destroy every copy of the private half outside the signing environment,
    including the file written in step 1 and the machine's shell history.
 
-## What a signed feed is published as
+### What a signed feed is published as
 
 Two assets on the release the application resolves as current:
 
@@ -80,7 +86,7 @@ Replacing those two assets on an existing release is the whole of what it takes
 to reach installations. No application release is involved, which is the point:
 recovery arrives as data.
 
-## Rotation and loss
+### Rotation and loss
 
 There is no revocation list and no second pinned key, deliberately: a second key
 is a second thing that can be stolen, and the failure it would cover — a lost
@@ -92,3 +98,30 @@ being what decides whether any of them enables anything.
 A feed's `sequence` only ever increases. A captured older feed replayed at an
 application that already holds a newer one is refused, so a replay cannot
 withdraw a certificate.
+
+## The certified client generation
+
+`certified-client.json` records one digest: the identity of the ArenaNet JSPI
+code artifacts — `Gw.jspi.js` and `Gw.jspi.wasm` — whose certificate is on
+`main`. `Gw.snapshot` and `version.json` are deliberately outside it, because
+game content is republished on schedules that have nothing to do with the WASM.
+
+It carries no authority whatsoever. Nothing reads it at run time; it decides
+only whether the scheduled recertification workflow does any work this quarter
+hour. A wrong digest costs a redundant derivation or a late one, and what a
+build may actually be transformed for is still decided by the tables compiled
+into the application and by the local structural proof.
+
+```json
+{ "formatVersion": 1, "codeGeneration": "<64 hex characters>" }
+```
+
+`pnpm client:official` prints what is published now beside what is recorded, and
+`pnpm client:official --record <digest>` writes the generation it is handed.
+The digest is an argument and not a fresh fetch on purpose: a derivation is
+several minutes of downloading and certifying, ArenaNet may republish inside
+that window, and a record naming a generation nothing certified would leave the
+detector reading published == recorded and hiding the new build until the patch
+after it. A record this file's parser cannot read is a failure rather than a
+mismatch — reporting it as changed would chase a client that may already be
+certified, and reporting it as unchanged would hide a patch forever.

--- a/certificates/certified-client.json
+++ b/certificates/certified-client.json
@@ -1,0 +1,4 @@
+{
+  "formatVersion": 1,
+  "codeGeneration": "06bff323bf52656a578da1c82452d5fceda648f6b88005a2f3289cb8b2406b1d"
+}

--- a/docs/gwonmac-tools-wasm.md
+++ b/docs/gwonmac-tools-wasm.md
@@ -152,8 +152,10 @@ alone is not enough evidence for that decision.
 This fail-closed behavior is the last safety net, not the desired update
 experience. ArenaNet update continuity needs three operational layers:
 
-1. a scheduled canary detects a new official hash before or immediately after
-   rollout and preserves only bounded structural evidence;
+1. a scheduled detector notices a new official build within the quarter hour and
+   preserves only bounded structural evidence —
+   `.github/workflows/client-recertification.yml`, described in
+   [`wasm-host.md`](wasm-host.md);
 2. the recertifier derives hook and layout candidates from semantic anchors and
    runs the complete offline transform/kernel suite;
 3. a bounded live confirmation promotes the new exact certificate in an app

--- a/docs/wasm-host.md
+++ b/docs/wasm-host.md
@@ -217,6 +217,61 @@ certified build whose transform failed from being reported as available.
 `src/renderer/client-compatibility-notice.ts` turns them into the sentences
 both surfaces show.
 
+## Noticing the patch
+
+Everything above decides correctly on a machine that already has the new bytes.
+What it does not do is tell anyone a new build exists, and a certificate nobody
+starts deriving is a week of `template-only` for every player.
+
+`.github/workflows/client-recertification.yml` is that first layer, and it is
+built to be boring. A quarter-hourly job fetches one patch manifest, fingerprints
+`Gw.jspi.js` and `Gw.jspi.wasm` through `fingerprintClientGeneration`, and
+compares the result against `certificates/certified-client.json`. Matching, it
+ends in about a second having installed nothing, compiled nothing, and
+downloaded no client byte — Node runs the detector script directly, because
+`pnpm <script>` would resolve this repository's whole dependency tree first and
+that install, not the fetch, is what a cheap path has to exclude. A scheduled
+run that cannot reach the patch service fails, and that visible failure is how a
+silently dead detector is noticed.
+
+A generation that already has a branch or an open tracking issue is treated the
+same way as an unchanged one. Certifying a new build takes a person, and every
+quarter hour of that latency would otherwise re-run the whole derivation and
+file the proposal again; the red runs it produced would bury the heartbeat the
+paragraph above depends on.
+
+The identity is deliberately narrower than `clientFingerprint`, which also
+covers `Gw.snapshot` and `version.json` because it answers a different question —
+whether an *installed* generation may be rolled back to. Game content moves
+constantly; folding it in here would run a full derivation every content patch to
+conclude nothing changed.
+
+On a change, a macOS job downloads the code artifacts through the same
+`PatchClient` the application uses — chunk-hash verified, and `Gw.snapshot` is
+never assembled — and runs `certification template --write` and
+`certification recertify` against them. What it can derive it derives; what it
+cannot, it reports. Then a third job pushes a branch carrying the regenerated
+authoring table and the recorded generation, opens a pull request, and opens a
+tracking issue either way: *auto-derived, PR ready*, or *layout changed,
+investigation needed*. The issue closes itself on the first detector run that
+finds the published generation recorded on `main`.
+
+The pull request is a proposal and nothing more, and it says so out loud: GitHub
+starts no workflow for a pull request opened by a run's own token, so the body
+asks whoever picks it up to close and reopen it. The alternative is a personal
+access token, which is a secret this workflow would then be holding for a job
+whose whole point is that it cannot do anything on its own.
+
+Three properties make this safe to leave running unattended. It holds no secret;
+its only credential is the run's own `GITHUB_TOKEN` and the strongest thing it
+can do is propose. It uploads evidence — reports, the candidate feed, the source
+diff — and never client bytes, because this project does not redistribute
+ArenaNet's binaries. And its branch certifies nothing until the pull request's
+own `pnpm verify` gate passes on it, which is the same gate every other change
+faces. The Enhancement table stays untouched by machine for the reason the feed's
+enhancement half is exact-build only: its layout words are client-memory
+addresses no structural anchor re-derives.
+
 ## The certificate feed
 
 The tables above are compiled in, so today a new ArenaNet build waits for an

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:release": "node --import ./scripts/ts-hook.mjs --experimental-strip-types --test --test-timeout=60000 tests/release/*.ts",
     "enhancements:live": "pnpm build && node --import ./scripts/ts-hook.mjs --experimental-strip-types scripts/enhancements-live.ts",
     "certification": "pnpm build && node build/tools/certification.js",
+    "client:official": "node --import ./scripts/ts-hook.mjs --experimental-strip-types scripts/official-client.ts",
     "enhancements:visual": "pnpm build && node --import ./scripts/ts-hook.mjs --experimental-strip-types scripts/enhancements-visual.ts",
     "enhancements:kernel:verify": "pnpm build && node scripts/verify-companion-kernel.mjs",
     "snapshot:prune": "node --import ./scripts/ts-hook.mjs --experimental-strip-types scripts/snapshot-retention.ts",

--- a/scripts/official-client.ts
+++ b/scripts/official-client.ts
@@ -1,0 +1,204 @@
+// Which ArenaNet client generation is published right now, and — on demand —
+// its code artifacts on disk. This is what the recertification workflow asks
+// before it decides whether anything needs deriving.
+//
+// It is not part of the certification chain and deliberately not a
+// `certification` subcommand: `pnpm certification` builds the companion kernel
+// first, because the Enhancement transform embeds it. Detection must cost a
+// manifest fetch and nothing else, so this runs straight off the TypeScript
+// loader with no build, no installed packages, and no client bytes.
+//
+// The identity it compares is the JSPI code generation — `Gw.jspi.js` and
+// `Gw.jspi.wasm` — and not `clientFingerprint`, which additionally covers
+// `Gw.snapshot` and `version.json` because it answers a different question:
+// whether an *installed* generation may be rolled back to. Game content is
+// republished on schedules that have nothing to do with the WASM, and folding
+// it in here would send every content patch through a full derivation that
+// concludes nothing changed. Both identities go through
+// `fingerprintClientGeneration`, so there is one hashing policy and two scopes.
+//
+// The recorded identity carries no authority. It decides only whether the
+// deriver runs; a wrong value costs a redundant derivation or a late one, and
+// what a build may actually be transformed for is still decided by the
+// certified tables and the local structural proof. It must still be the
+// generation that was certified rather than the one published a minute later,
+// which is why `--record` is given its digest and fetches nothing.
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import {
+  JSPI_ARTIFACTS,
+  PATCH_REQUEST_TIMEOUT_MS,
+} from "../src/main/core/access-key.js";
+import { fingerprintClientGeneration } from "../src/main/core/client-fingerprint.js";
+import type { Manifest } from "../src/main/core/manifest.js";
+import { PatchClient } from "../src/main/core/patch-client.js";
+import { clientArtifactPath } from "../src/main/core/paths.js";
+import { createBoundedPatchFetch } from "../src/main/core/patch-transport.js";
+import { isDigest, type Digest } from "../src/shared/digest.js";
+
+export const RECORD = "certificates/certified-client.json";
+
+export interface CertifiedClientRecord {
+  readonly formatVersion: 1;
+  readonly codeGeneration: Digest;
+}
+
+/** The identity of the published code artifacts, independent of game content. */
+export function officialCodeGeneration(manifest: Manifest): Digest {
+  return fingerprintClientGeneration({
+    compression: manifest.compression,
+    chunkSize: manifest.chunkSize,
+    files: JSPI_ARTIFACTS.map((name) => {
+      const entry = manifest.entry(name);
+      if (!entry) throw new Error(`the published manifest is missing ${name}`);
+      return { name, size: entry.size, chunkHashes: entry.chunkHashes };
+    }),
+  });
+}
+
+/**
+ * A record this file cannot read is a failure, never a mismatch: reporting it
+ * as changed would send the deriver after a client that may be the certified
+ * one, and reporting it as unchanged would hide a patch forever.
+ */
+export function parseCertifiedClientRecord(raw: unknown): CertifiedClientRecord {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new Error(`${RECORD} must be an object`);
+  }
+  const value = raw as Record<string, unknown>;
+  if (value.formatVersion !== 1) {
+    throw new Error(`${RECORD} has an unreadable format version`);
+  }
+  if (!isDigest(value.codeGeneration)) {
+    throw new Error(`${RECORD} has no 64-hex codeGeneration`);
+  }
+  const unknown = Object.keys(value).filter(
+    (key) => key !== "formatVersion" && key !== "codeGeneration",
+  );
+  if (unknown.length > 0) {
+    throw new Error(`${RECORD} has unknown fields: ${unknown.join(", ")}`);
+  }
+  return { formatVersion: 1, codeGeneration: value.codeGeneration };
+}
+
+export function serializeCertifiedClientRecord(codeGeneration: Digest): string {
+  return `${JSON.stringify({ formatVersion: 1, codeGeneration }, null, 2)}\n`;
+}
+
+/**
+ * The three things this script does, as one closed choice.
+ *
+ * Recording takes the generation to write as an argument and reaches no
+ * network. A derivation is three commands over as many minutes, and ArenaNet
+ * may republish inside that window: a record that refetched would name whatever
+ * is published at record time rather than the bytes the certification command
+ * line just succeeded against, and the detector would then read published ==
+ * recorded and hide the new build until the patch after it.
+ */
+export type OfficialClientCommand =
+  | { readonly kind: "detect" }
+  | { readonly kind: "download"; readonly directory: string }
+  | { readonly kind: "record"; readonly generation: Digest };
+
+export function parseCommand(argv: readonly string[]): OfficialClientCommand {
+  const value = (name: string): string | null => {
+    const index = argv.indexOf(name);
+    return index >= 0 ? argv[index + 1] ?? null : null;
+  };
+  const downloading = argv.includes("--download");
+  const recording = argv.includes("--record");
+  if (downloading && recording) {
+    throw new Error("--download fetches and --record writes; run them apart");
+  }
+  if (recording) {
+    const generation = value("--record");
+    if (!isDigest(generation)) {
+      throw new Error("--record needs the 64-hex generation that was certified");
+    }
+    return { kind: "record", generation };
+  }
+  if (downloading) {
+    const directory = value("--download");
+    if (!directory) throw new Error("--download needs a directory");
+    return { kind: "download", directory };
+  }
+  return { kind: "detect" };
+}
+
+/**
+ * Steps report through `$GITHUB_OUTPUT` when a workflow supplies one; the same
+ * JSON goes to stdout either way, so a local run sees exactly what CI branches
+ * on. Every value is one line — a digest, a boolean or a path this run chose —
+ * so no heredoc delimiter is needed and none may be introduced without one.
+ */
+async function publishStepOutputs(
+  values: Readonly<Record<string, string>>,
+): Promise<void> {
+  const file = process.env.GITHUB_OUTPUT;
+  if (!file) return;
+  await writeFile(
+    file,
+    Object.entries(values).map(([key, value]) => `${key}=${value}\n`).join(""),
+    { flag: "a" },
+  );
+}
+
+export async function main(argv: readonly string[]): Promise<void> {
+  const command = parseCommand(argv);
+
+  if (command.kind === "record") {
+    await writeFile(RECORD, serializeCertifiedClientRecord(command.generation));
+    process.stdout.write(`${JSON.stringify({ recorded: command.generation })}\n`);
+    await publishStepOutputs({ recorded: command.generation });
+    return;
+  }
+
+  // `fetchManifest` touches neither directory, so detection creates nothing on
+  // disk. A download gets the directory it was given; putting client bytes
+  // anywhere the caller did not name is not this script's decision to make.
+  const download = command.kind === "download" ? command.directory : null;
+  const workingDir =
+    download ?? (await mkdtemp(path.join(tmpdir(), "gwonmac-official-")));
+  const client = new PatchClient({
+    artifactsDir: path.join(workingDir, "artifacts"),
+    chunksDir: path.join(workingDir, "chunks"),
+    fetch: createBoundedPatchFetch(fetch, PATCH_REQUEST_TIMEOUT_MS),
+  });
+
+  const manifest = await client.fetchManifest();
+  const fingerprint = officialCodeGeneration(manifest);
+  const recorded = parseCertifiedClientRecord(
+    JSON.parse(await readFile(RECORD, "utf8")),
+  ).codeGeneration;
+
+  if (download) {
+    // Publishes the JSPI artifacts and `version.json` and never assembles
+    // `Gw.snapshot`; every byte is verified against the manifest chunk hash
+    // that named it before it is written.
+    await client.update();
+  }
+
+  // The fingerprint travels with the bytes: `--record` takes this value back as
+  // an argument, so what gets recorded is the generation this run downloaded.
+  const wasm = download
+    ? clientArtifactPath(path.join(workingDir, "artifacts"), "Gw.jspi.wasm")
+    : "";
+  process.stdout.write(`${JSON.stringify({
+    fingerprint,
+    recorded,
+    changed: fingerprint !== recorded,
+    wasm: wasm || null,
+  })}\n`);
+  await publishStepOutputs({
+    changed: String(fingerprint !== recorded),
+    fingerprint,
+    recorded,
+    wasm,
+  });
+}
+
+if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
+  await main(process.argv.slice(2));
+}

--- a/src/main/certification/template-save-compat.ts
+++ b/src/main/certification/template-save-compat.ts
@@ -93,6 +93,12 @@ export interface KnownTemplateSaveBuild {
   readonly bridges: readonly StubBridge[];
 }
 
+/**
+ * Oldest first. The order is load-bearing: the last member is the shape
+ * baseline `deriveEquivalentTemplateSaveBuild` and `local-client-verifier.ts`
+ * measure an unknown client against, so a new build is appended and never
+ * inserted. `certification template --write` appends for the same reason.
+ */
 export const TEMPLATE_SAVE_BUILDS: readonly KnownTemplateSaveBuild[] =
   Object.freeze([
     Object.freeze({

--- a/src/tools/certification.ts
+++ b/src/tools/certification.ts
@@ -8,6 +8,14 @@
  * separate commands this replaced cannot drift apart in how they locate the
  * installed client or spell a failure.
  *
+ * `template --write` is the one subcommand that changes a tracked file. It
+ * adds a derived entry to the authoring table so a patch-day branch is opened
+ * by the same derivation a developer would run by hand, and it refuses every
+ * case but a new structurally derived build — including one already certified.
+ * It never touches `ENHANCEMENT_BUILDS`: those layout words are client-memory
+ * addresses no structural anchor re-derives, so nothing may add them without a
+ * person measuring them.
+ *
  * Machine-readable output goes to stdout and human findings go to stderr, so a
  * caller can pipe one without losing the other. A misuse exits 2 and a refusal
  * the chain itself made exits 1, uniformly across the four subcommands; only a
@@ -37,14 +45,16 @@ import {
 } from "./enhancement-workspace.js";
 import {
   formatBuildEntry,
+  insertBuildEntry,
   inspectTemplateSaveCandidate,
+  TEMPLATE_SAVE_TABLE,
 } from "./template-save-recert.js";
 
 const USAGE =
   "usage: certification <command>\n"
   + "  doctor [--profile PATH]              why Enhancement is or is not running here\n"
   + "  recertify [PATH/Gw.jspi.wasm]        draft an Enhancement build entry, with evidence\n"
-  + "  template [PATH/Gw.jspi.wasm] [--emit-ts] [--expect-certified]\n"
+  + "  template [PATH/Gw.jspi.wasm] [--emit-ts] [--write] [--expect-certified]\n"
   + "                                       re-derive the template-save build entry\n"
   + "  transform INPUT.wasm OUTPUT.wasm     write the derived Enhancement module\n";
 
@@ -96,6 +106,7 @@ async function recertify(argv: readonly string[]): Promise<void> {
 
 async function template(argv: readonly string[]): Promise<void> {
   const emitTypeScript = argv.includes("--emit-ts");
+  const writeEntry = argv.includes("--write");
   const expectCertified = argv.includes("--expect-certified");
   const positional = positionalArguments(argv);
   if (positional.length > 1) {
@@ -129,6 +140,27 @@ async function template(argv: readonly string[]): Promise<void> {
   if (report.status === "failed") {
     process.exitCode = 1;
     return;
+  }
+
+  // `--write` edits the authoring source, so it refuses everything except the
+  // one case it was written for: a structurally derived entry for a build the
+  // table does not list. An already-certified build is not a smaller version
+  // of that case — it is the answer "nothing to do", and writing anything
+  // would produce a branch whose diff nobody asked for.
+  if (writeEntry) {
+    if (!report.entry || report.certified) {
+      process.stderr.write(
+        `certification template --write: nothing to add for ${report.sha256}\n`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+    const table = path.resolve(TEMPLATE_SAVE_TABLE);
+    await writeAtomic(
+      table,
+      insertBuildEntry(await readFile(table, "utf8"), report.entry),
+    );
+    process.stderr.write(`certification template: added ${report.sha256} to ${TEMPLATE_SAVE_TABLE}\n`);
   }
   if (expectCertified && report.matchesCertifiedEntry !== true) {
     process.stderr.write(

--- a/src/tools/template-save-recert.ts
+++ b/src/tools/template-save-recert.ts
@@ -8,7 +8,13 @@
  * the shape of its output.
  *
  * An empty difference list means the checked-in entry is still exact. A
- * non-empty one is a finding for a human to read, never an entry to apply.
+ * non-empty one is a finding for a human to read, never an entry to apply: a
+ * build already in the table was certified by somebody, and this file refuses
+ * to overwrite it.
+ *
+ * It also owns how a *new* entry is spelled into the authoring table, so the
+ * text a developer pastes and the text CI splices in are produced by the same
+ * function and cannot drift into two formats of the same fact.
  */
 import {
   analyzeTemplateSaveCandidate,
@@ -106,6 +112,47 @@ export function inspectTemplateSaveCandidate(
       ),
     ],
   };
+}
+
+/** The authoring table, as `certification template --write` addresses it. */
+export const TEMPLATE_SAVE_TABLE =
+  "src/main/certification/template-save-compat.ts";
+
+const TABLE_OPEN =
+  "export const TEMPLATE_SAVE_BUILDS: readonly KnownTemplateSaveBuild[] =\n"
+  + "  Object.freeze([\n";
+const TABLE_CLOSE = "\n  ]);\n";
+
+/**
+ * The derived entry appended to `TEMPLATE_SAVE_BUILDS`.
+ *
+ * Appended, not prepended: the *last* member is the shape baseline that
+ * `deriveEquivalentTemplateSaveBuild` and `local-client-verifier.ts` compare a
+ * structurally derived candidate against, so a newer entry anywhere else
+ * silently makes an older build the standard every unknown client is measured
+ * by.
+ *
+ * Only ever an insertion. An entry already in the table is a build somebody
+ * certified, and overwriting it here would let a derivation quietly replace a
+ * reviewed fact. A table this cannot find is a refusal too — a silent no-op
+ * would produce a branch that changes nothing and reads as success.
+ */
+export function insertBuildEntry(
+  source: string,
+  entry: KnownTemplateSaveBuild,
+): string {
+  if (source.includes(`"${entry.sha256}"`)) {
+    throw new Error(`${TEMPLATE_SAVE_TABLE} already lists ${entry.sha256}`);
+  }
+  const open = source.indexOf(TABLE_OPEN);
+  const close = open < 0
+    ? -1
+    : source.indexOf(TABLE_CLOSE, open + TABLE_OPEN.length);
+  if (close < 0) {
+    throw new Error(`${TEMPLATE_SAVE_TABLE} has no TEMPLATE_SAVE_BUILDS table to extend`);
+  }
+  const at = close + 1;
+  return `${source.slice(0, at)}${formatBuildEntry(entry)}\n${source.slice(at)}`;
 }
 
 /** Paste-ready TypeScript for the entry, emitted to stderr by the CLI. */

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -594,6 +594,135 @@ test("the website suite runs on its own path-filtered workflow", () => {
   assert.doesNotMatch(script("verify"), /test:website/);
 });
 
+test("the patch detector is cheap, secretless, and only ever proposes", () => {
+  const workflow = read(".github/workflows/client-recertification.yml");
+  // Blanked rather than dropped, so a reported offset is the one an editor
+  // shows. A job's prose sits above its key and would otherwise be scanned as
+  // part of the job before it.
+  const body = workflow
+    .split("\n")
+    .map((line) => (/^\s*#/u.test(line) ? "" : line))
+    .join("\n");
+  const detect = body.slice(body.indexOf("\n  detect:"), body.indexOf("\n  derive:"));
+  const derive = body.slice(body.indexOf("\n  derive:"), body.indexOf("\n  publish:"));
+  const publish = body.slice(body.indexOf("\n  publish:"));
+  assert.ok(detect && derive && publish, "the three jobs are not all present");
+
+  // No secret of any kind reaches this workflow. `github.token` is the run's
+  // own credential and is what keeps `secrets.` absent rather than merely
+  // narrow, so the scan can be exact.
+  assert.doesNotMatch(workflow, /secrets\./);
+  assert.match(workflow, /GH_TOKEN: \$\{\{ github\.token \}\}/);
+  assert.match(workflow, /^permissions:\n {2}contents: read$/mu);
+  assert.match(workflow, /schedule:[\s\S]*cron: "\*\/15 \* \* \* \*"/);
+  assert.match(workflow, /workflow_dispatch:/);
+  assert.match(workflow, /group: arenanet-client-recertification/);
+
+  // The unchanged path runs ninety-six times a day. It reads one manifest:
+  // no packages, no compiler, no client bytes, and nothing out of the
+  // certification command line, which builds the companion kernel first.
+  assert.match(detect, /runs-on: ubuntu-latest/);
+  // Node runs the script, not `pnpm <script>`: the run wrapper resolves this
+  // repository's dependency tree before the script starts, so the word `pnpm`
+  // anywhere in this job is the install the cheap path exists to avoid. That
+  // makes the absence the assertion rather than the absence of one spelling
+  // of it — `pnpm/action-setup` and `pnpm install` are the same defect here.
+  assert.match(
+    detect,
+    /run: node --import \.\/scripts\/ts-hook\.mjs --experimental-strip-types scripts\/official-client\.ts$/mu,
+  );
+  assert.doesNotMatch(detect, /pnpm|rustup|certification\.js|--download/);
+  assert.match(detect, /permissions:\n {6}contents: read\n {6}issues: write/);
+  assert.match(
+    detect,
+    /if: steps\.published\.outputs\.changed == 'false'[\s\S]*gh issue close/,
+  );
+  // A generation with a branch or an open issue is already proposed, and
+  // re-deriving it every quarter hour costs a macOS job and buries the
+  // fetch-failure heartbeat under a run that fails on the push it repeats.
+  assert.match(detect, /changed: \$\{\{ steps\.unproposed\.outputs\.changed \}\}/);
+  assert.match(
+    detect,
+    /gh api "repos\/\$GITHUB_REPOSITORY\/git\/ref\/heads\/client-recertification\/\$short"/,
+  );
+  assert.match(detect, /gh issue list --state open --label client-recertification[\s\S]*?changed=false/);
+
+  // Derivation is macOS, on change only, and installs the pinned toolchain
+  // before the compiler runs. tests/policy/toolchain-floors.test.ts scans every
+  // workflow for that ordering; this pins the job's reason to exist beside it.
+  assert.match(derive, /if: needs\.detect\.outputs\.changed == 'true'/);
+  assert.match(derive, /runs-on: macos-15/);
+  assert.ok(
+    derive.indexOf("run: rustup toolchain install") < derive.indexOf("run: pnpm build"),
+    "the kernel is compiled on the runner's own toolchain",
+  );
+  assert.match(derive, /permissions:\n {6}contents: read/);
+  assert.doesNotMatch(derive, /contents: write|issues: write|pull-requests: write/);
+  assert.match(derive, /pnpm client:official --download "\$RUNNER_TEMP\/official"/);
+  assert.match(derive, /certification\.js template "\$WASM" --emit-ts --write/);
+  assert.match(derive, /certification\.js recertify "\$WASM"/);
+  // The report is printed before `--write` edits the table, so the exit code is
+  // the only thing that separates a written entry from one that threw on the
+  // way to disk. Dropping it lets the branch claim a certificate it lacks.
+  assert.match(derive, /template_exit=\$\?/);
+  assert.match(
+    derive,
+    /if \[ "\$status" = "derived" \] && \[ "\$template_exit" -eq 0 \]/,
+  );
+  assert.match(
+    derive,
+    /elif \[ "\$status" = "certified" \] && \[ "\$template_exit" -eq 1 \]/,
+  );
+  // One fetch per derivation: the recorded generation is the one whose bytes
+  // were downloaded and certified, never whatever a later fetch would return.
+  assert.match(derive, /FINGERPRINT: \$\{\{ steps\.official\.outputs\.fingerprint \}\}/);
+  assert.match(derive, /pnpm client:official --record "\$FINGERPRINT"/);
+
+  // Evidence only: the sole upload path is the evidence directory, and the
+  // downloaded client artifacts live somewhere no upload names.
+  const uploaded = [...derive.matchAll(/^ {10}path: (.+)$/gmu)].map(
+    (match) => match[1],
+  );
+  assert.deepEqual(uploaded, ["${{ runner.temp }}/evidence"]);
+  assert.doesNotMatch(derive, /path:[^\n]*(?:Gw\.|official)/);
+
+  // Stage one only. It pushes a branch and proposes; a rejected pull request
+  // still leaves the branch and an issue naming it.
+  assert.match(publish, /permissions:\n {6}actions: read\n {6}contents: write/);
+  assert.doesNotMatch(publish, /pnpm install|pnpm build|pnpm certification/);
+  assert.match(publish, /if: always\(\) && needs\.derive\.result != 'skipped'/);
+  assert.equal(body.match(/persist-credentials: true/gu)?.length, 1);
+  assert.match(publish, /persist-credentials: true/);
+  assert.match(
+    publish,
+    /test "\$\(tr -d '\\n' < evidence\/SOURCE_COMMIT\.txt\)" = "\$GITHUB_SHA"/,
+  );
+  assert.match(publish, /git apply evidence\/tables\.patch/);
+  // The branch and the issue name the generation the deriver certified, not the
+  // one the detector saw a job earlier; those differ when ArenaNet republishes.
+  assert.match(
+    publish,
+    /FINGERPRINT: \$\{\{ needs\.derive\.outputs\.fingerprint \|\| needs\.detect\.outputs\.fingerprint \}\}/,
+  );
+  assert.match(
+    publish,
+    /if gh pr create[\s\S]*?opened=true[\s\S]*?else[\s\S]*?opened=false/,
+  );
+  assert.match(publish, /continue-on-error: true/);
+  // A pull request opened by the run's own token starts no workflow, so the
+  // proposal has to say how its gate gets run rather than imply it already is.
+  assert.match(publish, /Close and reopen this pull request/);
+  assert.match(publish, /auto-derived, PR ready/);
+  assert.match(publish, /layout changed, investigation needed/);
+  assert.match(publish, /gh issue create --label client-recertification/);
+
+  // The record the detector compares against is data with no authority: one
+  // format version and one digest, and no field a decision could hide in.
+  const record: unknown = JSON.parse(read("certificates/certified-client.json"));
+  assert.ok(record !== null && typeof record === "object");
+  assert.deepEqual(Object.keys(record).sort(), ["codeGeneration", "formatVersion"]);
+});
+
 test("the scheduled canary exercises the latest ArenaNet client conservatively", () => {
   const workflow = read(".github/workflows/client-canary.yml");
   assert.match(workflow, /schedule:[\s\S]*cron:/);

--- a/tests/unit/official-client.test.ts
+++ b/tests/unit/official-client.test.ts
@@ -1,0 +1,179 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "node:test";
+import {
+  officialCodeGeneration,
+  parseCertifiedClientRecord,
+  parseCommand,
+  RECORD,
+  serializeCertifiedClientRecord,
+} from "../../scripts/official-client.ts";
+import { Manifest } from "../../src/main/core/manifest.js";
+import { asDigest } from "../../src/shared/digest.js";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
+
+const CHUNK = 262_144;
+
+function hashes(count: number, seed: string): string[] {
+  return Array.from({ length: count }, (_, index) =>
+    `${seed}${index}`.padEnd(64, "0"));
+}
+
+function manifest(overrides: {
+  wasm?: string[];
+  js?: string[];
+  snapshot?: string[];
+  version?: string[];
+} = {}): Manifest {
+  return new Manifest({
+    compressionMode: "none",
+    chunkSize: CHUNK,
+    files: [
+      {
+        name: "Gw.jspi.wasm",
+        size: 2 * CHUNK,
+        chunkHashes: overrides.wasm ?? hashes(2, "aa"),
+      },
+      {
+        name: "Gw.jspi.js",
+        size: CHUNK,
+        chunkHashes: overrides.js ?? hashes(1, "bb"),
+      },
+      {
+        name: "Gw.snapshot",
+        size: 3 * CHUNK,
+        chunkHashes: overrides.snapshot ?? hashes(3, "cc"),
+      },
+      {
+        name: "version.json",
+        size: CHUNK,
+        chunkHashes: overrides.version ?? hashes(1, "dd"),
+      },
+    ],
+  });
+}
+
+describe("the published code generation", () => {
+  it("is the identity of the two JSPI artifacts and nothing else", () => {
+    const baseline = officialCodeGeneration(manifest());
+    // Game content and the build marker are republished on schedules that have
+    // nothing to do with the WASM. If either moved this identity, every content
+    // patch would start a full derivation that concludes nothing changed.
+    assert.equal(
+      officialCodeGeneration(manifest({ snapshot: hashes(3, "ee") })),
+      baseline,
+    );
+    assert.equal(
+      officialCodeGeneration(manifest({ version: hashes(1, "ee") })),
+      baseline,
+    );
+    assert.notEqual(
+      officialCodeGeneration(manifest({ wasm: hashes(2, "ee") })),
+      baseline,
+    );
+    assert.notEqual(
+      officialCodeGeneration(manifest({ js: hashes(1, "ee") })),
+      baseline,
+    );
+  });
+
+  it("refuses a manifest that names no code artifact", () => {
+    const withoutWasm = new Manifest({
+      compressionMode: "none",
+      chunkSize: CHUNK,
+      files: [
+        { name: "Gw.jspi.js", size: CHUNK, chunkHashes: hashes(1, "bb") },
+      ],
+    });
+    assert.throws(
+      () => officialCodeGeneration(withoutWasm),
+      /missing Gw\.jspi\.wasm/,
+    );
+  });
+});
+
+describe("the command line", () => {
+  const digest = asDigest("a".repeat(64));
+
+  it("reads the three things this script does", () => {
+    assert.deepEqual(parseCommand([]), { kind: "detect" });
+    assert.deepEqual(parseCommand(["--download", "/tmp/official"]), {
+      kind: "download",
+      directory: "/tmp/official",
+    });
+    assert.deepEqual(parseCommand(["--record", digest]), {
+      kind: "record",
+      generation: digest,
+    });
+  });
+
+  // Recording is given the generation the derivation certified, so a value that
+  // is not a digest is a mistake rather than an invitation to go and fetch one:
+  // whatever is published at record time may be a build nothing has certified.
+  it("refuses a record it was not handed a generation for", () => {
+    for (const argv of [
+      ["--record"],
+      ["--record", ""],
+      ["--record", "not-a-digest"],
+      ["--record", "A".repeat(64)],
+      ["--record", "a".repeat(63)],
+      ["--record", "--download", "/tmp/official"],
+    ]) {
+      assert.throws(() => parseCommand(argv), Error, argv.join(" "));
+    }
+  });
+
+  it("refuses to fetch and record in the same run", () => {
+    assert.throws(
+      () => parseCommand(["--download", "/tmp/official", "--record", digest]),
+      /run them apart/u,
+    );
+  });
+
+  it("refuses a download with nowhere to put the bytes", () => {
+    assert.throws(() => parseCommand(["--download"]), /needs a directory/u);
+  });
+});
+
+describe("the recorded client generation", () => {
+  const digest = asDigest("a".repeat(64));
+
+  it("round-trips through its own serializer", () => {
+    assert.deepEqual(
+      parseCertifiedClientRecord(
+        JSON.parse(serializeCertifiedClientRecord(digest)),
+      ),
+      { formatVersion: 1, codeGeneration: digest },
+    );
+  });
+
+  // A record this cannot read must fail rather than resolve either way:
+  // "changed" sends the deriver after a client that may be certified already,
+  // and "unchanged" hides a patch forever.
+  it("refuses everything it cannot read exactly", () => {
+    for (const raw of [
+      null,
+      [],
+      "a".repeat(64),
+      {},
+      { formatVersion: 2, codeGeneration: digest },
+      { formatVersion: 1 },
+      { formatVersion: 1, codeGeneration: "A".repeat(64) },
+      { formatVersion: 1, codeGeneration: "a".repeat(63) },
+      { formatVersion: 1, codeGeneration: digest, trustMe: true },
+    ]) {
+      assert.throws(() => parseCertifiedClientRecord(raw), Error, JSON.stringify(raw));
+    }
+  });
+
+  it("is a tracked file the detector can read today", async () => {
+    const record = parseCertifiedClientRecord(
+      JSON.parse(await readFile(path.join(root, RECORD), "utf8")),
+    );
+    assert.equal(record.formatVersion, 1);
+    assert.match(record.codeGeneration, /^[a-f0-9]{64}$/u);
+  });
+});

--- a/tests/unit/template-save-recert.test.ts
+++ b/tests/unit/template-save-recert.test.ts
@@ -3,13 +3,17 @@ import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
 import {
   compareToCertified,
   deriveTemplateSaveBuild,
   draftTemplateSaveBuild,
   formatBuildEntry,
+  insertBuildEntry,
   inspectTemplateSaveCandidate,
+  TEMPLATE_SAVE_TABLE,
 } from "../../src/tools/template-save-recert.js";
+import { TEMPLATE_SAVE_BUILDS } from "../../src/main/certification/template-save-compat.js";
 import {
   isLocalClientVerification,
   verifyLocalClientBytes,
@@ -575,5 +579,78 @@ describe("template-save re-certification", () => {
     assert.ok(addressDecision.templateSaveBuild);
     assert.equal(addressDecision.enhancementBuild, null);
     assert.deepEqual(addressDecision.reasons, ["enhancement-layout-changed"]);
+  });
+});
+
+describe("adding a derived entry to the authoring table", () => {
+  const candidate = {
+    sha256: "0".repeat(64),
+    outputSha256: "1".repeat(64),
+    importCount: 219,
+    carrierImport: 207,
+    bridges: [
+      {
+        kind: "ensureDirectory" as const,
+        stubFunction: 185,
+        stubBody: [0x00, 0x41, 0x02, 0x0b],
+        callSites: [{ localFunction: 9538, bodyOffset: 171 }],
+      },
+    ],
+  };
+
+  const table = async () =>
+    readFile(
+      path.join(
+        path.dirname(fileURLToPath(import.meta.url)),
+        "../..",
+        TEMPLATE_SAVE_TABLE,
+      ),
+      "utf8",
+    );
+
+  // The last member is the shape baseline every structurally derived candidate
+  // is measured against, so a derived entry that lands anywhere but the end
+  // quietly makes an older build the standard.
+  it("appends the formatted entry to the end of the real table", async () => {
+    const source = await table();
+    const written = insertBuildEntry(source, candidate);
+    assert.ok(
+      written.includes(`${formatBuildEntry(candidate)}\n  ]);\n`),
+      "the derived entry is not the last table member",
+    );
+    assert.ok(
+      written.indexOf(`"${candidate.sha256}"`)
+        > written.indexOf(`"${TEMPLATE_SAVE_BUILDS.at(-1)!.sha256}"`),
+      "the derived entry does not follow the previous baseline",
+    );
+    // Everything the table already said is still there, in order: an insertion
+    // is the only edit this makes.
+    assert.equal(written.replace(`${formatBuildEntry(candidate)}\n`, ""), source);
+    for (const build of TEMPLATE_SAVE_BUILDS) {
+      assert.ok(written.includes(`"${build.sha256}"`), build.sha256);
+    }
+  });
+
+  it("refuses to restate a build somebody already certified", async () => {
+    const source = await table();
+    const certified = TEMPLATE_SAVE_BUILDS[0]!;
+    assert.throws(
+      () => insertBuildEntry(source, { ...candidate, sha256: certified.sha256 }),
+      /already lists/,
+    );
+  });
+
+  // A silent no-op here produces a branch that changes nothing and a pull
+  // request that reads as a successful derivation.
+  it("refuses a source with no table to extend", () => {
+    const opened =
+      "export const TEMPLATE_SAVE_BUILDS: readonly KnownTemplateSaveBuild[] =\n"
+      + "  Object.freeze([\n";
+    for (const source of ["export const TEMPLATE_SAVE_BUILDS = [];\n", opened]) {
+      assert.throws(
+        () => insertBuildEntry(source, candidate),
+        /no TEMPLATE_SAVE_BUILDS table/,
+      );
+    }
   });
 });


### PR DESCRIPTION
## What ships

`client-recertification.yml`: the pipeline that notices an ArenaNet patch and derives what the new build certifies, on GitHub infrastructure only.

- **Detect** (every 15 minutes + dispatch): fetches only the official fingerprint and compares it against the last certified identity. The unchanged path is genuinely seconds — the job runs a dependency-free Node script directly, with no package manager, no install, no toolchain. A policy test asserts the *absence* of a package manager in that job, not just a spelling.
- **Derive** (macOS, on change only): downloads and hash-verifies the official artifacts, runs the consolidated certification CLI against the new build, and produces a candidate feed entry plus bounded structural-evidence artifacts. Evidence only — no client bytes are ever uploaded.
- **Publish stage 1** (no secrets anywhere in this workflow): pushes a branch with the regenerated authoring tables, opens an auto-PR running full verify, and opens a tracking issue either way — "auto-derived, PR ready" or "layout changed, investigation needed" with evidence attached. Falls back to branch + issue if repo policy blocks PR creation. The issue closes automatically once the identity is certified.

## What review caught (and the fixes)

- The detect job originally triggered a full implicit `pnpm install` on every tick — the "seconds when unchanged" criterion was false. Fixed by running the script bare; its import closure is 19 files with zero non-builtin specifiers, and policy pins that.
- `--record` re-fetched the manifest at record time, so a republish during the derive window could record a fingerprint for bytes that were never certified. Fixed: recording takes the digest of what was actually downloaded; download and record can no longer race.
- Repeated ticks during the human-review window no longer re-run the expensive derive or force-push over the open PR branch; derive-failure and issue-close paths were hardened against masked exits.

## Review focus

- The detect job's import closure claim and its policy assertion.
- The outcome decision path: exit codes are honored, not just parsed stdout.

## Verification

`set -o pipefail; pnpm check` green; the policy suite mirrors the release-pipeline tests (no secrets in any job, detector cheapness, evidence-only uploads, pinned toolchain where the kernel builds). A dispatch run on the current live client is designed to produce a clean "already certified" no-op — worth doing once after merge.
