### PR TITLE
Release 2026.8.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "guild-wars",
   "productName": "Guild Wars Reforged",
-  "version": "2026.7.0-beta.3",
+  "version": "2026.8.0-beta.1",
   "private": true,
   "packageManager": "pnpm@11.13.1",
   "type": "module",


### PR DESCRIPTION
## What ships

The version bump for the follow-up beta from the corrected signing identity. Its purpose, per [docs/release-verification.md](https://github.com/Mat4m0/gwonmac/blob/main/docs/release-verification.md): the cutover beta (v2026.7.0-beta.3) must prove it auto-updates into a newer signed build with the profile and both Data Protection Keychain items retained, before the stable gate (`SIGNED_BETA_UPDATE_PROVEN`) may open.

Beyond being that update target, this beta is the first build carrying the certificate-feed client (fetch, verify, store), the pinned feed key, the consolidated certification subsystem, and the salvage-cursor fix — the full Wave 1–3 + 5 line-up.

## Verification

One-line diff. The release itself is dispatched by hand after merge and runs the full verify + signing + notarization path under the release environment approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)