### PR TITLE
Gate pointer lock on the client's own cursor state

### DIFF
--- a/scripts/enhancements-live/scenarios.ts
+++ b/scripts/enhancements-live/scenarios.ts
@@ -507,6 +507,11 @@ const CURSOR_PHASES = Object.freeze([
   Object.freeze({ seconds: 8, ask: "press Escape and return to the plain arrow" }),
   Object.freeze({ seconds: 12, ask: "drag an inventory item and hold it" }),
   Object.freeze({ seconds: 10, ask: "open the world map and hover a travel destination" }),
+  // Whether the client hides its own cursor during mouse-look — and does not
+  // during a map pan — decides if pointer lock can be gated on the client's
+  // cursor state instead of a new certified world-map read (input.ts).
+  Object.freeze({ seconds: 12, ask: "in the world, hold right-click and rotate the camera" }),
+  Object.freeze({ seconds: 12, ask: "open the world map and right-drag to pan it" }),
 ]);
 const CURSOR_SAMPLE_INTERVAL_MS = 50;
 const CURSOR_MAX_CHANGES = 192;

--- a/src/renderer/enhancements.ts
+++ b/src/renderer/enhancements.ts
@@ -460,6 +460,12 @@ export async function installEnhancements(
         transitionHold: () => !retry.expired && refresh.armed(),
       });
       disposeCursor = cursor.dispose;
+      // Production-safe console probe: the same bounded presentation state the
+      // developer runtime projects — no pixels, no pointers. Exists to answer
+      // mode questions from a live session, e.g. whether the client hides its
+      // cursor during right-drag mouse-look (the pointer-lock gating question
+      // in input.ts) without a developer program.
+      window.gwCursorState = () => cursor?.state ?? null;
     }
     const readout = observeState
       ? createTargetReadout(document.body)

--- a/src/renderer/enhancements.ts
+++ b/src/renderer/enhancements.ts
@@ -460,37 +460,13 @@ export async function installEnhancements(
         transitionHold: () => !retry.expired && refresh.armed(),
       });
       disposeCursor = cursor.dispose;
-      // Production-safe console probe: the same bounded presentation state the
-      // developer runtime projects — no pixels, no pointers. Exists to answer
-      // mode questions from a live session, e.g. whether the client hides its
-      // cursor during right-drag mouse-look (the pointer-lock gating question
-      // in input.ts) without a developer program.
+      // The client's own cursor state, projected for two consumers: the
+      // console, for mode questions from a live session, and the pointer-lock
+      // gate in input.ts, which reads `hidden` to tell mouse-look from a map
+      // pan (measured 2026-08-03: mouse-look hides the client cursor within a
+      // tick of the right press; a map pan never does). Bounded presentation
+      // state only — no pixels, no pointers.
       window.gwCursorState = () => cursor?.state ?? null;
-      // Hands are busy during the gesture under measurement, so the probe
-      // logs itself: state on every right-button press, twice a second while
-      // it is held, and on release. Quiet otherwise. Temporary — it leaves
-      // with the measurement branch once the mode question is answered.
-      const probeLog = (phase: string) => {
-        const state = cursor?.state;
-        console.info(
-          `[cursor-probe] ${phase} hidden=${state?.hidden} valid=${state?.valid} ` +
-          `hash=${state?.pixelHash} lock=${document.pointerLockElement !== null}`,
-        );
-      };
-      let probeTimer: ReturnType<typeof setInterval> | null = null;
-      window.addEventListener('mousedown', (event) => {
-        if (event.button !== 2) return;
-        probeLog('right-down');
-        probeTimer ??= setInterval(() => probeLog('right-held'), 500);
-      }, true);
-      window.addEventListener('mouseup', (event) => {
-        if (event.button !== 2) return;
-        probeLog('right-up');
-        if (probeTimer !== null) {
-          clearInterval(probeTimer);
-          probeTimer = null;
-        }
-      }, true);
     }
     const readout = observeState
       ? createTargetReadout(document.body)

