### PR TITLE
Bound quit cleanup so pressing quit always quits

### DIFF
--- a/src/main/lifecycle.ts
+++ b/src/main/lifecycle.ts
@@ -13,10 +13,43 @@
  * at all.
  */
 import { app } from "electron";
-import { errorCode } from "../shared/errors.js";
+import { errorCode, GwError } from "../shared/errors.js";
 import { flushDiagnostics, logEvent } from "./diagnostics.js";
 
 export type CleanupTask = () => void | Promise<void>;
+
+// A task that hangs must not strand the ones behind it — or the quit. Several
+// cleanup steps await promises with no deadline of their own (a Steam sign-in
+// sheet that quit itself would have closed, an in-flight client update), and
+// before-quit cancels the default quit, so an unbounded task used to leave
+// Cmd+Q doing nothing at all. Five seconds matches the renderer-command
+// budget; a step that needs longer at quit is a bug in the step.
+const TASK_TIMEOUT_MS = 5_000;
+
+// The absolute ceiling between the quit request and process exit, cleanup
+// finished or not. Liveness outranks tidiness: pressing quit must always
+// quit.
+const QUIT_WATCHDOG_MS = 15_000;
+
+async function bounded(task: CleanupTask): Promise<void> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      Promise.resolve(task()),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () =>
+            reject(
+              new GwError("quit_task_timeout", "quit cleanup task timed out"),
+            ),
+          TASK_TIMEOUT_MS,
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
 
 const cleanups: CleanupTask[] = [];
 let quitting = false;
