### PR TITLE
Name the evidence directory where the runner context exists

### DIFF
--- a/.github/workflows/client-recertification.yml
+++ b/.github/workflows/client-recertification.yml
@@ -112,8 +112,6 @@ jobs:
     timeout-minutes: 45
     permissions:
       contents: read
-    env:
-      EVIDENCE: ${{ runner.temp }}/evidence
     outputs:
       outcome: ${{ steps.derive.outputs.outcome }}
       summary: ${{ steps.derive.outputs.summary }}
@@ -122,6 +120,10 @@ jobs:
       # which is what the branch, the record and the issue must all name.
       fingerprint: ${{ steps.official.outputs.fingerprint }}
     steps:
+      # The runner context does not exist in a job-level env, so the evidence
+      # directory is named here, where the shell's own RUNNER_TEMP does.
+      - name: Name the evidence directory
+        run: echo "EVIDENCE=$RUNNER_TEMP/evidence" >> "$GITHUB_ENV"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false


### PR DESCRIPTION
## What ships

GitHub refuses to parse `client-recertification.yml` at dispatch time: the `runner` context does not exist in a job-level `env`, so `EVIDENCE: ${{ runner.temp }}/evidence` is a parse error — caught by the first real `workflow_dispatch` smoke test after #76 merged. The evidence directory is now named in the job's first step, where the shell's own `RUNNER_TEMP` exists; the step-level artifact path at the end of the job was already legal and is unchanged.

## Verification

`actionlint` (which catches context-availability errors the policy suite cannot) is clean on both new workflows; the detector policy test passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)