--- a/src/renderer/enhancements.ts
+++ b/src/renderer/enhancements.ts
@@ -466,6 +466,31 @@ export async function installEnhancements(
       // cursor during right-drag mouse-look (the pointer-lock gating question
       // in input.ts) without a developer program.
       window.gwCursorState = () => cursor?.state ?? null;
+      // Hands are busy during the gesture under measurement, so the probe
+      // logs itself: state on every right-button press, twice a second while
+      // it is held, and on release. Quiet otherwise. Temporary — it leaves
+      // with the measurement branch once the mode question is answered.
+      const probeLog = (phase: string) => {
+        const state = cursor?.state;
+        console.info(
+          `[cursor-probe] ${phase} hidden=${state?.hidden} valid=${state?.valid} ` +
+          `hash=${state?.pixelHash} lock=${document.pointerLockElement !== null}`,
+        );
+      };
+      let probeTimer: ReturnType<typeof setInterval> | null = null;
+      window.addEventListener('mousedown', (event) => {
+        if (event.button !== 2) return;
+        probeLog('right-down');
+        probeTimer ??= setInterval(() => probeLog('right-held'), 500);
+      }, true);
+      window.addEventListener('mouseup', (event) => {
+        if (event.button !== 2) return;
+        probeLog('right-up');
+        if (probeTimer !== null) {
+          clearInterval(probeTimer);
+          probeTimer = null;
+        }
+      }, true);
     }
     const readout = observeState
       ? createTargetReadout(document.body)

--- a/src/renderer/gw-native.d.ts
+++ b/src/renderer/gw-native.d.ts
@@ -201,6 +201,14 @@ declare global {
     }>;
     gwCompanionRuntime?: CompanionDeveloperRuntime | CompanionObserverRuntime | null;
     gwCompanionState?: CompanionState;
