### PR TITLE
Watch the WASM heap and warn before the 2 GiB cap kills the client

### DIFF
--- a/internal/upstream/README.md
+++ b/internal/upstream/README.md
@@ -27,6 +27,7 @@ hash, that routes the broken routines back into the host.
 | [host-bridge.md](host-bridge.md) | us | What we actually ship: the transform, the five markers, the bridge contract, and the invariants that must hold. |
 | [recertify.md](recertify.md) | us | The procedure when ArenaNet publishes a new client. Every index and offset below is build-specific. |
 | [investigation-log.md](investigation-log.md) | us | The chronology, including every wrong turn and what corrected it. Read this before re-deriving anything. |
+| [memory-exhaustion-log.md](memory-exhaustion-log.md) | us | Open: long-session `wasm.abort`s with the heap pegged at the client's compiled-in 2 GiB cap. The heap-staircase instrumentation and what the next crash bundle must answer. |
 | [investigation-template.md](investigation-template.md) | us | The shape a round takes — hypothesis, what was built, the measurement that killed it, the lesson. Copy it to start the next log. |
 
 ## The build this describes

--- a/internal/upstream/memory-exhaustion-log.md
+++ b/internal/upstream/memory-exhaustion-log.md
@@ -1,0 +1,123 @@
+# Investigation log — long-session WASM aborts (memory exhaustion)
+
+Two players, same evening (2026-08-03), both on app 2026.8.3 / client build
+38797, both M1 Pro 16 GB: `wasm.abort` hours into play. Open — the
+instrumentation that decides the remaining question shipped in this round, and
+the answer arrives with the next crash bundle. Kept in the
+[investigation-template.md](investigation-template.md) shape; read
+[investigation-log.md](investigation-log.md) first for the conventions.
+
+## Round 0 — the reported crashes
+
+| Session | Machine | Length at abort | reasonKind | Fingerprint | Peak heap backing |
+| --- | --- | --- | --- | --- | --- |
+| `5eb4a64e` | matthias | 3 h 18 m | `assertion` | `99d845da` | 2,147,483,648 |
+| `9ae56272` | romi | 2 h 23 m | `assertion` | `a860e578` | 2,147,483,648 |
+
+Both crashed within six minutes of each other (20:00:45 and 20:06:39 UTC)
+while playing together. Both bundles also show `socket.error {code: reset}` at
+identical wall-clock seconds (19:41:21, 19:54:58) on both machines — the
+resets are server-side and exonerate the host socket layer.
+
+## Round 1 — wrong: "the previous session did not crash"
+
+**Hypothesis.** The exported bundle's `previousSession` block
+(`abnormalReason: "webContents.destroyed"`, 0 errors) meant the player's
+history held one mid-session abort and nothing else; the earlier session was a
+clean user quit mislabelled by the clean-shutdown check.
+
+**Built.** A triage conclusion delivered to the player ("the previous session
+did not crash"), and a background task scoped to the cosmetic mislabel in
+`report.ts`.
+
+**Wrong because** the diagnostics directory on disk held **five** sessions,
+not the bundle's two. Read directly:
+
+```
+session-8dba412a  2026.8.2  1.7 min  wasm.abort  other  a6311932
+session-90067a67  2026.8.2  1.1 min  wasm.abort  other  a6311932
+session-5eb4a64e  2026.8.3  207 min  wasm.abort  assertion  99d845da
+```
+
+Two crashed sessions with an identical repeating fingerprint were invisible to
+the export: `report.ts` keeps only the single newest previous session
+(`groups → sort by newestMtime → [0]`). The player's "I was crashing, I was
+not quitting" was correct and the bundle was structurally unable to show it.
+
+**Kept anyway.** The clean-shutdown mislabel is real (`quit.cleanupCompleted`
+must be the *final* record, but a normal quit logs `webContents.destroyed`
+after it) — it is folded into the re-scoped export task rather than standing
+alone.
+
+**Lesson.** State what the instrument cannot see before concluding from its
+silence. A bundle that carries one previous session proves nothing about the
+sessions it dropped; the on-disk `session-*.jsonl` files are the record, and
+they cost one directory listing to check.
+
+## Round 2 — right: the heap is pegged at its own cap
+
+**Hypothesis.** `socket.rendererPeakSourceBackingBytes` = 2,147,483,648 —
+exactly 2^31 — is the WASM heap's `ArrayBuffer` at its build-time maximum, and
+the aborts are allocation failure downstream of memory exhaustion.
+
+**Measured.** The client's own glue, cached at
+`~/Library/Application Support/Guild Wars/game/artifacts/Gw.jspi.js`:
+
+```js
+var getHeapMax = () =>
+    // Stay one Wasm page short of 4GB: ...
+    2147483648;
+```
+
+The cap is compiled in. Both crashed machines recorded peak backing at that
+exact number. The build is assertions-enabled
+(`assert()` → `abort('Assertion failed: …')`), so `reasonKind: "assertion"` is
+trustworthy, and `Module.onAbort` receives the raw reason before Emscripten's
+`Aborted(...)` wrapping — the renderer's classifier sees clean text.
+
+Differing fingerprints across the two machines are consistent with
+exhaustion, not against it: at the cap, whichever allocation fails first trips
+its own assertion. Fingerprinting all 96 abort/assert string literals in the
+glue matched neither fingerprint, so the failing assertions carry
+variable/wasm-side text — the prose itself is still needed (round 3's overlay
+disclosure captures it at the next crash).
+
+**Lesson.** The cheapest decisive instrument was the client's own artifact on
+disk. Before designing renderer probes, read what the machine already has.
+
+## Round 3 — the instrumentation (shipped, 2026-08-03)
+
+What remains unknown is the growth *shape* — steady leak vs. per-zone
+accumulation vs. load-spike ratchet. Deliberately **not** built: dlmalloc heap
+walkers and a malloc/free wasm transform, because leak-vs-fragmentation has
+the same treatment either way (the fix is ArenaNet's; ours is evidence plus a
+survivable failure). Shipped instead:
+
+- `wasm.heapGrew {fromBytes, toBytes}` — heap growth is discrete and rare, so
+  every rise observed at the ~2 s metrics flush is an event (steps inside one
+  flush window coalesce; a run's first event rises from 0); read against the
+  `socket.open` map transitions already in the log, the staircase answers the
+  shape question per bundle.
+- `heapBytes` on `wasm.abort` / `wasm.exit`, plus
+  `renderer.wasmHeapBytes` / `renderer.peakWasmHeapBytes` gauges and a
+  summarize line against the 2048 MiB cap.
+- The crash overlay's "Technical details" disclosure: the abort prose plus
+  heap-at-death, renderer-local (the export still carries only reason kind and
+  fingerprint).
+- The heap watermark notice at 1.75 GiB / 1.875 GiB with a safe-place reload
+  (best-effort `FS.syncfs`, then the View → Reload Game reload), so the death
+  happens at a moment the player picks.
+
+## Open — what decides it
+
+1. Next crash bundle: the `wasm.heapGrew` staircase against `socket.open`
+   markers, `heapBytes` at the abort, and the player-read assertion text.
+2. Then the upstream report: heap-at-cap evidence from N machines, growth
+   shape, assertion text, and the one-flag ask — the glue's own comment says
+   the 2 GiB cap only exists to stay clear of 4 GB wraparound, and Emscripten
+   supports 4 GB wasm32 heaps (`-sMAXIMUM_MEMORY=4GB`).
+3. Separate defects surfaced along the way, not part of this issue:
+   the export hiding crashed sessions (task filed: crash history + fingerprint
+   rollup in the bundle), quit-time `filesystem.sync` failing on every
+   observed quit (no error code recorded yet), and quit-teardown aborts
+   (`a6311932`, 10 ms after `sockets.closeAll()`) being counted as crashes.

--- a/src/main/diagnostics/renderer.ts
+++ b/src/main/diagnostics/renderer.ts
@@ -26,6 +26,10 @@ import { asRendererFingerprint } from "./schema.js";
 let graphics: GraphicsDiagnostics | null = null;
 let rendererClockOffsetUs = 0;
 let rendererClockSynchronized = false;
+// The last WASM heap size a metrics flush reported. Wasm memory only grows
+// within one client run, so each increase is one step of the whole heap
+// staircase; a smaller value means a reloaded client and resets the baseline.
+let lastWasmHeapBytes = 0;
 
 /** The renderer's graphics description, as an export carries it. */
 export function graphicsSnapshot(): GraphicsDiagnostics | null {
@@ -103,6 +107,24 @@ export function recordRendererMetrics(value: RendererMetrics): void {
   recorder.count("socket.rendererCompactBytes", value.socketCompactBytes);
   recorder.count("socket.rendererSettles", value.socketSettles);
   recorder.count("diagnostics.rendererDropped", value.droppedRecords);
+  if (value.wasmHeapBytes > 0) {
+    recorder.setLatest("renderer.wasmHeapBytes", value.wasmHeapBytes);
+    recorder.setPeak("renderer.peakWasmHeapBytes", value.wasmHeapBytes);
+    // Growth is discrete and rare (the glue steps geometrically toward its
+    // cap), so every observed rise between flushes becomes one event — steps
+    // inside one flush window coalesce. Read with the socket.open map
+    // transitions around it, the sequence answers whether a session leaked
+    // steadily or stepped up on zone loads — the question a heap-cap abort
+    // asks. A decrease is a reloaded client, not a shrink: baseline only.
+    if (value.wasmHeapBytes > lastWasmHeapBytes) {
+      logEvent({
+        k: "wasm.heapGrew",
+        fromBytes: lastWasmHeapBytes,
+        toBytes: value.wasmHeapBytes,
+      });
+    }
+    lastWasmHeapBytes = value.wasmHeapBytes;
+  }
   for (const event of value.rendererEvents) {
     recorder.count(`renderer.event.${event.name}`);
     const fingerprint = event.fingerprint
@@ -251,6 +273,7 @@ export function recordRendererMilestone(
         clockSynchronized: rendererClockSynchronized,
         reasonKind: fields.reasonKind,
         fingerprint: asRendererFingerprint(fields.fingerprint),
+        heapBytes: fields.heapBytes,
       },
       { timestampUs },
     );
@@ -264,6 +287,7 @@ export function recordRendererMilestone(
         k: "wasm.exit",
         clockSynchronized: rendererClockSynchronized,
         code: fields.code,
+        heapBytes: fields.heapBytes,
       },
       { timestampUs },
     );

--- a/src/main/diagnostics/schema.ts
+++ b/src/main/diagnostics/schema.ts
@@ -1227,6 +1227,9 @@ export const DIAGNOSTIC_EVENT_SCHEMA = {
   // in the renderer into a closed reason kind plus a non-text fingerprint, so
   // the export can name the failing native operation class without carrying
   // prose; a non-zero exit carries only the client's own numeric code.
+  // `heapBytes` is the WASM linear memory at death: the glue caps it at
+  // 2 GiB, so a crash recorded at the cap is memory exhaustion whatever
+  // prose the abort carried.
   "wasm.abort": {
     subsystem: "renderer",
     level: "error",
@@ -1234,12 +1237,24 @@ export const DIAGNOSTIC_EVENT_SCHEMA = {
       clockSynchronized: boolean,
       reasonKind: literal(WASM_ABORT_REASON_KINDS),
       fingerprint: isRendererFingerprint,
+      heapBytes: finiteNumber,
     },
   },
   "wasm.exit": {
     subsystem: "renderer",
     level: "error",
-    fields: { clockSynchronized: boolean, code: finiteNumber },
+    fields: { clockSynchronized: boolean, code: finiteNumber, heapBytes: finiteNumber },
+  },
+  // The heap staircase, sampled: the renderer reports heap size with each
+  // metrics flush (~2 s) and every observed rise becomes one event, so
+  // near-simultaneous growth steps can coalesce and a run's first event
+  // rises from 0. Read with the socket.open map transitions around it, the
+  // sequence answers whether a session leaked steadily or stepped up on
+  // zone loads — the question every heap-cap abort asks.
+  "wasm.heapGrew": {
+    subsystem: "renderer",
+    level: "info",
+    fields: { fromBytes: finiteNumber, toBytes: finiteNumber },
   },
   // The renderer's Enhancement installation lifecycle. `clientPrepared` above
   // says a transformed module was served; only these say whether the hook was

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -362,6 +362,10 @@ interface ParsedMilestone {
   fields: RendererMilestoneFields | undefined;
 }
 
+/** A byte count as the renderer reports one: a non-negative safe integer. */
+const isByteCount = (value: unknown): value is number =>
+  typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+
 const asMilestone: Parser<ParsedMilestone> = (args) => {
   exact(args, 3);
   const [name, rendererTimestampUs, fields] = args;
@@ -401,23 +405,29 @@ const asMilestone: Parser<ParsedMilestone> = (args) => {
   } else if (name === "wasm.abort") {
     const valid =
       recordIsObject
-      && Object.keys(record).length === 2
+      && Object.keys(record).length === 3
       && typeof record.reasonKind === "string"
       && (WASM_ABORT_REASON_KINDS as readonly string[]).includes(record.reasonKind)
-      && isRendererFingerprint(record.fingerprint);
+      && isRendererFingerprint(record.fingerprint)
+      && isByteCount(record.heapBytes);
     if (!valid) throw new ValidationError("invalid renderer milestone");
     milestoneFields = {
       reasonKind: record.reasonKind as WasmAbortReasonKind,
       fingerprint: record.fingerprint as string,
+      heapBytes: record.heapBytes as number,
     };
   } else if (name === "wasm.exit") {
     const valid =
       recordIsObject
-      && Object.keys(record).length === 1
+      && Object.keys(record).length === 2
       && typeof record.code === "number"
-      && Number.isSafeInteger(record.code);
+      && Number.isSafeInteger(record.code)
+      && isByteCount(record.heapBytes);
     if (!valid) throw new ValidationError("invalid renderer milestone");
-    milestoneFields = { code: record.code as number };
+    milestoneFields = {
+      code: record.code as number,
+      heapBytes: record.heapBytes as number,
+    };
   } else if (name === "enhancement.installed") {
     const valid =
       recordIsObject

--- a/src/renderer/diagnostics.ts
+++ b/src/renderer/diagnostics.ts
@@ -108,6 +108,7 @@
     socketSettles: 0,
     inputToSubmitCount: 0,
     droppedRecords: 0,
+    wasmHeapBytes: 0,
     rendererEvents: [],
     raf: histogram(),
     swap: histogram(),
@@ -246,6 +247,7 @@
     batch.intervalMs = now - periodStarted;
     batch.visible = !document.hidden;
     batch.focused = document.hasFocus();
+    batch.wasmHeapBytes = window.gwWasmHeapBytes?.() ?? 0;
     periodStarted = now;
     flushing = true;
     try {

--- a/src/renderer/failure-messages.ts
+++ b/src/renderer/failure-messages.ts
@@ -183,6 +183,44 @@ export interface ClientCrashPresentation {
 const CRASH_RETRY = 'Retry';
 const CRASH_REPORT = 'Report a Problem…';
 
+export interface MemoryPressurePresentation {
+  label: string;
+  detail: string;
+  reloadButton: string;
+  dismissButton: string;
+}
+
+/**
+ * The game client's WASM heap is approaching its hard 2 GiB cap; once it gets
+ * there the next big allocation kills the client wherever the player happens
+ * to be standing. These sentences exist so the player spends that death at a
+ * moment of their choosing: reloading from a town or outpost is a quick relog
+ * that loses nothing, while an uncontrolled crash mid-mission loses the run.
+ */
+const MEMORY_RELOAD = 'Reload Now';
+const MEMORY_DISMISS = 'Later';
+
+export function memoryPressurePresentation(
+  level: 'low' | 'critical',
+): MemoryPressurePresentation {
+  const critical = level === 'critical';
+  return {
+    label: critical
+      ? 'Guild Wars is almost out of memory.'
+      : 'Guild Wars is running low on memory.',
+    detail: critical
+      ? 'A crash is likely soon. Head to a town or outpost at the next '
+        + 'safe moment and choose Reload Now — that is a quick relog, and '
+        + 'from an outpost you lose nothing.'
+      : 'After long sessions the game can crash when memory runs out. To '
+        + 'pick the moment yourself, finish what you are doing, return to a '
+        + 'town or outpost, and choose Reload Now — it works like a quick '
+        + 'relog.',
+    reloadButton: MEMORY_RELOAD,
+    dismissButton: MEMORY_DISMISS,
+  };
+}
+
 export function clientCrashPresentation(
   crashCount: number,
 ): ClientCrashPresentation {

--- a/src/renderer/gw-native.d.ts
+++ b/src/renderer/gw-native.d.ts
@@ -48,8 +48,14 @@ declare global {
     set(message: string, fraction: number | null, detail?: string): void;
     fail(message: string, detail?: string): void;
     failFilesystem(): void;
-    /** The running game client crashed; count is per app run. */
-    failCrash(crashCount: number): void;
+    /**
+     * The running game client crashed; count is per app run. `technicalDetail`
+     * is the abort's own prose plus heap size — it renders behind a disclosure
+     * on the overlay and never leaves the renderer; an omitted value keeps the
+     * text a previous call supplied, so the repeat-crash copy upgrade cannot
+     * erase it.
+     */
+    failCrash(crashCount: number, technicalDetail?: string): void;
     done(): void;
     waitForClient(): Promise<boolean>;
   }
@@ -191,6 +197,8 @@ declare global {
     gwLoading: LoadingController;
     gwDiagnostics: RendererDiagnostics;
     gwSnapshotState?(): Partial<RendererMetrics>;
+    /** Current WASM linear-memory size; present once the client is hosted. */
+    gwWasmHeapBytes?(): number;
     gwResolveDataStrategy(snapshotBytes: number): Promise<void>;
     gwLog(visible?: boolean): boolean;
     gwEvictMemory(): number;

--- a/src/renderer/harness.css
+++ b/src/renderer/harness.css
@@ -49,6 +49,53 @@ html,body { width:100%; height:100%; margin:0; overflow:hidden;
 }
 #capture-status[hidden] { display: none; }
 
+/* The heap watermark notice. Top-centred over the running game; amber while
+   there is headroom, red once the next growth step would hit the 2 GiB cap.
+   Buttons are the only interactive surface — the div itself must not feel
+   like a dialog that blocks play. */
+#memory-notice {
+  position: fixed;
+  top: 14px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 9;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  max-width: min(90vw, 680px);
+  box-sizing: border-box;
+  padding: 8px 12px;
+  border: 1px solid #8a6d3b;
+  border-radius: 6px;
+  color: #f5ead9;
+  background: #1c1408ee;
+  font: 13px/1.45 Tahoma, sans-serif;
+  box-shadow: 0 2px 10px #0008;
+}
+#memory-notice[hidden] { display: none; }
+#memory-notice.critical {
+  border-color: #945b4f;
+  background: #1b0c0bee;
+  color: #fff1e9;
+}
+#memory-notice-label { display: block; }
+#memory-notice-actions { display: flex; gap: 8px; flex-shrink: 0; }
+#memory-notice button {
+  font: 12px Tahoma, sans-serif;
+  padding: 5px 12px;
+  border: 1px solid #776a55;
+  border-radius: 4px;
+  background: #2b2a20;
+  color: inherit;
+  cursor: pointer;
+}
+#memory-notice button:hover { border-color: #a99878; }
+#memory-notice button:focus-visible { outline: 2px solid #ff9d66;
+                                      outline-offset: 2px; }
+#memory-notice button:active { transform: scale(.97); }
+#memory-notice.critical button { border-color: #8a5f55; }
+#memory-notice.critical button:hover { border-color: #c08a7c; }
+
 /* The Steam sign-in status line: quiet, bottom-centred over the client's own
    login screen, and gone on its own — it explains, it never blocks. */
 #login-status {

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -268,6 +268,118 @@ window.gwLog = (on = true) => {
   return on;
 };
 
+/**
+ * The heap watermark. The client's WASM memory is capped by its own build
+ * (`WASM_HEAP_CAP_BYTES` in the shared contracts), memory only ever grows
+ * within one run, and a session that reaches the cap dies on whatever
+ * allocation comes next — historically hours in and mid-mission. The watcher
+ * moves that death to a moment the player picks: warn while there is headroom
+ * to travel somewhere safe, escalate when the next growth step would hit the
+ * cap. Reloading is a quick relog; from a town or outpost it loses nothing.
+ *
+ * A classic script cannot static-import, so the cap arrives via one dynamic
+ * import; until it resolves the thresholds are Infinity and the watcher is
+ * silent, which costs at most one 15-second tick at startup.
+ */
+const MIB = 1_048_576;
+let heapCapBytes = 0;
+let heapWarnBytes = Infinity; // cap − 256 MiB — time to finish up.
+let heapCriticalBytes = Infinity; // cap − 128 MiB — go now.
+void import('../shared/contracts.js')
+  .then(({ WASM_HEAP_CAP_BYTES }) => {
+    heapCapBytes = WASM_HEAP_CAP_BYTES;
+    heapWarnBytes = WASM_HEAP_CAP_BYTES - 256 * MIB;
+    heapCriticalBytes = WASM_HEAP_CAP_BYTES - 128 * MIB;
+  })
+  .catch(() => {});
+let heapNoticeLevel: 'none' | 'low' | 'critical' = 'none';
+
+const wasmHeapBytes = () => Module.HEAPU8?.buffer.byteLength ?? 0;
+window.gwWasmHeapBytes = wasmHeapBytes;
+
+/**
+ * What the crash overlay shows behind its disclosure: the abort's own prose
+ * plus the heap size at death. Renderer-local by design — the diagnostics
+ * export carries only the closed reason vocabulary and fingerprint, and this
+ * app keeps no browser storage, so the overlay is the one place the prose
+ * survives until the player reloads.
+ */
+const crashTechnicalDetail = (reason: unknown, heapBytes: number): string => {
+  const text = reason instanceof Error
+    ? `${reason.name}: ${reason.message}\n${reason.stack ?? ''}`
+    : String(reason ?? '');
+  const cap = heapCapBytes ? ` of ${Math.round(heapCapBytes / MIB)} MiB` : '';
+  return (
+    `WASM heap at crash: ${Math.round(heapBytes / MIB)} MiB${cap}\n${text}`
+  ).slice(0, 8192);
+};
+
+// Static markup, and this script loads at the end of <body>, so the elements
+// exist here; a missing id degrades to a watcher that never presents.
+const heapNoticeRoot = document.getElementById('memory-notice');
+const heapNoticeLabel = document.getElementById('memory-notice-label');
+const heapNoticeDetail = document.getElementById('memory-notice-detail');
+const heapNoticeReload = document.getElementById('memory-notice-reload');
+const heapNoticeLater = document.getElementById('memory-notice-later');
+heapNoticeReload?.addEventListener('click', () => {
+  hideHeapNotice();
+  reloadClientSafely();
+});
+heapNoticeLater?.addEventListener('click', hideHeapNotice);
+
+function hideHeapNotice() {
+  if (heapNoticeRoot) heapNoticeRoot.hidden = true;
+}
+
+/**
+ * Best-effort save sync, then the same page reload the crash overlay's Retry
+ * performs; the beforeunload dispose closes this run's game sockets on the
+ * way out. The quit path has shown the sync can fail, so the reload never
+ * waits on it for more than a beat — IDBFS auto-persist has usually written
+ * already.
+ */
+function reloadClientSafely() {
+  let reloaded = false;
+  const reload = () => {
+    if (reloaded) return;
+    reloaded = true;
+    window.location.reload();
+  };
+  setTimeout(reload, 1_500);
+  const fs = window.Module?.FS;
+  if (fs) fs.syncfs(false, reload);
+  else reload();
+}
+
+async function presentHeapNotice(level: 'low' | 'critical') {
+  if (
+    !heapNoticeRoot || !heapNoticeLabel || !heapNoticeDetail
+    || !heapNoticeReload || !heapNoticeLater
+  ) return;
+  const { memoryPressurePresentation } = await import('./failure-messages.js');
+  const copy = memoryPressurePresentation(level);
+  heapNoticeLabel.textContent = copy.label;
+  heapNoticeDetail.textContent = copy.detail;
+  heapNoticeReload.textContent = copy.reloadButton;
+  heapNoticeLater.textContent = copy.dismissButton;
+  heapNoticeRoot.classList.toggle('critical', level === 'critical');
+  heapNoticeRoot.hidden = false;
+}
+
+setInterval(() => {
+  if (crashRecorded) return;
+  const bytes = wasmHeapBytes();
+  const level = bytes >= heapCriticalBytes
+    ? 'critical'
+    : bytes >= heapWarnBytes ? 'low' : 'none';
+  // Escalation is one-way and each level presents once: the heap cannot
+  // shrink within a client run, and a reload resets this whole script.
+  if (level === 'none' || level === heapNoticeLevel) return;
+  heapNoticeLevel = level;
+  log(`[memory] wasm heap at ${Math.round(bytes / MIB)} MiB — ${level} notice`);
+  presentHeapNotice(level).catch(() => {});
+}, 15_000);
+
 const STARTUP_LABELS = {
   connecting: 'Starting Guild Wars',
   downloading: 'Preparing files needed to start',
@@ -665,12 +777,14 @@ Module = {
     // call presents and records — a repeat would reset the escalated copy
     // back to first-crash and steal focus again. The prose never crosses
     // IPC — it collapses into the closed reason vocabulary plus a
-    // fingerprint.
+    // fingerprint, and stays readable on the overlay's disclosure.
     if (crashRecorded) return;
     crashRecorded = true;
+    hideHeapNotice();
+    const heapBytes = wasmHeapBytes();
     // The overlay first, with the first-crash presentation; the recorded
     // count upgrades it below once main has counted this crash.
-    window.gwLoading?.failCrash(1);
+    window.gwLoading?.failCrash(1, crashTechnicalDetail(reason, heapBytes));
     void (async () => {
       const { classifyWasmAbortReason, wasmAbortFingerprint } =
         await import('./wasm-abort-reason.js');
@@ -680,6 +794,7 @@ Module = {
         {
           reasonKind: classifyWasmAbortReason(reason),
           fingerprint: wasmAbortFingerprint(reason),
+          heapBytes,
         },
       );
       await escalateRepeatedCrash();
@@ -700,17 +815,22 @@ Module = {
       // first-crash and count the same death twice.
       if (crashRecorded) return;
       crashRecorded = true;
-      window.gwLoading?.failCrash(1);
+      hideHeapNotice();
+      // `code` is declared unknown at the Module boundary; anything the
+      // glue passes that is not a plain integer records as the -1 the
+      // schema can still account for.
+      const exitCode =
+        typeof code === 'number' && Number.isSafeInteger(code) ? code : -1;
+      const heapBytes = wasmHeapBytes();
+      window.gwLoading?.failCrash(
+        1,
+        crashTechnicalDetail(`client exit code ${exitCode}`, heapBytes),
+      );
       void (async () => {
-        // `code` is declared unknown at the Module boundary; anything the
-        // glue passes that is not a plain integer records as the -1 the
-        // schema can still account for.
-        const exitCode =
-          typeof code === 'number' && Number.isSafeInteger(code) ? code : -1;
         await native().diagnostics.recordRendererMilestone(
           'wasm.exit',
           performance.now() * 1000,
-          { code: exitCode },
+          { code: exitCode, heapBytes },
         );
         await escalateRepeatedCrash();
       })().catch(() => {});

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -277,21 +277,33 @@ window.gwLog = (on = true) => {
  * to travel somewhere safe, escalate when the next growth step would hit the
  * cap. Reloading is a quick relog; from a town or outpost it loses nothing.
  *
- * A classic script cannot static-import, so the cap arrives via one dynamic
- * import; until it resolves the thresholds are Infinity and the watcher is
- * silent, which costs at most one 15-second tick at startup.
+ * A classic script cannot static-import, so the cap arrives via a dynamic
+ * import — on the first watcher tick, not at boot. Boot would work here, but
+ * it would also put the canonical contract into the module cache before the
+ * Enhancement runtime imports it, and the packaged proof that the runtime
+ * resolves the canonical module observes that import as a request. Until the
+ * import lands the thresholds are Infinity and the watcher is silent, which
+ * costs one 15-second tick and nothing else: no heap reaches a watermark
+ * that fast.
  */
 const MIB = 1_048_576;
 let heapCapBytes = 0;
 let heapWarnBytes = Infinity; // cap − 256 MiB — time to finish up.
 let heapCriticalBytes = Infinity; // cap − 128 MiB — go now.
-void import('../shared/contracts.js')
-  .then(({ WASM_HEAP_CAP_BYTES }) => {
-    heapCapBytes = WASM_HEAP_CAP_BYTES;
-    heapWarnBytes = WASM_HEAP_CAP_BYTES - 256 * MIB;
-    heapCriticalBytes = WASM_HEAP_CAP_BYTES - 128 * MIB;
-  })
-  .catch(() => {});
+let heapCapRequested = false;
+function requestHeapCap() {
+  if (heapCapRequested) return;
+  heapCapRequested = true;
+  void import('../shared/contracts.js')
+    .then(({ WASM_HEAP_CAP_BYTES }) => {
+      heapCapBytes = WASM_HEAP_CAP_BYTES;
+      heapWarnBytes = WASM_HEAP_CAP_BYTES - 256 * MIB;
+      heapCriticalBytes = WASM_HEAP_CAP_BYTES - 128 * MIB;
+    })
+    // A failed load retries on the next tick rather than silencing the
+    // watermark for the whole session.
+    .catch(() => { heapCapRequested = false; });
+}
 let heapNoticeLevel: 'none' | 'low' | 'critical' = 'none';
 
 const wasmHeapBytes = () => Module.HEAPU8?.buffer.byteLength ?? 0;
@@ -368,6 +380,7 @@ async function presentHeapNotice(level: 'low' | 'critical') {
 
 setInterval(() => {
   if (crashRecorded) return;
+  requestHeapCap();
   const bytes = wasmHeapBytes();
   const level = bytes >= heapCriticalBytes
     ? 'critical'

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -81,6 +81,14 @@
       <button type="button" id="loading-retry" hidden>Retry</button>
     </div>
 
+    <!-- The crash's own message and heap-at-death, renderer-local: the
+         exported report deliberately carries neither, so this disclosure is
+         where a player reads or screenshots the real text before reloading. -->
+    <details id="loading-crash-detail" hidden>
+      <summary>Technical details</summary>
+      <pre id="loading-crash-text"></pre>
+    </details>
+
     <!-- One decision, two cards, and a single plainly-worded consent line.
          The game tools live in Settings: their defaults are right for a first
          launch, and a player who has never played has no basis to answer. -->
@@ -192,6 +200,20 @@
 
 <div id="log"></div>
 <output id="diagnostics" aria-live="off"></output>
+<!-- The heap watermark notice: shown over the running game when WASM memory
+     nears its 2 GiB cap, so the player can reload from a safe place instead
+     of crashing mid-mission. harness.ts owns when; failure-messages.ts owns
+     the words. -->
+<div id="memory-notice" role="status" aria-live="polite" hidden>
+  <div id="memory-notice-text">
+    <strong id="memory-notice-label"></strong>
+    <span id="memory-notice-detail"></span>
+  </div>
+  <div id="memory-notice-actions">
+    <button type="button" id="memory-notice-later"></button>
+    <button type="button" id="memory-notice-reload"></button>
+  </div>
+</div>
 <output id="capture-status" hidden aria-live="off">
   <span class="capture-dot" aria-hidden="true"></span>
   <span id="capture-label">Performance capture · 00:00</span>

--- a/src/renderer/loading.css
+++ b/src/renderer/loading.css
@@ -149,6 +149,20 @@
 #loading-dock:has(#data-download:not([hidden])) #loading-boot { display:none; }
 #loading-dock:has(#data-download:not([hidden])) #loading-bar { display:none; }
 
+/* The crash's technical detail: a full-width row under the boot line, closed
+   by default so the plain-language sentence stays the first thing read. */
+#loading-crash-detail { flex-basis:100%; margin-top:8px; }
+#loading-crash-detail[hidden] { display:none; }
+#loading-crash-detail summary { cursor:pointer; font-size:12px;
+                                color:#d8caaaad; }
+#loading-crash-text { max-height:140px; overflow:auto; margin:6px 0 0;
+                      padding:8px 10px; background:#000a;
+                      border:1px solid #3a2f24; border-radius:4px;
+                      font:11px/1.5 ui-monospace, Menlo, monospace;
+                      white-space:pre-wrap; overflow-wrap:anywhere;
+                      user-select:text; -webkit-user-select:text; }
+#loading-dock:has(#loading-crash-detail:not([hidden])) { flex-wrap:wrap; }
+
 #loading-label { font-size:17px; letter-spacing:.02em; color:#f2e8d2;
                  text-shadow:0 1px 6px #000c; }
 #loading-detail { min-height:1.3em; font-size:13px; color:#e8dcc099;

--- a/src/renderer/loading.ts
+++ b/src/renderer/loading.ts
@@ -43,6 +43,8 @@ window.gwLoading = (function (): LoadingController {
   const label = el('loading-label'), detail = el('loading-detail');
   const retry = el('loading-retry') as HTMLButtonElement;
   const report = el('loading-report') as HTMLButtonElement;
+  const crashDetail = el('loading-crash-detail') as HTMLDetailsElement;
+  const crashDetailText = el('loading-crash-text');
   let recovery: 'client' | 'filesystem' = 'client';
   // Bumped by every state change so failCrash's async copy upgrade can tell
   // it has been overtaken — e.g. by a Retry already in progress.
@@ -64,6 +66,8 @@ window.gwLoading = (function (): LoadingController {
     detail.textContent = sub;
     retry.hidden = false;
     report.hidden = true;
+    crashDetail.hidden = true;
+    crashDetail.open = false;
     bar.classList.remove('busy');
     fill.style.width = '100%';
     fill.style.background = '#b8452f';
@@ -107,10 +111,20 @@ window.gwLoading = (function (): LoadingController {
       retry.textContent = 'Reset Saved Files…';
     },
 
-    failCrash(crashCount) {
+    failCrash(crashCount, technicalDetail) {
       // The synchronous frame first: the overlay must appear even if module
       // loading is broken. The crash copy then upgrades it in place.
       api.fail('The game client stopped unexpectedly.');
+      // The abort's own prose plus heap-at-death, behind a disclosure. It
+      // never leaves the renderer — the exported report carries only the
+      // closed reason vocabulary — so this panel is where a player reads or
+      // screenshots the real message before reloading. An omitted value keeps
+      // the text from the first call: the repeat-crash copy upgrade passes
+      // none and must not erase it.
+      if (technicalDetail !== undefined) {
+        crashDetailText.textContent = technicalDetail;
+      }
+      crashDetail.hidden = !crashDetailText.textContent;
       const generation = stateGeneration;
       void import('./failure-messages.js')
         .then(({ clientCrashPresentation }) => {

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -46,6 +46,16 @@ export interface SnapshotMetadata {
 export const ARENANET_REQUEST_CEILING = 8;
 
 /**
+ * The game client's WASM heap maximum, compiled into ArenaNet's build: the
+ * glue's `getHeapMax()` returns exactly this. Every surface that reasons
+ * about heap headroom — the renderer's watermark notice, the crash detail,
+ * the diagnostics summary — derives from this one number, so a future client
+ * built with a larger cap (`-sMAXIMUM_MEMORY=4GB` is the upstream ask) is a
+ * one-line change here rather than a hunt for stale "2048 MiB" literals.
+ */
+export const WASM_HEAP_CAP_BYTES = 2_147_483_648;
+
+/**
  * Why a ready client is not simply "ready": the launch took a fallback the
  * player may want to know about. A closed union for the same reason failure
  * codes are one: the sentence the player reads belongs to the renderer

--- a/src/shared/diagnostics.ts
+++ b/src/shared/diagnostics.ts
@@ -130,6 +130,10 @@ const RENDERER_NUMERIC_METRICS = [
   "socketSettles",
   "inputToSubmitCount",
   "droppedRecords",
+  // The WASM linear-memory size at flush time. It only ever grows within one
+  // client run (the glue caps it at 2 GiB), so the sequence of changes is the
+  // whole heap-growth story a memory-exhaustion triage needs.
+  "wasmHeapBytes",
 ] as const;
 
 type RendererNumericMetric = (typeof RENDERER_NUMERIC_METRICS)[number];
@@ -234,9 +238,18 @@ export type WasmAbortReasonKind = (typeof WASM_ABORT_REASON_KINDS)[number];
 
 export interface RendererMilestoneFieldsByName {
   "build.info": { programId: string | number; buildId: string | number };
-  "wasm.abort": { reasonKind: WasmAbortReasonKind; fingerprint: string };
+  /**
+   * `heapBytes` is the WASM linear-memory size at the moment of death. The
+   * glue caps the heap at 2 GiB, so a crash recorded at that cap is memory
+   * exhaustion whatever prose the abort carried.
+   */
+  "wasm.abort": {
+    reasonKind: WasmAbortReasonKind;
+    fingerprint: string;
+    heapBytes: number;
+  };
   /** A non-zero client exit: the other way the running game dies. */
-  "wasm.exit": { code: number };
+  "wasm.exit": { code: number; heapBytes: number };
   /**
    * The hook went live. `capabilityProfile` is the closed profile vocabulary
    * from contracts — typed as string here because contracts imports this file;
@@ -414,6 +427,7 @@ function isConsistent(metrics: RendererMetrics): boolean {
     "socketSettles",
     "inputToSubmitCount",
     "droppedRecords",
+    "wasmHeapBytes",
   ];
   const bounded = ({ name, countKey }: (typeof RENDERER_HISTOGRAMS)[number]) => {
     const count = metrics[countKey];

--- a/src/tools/diagnostics/summarize.ts
+++ b/src/tools/diagnostics/summarize.ts
@@ -9,6 +9,7 @@
  * it was incomplete.
  */
 import { resolve } from "node:path";
+import { WASM_HEAP_CAP_BYTES } from "../../shared/contracts.js";
 import { withCapture, validateCapture } from "./common.js";
 
 const input = process.argv[2];
@@ -174,6 +175,9 @@ if (!input) {
     console.log(`  event-loop p99   ${milliseconds(Number(summary.latest["main.eventLoopP99Us"]) || 0)}`);
     console.log(`  main RSS peak    ${((Number(summary.latest["main.peakRssBytes"]) || 0) / 1048576).toFixed(0)} MB`);
     console.log(`  renderer RSS peak ${((Number(summary.latest["process.tab.peakRssBytes"]) || 0) / 1048576).toFixed(0)} MB`);
+    // Against the client's compiled-in cap: a peak at the cap plus a
+    // wasm.abort is memory exhaustion, whatever the abort's reason kind says.
+    console.log(`  wasm heap peak   ${((Number(summary.latest["renderer.peakWasmHeapBytes"]) || 0) / 1048576).toFixed(0)} MiB of ${(WASM_HEAP_CAP_BYTES / 1048576).toFixed(0)} MiB`);
     console.log(`  GPU RSS peak     ${((Number(summary.latest["process.gpu.peakRssBytes"]) || 0) / 1048576).toFixed(0)} MB`);
   });
 }

--- a/tests/packaged-enhancement-runtime.ts
+++ b/tests/packaged-enhancement-runtime.ts
@@ -870,22 +870,33 @@ async function assertTargetReadoutLifecycle() {
       ],
       "the packaged install lifecycle did not reach the diagnostics log",
     );
+    // The request listener attaches after boot, and the harness now imports
+    // the shared contract during boot for its heap watermark — a module the
+    // ES-module cache then serves to the control without a second request.
+    // The performance timeline sees every load since page start, so the
+    // merged list is the instrument that can still prove the control's
+    // dependency graph resolves to the canonical modules.
+    const performanceResources = await fixture.page.evaluate(() =>
+      performance.getEntriesByType("resource").map((entry) => entry.name));
+    const allResources = [...resources, ...performanceResources];
     assert.ok(
-      resources.some(
+      allResources.some(
         (url) => new URL(url).pathname === "/companion-kernel.wasm",
       ),
       "the installed control never fetched the packaged Enhancement kernel",
     );
     assert.ok(
-      resources.some((url) => new URL(url).pathname === "/enhancements.js"),
+      allResources.some((url) => new URL(url).pathname === "/enhancements.js"),
       "the installed control never imported the packaged Enhancement runtime",
     );
     assert.ok(
-      resources.some((url) => new URL(url).pathname === "/shared/contracts.js"),
-      "the installed control never loaded the canonical capability contract",
+      allResources.some(
+        (url) => new URL(url).pathname === "/shared/contracts.js",
+      ),
+      "the canonical capability contract was never loaded",
     );
     assert.ok(
-      resources.some(
+      allResources.some(
         (url) => new URL(url).pathname === "/shared/project-identity.js",
       ),
       "the canonical contract dependency graph was incomplete",

--- a/tests/packaged-enhancement-runtime.ts
+++ b/tests/packaged-enhancement-runtime.ts
@@ -870,33 +870,22 @@ async function assertTargetReadoutLifecycle() {
       ],
       "the packaged install lifecycle did not reach the diagnostics log",
     );
-    // The request listener attaches after boot, and the harness now imports
-    // the shared contract during boot for its heap watermark — a module the
-    // ES-module cache then serves to the control without a second request.
-    // The performance timeline sees every load since page start, so the
-    // merged list is the instrument that can still prove the control's
-    // dependency graph resolves to the canonical modules.
-    const performanceResources = await fixture.page.evaluate(() =>
-      performance.getEntriesByType("resource").map((entry) => entry.name));
-    const allResources = [...resources, ...performanceResources];
     assert.ok(
-      allResources.some(
+      resources.some(
         (url) => new URL(url).pathname === "/companion-kernel.wasm",
       ),
       "the installed control never fetched the packaged Enhancement kernel",
     );
     assert.ok(
-      allResources.some((url) => new URL(url).pathname === "/enhancements.js"),
+      resources.some((url) => new URL(url).pathname === "/enhancements.js"),
       "the installed control never imported the packaged Enhancement runtime",
     );
     assert.ok(
-      allResources.some(
-        (url) => new URL(url).pathname === "/shared/contracts.js",
-      ),
-      "the canonical capability contract was never loaded",
+      resources.some((url) => new URL(url).pathname === "/shared/contracts.js"),
+      "the installed control never loaded the canonical capability contract",
     );
     assert.ok(
-      allResources.some(
+      resources.some(
         (url) => new URL(url).pathname === "/shared/project-identity.js",
       ),
       "the canonical contract dependency graph was incomplete",

--- a/tests/unit/diagnostics.test.ts
+++ b/tests/unit/diagnostics.test.ts
@@ -48,6 +48,7 @@ function metrics(): RendererMetrics {
     socketSettles: 1,
     inputToSubmitCount: 1,
     droppedRecords: 0,
+    wasmHeapBytes: 335_544_320,
     rendererEvents: [],
     raf: {
       buckets: [0, 0, 0, 0, 0, 0, 0, 0, 120, 0, 0, 0, 0, 0, 0, 0, 0, 0],

--- a/tests/unit/failure-codes-become-sentences-in-the-renderer.test.ts
+++ b/tests/unit/failure-codes-become-sentences-in-the-renderer.test.ts
@@ -14,6 +14,7 @@ import {
   describeSnapshotReadFailure as snapshotRead,
   describeSteamRefusal,
   failureDetail,
+  memoryPressurePresentation,
   suggestReport,
 } from "../../src/renderer/failure-messages.js";
 import { NOTICE_CODES } from "../../src/shared/contracts.ts";
@@ -179,5 +180,32 @@ describe("renderer failure messages", () => {
     assert.equal(first.reportButton, repeated.reportButton);
     // An unreadable count degrades to the first-crash presentation.
     assert.deepEqual(clientCrashPresentation(0), first);
+  });
+
+  it("escalates the memory watermark words, not its actions", () => {
+    const low = memoryPressurePresentation("low");
+    const critical = memoryPressurePresentation("critical");
+    for (const notice of [low, critical]) {
+      for (const text of [
+        notice.label,
+        notice.detail,
+        notice.reloadButton,
+        notice.dismissButton,
+      ]) {
+        assert.ok(text.length > 0, "memory notice has empty prose");
+      }
+      // The whole point of the notice: the player picks a safe place first.
+      assert.match(notice.detail, /town or outpost/);
+      // The detail must name the button it tells the player to press.
+      assert.ok(notice.detail.includes(notice.reloadButton));
+    }
+    // Low reads as headroom; critical reads as imminent.
+    assert.match(low.label, /running low/);
+    assert.match(critical.label, /almost out of memory/);
+    assert.match(critical.detail, /^A crash is likely soon/);
+    // Buttons are identical across levels: escalation changes the words,
+    // not the actions.
+    assert.equal(low.reloadButton, critical.reloadButton);
+    assert.equal(low.dismissButton, critical.dismissButton);
   });
 });

--- a/tests/unit/wasm-abort-reason.test.ts
+++ b/tests/unit/wasm-abort-reason.test.ts
@@ -81,13 +81,14 @@ describe("wasm abort fingerprints", () => {
 });
 
 describe("the recorded abort event", () => {
-  it("is an error-level renderer event carrying kind and fingerprint", () => {
+  it("is an error-level renderer event carrying kind, fingerprint, and heap", () => {
     assert.deepEqual(
       diagnosticEventRecord({
         k: "wasm.abort",
         clockSynchronized: true,
         reasonKind: "indirectCall",
         fingerprint: asRendererFingerprint(wasmAbortFingerprint("x")),
+        heapBytes: 2_147_483_648,
       }),
       {
         subsystem: "renderer",
@@ -97,7 +98,26 @@ describe("the recorded abort event", () => {
           clockSynchronized: true,
           reasonKind: "indirectCall",
           fingerprint: wasmAbortFingerprint("x"),
+          heapBytes: 2_147_483_648,
         },
+      },
+    );
+  });
+});
+
+describe("the recorded heap staircase", () => {
+  it("is an info-level renderer event carrying both sides of a growth step", () => {
+    assert.deepEqual(
+      diagnosticEventRecord({
+        k: "wasm.heapGrew",
+        fromBytes: 1_879_048_192,
+        toBytes: 1_979_711_488,
+      }),
+      {
+        subsystem: "renderer",
+        level: "info",
+        name: "wasm.heapGrew",
+        fields: { fromBytes: 1_879_048_192, toBytes: 1_979_711_488 },
       },
     );
   });


### PR DESCRIPTION
## What this ships to users

Two players crashed on the same evening, hours into play, with the game's WASM heap pegged at exactly its compiled-in 2 GiB cap. Until now the first warning was the crash itself, the abort's real message died with the page, and a mission run died with it.

- **A memory warning before the crash.** When the heap nears the cap the game shows a small notice: amber at cap−256 MiB ("finish what you are doing, return to a town or outpost"), red at cap−128 MiB ("a crash is likely soon"). **Reload Now** syncs saves best-effort and reloads — a quick relog, timed by the player instead of by the allocator.
- **The crash screen now tells the truth.** A "Technical details" disclosure on the crash overlay shows the abort's own message and the heap size at death, so a player can read or screenshot the real cause before reloading.

## What changed

- `wasm.heapGrew {fromBytes, toBytes}`: every heap rise observed at the ~2 s metrics flush becomes one event. Read against the `socket.open` map-transition markers already in the log, the staircase distinguishes a steady leak from per-zone accumulation — the open question in [internal/upstream/memory-exhaustion-log.md](https://github.com/Mat4m0/gwonmac/blob/heap-watermark/internal/upstream/memory-exhaustion-log.md), which this PR also adds (investigation in the house shape, wrong turn included).
- `heapBytes` on `wasm.abort`/`wasm.exit` (renderer → validated IPC → schema), plus `renderer.wasmHeapBytes` / `renderer.peakWasmHeapBytes` gauges and a `wasm heap peak … of 2048 MiB` line in `summarize`.
- `WASM_HEAP_CAP_BYTES` in shared contracts is the single declaration of the cap; the watermark thresholds, crash detail, and summarize line all derive from it (the harness, a classic script, receives it via a dynamic import on the watcher's first 15-second tick — deliberately not at boot, so the packaged target-readout proof still observes the Enhancement runtime's own request for the canonical contract; a failed load retries on the next tick).
- The heap read is one getter (`window.gwWasmHeapBytes` → `Module.HEAPU8.buffer.byteLength`) picked up by the existing flush — no new channels, no new intervals beyond one 15 s watcher.

## What deliberately did not change

- **No prose crosses IPC.** The export still carries only the closed reason vocabulary plus 8-hex fingerprints; the abort text lives and dies in the renderer, on the overlay.
- **No browser storage** (the app's standing rule): crash detail survives until reload, not across it.
- **No allocator instrumentation.** Leak-vs-fragmentation has the same treatment either way; the fix for the cap itself is ArenaNet's (`-sMAXIMUM_MEMORY=4GB` is the upstream ask once a staircase bundle lands).
- `wasmAbortFingerprint` input is untouched — fingerprint continuity with the two already-collected bundles matters.

## Review focus

- **Sampled semantics:** `wasm.heapGrew` derives from 2 s flush samples, so near-simultaneous growth steps coalesce and a run's first event rises from 0; comments/schema say so explicitly. The `lastWasmHeapBytes` baseline treats a decrease as a reloaded client (wasm memory cannot shrink).
- **Reload path:** `reloadClientSafely` uses `location.reload()` — the same mechanism as the crash overlay's Retry; renderer-owned sockets close via the existing `beforeunload` → socket-host dispose (observed in real telemetry as `socket.close {reason: "requested"}`). It is *not* main's menu reload; the comment no longer claims it is.
- **Overlay detail retention:** `failCrash(count)` with an omitted detail keeps the text from the first call, so the async repeat-crash copy upgrade cannot erase it.

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm check:links` — clean
- `pnpm test:unit` — 752 pass (new: heapGrew record shape, abort event with `heapBytes`, memory-notice copy contract)
- `pnpm test:policy` — 156 pass
- Not run locally: Electron e2e (no behavior asserted there changed; `failCrash(1)` remains a valid call — the detail param is optional)
- CI `verify` (package + smoke + enhancement runtime) — green after moving the cap import off boot; a boot-time import cached the contract before the packaged proof's request listener could observe any load

## Known follow-ups

- The diagnostics export still carries only the single newest previous session, which hid two of this incident's three crashes — separate task, filed.
- Quit-time `filesystem.sync` fails on every observed quit with no recorded reason; quit-teardown aborts are still counted as crashes. Both separate.
- Reviewed by four parallel cleanup agents (reuse / simplification / efficiency / altitude); accepted findings applied — notably the shared cap constant, deduped notice copy, hoisted DOM wiring, and honest sampled-semantics wording. Codex (gpt-5.6-sol) review was blocked: model unavailable on this account.
