### PR TITLE
Let Cmd+C copy the game's active text field to the macOS clipboard

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -212,6 +212,22 @@ ArenaNet, not here: see the Guild Wars support site at
 <https://help.guildwars.com/> for how Steam and Guild Wars accounts are
 connected.
 
+## Copy and paste
+
+Pasting into the game works everywhere text can be typed: press **⌘V** in any
+game text field.
+
+Copying out of the game works for the text field you are editing — chat
+entry, a search box, the guild announcement editor. **⌘C** copies the field's
+selected text, or the whole field when nothing is selected, and password
+fields are never copied.
+
+Text the game merely displays — chat history, item names, a guild's status
+line — cannot be copied, even where the game lets you highlight it. The web
+build of ArenaNet's client ships without the clipboard support the Windows
+client has, so the highlight never reaches macOS. Until that is fixed
+upstream, retype or screenshot what you need.
+
 ## Report a problem
 
 Open the project’s bug form on GitHub, or choose **Help → Report a Problem…**

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -13,7 +13,7 @@
  * decided behind these handlers; this file validates arguments, names the
  * subsystem that answers, and returns codes rather than inventing prose.
  */
-import { BrowserWindow, dialog, ipcMain, shell, app } from "electron";
+import { BrowserWindow, clipboard, dialog, ipcMain, shell, app } from "electron";
 import { statfs, writeFile } from "node:fs/promises";
 import type {
   AppSettings,
@@ -324,6 +324,21 @@ const asSteamStoreback: Parser<{ token: string; expiry: number | null }> = (args
 const asRevealKind = one((value: unknown): RevealKind => {
   if (value !== "gameData") {
     throw new ValidationError("invalid reveal kind");
+  }
+  return value;
+});
+
+// Far above any text a game field holds, low enough that a renderer gone
+// wrong cannot stuff megabytes into the OS pasteboard.
+const CLIPBOARD_TEXT_CEILING = 64 * 1024;
+
+const asClipboardText = one((value: unknown): string => {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value.length > CLIPBOARD_TEXT_CEILING
+  ) {
+    throw new ValidationError("invalid clipboard text");
   }
   return value;
 });
@@ -802,6 +817,10 @@ export function registerIpcHandlers(ctx: IpcContext): {
 
     appRequestQuit: channel(nothing, () => {
       app.quit();
+    }),
+
+    clipboardWriteText: channel(asClipboardText, (_win, text) => {
+      clipboard.writeText(text);
     }),
 
     clientRetry: channel(nothing, () => ctx.retryClient()),

--- a/src/preload/preload.body.cjs
+++ b/src/preload/preload.body.cjs
@@ -212,6 +212,9 @@ const api = {
     reveal: (kind) => ipcRenderer.invoke(IPC.appRevealPath, kind),
     requestQuit: () => ipcRenderer.invoke(IPC.appRequestQuit),
   },
+  clipboard: {
+    writeText: (text) => ipcRenderer.invoke(IPC.clipboardWriteText, text),
+  },
   client: {
     retry: () => ipcRenderer.invoke(IPC.clientRetry),
     healthy: (token) => ipcRenderer.invoke(IPC.clientHealthy, token),

--- a/src/renderer/clipboard-copy.ts
+++ b/src/renderer/clipboard-copy.ts
@@ -1,0 +1,61 @@
+/**
+ * Cmd+C from the game's text proxy to the OS clipboard. The Emscripten client
+ * ships no clipboard platform layer — the Windows client's SetClipboardData
+ * path was never ported — so the one copy the host can perform truthfully is
+ * of the OSK proxy field the client is editing through. This module refuses to
+ * approximate canvas-rendered text (chat lines, item names, guild status): it
+ * has no model of it, and docs/user-guide.md records that limitation.
+ */
+
+type ClipboardField = HTMLInputElement | HTMLTextAreaElement;
+
+type ClipboardCopyOptions = {
+  /** The OSK proxy fields; anything else never reaches the clipboard. */
+  fields: Iterable<unknown>;
+  writeText(text: string): Promise<void>;
+  log(...values: unknown[]): void;
+};
+
+const isCopyableField = (value: unknown): value is ClipboardField =>
+  value instanceof HTMLTextAreaElement ||
+  // The password proxy is excluded the way Chromium excludes password
+  // inputs from native copy: secrets do not leave through this path.
+  (value instanceof HTMLInputElement && value.type !== 'password');
+
+export const installClipboardCopy = ({
+  fields,
+  writeText,
+  log,
+}: ClipboardCopyOptions): void => {
+  const sources = new Set<ClipboardField>();
+  for (const field of fields) {
+    if (isCopyableField(field)) sources.add(field);
+  }
+
+  window.addEventListener('keydown', (event) => {
+    if (!event.isTrusted || event.code !== 'KeyC') return;
+    if (!event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) {
+      return;
+    }
+    const active = document.activeElement;
+    if (!isCopyableField(active) || !sources.has(active)) return;
+    const { selectionStart, selectionEnd, value } = active;
+    // The client tracks its in-field selection internally and does not mirror
+    // every change onto the proxy, so a collapsed DOM selection means the
+    // whole field — the "copy what I typed" the native path cannot offer —
+    // rather than nothing.
+    const text =
+      selectionStart !== null &&
+      selectionEnd !== null &&
+      selectionStart !== selectionEnd
+        ? value.slice(selectionStart, selectionEnd)
+        : value;
+    if (!text) return;
+    writeText(text).catch((error: unknown) => {
+      log(
+        '[warn] clipboard write refused:',
+        error instanceof Error ? error.message : String(error),
+      );
+    });
+  }, true);
+};

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -326,6 +326,7 @@ let host: typeof import('./graphics.js') &
   typeof import('./gl-program-cache.js') &
   typeof import('./filesystem.js') &
   typeof import('./input.js') &
+  typeof import('./clipboard-copy.js') &
   typeof import('./template-save-compatibility.js') &
   typeof import('./template-filesystem-trace.js');
 
@@ -828,6 +829,11 @@ function loadGlue() {
   const oskInputs = new Set<EventTarget | null>(
     Object.values(Module.oskInput).filter(Boolean),
   );
+  host.installClipboardCopy({
+    fields: oskInputs,
+    writeText: (text) => native().clipboard.writeText(text),
+    log,
+  });
 
   // The desktop text proxy and the same-window Toolbox overlay are part of the
   // game experience, not a loss of application focus. Keep the client's
@@ -879,6 +885,7 @@ function loadGlue() {
       glProgramCache,
       filesystem,
       input,
+      clipboardCopy,
       templateSaveCompatibility,
       templateFilesystemTrace,
       clientHealth,
@@ -890,6 +897,7 @@ function loadGlue() {
       import('./gl-program-cache.js'),
       import('./filesystem.js'),
       import('./input.js'),
+      import('./clipboard-copy.js'),
       import('./template-save-compatibility.js'),
       import('./template-filesystem-trace.js'),
       import('./client-health.js'),
@@ -900,6 +908,7 @@ function loadGlue() {
       ...glProgramCache,
       ...filesystem,
       ...input,
+      ...clipboardCopy,
       ...templateSaveCompatibility,
       ...templateFilesystemTrace,
     };

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -711,6 +711,7 @@ export const IPC = {
   appOpenExternal: "gw:app:openExternal",
   appRevealPath: "gw:app:revealPath",
   appRequestQuit: "gw:app:requestQuit",
+  clipboardWriteText: "gw:clipboard:writeText",
   clientRetry: "gw:client:retry",
   clientHealthy: "gw:client:healthy",
   clientSession: "gw:client:session",
@@ -857,6 +858,15 @@ export interface GwNativeApi {
     /** Reveal a named app directory in Finder. */
     reveal(kind: RevealKind): Promise<void>;
     requestQuit(): Promise<void>;
+  };
+  clipboard: {
+    /**
+     * Copy out of the game's text proxy. The Emscripten client ships no
+     * clipboard platform layer, so the only text that can truthfully reach
+     * the OS clipboard is what a proxy field holds; canvas-rendered text
+     * never arrives here.
+     */
+    writeText(text: string): Promise<void>;
   };
   client: {
     retry(): Promise<void>;

--- a/tests/electron/input-clipboard.spec.ts
+++ b/tests/electron/input-clipboard.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "@playwright/test";
+import { closeOffline, launchOffline } from "./fixtures.mjs";
+import { startGameInput } from "./input-helpers.js";
+
+/** The page-side handle the OSK focus guard honours. */
+type OskWindow = typeof window & {
+  Module: { oskActiveInput?: Element | null };
+};
+
+test.describe("renderer clipboard copy", () => {
+  test("Cmd+C copies the active game text proxy, and never the password proxy", async () => {
+    const fixture = await launchOffline("gw-clipboard-e2e-");
+    try {
+      const { app, page } = fixture;
+      await startGameInput(page);
+      const before = await app.evaluate(({ clipboard }) => clipboard.readText());
+      try {
+        // The client marks the field it is editing through as the active OSK
+        // input; the harness focus guard bounces any other focus off. Editing
+        // state, not test scaffolding.
+        await page.evaluate(() => {
+          const field = globalThis.document.getElementById("osk-input-text");
+          if (!(field instanceof globalThis.HTMLInputElement)) {
+            throw new Error("the text proxy is missing");
+          }
+          (window as OskWindow).Module.oskActiveInput = field;
+          field.value = "gw copy proof";
+          field.focus();
+          field.setSelectionRange(0, 2);
+        });
+        await page.keyboard.press("Meta+c");
+        await expect
+          .poll(() => app.evaluate(({ clipboard }) => clipboard.readText()))
+          .toBe("gw");
+
+        // A collapsed selection copies the whole field: the client keeps its
+        // in-field selection to itself, and "nothing" would be the one answer
+        // the player can see is wrong.
+        await page.evaluate(() => {
+          const field = globalThis.document.getElementById("osk-input-text");
+          if (!(field instanceof globalThis.HTMLInputElement)) {
+            throw new Error("the text proxy is missing");
+          }
+          field.setSelectionRange(3, 3);
+        });
+        await page.keyboard.press("Meta+c");
+        await expect
+          .poll(() => app.evaluate(({ clipboard }) => clipboard.readText()))
+          .toBe("gw copy proof");
+
+        // Secrets do not leave through this path.
+        await app.evaluate(({ clipboard }) => clipboard.writeText("sentinel"));
+        await page.evaluate(() => {
+          const field = globalThis.document.getElementById("osk-input-password");
+          if (!(field instanceof globalThis.HTMLInputElement)) {
+            throw new Error("the password proxy is missing");
+          }
+          (window as OskWindow).Module.oskActiveInput = field;
+          field.value = "hunter2";
+          field.focus();
+          field.select();
+        });
+        await page.keyboard.press("Meta+c");
+        // A negative can only be observed by outlasting the positive path's
+        // round trip several times over.
+        await page.waitForTimeout(250);
+        expect(
+          await app.evaluate(({ clipboard }) => clipboard.readText()),
+        ).toBe("sentinel");
+      } finally {
+        await app.evaluate(
+          ({ clipboard }, text) => clipboard.writeText(text),
+          before,
+        );
+      }
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+});

--- a/tests/electron/sandbox.spec.ts
+++ b/tests/electron/sandbox.spec.ts
@@ -46,6 +46,7 @@ test.describe("sandbox boundary", () => {
           "appUpdates",
           "cache",
           "client",
+          "clipboard",
           "commands",
           "credentials",
           "diagnostics",

--- a/tests/release/preload-behaviour.test.ts
+++ b/tests/release/preload-behaviour.test.ts
@@ -233,6 +233,11 @@ const INVOCATIONS: Invocation[] = [
   { path: "app.openExternal", args: ["support"], channel: IPC.appOpenExternal },
   { path: "app.reveal", args: ["gameData"], channel: IPC.appRevealPath },
   { path: "app.requestQuit", args: [], channel: IPC.appRequestQuit },
+  {
+    path: "clipboard.writeText",
+    args: ["copied text"],
+    channel: IPC.clipboardWriteText,
+  },
   { path: "client.retry", args: [], channel: IPC.clientRetry },
   {
     path: "client.healthy",


### PR DESCRIPTION
Stack #87, PR 3 of 4 · base: `demand-read-preemption` (#84) · next: #86

Partially addresses #82.

## What this ships to users

**⌘C now copies out of the game** — for the text field you are editing: chat entry, search boxes, the guild announcement editor. It copies the field's selected text, or the whole field when nothing is selected. The password field is never copied. Paste (⌘V) was already working and is untouched.

Text the game merely renders — chat history, item names, a guild's status line — still cannot be copied, and the user guide now says so honestly.

## What changed

Investigation first: the shipped `Gw.jspi.wasm`/`Gw.jspi.js` contain **zero clipboard code**. The Windows client's `SetClipboardData` path was never ported to the Emscripten build, so no amount of host plumbing can copy a canvas highlight — the client never asks. Paste works by accident of architecture: typing runs through real DOM `<input>` proxies that Chromium pastes into natively.

The one copy the host can perform truthfully is of the OSK proxy field the client is editing through:

- `src/renderer/clipboard-copy.ts` (new): ⌘C on the active proxy field → selection or whole field → the bridge. Password proxy excluded outright; collapsed-selection fallback is deliberate because the client keeps its in-field selection to itself and "nothing" would be visibly wrong.
- A `clipboard.writeText` capability crossing the bridge like every other native invariant: canonical channel in `src/shared/contracts.ts`, frozen preload transport, validated main handler (`src/main/ipc.ts`) with a 64 KB ceiling.
- `docs/user-guide.md`: new "Copy and paste" section recording what works and what upstream still owes.
- `tests/electron/sandbox.spec.ts`: the human-reviewed capability surface gains its `clipboard` entry.

## What deliberately did not change

- No attempt to read the client's canvas text selection. That is exact-build certified-memory territory (companion-kernel snapshot ABI) — deferred by explicit decision, revisit if upstream stays silent.
- The Edit-menu roles stay: they serve the renderer's own text fields.

## Review focus

- The main-process validator: string, non-empty, ≤64 KB — is that the right ceiling?
- `clipboard-copy.ts`'s modifier guard (`⌘C` exactly — no Ctrl/Alt/Shift) and the password exclusion.
- Whether the whole-field fallback on collapsed selection is the behaviour we want to promise in the user guide.

## Verification

- New `tests/electron/input-clipboard.spec.ts`: real end-to-end round trip through the built app — ⌘C on the focused proxy lands the selection on the actual macOS clipboard, collapsed selection copies the whole field, the password proxy leaves a sentinel untouched. Restores the user's clipboard afterwards.
- Preload generation + release behaviour tests (18) green — the new channel is called and covered.
- `pnpm test:policy` (156, module headers incl. the new file), `pnpm typecheck`, `pnpm lint` clean.

## Known follow-ups

- File the clipboard gap upstream with ArenaNet: a two-line `EM_ASM` hook in the client's platform layer would enable real copy-out of highlighted text; the host's `Module` namespace pattern is ready to answer it.
- #86 adds `clipboard.copied` / `clipboard.writeFailed` flight-recorder events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
