### PR TITLE
Serve the website download buttons already pointing at the DMG

### DIFF
--- a/apps/website/app/pages/index.vue
+++ b/apps/website/app/pages/index.vue
@@ -21,13 +21,16 @@ const { locale } = useI18n();
 type Localized = string | { en: string; de?: string };
 const localize = (value: Localized) => getLocalizedSiteText(value, locale.value);
 
-const RELEASES_URL = "https://github.com/Mat4m0/gwonmac/releases/latest";
+// The buttons link to /download, the site's live redirect to the newest DMG, so
+// the prerendered HTML carries the right target from the first paint. Resolving
+// the DMG in the browser instead raced hydration: a third of clicks landed on
+// the releases page because the fetch had not answered yet.
+const DOWNLOAD_PATH = "/download";
 // /api/latest resolves the newest downloadable release from GitHub (cached
 // server-side, beta channel during the launch phase). Fetched in the browser so
-// the prerendered page never bakes in a stale version; until it answers, the
-// buttons link to the releases page.
+// the prerendered page never bakes in a stale version; it only names the
+// version in the fine print and the click event, so a late answer costs nothing.
 const { data: latestRelease } = useFetch<LatestRelease>("/api/latest", { server: false });
-const downloadUrl = computed(() => latestRelease.value?.url ?? RELEASES_URL);
 
 const { trackDownload, trackFaqOpen } = useTracking();
 
@@ -442,7 +445,7 @@ useSchemaJsonLd(() => [
         </p>
         <div class="mt-8 flex flex-wrap items-center justify-center gap-3">
           <NuxtLink
-            :to="downloadUrl"
+            :to="DOWNLOAD_PATH"
             target="_blank"
             rel="noopener noreferrer"
             class="gw-btn-primary"
@@ -622,7 +625,7 @@ useSchemaJsonLd(() => [
         <div class="gw-rule mt-6 w-[min(360px,80%)] text-xs">◆</div>
         <div class="mt-7 flex flex-wrap items-center justify-center gap-3">
           <NuxtLink
-            :to="downloadUrl"
+            :to="DOWNLOAD_PATH"
             target="_blank"
             rel="noopener noreferrer"
             class="gw-btn-primary"

--- a/tests/website-smoke.ts
+++ b/tests/website-smoke.ts
@@ -213,13 +213,13 @@ async function load(pathname: string): Promise<Response> {
   throw new Error(`website server did not start:\n${stderr}`);
 }
 
-// The release lookup is a client-side effect, so the offline fallback is what
-// every visitor is served first and what a visitor without JavaScript keeps.
-// Every rendered download button must already be a working link.
+// Every rendered download button points at /download, the live redirect, in the
+// HTML itself. Resolving the DMG in the browser instead left the buttons on the
+// releases page until hydration finished, and a third of clicks arrived first.
 const downloadLinks = (page: string) =>
   [
     ...page.matchAll(
-      /<a href="(https:\/\/github\.com\/[^"]+)"[^>]*>(?:(?!<\/a>)[\s\S])*?(?:Direct|Direkter) Download/g,
+      /<a href="([^"]+)"[^>]*>(?:(?!<\/a>)[\s\S])*?(?:Direct|Direkter) Download/g,
     ),
   ].map((match) => match[1]);
 
@@ -237,10 +237,11 @@ try {
   // Hero and final CTA.
   assert.equal(downloadLinks(html).length, 2);
   for (const href of downloadLinks(html)) {
-    assert.equal(href, `${EXTERNAL_URLS.releases}/latest`);
+    assert.equal(href, "/download");
   }
 
-  // The German landing page carries the same analytics and fallback buttons.
+  // The German landing page carries the same analytics and buttons; a
+  // locale-prefixed link would be answered by the /de/download alias below.
   const germanHome = await load("/de");
   assert.equal(germanHome.status, 200);
   const germanHtml = await germanHome.text();
@@ -250,6 +251,9 @@ try {
     /https:\/\/plausible\.io\/js\/pa--X4qMlLVyMnUW4L8emwE_\.js/,
   );
   assert.equal(downloadLinks(germanHtml).length, 2);
+  for (const href of downloadLinks(germanHtml)) {
+    assert.match(href, /^\/(de\/)?download$/);
+  }
 
   // The install guide replaced the old /install page and still hands the
   // visitor the releases page.
@@ -272,6 +276,12 @@ try {
     download.headers.get("location") ?? "",
     new RegExp(`^${EXTERNAL_URLS.releases}/`),
   );
+  // The alias the layer's locale-prefixed links land on.
+  const germanDownload = await globalThis.fetch(`http://${host}:${port}/de/download`, {
+    redirect: "manual",
+  });
+  assert.equal(germanDownload.status, 302);
+  assert.equal(germanDownload.headers.get("location"), "/download");
 
   // The API route answers with the policy above whatever GitHub does: a direct
   // DMG when one is eligible, the releases page otherwise — always this repo.

--- a/tests/website-smoke.ts
+++ b/tests/website-smoke.ts
@@ -221,7 +221,7 @@ const downloadLinks = (page: string) =>
     ...page.matchAll(
       /<a href="([^"]+)"[^>]*>(?:(?!<\/a>)[\s\S])*?(?:Direct|Direkter) Download/g,
     ),
