### PR TITLE
Land a launch-check update before the game starts

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -316,10 +316,20 @@ and the app still re-derives every claim against the client on your machine
 before anything switches back on. Neither request sends anything about you or
 your installation.
 
-An eligible update downloads in the background. When it is ready, choose
-**Restart to Update** or choose Later and let it install on the next ordinary
-restart. Restarting while Guild Wars is connected asks before disconnecting.
-The app saves its persistent game filesystem before either kind of restart.
+**At launch, an update lands before the game starts.** While the launch check
+or its download is running, the loading screen holds at that step instead of
+starting an outdated version; when the update is ready, the app restarts
+itself into the new version and then starts the game. **Play Without
+Updating** on the loading screen skips the wait — the download continues in
+the background and installs on the next restart. A failed or offline check
+never delays play, and with automatic checks off the launch is not held at
+all.
+
+An update found while you are already playing downloads in the background.
+When it is ready, choose **Restart to Update** or choose Later and let it
+install on the next ordinary restart. Restarting while Guild Wars is
+connected asks before disconnecting. The app saves its persistent game
+filesystem before either kind of restart.
 
 Stable installations receive stable releases only. Preview installations may
 receive a newer preview or advance to stable. A failed check is never reported

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -33,6 +33,7 @@
     <a href="#" id="loading-update-check">Check for Updates</a>
     <a href="#" id="loading-update-get" class="update"
        data-external="releases" hidden>Get the update</a>
+    <a href="#" id="loading-update-skip" hidden>Play Without Updating</a>
     <a href="#" data-settings>Settings</a>
     <a href="#" data-external="discord">Discord</a>
     <a href="#" data-external="github">GitHub</a>

