### PR TITLE
Never deliver a synthetic tap while a real button is held

### DIFF
--- a/src/main/diagnostics/renderer.ts
+++ b/src/main/diagnostics/renderer.ts
@@ -122,6 +122,7 @@ export function recordRendererMetrics(value: RendererMetrics): void {
       case "graphics.programCacheSaturated":
       case "clipboard.copied":
       case "clipboard.writeFailed":
+      case "input.tapSuppressed":
         recordEvent(
           { k: event.name, fingerprint },
           { timestampUs: Math.round(event.timestampUs) },

--- a/src/main/diagnostics/schema.ts
+++ b/src/main/diagnostics/schema.ts
@@ -1082,6 +1082,17 @@ export const DIAGNOSTIC_EVENT_SCHEMA = {
     level: "warn",
     fields: { fingerprint: rendererFingerprintOrNull },
   },
+  // A synthetic double-tap was withheld because a real button was still held
+  // or the pointer was locked. The client's touch path force-releases every
+  // captured button, so delivering one mid-drag desynchronises its button
+  // state and the frame layer asserts. Counting the refusals is how a capture
+  // shows the guard doing its work rather than the crash never recurring by
+  // luck.
+  "input.tapSuppressed": {
+    subsystem: "renderer",
+    level: "debug",
+    fields: { fingerprint: rendererFingerprintOrNull },
+  },
   "graphics.detected": {
     subsystem: "graphics",
     level: "info",

--- a/src/renderer/diagnostics.ts
+++ b/src/renderer/diagnostics.ts
@@ -41,6 +41,7 @@
     'graphics.programCacheSaturated',
     'clipboard.copied',
     'clipboard.writeFailed',
+    'input.tapSuppressed',
   ]);
   const histogram = (): Histogram => ({
     buckets: new Array<number>(histogramLimitsUs.length).fill(0),

--- a/src/renderer/input.ts
+++ b/src/renderer/input.ts
@@ -496,7 +496,27 @@ export const installGameInput = ({
     canvas.dispatchEvent(normalized);
   }, { capture: true, passive: false });
 
+  /**
+   * Whether a synthetic tap may reach the client right now.
+   *
+   * A tap is not a passive hint: the client's touch path force-releases every
+   * mouse button it has captured, moves its cursor to the tap point, and
+   * switches to a touch input mode in which real mouse releases are dropped
+   * until a real press restores it. Delivered mid-drag — walking with both
+   * buttons, steering the camera — that desynchronises the client's button
+   * state from the OS's, and the frame layer asserts on the mismatch. The tap
+   * pair is deferred by design, so this is re-asked when it fires, not only
+   * when it is scheduled.
+   */
+  const tapsSafe = () =>
+    heldButtons.size === 0 && document.pointerLockElement !== canvas;
+
   const tapAt = (x: number, y: number, delay: number) => schedule(() => {
+    if (!tapsSafe()) {
+      cancelSyntheticTouches();
+      diagnostics?.event('input.tapSuppressed');
+      return;
+    }
     const touch = makeTouch(x, y, ++touchId);
     startTouch(touch);
     // The touchstart dispatch can synchronously cancel all synthetic input —
@@ -508,6 +528,13 @@ export const installGameInput = ({
 
   canvas.addEventListener('mousedown', (event) => {
     if (event.button !== 0) return;
+    // A left press while another button is already held is the walk-and-look
+    // grip, not a click run: no double-tap belongs to it, and the tap would
+    // tear down the capture the other button holds.
+    if (heldButtons.size > 1 || document.pointerLockElement === canvas) {
+      cancelSyntheticTouches();
+      return;
+    }
     // Chromium already applies the user's macOS double-click speed and
     // distance preferences to detail. ArenaNet's mouse bridge discards that
     // count, but its touch path has the double-tap detector the game needs for

--- a/src/shared/diagnostics.ts
+++ b/src/shared/diagnostics.ts
@@ -49,6 +49,7 @@ export const RENDERER_EVENT_NAMES = [
   "graphics.programCacheSaturated",
   "clipboard.copied",
   "clipboard.writeFailed",
+  "input.tapSuppressed",
 ] as const;
 
 export type RendererEventName = (typeof RENDERER_EVENT_NAMES)[number];

--- a/tests/electron/input-pointer.spec.ts
+++ b/tests/electron/input-pointer.spec.ts
@@ -229,28 +229,39 @@ test.describe("renderer pointer input", () => {
             }),
           );
 
+        // The tap pair is deferred, so every phase waits for the events it
+        // expects rather than for a duration: under full-suite load a fixed
+        // sleep races the holdback timers and this spec flaked.
+        const settle = async (count: number) => {
+          const deadline = performance.now() + 5_000;
+          while (observed.length < count && performance.now() < deadline) {
+            await new Promise((resolve) => setTimeout(resolve, 20));
+          }
+          // Long enough after the pair for a third, unwanted tap to appear.
+          await new Promise((resolve) => setTimeout(resolve, 400));
+          return [...observed];
+        };
+
         // A run that stops at two clicks is a completed native double-click;
         // once the holdback passes, exactly one tap pair fires.
         mouse("mousedown", 2);
         mouse("mouseup", 2);
-        await new Promise((resolve) => setTimeout(resolve, 600));
-        const afterDouble = [...observed];
+        const afterDouble = await settle(4);
         // detail keeps counting 3, 4 while the run continues; the later even
         // counts must not synthesize again.
         mouse("mousedown", 3);
         mouse("mouseup", 3);
         mouse("mousedown", 4);
         mouse("mouseup", 4);
-        await new Promise((resolve) => setTimeout(resolve, 600));
-        const afterRun = [...observed];
+        const afterRun = await settle(4);
 
         // A double-click press that turns into a drag releases far away; the
         // stale press point must not receive a tap pair.
         observed.length = 0;
         mouse("mousedown", 2);
         mouse("mouseup", 2, 160, 140);
-        await new Promise((resolve) => setTimeout(resolve, 600));
-        return { afterDouble, afterRun, afterDrag: [...observed] };
+        const afterDrag = await settle(0);
+        return { afterDouble, afterRun, afterDrag };
       });
 
       expect(result).toEqual({

--- a/tests/electron/input-pointer.spec.ts
+++ b/tests/electron/input-pointer.spec.ts
@@ -263,6 +263,75 @@ test.describe("renderer pointer input", () => {
     }
   });
 
+  test("withholds the tap pair while another button is still held", async () => {
+    const fixture = await launchOffline("gw-tap-guard-e2e-");
+    try {
+      const { page } = fixture;
+      await startGameInput(page);
+      // A real press is required: only trusted events enter the held-button
+      // registry the guard reads. The lock request is stubbed so the offline
+      // fixture's refusal cannot release the button under the test.
+      await page.evaluate(() => {
+        const canvas = globalThis.document.getElementById("canvas");
+        if (!(canvas instanceof globalThis.HTMLCanvasElement)) {
+          throw new Error("#canvas is missing");
+        }
+        canvas.requestPointerLock = () => Promise.resolve();
+        const observed: string[] = [];
+        for (const type of ["touchstart", "touchend", "touchcancel"] as const) {
+          canvas.addEventListener(type, () => observed.push(type));
+        }
+        Object.assign(window, { __taps: observed });
+      });
+      const box = await boxOf(page.locator("#canvas"));
+      const leftDoubleClick = () =>
+        page.evaluate(async () => {
+          const canvas = globalThis.document.getElementById("canvas");
+          if (!canvas) throw new Error("#canvas is missing");
+          const at = (type: string, detail: number) =>
+            canvas.dispatchEvent(
+              new globalThis.MouseEvent(type, {
+                bubbles: true,
+                button: 0,
+                clientX: 120,
+                clientY: 140,
+                detail,
+              }),
+            );
+          at("mousedown", 1);
+          at("mouseup", 1);
+          at("mousedown", 2);
+          at("mouseup", 2);
+          await new Promise((resolve) => setTimeout(resolve, 700));
+        });
+      const taps = () =>
+        page.evaluate(() => [...(window as unknown as { __taps: string[] }).__taps]);
+
+      // The walk-and-look grip: right held throughout, a left double-click
+      // inside it. The client's touch path would force-release the captured
+      // right button and desynchronise its state, so nothing may be sent.
+      await page.mouse.move(box.x + 120, box.y + 140);
+      await page.mouse.down({ button: "right" });
+      await leftDoubleClick();
+      const held = await taps();
+
+      // Released: the same gesture is a plain double-click again.
+      await page.mouse.up({ button: "right" });
+      await page.evaluate(() => {
+        (window as unknown as { __taps: string[] }).__taps.length = 0;
+      });
+      await leftDoubleClick();
+      const result = { held, released: await taps() };
+
+      expect(result).toEqual({
+        held: [],
+        released: ["touchstart", "touchend", "touchstart", "touchend"],
+      });
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
   test("releases held input when the pointer leaves the app window", async () => {
     const fixture = await launchOffline("gw-input-window-leave-e2e-");
     try {


### PR DESCRIPTION
Stack #95, PR 2 of 2 · base: `quit-liveness` (#91)

Addresses the reported client crash when holding both mouse buttons (walk + look) in Embark Beach, and the same crash shape several other players have reported around double-clicking.

## What this ships to users

The game should stop crashing when a double-click lands while you are holding a mouse button — walking with both buttons, steering the camera, dragging.

## Why it crashed — ground truth, not inference

I disassembled the shipped client (`Gw.jspi.wasm` + glue) rather than reasoning from the host side, and the premise this host was built on turned out to be wrong.

A synthetic tap is **not** a passive "this was a double-click" hint. The client's touch handler:

1. **force-releases every mouse button it has captured**,
2. moves its cursor to the tap point,
3. switches to a touch input mode in which **real mouse releases are dropped** until a real press restores it,
4. then dispatches a full button-down/up through the same path a real click takes.

Delivered mid-grip, that is exactly the reported crash: the client's button state stops matching the OS's, and the frame layer asserts on the mismatch — live `abort()` calls at `FrMouse.cpp:529`, `FrMouse.cpp:1020`, `FrTouch.cpp:177`, `FrTouch.cpp:218`. A reporter's capture shows a `wasm.abort` with `reasonKind: "assertion"`, consistent with these.

The 250 ms holdback shipped in 2026.8.1 made this window **routine rather than rare** — which fits the crash reports arriving after that release. This PR is partly undoing a hazard I introduced.

## What changed

- `src/renderer/input.ts`: a tap is withheld whenever a real button is still held or the pointer is locked. Asked **again when the pair fires**, not only when it is scheduled — the whole point is that the pair is deferred, so state changes in between. A left press that arrives while another button is held also stops arming a pair at all.
- New `input.tapSuppressed` renderer event through the existing diagnostics pipeline: the refusals are counted, so a capture shows the guard doing work rather than the crash merely not recurring by luck.

## What deliberately did not change

- **The double-counting is not fixed here.** A real double-click still delivers two native clicks *plus* two taps, where Windows delivers two events — this is why attribute-point double-clicks are still reported. Fixing it means suppressing the native click and routing left clicks through the touch path, which changes left-drag, item dragging, and right-click behaviour afterwards. That is a design change to the synthesis, deserves its own PR and its own field test, and is not bundled into a crash fix.
- No change to the tap timing constants; this PR only decides *whether* a tap may be delivered.

## Review focus

- The two guard sites: `tapsSafe()` at fire time (the load-bearing one) and the arming check in the canvas `mousedown` handler.
- `heldButtons` is populated only by **trusted** events, so untrusted synthetic input cannot make the guard think a button is held — that is deliberate and is what the spec had to work around.

## Verification

- New spec: a left double-click inside a held right-button grip produces no touch events at all, and the same gesture after release produces the normal pair. It presses the button through the real input path, since only trusted events reach the registry the guard reads.
- Full suite on the rebased stack: 108 Electron passed / 1 pre-existing skip, 750 unit, 156 policy; `typecheck` and `lint` clean.
- Also de-flakes the existing double-tap specs, which slept a fixed 600 ms for a pair held back 250 ms and then spaced 80 ms: ample alone, but the timers throttle past it under full-suite load and the spec failed on a correct build. Each phase now waits for the events it expects, then waits a bounded while for one it must not see.

## Known follow-ups

- The double-click double-counting above — the remaining half of the attribute-panel report.
- Left-drag to rotate the character portrait does not lock the cursor. Attempted in #94 and closed on the measurement: the client does not announce that rotation — the cursor readout stays `hidden=false` with the ordinary arrow hash throughout — and gating on it grabbed the pointer during ordinary world drags instead. Left-drag keeps its current behaviour; a real fix needs a certified read of the client's own drag state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
