### PR TITLE
Stop fast click runs and drags from synthesizing phantom double-clicks

### DIFF
--- a/src/renderer/input.ts
+++ b/src/renderer/input.ts
@@ -16,6 +16,11 @@ const POINTER_ROAM = 16;
 // dropped. Four cross a drag's whole range; further is a teleport, not a drag.
 const MAX_POINTER_REGRABS = 4;
 
+// Chromium's own double-click slop: clicks further apart than this are
+// separate clicks, so a press that travelled further before releasing was a
+// drag, not half of a double-click.
+const DOUBLE_CLICK_SLOP = 4;
+
 // ArenaNet's web client identifies a binding by KeyboardEvent.key, which is a
 // character from the active keyboard layout. Give each main-block position a
 // unique stable US-layout character instead. `code` already is the browser's
@@ -96,6 +101,7 @@ export const installGameInput = ({
   let pendingTap: { x: number; y: number } | null = null;
   let touchId = 0;
   let virtualCursor: { x: number; y: number } | null = null;
+  let lockOrigin: { x: number; y: number } | null = null;
   let pointerWanted = false;
   let releasing = false;
   let wheelRemainder = 0;
@@ -251,7 +257,23 @@ export const installGameInput = ({
 
   function releasePointer() {
     pointerWanted = false;
+    // Exiting the lock returns the OS cursor to where the lock engaged, while
+    // the roam/re-anchor walk left the client's absolute position elsewhere —
+    // the source of the post-pan cursor jump. Walk the virtual cursor back
+    // before dropping it so the client's last mousemove agrees with the
+    // restored OS cursor. Callers sequence this after the button release so
+    // the walk cannot steer a still-held camera drag.
+    if (virtualCursor && lockOrigin) {
+      const dx = lockOrigin.x - virtualCursor.x;
+      const dy = lockOrigin.y - virtualCursor.y;
+      if (dx || dy) {
+        const rect = canvas.getBoundingClientRect();
+        virtualCursor = { x: lockOrigin.x, y: lockOrigin.y };
+        sendMouse('mousemove', rect, 0, 0, dx, dy);
+      }
+    }
     virtualCursor = null;
+    lockOrigin = null;
     canvas.classList.remove('cursor-hidden');
     if (document.pointerLockElement === canvas) document.exitPointerLock();
   }
@@ -305,8 +327,10 @@ export const installGameInput = ({
   function releaseButtons() {
     const inputs = [...heldButtons.values()];
     heldButtons.clear();
-    releasePointer();
+    // Releases go first: the client must see the drag end at the coordinates
+    // it held before releasePointer walks the virtual cursor back.
     for (const input of inputs) dispatchButtonRelease(input);
+    releasePointer();
   }
 
   function releaseAll() {
@@ -469,8 +493,12 @@ export const installGameInput = ({
     // count, but its touch path has the double-tap detector the game needs for
     // actions such as equipping an item. Preserve every mouse event and append
     // exactly that missing signal for each completed native double-click.
+    // detail counts the whole click run, so only the transition into its
+    // second click is one: the later even counts (4, 6, …) are rapid single
+    // clicks continuing the run, and synthesizing for them turned fast
+    // attribute-point clicking into spurious double-clicks.
     cancelSyntheticTouches();
-    if (event.detail > 0 && event.detail % 2 === 0) {
+    if (event.detail === 2) {
       pendingTap = { x: event.clientX, y: event.clientY };
     }
   }, true);
@@ -479,6 +507,12 @@ export const installGameInput = ({
     if (event.button !== 0 || !pendingTap) return;
     const { x, y } = pendingTap;
     pendingTap = null;
+    // A press that travelled past the slop before releasing was a drag; a tap
+    // pair at the stale press point would act far from where the drag ended.
+    if (
+      Math.abs(event.clientX - x) > DOUBLE_CLICK_SLOP ||
+      Math.abs(event.clientY - y) > DOUBLE_CLICK_SLOP
+    ) return;
     tapAt(x, y, 20);
     tapAt(x, y, 100);
   }, true);
@@ -537,6 +571,9 @@ export const installGameInput = ({
       x: event.clientX - rect.left,
       y: event.clientY - rect.top,
     };
+    // Where Chromium will restore the OS cursor when the lock ends, and so
+    // where releasePointer must walk the virtual cursor back to.
+    lockOrigin = { x: virtualCursor.x, y: virtualCursor.y };
     pointerWanted = true;
     if (document.pointerLockElement === canvas) return;
     try {
@@ -577,7 +614,10 @@ export const installGameInput = ({
   document.addEventListener('mouseup', (event) => {
     if (event.button === 2 && event.isTrusted) {
       pointerWanted = false;
-      releasePointer();
+      // The client must integrate this release at the lock's frozen
+      // coordinates before the cursor walks back — reconciling first would
+      // steer the camera by the walk. A microtask runs once dispatch ends.
+      queueMicrotask(releasePointer);
     }
   }, true);
   document.addEventListener('pointerlockchange', () => {

--- a/src/renderer/input.ts
+++ b/src/renderer/input.ts
@@ -101,7 +101,6 @@ export const installGameInput = ({
   let pendingTap: { x: number; y: number } | null = null;
   let touchId = 0;
   let virtualCursor: { x: number; y: number } | null = null;
-  let lockOrigin: { x: number; y: number } | null = null;
   let pointerWanted = false;
   let releasing = false;
   let wheelRemainder = 0;
@@ -255,25 +254,15 @@ export const installGameInput = ({
     return key;
   };
 
+  // Deliberately no position reconciliation here. The client samples mouse
+  // state per frame, so a "walk the cursor back to the lock origin" move
+  // dispatched at release lands in the same frame as the button-up and is
+  // integrated into the camera — releasing a rotation visibly un-rotated it.
+  // Event order within a frame cannot fix that; the client resyncs its
+  // absolute position from the first real mousemove after the lock ends.
   function releasePointer() {
     pointerWanted = false;
-    // Exiting the lock returns the OS cursor to where the lock engaged, while
-    // the roam/re-anchor walk left the client's absolute position elsewhere —
-    // the source of the post-pan cursor jump. Walk the virtual cursor back
-    // before dropping it so the client's last mousemove agrees with the
-    // restored OS cursor. Callers sequence this after the button release so
-    // the walk cannot steer a still-held camera drag.
-    if (virtualCursor && lockOrigin) {
-      const dx = lockOrigin.x - virtualCursor.x;
-      const dy = lockOrigin.y - virtualCursor.y;
-      if (dx || dy) {
-        const rect = canvas.getBoundingClientRect();
-        virtualCursor = { x: lockOrigin.x, y: lockOrigin.y };
-        sendMouse('mousemove', rect, 0, 0, dx, dy);
-      }
-    }
     virtualCursor = null;
-    lockOrigin = null;
     canvas.classList.remove('cursor-hidden');
     if (document.pointerLockElement === canvas) document.exitPointerLock();
   }
@@ -327,10 +316,8 @@ export const installGameInput = ({
   function releaseButtons() {
     const inputs = [...heldButtons.values()];
     heldButtons.clear();
-    // Releases go first: the client must see the drag end at the coordinates
-    // it held before releasePointer walks the virtual cursor back.
-    for (const input of inputs) dispatchButtonRelease(input);
     releasePointer();
+    for (const input of inputs) dispatchButtonRelease(input);
   }
 
   function releaseAll() {
@@ -571,9 +558,6 @@ export const installGameInput = ({
       x: event.clientX - rect.left,
       y: event.clientY - rect.top,
     };
-    // Where Chromium will restore the OS cursor when the lock ends, and so
-    // where releasePointer must walk the virtual cursor back to.
-    lockOrigin = { x: virtualCursor.x, y: virtualCursor.y };
     pointerWanted = true;
     if (document.pointerLockElement === canvas) return;
     try {
@@ -614,10 +598,7 @@ export const installGameInput = ({
   document.addEventListener('mouseup', (event) => {
     if (event.button === 2 && event.isTrusted) {
       pointerWanted = false;
-      // The client must integrate this release at the lock's frozen
-      // coordinates before the cursor walks back — reconciling first would
-      // steer the camera by the walk. A microtask runs once dispatch ends.
-      queueMicrotask(releasePointer);
+      releasePointer();
     }
   }, true);
   document.addEventListener('pointerlockchange', () => {

--- a/src/renderer/input.ts
+++ b/src/renderer/input.ts
@@ -21,6 +21,15 @@ const MAX_POINTER_REGRABS = 4;
 // drag, not half of a double-click.
 const DOUBLE_CLICK_SLOP = 4;
 
+// A deliberate double-click and the first two clicks of a fast burst are
+// physically identical; only what follows tells them apart. The synthetic tap
+// pair is therefore held back long enough for a continuing burst's third
+// press to cancel it — the Windows client ignores double-clicks on buttons,
+// so a burst (attribute points) must produce plain clicks and nothing else.
+// The cost is a real double-click's action landing this much later.
+const DOUBLE_TAP_HOLDBACK_MS = 250;
+const DOUBLE_TAP_GAP_MS = 80;
+
 // ArenaNet's web client identifies a binding by KeyboardEvent.key, which is a
 // character from the active keyboard layout. Give each main-block position a
 // unique stable US-layout character instead. `code` already is the browser's
@@ -470,6 +479,10 @@ export const installGameInput = ({
   const tapAt = (x: number, y: number, delay: number) => schedule(() => {
     const touch = makeTouch(x, y, ++touchId);
     startTouch(touch);
+    // The touchstart dispatch can synchronously cancel all synthetic input —
+    // releaseAll from a listener the client installed. A touchend for a touch
+    // no longer tracked would restate an input the cancel already retracted.
+    if (!syntheticTouches.has(touch.identifier)) return;
     schedule(() => finishTouch('touchend', touch), 30);
   }, delay);
 
@@ -500,8 +513,8 @@ export const installGameInput = ({
       Math.abs(event.clientX - x) > DOUBLE_CLICK_SLOP ||
       Math.abs(event.clientY - y) > DOUBLE_CLICK_SLOP
     ) return;
-    tapAt(x, y, 20);
-    tapAt(x, y, 100);
+    tapAt(x, y, DOUBLE_TAP_HOLDBACK_MS);
+    tapAt(x, y, DOUBLE_TAP_HOLDBACK_MS + DOUBLE_TAP_GAP_MS);
   }, true);
 
   canvas.addEventListener('mouseleave', () => {

--- a/tests/electron/input-camera.spec.ts
+++ b/tests/electron/input-camera.spec.ts
@@ -234,6 +234,39 @@ test.describe("renderer camera input", () => {
     }
   });
 
+  test("walks the virtual cursor back to the lock origin on release", async () => {
+    const fixture = await launchOffline("gw-pointer-reconcile-e2e-");
+    try {
+      const { page } = fixture;
+      await startGameInput(page);
+      const canvas = page.locator("#canvas");
+      const box = await boxOf(canvas);
+      await watchCameraDrag(page, box);
+
+      // The same overrun as the roam test: the re-anchor leaves the client's
+      // absolute position at -9 while the OS cursor will be restored to the
+      // press point. The release must close that gap with one walk-back move,
+      // after the button release, with no buttons reported held.
+      await page.mouse.move(box.x + 20, box.y + CAMERA_Y);
+      await page.mouse.up({ button: "right" });
+      await expect
+        .poll(() =>
+          page.evaluate(() =>
+            (window as CameraInputWindow).__cameraEvents.at(-1),
+          ),
+        )
+        .toEqual({
+          type: "mousemove",
+          button: 0,
+          buttons: 0,
+          clientX: box.x + 100,
+          movementX: 14,
+        });
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
   test("releases only held mouse buttons when pointer lock is lost", async () => {
     const fixture = await launchOffline("gw-pointer-loss-e2e-");
     try {

--- a/tests/electron/input-camera.spec.ts
+++ b/tests/electron/input-camera.spec.ts
@@ -234,8 +234,8 @@ test.describe("renderer camera input", () => {
     }
   });
 
-  test("walks the virtual cursor back to the lock origin on release", async () => {
-    const fixture = await launchOffline("gw-pointer-reconcile-e2e-");
+  test("ends a camera drag without dispatching any position reconciliation", async () => {
+    const fixture = await launchOffline("gw-pointer-release-e2e-");
     try {
       const { page } = fixture;
       await startGameInput(page);
@@ -243,25 +243,25 @@ test.describe("renderer camera input", () => {
       const box = await boxOf(canvas);
       await watchCameraDrag(page, box);
 
-      // The same overrun as the roam test: the re-anchor leaves the client's
-      // absolute position at -9 while the OS cursor will be restored to the
-      // press point. The release must close that gap with one walk-back move,
-      // after the button release, with no buttons reported held.
+      // The same overrun as the roam test leaves the client's absolute
+      // position away from the press point. The release must NOT try to walk
+      // it back: the client samples mouse state per frame, so a walk-back
+      // move lands in the release's frame and is integrated into the camera —
+      // shipping one made every rotation visibly snap back on release.
       await page.mouse.move(box.x + 20, box.y + CAMERA_Y);
+      const beforeRelease = await page.evaluate(
+        () => (window as CameraInputWindow).__cameraEvents.length,
+      );
       await page.mouse.up({ button: "right" });
-      await expect
-        .poll(() =>
-          page.evaluate(() =>
-            (window as CameraInputWindow).__cameraEvents.at(-1),
-          ),
-        )
-        .toEqual({
-          type: "mousemove",
-          button: 0,
-          buttons: 0,
-          clientX: box.x + 100,
-          movementX: 14,
-        });
+      await page.waitForTimeout(100);
+      const moves = await page.evaluate(
+        (from) =>
+          (window as CameraInputWindow).__cameraEvents
+            .slice(from)
+            .filter(({ type }) => type === "mousemove"),
+        beforeRelease,
+      );
+      expect(moves).toEqual([]);
     } finally {
       await closeOffline(fixture);
     }

--- a/tests/electron/input-pointer.spec.ts
+++ b/tests/electron/input-pointer.spec.ts
@@ -56,6 +56,16 @@ test.describe("renderer pointer input", () => {
         for (const type of ["touchstart", "touchend", "touchcancel"] as const) {
           canvas.addEventListener(type, () => events.push(type));
         }
+        // Reset while the first tap is in flight. Dispatching it from the
+        // tap's own touchstart makes the interruption deterministic instead
+        // of racing the holdback and tap timers.
+        canvas.addEventListener(
+          "touchstart",
+          () => {
+            window.dispatchEvent(new globalThis.CustomEvent("gw:input-reset"));
+          },
+          { once: true },
+        );
         const mouse = (type: string, detail = 0) =>
           canvas.dispatchEvent(
             new globalThis.MouseEvent(type, {
@@ -70,9 +80,13 @@ test.describe("renderer pointer input", () => {
         mouse("mouseup", 1);
         mouse("mousedown", 2);
         mouse("mouseup", 2);
-        await new Promise((resolve) => setTimeout(resolve, 30));
-        window.dispatchEvent(new globalThis.CustomEvent("gw:input-reset"));
-        await new Promise((resolve) => setTimeout(resolve, 60));
+        const deadline = performance.now() + 2_000;
+        while (events.length < 2 && performance.now() < deadline) {
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+        // Long enough for the cancelled second tap to have fired if the
+        // reset had failed to clear it.
+        await new Promise((resolve) => setTimeout(resolve, 250));
         return events;
       });
       expect(touchEvents).toEqual([
@@ -215,18 +229,19 @@ test.describe("renderer pointer input", () => {
             }),
           );
 
-        // A fast run of clicks on one spot: detail keeps counting 2, 3, 4.
-        // Only the transition into the second click is a native double-click;
-        // the later even counts must not synthesize again.
+        // A run that stops at two clicks is a completed native double-click;
+        // once the holdback passes, exactly one tap pair fires.
         mouse("mousedown", 2);
         mouse("mouseup", 2);
-        await new Promise((resolve) => setTimeout(resolve, 200));
+        await new Promise((resolve) => setTimeout(resolve, 600));
         const afterDouble = [...observed];
+        // detail keeps counting 3, 4 while the run continues; the later even
+        // counts must not synthesize again.
         mouse("mousedown", 3);
         mouse("mouseup", 3);
         mouse("mousedown", 4);
         mouse("mouseup", 4);
-        await new Promise((resolve) => setTimeout(resolve, 200));
+        await new Promise((resolve) => setTimeout(resolve, 600));
         const afterRun = [...observed];
 
         // A double-click press that turns into a drag releases far away; the
@@ -234,7 +249,7 @@ test.describe("renderer pointer input", () => {
         observed.length = 0;
         mouse("mousedown", 2);
         mouse("mouseup", 2, 160, 140);
-        await new Promise((resolve) => setTimeout(resolve, 200));
+        await new Promise((resolve) => setTimeout(resolve, 600));
         return { afterDouble, afterRun, afterDrag: [...observed] };
       });
 
@@ -364,7 +379,7 @@ test.describe("renderer pointer input", () => {
     }
   });
 
-  test("cancels an active synthetic tap before a rapid follow-up click", async () => {
+  test("a continuing click burst cancels the held-back tap pair entirely", async () => {
     const fixture = await launchOffline("gw-double-click-cancel-e2e-");
     try {
       const { page } = fixture;
@@ -387,12 +402,15 @@ test.describe("renderer pointer input", () => {
             }),
           );
 
+        // The third press of an attribute-point burst arrives inside the
+        // holdback: no tap ever fires, so the client sees plain clicks and
+        // nothing else — the Windows behaviour for buttons.
         mouse("mousedown", 2);
         mouse("mouseup", 2);
-        await new Promise((resolve) => setTimeout(resolve, 30));
+        await new Promise((resolve) => setTimeout(resolve, 100));
         mouse("mousedown", 3);
         mouse("mouseup", 3);
-        await new Promise((resolve) => setTimeout(resolve, 150));
+        await new Promise((resolve) => setTimeout(resolve, 700));
         const interrupted = [...observed];
 
         observed.length = 0;
@@ -406,12 +424,12 @@ test.describe("renderer pointer input", () => {
           }),
         );
         mouse("mouseup", 2);
-        await new Promise((resolve) => setTimeout(resolve, 150));
+        await new Promise((resolve) => setTimeout(resolve, 700));
         return { interrupted, afterLeave: observed };
       });
 
       expect(result).toEqual({
-        interrupted: ["touchstart", "touchcancel"],
+        interrupted: [],
         afterLeave: [],
       });
     } finally {

--- a/tests/electron/input-pointer.spec.ts
+++ b/tests/electron/input-pointer.spec.ts
@@ -192,6 +192,62 @@ test.describe("renderer pointer input", () => {
     }
   });
 
+  test("synthesizes one double-tap per click run and none after a drag", async () => {
+    const fixture = await launchOffline("gw-double-click-run-e2e-");
+    try {
+      const { page } = fixture;
+      await startGameInput(page);
+      const result = await page.evaluate(async () => {
+        const canvas = globalThis.document.getElementById("canvas");
+        if (!canvas) throw new Error("#canvas is missing");
+        const observed: string[] = [];
+        for (const type of ["touchstart", "touchend", "touchcancel"] as const) {
+          canvas.addEventListener(type, () => observed.push(type));
+        }
+        const mouse = (type: string, detail: number, x = 120, y = 140) =>
+          canvas.dispatchEvent(
+            new globalThis.MouseEvent(type, {
+              bubbles: true,
+              button: 0,
+              clientX: x,
+              clientY: y,
+              detail,
+            }),
+          );
+
+        // A fast run of clicks on one spot: detail keeps counting 2, 3, 4.
+        // Only the transition into the second click is a native double-click;
+        // the later even counts must not synthesize again.
+        mouse("mousedown", 2);
+        mouse("mouseup", 2);
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        const afterDouble = [...observed];
+        mouse("mousedown", 3);
+        mouse("mouseup", 3);
+        mouse("mousedown", 4);
+        mouse("mouseup", 4);
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        const afterRun = [...observed];
+
+        // A double-click press that turns into a drag releases far away; the
+        // stale press point must not receive a tap pair.
+        observed.length = 0;
+        mouse("mousedown", 2);
+        mouse("mouseup", 2, 160, 140);
+        await new Promise((resolve) => setTimeout(resolve, 200));
+        return { afterDouble, afterRun, afterDrag: [...observed] };
+      });
+
+      expect(result).toEqual({
+        afterDouble: ["touchstart", "touchend", "touchstart", "touchend"],
+        afterRun: ["touchstart", "touchend", "touchstart", "touchend"],
+        afterDrag: [],
+      });
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
   test("releases held input when the pointer leaves the app window", async () => {
     const fixture = await launchOffline("gw-input-window-leave-e2e-");
     try {


### PR DESCRIPTION
Stack #87, PR 1 of 4 · base: `main` · next: #84

## What this ships to users

Two of the reported input bugs are gone:

- Rapidly clicking the attribute-point **+/-** buttons no longer registers spurious double-clicks.
- A press that turns into a drag no longer fires a stale double-tap at its starting point — the "acts far from the cursor" half of the map-pan report.

## What changed

**Double-click synthesis** (`src/renderer/input.ts`), reworked twice on field feedback. The host synthesizes a touch double-tap because ArenaNet's mouse bridge discards the native click count. It fired on `detail % 2 === 0` — but `MouseEvent.detail` counts the whole click run, so clicks 2, 4, and 6 of one fast burst *each* produced a double-click. Edge-triggering on `detail === 2` cut that to one phantom per burst, which testing showed is still one too many: a burst's first two clicks are physically identical to a deliberate double-click, and only what follows tells them apart. The tap pair is therefore **held back 250 ms** so a continuing burst's third press cancels it before anything fires — a burst produces plain clicks and nothing else, matching the Windows client, which ignores double-clicks on buttons. The cost is a real double-click's action (equip/use) landing that beat later. Additionally, a press that travelled past Chromium's 4 px slop before releasing is treated as the drag it was, not tapped at the stale press point.

**Latent stray fixed on the way:** a reset arriving synchronously during a synthetic touchstart's dispatch cancelled the touch but still scheduled its touchend, restating an input the cancel had retracted. The touchend is now scheduled only while the touch is still tracked.

**Release-time cursor reconciliation: attempted, field-tested, removed.** A walk-the-cursor-back-to-lock-origin move on right-drag release made every camera rotation snap back: the client samples mouse state per frame, so the walk-back lands in the release's frame and is integrated into the camera regardless of event order within it. `releasePointer` now carries a comment recording why no reconciliation belongs there, and a spec pins that a release dispatches no synthetic move at all.

## What deliberately did not change

- No release-time position reconciliation (see above — the per-frame sampler makes it impossible from the host side).
- No "which client screen is active" predicate. The world map arguably shouldn't get camera-rotation semantics at all, but the host has no model of client screens; that would be certified-memory-read territory.
- Known trade-off: two deliberate double-clicks inside one uninterrupted click run (same 4 px spot, each within the OS double-click interval) now synthesize one double-tap, not two. The run resets on any pause or movement, so this is far rarer than the bug it removes.

## Review focus

- The release-path event ordering above — `releaseButtons` reorder and the `queueMicrotask(releasePointer)` on trusted right-mouseup.
- Interplay with `src/renderer/cursor-refresh.ts`: its synthetic moves disarm while the lock is held, and the reconcile move fires while still locked, so they cannot interleave — worth a second pair of eyes.

## Verification

- `npx playwright test input-pointer input-camera input-keyboard`: 15/15, including new specs "synthesizes one double-tap per click run and none after a drag", "a continuing click burst cancels the held-back tap pair entirely", and "ends a camera drag without dispatching any position reconciliation"; the reset-interruption test now triggers deterministically from inside touchstart dispatch instead of racing timers.
- Field-tested by the maintainer: clipboard and tooltip fixes confirmed; the first-cut reconciliation was caught un-rotating the camera and removed.
- `pnpm typecheck`, `pnpm lint` clean.

## Known follow-ups

- If map-pan cursor jumps persist after the drag guard, the remaining fix is client-side (per-frame sampling defeats any host-dispatched correction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
