### PR TITLE
Publish the signed feed, reproduced twice and signed in isolation

### DIFF
--- a/.github/workflows/certificate-feed-publication.yml
+++ b/.github/workflows/certificate-feed-publication.yml
@@ -1,0 +1,524 @@
+# The only path that turns the certification tables on main into a signed
+# certificate feed installations fetch. It publishes data and nothing else:
+# every field it moves is a hash, an address, an index or a message identifier,
+# and every fact it delivers is re-established locally before it enables
+# anything. The key holder can withhold a certificate and cannot mint one.
+#
+# The shape follows the versioned release: derive, prove, then hand the proven
+# bytes to one isolated job that holds the credential and does nothing else.
+# Two runners derive the candidate independently and their outputs must be
+# identical, so what gets signed is a property of this repository rather than of
+# a runner — a machine that was tampered with disagrees with the other one and
+# blocks the publication instead of signing its own answer.
+#
+# Nothing here runs until the go-live checklist in certificates/README.md is
+# done: the pinned key is a placeholder in every clone, and this workflow
+# refuses in its first job while it stays one.
+name: Certificate feed publication
+
+on:
+  # The authoring tables a feed is derived from and the pin that decides
+  # whether any feed is believed. A recertification merged to main changes the
+  # first, which is precisely the moment a certificate should reach
+  # installations that will not see an application release for weeks.
+  push:
+    branches: [main]
+    paths:
+      - src/main/certification/template-save-compat.ts
+      - src/main/certification/enhancement-builds.ts
+      - certificates/public-key.txt
+  workflow_dispatch:
+    inputs:
+      enhancement_facts:
+        # The tier decision, and the only thing a person adds to a publication.
+        # Template-save facts are re-derived from the client bytes by every
+        # installation that receives them, so reproduction plus the approval
+        # gate is their whole story. Enhancement facts are not re-derivable —
+        # their layout words are client-memory addresses with no structural
+        # anchor — so they are published only when a person dispatched the run
+        # and said that is what they meant.
+        description: Publish a candidate whose entries carry Enhancement facts.
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: certificate-feed-publication
+  cancel-in-progress: false
+
+jobs:
+  # What a candidate must be, resolved once so both reproductions derive the
+  # same document. It holds no secret and writes nothing outside the run.
+  target:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      current: ${{ steps.resolve.outputs.current }}
+      sequence: ${{ steps.resolve.outputs.sequence }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+
+      # The application's own rule, run against the committed file rather than
+      # restated here. While the placeholder stands, no installation trusts any
+      # feed, so a signature made today would be spent on nobody — and the
+      # approval it would consume is a person's attention.
+      - name: Refuse to publish while no key is pinned
+        run: |
+          node --import ./scripts/ts-hook.mjs --experimental-strip-types -e '
+            const { readFileSync } = await import("node:fs");
+            const { certificateFeedTrust } = await import(
+              "./src/main/certification/certificate-feed-trust.js"
+            );
+            const pinned = readFileSync("certificates/public-key.txt", "utf8");
+            if (certificateFeedTrust(pinned).remote) process.exit(0);
+            console.error(
+              "certificates/public-key.txt still holds the placeholder, so no"
+                + " installation would trust a feed signed today. Work through"
+                + " the go-live checklist in certificates/README.md first.",
+            );
+            process.exit(1);
+          '
+
+      - name: Resolve the sequence a candidate must carry
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -o pipefail
+          mkdir -p published
+          # Which release carries a feed is asked of the release list itself,
+          # not probed by attempting a download per tag: `gh release download`
+          # exits the same way for "this release carries no feed" and "the
+          # download failed", and a scan that cannot tell those apart walks past
+          # the newest feed to an older one — uploads always target the release
+          # in force, so older releases keep the assets they were given — or off
+          # the end into the compiled-in floor, and publishes a sequence
+          # installations have already passed. A failed read fails this step.
+          #
+          # Every release rather than a window, for the same reason: enough
+          # application releases between two publications would push the newest
+          # feed out of a windowed scan.
+          #
+          # Newest first, and the scan stops at the newest release that carries
+          # a feed rather than at the newest release: an application release
+          # publishes no feed assets, so the release installations read today is
+          # regularly not the one the last feed landed on.
+          feeds="$(gh api --paginate "repos/$GITHUB_REPOSITORY/releases" \
+            --jq '.[]
+              | select(.draft == false and .prerelease == false)
+              | select([.assets[].name] | index("certificate-feed.json"))
+              | .tag_name')"
+          tag="$(head -n 1 <<< "$feeds")"
+          published=""
+          if [ -n "$tag" ]; then
+            gh release download "$tag" --repo "$GITHUB_REPOSITORY" \
+              --pattern certificate-feed.json --dir published --clobber
+            published="$(jq -r '.sequence' published/certificate-feed.json)"
+            case "$published" in
+              "" | *[!0-9]*)
+                echo "Published sequence is not a number: $published" >&2
+                exit 1
+                ;;
+            esac
+          fi
+          # The floor a candidate must beat, resolved here and nowhere else,
+          # because this is the only job that can see both numbers. It is the
+          # newer of the feed in force and the snapshot compiled into this
+          # release: a release can ship a snapshot that has overtaken the
+          # published feed, and asking for `published + 1` there names a
+          # sequence `publicationSequence` refuses on both reproduction legs —
+          # with no in-band way to publish anything ever again.
+          bundled="$(node --import ./scripts/ts-hook.mjs \
+            --experimental-strip-types -e '
+              const { BUNDLED_CERTIFICATE_FEED_SEQUENCE } = await import(
+                "./src/main/certification/certificate-feed.js"
+              );
+              console.log(BUNDLED_CERTIFICATE_FEED_SEQUENCE);
+            ')"
+          case "$bundled" in
+            "" | *[!0-9]*)
+              echo "Bundled sequence is not a number: $bundled" >&2
+              exit 1
+              ;;
+          esac
+          current="$bundled"
+          if [ -n "$published" ] && [ "$published" -gt "$bundled" ]; then
+            current="$published"
+          fi
+          {
+            echo "current=$current"
+            echo "sequence=$((current + 1))"
+          } >> "$GITHUB_OUTPUT"
+          # Written unconditionally so the handover below is one artifact in
+          # both states. No certificate-feed.json beside it means nothing has
+          # been published yet, and this number is then the compiled-in floor.
+          echo "$current" > published/resolved-floor.txt
+
+      # The feed in force, carried forward as the thing the tier decision is
+      # measured against.
+      - name: Hand over the feed currently in force
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: certificate-feed-published
+          path: published
+          retention-days: 7
+          if-no-files-found: error
+
+  # Two runners, one document. Each derives the candidate from the tree and
+  # nothing else: no package manager, no dependency tree, no build output. The
+  # generator's import graph is this repository plus Node builtins, which is
+  # what makes "identical" a statement about the tables rather than about what a
+  # registry served each runner.
+  reproduce:
+    needs: target
+    strategy:
+      fail-fast: false
+      matrix:
+        runner: [ubuntu-latest, macos-15]
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+
+      - name: Derive the candidate from the tables in this tree
+        env:
+          SEQUENCE: ${{ needs.target.outputs.sequence }}
+        run: |
+          mkdir -p candidate
+          node --import ./scripts/ts-hook.mjs --experimental-strip-types \
+            scripts/generate-certificate-feed.ts \
+            --sequence "$SEQUENCE" --out candidate/certificate-feed.json
+          # The pin travels with the document because the job that signs checks
+          # nothing out: it is public data, it is what a signature has to verify
+          # under, and reproducing it here puts it under the same agreement.
+          cp certificates/public-key.txt candidate/public-key.txt
+          ( cd candidate && shasum -a 256 certificate-feed.json public-key.txt )
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: certificate-feed-candidate-${{ matrix.runner }}
+          path: candidate
+          retention-days: 7
+          if-no-files-found: error
+
+  # The reproduction gate. Publication continues only from bytes two
+  # independent runners produced identically; a disagreement is a fact about
+  # this repository that a person has to read, so it blocks and files itself.
+  agree:
+    needs: [target, reproduce]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    outputs:
+      digest: ${{ steps.compare.outputs.digest }}
+      tier: ${{ steps.tier.outputs.tier }}
+    steps:
+      - name: Receive both reproductions
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          pattern: certificate-feed-candidate-*
+          path: reproduced
+
+      - name: Require the two reproductions to be byte-identical
+        id: compare
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          # Two hashes that failed to be computed are equal, and this step is
+          # the whole reproduction gate. A broken pipeline has to fail it.
+          set -o pipefail
+          legs=(reproduced/*/)
+          test "${#legs[@]}" = "2"
+          first="${legs[0]}"
+          second="${legs[1]}"
+          for file in certificate-feed.json public-key.txt; do
+            left="$(shasum -a 256 "$first$file" | cut -d ' ' -f 1)"
+            right="$(shasum -a 256 "$second$file" | cut -d ' ' -f 1)"
+            if [ "$left" = "$right" ]; then continue; fi
+            gh label create certificate-feed --force --color 5319e7 \
+              --description "The signed certificate feed and its publication"
+            {
+              echo "Two runners derived different \`$file\` from \`$GITHUB_SHA\`,"
+              echo "so nothing was signed and nothing was published."
+              echo
+              echo "- \`$(basename "$first")\`: \`$left\`"
+              echo "- \`$(basename "$second")\`: \`$right\`"
+              echo "- evidence: $RUN_URL"
+              echo
+              echo "A certificate feed is derived from the tables in this tree by"
+              echo "Node builtins alone, so the two answers cannot differ for a"
+              echo "reason this repository is allowed to have. Find the reason"
+              echo "before dispatching this workflow again."
+            } > mismatch.md
+            gh issue create --label certificate-feed --body-file mismatch.md \
+              --title "Certificate feed reproduction disagreed on $file"
+            exit 1
+          done
+          mkdir -p candidate
+          cp "$first"certificate-feed.json "$first"public-key.txt candidate/
+          digest="$(shasum -a 256 candidate/certificate-feed.json | cut -d ' ' -f 1)"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+
+      - name: Receive the feed currently in force
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: certificate-feed-published
+          path: published
+
+      # The tier is read out of the candidate rather than declared beside it: an
+      # entry the publication adds or changes decides its own tier, so nobody
+      # has to remember which half of a table they edited.
+      - name: Decide the publication tier
+        id: tier
+        env:
+          ACKNOWLEDGED: ${{ inputs.enhancement_facts }}
+        run: |
+          tier="$(node -e '
+            const { readFileSync } = await import("node:fs");
+            const read = (file) => {
+              try { return JSON.parse(readFileSync(file, "utf8")); }
+              catch { return { entries: [] }; }
+            };
+            const published = new Map(
+              read(process.argv[2]).entries.map(
+                (entry) => [entry.templateSave.sha256, JSON.stringify(entry)],
+              ),
+            );
+            const moved = read(process.argv[1]).entries.filter(
+              (entry) =>
+                published.get(entry.templateSave.sha256) !== JSON.stringify(entry),
+            );
+            console.log(
+              moved.some((entry) => entry.enhancement !== null)
+                ? "enhancement"
+                : "template",
+            );
+          ' candidate/certificate-feed.json published/certificate-feed.json)"
+          echo "tier=$tier" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Certificate feed candidate"
+            echo
+            echo "- tier: \`$tier\`"
+            echo "- sha256: \`${{ steps.compare.outputs.digest }}\`"
+            if [ "$tier" = "enhancement" ] && [ "$ACKNOWLEDGED" != "true" ]; then
+              echo
+              echo "This candidate adds or changes an entry carrying Enhancement"
+              echo "facts, which no installation re-derives. It is not signed by"
+              echo "a run that nobody dispatched: run this workflow by hand with"
+              echo "\`enhancement_facts\` set, and approve it in the"
+              echo "certificate-publishing environment."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: certificate-feed-candidate
+          path: candidate
+          retention-days: 7
+          if-no-files-found: error
+
+  # The one job that can read the private key, and the only job in this
+  # repository that holds it at all. It checks nothing out: a working tree
+  # beside a signing key is every script in it running beside a signing key.
+  # What it has is bytes two runners agreed on, which it reads as data and never
+  # executes, and the credentials to attach two assets to a release.
+  sign:
+    needs: [target, reproduce, agree]
+    # A candidate that only moves template-save facts reaches the approval gate
+    # on the push that produced it. One that moves Enhancement facts reaches it
+    # only when a person dispatched the run and acknowledged the tier, because
+    # nothing on the receiving machine re-derives those addresses.
+    if: >-
+      github.ref == 'refs/heads/main'
+      && (needs.agree.outputs.tier == 'template' || inputs.enhancement_facts)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: certificate-publishing
+    permissions:
+      contents: write
+    steps:
+      - name: Receive the reproduced candidate
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: certificate-feed-candidate
+          path: candidate
+
+      - name: Bind these bytes to what both runners reproduced
+        env:
+          DIGEST: ${{ needs.agree.outputs.digest }}
+        run: |
+          set -o pipefail
+          test "$(shasum -a 256 candidate/certificate-feed.json | cut -d ' ' -f 1)" \
+            = "$DIGEST"
+
+      # Deliberately not the repository's parser: this job signs the tables and
+      # cannot also be the thing that decides they are well formed. The full
+      # schema ran twice already, inside each reproduction. What is restated
+      # here is only what a signature must never cover blindly — the exact
+      # spelling the bytes have, the version a reader will accept, and the
+      # ordering that makes "the certificate for this hash" a question with one
+      # answer.
+      - name: Check the candidate before signing it
+        env:
+          SEQUENCE: ${{ needs.target.outputs.sequence }}
+        run: |
+          node -e '
+            const { readFileSync } = await import("node:fs");
+            const bytes = readFileSync(process.argv[1]);
+            const fail = (why) => {
+              console.error("candidate feed: " + why);
+              process.exit(1);
+            };
+            if (bytes[0] === 0xef) fail("carries a byte-order mark");
+            let text = "";
+            try {
+              text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+            } catch { fail("is not UTF-8"); }
+            const document = JSON.parse(text);
+            if (JSON.stringify(document, null, 2) + "\n" !== text) {
+              fail("is not the one spelling a signature and a parser both accept");
+            }
+            if (Object.keys(document).join() !== "formatVersion,sequence,entries") {
+              fail("does not carry exactly the three declared fields");
+            }
+            if (document.formatVersion !== 1) fail("declares an unreadable version");
+            if (document.sequence !== Number(process.argv[2])) {
+              fail("carries sequence " + document.sequence + ", not " + process.argv[2]);
+            }
+            let previous = "";
+            for (const entry of document.entries) {
+              if (Object.keys(entry).join() !== "templateSave,enhancement") {
+                fail("an entry carries fields this publication does not understand");
+              }
+              const key = entry.templateSave.sha256;
+              if (typeof key !== "string" || !/^[0-9a-f]{64}$/.test(key)) {
+                fail("an entry is not keyed by a client hash");
+              }
+              if (key <= previous) fail("entries are unordered or duplicated");
+              previous = key;
+            }
+          ' candidate/certificate-feed.json "$SEQUENCE"
+
+      # Resolved again here rather than taken from the job that resolved it
+      # before reproduction. An approval is granted whenever a person gets to
+      # it, and a feed published in that gap has to block this one rather than
+      # be overwritten by a sequence installations have already passed.
+      - name: Refuse a sequence the published feed has already reached
+        id: rolling
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SEQUENCE: ${{ needs.target.outputs.sequence }}
+        run: |
+          set -o pipefail
+          release="$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq '.tag_name')"
+          test -n "$release"
+          echo "release=$release" >> "$GITHUB_OUTPUT"
+          # Asked of the release list for the reason the target job gives, and
+          # here it is the whole point of the step: a failed download that read
+          # as "this release carries no feed" would walk the scan past the feed
+          # in force and skip the comparison below, disabling this gate exactly
+          # when it cannot see what it guards against.
+          feeds="$(gh api --paginate "repos/$GITHUB_REPOSITORY/releases" \
+            --jq '.[]
+              | select(.draft == false and .prerelease == false)
+              | select([.assets[].name] | index("certificate-feed.json"))
+              | .tag_name')"
+          tag="$(head -n 1 <<< "$feeds")"
+          if [ -n "$tag" ]; then
+            mkdir -p "$RUNNER_TEMP/published"
+            gh release download "$tag" --repo "$GITHUB_REPOSITORY" \
+              --pattern certificate-feed.json --dir "$RUNNER_TEMP/published" \
+              --clobber
+            current="$(jq -r '.sequence' "$RUNNER_TEMP/published/certificate-feed.json")"
+            case "$current" in
+              "" | *[!0-9]*)
+                echo "Published sequence is not a number: $current" >&2
+                exit 1
+                ;;
+            esac
+            # Which number a candidate carries was decided once, by the job that
+            # could see both the feed in force and the compiled-in floor. What
+            # is left for this moment is that nothing has published since: a
+            # feed that reached these assets in the gap came through this same
+            # workflow and so carries at least this candidate's sequence, and a
+            # candidate still strictly ahead of the feed in force is a candidate
+            # nothing overtook.
+            test "$SEQUENCE" -gt "$current"
+          fi
+
+      - name: Sign the candidate under the pinned key
+        env:
+          # The one secret that can produce a feed signature, named in this job
+          # and in no other. Everything it can do is deny installations a
+          # certificate: what it signs is proposals the receiving machine
+          # re-establishes locally before anything is enabled.
+          CERTIFICATE_FEED_SIGNING_KEY: ${{ secrets.CERTIFICATE_FEED_SIGNING_KEY }}
+        run: |
+          set -o pipefail
+          umask 077
+          test -n "$CERTIFICATE_FEED_SIGNING_KEY"
+          key="$RUNNER_TEMP/feed-signing.key"
+          printf '%s\n' "$CERTIFICATE_FEED_SIGNING_KEY" > "$key"
+          # The key ceremony's own command, run against the secret rather than
+          # against a note about it: the raw 32 bytes of this key's public half
+          # have to be the line the application pins, or the signature made
+          # below would verify for nobody and cost a release asset.
+          test "$(openssl pkey -in "$key" -pubout -outform DER | tail -c 32 | base64)" \
+            = "$(tr -d '\n' < candidate/public-key.txt)"
+          openssl pkeyutl -sign -inkey "$key" -rawin \
+            -in candidate/certificate-feed.json \
+            -out "$RUNNER_TEMP/certificate-feed.sig"
+          test "$(wc -c < "$RUNNER_TEMP/certificate-feed.sig")" = "64"
+          # Verified here, before anything is uploaded, by the same detached
+          # check the application runs. A signature nobody can verify is a
+          # denial of service published by hand.
+          openssl pkey -in "$key" -pubout -out "$RUNNER_TEMP/feed-public.pem"
+          openssl pkeyutl -verify -pubin -inkey "$RUNNER_TEMP/feed-public.pem" \
+            -rawin -in candidate/certificate-feed.json \
+            -sigfile "$RUNNER_TEMP/certificate-feed.sig"
+          base64 -w 0 < "$RUNNER_TEMP/certificate-feed.sig" \
+            > candidate/certificate-feed.json.sig
+          printf '\n' >> candidate/certificate-feed.json.sig
+
+      - name: Publish the feed and its detached signature
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE: ${{ steps.rolling.outputs.release }}
+        run: |
+          gh release upload "$RELEASE" --repo "$GITHUB_REPOSITORY" --clobber \
+            candidate/certificate-feed.json candidate/certificate-feed.json.sig
+          fetched="$RUNNER_TEMP/fetched"
+          mkdir -p "$fetched"
+          gh release download "$RELEASE" --repo "$GITHUB_REPOSITORY" \
+            --dir "$fetched" --clobber --pattern 'certificate-feed.json*'
+          cmp candidate/certificate-feed.json "$fetched/certificate-feed.json"
+          cmp candidate/certificate-feed.json.sig "$fetched/certificate-feed.json.sig"
+          {
+            echo "### Certificate feed published"
+            echo
+            echo "- release: \`$RELEASE\`"
+            echo "- sha256: \`$(shasum -a 256 candidate/certificate-feed.json | cut -d ' ' -f 1)\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Delete the signing key
+        if: always()
+        run: rm -f "$RUNNER_TEMP/feed-signing.key"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ is meant to inherit the dead ends rather than walk back into them.
 | `src/main/main.ts`        | composition root, ArenaNet client update, app state           |
 | `src/main/core/`          | chunks, manifest, DNS, sockets, settings                      |
 | `src/main/certification/` | the official -> template-save -> Enhancement chain: certified tables, both transforms, the isolated proof, the Enhancement switches, the certificate feed and its delivery |
-| `certificates/`           | the pinned certificate-feed public key, its key ceremony, and the client generation this repository has certified |
+| `certificates/`           | the pinned certificate-feed public key, its key ceremony, how a signed feed is published, and the client generation this repository has certified |
 | `src/main/protocol.ts`    | secure `gw://app` routing and snapshot ranges                 |
 | `src/main/ipc.ts`         | validated native capability handlers                          |
 | `src/main/diagnostics.ts` | the diagnostics subsystem's one entry point                   |
@@ -346,6 +346,18 @@ the layout stopped being derivable. It holds no secret, uploads evidence and
 never client bytes, and its branch is worth nothing until the pull request's
 `pnpm verify` gate passes on it. The recorded generation carries no authority;
 it decides only whether that job runs.
+
+`.github/workflows/certificate-feed-publication.yml` is the only path from a
+merged table to a signed feed. Two runners derive the candidate from the tree
+alone and their bytes must be identical; a disagreement publishes nothing and
+files both hashes. The candidate's `sequence` is one past the higher of the feed
+in force and the bundled snapshot, resolved in the one job that sees both. One
+isolated job holds the private key, checks nothing out, refuses a candidate the
+published feed has caught up with while a person was approving it, and uploads
+the two assets. Template-save facts reach the approval gate on the push that
+produced them; Enhancement facts reach it only on a dispatch that says so,
+because nothing on the receiving machine re-derives them. `certificates/README.md` owns
+that mechanism and the go-live checklist the repository owner performs by hand.
 
 For enhancement work, begin with `pnpm certification doctor`, use the offline layers in
 `docs/enhancement-development.md`, and finish with one scoped `enhancements:live`

--- a/certificates/README.md
+++ b/certificates/README.md
@@ -78,13 +78,77 @@ Two assets on the release the application resolves as current:
 
 `pnpm build` writes the document the shipped tables derive to
 `build/certificates/feed.json`; a published feed is that document with a
-`sequence` higher than any feed already released. Sign the bytes, not a
-re-serialised copy of them — the parser accepts exactly one spelling, and a
-signature that covers a different one verifies against nothing.
+`sequence` higher than both any feed already released and the snapshot compiled
+into the application. Both floors bind, so what a candidate must beat is the
+higher of them: a feed that does not beat the released one is a replay every
+installation holding it refuses, and one that does not beat the compiled-in
+snapshot is adopted by nobody, because `governingCertificateFeed` keeps the
+newer of the two. Sign the bytes, not a re-serialised copy of them — the parser
+accepts exactly one spelling, and a signature that covers a different one
+verifies against nothing.
 
 Replacing those two assets on an existing release is the whole of what it takes
 to reach installations. No application release is involved, which is the point:
 recovery arrives as data.
+
+## Publication
+
+`.github/workflows/certificate-feed-publication.yml` is the only path from the
+tables on `main` to those two assets, and it runs on a push that changes a
+certification table or this pin.
+
+It derives the candidate twice, on two runners, from the tree and a Node and
+nothing else — the generator's whole import graph is this repository plus Node
+builtins, so there is no dependency tree for two machines to disagree about. The
+two answers must be byte-identical. A disagreement publishes nothing and opens
+an issue carrying both hashes, because a derivation that is not reproducible is
+a fact about this repository that a person has to read.
+
+The candidate's `sequence` is one past the higher of the two floors above — the
+feed in force and the bundled snapshot — resolved in the one job that can see
+both, so the two rules can never contradict. That job asks the release list
+which release carries a feed rather than probing each one with a download,
+because a download that failed and a release that never had the asset are the
+same exit code, and reading the first as the second names a sequence
+installations have already passed.
+
+The job that signs holds the private key and checks nothing out: a working tree
+beside a signing key is every script in it running beside a signing key. It
+receives the reproduced bytes as data, re-hashes them against what the two
+runners agreed on, restates the spelling and ordering rules a signature must not
+cover blindly, and refuses a candidate the published feed has caught up with —
+resolved again at that moment rather than before the approval, so a feed
+published while a person was deciding blocks this one instead of being
+overwritten.
+
+The tier is read out of the candidate. An entry that only moves template-save
+facts reaches the approval gate on the push that produced it, because every
+installation re-derives those facts from its own client bytes. An entry carrying
+Enhancement facts reaches it only on a run someone dispatched with
+`enhancement_facts` set: nothing on the receiving machine re-derives a layout
+address, so a person says that is what they meant.
+
+## The go-live checklist
+
+Four things this repository cannot do for itself. Each one is a setting or a
+secret in an account, and scripting around any of them would mean holding the
+credentials that can change it — a larger blast radius than the thing being
+automated. Until all four are done the publication workflow refuses in its first
+job, which is the intended state of every clone.
+
+1. In **Settings → Actions → General**, allow GitHub Actions to create and
+   approve pull requests. Without it the recertification workflow pushes its
+   branch and files its issue but cannot open the proposal.
+2. Create the **`certificate-publishing`** environment with required reviewers
+   and a deployment branch rule limiting it to `main`. This is the one-click
+   human approval every publication passes through.
+3. Run the key ceremony above on an offline machine, and add the private half as
+   the environment secret **`CERTIFICATE_FEED_SIGNING_KEY`** — on that
+   environment, never as a repository secret. It is the PEM `openssl genpkey`
+   wrote, pasted whole.
+4. Replace the placeholder line in `public-key.txt` with the printed public key,
+   commit that on its own, and ship a release carrying it. Until that release is
+   what installations run, they trust no feed at all.
 
 ### Rotation and loss
 

--- a/scripts/generate-certificate-feed.ts
+++ b/scripts/generate-certificate-feed.ts
@@ -1,5 +1,7 @@
-// The one producer of build/certificates/feed.json, the certificate feed
-// snapshot bundled inside the application.
+// The one producer of a certificate feed document: the snapshot bundled inside
+// the application, and the candidate a publication signs. They are the same
+// derivation from the same tables at a different `sequence`, which is what lets
+// a published feed be reproduced from the tree alone and compared byte for byte.
 //
 // The TypeScript tables under src/main/certification stay the authoring source:
 // the isolated proof is compiled against them and cannot read a file. This
@@ -7,14 +9,19 @@
 //
 // It reads the source rather than build/main's compiled copy for the reason
 // scripts/generate-preload.ts gives: an input that depends on a build step lets
-// a stale build/ produce a stale artifact.
+// a stale build/ produce a stale artifact. Its whole import graph is this
+// repository's own modules and Node builtins, so a reproduction needs a
+// checkout and a Node and nothing else — no package manager, no dependency
+// tree, nothing a registry could move under two runners that must agree.
 //
 // The round trip is checked here rather than only in the unit suite. These are
 // the bytes a signature would cover and the bytes a reader parses, so a table
 // this schema cannot express canonically has to fail the build that ships it.
 import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
 import { pathToFileURL } from "node:url";
 import {
+  BUNDLED_CERTIFICATE_FEED_SEQUENCE,
   bundledCertificateFeed,
   parseCertificateFeed,
   serializeCertificateFeed,
@@ -22,8 +29,13 @@ import {
 
 export const OUTPUT = "build/certificates/feed.json";
 
-export function generate(): Uint8Array {
-  const bytes = serializeCertificateFeed(bundledCertificateFeed());
+export function generate(
+  sequence: number = BUNDLED_CERTIFICATE_FEED_SEQUENCE,
+): Uint8Array {
+  const bytes = serializeCertificateFeed({
+    ...bundledCertificateFeed(),
+    sequence,
+  });
   const reread = serializeCertificateFeed(parseCertificateFeed(bytes));
   if (Buffer.compare(Buffer.from(bytes), Buffer.from(reread)) !== 0) {
     throw new Error(
@@ -33,8 +45,50 @@ export function generate(): Uint8Array {
   return bytes;
 }
 
+/**
+ * The sequence a published candidate may carry. It has to beat the snapshot
+ * compiled into the application, because a feed that does not is one no
+ * installation will ever adopt — `governingCertificateFeed` keeps the newer of
+ * the two, and the snapshot needs nothing from the network. The upper bound is
+ * the parser's own unsigned-word rule and is left to it: `generate` reads every
+ * document it writes.
+ */
+export function publicationSequence(text: string): number {
+  if (!/^(?:0|[1-9][0-9]*)$/.test(text)) {
+    throw new Error(`--sequence must be a decimal integer, not ${JSON.stringify(text)}`);
+  }
+  const sequence = Number(text);
+  if (sequence <= BUNDLED_CERTIFICATE_FEED_SEQUENCE) {
+    throw new Error(
+      `--sequence ${sequence} does not beat the bundled snapshot's `
+        + `${BUNDLED_CERTIFICATE_FEED_SEQUENCE}, so no installation would adopt it`,
+    );
+  }
+  return sequence;
+}
+
+interface Arguments {
+  readonly sequence: number;
+  readonly out: string;
+}
+
+export function parseArguments(argv: readonly string[]): Arguments {
+  let sequence = BUNDLED_CERTIFICATE_FEED_SEQUENCE;
+  let out = OUTPUT;
+  for (let index = 0; index < argv.length; index += 2) {
+    const flag = argv[index];
+    const value = argv[index + 1];
+    if (value === undefined) throw new Error(`${flag} needs a value`);
+    if (flag === "--sequence") sequence = publicationSequence(value);
+    else if (flag === "--out") out = value;
+    else throw new Error(`unknown argument ${JSON.stringify(flag)}`);
+  }
+  return { sequence, out };
+}
+
 if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
-  mkdirSync("build/certificates", { recursive: true });
-  writeFileSync(OUTPUT, generate());
-  console.log(`generated certificate feed -> ${OUTPUT}`);
+  const { sequence, out } = parseArguments(process.argv.slice(2));
+  mkdirSync(path.dirname(out), { recursive: true });
+  writeFileSync(out, generate(sequence));
+  console.log(`generated certificate feed ${sequence} -> ${out}`);
 }

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -13,7 +13,7 @@
 // a real window in tests/electron/sandbox.spec.ts), and the three assertions
 // that still need the compiled build (tests/release/).
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
@@ -721,6 +721,161 @@ test("the patch detector is cheap, secretless, and only ever proposes", () => {
   const record: unknown = JSON.parse(read("certificates/certified-client.json"));
   assert.ok(record !== null && typeof record === "object");
   assert.deepEqual(Object.keys(record).sort(), ["codeGeneration", "formatVersion"]);
+});
+
+test("the feed publication reproduces twice and signs in isolation", () => {
+  const workflow = read(".github/workflows/certificate-feed-publication.yml");
+  // Blanked rather than dropped, for the reason the detector's scan gives: a
+  // job's prose sits above its key and would be read as part of the job before.
+  const body = workflow
+    .split("\n")
+    .map((line) => (/^\s*#/u.test(line) ? "" : line))
+    .join("\n");
+  const target = body.slice(body.indexOf("\n  target:"), body.indexOf("\n  reproduce:"));
+  const reproduce = body.slice(body.indexOf("\n  reproduce:"), body.indexOf("\n  agree:"));
+  const agree = body.slice(body.indexOf("\n  agree:"), body.indexOf("\n  sign:"));
+  const sign = body.slice(body.indexOf("\n  sign:"));
+  assert.ok(target && reproduce && agree && sign, "the four jobs are not all present");
+
+  assert.match(workflow, /^permissions:\n {2}contents: read$/mu);
+  assert.match(workflow, /group: certificate-feed-publication/);
+  // The tables a feed is derived from, and the pin that decides whether one is
+  // believed. A trigger wider than that publishes on commits that cannot have
+  // changed a single byte of the document.
+  assert.match(
+    workflow,
+    /paths:\n {6}- src\/main\/certification\/template-save-compat\.ts\n {6}- src\/main\/certification\/enhancement-builds\.ts\n {6}- certificates\/public-key\.txt\n/,
+  );
+
+  // Nothing is published while the pin is the committed placeholder, and the
+  // refusal runs the application's own rule rather than restating the sentinel.
+  assert.match(target, /certificateFeedTrust\(pinned\)\.remote/);
+  assert.match(target, /go-live checklist in certificates\/README\.md/);
+
+  // Two runners, and they have to be two different machines for the comparison
+  // to be evidence about this repository rather than about one runner.
+  const runners = reproduce.match(/runner: \[(.+)\]/u)?.[1] ?? "";
+  assert.deepEqual(runners.split(", "), ["ubuntu-latest", "macos-15"]);
+  assert.match(reproduce, /runs-on: \$\{\{ matrix\.runner \}\}/);
+  assert.match(reproduce, /fail-fast: false/);
+  // The derivation is the tree plus a Node and nothing else. A package manager
+  // here would make two runners agree about a registry as much as about the
+  // tables, and would put a thousand install scripts in the reproduction.
+  assert.match(
+    reproduce,
+    /scripts\/generate-certificate-feed\.ts \\\n {12}--sequence "\$SEQUENCE" --out candidate\/certificate-feed\.json/,
+  );
+  assert.doesNotMatch(reproduce, /pnpm|rustup|pnpm build/);
+  assert.match(reproduce, /cp certificates\/public-key\.txt candidate\/public-key\.txt/);
+
+  // A disagreement blocks and files itself with both answers. Without the
+  // hashes in the issue, the run that found it is the only place they exist.
+  assert.match(agree, /permissions:\n {6}contents: read\n {6}issues: write/);
+  // Two hashes that were never computed compare equal, so the gate needs the
+  // pipeline's exit code rather than only its last command's.
+  assert.match(agree, /set -o pipefail\n {10}legs=\(reproduced\/\*\/\)/);
+  assert.match(agree, /if \[ "\$left" = "\$right" \]; then continue; fi/);
+  assert.match(agree, /gh issue create --label certificate-feed/);
+  assert.match(agree, /\$\(basename "\$first"\)[\s\S]*\$left[\s\S]*\$\(basename "\$second"\)[\s\S]*\$right/);
+  assert.match(agree, /--title "Certificate feed reproduction disagreed on \$file"\n {12}exit 1\n/);
+  assert.match(agree, /digest=\$digest/);
+
+  // The tier is computed from the candidate against the feed already in force,
+  // so an entry decides its own tier. Template-save facts are re-derived on the
+  // machine that receives them; Enhancement facts are not, and reach the
+  // approval gate only on a run a person dispatched saying so.
+  assert.match(agree, /moved\.some\(\(entry\) => entry\.enhancement !== null\)/);
+  assert.match(
+    sign,
+    /if: >-\n {6}github\.ref == 'refs\/heads\/main'\n {6}&& \(needs\.agree\.outputs\.tier == 'template' \|\| inputs\.enhancement_facts\)/,
+  );
+
+  // The job that holds the key checks nothing out. A working tree beside a
+  // signing key is every script in it running beside a signing key, and an
+  // artifact is data this job reads rather than code it runs.
+  assert.doesNotMatch(sign, /actions\/checkout|persist-credentials|pnpm|scripts\//);
+  assert.match(sign, /environment: certificate-publishing/);
+  assert.match(sign, /permissions:\n {6}contents: write/);
+  const actions = [...sign.matchAll(/uses: ([^@]+)@/gu)].map((match) => match[1]);
+  assert.deepEqual([...new Set(actions)], ["actions/download-artifact"]);
+
+  // One secret, named in one job of one workflow. Its absence everywhere else
+  // is the assertion, because a second naming is a second job that can read it.
+  const secret = "secrets.CERTIFICATE_FEED_SIGNING_KEY";
+  assert.equal(workflow.split(secret).length - 1, 1);
+  assert.ok(sign.includes(secret));
+  for (const file of readdirSync(path.join(root, ".github/workflows"))) {
+    if (file === "certificate-feed-publication.yml") continue;
+    assert.doesNotMatch(read(`.github/workflows/${file}`), /CERTIFICATE_FEED_SIGNING_KEY/);
+  }
+
+  // The bytes signed are the bytes two runners agreed on, and the key that
+  // signs them is the key installations pin. Neither is taken on trust.
+  assert.match(sign, /shasum -a 256 candidate\/certificate-feed\.json[\s\S]*= "\$DIGEST"/);
+  assert.match(
+    sign,
+    /openssl pkey -in "\$key" -pubout -outform DER \| tail -c 32 \| base64\)" \\\n {12}= "\$\(tr -d '\\n' < candidate\/public-key\.txt\)"/,
+  );
+  assert.match(sign, /openssl pkeyutl -verify -pubin/);
+  assert.match(sign, /name: Delete the signing key\n {8}if: always\(\)/);
+
+  // Sequence enforcement. The floor a candidate must beat is resolved in one
+  // place, by the one job that can see both numbers: a release may ship a
+  // snapshot that has overtaken the published feed, and `published + 1` there
+  // names a sequence the generator's own floor refuses on both reproduction
+  // legs, with no in-band way to publish again.
+  assert.equal(body.match(/echo "sequence=\$\(\(current \+ 1\)\)"/gu)?.length, 1);
+  assert.match(target, /echo "sequence=\$\(\(current \+ 1\)\)"/);
+  assert.match(
+    target,
+    /current="\$bundled"\n {10}if \[ -n "\$published" \] && \[ "\$published" -gt "\$bundled" \]; then\n {12}current="\$published"/,
+  );
+  // What is left for the moment after the approval is that nothing published in
+  // the gap: any feed that reached these assets came through this workflow and
+  // carries at least this candidate's sequence.
+  assert.match(sign, /test "\$SEQUENCE" -gt "\$current"/);
+  // Both scans stop at the newest release carrying a feed rather than at the
+  // newest release: an application release publishes no feed assets, and
+  // restarting the sequence there would publish one every installation refuses.
+  // Which release carries one is asked of the release list, over every release
+  // rather than a window, because `gh release download` exits the same way for
+  // "carries no feed" and "the download failed" — and reading the second as the
+  // first walks the scan past the feed in force, in the signing job disabling
+  // the gate exactly when it cannot see what it guards against.
+  assert.equal(
+    body.match(
+      /gh api --paginate "repos\/\$GITHUB_REPOSITORY\/releases" \\\n {12}--jq '\.\[\]\n {14}\| select\(\.draft == false and \.prerelease == false\)\n {14}\| select\(\[\.assets\[\]\.name\] \| index\("certificate-feed\.json"\)\)\n {14}\| \.tag_name'/gu,
+    )?.length,
+    2,
+  );
+  assert.doesNotMatch(body, /--limit \d+|> \/dev\/null 2>&1/u);
+  assert.match(sign, /gh release upload "\$RELEASE" --repo "\$GITHUB_REPOSITORY" --clobber/);
+  assert.match(sign, /cmp candidate\/certificate-feed\.json "\$fetched\/certificate-feed\.json"/);
+
+  // Only the signing job may write to a release, and nothing in this workflow
+  // may push a branch or open a pull request.
+  assert.equal(body.match(/contents: write/gu)?.length, 1);
+  assert.doesNotMatch(workflow, /pull-requests: write|id-token: write|git push/);
+
+  // The two asset names are the ones the application fetches. A rename here is
+  // a feed published where nothing looks for it.
+  const delivery = read("src/main/certification/certificate-feed-delivery.ts");
+  for (const asset of ["certificate-feed.json", "certificate-feed.json.sig"]) {
+    assert.ok(sign.includes(`candidate/${asset}`), `${asset} is never published`);
+    assert.ok(delivery.includes(`"${asset}"`), `${asset} is not what the app fetches`);
+  }
+});
+
+test("the certificate ceremony documents what the owner has to do by hand", () => {
+  const ceremony = read("certificates/README.md");
+  // These four are settings and secrets in accounts this repository cannot
+  // reach. Scripting around them would mean holding the credentials that can
+  // change them, which is a larger blast radius than the thing being automated.
+  assert.match(ceremony, /## The go-live checklist/);
+  assert.match(ceremony, /allow GitHub Actions to create/i);
+  assert.match(ceremony, /certificate-publishing[\s\S]*required reviewers/);
+  assert.match(ceremony, /CERTIFICATE_FEED_SIGNING_KEY/);
+  assert.match(ceremony, /placeholder line in `public-key\.txt`/);
 });
 
 test("the scheduled canary exercises the latest ArenaNet client conservatively", () => {

--- a/tests/unit/generate-certificate-feed.test.ts
+++ b/tests/unit/generate-certificate-feed.test.ts
@@ -1,0 +1,96 @@
+// The producer of both feed documents this repository has: the snapshot the
+// build bundles, and the candidate a publication signs. What is asserted here
+// is that they are one derivation — same tables, same bytes, one number apart —
+// because the publication workflow proves a candidate by deriving it twice on
+// two runners and comparing, and that comparison means nothing if the generator
+// can answer differently for reasons other than the tables.
+//
+// Keypairs are generated per run and never leave this process. No private key
+// material exists in this repository.
+import assert from "node:assert/strict";
+import { generateKeyPairSync, sign } from "node:crypto";
+import { describe, it } from "node:test";
+import {
+  generate,
+  parseArguments,
+  publicationSequence,
+  OUTPUT,
+} from "../../scripts/generate-certificate-feed.ts";
+import {
+  BUNDLED_CERTIFICATE_FEED_SEQUENCE,
+  parseCertificateFeed,
+} from "../../src/main/certification/certificate-feed.ts";
+import {
+  certificateFeedTrust,
+  verifyFetchedCertificateFeed,
+} from "../../src/main/certification/certificate-feed-trust.ts";
+
+const PUBLICATION_SEQUENCE = BUNDLED_CERTIFICATE_FEED_SEQUENCE + 41;
+
+describe("the certificate feed generator", () => {
+  it("writes the bundled snapshot's sequence when it is asked for nothing", () => {
+    assert.deepEqual(parseArguments([]), {
+      sequence: BUNDLED_CERTIFICATE_FEED_SEQUENCE,
+      out: OUTPUT,
+    });
+    assert.equal(
+      parseCertificateFeed(generate()).sequence,
+      BUNDLED_CERTIFICATE_FEED_SEQUENCE,
+    );
+  });
+
+  it("changes nothing but the sequence when it is asked for a publication", () => {
+    const bundled = new TextDecoder().decode(generate());
+    const candidate = new TextDecoder().decode(generate(PUBLICATION_SEQUENCE));
+    assert.equal(
+      candidate.replace(
+        `"sequence": ${PUBLICATION_SEQUENCE}`,
+        `"sequence": ${BUNDLED_CERTIFICATE_FEED_SEQUENCE}`,
+      ),
+      bundled,
+    );
+  });
+
+  it("refuses a sequence no installation would ever adopt", () => {
+    // At or below the compiled-in snapshot, `governingCertificateFeed` keeps
+    // what it already has, so publishing one spends a signature on nothing.
+    for (const sequence of ["0", `${BUNDLED_CERTIFICATE_FEED_SEQUENCE}`]) {
+      assert.throws(() => publicationSequence(sequence), /does not beat/u);
+    }
+    for (const sequence of ["", " 2", "2.0", "+2", "-2", "0x2", "02"]) {
+      assert.throws(() => publicationSequence(sequence), /decimal integer/u);
+    }
+  });
+
+  it("reads the two flags a publication passes, and no others", () => {
+    assert.deepEqual(
+      parseArguments(["--sequence", "7", "--out", "candidate/certificate-feed.json"]),
+      { sequence: 7, out: "candidate/certificate-feed.json" },
+    );
+    assert.throws(() => parseArguments(["--seq", "7"]), /unknown argument/u);
+    assert.throws(() => parseArguments(["--sequence"]), /needs a value/u);
+  });
+});
+
+describe("the two assets a publication uploads", () => {
+  it("verify against the pinned line the key ceremony prints", () => {
+    // Exactly what the workflow does with `openssl`: the pin is the raw 32
+    // bytes of the public half in base64, and the detached signature travels as
+    // base64 with a trailing newline. Both spellings are asserted here because
+    // the signing job holds no repository code that could assert them.
+    const pair = generateKeyPairSync("ed25519");
+    const spki = pair.publicKey.export({ format: "der", type: "spki" });
+    const pinned = `${spki.subarray(spki.byteLength - 32).toString("base64")}\n`;
+    const document = generate(PUBLICATION_SEQUENCE);
+    const detached = `${Buffer.from(sign(null, document, pair.privateKey)).toString("base64")}\n`;
+
+    assert.equal(detached.trim().length, 88);
+    const trust = certificateFeedTrust(pinned);
+    const feed = verifyFetchedCertificateFeed(
+      trust,
+      document,
+      Buffer.from(detached.trim(), "base64"),
+    );
+    assert.equal(feed.sequence, PUBLICATION_SEQUENCE);
+  });
+});


### PR DESCRIPTION
## What ships

The final stage: signed feed publication, with the trust machinery arranged so no single failure — machine or human — can ship a wrong certificate.

- **Double reproduction**: two independent runners each derive the feed candidate from scratch; publication requires byte-identical outputs. A mismatch blocks and opens an issue carrying both hashes.
- **Isolated signing**: the sign job never checks out the repository and runs no third-party actions — it downloads only the reproduced candidate artifact, re-validates it under the feed schema, enforces the sequence successor rule, signs, and uploads feed + detached signature to the rolling release the app reads. It is gated behind a dedicated `certificate-publishing` environment whose required reviewers are the one-click human approval.
- **Tiering, encoded in the workflow**: entries carrying only template-layer facts may publish automatically once reproduction matches; entries carrying Enhancement facts always wait for the environment approval.
- **Go-live checklist** documented with the key-ceremony doc: enable Actions PR creation, create the environment with required reviewers, run the key ceremony, replace the sentinel. Owner steps, listed rather than scripted around.

## What review caught (and the fixes)

- The sequence gate failed *open* on transient network errors — a suppressed `gh release download` probe made "download failed" indistinguishable from "no feed published yet", which disabled the gate exactly when it couldn't see the feed it guards. The probe is gone; the release list is read once, paginated, unsuppressed, under pipefail, so absence is a verified fact.
- The generator's sequence floor and the workflow's strict successor rule could contradict and permanently wedge publication after a deleted release; the floor is now reconciled in one place.

## Review focus

- The sign job's isolation properties (no checkout, no third-party actions, secret name confined to that job) — policy tests pin each.
- The sequence gate's failure direction: every error path must block, never skip.

## Verification

`set -o pipefail; pnpm check` green (156 policy tests across the stack). The workflow cannot fully run until the go-live checklist is complete; structure + policy tests are the reviewable evidence.
