### PR TITLE
Record the events that prove the input, clipboard, and streaming fixes work

### DIFF
--- a/src/main/diagnostics/renderer.ts
+++ b/src/main/diagnostics/renderer.ts
@@ -118,6 +118,10 @@ export function recordRendererMetrics(value: RendererMetrics): void {
       case "filesystem.persistenceFailed":
       case "audio.resumeFailed":
       case "pointerLock.failed":
+      case "snapshot.readFailed":
+      case "graphics.programCacheSaturated":
+      case "clipboard.copied":
+      case "clipboard.writeFailed":
         recordEvent(
           { k: event.name, fingerprint },
           { timestampUs: Math.round(event.timestampUs) },

--- a/src/main/diagnostics/schema.ts
+++ b/src/main/diagnostics/schema.ts
@@ -1056,6 +1056,32 @@ export const DIAGNOSTIC_EVENT_SCHEMA = {
     level: "warn",
     fields: { fingerprint: rendererFingerprintOrNull },
   },
+  // A demand read the client was awaiting rejected — the failure mode behind
+  // black textures. The count and timestamps tie a visual artifact report to
+  // the reads that failed under it.
+  "snapshot.readFailed": {
+    subsystem: "snapshot",
+    level: "error",
+    fields: { fingerprint: rendererFingerprintOrNull },
+  },
+  // The 1024-program ceiling was reached; later programs degrade to
+  // pass-through polling. Its absence in a capture rules the cache out of a
+  // rendering-artifact investigation.
+  "graphics.programCacheSaturated": {
+    subsystem: "graphics",
+    level: "warn",
+    fields: { fingerprint: rendererFingerprintOrNull },
+  },
+  "clipboard.copied": {
+    subsystem: "renderer",
+    level: "info",
+    fields: { fingerprint: rendererFingerprintOrNull },
+  },
+  "clipboard.writeFailed": {
+    subsystem: "renderer",
+    level: "warn",
+    fields: { fingerprint: rendererFingerprintOrNull },
+  },
   "graphics.detected": {
     subsystem: "graphics",
     level: "info",

--- a/src/renderer/clipboard-copy.ts
+++ b/src/renderer/clipboard-copy.ts
@@ -13,6 +13,7 @@ type ClipboardCopyOptions = {
   /** The OSK proxy fields; anything else never reaches the clipboard. */
   fields: Iterable<unknown>;
   writeText(text: string): Promise<void>;
+  diagnostics?: GameInputDiagnostics;
   log(...values: unknown[]): void;
 };
 
@@ -25,6 +26,7 @@ const isCopyableField = (value: unknown): value is ClipboardField =>
 export const installClipboardCopy = ({
   fields,
   writeText,
+  diagnostics,
   log,
 }: ClipboardCopyOptions): void => {
   const sources = new Set<ClipboardField>();
@@ -51,11 +53,15 @@ export const installClipboardCopy = ({
         ? value.slice(selectionStart, selectionEnd)
         : value;
     if (!text) return;
-    writeText(text).catch((error: unknown) => {
-      log(
-        '[warn] clipboard write refused:',
-        error instanceof Error ? error.message : String(error),
-      );
-    });
+    writeText(text).then(
+      () => diagnostics?.event('clipboard.copied'),
+      (error: unknown) => {
+        diagnostics?.event('clipboard.writeFailed', error);
+        log(
+          '[warn] clipboard write refused:',
+          error instanceof Error ? error.message : String(error),
+        );
+      },
+    );
   }, true);
 };

--- a/src/renderer/diagnostics.ts
+++ b/src/renderer/diagnostics.ts
@@ -37,6 +37,10 @@
     'filesystem.persistenceFailed',
     'audio.resumeFailed',
     'pointerLock.failed',
+    'snapshot.readFailed',
+    'graphics.programCacheSaturated',
+    'clipboard.copied',
+    'clipboard.writeFailed',
   ]);
   const histogram = (): Histogram => ({
     buckets: new Array<number>(histogramLimitsUs.length).fill(0),

--- a/src/renderer/gl-program-cache.ts
+++ b/src/renderer/gl-program-cache.ts
@@ -92,10 +92,19 @@ export const installGlProgramCache = ({
     return words;
   }
 
+  let saturationRecorded = false;
   env.glCreateProgram = function (this: unknown, ...args) {
     const program = createProgram.apply(this, args);
-    if (typeof program === 'number' && program > 0 && programs.size < MAX_PROGRAMS) {
-      programs.set(program, false);
+    if (typeof program === 'number' && program > 0) {
+      if (programs.size < MAX_PROGRAMS) {
+        programs.set(program, false);
+      } else if (!saturationRecorded) {
+        // Degrading to pass-through is safe but must not be silent: a capture
+        // without this event rules the ceiling out of an artifact report.
+        saturationRecorded = true;
+        window.gwDiagnostics?.event('graphics.programCacheSaturated');
+        log(`[warn] GL program cache full at ${MAX_PROGRAMS} — later programs pass through`);
+      }
     }
     return program;
   };

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -832,6 +832,7 @@ function loadGlue() {
   host.installClipboardCopy({
     fields: oskInputs,
     writeText: (text) => native().clipboard.writeText(text),
+    diagnostics: window.gwDiagnostics,
     log,
   });
 

--- a/src/renderer/image-source.ts
+++ b/src/renderer/image-source.ts
@@ -88,6 +88,11 @@ type ImageDiagnostics = {
     bytes: number,
     source: 'memory' | 'native',
   ): void;
+  /**
+   * A demand read the client was awaiting rejected. Black textures are this
+   * failure's visible face; the event is what ties a capture to it.
+   */
+  event?(name: 'snapshot.readFailed', value?: unknown): void;
 };
 
 export type ImageSource = {
@@ -430,11 +435,21 @@ export function createImageSource({
       const source = data === null ? 'native' : 'memory';
       if (data === null) {
         const [first, last] = chunkRange(offset, bytes);
-        const fetched = await fetchDemandChunks(first, last);
+        let fetched;
+        try {
+          fetched = await fetchDemandChunks(first, last);
+        } catch (error) {
+          diagnostics?.event?.('snapshot.readFailed', error);
+          throw error;
+        }
         data = assembleRange(offset, bytes, (index) => fetched[index - first]);
       }
       if (data === null || data.length !== bytes) {
-        throw new Error(`image read ${offset}+${bytes}: assembled ${data && data.length}`);
+        const failure = new Error(
+          `image read ${offset}+${bytes}: assembled ${data && data.length}`,
+        );
+        diagnostics?.event?.('snapshot.readFailed', failure);
+        throw failure;
       }
       stats.reads++;
       stats.bytes += bytes;

--- a/src/shared/diagnostics.ts
+++ b/src/shared/diagnostics.ts
@@ -45,6 +45,10 @@ export const RENDERER_EVENT_NAMES = [
   "filesystem.persistenceFailed",
   "audio.resumeFailed",
   "pointerLock.failed",
+  "snapshot.readFailed",
+  "graphics.programCacheSaturated",
+  "clipboard.copied",
+  "clipboard.writeFailed",
 ] as const;
 
 export type RendererEventName = (typeof RENDERER_EVENT_NAMES)[number];


### PR DESCRIPTION
Stack #87, PR 4 of 4 · base: `clipboard-copy-out` (#85)

## What this ships to users

Nothing visible — this is the observability half of the round. When a player records a diagnostics capture (`.gwdiag`), it now answers the questions this stack's fixes raise: did they engage, and when something still looks wrong, why.

## What changed

Four renderer events join the flight recorder, each wired through the existing pipeline (shared name list → renderer whitelist → main schema → recorder), no new machinery:

| Event | Level | Witness for |
|---|---|---|
| `snapshot.readFailed` | error | A demand read the client was awaiting rejected — the failure mode behind black textures. A compass-artifact capture now shows whether streaming failed under it. |
| `graphics.programCacheSaturated` | warn | The 1024-program ceiling was reached and later programs degraded to pass-through. Previously invisible outside a live `gwGlRecon()` call; its absence in a capture rules the cache out of an artifact investigation. |
| `clipboard.copied` / `clipboard.writeFailed` | info / warn | Whether ⌘C copies actually land on the OS clipboard in the field, and why not when they don't. |

Emit sites: `image-source.ts` (both demand-read failure paths, via a narrow optional `event` on its diagnostics port), `gl-program-cache.ts` (once per session, with a console warning), `clipboard-copy.ts` (on settle of the bridge write). A fifth event (`pointer.reconciled`) shipped briefly and left with the reverted reconciliation it witnessed.

## What deliberately did not change

- No new counters in the `RendererMetrics` batch — events already count automatically as `renderer.event.<name>` and carry timestamps, which is exactly what correlating a visual report needs.
- The scheduler's existing gauges (`snapshot.queuedDemand` etc.) already cover the preemption fix; nothing added there.

## Review focus

- Schema choices: subsystems (`snapshot`/`graphics`/`renderer`) and levels — `clipboard.copied` at info means every copy is one record; volume is bounded by the existing 64-events-per-batch cap.

## Verification

- `pnpm test:unit`: 749/749 (schema/whitelist coherence is enforced by the existing diagnostics tests).
- `pnpm test:policy`: 156/156. Full Electron suite on the stack: 103 passed, 1 skipped.
- `pnpm typecheck`, `pnpm lint` clean.

## Known follow-ups

- If a compass-artifact capture arrives showing `snapshot.readFailed` clusters, the next step is per-asset attribution (offset → file) — deliberately out of scope until the evidence asks for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