+    /** The cursor's bounded presentation state; present once the nativeCursor enhancement installs. */
+    gwCursorState?(): Readonly<{
+      generation: number;
+      pixelHash: number;
+      hidden: boolean;
+      valid: boolean;
+      cssLength: number;
+    }> | null;
     readonly gwEnhancementSettings: Readonly<{
       create(options: {
         form: HTMLFormElement;

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -814,6 +814,10 @@ function loadGlue() {
   inputHost = host.installGameInput({
     canvas: c,
     diagnostics: window.gwDiagnostics,
+    // Read through the window global rather than a module handle: input
+    // installs before the enhancement chain decides whether a certified
+    // cursor readout exists at all.
+    clientCursorHidden: () => window.gwCursorState?.()?.hidden ?? null,
     log,
   });
   // Text entry runs through these, not through keydown on the canvas. Stray

--- a/src/renderer/input.ts
+++ b/src/renderer/input.ts
@@ -95,12 +95,25 @@ type HeldButton = {
 type GameInputOptions = {
   canvas: HTMLCanvasElement;
   diagnostics?: GameInputDiagnostics;
+  /**
+   * The client's own cursor-hidden state through the certified cursor
+   * readout, or null while that readout is unavailable (enhancement off,
+   * uncertified build, not yet installed). Measured 2026-08-03: entering
+   * mouse-look hides the client's cursor within a tick of the right press;
+   * a world-map pan never hides it.
+   */
+  clientCursorHidden?: () => boolean | null;
   log(...values: unknown[]): void;
 };
+
+// How often a held right-drag re-asks the client whether it entered
+// mouse-look, matching the cursor observer's own sampling cadence.
+const POINTER_MODE_INTERVAL_MS = 50;
 
 export const installGameInput = ({
   canvas,
   diagnostics,
+  clientCursorHidden,
   log,
 }: GameInputOptions): GameInputController => {
   const heldKeys = new Map<string, HeldKey>();
@@ -111,6 +124,12 @@ export const installGameInput = ({
   let touchId = 0;
   let virtualCursor: { x: number; y: number } | null = null;
   let pointerWanted = false;
+  let modeWatch: ReturnType<typeof setInterval> | null = null;
+
+  function stopModeWatch() {
+    if (modeWatch !== null) clearInterval(modeWatch);
+    modeWatch = null;
+  }
   let releasing = false;
   let wheelRemainder = 0;
   let wheelDirection = 0;
@@ -271,6 +290,7 @@ export const installGameInput = ({
   // absolute position from the first real mousemove after the lock ends.
   function releasePointer() {
     pointerWanted = false;
+    stopModeWatch();
     virtualCursor = null;
     canvas.classList.remove('cursor-hidden');
     if (document.pointerLockElement === canvas) document.exitPointerLock();
@@ -564,14 +584,17 @@ export const installGameInput = ({
     }
   };
 
-  canvas.addEventListener('mousedown', (event) => {
-    if (event.button !== 2 || !event.isTrusted) return;
+  const engagePointerLock = () => {
+    // The trusted-move handler keeps these coordinates current, so a lock
+    // engaged mid-drag seeds the virtual cursor where the pointer now is and
+    // the drag continues without a seam.
+    const held = heldButtons.get(2);
+    if (!held) return;
     const rect = canvas.getBoundingClientRect();
     virtualCursor = {
-      x: event.clientX - rect.left,
-      y: event.clientY - rect.top,
+      x: held.clientX - rect.left,
+      y: held.clientY - rect.top,
     };
-    pointerWanted = true;
     if (document.pointerLockElement === canvas) return;
     try {
       const request = canvas.requestPointerLock();
@@ -595,6 +618,34 @@ export const installGameInput = ({
       );
       releaseButtons();
     }
+  };
+
+  canvas.addEventListener('mousedown', (event) => {
+    if (event.button !== 2 || !event.isTrusted) return;
+    pointerWanted = true;
+    // Right-click is two modes the press alone cannot tell apart: mouse-look,
+    // which needs the lock and the roam walk, and a map/UI pan, which must
+    // stay a plain absolute drag or the cursor vanishes and the pan jumps.
+    // The client separates them itself — entering mouse-look hides its cursor
+    // within a tick — so when that readout is available the lock waits for
+    // it. Without the readout the lock engages at the press, as it always
+    // has: today's behaviour is the fallback, not the map's.
+    const hidden = clientCursorHidden ? clientCursorHidden() : null;
+    if (hidden !== false) {
+      engagePointerLock();
+      return;
+    }
+    stopModeWatch();
+    modeWatch = setInterval(() => {
+      if (!pointerWanted || !heldButtons.has(2)) {
+        stopModeWatch();
+        return;
+      }
+      if (clientCursorHidden?.() === true) {
+        stopModeWatch();
+        engagePointerLock();
+      }
+    }, POINTER_MODE_INTERVAL_MS);
   }, true);
 
   document.addEventListener('mousemove', (event) => {

--- a/tests/electron/input-camera.spec.ts
+++ b/tests/electron/input-camera.spec.ts
@@ -16,6 +16,8 @@ type CameraInputWindow = typeof window & {
   __cameraEvents: CameraEvent[];
   __cameraDrains: number;
   __cameraTasks: number[];
+  __lockRequests: number;
+  __cursorHidden: boolean;
 };
 
 test.describe("renderer camera input", () => {
@@ -262,6 +264,91 @@ test.describe("renderer camera input", () => {
         beforeRelease,
       );
       expect(moves).toEqual([]);
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
+  // The client separates right-click's two modes itself: entering mouse-look
+  // hides its cursor within a tick, a map/UI pan never does (measured
+  // 2026-08-03). These two tests pin the lock gate on that readout.
+  const watchLockRequests = async (page: Page, hidden: boolean) => {
+    await page.evaluate((cursorHidden) => {
+      const canvas = globalThis.document.getElementById("canvas");
+      const loading = globalThis.document.getElementById("loading");
+      if (!canvas || !loading) throw new Error("the renderer shell is missing");
+      loading.classList.add("gone");
+      const testWindow = window as CameraInputWindow;
+      testWindow.__lockRequests = 0;
+      testWindow.__cursorHidden = cursorHidden;
+      (canvas as HTMLCanvasElement).requestPointerLock = () => {
+        testWindow.__lockRequests += 1;
+        return Promise.resolve();
+      };
+      testWindow.gwCursorState = () => Object.freeze({
+        generation: 1,
+        pixelHash: 1,
+        hidden: testWindow.__cursorHidden,
+        valid: true,
+        cssLength: 0,
+      });
+      canvas.focus();
+    }, hidden);
+  };
+
+  test("keeps a right-drag unlocked while the client cursor stays visible", async () => {
+    const fixture = await launchOffline("gw-pointer-map-pan-e2e-");
+    try {
+      const { page } = fixture;
+      await startGameInput(page);
+      await watchLockRequests(page, false);
+      const box = await boxOf(page.locator("#canvas"));
+      await page.mouse.move(box.x + 100, box.y + 100);
+      await page.mouse.down({ button: "right" });
+      // Long enough for several mode-watch samples to have asked the client.
+      await page.waitForTimeout(300);
+      await page.mouse.move(box.x + 60, box.y + 100);
+      await page.mouse.up({ button: "right" });
+      expect(
+        await page.evaluate(
+          () => (window as CameraInputWindow).__lockRequests,
+        ),
+      ).toBe(0);
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
+  test("locks the pointer once the client hides its cursor", async () => {
+    const fixture = await launchOffline("gw-pointer-mouselook-e2e-");
+    try {
+      const { page } = fixture;
+      await startGameInput(page);
+      await watchLockRequests(page, false);
+      const box = await boxOf(page.locator("#canvas"));
+      await page.mouse.move(box.x + 100, box.y + 100);
+      await page.mouse.down({ button: "right" });
+      await page.waitForTimeout(150);
+      expect(
+        await page.evaluate(
+          () => (window as CameraInputWindow).__lockRequests,
+        ),
+      ).toBe(0);
+      // The client enters mouse-look a tick after the press; the held drag's
+      // mode watch must escalate to the lock on its own.
+      await page.evaluate(() => {
+        (window as CameraInputWindow).__cursorHidden = true;
+      });
+      await expect
+        .poll(
+          () =>
+            page.evaluate(() => (window as CameraInputWindow).__lockRequests),
+          // The mode watch samples every 50 ms, but a loaded machine running
+          // the whole suite can throttle background timers well past that.
+          { timeout: 15_000 },
+        )
+        .toBe(1);
+      await page.mouse.up({ button: "right" });
     } finally {
       await closeOffline(fixture);
     }


### PR DESCRIPTION
Stack #87, PR 5 of 5 · base: `hook-metrics` (#86)

## What this ships to users

Right-click finally means the right thing in both of its modes:

- **World map / UI panning**: right-drag keeps the cursor visible and pans like a left-drag — no more vanishing cursor, no more jumping.
- **In-world mouse-look**: unchanged — pointer lock and the roam walk engage as before, a beat after the press.

## How it knows which mode it's in

Investigation confirmed no map-open state is observable in a shipped session, and porting the Windows tooling's `WorldMapState` word would cost a full re-certification round. But the client separates the modes itself: a live measurement (this PR's first commit added the probe; the log is in the session record) showed **entering mouse-look hides the client's own cursor within a tick of the right press, and a map pan never does** — the pan even carries distinct cursor art. That counter is already published every tick through the certified cursor region.

So the gate is: on right press, if the cursor readout is available, don't lock — watch it at 50 ms. The moment the client hides its cursor, escalate to pointer lock, seeding the virtual cursor from the held button's current coordinates so the drag continues without a seam. If it never hides (map/UI), never lock. **Fallback:** without the readout (nativeCursor enhancement off, uncertified build, not yet installed), the lock engages at the press exactly as today — old behaviour is the fallback, not the map's.

## What changed

- `src/renderer/input.ts`: `engagePointerLock` extracted; right-mousedown starts a mode watch when `clientCursorHidden` is available; `releasePointer` stops it on every release path.
- `src/renderer/harness.ts`: passes `clientCursorHidden` reading through `window.gwCursorState` (input installs before the enhancement chain decides whether the readout exists).
- `src/renderer/enhancements.ts`: `gwCursorState` (added for the measurement) stays, now load-bearing; the probe's temporary self-logging leaves.
- Live `cursor-capture` scenario keeps the two right-drag phases so the evidence is reproducible against future client builds.

## What deliberately did not change

- The camera path under lock — roam budget, re-anchors, release semantics — is untouched. The lock arriving ~50–100 ms after the press is the only difference in-world, during which the client integrates the same absolute moves it always did.
- No certified `world_map_state` read. If a future client build stops hiding the cursor in mouse-look, that is the fallback plan (reserved cursor-snapshot word; GWCA semantics documented in the investigation).

## Review focus

- The mode-watch lifecycle: started only on trusted right press with a live readout, stopped in `releasePointer` (every release path converges there) and when the held button disappears.
- The `hidden !== false` fallback branch: `null` (no readout) and stale `true` both engage at press — both deliberately collapse to today's behaviour.
- Timer throttling: the watch is a 50 ms interval; in an occluded window it may sample slower, which only delays lock escalation, never causes a wrong lock.

## Verification

- Two new specs: "keeps a right-drag unlocked while the client cursor stays visible" and "locks the pointer once the client hides its cursor" (escalation mid-drag, via a controllable fake readout).
- 26/26 across input-pointer, input-camera, input-keyboard, input-clipboard, enhancement-cursor, sandbox; `pnpm typecheck`, `pnpm lint` clean.
- Field measurement by the maintainer (probe log): mouse-look `hidden=true` within one 500 ms sample on every rotate; map pan `hidden=false` throughout, distinct art hash.

## Known follow-ups

- Map panning with the nativeCursor enhancement disabled keeps today's (broken-on-map) behaviour — acceptable while the toggle defaults on; the certified map-state read is the escape hatch if that ever matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