--- a/src/renderer/loading.ts
+++ b/src/renderer/loading.ts
@@ -275,20 +275,82 @@ window.gwLoading = (function (): LoadingController {
     api.set('Checking the game client', null);
     // Resolved before the first progress event can arrive, so the failure
     // path below stays synchronous.
-    const [{ describeLaunchFailure, describeNotice, failureDetail }, { DownloadDetailLine }] =
-      await Promise.all([
-        import('./failure-messages.js'),
-        import('./progress-display.js'),
-      ]);
+    const [
+      { describeLaunchFailure, describeNotice, failureDetail },
+      { DownloadDetailLine },
+      { launchGateDecision },
+    ] = await Promise.all([
+      import('./failure-messages.js'),
+      import('./progress-display.js'),
+      import('./update-action.js'),
+    ]);
 
     return new Promise<boolean>((resolve) => {
       let settled = false;
+      let gating = false;
       const detailLine = new DownloadDetailLine();
       const finish = (ok: boolean) => {
         if (settled) return;
         settled = true;
         unsub();
         resolve(ok);
+      };
+
+      // The launch gate: an update the launch check discovered lands before
+      // the outdated version gets a whole session. The gate holds the client
+      // start while the check or its download is in flight, restarts into a
+      // ready update, and releases on every settled state — a failed check
+      // never delays play, and "Play Without Updating" is the player's
+      // override while a download runs.
+      const holdForLaunchUpdate = (startClient: () => void) => {
+        const skip = el('loading-update-skip');
+        let gateSettled = false;
+        let unsubscribe = () => {};
+        let installFallback: ReturnType<typeof setTimeout> | null = null;
+        const release = () => {
+          if (gateSettled) return;
+          gateSettled = true;
+          unsubscribe();
+          skip.hidden = true;
+          if (installFallback !== null) clearTimeout(installFallback);
+          startClient();
+        };
+        skip.addEventListener('click', (event) => {
+          event.preventDefault();
+          release();
+        });
+        const consider = (
+          state: import('../shared/contracts.js').AppUpdateState,
+        ) => {
+          if (gateSettled) return;
+          const decision = launchGateDecision(state);
+          if (decision === 'proceed') {
+            release();
+            return;
+          }
+          if (decision === 'install' && state.phase === 'ready') {
+            skip.hidden = true;
+            api.set(
+              `Updating to version ${state.latestVersion}`,
+              null,
+              'Guild Wars Reforged restarts to finish the update.',
+            );
+            void window.gwNative.appUpdates.restartAndInstall();
+            // A refused restart must not hold the launch hostage.
+            installFallback = setTimeout(release, 10_000);
+            return;
+          }
+          skip.hidden = false;
+          api.set(
+            state.phase === 'downloading'
+              ? `Downloading version ${state.latestVersion}`
+              : 'Checking for updates',
+            null,
+            'The game starts when the update is ready.',
+          );
+        };
+        unsubscribe = window.gwNative.appUpdates.onState(consider);
+        void window.gwNative.appUpdates.getState().then(consider).catch(release);
       };
 
       const apply = (p: DownloadProgress) => {
@@ -299,14 +361,18 @@ window.gwLoading = (function (): LoadingController {
         }
         window.gwAutomation.set(`launcher.${p.phase}`);
         if (p.phase === 'ready') {
-          api.set(
-            'Starting Guild Wars',
-            null,
-            p.noticeCode ? describeNotice(p.noticeCode) : '',
-          );
-          // A client is active now, so the footer can name its build.
-          void renderFooterStatus();
-          finish(true);
+          if (gating) return;
+          gating = true;
+          holdForLaunchUpdate(() => {
+            api.set(
+              'Starting Guild Wars',
+              null,
+              p.noticeCode ? describeNotice(p.noticeCode) : '',
+            );
+            // A client is active now, so the footer can name its build.
+            void renderFooterStatus();
+            finish(true);
+          });
           return;
         }
         const frac = p.total ? p.received / p.total : null;

--- a/src/renderer/update-action.ts
+++ b/src/renderer/update-action.ts
@@ -55,6 +55,30 @@ export function formatLastChecked(
   return `Last checked ${plural(Math.floor(hours / 24), 'day')} ago`;
 }
 
+export type LaunchGateDecision = 'hold' | 'install' | 'proceed';
+
+/**
+ * What the loading screen does with the updater's state before it starts the
+ * game client: hold while the launch check or its download is in flight,
+ * install a ready update before the outdated version gets a whole session,
+ * and otherwise start the game. The off-path states never delay a launch —
+ * idle is what checks-turned-off looks like, and a failed check has already
+ * said everything it can.
+ */
+export function launchGateDecision(state: AppUpdateState): LaunchGateDecision {
+  switch (state.phase) {
+    case 'checking':
+    case 'downloading':
+      return 'hold';
+    case 'ready':
+      return 'install';
+    case 'idle':
+    case 'up-to-date':
+    case 'failed':
+      return 'proceed';
+  }
+}
+
 export type UpdateActionView = {
   actionLabel: string;
   busy: boolean;

--- a/tests/unit/update-action.test.ts
+++ b/tests/unit/update-action.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   createUpdateAction,
   formatLastChecked,
+  launchGateDecision,
   type UpdateActionView,
 } from "../../src/renderer/update-action.ts";
 import type { AppUpdateState } from "../../src/shared/contracts.ts";
@@ -28,6 +29,55 @@ describe("update action", () => {
     assert.equal(
       formatLastChecked("1970-01-01T00:00:00.000Z", 2 * 60 * 60 * 1000),
       "Last checked 2 hours ago",
+    );
+  });
+
+  it("gates a launch on exactly the in-flight and ready updater states", () => {
+    const current = { currentVersion: "2026.8.0" };
+    // In flight: the game must not start outdated when the answer is seconds
+    // away, so the launch holds.
+    assert.equal(
+      launchGateDecision({ phase: "checking", ...current }),
+      "hold",
+    );
+    assert.equal(
+      launchGateDecision({
+        phase: "downloading",
+        latestVersion: "2026.8.1",
+        checkedAt: "2026-08-03T10:00:00.000Z",
+        ...current,
+      }),
+      "hold",
+    );
+    // Ready: the update installs before the outdated version gets a session.
+    assert.equal(
+      launchGateDecision({
+        phase: "ready",
+        latestVersion: "2026.8.1",
+        checkedAt: "2026-08-03T10:00:00.000Z",
+        ...current,
+      }),
+      "install",
+    );
+    // Settled states never delay play: idle is checks-off, and a failed
+    // check has already said everything it can.
+    assert.equal(launchGateDecision({ phase: "idle", ...current }), "proceed");
+    assert.equal(
+      launchGateDecision({
+        phase: "up-to-date",
+        latestVersion: "2026.8.0",
+        checkedAt: "2026-08-03T10:00:00.000Z",
+        ...current,
+      }),
+      "proceed",
+    );
+    assert.equal(
+      launchGateDecision({
+        phase: "failed",
+        reason: "offline",
+        ...current,
+      }),
+      "proceed",
     );
   });
 


### PR DESCRIPTION
Single PR · base: `main`

## What this ships to users

Opening the app right after a release no longer plays the outdated version. The launch update check now finishes **before** the game starts: while it checks or downloads, the loading screen holds at that step; when the update is ready, the app restarts itself into the new version and then starts the game. **Play Without Updating** on the loading screen skips the wait (the download continues in the background and installs on the next restart, as before).

This is exactly the "opened once after 2026.8.1 shipped, still played 2026.8.0" report from today.

## What changed

- `src/renderer/update-action.ts`: `launchGateDecision(state)` — a pure function beside the existing update-action state machine. `checking`/`downloading` → hold, `ready` → install, `idle`/`up-to-date`/`failed` → proceed.
- `src/renderer/loading.ts`: `waitForClient` runs the gate between the client's `ready` progress phase and "Starting Guild Wars". Presentation only: status line while holding, auto `restartAndInstall` on ready with a 10-second fallback so a refused restart never holds the launch hostage, release on every settled state.
- `src/renderer/index.html`: the `Play Without Updating` link, hidden except while the gate holds a download.
- `docs/user-guide.md`: the Updates section now describes launch behaviour and the skip, and keeps the mid-session flow unchanged.

## What deliberately did not change

- **User control is preserved.** With **Automatically check for and download app updates** off, the updater stays `idle` at launch and the gate releases instantly — an opted-out launch is not held for even a frame, and reaches GitHub zero times, same as before.
- A failed, offline, or rate-limited check never delays play; the gate only ever waits on work that is actually in flight.
- Mid-session updates keep the existing "Restart to Update / Later" flow, including the ask-before-disconnect guard.
- The updater itself (`src/main/app-updater.ts`) is untouched — the gate is a consumer of its published state, not a second updater.

## Review focus

- Gate lifecycle in `loading.ts`: single entry via the `gating` flag (the `ready` progress phase can be delivered twice — once from `progress.current()`, once from the event), release exactly once, skip listener and install fallback cleaned up on release.
- The 10-second install fallback: right trade-off between a wedged Squirrel restart and double-starting?
- Copy: "Play Without Updating", "Updating to version X", "The game starts when the update is ready."

## Verification

- New unit test drives `launchGateDecision` through all six updater states with the reasoning in comments (750 unit tests total, green).
- Full Electron suite: 106 passed, 1 pre-existing skip — including launcher, app, settings, and diagnostics specs that exercise the loading path end to end (in dev fixtures the launch check settles as `updater-unavailable`, which the gate treats as proceed; observed launch behaviour is unchanged there).
- `pnpm typecheck`, `pnpm lint`, `pnpm check:links` clean.

## Known follow-ups

- None planned. If a future report wants progress percent while the update downloads, Squirrel.Mac does not expose download progress — that would need a different transport, not a UI tweak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