@@ -41,7 +74,7 @@ export async function runQuitCleanup(): Promise<void> {
   cleanups.length = 0;
   for (const task of tasks) {
     try {
-      await task();
+      await bounded(task);
     } catch (err) {
       logEvent({ k: "quit.cleanupFailed", code: errorCode(err) });
       // The prose stays on the developer console, which is not exported.
@@ -62,7 +95,13 @@ export function wireLifecycle(): void {
     if (quitting) return;
     logEvent({ k: "app.beforeQuit" });
     event.preventDefault();
-    void runQuitCleanup().finally(() => app.exit(0));
+    // preventDefault above makes app.exit the only way this process ends, so
+    // it must not depend on cleanup settling: the watchdog exits regardless.
+    const watchdog = setTimeout(() => app.exit(0), QUIT_WATCHDOG_MS);
+    void runQuitCleanup().finally(() => {
+      clearTimeout(watchdog);
+      app.exit(0);
+    });
   });
 
   app.on("window-all-closed", () => {

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -79,6 +79,9 @@ export const ERROR_CODES = [
   "net_offline",
   "not_ready",
   "proxy_path",
+  /** A quit-cleanup task exceeded its budget and the pass moved on without
+   * it. Named so a hang and a throw stay distinguishable in a capture. */
+  "quit_task_timeout",
   "range_required",
   "response_limit",
   "response_too_large",

--- a/tests/electron/app.spec.ts
+++ b/tests/electron/app.spec.ts
@@ -250,6 +250,53 @@ test.describe("Electron application", () => {
     }
   });
 
+  test("the app-menu Quit item exits cleanly", async () => {
+    // The Cmd+Q accelerator is this menu role; red-X coverage does not reach
+    // it. The role's app.quit() must end the process even though before-quit
+    // hands the exit to the bounded cleanup pass.
+    const env = launchEnv({ GW_OFFLINE_SHELL: "1", GW_BACKGROUND_LAUNCH: "1" });
+    const userData = await mkdtemp(
+      path.join(tmpdir(), "gw-electron-menu-quit-e2e-"),
+    );
+    const app = await launch(userData, env);
+    try {
+      const page = await app.firstWindow({ timeout: 30_000 });
+      await page.waitForLoadState("domcontentloaded");
+      const electronProcess = app.process();
+      const exited = new Promise<ProcessExit>((resolve) => {
+        electronProcess.once("exit", (code, signal) => resolve({ code, signal }));
+      });
+      // The Cmd+Q accelerator is the stock role, which macOS drives through
+      // the native terminate: selector — unreachable from a programmatic
+      // click. Assert the item exists, then request quit the way the
+      // selector does: app.quit(), the entry the bounded cleanup pass owns.
+      const hasQuitItem = await app.evaluate(({ Menu }) =>
+        (Menu.getApplicationMenu()?.items ?? []).some((top) =>
+          (top.submenu?.items ?? []).some((item) => item.role === "quit"),
+        ),
+      );
+      expect(hasQuitItem).toBe(true);
+      await app.evaluate(({ app: electronApp }) => {
+        electronApp.quit();
+      }).catch(() => undefined);
+      expect(await exited).toEqual({ code: 0, signal: null });
+
+      const diagnosticsDir = path.join(userData, "diagnostics");
+      const sessionFiles = (await readdir(diagnosticsDir))
+        .filter((name) => name.endsWith(".jsonl"))
+        .map((name) => path.join(diagnosticsDir, name));
+      const events = (
+        await Promise.all(sessionFiles.map((file) => readFile(file, "utf8")))
+      ).join("\n");
+      expect(events).toContain('"name":"app.beforeQuit"');
+      expect(events).toContain('"name":"quit.cleanupCompleted"');
+      expect(events).not.toContain('"name":"quit.cleanupFailed"');
+    } finally {
+      await app.close().catch(() => undefined);
+      await rm(userData, { recursive: true, force: true });
+    }
+  });
+
   test("restores fullscreen and normal bounds, then resets safely", async () => {
     // No GW_BACKGROUND_LAUNCH: setFullScreen is unreliable on a non-key window.
     const env = launchEnv({ GW_OFFLINE_SHELL: "1" });


### PR DESCRIPTION
Stack #95, PR 1 of 2 · base: `main` · next: #92

Fixes the "Cmd-Q to quit doesn't work" report.

## What this ships to users

Quit always quits. Choosing Quit — from the menu or ⌘Q — ends the app even when a cleanup step hangs.

## Why it was broken

`before-quit` cancels the default quit and hands the only exit to `runQuitCleanup`, whose tasks await promises with no deadline of their own: a Steam sign-in sheet that quit itself would have closed, an in-flight client update, an unbounded secret drain. One hung task left the app alive with the quit apparently ignored — no error, no exit. A reporter's capture shows that shape directly (`quit.rendererSyncIncomplete` immediately before a `wasm.abort`), and the same session's crash is the kind of event that leaves a cleanup step waiting.

## What changed

`src/main/lifecycle.ts`:
- each cleanup task gets a 5-second budget; a hang is recorded as the new `quit_task_timeout` code and stepped over — the same contract the pass already kept for throws;
- a 15-second watchdog calls `app.exit(0)` regardless. Liveness outranks tidiness.

## What deliberately did not change

- **The ⌘Q opt-in setting was tried and dropped.** Unbinding ⌘Q means replacing the stock quit role with a custom item, and macOS routes ⌘Q to the standard terminate item — so the custom item is shadowed and the key silently does nothing. Field testing confirmed it, and there is no way to verify the native key path automatically (Playwright cannot send menu key equivalents). ⌘Q keeps the stock role and behaves like every other Mac app. If accidental quits become a real complaint, the reliable shape is a confirmation while a game connection is open, not a rebinding.
- The unbounded awaits stay as they are; bounding them at the source is the follow-up below. This PR makes them non-fatal to the quit, which is the user-visible bug.
- Every quit entry point (menu, ⌘Q, red X, in-app request, clean WASM exit) converges on the same bounded pass.

## Review focus

- `TASK_TIMEOUT_MS` = 5 s (matches the renderer-command budget) and `QUIT_WATCHDOG_MS` = 15 s. The watchdog only matters if a task both hangs *and* its own timeout somehow does not fire.
- The new spec drives `app.quit()` rather than a menu click: the stock role's key equivalent is a native path, and asserting the item exists plus the quit behaviour is what can honestly be automated.

## Verification

- New Electron spec covering the app-menu quit path, which had zero coverage — the existing red-X spec never reached it.
- Full suite: 108 Electron passed / 1 pre-existing skip, 750 unit, 156 policy; `typecheck`, `lint`, `check:links` clean.

## Known follow-ups

- Bound the individual hangs at their source: destroy an open Steam sign-in window at the start of cleanup, and give `steam.settled()` its own deadline, so `drainSecrets` cannot wait on a window quit would have closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
