### PR TITLE
Prove ownership of the site to Google Search Console

### DIFF
--- a/apps/website/nuxt.config.ts
+++ b/apps/website/nuxt.config.ts
@@ -12,7 +12,13 @@ export default defineNuxtConfig({
         { rel: "apple-touch-icon", sizes: "180x180", href: "/apple-touch-icon.png" },
         { rel: "manifest", href: "/site.webmanifest" },
       ],
-      meta: [{ name: "apple-mobile-web-app-title", content: "gwonmac" }],
+      meta: [
+        { name: "apple-mobile-web-app-title", content: "gwonmac" },
+        {
+          name: "google-site-verification",
+          content: "mFA4hQqscVMdgB5EefYAjQxRZRBYMDJeJ7Rqbx76ewk",
+        },
+      ],
       script: [
         {
           async: true,


### PR DESCRIPTION
## What changed

The site head now carries the Google Search Console verification token, so `https://gwonmac.vercel.app/` can be claimed as a URL-prefix property and its indexing status, queries, and sitemap health become visible.

A domain property is not an option here. That method verifies through a DNS TXT record on `vercel.app`, which is Vercel's zone rather than ours, so the URL-prefix property is the only route available while the site lives on a `vercel.app` host. The token is load-bearing rather than decorative: deleting it unverifies the property.

Nothing else in the SEO setup needed changing, and this PR deliberately changes nothing else. The audit behind that:

| Signal | State |
| --- | --- |
| `<link rel="canonical">` | Correct on every page, derived from `site.json` |
| hreflang `en-US` / `de-DE` / `x-default` | Present |
| `robots.txt` | Indexable, points at the sitemap index |
| `sitemap_index.xml` | Live, one sitemap per locale |
| `og:*` / `twitter:*` / JSON-LD | Emitted per page by the layer — `og:type: article` and `TechArticle` on posts |
| Preview deployments | De-indexed by Vercel's automatic `X-Robots-Tag: noindex` |

The duplicate-content guidance about `*.vercel.app` versus a custom domain does not apply yet, because there is no custom domain — one host cannot split its own ranking signals. Its `X-Robots-Tag: noindex` step would actively hurt today: `gwonmac.vercel.app` *is* the indexed canonical, so marking it `noindex` would drop the pages that currently rank. When a custom domain does arrive, the move is a one-line change to `url` in `site.json` (canonical, hreflang, sitemap, and robots all derive from it), a redirect from the old host, and Search Console's Change of Address — not a `noindex` header.

## Verification

- `pnpm run check` in `apps/website` (lint + `nuxi typecheck`): clean.
- `pnpm run build` in `apps/website`: succeeds; the tag renders into all 18 prerendered pages, EN and DE, verified by grepping `.output/public`.
- Canonical and `robots` meta re-checked in the build output and unchanged: `https://gwonmac.vercel.app/` and `index, follow, max-image-preview:large`.

- [x] I ran the relevant automated tests.
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [ ] I updated documentation when behavior or an invariant changed. — no behavior or invariant changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