-  ].map((match) => match[1]);
+  ].map((match) => match[1] ?? assert.fail("download link without href"));
 
 try {
   const home = await load("/");


### PR DESCRIPTION
Single PR · base: `main`

Plausible shows a third of download clicks landing on the GitHub releases page instead of a DMG: 15 visitors on `releases/latest` against 27 across the direct download links. Nobody chose that — it is the button's pre-hydration state.

## What this ships to users

Clicking **Direct Download** starts the download. Before, clicking it in the first second or two — or with JavaScript blocked — dropped you on the GitHub releases page to find the right `.dmg` among the checksums, SBOMs, and updater ZIPs yourself.

## Why a third of clicks missed

The homepage is prerendered, and it resolved the newest DMG in the browser:

```ts
const { data: latestRelease } = useFetch<LatestRelease>("/api/latest", { server: false });
const downloadUrl = computed(() => latestRelease.value?.url ?? RELEASES_URL);
```

So the HTML shipped with `href=".../releases/latest"`, and the real target only appeared after the JS downloaded, Vue hydrated, and `/api/latest` answered — on a cold server cache that includes a GitHub round-trip. On a phone that window is seconds, not milliseconds, and it opens on the page's single most important control. Anyone clicking inside it, or running without JavaScript, kept the fallback.

The `server: false` was deliberate and its reason still holds: an SSR fetch would bake one build-time answer into a prerendered page and go stale on the next release. The mistake was letting the *button target* depend on that fetch at all.

## What changed

- `apps/website/app/pages/index.vue` — the hero and final-CTA buttons link to `/download`. `RELEASES_URL` and the `downloadUrl` computed are gone. The `useFetch` stays, now feeding only the version in the fine print and the `version` prop on the click event.
- `tests/website-smoke.ts` — the test asserted the old contract (`every rendered button === releases/latest`), so it moves with it: `/download` on the English page, `/download` or a locale-prefixed variant on the German one, plus a new check that the `/de/download` alias redirects.

No new route, no config change. `/download` already existed as the site's live redirect and already serves the install guide's link — this makes it the site's one download link rather than its second one.

## What deliberately did not change

- **The homepage stays prerendered.** The alternative fix was SSR plus an ISR rule on `/`, which keeps the GitHub URL in the HTML and so keeps these clicks in Plausible's outbound-links report. It also gives up the static homepage and, during a GitHub outage, bakes the fallback into cached HTML for the full window. Not worth it for an analytics view that a custom event already covers.
- **`/api/latest` and the selection policy are untouched.** Which release is newest was never the problem.
- The install guide and its German counterpart already pointed at `/download` and are unchanged.

## Review focus

- **Analytics needs a change on the Plausible side before this ships.** These clicks are same-origin now, so they leave the *Outbound Links* report, and a 302 fires no pageview — `/download` will not appear there either. The `Download Clicked` custom event already carries `source` and `version` and becomes the funnel metric; it wants a goal configured, or downloads will read as zero. Useful side effect: `version: "unknown"` on that event now means "clicked before the version fetch answered", which counts precisely the population this PR rescues.
- `target="_blank"` is kept on both buttons, unchanged from before. The redirect ends at a `Content-Disposition: attachment` asset, so the opened tab closes itself.
- German renders `/download` unprefixed today, so the `/de/download` alias is not load-bearing for the homepage. The test allows either form rather than pinning behaviour that belongs to the docs layer.

## Verification

- `pnpm test:website` (website typecheck + build + smoke) green.
- Grepped the built output directly rather than trusting the assertions: `href="/download"` appears twice in both `.output/public/index.html` and `.output/public/de/index.html`, and `releases/latest` no longer appears in either.
- `pnpm lint` clean; `pnpm test:policy` 156 passed.
- Not run: the Electron and unit suites — nothing outside `apps/website` and its smoke test is touched.

## Known follow-ups

- None planned. If the per-version breakdown is missed once this lands, it belongs in the `Download Clicked` event props, not in a second link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
