### PR TITLE
Give the client its own double-click flag and delete the synthetic taps

### DIFF
--- a/docs/process-model.md
+++ b/docs/process-model.md
@@ -95,14 +95,46 @@ half of it, and the `gl.programQuery*` counters prove it is engaged against the
 downloaded client.
 
 The renderer also supplies focus, OSK fields, trusted-interaction audio resume,
-fullscreen, trackpad-wheel normalization, macOS double-click repair, and
-right-drag pointer lock. `input.ts` owns the one canvas input policy. Mouse,
-trackpad, and Magic Mouse clicks and drags pass through unchanged. Chromium's
-native even click count adds the two touch taps ArenaNet's WebAssembly client
-needs for a double-click action; there is no device mode or input setting. One
-held-input registry releases keys, buttons, and an interrupted repair tap when
-focus or native UI consumes an input release. Pointer lock uses a virtual cursor
-and recycles a held drag so camera rotation does not stall.
+fullscreen, trackpad-wheel normalization, and right-drag pointer lock.
+`input.ts` owns the one canvas input policy. Mouse, trackpad, and Magic Mouse
+clicks and drags pass through unchanged, and the host dispatches no input event
+of its own except the releases below; there is no device mode and no input
+setting. One held-input registry releases keys and buttons when focus or native
+UI consumes an input release. Pointer lock uses a virtual cursor and recycles a
+held drag so camera rotation does not stall.
+
+Double-click is the client's own. Its mouse path carries a per-press
+double-click flag from the input record through `FrMouse` to the widget under
+the cursor, and ArenaNet's glue never writes it, because `MouseEvent.detail` is
+not marshalled — `internal/upstream/mouse-double-click.md` holds the evidence.
+The certified chain's last stage appends one exported mutable global and one
+store to the mousedown callback, and `native-double-click.ts` writes Chromium's
+click count into that global before each trusted press: every even click of a
+run sets the flag, exactly as Windows raises `WM_LBUTTONDBLCLK`, and every
+other press clears it. The widget goes on deciding what a double-click means,
+which is the behaviour the Windows client has.
+
+The host used to reach the same action by synthesising a pair of touch taps.
+That path is gone rather than kept beside this one. A tap is not a hint: the
+client warps the cursor to it, force-releases every captured button, switches
+its pointer mode to touch, enters the drag machinery, and delivers a click of
+its own — so a double-click cost four clicks instead of two, arrived 360 ms
+late, and moved inventory items it was meant to use. An unrecognised client
+build is served untransformed and simply has no double-click until it is
+certified again; `tests/electron/input-pointer.spec.ts` refuses any touch event
+so the mechanism cannot return as a fallback.
+
+`input-trace.ts` is the instrument for the reports that path produces. Help →
+Diagnostics → Show Input Trace draws a bounded live list of what the input host
+saw — press with its click-run count and modifiers, release with the distance
+it travelled, each modifier key transition, and each press the double-click
+flag rode on, including the ones an uncertified client could not be told
+about. It observes and never decides: every call site is on
+a path whose behaviour is identical with the trace absent, and switching it off
+discards what it held. It is not the diagnostics recorder — nothing crosses
+IPC, nothing is written to disk, and the text the Copy button produces carries
+distances and counts but no coordinate, so it can be pasted into a public issue
+unread. `docs/user-guide.md` owns what a player is told about it.
 
 That recycle is rare by construction. The client keeps integrating mouse moves
 whose coordinates fall outside the canvas, so a held right-drag is free to roam

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -100,9 +100,11 @@ scale. Compared with 1×, 1.5× renders 2.25 times as many pixels and 2× render
 four times as many pixels.
 Right-drag always locks the pointer while steering the camera and restores it
 on release. Mouse, trackpad, and Magic Mouse clicks and drags pass through to
-Guild Wars unchanged. A macOS double-click automatically supplies the
-double-tap signal required by the official web client; there is no input mode to
-configure. Main-block letter, number-row, and punctuation bindings stay on the
+Guild Wars unchanged. A macOS double-click reaches Guild Wars as a
+double-click, using your own system double-click speed and distance settings;
+there is no input mode to configure. On a client build this host has not
+certified, double-click is unavailable until it is — the same builds that lose
+build templates and the game's own cursor. Main-block letter, number-row, and punctuation bindings stay on the
 same physical keys when the macOS input source changes, while chat and other
 text fields continue to type the active layout. Extra ISO/JIS keys and the
 numeric keypad retain the official web client's layout behavior. The in-game
@@ -238,6 +240,14 @@ in the app to export diagnostics and open it. Diagnostics are optional.
 - For stutter, choose **Record Performance Problem**, reproduce it, press
   **Cmd+Shift+M** when it is visible, then use
   **Help → Diagnostics → Stop Capture**.
+- For a mouse problem — a click that arrives twice, a double-click that does
+  nothing — choose
+  **Help → Diagnostics → Show Input Trace**, reproduce it, then press **Copy**
+  on the panel and paste the text straight into the report. It is a live list
+  of every button press and release and what the app decided to do with it.
+  Nothing is written to disk and nothing is sent anywhere; the text holds
+  counts and distances, never where your pointer was or where your window is,
+  and closing the trace discards it.
 - When investigating a repeatable long loading stall with a Chromium trace,
   start the trace and wait five seconds before entering the portal or changing
   maps. Stop the capture after the destination has rendered. The initial wait

--- a/internal/upstream/README.md
+++ b/internal/upstream/README.md
@@ -26,6 +26,7 @@ hash, that routes the broken routines back into the host.
 | [client-internals.md](client-internals.md) | us | The reference we had to build: function indices, data layouts, path conventions, the list filter. Everything a future change to this area needs. |
 | [host-bridge.md](host-bridge.md) | us | What we actually ship: the transform, the five markers, the bridge contract, and the invariants that must hold. |
 | [recertify.md](recertify.md) | us | The procedure when ArenaNet publishes a new client. Every index and offset below is build-specific. |
+| [mouse-double-click.md](mouse-double-click.md) | **ArenaNet** and us | A second, unrelated finding: the client's mouse path carries a double-click flag all the way to `FrMouse`, and the Emscripten glue never writes it. Why the host synthesises touch taps, what that costs, and the one byte that would end it. |
 | [investigation-log.md](investigation-log.md) | us | The chronology, including every wrong turn and what corrected it. Read this before re-deriving anything. |
 | [memory-exhaustion-log.md](memory-exhaustion-log.md) | us | Open: long-session `wasm.abort`s with the heap pegged at the client's compiled-in 2 GiB cap. The heap-staircase instrumentation and what the next crash bundle must answer. |
 | [investigation-template.md](investigation-template.md) | us | The shape a round takes — hypothesis, what was built, the measurement that killed it, the lesson. Copy it to start the next log. |

--- a/internal/upstream/investigation-log.md
+++ b/internal/upstream/investigation-log.md
@@ -311,3 +311,87 @@ by re-aiming the stored click on canvas movement instead of forgetting it.
 The lesson joins the list: **test the composition, not only the parts** — a
 predicate proven right in isolation was delivered one frame late by the
 wiring.
+
+## Round 12 — two wrong turns on Ctrl+click (2026-08-04)
+
+**Report.** "I can't Ctrl-Click to call out enemy targets."
+
+- **Hypothesis: macOS translates Control+left into a right press before the
+  page sees it.** Wrong, and it was written into a source comment as fact
+  before anything measured it. Chromium's
+  `content/common/input/web_input_event_builders_mac.mm` maps
+  `NSEventTypeLeftMouseDown` to `Button::kLeft` unconditionally, with no
+  modifier check — WebKit remaps, Blink deliberately does not. A probe under
+  the pinned Electron 43.2.0 delivers `mousedown button:0, buttons:1,
+  ctrlKey:true, isTrusted:true`, plus a `contextmenu`, and suppresses `click`.
+  The host was never the problem.
+- **Hypothesis: that extra `contextmenu` reaches the client and reads as a
+  right button.** Also wrong, and killed in one command. `contextmenu` appears
+  zero times in `Gw.jspi.js`, there is no `contextmenu` among the twelve
+  input callbacks the client registers, and Emscripten has no such API. The
+  client cannot be listening for it. The `preventDefault` on the canvas is a
+  browser-affordance suppression and nothing more.
+
+**What the search actually found.** `#2448`, the mousedown callback, reads
+exactly three things out of Emscripten's 64-byte event struct: the button at
+`+28` and the canvas-relative coordinates at `+40`/`+44`. The four modifier
+bytes at `+24…+27` — `ctrlKey`, `shiftKey`, `altKey`, `metaKey` — are never
+read by any mouse callback.
+
+So a click carries no modifiers of its own. `#829` fills the press message's
+modifier word from a global at `0x28cf0c` that only the *keyboard* path
+maintains: `#829`'s keydown branch ORs `1 << key` into it for key codes 0, 1
+and 2, and its keyup branch clears the same bit. The client's
+`KeyboardEvent.key` table gives `Control` code 1 and `Shift` code 2.
+
+**Consequence for the next reader.** Ctrl+click is a *keyboard* path bug, not a
+mouse one. Whatever breaks it breaks the Control keydown reaching the client or
+being mapped, and no amount of work on the mouse path can reach it. The input
+trace records modifier key transitions as their own rows for exactly this
+reason: a report showing a press with `+ctrl` and no `ctrl down` row before it
+names the failure immediately.
+
+**Lesson.** Round 3's lesson again, in its third costume: a comment that states
+a platform behaviour as fact is an unfalsifiable instrument until something
+measures it. This one was worse than a silent instrument, because it was also
+the interpretation guide printed beside the trace — it would have told the next
+reader to disbelieve a correct measurement. **Do not write a platform claim into
+a comment that has not been executed.**
+
+## Round 13 — the tap pair collapsed under its own timers (2026-08-04)
+
+**Report.** "Clicking is still not good." The input trace shipped the same day
+answered it in three lines:
+
+```
+388090    0ms  ARMED double-tap pair
+388429  339ms  SENT  double-tap 1/2
+388449   19ms  SENT  double-tap 2/2
+```
+
+The pair is scheduled at +250 ms and +330 ms. The first tap arrived 89 ms late
+and the second 19 ms behind it rather than 80 ms, because both timers were
+queued up front: once the main thread blocks past the second deadline, the two
+come due together and the spacing between them is whatever the task queue
+happens to do.
+
+**Why that breaks the double-click rather than merely rushing it.** A tap is
+held 30 ms, so tap 1's `touchend` was due at 388459 — ten milliseconds *after*
+tap 2's `touchstart`. `#2454` allocates the first free touch slot on each
+`touchstart` and frees it on `touchend`, so two live touches take two slots,
+and the detector in `#6614` requires the second tap to reuse the first one's
+slot. Different slots, no double-tap: the client sees two unrelated first taps
+and the action never fires.
+
+**Fix.** Chain the pair instead of scheduling it. Tap 2 is scheduled from tap
+1's release, so the order `start, end, start, end` holds at any timer lag. The
+regression test blocks the renderer's main thread for 500 ms after arming —
+against the old code it produces `start, start, end, end`.
+
+**Lesson.** Two independent timers are not a sequence. Where the order matters
+to the receiver, chain the steps; a delay is a hope, and this one was measured
+failing on a machine whose logs show frames of several seconds.
+
+**Note for the next reader.** This is a repair of the workaround, not of the
+defect. `mouse-double-click.md` records the byte that would delete the whole
+mechanism.

--- a/internal/upstream/mouse-double-click.md
+++ b/internal/upstream/mouse-double-click.md
@@ -1,0 +1,265 @@
+# The client's mouse double-click channel is complete and never fed
+
+The reference for why gwonmac synthesises touch taps, and why it should stop.
+
+Client examined:
+
+| | |
+| --- | --- |
+| Artifact | `Gw.jspi.wasm` |
+| Build | 38735 (`version.json`: 1.1.7) |
+| Size | 8,196,702 bytes |
+
+Function index = local code-section index + 219 (the function import count).
+Source attribution comes from the assertion strings embedded in each
+translation unit; every offset below is a byte offset into the named function
+body and was produced by full instruction decode, not by byte matching.
+
+## The finding in one line
+
+The client carries a per-press double-click flag all the way from its
+Emscripten input record to `FrMouse`, and the Emscripten glue never writes it,
+because `MouseEvent.detail` is not marshalled and the record byte is memset to
+zero.
+
+## The channel, end to end
+
+```text
+Chromium MouseEvent
+  detail                                        ← dropped here, never marshalled
+  ↓ fillMouseEventData (Gw.jspi.js)             writes 0,8,12,16,20,24-27,28,30,32,36,40,44
+  ↓ of a 64-byte struct; bytes 48-63 are never written by any path
+#2448  table slot 903, the mousedown callback
+         memset(rec, 0, 24)                     ← #267 -> #17666, two-argument memset-zero
+         rec[0]  = 18                           kind: mouse button down
+         rec[4]  = targetX * devicePixelRatio
+         rec[8]  = targetY * devicePixelRatio
+         rec[12] = event.button                 (u16 at struct+28)
+         rec[16] = -- never written --          ← the flag's slot
+         #791 enqueue                           Base/Os/Emscripten/EmscriptenInput.cpp
+  ↓
+#794   dequeue, #828 per-frame pump, driven by the event loop #883 (Engine/Event/EvtApi.cpp)
+  ↓
+#829   translate record -> engine message, 36-way br_table on rec[0]
+         kind 18 -> engine message 30, payload 24 bytes:
+           msg[0]     = rec[12]                 button
+           msg[4]     = rec[16]                 ← the flag, structurally zero
+           msg[8..15] = cursor x, y as f32
+           msg[16]    = button state bitfield
+           msg[20]    = modifier state
+  ↓
+#6293  table slot 1736, bound to engine message 30 by #6659 (Engine/Frame/FrApi.cpp init)
+         sets pointer mode 0 (mouse), then
+         #6269(msg + 8, msg[0], msg[4] & 1)
+                                    ^^^^^^^^^^  the double-click argument
+```
+
+`#6269` is `Engine/Frame/FrMouse.cpp` (it asserts `underMouse` at line 736) and
+is the one click-delivery routine. Its signature is
+`(Vec2* pos, unsigned button, bool doubleClick)`, and at `+182…+201` the third
+argument is what sets the flag:
+
+```wasm
+local.get 2          ;; doubleClick
+i32.eqz
+br_if                ;; leave the word alone when it is false
+i32.load  offset=12
+i32.const 1
+i32.or
+i32.store offset=12  ;; selectFlags |= FLAG_DBL_CLICK
+```
+
+The flag values fall out of `#15917`'s two asserts, which the compiler folded
+into `(flags & 3) == 1`, and out of the `br_table` at `#6269+93` that ORs in
+`2` or `4` by pointer mode:
+
+| Flag | Value |
+| --- | --- |
+| `FLAG_DBL_CLICK` | `0x1` |
+| `FLAG_DUE_TO_CLICK` | `0x2` |
+| `FLAG_NO_INTERACT` | `0x4` |
+
+`#6270` (`FrMouse.cpp:192`) then lifts the bit into its own field —
+`msg[40] = evt[4] & 1` — before posting to the widget under the cursor.
+
+`#6269` has exactly three callers, each supplying that argument from its own
+source:
+
+| Caller | Pointer mode | Where its double-click bit comes from |
+| --- | --- | --- |
+| `#6293` | 0, mouse | `msg[4] & 1` — **always 0 on the web client** |
+| `#6304` | 1, gamepad | `FrGamepad.cpp` `#6372`, a 400 ms window (`i32.const 399`) |
+| `#6309` | 2, touch | the `FrTouch` double-tap detector, below |
+
+So the mouse path is not missing a feature. It is missing one byte.
+
+Worth recording because it looks like the answer and is not: `#6293` does keep
+press timestamps (`+44/+51` saves the previous press time, `+213` stamps the
+current one) and `#6290` returns the difference. Its only consumers are three
+`FrGamepad` functions comparing against `i32.const 2001` — a "has the mouse
+been used recently" idle check. Nothing in `FrMouse.cpp` performs timing
+arithmetic; every `i32.sub` in the file is stack-frame setup or intrusive-list
+pointer math.
+
+## The touch double-tap detector
+
+`#6614`, table slot 1752, `Engine/Frame/FrTouch.cpp`. The detector runs only
+for the first touch down (`s_activeTouchId == -1`) and requires all three:
+
+| Condition | Constant | Address |
+| --- | --- | --- |
+| same touch slot as the previous tap | — | `0x283bd0` current, `0x283bd4` previous |
+| `now - lastTapTime <= 499` ms | `i32.const 499`, unsigned | `0x5a21b4` |
+| `dx² + dy² < slopX² + slopY²` | `0x3d086595` = 0.0333f each | `0x5a21b4`, `0x5a21b8` |
+
+The slop is set once by `#6618` and is in the client's normalised coordinate
+space, not pixels. The "same touch slot" test is satisfied by consecutive
+single taps because `#2454` maps browser touch identifiers onto small slot
+indices and frees the slot on `touchend`, so a second tap reclaims the first
+tap's slot. A host that overlaps its two taps would allocate two slots and the
+detector would refuse.
+
+## What a tap costs, which is why it is the wrong mechanism
+
+`#6309` is the whole touch-to-click bridge:
+
+```c
+FrTouchTap(pos, isDouble) {
+    Frame::SetCursorPos(pos, 1);            // #6264 — warps the cursor to the tap
+    if (s_pointerMode != 2) {                // 0 mouse, 1 gamepad, 2 touch
+        while (s_captureList) release(...);  // #6276 — force-releases every captured button
+        s_pointerMode = 2;
+    }
+    s_buttonFlags |= 2;
+    if (!(prev & 4)) { s_buttonFlags |= 6; FrCursor::Update(0); ... }
+    else FrMouse::BeginDrag(pos);            // #6273, asserts s_dragSource
+    FrMouse::Click(pos, 0, isDouble);        // #6269
+}
+```
+
+Three consequences, and each one matches a report from players:
+
+- **The cursor is warped and every held button is force-released.** A tap
+  delivered while a button is down desynchronises the client's button state
+  from the OS's. `input.ts` already defends against this with `tapsSafe()`.
+- **The pointer mode is switched to touch and stays there** until a real press
+  restores it. Real mouse releases are dropped in that window.
+- **`#6273` enters the drag machinery.** This is the mechanism behind
+  "double-clicking in my inventory moves the item to a random slot": the tap
+  pair picks the item up and drops it wherever the drag resolves.
+
+None of that happens on the mouse path. `#6293` sets pointer mode 0, releases
+nothing, warps nothing, and calls `#6269` directly.
+
+## Why two fast single clicks become a double-click
+
+This is not a defect in the client, and it is worth stating plainly because it
+is the shape of four of the five click reports.
+
+Chromium's `detail` counts a click run under the user's macOS double-click
+interval and distance preferences. Windows' `WM_LBUTTONDBLCLK` counts the same
+run under the same kind of preference. Neither can distinguish a deliberate
+double-click from two quick single clicks on the same spot, and neither is
+supposed to: the decision belongs to the widget under the cursor. The Windows
+client makes it per widget — a vendor's Sell button treats the second press as
+another click, an inventory slot treats it as "use".
+
+gwonmac's synthetic tap pair takes that decision away from the widget. It
+converts the second press of *any* fast click run into a touch double-tap,
+which is a different interaction with the side effects above. Selling two
+items in a row, or spending two attribute points in a row, hits the same
+screen position inside the double-click interval, so it produces `detail === 2`
+and therefore a spurious tap pair.
+
+Feeding `msg[4]` instead would hand the widget the same signal Windows hands
+it, and the widget would go on deciding.
+
+## How this was established
+
+Twice, independently, from the module bytes alone — once forward from the
+Emscripten callbacks and once backward from the `FLAG_DBL_CLICK` assert. Both
+derivations produced the same chain and the same missing byte. Every function
+index, offset and constant above came from full instruction decode
+(`tools/wasmscan.py`), never from byte matching, because the module's
+constants use LLVM's zero-padded LEB128 and a byte search for a canonical
+encoding silently finds nothing.
+
+Two supporting negatives: the import list contains no
+`emscripten_set_dblclick_callback` (all seventeen `emscripten_set_*_callback`
+imports were enumerated), and the strings `dblclick`, `clickCount` and
+`DblClick` appear nowhere in the binary.
+
+## Reproduction
+
+No host modification is required to observe the dead channel:
+
+1. Instrument `fillMouseEventData` in `Gw.jspi.js` — `e.detail` is read
+   nowhere in the file.
+2. Decode `#2448`. The 24-byte record is zeroed by `#267` and only four fields
+   are written; offset 16 is not one of them.
+3. Decode `#6293`. It reads `msg[4] & 1` and passes it to `#6269`.
+
+## The ask for ArenaNet
+
+`fillMouseEventData` should marshal `MouseEvent.detail`, and the mousedown
+callback should set the double-click bit at record offset 16 when the count is
+even — the same condition Windows uses to raise `WM_LBUTTONDBLCLK`. Everything
+downstream of that byte already works.
+
+## The cost nobody had counted: four clicks per double-click
+
+`#6614` calls `#6309` once per first-touch-down — that is, once per tap — and
+`#6309` ends in `#6269`, which is the client's one click-delivery routine. A
+tap is therefore not a hint that a double-click happened. It is a click.
+
+So a synthesised double-click delivers **four** clicks to whatever is under
+the cursor:
+
+| Source | Delivered by | `FLAG_DBL_CLICK` |
+| --- | --- | --- |
+| the player's first press | `#6293` → `#6269` | 0 |
+| the player's second press | `#6293` → `#6269` | 0 |
+| synthetic tap 1 | `#6309` → `#6269` | 0 |
+| synthetic tap 2 | `#6309` → `#6269` | 1 |
+
+The Windows client receives two, the second carrying the flag.
+
+This is the whole of the vendor and attribute-point reports, and it is not a
+tuning problem. The holdback and the burst cancellation decide *whether* a pair
+is sent; they cannot make a sent pair cost less than two extra clicks. Any
+widget that acts on a plain click — a Sell button, an attribute `+`, a dialogue
+option — is activated twice more than the player asked for, every single time
+they deliberately double-click.
+
+Feeding `msg[4]` removes both extra clicks by construction, because then the
+double-click is a property of the player's own second press and no additional
+press exists.
+
+## What this project now does about it
+
+The certified chain's last stage appends one exported mutable `i32` global and
+one store to the mousedown callback:
+
+```wasm
+local.get 3          ;; the frame pointer the record already lives on
+global.get $flag     ;; what the host wrote before this press
+i32.store offset=24  ;; record+16, the word #829 copies into msg[4]
+```
+
+It adds no function, moves no function index, and touches no table entry. The
+guard is the callback's own body hash: the store depends on local 3 being the
+frame pointer and the record sitting at frame+8, and a body that hashes to the
+certified value *is* that body. Because neither the template-save nor the
+Enhancement transform touches that function, one proof covers every predecessor
+the stage can consume, which is why it can run last and leave both existing
+build tables untouched.
+
+`src/renderer/native-double-click.ts` writes Chromium's click count into the
+global on every trusted press — set on each even click of a run, cleared
+otherwise — so the client receives exactly what Windows receives, under the
+player's own macOS double-click preferences. The synthetic tap pair is deleted
+rather than kept beside it, and an Electron spec refuses any touch event so it
+cannot return as a fallback.
+
+`pnpm certification double-click` re-derives the whole table from the official
+bytes and exits non-zero when it disagrees with what is checked in.

--- a/src/main/certification/client-module.ts
+++ b/src/main/certification/client-module.ts
@@ -23,6 +23,7 @@ import {
   discardDerivedWasm,
   inspectDerivedWasmCache,
   prepareDerivedWasm,
+  sha256File,
 } from "../core/derived-wasm.js";
 import {
   rewriteTemplateSaveWasm,
@@ -34,6 +35,12 @@ import {
   type KnownEnhancementBuild,
 } from "./enhancement-builds.js";
 import { transformEnhancementWasm } from "./enhancement-transform.js";
+import {
+  findNativeDoubleClickBuild,
+  nativeDoubleClickOutputSha256,
+  NATIVE_DOUBLE_CLICK_TRANSFORM_ABI,
+  rewriteNativeDoubleClickWasm,
+} from "./native-double-click.js";
 
 /**
  * The exact records matched while certifying the official client hash. The
@@ -53,7 +60,7 @@ export type ClientCertification =
     };
 
 export interface ClientModulePreparationFailure {
-  readonly stage: "template-save" | "enhancement";
+  readonly stage: "template-save" | "enhancement" | "native-double-click";
   readonly error: unknown;
 }
 
@@ -62,6 +69,12 @@ export interface PreparedClientModule {
   readonly state: ClientCompatibilityState;
   readonly enhancementBuild: KnownEnhancementBuild | null;
   readonly failure: ClientModulePreparationFailure | null;
+  /**
+   * Whether the served module carries the client's own mouse double-click
+   * flag. False means the renderer must keep synthesising touch taps, so this
+   * is the renderer's switch and not a report.
+   */
+  readonly nativeDoubleClick: boolean;
 }
 
 export interface PrepareClientModuleOptions {
@@ -71,6 +84,7 @@ export interface PrepareClientModuleOptions {
   readonly enhancementCapabilities: EnhancementCapabilities;
   readonly compatibilityCacheRoot: string;
   readonly enhancementCacheRoot: string;
+  readonly nativeDoubleClickCacheRoot: string;
 }
 
 function templateSaveCache(
@@ -157,7 +171,61 @@ async function discardEnhancementCache(
  * graceful and leaves the last good cache intact, but never serves it for a
  * different input.
  */
+/**
+ * The last stage, applied to whatever the chain above settled on.
+ *
+ * It is deliberately not part of the certification *state*: a module it cannot
+ * derive is served exactly as the previous stage produced it, and the renderer
+ * falls back to synthesising taps. So an unrecognised predecessor costs the
+ * player the double-click repair's latency, never the client.
+ */
+async function withNativeDoubleClick(
+  prepared: PreparedClientModule,
+  cacheRoot: string,
+): Promise<PreparedClientModule> {
+  const inputSha256 = await sha256File(prepared.wasmPath);
+  const build = findNativeDoubleClickBuild(inputSha256);
+  const expectedOutputSha256 = build
+    ? nativeDoubleClickOutputSha256(build, inputSha256)
+    : null;
+  if (!build || expectedOutputSha256 === null) {
+    await discardDerivedWasm(cacheRoot).catch(() => undefined);
+    return prepared;
+  }
+  try {
+    return {
+      ...prepared,
+      wasmPath: await prepareDerivedWasm(
+        prepared.wasmPath,
+        {
+          inputSha256,
+          cacheRoot,
+          transformAbi: NATIVE_DOUBLE_CLICK_TRANSFORM_ABI,
+          buildFingerprint: buildFingerprint(build),
+          expectedOutputSha256,
+        },
+        (base) => rewriteNativeDoubleClickWasm(base),
+      ),
+      nativeDoubleClick: true,
+    };
+  } catch (error) {
+    return {
+      ...prepared,
+      failure: prepared.failure ?? { stage: "native-double-click", error },
+    };
+  }
+}
+
 export async function prepareClientModule(
+  options: PrepareClientModuleOptions,
+): Promise<PreparedClientModule> {
+  return withNativeDoubleClick(
+    await prepareCertifiedChain(options),
+    options.nativeDoubleClickCacheRoot,
+  );
+}
+
+async function prepareCertifiedChain(
   options: PrepareClientModuleOptions,
 ): Promise<PreparedClientModule> {
   const {
@@ -174,6 +242,7 @@ export async function prepareClientModule(
       wasmPath: officialWasmPath,
       state: "uncertified",
       enhancementBuild: null,
+      nativeDoubleClick: false,
       failure: await discardUnsupportedCaches(
         compatibilityCacheRoot,
         enhancementCacheRoot,
@@ -188,6 +257,7 @@ export async function prepareClientModule(
       wasmPath: officialWasmPath,
       state: "uncertified",
       enhancementBuild: null,
+      nativeDoubleClick: false,
       failure: {
         stage: "template-save",
         error: new Error("template-save certification does not match client hash"),
@@ -210,6 +280,7 @@ export async function prepareClientModule(
       wasmPath: officialWasmPath,
       state: "uncertified",
       enhancementBuild: null,
+      nativeDoubleClick: false,
       failure: { stage: "template-save", error },
     };
   }
@@ -219,6 +290,7 @@ export async function prepareClientModule(
       wasmPath: templateSaveWasm,
       state: "template-only",
       enhancementBuild: null,
+      nativeDoubleClick: false,
       failure: await discardEnhancementCache(enhancementCacheRoot),
     };
   }
@@ -230,6 +302,7 @@ export async function prepareClientModule(
       wasmPath: templateSaveWasm,
       state: "template-only",
       enhancementBuild: null,
+      nativeDoubleClick: false,
       failure: {
         stage: "enhancement",
         error: new Error("Enhancement certification does not match template-save output"),
@@ -242,6 +315,7 @@ export async function prepareClientModule(
       wasmPath: templateSaveWasm,
       state: "certified",
       enhancementBuild: null,
+      nativeDoubleClick: false,
       failure: await discardEnhancementCache(enhancementCacheRoot),
     };
   }
@@ -263,6 +337,7 @@ export async function prepareClientModule(
       ),
       state: "certified",
       enhancementBuild,
+      nativeDoubleClick: false,
       failure: null,
     };
   } catch (error) {
@@ -270,6 +345,7 @@ export async function prepareClientModule(
       wasmPath: templateSaveWasm,
       state: "certified",
       enhancementBuild: null,
+      nativeDoubleClick: false,
       failure: { stage: "enhancement", error },
     };
   }

--- a/src/main/certification/enhancement-transform.ts
+++ b/src/main/certification/enhancement-transform.ts
@@ -37,6 +37,7 @@ import {
   encodeSection,
   parseCode,
   parseIndexVector,
+  parseExports,
   parseTypes,
   readSleb,
   readUleb,
@@ -45,6 +46,7 @@ import {
   splitSections,
   uleb,
   valueTypeName,
+  vectorPayload,
   WASM_HEADER,
   type FunctionType,
   type Section,
@@ -61,12 +63,6 @@ const DISPATCH_PARAMS = 6;
 const DISPATCH_TICK = 0;
 const DISPATCH_CURSOR = 1;
 const DISPATCH_UI = 2;
-
-interface WasmExport {
-  name: string;
-  kind: number;
-  index: number;
-}
 
 function fail(message: string): never {
   throw new Error(`enhancement transform: ${message}`);
@@ -99,32 +95,6 @@ function exactCapabilities(value: unknown): EnhancementCapabilities | null {
 function encodeName(value: string): Uint8Array {
   const bytes = new TextEncoder().encode(value);
   return concat(uleb(bytes.byteLength), bytes);
-}
-
-function parseExports(bytes: Uint8Array): WasmExport[] {
-  const cursor = { offset: 0 };
-  const count = readUleb(bytes, cursor);
-  const exports: WasmExport[] = [];
-  for (let index = 0; index < count; index += 1) {
-    const nameLength = readUleb(bytes, cursor);
-    const end = cursor.offset + nameLength;
-    if (end > bytes.byteLength) fail("truncated export name");
-    const name = new TextDecoder().decode(bytes.slice(cursor.offset, end));
-    cursor.offset = end;
-    const kind = bytes[cursor.offset++]!;
-    exports.push({ name, kind, index: readUleb(bytes, cursor) });
-  }
-  if (cursor.offset !== bytes.byteLength) fail("malformed export section");
-  return exports;
-}
-
-function vectorPayload(bytes: Uint8Array): {
-  count: number;
-  entries: Uint8Array;
-} {
-  const cursor = { offset: 0 };
-  const count = readUleb(bytes, cursor);
-  return { count, entries: bytes.slice(cursor.offset) };
 }
 
 function parseTable(bytes: Uint8Array): {

--- a/src/main/certification/native-double-click.ts
+++ b/src/main/certification/native-double-click.ts
@@ -1,0 +1,283 @@
+/**
+ * The native double-click transform: gives the client's own mouse double-click
+ * flag the one byte the Emscripten glue never writes.
+ *
+ * `internal/upstream/mouse-double-click.md` owns the evidence. In short: the
+ * client carries a per-press double-click bit from its input record through
+ * `FrMouse` to the widget under the cursor, every consumer of it works, and
+ * nothing ever sets it, because `fillMouseEventData` does not marshal
+ * `MouseEvent.detail` and the mousedown callback memsets the record byte to
+ * zero. Without it the host can only reach a double-click by synthesising a
+ * touch tap pair, which is a different interaction: it warps the cursor,
+ * force-releases captured buttons, enters the drag machinery, and delivers two
+ * extra clicks on top of the player's own two.
+ *
+ * This appends one exported mutable global and one store. It adds no function,
+ * moves no function index, and touches no table entry — the mousedown callback
+ * writes the flag the host put in the global into the record slot the client
+ * already reads.
+ *
+ * It refuses to own the decision about *when* a press is a double-click. That
+ * is Chromium's click count under the player's own macOS preferences, and the
+ * host writes it; this file only carries it across.
+ */
+import { createHash } from "node:crypto";
+import {
+  concat,
+  countFunctionImports,
+  encodeCode,
+  encodeSection,
+  parseCode,
+  parseExports,
+  readUleb,
+  sectionById,
+  splitSections,
+  uleb,
+  vectorPayload,
+  WASM_HEADER,
+  type Section,
+} from "../core/wasm-binary.js";
+
+declare const WebAssembly: {
+  validate(bytes: Uint8Array): boolean;
+};
+
+export const NATIVE_DOUBLE_CLICK_TRANSFORM_ABI = 1;
+
+/** The exported mutable global the host writes before each trusted press. */
+export const DOUBLE_CLICK_FLAG_EXPORT = "gwonmac_double_click";
+
+/**
+ * What must hold before a mousedown callback may be rewritten.
+ *
+ * `callbackBodySha256` is the whole proof. The transform inserts instructions
+ * at a fixed offset into that body and relies on local 3 being the frame
+ * pointer and the record living at frame+8; a body that hashes to the
+ * certified value *is* that body, so there is nothing left to infer. A build
+ * whose callback differs by a byte is refused rather than guessed at.
+ *
+ * `derivations` is separate from that proof and does a different job: it is
+ * the set of certified predecessor modules this stage may consume, each mapped
+ * to the module it produces. The chain runs this transform last, so those
+ * predecessors are the template-save output and the Enhancement output of each
+ * certified capability profile — and because the callback body survives both
+ * of those transforms untouched, one proof covers every entry.
+ */
+export interface NativeDoubleClickBuild {
+  /** Active table slot the client registers as its mousedown callback. */
+  readonly callbackTableSlot: number;
+  /** Function index that slot resolves to. */
+  readonly callbackFunctionIndex: number;
+  /** SHA-256 of that function's body, before the rewrite. */
+  readonly callbackBodySha256: string;
+  /** Byte offset in the body at which the flag store is inserted. */
+  readonly flagStoreOffset: number;
+  /**
+   * Byte offset from the frame pointer in local 3 to the record's flag word.
+   * The client's translator copies that word into the press message the
+   * double-click bit is masked out of.
+   */
+  readonly flagStoreFrameOffset: number;
+  /** Certified predecessor module hash -> the hash this stage produces. */
+  readonly derivations: Readonly<Record<string, string>>;
+}
+
+/**
+ * Build 38735, whose official module is
+ * `3229678d…`. Every hash below is reproduced by
+ * `pnpm certification double-click`, which re-runs the chain from the official
+ * bytes; the table is a cache of that derivation, never its authority.
+ */
+export const NATIVE_DOUBLE_CLICK_BUILDS: readonly NativeDoubleClickBuild[] = [
+  {
+    callbackTableSlot: 903,
+    callbackFunctionIndex: 2448,
+    callbackBodySha256:
+      "1f6d69d4364a8369aba990defe34f746063a412fb2e6bc0ae9cc1b4b236acf1e",
+    flagStoreOffset: 101,
+    flagStoreFrameOffset: 24,
+    derivations: {
+      // template-save output, with the Enhancement off
+      "9ee332604a9b2adbdfa1a8ab217f4fd1dac58b01a2443e037bc5bd11f279d094":
+        "e7d86cfcf7b09abbedd3afca758dbf4a3f3c6e1aa4d44e53b31e45e886d7f250",
+      // Enhancement outputs, one per certified capability profile
+      "a29b20f64cffff774b554787bf595a6aa8a6d56ff25e66ee73bf944cff5a1da3":
+        "2c03fb7ac535508d99bc96212d2e087d4322ef7d11cf3e0049f4019035326d50",
+      "d2b6970f61026b48f01defd4fbb59032544c27c89684abffed77987b06292f11":
+        "e69c026e942496b2fbd6bef056fb1eeb0b6ff5e51fed02846fb37a27c53a49f7",
+      "63a330bc7b922ce2432298e8b6f30eb2e4940a218acc999c243c1b0653b28997":
+        "ee642435a41221dd8d2db1dd326d650c1a86e00cd823743d867505a4246bfdc9",
+      "8ba7836b7d27d9a9e31cd85359b2964d5c88b4f577ea3648fb874155fec6da70":
+        "35d258f8373ccf3eb0321a48b98c0ace61a304683d3295b1712a5a71102d1da6",
+    },
+  },
+];
+
+function fail(message: string): never {
+  throw new Error(`native double-click transform: ${message}`);
+}
+
+const sha256 = (bytes: Uint8Array): string =>
+  createHash("sha256").update(bytes).digest("hex");
+
+function encodeName(name: string): Uint8Array {
+  const bytes = new TextEncoder().encode(name);
+  return concat(uleb(bytes.length), bytes);
+}
+
+/** The entry that may consume this module, or null when none may. */
+export function findNativeDoubleClickBuild(
+  inputSha256: string,
+): NativeDoubleClickBuild | null {
+  return (
+    NATIVE_DOUBLE_CLICK_BUILDS.find((build) =>
+      Object.hasOwn(build.derivations, inputSha256),
+    ) ?? null
+  );
+}
+
+/** The module this stage produces from a certified predecessor. */
+export function nativeDoubleClickOutputSha256(
+  build: NativeDoubleClickBuild,
+  inputSha256: string,
+): string | null {
+  return build.derivations[inputSha256] ?? null;
+}
+
+/**
+ * Every active table slot mapped to the function it holds. Only slot-zero
+ * segments with a constant offset appear in this module; anything else is
+ * refused rather than approximated, because a mislocated callback would
+ * rewrite an unrelated function.
+ */
+function tableSlotFunctions(body: Uint8Array): Map<number, number> {
+  const slots = new Map<number, number>();
+  const cursor = { offset: 0 };
+  const count = readUleb(body, cursor);
+  for (let segment = 0; segment < count; segment += 1) {
+    if (readUleb(body, cursor) !== 0) fail("unsupported element segment flags");
+    if (body[cursor.offset++] !== 0x41) fail("expected element i32.const");
+    const base = readUleb(body, cursor);
+    if (body[cursor.offset++] !== 0x0b) fail("malformed element offset");
+    const entries = readUleb(body, cursor);
+    for (let i = 0; i < entries; i += 1) {
+      slots.set(base + i, readUleb(body, cursor));
+    }
+  }
+  if (cursor.offset !== body.byteLength) fail("malformed element section");
+  return slots;
+}
+
+/**
+ * `local.get 3; global.get $flag; i32.store offset=<frameOffset>`.
+ *
+ * Three instructions and no branch: whatever the host last wrote lands in the
+ * record slot, so a press the host declared ordinary clears the slot as surely
+ * as a double-click sets it and no state survives between presses.
+ */
+function flagStore(globalIndex: number, frameOffset: number): Uint8Array {
+  return concat(
+    Uint8Array.of(0x20, 0x03),
+    Uint8Array.of(0x23),
+    uleb(globalIndex),
+    Uint8Array.of(0x36, 0x02),
+    uleb(frameOffset),
+  );
+}
+
+/**
+ * Rewrites one certified module. Returns the derived bytes; throws with the
+ * reason on any input the entry above does not exactly describe.
+ */
+export function rewriteNativeDoubleClickWasm(input: Uint8Array): Uint8Array {
+  const build = findNativeDoubleClickBuild(sha256(input));
+  if (!build) fail("module hash is not a certified build");
+  return rewriteWithBuild(input, build);
+}
+
+/**
+ * The rewrite itself, against an entry supplied rather than looked up. The
+ * production caller above resolves the entry by module hash; this is separated
+ * so the guards can be executed against modules the shipped table does not
+ * name, which is every module a test can build.
+ */
+export function rewriteWithBuild(
+  input: Uint8Array,
+  build: NativeDoubleClickBuild,
+): Uint8Array {
+  const sections = splitSections(input);
+  const slots = tableSlotFunctions(sectionById(sections, 9));
+  const held = slots.get(build.callbackTableSlot);
+  if (held !== build.callbackFunctionIndex) {
+    fail(
+      `table slot ${build.callbackTableSlot} holds function ${held}, ` +
+        `not ${build.callbackFunctionIndex}`,
+    );
+  }
+
+  const bodies = parseCode(sectionById(sections, 10));
+  const importCount = countFunctionImports(sectionById(sections, 2));
+  const localIndex = build.callbackFunctionIndex - importCount;
+  const body = bodies[localIndex];
+  if (!body) fail(`function ${build.callbackFunctionIndex} has no body`);
+  if (sha256(body) !== build.callbackBodySha256) {
+    fail("the mousedown callback is not the certified body");
+  }
+  if (build.flagStoreOffset > body.byteLength) {
+    fail("flag store offset lies outside the callback body");
+  }
+
+  const globals = vectorPayload(sectionById(sections, 6));
+  const exportSection = sectionById(sections, 7);
+  const exports = vectorPayload(exportSection);
+  if (
+    parseExports(exportSection).some(
+      (entry) => entry.name === DOUBLE_CLICK_FLAG_EXPORT,
+    )
+  ) {
+    fail(`export ${DOUBLE_CLICK_FLAG_EXPORT} already exists`);
+  }
+  const flagGlobalIndex = globals.count;
+
+  const nextBodies = [...bodies];
+  nextBodies[localIndex] = concat(
+    body.subarray(0, build.flagStoreOffset),
+    flagStore(flagGlobalIndex, build.flagStoreFrameOffset),
+    body.subarray(build.flagStoreOffset),
+  );
+
+  const rewritten = sections.map((section): Section => {
+    if (section.id === 6) {
+      return {
+        id: section.id,
+        body: concat(
+          uleb(globals.count + 1),
+          globals.entries,
+          // i32, mutable, initialised to zero: no press is a double-click
+          // until the host says so, including the first one after a reload.
+          Uint8Array.of(0x7f, 0x01, 0x41, 0x00, 0x0b),
+        ),
+      };
+    }
+    if (section.id === 7) {
+      return {
+        id: section.id,
+        body: concat(
+          uleb(exports.count + 1),
+          exports.entries,
+          encodeName(DOUBLE_CLICK_FLAG_EXPORT),
+          Uint8Array.of(0x03),
+          uleb(flagGlobalIndex),
+        ),
+      };
+    }
+    if (section.id === 10) {
+      return { id: section.id, body: encodeCode(nextBodies) };
+    }
+    return section;
+  });
+
+  const output = concat(WASM_HEADER, ...rewritten.map(encodeSection));
+  if (!WebAssembly.validate(output)) fail("rewritten module failed validation");
+  return output;
+}

--- a/src/main/client-runtime.ts
+++ b/src/main/client-runtime.ts
@@ -310,6 +310,7 @@ export class ClientRuntime {
       enhancementCapabilities: this.options.enhancementCapabilities,
       compatibilityCacheRoot: this.options.paths.compatibility,
       enhancementCacheRoot: this.options.paths.enhancements,
+      nativeDoubleClickCacheRoot: this.options.paths.nativeDoubleClick,
     });
     const state = prepared.state;
     this.compatibilityValue = {

--- a/src/main/core/paths.ts
+++ b/src/main/core/paths.ts
@@ -28,6 +28,7 @@ export interface GamePaths {
   certificateFeed: string;
   compatibility: string;
   enhancements: string;
+  nativeDoubleClick: string;
   chunks: string;
   bootChunks: string;
   cacheClearRequest: string;
@@ -53,6 +54,7 @@ export function gamePaths(userData: string): GamePaths {
     certificateFeed: path.join(game, "certificate-feed.json"),
     compatibility: path.join(game, "compatibility"),
     enhancements: path.join(game, "enhancements"),
+    nativeDoubleClick: path.join(game, "double-click"),
     chunks: path.join(game, "chunks"),
     bootChunks: path.join(game, "boot-chunks.json"),
     cacheClearRequest: path.join(userData, "clear-cache-on-start"),

--- a/src/main/core/wasm-binary.ts
+++ b/src/main/core/wasm-binary.ts
@@ -314,3 +314,45 @@ export function functionImportIndex(
   });
   return found;
 }
+
+export interface WasmExport {
+  name: string;
+  kind: number;
+  index: number;
+}
+
+/**
+ * A section whose body is one vector, split into its count and the bytes
+ * behind it — what a rewrite needs to append an entry without re-encoding the
+ * entries it is not touching.
+ */
+export function vectorPayload(bytes: Uint8Array): {
+  count: number;
+  entries: Uint8Array;
+} {
+  const cursor = { offset: 0 };
+  const count = readUleb(bytes, cursor);
+  return { count, entries: copyRange(bytes, cursor.offset, bytes.byteLength) };
+}
+
+export function parseExports(bytes: Uint8Array): WasmExport[] {
+  const cursor = { offset: 0 };
+  const count = readUleb(bytes, cursor);
+  const exports: WasmExport[] = [];
+  const decoder = new TextDecoder();
+  for (let index = 0; index < count; index += 1) {
+    const nameLength = readUleb(bytes, cursor);
+    const end = cursor.offset + nameLength;
+    if (end > bytes.byteLength) {
+      throw new Error("wasm-binary: truncated export name");
+    }
+    const name = decoder.decode(copyRange(bytes, cursor.offset, end));
+    cursor.offset = end;
+    const kind = bytes[cursor.offset++]!;
+    exports.push({ name, kind, index: readUleb(bytes, cursor) });
+  }
+  if (cursor.offset !== bytes.byteLength) {
+    throw new Error("wasm-binary: malformed export section");
+  }
+  return exports;
+}

--- a/src/main/diagnostics/renderer.ts
+++ b/src/main/diagnostics/renderer.ts
@@ -144,7 +144,6 @@ export function recordRendererMetrics(value: RendererMetrics): void {
       case "graphics.programCacheSaturated":
       case "clipboard.copied":
       case "clipboard.writeFailed":
-      case "input.tapSuppressed":
         recordEvent(
           { k: event.name, fingerprint },
           { timestampUs: Math.round(event.timestampUs) },

--- a/src/main/diagnostics/schema.ts
+++ b/src/main/diagnostics/schema.ts
@@ -295,6 +295,14 @@ export const DIAGNOSTIC_EVENT_SCHEMA = {
     level: "error",
     fields: { code },
   },
+  // Recorded instead of `quit.cleanupCompleted`, never beside it: the crash
+  // heuristic reads the absence of a completion, so a quit that ran out of
+  // time must say so rather than leave the next launch to call it a crash.
+  "quit.cleanupTimedOut": {
+    subsystem: "app",
+    level: "error",
+    fields: none,
+  },
   "quit.rendererSyncIncomplete": {
     subsystem: "app",
     level: "error",
@@ -1080,17 +1088,6 @@ export const DIAGNOSTIC_EVENT_SCHEMA = {
   "clipboard.writeFailed": {
     subsystem: "renderer",
     level: "warn",
-    fields: { fingerprint: rendererFingerprintOrNull },
-  },
-  // A synthetic double-tap was withheld because a real button was still held
-  // or the pointer was locked. The client's touch path force-releases every
-  // captured button, so delivering one mid-drag desynchronises its button
-  // state and the frame layer asserts. Counting the refusals is how a capture
-  // shows the guard doing its work rather than the crash never recurring by
-  // luck.
-  "input.tapSuppressed": {
-    subsystem: "renderer",
-    level: "debug",
     fields: { fingerprint: rendererFingerprintOrNull },
   },
   "graphics.detected": {

--- a/src/main/lifecycle.ts
+++ b/src/main/lifecycle.ts
@@ -33,22 +33,51 @@ export function onAppQuit(task: CleanupTask): () => void {
   };
 }
 
+/**
+ * How long the whole pass may take before the process leaves anyway.
+ *
+ * A quit request is answered by cancelling the quit and running cleanup, so
+ * until cleanup finishes the application is still there — and Cmd+Q, having
+ * already been consumed, looks like it did nothing. Every task is meant to be
+ * quick, but two of them are not bounded by anything of their own: the
+ * renderer filesystem sync waits out `RENDERER_COMMAND_TIMEOUT_MS`, and the
+ * client shutdown awaits an in-flight game update. This is the ceiling on all
+ * of it, chosen to sit above one renderer command and below the point where a
+ * person presses Cmd+Q a second time.
+ */
+export const QUIT_CLEANUP_DEADLINE_MS = 6_000;
+
 export async function runQuitCleanup(): Promise<void> {
   if (quitting) return;
   quitting = true;
   logEvent({ k: "quit.cleanupStarted" });
   const tasks = [...cleanups].reverse();
   cleanups.length = 0;
-  for (const task of tasks) {
-    try {
-      await task();
-    } catch (err) {
-      logEvent({ k: "quit.cleanupFailed", code: errorCode(err) });
-      // The prose stays on the developer console, which is not exported.
-      console.error("quit cleanup failed", err);
+  let deadline: ReturnType<typeof setTimeout> | undefined;
+  const expired = new Promise<"timed-out">((resolve) => {
+    deadline = setTimeout(() => resolve("timed-out"), QUIT_CLEANUP_DEADLINE_MS);
+  });
+  const pass = (async () => {
+    for (const task of tasks) {
+      try {
+        await task();
+      } catch (err) {
+        logEvent({ k: "quit.cleanupFailed", code: errorCode(err) });
+        // The prose stays on the developer console, which is not exported.
+        console.error("quit cleanup failed", err);
+      }
     }
-  }
-  logEvent({ k: "quit.cleanupCompleted" });
+  })();
+  const outcome = await Promise.race([pass.then(() => "completed" as const), expired]);
+  clearTimeout(deadline);
+  // A task still running past the deadline keeps running; nothing here can
+  // cancel it. What the deadline buys is that the process no longer waits for
+  // it, and that the record says which of the two happened.
+  logEvent(
+    outcome === "completed"
+      ? { k: "quit.cleanupCompleted" }
+      : { k: "quit.cleanupTimedOut" },
+  );
   await flushDiagnostics();
 }
 

--- a/src/main/window-menu.ts
+++ b/src/main/window-menu.ts
@@ -197,6 +197,17 @@ export function installApplicationMenu({
                 });
               },
             },
+            // The trace answers a different question from a capture — what the
+            // input host decided, not what the frame cost — so it is its own
+            // switch rather than a level of the capture it would otherwise
+            // have to be armed alongside.
+            {
+              id: "toggle-input-trace",
+              label: "Show Input Trace",
+              click: () => {
+                void sendRendererCommand(win, { type: "input.trace" });
+              },
+            },
             {
               id: "stop-capture",
               label: "Stop Capture",

--- a/src/renderer/commands.ts
+++ b/src/renderer/commands.ts
@@ -65,6 +65,9 @@
           });
         });
         break;
+      case 'input.trace':
+        dispatch('gw:input-trace');
+        break;
       case 'diagnostics.toggle':
         dispatch('gw:diagnostics-toggle');
         break;

--- a/src/renderer/diagnostics.ts
+++ b/src/renderer/diagnostics.ts
@@ -41,7 +41,6 @@
     'graphics.programCacheSaturated',
     'clipboard.copied',
     'clipboard.writeFailed',
-    'input.tapSuppressed',
   ]);
   const histogram = (): Histogram => ({
     buckets: new Array<number>(histogramLimitsUs.length).fill(0),

--- a/src/renderer/gw-native.d.ts
+++ b/src/renderer/gw-native.d.ts
@@ -44,6 +44,44 @@ declare global {
     releaseAll(): void;
   }
 
+  /**
+   * One thing the input host saw or decided, before the trace stamps it. The
+   * union is closed because a trace whose vocabulary can grow by writing a
+   * string is a trace nobody can summarise: every member here has a fixed row
+   * in the overlay and a fixed line in the copied transcript.
+   *
+   * `travelPx` is a distance, `detail` is Chromium's click-run count, and
+   * neither is a position — no member carries a coordinate, so the transcript
+   * a player pastes into a public issue cannot describe where their window is
+   * or what they clicked.
+   */
+  type InputTraceEntry =
+    | { kind: "press"; button: number; detail: number; modifiers: string }
+    | { kind: "release"; button: number; travelPx: number }
+    | { kind: "modifier"; key: "ctrl" | "shift" | "alt"; down: boolean }
+    /**
+     * A press Chromium counted as an even click of a run. `delivered` is
+     * whether the client could be told: false means the served module carries
+     * no double-click flag, which is what an uncertified build looks like from
+     * here and the first thing to check when double-click does nothing.
+     */
+    | { kind: "double-click"; delivered: boolean }
+    | { kind: "pointer-lock"; locked: boolean }
+    | { kind: "release-all"; cause: "blur" | "hidden" | "command" | "leave" };
+
+  /** An entry with the trace's own timing attached. */
+  type InputTraceRecord = InputTraceEntry & {
+    atMs: number;
+    sinceMs: number | null;
+  };
+
+  interface InputTrace {
+    enabled(): boolean;
+    /** Returns the state it switched to, so a caller can report it. */
+    toggle(): boolean;
+    record(entry: InputTraceEntry): void;
+  }
+
   interface LoadingController {
     set(message: string, fraction: number | null, detail?: string): void;
     fail(message: string, detail?: string): void;

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -425,6 +425,7 @@ let clientHealthConfirmation:
 let createClientHealthConfirmation:
   typeof import('./client-health.js').createClientHealthConfirmation;
 let inputHost: GameInputController | null = null;
+let inputTrace: InputTrace | null = null;
 window.gwApplySettings = (next) => {
   const previousScale = appSettings?.renderScale;
   const updated = { ...next };
@@ -451,6 +452,8 @@ let host: typeof import('./graphics.js') &
   typeof import('./gl-program-cache.js') &
   typeof import('./filesystem.js') &
   typeof import('./input.js') &
+  typeof import('./input-trace.js') &
+  typeof import('./native-double-click.js') &
   typeof import('./clipboard-copy.js') &
   typeof import('./template-save-compatibility.js') &
   typeof import('./template-filesystem-trace.js');
@@ -944,13 +947,43 @@ function loadGlue() {
     window.addEventListener(ev, resumeAudio, true);
   }
 
+  // The trace observes the input host and is switched on from the menu. It is
+  // built here, before the host, because the host takes it once and never asks
+  // again — a trace created later would watch nothing.
+  inputTrace = host.createInputTrace(
+    document.body,
+    (text) => native().clipboard.writeText(text),
+  );
+  window.addEventListener('gw:input-trace', () => {
+    log(`input trace: ${inputTrace?.toggle() ? 'on' : 'off'}`);
+  });
+
   inputHost = host.installGameInput({
     canvas: c,
     diagnostics: window.gwDiagnostics,
+    trace: inputTrace,
     // Read through the window global rather than a module handle: input
     // installs before the enhancement chain decides whether a certified
     // cursor readout exists at all.
     clientCursorHidden: () => window.gwCursorState?.()?.hidden ?? null,
+    log,
+  });
+
+  // After the input host, and both before the glue. Correctness only needs the
+  // flag written before the client's own canvas listener runs, and a
+  // window-capture listener always precedes one on the canvas. Order between
+  // these two settles something smaller: registered first, this recorded its
+  // trace row above the press it belongs to, which read like the flag arrived
+  // before the click. The instance is read per press because input installs
+  // long before the glue instantiates anything.
+  host.installNativeDoubleClick({
+    flag: () => {
+      const exported = gameWasmInstance?.exports?.['gwonmac_double_click'];
+      return exported && typeof exported === 'object' && 'value' in exported
+        ? (exported as { value: number })
+        : null;
+    },
+    trace: inputTrace,
     log,
   });
   // Text entry runs through these, not through keydown on the canvas. Stray
@@ -1023,6 +1056,8 @@ function loadGlue() {
       glProgramCache,
       filesystem,
       input,
+      inputTraceModule,
+      nativeDoubleClickModule,
       clipboardCopy,
       templateSaveCompatibility,
       templateFilesystemTrace,
@@ -1035,6 +1070,8 @@ function loadGlue() {
       import('./gl-program-cache.js'),
       import('./filesystem.js'),
       import('./input.js'),
+      import('./input-trace.js'),
+      import('./native-double-click.js'),
       import('./clipboard-copy.js'),
       import('./template-save-compatibility.js'),
       import('./template-filesystem-trace.js'),
@@ -1046,6 +1083,8 @@ function loadGlue() {
       ...glProgramCache,
       ...filesystem,
       ...input,
+      ...inputTraceModule,
+      ...nativeDoubleClickModule,
       ...clipboardCopy,
       ...templateSaveCompatibility,
       ...templateFilesystemTrace,

--- a/src/renderer/input-trace.ts
+++ b/src/renderer/input-trace.ts
@@ -1,0 +1,266 @@
+/**
+ * The input trace: a live, bounded record of what the input host saw and what
+ * it decided, drawn over the game so a player can reproduce a click bug and
+ * hand back the sequence that caused it.
+ *
+ * It owns the ring buffer, the overlay, and the text it copies out. It decides
+ * nothing about input — `input.ts` remains the one input policy and calls in
+ * here at the points where it makes a choice. Turning the trace off must not
+ * change a single client-visible event, so this module never dispatches, never
+ * cancels, and never touches the canvas.
+ *
+ * Deliberately not the diagnostics recorder: that is the certified,
+ * closed-schema, main-process path for shipped telemetry. This is a developer
+ * and bug-reporter instrument the player can read on screen and paste into an
+ * issue, and it never leaves the renderer unless the player copies it.
+ */
+
+// A hand cannot produce more than a few events per second that matter here,
+// and a reporter needs the run-up to the mistake rather than the whole
+// session. Two hundred entries is about a minute of deliberate clicking.
+const TRACE_CAPACITY = 200;
+
+// Rows drawn in the panel. The buffer keeps more than the panel shows so the
+// copied text carries the run-up that scrolled away.
+const VISIBLE_ROWS = 14;
+
+const OVERLAY_CSS = `
+/*
+ * Bottom left: the other fixed overlays own the rest — #capture-status the top
+ * left, #diagnostics the top right, Tools the bottom right — and a capture is
+ * exactly the thing most likely to be running at the same time as this. Only
+ * the two buttons take the pointer; every other pixel of the panel lets a
+ * click through to the game beneath it.
+ */
+#input-trace {
+  position: fixed;
+  bottom: 12px;
+  left: 12px;
+  z-index: 5;
+  width: 460px;
+  max-width: calc(100vw - 24px);
+  box-sizing: border-box;
+  padding: 8px 12px;
+  border: 1px solid #4a4740;
+  border-radius: 3px;
+  /* Near-opaque on purpose. At 0.88 the game's own chat drew straight through
+     the rows and the trace was unreadable in exactly the crowded district
+     someone would be debugging in. */
+  background: rgba(8, 8, 10, 0.97);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.55);
+  color: #e8e4d8;
+  font: 11px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-variant-numeric: tabular-nums;
+  pointer-events: none;
+  user-select: none;
+  -webkit-user-select: none;
+}
+#input-trace[hidden] { display: none; }
+#input-trace header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+  color: #c8aa6e;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+#input-trace header span[data-role="count"] { color: #8d8a82; margin-left: auto; }
+#input-trace button {
+  pointer-events: auto;
+  padding: 2px 8px;
+  border: 1px solid #524e44;
+  border-radius: 2px;
+  background: #1d1c19;
+  color: #e8e4d8;
+  font: inherit;
+  text-transform: none;
+  letter-spacing: 0;
+  cursor: default;
+}
+#input-trace button:hover { background: #2a2823; border-color: #6b6557; }
+#input-trace button:focus-visible { outline: 1px solid #c8aa6e; outline-offset: 1px; }
+#input-trace ol {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 1px;
+}
+#input-trace li { white-space: pre; overflow: hidden; text-overflow: ellipsis; }
+#input-trace li[data-tone="decision"] { color: #ffb488; }
+#input-trace li[data-tone="refused"] { color: #8d8a82; }
+#input-trace p {
+  margin: 6px 0 0;
+  color: #8d8a82;
+  white-space: normal;
+}
+`;
+
+const label = (record: InputTraceRecord): { text: string; tone: string } => {
+  const at = String(Math.round(record.atMs)).padStart(6, ' ');
+  const gap = record.sinceMs === null
+    ? '     —'
+    : `${String(Math.round(record.sinceMs)).padStart(5, ' ')}ms`;
+  switch (record.kind) {
+    case 'press':
+      return {
+        tone: 'event',
+        text: `${at} ${gap}  press  ${BUTTON_NAMES[record.button] ?? record.button}`
+          + `  run=${record.detail}${record.modifiers}`,
+      };
+    case 'release':
+      return {
+        tone: 'event',
+        text: `${at} ${gap}  release ${BUTTON_NAMES[record.button] ?? record.button}`
+          + `  moved=${record.travelPx}px`,
+      };
+    case 'modifier':
+      // Its own row rather than a column on the press, because the client
+      // builds the modifier state a click carries out of these events and not
+      // out of the click. A missing row here is the whole bug for Ctrl+click.
+      return {
+        tone: 'event',
+        text: `${at} ${gap}  ${record.key}${record.down ? ' down' : ' up'}`,
+      };
+    case 'double-click':
+      // Recorded from the press that carried it, so it sits immediately under
+      // its own `press … run=2` row rather than a quarter second later.
+      return record.delivered
+        ? { tone: 'decision', text: `${at} ${gap}  DOUBLE-CLICK flagged` }
+        : {
+            tone: 'refused',
+            text: `${at} ${gap}  DOUBLE-CLICK unavailable (client not certified)`,
+          };
+    case 'pointer-lock':
+      return {
+        tone: 'decision',
+        text: `${at} ${gap}  pointer lock ${record.locked ? 'engaged' : 'released'}`,
+      };
+    case 'release-all':
+      return { tone: 'refused', text: `${at} ${gap}  input released (${record.cause})` };
+  }
+};
+
+const BUTTON_NAMES: Readonly<Record<number, string>> = {
+  0: 'left ',
+  1: 'middle',
+  2: 'right',
+};
+
+/**
+ * `writeText` is the native clipboard bridge, not `navigator.clipboard`: the
+ * renderer is a sandboxed custom-scheme document, so the Clipboard API rejects
+ * the write and the button reported a failure it could do nothing about. The
+ * same bridge already serves Cmd+C from the game's text proxy.
+ */
+export function createInputTrace(
+  parent: HTMLElement,
+  writeText: (text: string) => Promise<void>,
+): InputTrace {
+  const style = document.createElement('style');
+  style.textContent = OVERLAY_CSS;
+  const root = document.createElement('div');
+  root.id = 'input-trace';
+  root.hidden = true;
+  root.innerHTML = `
+    <header>
+      Input trace
+      <button type="button" data-role="copy">Copy</button>
+      <button type="button" data-role="clear">Clear</button>
+      <span data-role="count"></span>
+    </header>
+    <ol data-role="rows"></ol>
+    <p data-role="hint">Reproduce the problem, then Copy and paste it into the issue.</p>
+  `;
+  parent.append(style, root);
+
+  const rows = root.querySelector<HTMLOListElement>('[data-role="rows"]')!;
+  const count = root.querySelector<HTMLElement>('[data-role="count"]')!;
+  const copyButton = root.querySelector<HTMLButtonElement>('[data-role="copy"]')!;
+  const clearButton = root.querySelector<HTMLButtonElement>('[data-role="clear"]')!;
+
+  const entries: InputTraceRecord[] = [];
+  let enabled = false;
+  let lastAt: number | null = null;
+  // A frame's worth of records is one repaint, not one repaint each: a burst
+  // that arrives inside a single task must not lay out the panel per entry.
+  let painting = false;
+
+  const paint = () => {
+    painting = false;
+    const shown = entries.slice(-VISIBLE_ROWS);
+    rows.replaceChildren(...shown.map((record) => {
+      const { text, tone } = label(record);
+      const li = document.createElement('li');
+      li.dataset.tone = tone;
+      li.textContent = text;
+      return li;
+    }));
+    count.textContent = `${entries.length}/${TRACE_CAPACITY}`;
+  };
+
+  const schedulePaint = () => {
+    if (painting) return;
+    painting = true;
+    requestAnimationFrame(paint);
+  };
+
+  copyButton.addEventListener('click', () => {
+    void writeText(transcript(entries)).then(
+      () => { copyButton.textContent = 'Copied'; },
+      () => { copyButton.textContent = 'Copy failed'; },
+    ).then(() => {
+      setTimeout(() => { copyButton.textContent = 'Copy'; }, 1_500);
+    });
+  });
+  clearButton.addEventListener('click', () => {
+    entries.length = 0;
+    lastAt = null;
+    schedulePaint();
+  });
+
+  return Object.freeze({
+    enabled: () => enabled,
+    toggle() {
+      enabled = !enabled;
+      root.hidden = !enabled;
+      // A trace that keeps accumulating while hidden would hand back a
+      // transcript of whatever the player did after they stopped looking.
+      if (!enabled) {
+        entries.length = 0;
+        lastAt = null;
+      }
+      schedulePaint();
+      return enabled;
+    },
+    record(entry: InputTraceEntry) {
+      if (!enabled) return;
+      const atMs = performance.now();
+      const record = {
+        ...entry,
+        atMs,
+        sinceMs: lastAt === null ? null : atMs - lastAt,
+      } as InputTraceRecord;
+      lastAt = atMs;
+      entries.push(record);
+      if (entries.length > TRACE_CAPACITY) entries.shift();
+      schedulePaint();
+    },
+  });
+}
+
+/**
+ * The text the Copy button produces: the same rows the panel draws, oldest
+ * first, under a header naming what produced them. Nothing here is an
+ * identifier — no coordinates, no window position, no account state — so a
+ * player can paste it into a public issue without reading it first.
+ */
+function transcript(entries: readonly InputTraceRecord[]): string {
+  const head = [
+    `gwonmac input trace — ${entries.length} events`,
+    'columns: elapsed  gap  event  detail',
+    '',
+  ];
+  return [...head, ...entries.map((record) => label(record).text)].join('\n');
+}

--- a/src/renderer/input.ts
+++ b/src/renderer/input.ts
@@ -16,20 +16,6 @@ const POINTER_ROAM = 16;
 // dropped. Four cross a drag's whole range; further is a teleport, not a drag.
 const MAX_POINTER_REGRABS = 4;
 
-// Chromium's own double-click slop: clicks further apart than this are
-// separate clicks, so a press that travelled further before releasing was a
-// drag, not half of a double-click.
-const DOUBLE_CLICK_SLOP = 4;
-
-// A deliberate double-click and the first two clicks of a fast burst are
-// physically identical; only what follows tells them apart. The synthetic tap
-// pair is therefore held back long enough for a continuing burst's third
-// press to cancel it — the Windows client ignores double-clicks on buttons,
-// so a burst (attribute points) must produce plain clicks and nothing else.
-// The cost is a real double-click's action landing this much later.
-const DOUBLE_TAP_HOLDBACK_MS = 250;
-const DOUBLE_TAP_GAP_MS = 80;
-
 // ArenaNet's web client identifies a binding by KeyboardEvent.key, which is a
 // character from the active keyboard layout. Give each main-block position a
 // unique stable US-layout character instead. `code` already is the browser's
@@ -49,6 +35,30 @@ const PHYSICAL_PUNCTUATION_KEYS: Readonly<Record<string, string>> = {
   Period: '.',
   Slash: '/',
 };
+
+// The modifier keys the client tracks, by the `KeyboardEvent.key` it reads.
+// It has no fourth: Command is not a Guild Wars modifier.
+const TRACED_MODIFIERS: Readonly<Record<string, 'ctrl' | 'shift' | 'alt'>> = {
+  Control: 'ctrl',
+  Shift: 'shift',
+  Alt: 'alt',
+};
+
+/**
+ * The modifiers a press carried, as the trace prints them.
+ *
+ * Worth knowing when reading one: the client does not use these. Its mouse
+ * callback reads only the button and the position out of the event and never
+ * touches the modifier bytes beside them, so a press message carries a
+ * modifier state the client accumulated from *key* events instead. A trace
+ * that shows `left +ctrl` on the press and no Control key down before it is
+ * therefore a report about the keyboard path, not the mouse one.
+ */
+const modifierText = (event: MouseEvent): string =>
+  (event.ctrlKey ? ' +ctrl' : '') +
+  (event.shiftKey ? ' +shift' : '') +
+  (event.altKey ? ' +alt' : '') +
+  (event.metaKey ? ' +cmd' : '');
 
 const physicalKey = (code: string, fallback: string): string => {
   if (/^Key[A-Z]$/.test(code)) return code.slice(3).toLowerCase();
@@ -82,6 +92,11 @@ type HeldKey = {
 type HeldButton = {
   target: EventTarget | null;
   button: number;
+  // Where the press landed, which the moves below deliberately do not update:
+  // the trace reports how far a press travelled before its release, and the
+  // live coordinates have already been walked to the pointer by then.
+  originX: number;
+  originY: number;
   clientX: number;
   clientY: number;
   screenX: number;
@@ -95,6 +110,12 @@ type HeldButton = {
 type GameInputOptions = {
   canvas: HTMLCanvasElement;
   diagnostics?: GameInputDiagnostics;
+  /**
+   * The developer trace, when the player has switched it on. It observes and
+   * never decides: every call here is on a path whose behaviour is identical
+   * with the trace absent.
+   */
+  trace?: InputTrace;
   /**
    * The client's own cursor-hidden state through the certified cursor
    * readout, or null while that readout is unavailable (enhancement off,
@@ -113,18 +134,23 @@ const POINTER_MODE_INTERVAL_MS = 50;
 export const installGameInput = ({
   canvas,
   diagnostics,
+  trace,
   clientCursorHidden,
   log,
 }: GameInputOptions): GameInputController => {
   const heldKeys = new Map<string, HeldKey>();
   const heldButtons = new Map<number, HeldButton>();
-  const syntheticTouches = new Map<number, Touch>();
-  const tapTimers = new Set<ReturnType<typeof setTimeout>>();
-  let pendingTap: { x: number; y: number } | null = null;
-  let touchId = 0;
   let virtualCursor: { x: number; y: number } | null = null;
   let pointerWanted = false;
   let modeWatch: ReturnType<typeof setInterval> | null = null;
+  // The lock state the trace last reported, which is not the same as the lock
+  // state. A right-click shorter than the lock's round trip resolves its
+  // request after the button is already up, so the exit below runs before the
+  // browser delivers the change event that announced the lock — and both that
+  // event and the one for the exit then read an already-cleared
+  // `pointerLockElement`. Reporting each of those is how a lock nobody held
+  // came out of the trace as "released" twice with no "engaged" above it.
+  let lockTraced = false;
 
   function stopModeWatch() {
     if (modeWatch !== null) clearInterval(modeWatch);
@@ -151,68 +177,6 @@ export const installGameInput = ({
       else if (button === 4) buttons |= 16;
     }
     return buttons;
-  };
-
-  const schedule = (callback: () => void, delay: number) => {
-    const timer = setTimeout(() => {
-      tapTimers.delete(timer);
-      callback();
-    }, delay);
-    tapTimers.add(timer);
-    return timer;
-  };
-
-  const cancelTapTimers = () => {
-    for (const timer of tapTimers) clearTimeout(timer);
-    tapTimers.clear();
-  };
-
-  const makeTouch = (x: number, y: number, identifier: number) => new Touch({
-    identifier,
-    target: canvas,
-    clientX: x,
-    clientY: y,
-    pageX: x,
-    pageY: y,
-    screenX: x,
-    screenY: y,
-    radiusX: 5,
-    radiusY: 5,
-    rotationAngle: 0,
-    force: 1,
-  });
-
-  const sendTouch = (
-    type: 'touchstart' | 'touchend' | 'touchcancel',
-    touch: Touch,
-  ) => {
-    const ended = type === 'touchend' || type === 'touchcancel';
-    canvas.dispatchEvent(new TouchEvent(type, {
-      bubbles: true,
-      cancelable: true,
-      composed: true,
-      touches: ended ? [] : [touch],
-      targetTouches: ended ? [] : [touch],
-      changedTouches: [touch],
-    }));
-  };
-
-  const startTouch = (touch: Touch) => {
-    syntheticTouches.set(touch.identifier, touch);
-    sendTouch('touchstart', touch);
-  };
-  const finishTouch = (type: 'touchend' | 'touchcancel', touch: Touch) => {
-    syntheticTouches.delete(touch.identifier);
-    sendTouch(type, touch);
-  };
-
-  const cancelSyntheticTouches = () => {
-    cancelTapTimers();
-    pendingTap = null;
-    for (const touch of syntheticTouches.values()) {
-      sendTouch('touchcancel', touch);
-    }
-    syntheticTouches.clear();
   };
 
   const sendMouse = (
@@ -353,9 +317,6 @@ export const installGameInput = ({
     if (releasing) return;
     releasing = true;
     try {
-      // A double-click repair interrupted between its two taps must not leave
-      // ArenaNet's touch detector held across a native modal or focus change.
-      cancelSyntheticTouches();
       resetWheel();
       releaseKeys();
       releaseButtons();
@@ -369,6 +330,8 @@ export const installGameInput = ({
     const held = heldKeys.get(event.code);
     const key = clientKey(event, event.repeat ? held?.key : undefined);
     if (event.repeat && held) return;
+    const modifier = TRACED_MODIFIERS[key];
+    if (modifier) trace?.record({ kind: 'modifier', key: modifier, down: true });
     heldKeys.set(event.code, {
       target: event.target,
       key,
@@ -386,7 +349,9 @@ export const installGameInput = ({
   window.addEventListener('keyup', (event) => {
     if (!event.isTrusted) return;
     const held = heldKeys.get(event.code);
-    clientKey(event, held?.key);
+    const key = clientKey(event, held?.key);
+    const modifier = TRACED_MODIFIERS[key];
+    if (modifier) trace?.record({ kind: 'modifier', key: modifier, down: false });
     heldKeys.delete(event.code);
     // A release landing on renderer UI (the Tools palette) never bubbles back
     // to the client's canvas listeners, so a press the canvas received would
@@ -409,9 +374,17 @@ export const installGameInput = ({
   }, true);
   window.addEventListener('mousedown', (event) => {
     if (!event.isTrusted) return;
+    trace?.record({
+      kind: 'press',
+      button: event.button,
+      detail: event.detail,
+      modifiers: modifierText(event),
+    });
     heldButtons.set(event.button, {
       target: event.target,
       button: event.button,
+      originX: event.clientX,
+      originY: event.clientY,
       clientX: event.clientX,
       clientY: event.clientY,
       screenX: event.screenX,
@@ -425,6 +398,16 @@ export const installGameInput = ({
   window.addEventListener('mouseup', (event) => {
     if (!event.isTrusted) return;
     const held = heldButtons.get(event.button);
+    trace?.record({
+      kind: 'release',
+      button: event.button,
+      travelPx: held
+        ? Math.round(Math.hypot(
+          event.clientX - held.originX,
+          event.clientY - held.originY,
+        ))
+        : 0,
+    });
     heldButtons.delete(event.button);
     if (held && held.target === canvas && event.target !== canvas) {
       dispatchButtonRelease(held);
@@ -444,11 +427,20 @@ export const installGameInput = ({
     }
   }, true);
 
-  window.addEventListener('blur', releaseAll);
-  window.addEventListener('pagehide', releaseAll);
-  window.addEventListener('gw:input-reset', releaseAll);
+  const releaseFor = (cause: 'blur' | 'hidden' | 'command' | 'leave') => () => {
+    // Only the causes are named, not a new reason to release: every one of
+    // these already released everything, and the trace exists to say which
+    // native interruption ended a drag the player thought they still had.
+    if (heldKeys.size || heldButtons.size) {
+      trace?.record({ kind: 'release-all', cause });
+    }
+    releaseAll();
+  };
+  window.addEventListener('blur', releaseFor('blur'));
+  window.addEventListener('pagehide', releaseFor('blur'));
+  window.addEventListener('gw:input-reset', releaseFor('command'));
   document.addEventListener('visibilitychange', () => {
-    if (document.visibilityState === 'hidden') releaseAll();
+    if (document.visibilityState === 'hidden') releaseFor('hidden')();
   });
 
   // Pixel deltas from trackpads become bounded pixel steps; discrete mouse
@@ -495,78 +487,6 @@ export const installGameInput = ({
     normalizedWheels.add(normalized);
     canvas.dispatchEvent(normalized);
   }, { capture: true, passive: false });
-
-  /**
-   * Whether a synthetic tap may reach the client right now.
-   *
-   * A tap is not a passive hint: the client's touch path force-releases every
-   * mouse button it has captured, moves its cursor to the tap point, and
-   * switches to a touch input mode in which real mouse releases are dropped
-   * until a real press restores it. Delivered mid-drag — walking with both
-   * buttons, steering the camera — that desynchronises the client's button
-   * state from the OS's, and the frame layer asserts on the mismatch. The tap
-   * pair is deferred by design, so this is re-asked when it fires, not only
-   * when it is scheduled.
-   */
-  const tapsSafe = () =>
-    heldButtons.size === 0 && document.pointerLockElement !== canvas;
-
-  const tapAt = (x: number, y: number, delay: number) => schedule(() => {
-    if (!tapsSafe()) {
-      cancelSyntheticTouches();
-      diagnostics?.event('input.tapSuppressed');
-      return;
-    }
-    const touch = makeTouch(x, y, ++touchId);
-    startTouch(touch);
-    // The touchstart dispatch can synchronously cancel all synthetic input —
-    // releaseAll from a listener the client installed. A touchend for a touch
-    // no longer tracked would restate an input the cancel already retracted.
-    if (!syntheticTouches.has(touch.identifier)) return;
-    schedule(() => finishTouch('touchend', touch), 30);
-  }, delay);
-
-  canvas.addEventListener('mousedown', (event) => {
-    if (event.button !== 0) return;
-    // A left press while another button is already held is the walk-and-look
-    // grip, not a click run: no double-tap belongs to it, and the tap would
-    // tear down the capture the other button holds.
-    if (heldButtons.size > 1 || document.pointerLockElement === canvas) {
-      cancelSyntheticTouches();
-      return;
-    }
-    // Chromium already applies the user's macOS double-click speed and
-    // distance preferences to detail. ArenaNet's mouse bridge discards that
-    // count, but its touch path has the double-tap detector the game needs for
-    // actions such as equipping an item. Preserve every mouse event and append
-    // exactly that missing signal for each completed native double-click.
-    // detail counts the whole click run, so only the transition into its
-    // second click is one: the later even counts (4, 6, …) are rapid single
-    // clicks continuing the run, and synthesizing for them turned fast
-    // attribute-point clicking into spurious double-clicks.
-    cancelSyntheticTouches();
-    if (event.detail === 2) {
-      pendingTap = { x: event.clientX, y: event.clientY };
-    }
-  }, true);
-
-  canvas.addEventListener('mouseup', (event) => {
-    if (event.button !== 0 || !pendingTap) return;
-    const { x, y } = pendingTap;
-    pendingTap = null;
-    // A press that travelled past the slop before releasing was a drag; a tap
-    // pair at the stale press point would act far from where the drag ended.
-    if (
-      Math.abs(event.clientX - x) > DOUBLE_CLICK_SLOP ||
-      Math.abs(event.clientY - y) > DOUBLE_CLICK_SLOP
-    ) return;
-    tapAt(x, y, DOUBLE_TAP_HOLDBACK_MS);
-    tapAt(x, y, DOUBLE_TAP_HOLDBACK_MS + DOUBLE_TAP_GAP_MS);
-  }, true);
-
-  canvas.addEventListener('mouseleave', () => {
-    pendingTap = null;
-  }, true);
 
   // The client steers from absolute coordinates, so a held right-drag eventually
   // runs out of the room a re-anchor gives it. Release and re-press at center
@@ -694,6 +614,10 @@ export const installGameInput = ({
   }, true);
   document.addEventListener('pointerlockchange', () => {
     const locked = document.pointerLockElement === canvas;
+    if (locked !== lockTraced) {
+      lockTraced = locked;
+      trace?.record({ kind: 'pointer-lock', locked });
+    }
     canvas.classList.toggle('cursor-hidden', locked);
     if (locked && !pointerWanted) {
       document.exitPointerLock();
@@ -706,10 +630,9 @@ export const installGameInput = ({
     log('[warn] pointer lock failed (needs a user gesture and focused document)');
     releaseButtons();
   });
-  document.documentElement.addEventListener('mouseleave', releaseAll);
+  document.documentElement.addEventListener('mouseleave', releaseFor('leave'));
 
   canvas.addEventListener('contextmenu', (event) => event.preventDefault());
-  log('macOS double-click repair: enabled');
   canvas.dataset.inputReady = 'true';
 
   return Object.freeze({

--- a/src/renderer/native-double-click.ts
+++ b/src/renderer/native-double-click.ts
@@ -1,0 +1,61 @@
+/**
+ * Tells the client which presses are double-clicks, using its own flag.
+ *
+ * The served module carries one exported mutable global (see
+ * `src/main/certification/native-double-click.ts`). Its mousedown callback
+ * copies that global into the input record's flag word, the translator carries
+ * the word into the press message, and `FrMouse` masks bit 0 out of it as
+ * `FLAG_DBL_CLICK`. All of that is the client's; the only thing missing was
+ * something to write the global, and that is this file.
+ *
+ * It decides nothing about what a double-click is. Chromium's `detail` already
+ * counts a click run under the player's own macOS double-click speed and
+ * distance preferences, and Windows raises `WM_LBUTTONDBLCLK` on every even
+ * click of a run — so every even count sets the flag and every other press
+ * clears it.
+ *
+ * The write is unconditional on every trusted press, including the ones that
+ * are not double-clicks and the ones on other buttons. That is what keeps it
+ * stateless: the client reads the global exactly once per press, so a press
+ * that failed to reach the client cannot leave a set flag behind for the next
+ * one.
+ */
+
+/** A `WebAssembly.Global` is all this needs, narrowed to what it writes. */
+type FlagGlobal = { value: number };
+
+type NativeDoubleClickOptions = {
+  /**
+   * The exported flag, or null when the served module does not carry it —
+   * an unrecognised client build, which the certification chain serves
+   * untransformed. There is no fallback: the client simply has no
+   * double-click until its build is certified again.
+   */
+  flag: () => FlagGlobal | null;
+  trace?: InputTrace;
+  log(...values: unknown[]): void;
+};
+
+export const installNativeDoubleClick = ({
+  flag,
+  trace,
+  log,
+}: NativeDoubleClickOptions): void => {
+  // Capture phase on the window, so this runs before the listener the client's
+  // glue registers on the canvas and the flag is already in place when the
+  // callback reads it. Registered here rather than on the canvas for the same
+  // reason: capture descends from the root, so an ancestor always precedes it.
+  window.addEventListener('mousedown', (event) => {
+    if (!event.isTrusted) return;
+    const global = flag();
+    const doubleClick = event.button === 0 && event.detail % 2 === 0;
+    if (global) global.value = doubleClick ? 1 : 0;
+    // Recorded even when there is nothing to write to. A double-click that
+    // the client cannot be told about is the report worth having, and the
+    // absent row would otherwise look like the press never happened.
+    if (doubleClick) {
+      trace?.record({ kind: 'double-click', delivered: global !== null });
+    }
+  }, true);
+  log('native double-click: enabled');
+};

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -671,6 +671,7 @@ export type RendererCommand =
       checkForUpdates?: boolean;
     }
   | { type: "filesystem.sync" }
+  | { type: "input.trace" }
   | { type: "diagnostics.toggle" }
   | {
       type: "diagnostics.capture";

--- a/src/shared/diagnostics.ts
+++ b/src/shared/diagnostics.ts
@@ -49,7 +49,6 @@ export const RENDERER_EVENT_NAMES = [
   "graphics.programCacheSaturated",
   "clipboard.copied",
   "clipboard.writeFailed",
-  "input.tapSuppressed",
 ] as const;
 
 export type RendererEventName = (typeof RENDERER_EVENT_NAMES)[number];

--- a/src/tools/certification.ts
+++ b/src/tools/certification.ts
@@ -32,6 +32,14 @@ import {
 } from "../main/certification/enhancement-builds.js";
 import { transformEnhancementWasm } from "../main/certification/enhancement-transform.js";
 import {
+  NATIVE_DOUBLE_CLICK_BUILDS,
+  rewriteWithBuild,
+} from "../main/certification/native-double-click.js";
+import {
+  findTemplateSaveBuild,
+  rewriteTemplateSaveWasm,
+} from "../main/certification/template-save-compat.js";
+import {
   ENHANCEMENT_CAPABILITY_PROFILES,
   ENHANCEMENT_TRANSFORM_ABI,
 } from "../shared/contracts.js";
@@ -56,7 +64,8 @@ const USAGE =
   + "  recertify [PATH/Gw.jspi.wasm]        draft an Enhancement build entry, with evidence\n"
   + "  template [PATH/Gw.jspi.wasm] [--emit-ts] [--write] [--expect-certified]\n"
   + "                                       re-derive the template-save build entry\n"
-  + "  transform INPUT.wasm OUTPUT.wasm     write the derived Enhancement module\n";
+  + "  transform INPUT.wasm OUTPUT.wasm     write the derived Enhancement module\n"
+  + "  double-click [PATH/Gw.jspi.wasm]     re-derive the native double-click table\n";
 
 /**
  * The one fixed profile the command line emits. The other certified profiles
@@ -204,7 +213,77 @@ async function transform(argv: readonly string[]): Promise<void> {
   })}\n`);
 }
 
-const COMMANDS = Object.freeze({ doctor, recertify, template, transform });
+/**
+ * Re-derives the native double-click table by running the whole chain from the
+ * official bytes: template-save, then each certified Enhancement profile, then
+ * this transform against every one of those outputs.
+ *
+ * It reads nothing from the shipped table except the structural entry — the
+ * callback's slot, index, body hash and offsets — so a disagreement between
+ * what it prints and what is checked in is a real change in the client rather
+ * than a restatement of the constant being checked.
+ */
+async function doubleClick(argv: readonly string[]): Promise<void> {
+  const [filename] = positionalArguments(argv);
+  const official = new Uint8Array(
+    await readFile(filename ?? installedClientArtifact()),
+  );
+  const officialSha256 = createHash("sha256").update(official).digest("hex");
+  const templateBuild = findTemplateSaveBuild(officialSha256);
+  if (!templateBuild) {
+    throw new Error(`unsupported official WASM hash ${officialSha256}`);
+  }
+  const templateSave = rewriteTemplateSaveWasm(official, templateBuild);
+  const predecessors: Array<[string, Uint8Array]> = [
+    ["template-save", templateSave],
+  ];
+  const enhancementBuild = findEnhancementBuild(
+    createHash("sha256").update(templateSave).digest("hex"),
+  );
+  if (enhancementBuild) {
+    for (const [profile, capabilities] of Object.entries(
+      ENHANCEMENT_CAPABILITY_PROFILES,
+    )) {
+      predecessors.push([
+        profile,
+        transformEnhancementWasm(templateSave, enhancementBuild, {
+          ...capabilities,
+        }),
+      ]);
+    }
+  }
+  const derivations: Record<string, string> = {};
+  for (const [, bytes] of predecessors) {
+    const input = createHash("sha256").update(bytes).digest("hex");
+    derivations[input] = createHash("sha256")
+      .update(rewriteWithBuild(bytes, NATIVE_DOUBLE_CLICK_BUILDS[0]!))
+      .digest("hex");
+  }
+  const shipped = NATIVE_DOUBLE_CLICK_BUILDS[0]!.derivations;
+  const matches =
+    JSON.stringify(Object.entries(derivations).sort())
+    === JSON.stringify(Object.entries(shipped).sort());
+  process.stdout.write(`${JSON.stringify({
+    officialSha256,
+    predecessors: predecessors.map(([name]) => name),
+    derivations,
+    matchesShippedTable: matches,
+  }, null, 2)}\n`);
+  if (!matches) {
+    process.stderr.write(
+      "certification double-click: derived table does not match the shipped one\n",
+    );
+    process.exitCode = 1;
+  }
+}
+
+const COMMANDS = Object.freeze({
+  doctor,
+  recertify,
+  template,
+  transform,
+  "double-click": doubleClick,
+});
 
 // The subcommand name is argv, so the lookup has to be closed over own
 // properties: a plain object answers for its prototype, which made

--- a/tests/electron/enhancement-runtime.spec.ts
+++ b/tests/electron/enhancement-runtime.spec.ts
@@ -115,6 +115,7 @@ test.describe("Enhancement runtime selection", () => {
         enhancementCapabilities,
         compatibilityCacheRoot: paths.compatibility,
         enhancementCacheRoot: paths.enhancements,
+        nativeDoubleClickCacheRoot: paths.nativeDoubleClick,
       });
       const bytes = await readFile(selected.wasmPath);
       const module = new WebAssembly.Module(bytes);

--- a/tests/electron/input-pointer.spec.ts
+++ b/tests/electron/input-pointer.spec.ts
@@ -9,7 +9,7 @@ type PointerInputWindow = typeof window & {
 };
 
 test.describe("renderer pointer input", () => {
-  test("releases held input and cancels synthetic touches", async () => {
+  test("releases held keys and buttons on an input reset", async () => {
     const fixture = await launchOffline("gw-input-e2e-");
     try {
       const { page } = fixture;
@@ -49,50 +49,47 @@ test.describe("renderer pointer input", () => {
       await page.keyboard.up("w");
       await page.mouse.up({ button: "left" });
 
-      const touchEvents = await page.evaluate(async () => {
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
+  test("never dispatches a touch event, whatever the click run", async () => {
+    // The host used to reach the client's double-click by synthesising a pair
+    // of touch taps. That path is gone — the client's own flag carries it now
+    // — and it must not come back as a fallback: a tap warps the cursor,
+    // force-releases captured buttons, enters the drag machinery, and delivers
+    // an extra click of its own. See internal/upstream/mouse-double-click.md.
+    const fixture = await launchOffline("gw-no-touch-e2e-");
+    try {
+      const { page } = fixture;
+      await startGameInput(page);
+      const touches = await page.evaluate(async () => {
         const canvas = globalThis.document.getElementById("canvas");
         if (!canvas) throw new Error("#canvas is missing");
-        const events: string[] = [];
-        for (const type of ["touchstart", "touchend", "touchcancel"] as const) {
-          canvas.addEventListener(type, () => events.push(type));
+        const seen: string[] = [];
+        for (const type of [
+          "touchstart", "touchend", "touchmove", "touchcancel",
+        ] as const) {
+          canvas.addEventListener(type, () => seen.push(type));
         }
-        // Reset while the first tap is in flight. Dispatching it from the
-        // tap's own touchstart makes the interruption deterministic instead
-        // of racing the holdback and tap timers.
-        canvas.addEventListener(
-          "touchstart",
-          () => {
-            window.dispatchEvent(new globalThis.CustomEvent("gw:input-reset"));
-          },
-          { once: true },
-        );
-        const mouse = (type: string, detail = 0) =>
+        const mouse = (type: string, detail: number) =>
           canvas.dispatchEvent(
             new globalThis.MouseEvent(type, {
-              bubbles: true,
-              button: 0,
-              clientX: 100,
-              clientY: 100,
-              detail,
+              bubbles: true, button: 0, clientX: 120, clientY: 140, detail,
             }),
           );
-        mouse("mousedown", 1);
-        mouse("mouseup", 1);
-        mouse("mousedown", 2);
-        mouse("mouseup", 2);
-        const deadline = performance.now() + 2_000;
-        while (events.length < 2 && performance.now() < deadline) {
-          await new Promise((resolve) => setTimeout(resolve, 10));
+        // A double-click, then a longer run, then a drag — every shape that
+        // used to arm, fire, or refuse a tap pair.
+        for (const detail of [1, 2, 3, 4, 5, 6]) {
+          mouse("mousedown", detail);
+          mouse("mouseup", detail);
         }
-        // Long enough for the cancelled second tap to have fired if the
-        // reset had failed to clear it.
-        await new Promise((resolve) => setTimeout(resolve, 250));
-        return events;
+        // Well past the old 250 ms holdback plus its gap.
+        await new Promise((resolve) => setTimeout(resolve, 600));
+        return seen;
       });
-      expect(touchEvents).toEqual([
-        "touchstart",
-        "touchcancel",
-      ]);
+      expect(touches).toEqual([]);
     } finally {
       await closeOffline(fixture);
     }
@@ -150,199 +147,6 @@ test.describe("renderer pointer input", () => {
       await closeOffline(fixture);
     }
   });
-  test("uses the native click count for double-tap compatibility", async () => {
-    const fixture = await launchOffline("gw-double-click-e2e-");
-    try {
-      const { page } = fixture;
-      await startGameInput(page);
-      const touchEvents = await page.evaluate(async () => {
-        const canvas = globalThis.document.getElementById("canvas");
-        if (!canvas) throw new Error("#canvas is missing");
-        const observed: Array<{ type: string; identifier: number }> = [];
-        for (const type of ["touchstart", "touchend", "touchcancel"] as const) {
-          canvas.addEventListener(type, (event) => {
-            const touch = event.changedTouches[0];
-            if (!touch) throw new Error(`${type} carried no changed touch`);
-            observed.push({ type, identifier: touch.identifier });
-          });
-        }
-        const mouse = (type: string, detail: number) =>
-          canvas.dispatchEvent(
-            new globalThis.MouseEvent(type, {
-              bubbles: true,
-              button: 0,
-              clientX: 120,
-              clientY: 140,
-              detail,
-            }),
-          );
-
-        // The OS may recognize a deliberately slow pair according to the
-        // user's accessibility preference. The host must trust that native
-        // count instead of applying its former 400 ms cutoff.
-        mouse("mousedown", 1);
-        mouse("mouseup", 1);
-        await new Promise((resolve) => setTimeout(resolve, 450));
-        mouse("mousedown", 2);
-        mouse("mouseup", 2);
-        const deadline = performance.now() + 2_000;
-        while (observed.length < 4 && performance.now() < deadline) {
-          await new Promise((resolve) => setTimeout(resolve, 10));
-        }
-        return observed;
-      });
-
-      expect(touchEvents.map(({ type }) => type)).toEqual([
-        "touchstart",
-        "touchend",
-        "touchstart",
-        "touchend",
-      ]);
-      expect(new Set(touchEvents.map(({ identifier }) => identifier)).size).toBe(
-        2,
-      );
-    } finally {
-      await closeOffline(fixture);
-    }
-  });
-
-  test("synthesizes one double-tap per click run and none after a drag", async () => {
-    const fixture = await launchOffline("gw-double-click-run-e2e-");
-    try {
-      const { page } = fixture;
-      await startGameInput(page);
-      const result = await page.evaluate(async () => {
-        const canvas = globalThis.document.getElementById("canvas");
-        if (!canvas) throw new Error("#canvas is missing");
-        const observed: string[] = [];
-        for (const type of ["touchstart", "touchend", "touchcancel"] as const) {
-          canvas.addEventListener(type, () => observed.push(type));
-        }
-        const mouse = (type: string, detail: number, x = 120, y = 140) =>
-          canvas.dispatchEvent(
-            new globalThis.MouseEvent(type, {
-              bubbles: true,
-              button: 0,
-              clientX: x,
-              clientY: y,
-              detail,
-            }),
-          );
-
-        // The tap pair is deferred, so every phase waits for the events it
-        // expects rather than for a duration: under full-suite load a fixed
-        // sleep races the holdback timers and this spec flaked.
-        const settle = async (count: number) => {
-          const deadline = performance.now() + 5_000;
-          while (observed.length < count && performance.now() < deadline) {
-            await new Promise((resolve) => setTimeout(resolve, 20));
-          }
-          // Long enough after the pair for a third, unwanted tap to appear.
-          await new Promise((resolve) => setTimeout(resolve, 400));
-          return [...observed];
-        };
-
-        // A run that stops at two clicks is a completed native double-click;
-        // once the holdback passes, exactly one tap pair fires.
-        mouse("mousedown", 2);
-        mouse("mouseup", 2);
-        const afterDouble = await settle(4);
-        // detail keeps counting 3, 4 while the run continues; the later even
-        // counts must not synthesize again.
-        mouse("mousedown", 3);
-        mouse("mouseup", 3);
-        mouse("mousedown", 4);
-        mouse("mouseup", 4);
-        const afterRun = await settle(4);
-
-        // A double-click press that turns into a drag releases far away; the
-        // stale press point must not receive a tap pair.
-        observed.length = 0;
-        mouse("mousedown", 2);
-        mouse("mouseup", 2, 160, 140);
-        const afterDrag = await settle(0);
-        return { afterDouble, afterRun, afterDrag };
-      });
-
-      expect(result).toEqual({
-        afterDouble: ["touchstart", "touchend", "touchstart", "touchend"],
-        afterRun: ["touchstart", "touchend", "touchstart", "touchend"],
-        afterDrag: [],
-      });
-    } finally {
-      await closeOffline(fixture);
-    }
-  });
-
-  test("withholds the tap pair while another button is still held", async () => {
-    const fixture = await launchOffline("gw-tap-guard-e2e-");
-    try {
-      const { page } = fixture;
-      await startGameInput(page);
-      // A real press is required: only trusted events enter the held-button
-      // registry the guard reads. The lock request is stubbed so the offline
-      // fixture's refusal cannot release the button under the test.
-      await page.evaluate(() => {
-        const canvas = globalThis.document.getElementById("canvas");
-        if (!(canvas instanceof globalThis.HTMLCanvasElement)) {
-          throw new Error("#canvas is missing");
-        }
-        canvas.requestPointerLock = () => Promise.resolve();
-        const observed: string[] = [];
-        for (const type of ["touchstart", "touchend", "touchcancel"] as const) {
-          canvas.addEventListener(type, () => observed.push(type));
-        }
-        Object.assign(window, { __taps: observed });
-      });
-      const box = await boxOf(page.locator("#canvas"));
-      const leftDoubleClick = () =>
-        page.evaluate(async () => {
-          const canvas = globalThis.document.getElementById("canvas");
-          if (!canvas) throw new Error("#canvas is missing");
-          const at = (type: string, detail: number) =>
-            canvas.dispatchEvent(
-              new globalThis.MouseEvent(type, {
-                bubbles: true,
-                button: 0,
-                clientX: 120,
-                clientY: 140,
-                detail,
-              }),
-            );
-          at("mousedown", 1);
-          at("mouseup", 1);
-          at("mousedown", 2);
-          at("mouseup", 2);
-          await new Promise((resolve) => setTimeout(resolve, 700));
-        });
-      const taps = () =>
-        page.evaluate(() => [...(window as unknown as { __taps: string[] }).__taps]);
-
-      // The walk-and-look grip: right held throughout, a left double-click
-      // inside it. The client's touch path would force-release the captured
-      // right button and desynchronise its state, so nothing may be sent.
-      await page.mouse.move(box.x + 120, box.y + 140);
-      await page.mouse.down({ button: "right" });
-      await leftDoubleClick();
-      const held = await taps();
-
-      // Released: the same gesture is a plain double-click again.
-      await page.mouse.up({ button: "right" });
-      await page.evaluate(() => {
-        (window as unknown as { __taps: string[] }).__taps.length = 0;
-      });
-      await leftDoubleClick();
-      const result = { held, released: await taps() };
-
-      expect(result).toEqual({
-        held: [],
-        released: ["touchstart", "touchend", "touchstart", "touchend"],
-      });
-    } finally {
-      await closeOffline(fixture);
-    }
-  });
-
   test("releases held input when the pointer leaves the app window", async () => {
     const fixture = await launchOffline("gw-input-window-leave-e2e-");
     try {
@@ -454,64 +258,6 @@ test.describe("renderer pointer input", () => {
         [0, result.viewport[1] - 1],
         [result.viewport[0] - 1, result.viewport[1] - 1],
       ]);
-    } finally {
-      await closeOffline(fixture);
-    }
-  });
-
-  test("a continuing click burst cancels the held-back tap pair entirely", async () => {
-    const fixture = await launchOffline("gw-double-click-cancel-e2e-");
-    try {
-      const { page } = fixture;
-      await startGameInput(page);
-      const result = await page.evaluate(async () => {
-        const canvas = globalThis.document.getElementById("canvas");
-        if (!canvas) throw new Error("#canvas is missing");
-        const observed: string[] = [];
-        for (const type of ["touchstart", "touchend", "touchcancel"] as const) {
-          canvas.addEventListener(type, () => observed.push(type));
-        }
-        const mouse = (type: string, detail: number) =>
-          canvas.dispatchEvent(
-            new globalThis.MouseEvent(type, {
-              bubbles: true,
-              button: 0,
-              clientX: 120,
-              clientY: 140,
-              detail,
-            }),
-          );
-
-        // The third press of an attribute-point burst arrives inside the
-        // holdback: no tap ever fires, so the client sees plain clicks and
-        // nothing else — the Windows behaviour for buttons.
-        mouse("mousedown", 2);
-        mouse("mouseup", 2);
-        await new Promise((resolve) => setTimeout(resolve, 100));
-        mouse("mousedown", 3);
-        mouse("mouseup", 3);
-        await new Promise((resolve) => setTimeout(resolve, 700));
-        const interrupted = [...observed];
-
-        observed.length = 0;
-        mouse("mousedown", 2);
-        canvas.dispatchEvent(
-          new globalThis.MouseEvent("mouseleave", {
-            bubbles: true,
-            button: 0,
-            clientX: 400,
-            clientY: 400,
-          }),
-        );
-        mouse("mouseup", 2);
-        await new Promise((resolve) => setTimeout(resolve, 700));
-        return { interrupted, afterLeave: observed };
-      });
-
-      expect(result).toEqual({
-        interrupted: [],
-        afterLeave: [],
-      });
     } finally {
       await closeOffline(fixture);
     }

--- a/tests/electron/input-trace.spec.ts
+++ b/tests/electron/input-trace.spec.ts
@@ -1,0 +1,161 @@
+import { expect, test } from "@playwright/test";
+import { closeOffline, launchOffline } from "./fixtures.mjs";
+import { boxOf, startGameInput } from "./input-helpers.js";
+
+/**
+ * The trace is the instrument a bug report is built from, so what it must be
+ * proved to do is: cost nothing until it is switched on, name the decision
+ * that produced a double-tap pair, and carry no coordinate out of the
+ * renderer.
+ */
+/**
+ * The panel coalesces a burst of records into one repaint, so every read polls
+ * rather than assuming the last event has already been laid out.
+ */
+const traceText = (page: import("@playwright/test").Page) =>
+  page.evaluate(() =>
+    [...globalThis.document.querySelectorAll("#input-trace li")]
+      .map((li) => li.textContent ?? "")
+      .join("\n"),
+  );
+
+const expectTrace = (page: import("@playwright/test").Page) =>
+  expect.poll(() => traceText(page));
+
+const toggleTrace = (page: import("@playwright/test").Page) =>
+  page.evaluate(() =>
+    window.dispatchEvent(new globalThis.CustomEvent("gw:input-trace")),
+  );
+
+/**
+ * Announces a lock state the way the browser does: set the element, then
+ * deliver the change event that reports it. Stubbed rather than driven for
+ * real, because the case worth pinning is the one where the two disagree.
+ */
+const announceLock = (page: import("@playwright/test").Page, locked: boolean) =>
+  page.evaluate((want) => {
+    Object.defineProperty(globalThis.document, "pointerLockElement", {
+      configurable: true,
+      value: want ? globalThis.document.getElementById("canvas") : null,
+    });
+    globalThis.document.dispatchEvent(new globalThis.Event("pointerlockchange"));
+  }, locked);
+
+test.describe("input trace", () => {
+  test("stays silent until it is switched on", async () => {
+    const fixture = await launchOffline("gw-input-trace-off-");
+    try {
+      const { page } = fixture;
+      await startGameInput(page);
+      const box = await boxOf(page.locator("#canvas"));
+      await page.mouse.move(box.x + 80, box.y + 80);
+      await page.mouse.down();
+      await page.mouse.up();
+      await expect(page.locator("#input-trace")).toBeHidden();
+      expect(await traceText(page)).toBe("");
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
+  test("names the press the client's double-click flag rode on", async () => {
+    const fixture = await launchOffline("gw-input-trace-on-");
+    try {
+      const { page } = fixture;
+      await startGameInput(page);
+      await page.evaluate(() => {
+        globalThis.document.getElementById("loading")?.classList.add("gone");
+      });
+      await toggleTrace(page);
+      await expect(page.locator("#input-trace")).toBeVisible();
+
+      const box = await boxOf(page.locator("#canvas"));
+      await page.mouse.move(box.x + 120, box.y + 120);
+      await page.mouse.dblclick(box.x + 120, box.y + 120);
+
+      // The offline fixture serves no certified client, so the row states that
+      // the flag had nowhere to go. Either way the row is on the press itself,
+      // which is the property being pinned: nothing is deferred any more.
+      await expectTrace(page).toContain("DOUBLE-CLICK");
+      // The flag row belongs under the press it rode on, not above it. Both
+      // listeners are window-capture, so registration order decides this and
+      // nothing else would catch it flipping back.
+      const rows = (await traceText(page)).split("\n");
+      const flagged = rows.findIndex((row) => row.includes("DOUBLE-CLICK"));
+      expect(rows[flagged - 1]).toContain("run=2");
+      const afterDouble = await traceText(page);
+      expect(afterDouble).toContain("run=2");
+
+      // The flag rides on the press itself, so a three-click run flags the
+      // second press and the fourth, exactly as Windows raises its own
+      // double-click message on every even click. Nothing is held back and
+      // nothing is retracted, which is the whole point of the native path.
+      await page.evaluate(() => {
+        globalThis.document
+          .querySelector<HTMLButtonElement>('#input-trace [data-role="clear"]')
+          ?.click();
+      });
+      for (const clickCount of [1, 2, 3] as const) {
+        await page.mouse.down({ clickCount });
+        await page.mouse.up({ clickCount });
+      }
+      await expectTrace(page).toContain("run=3");
+      const burst = await traceText(page);
+      expect(burst.match(/DOUBLE-CLICK/gu)?.length ?? 0).toBe(1);
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
+  test("reports each pointer lock once, however it was announced", async () => {
+    const fixture = await launchOffline("gw-input-trace-lock-");
+    try {
+      const { page } = fixture;
+      await startGameInput(page);
+      await toggleTrace(page);
+
+      await announceLock(page, true);
+      await announceLock(page, false);
+      // A right-click shorter than the lock's round trip announces itself as
+      // unlocked twice over, once for a lock that was already exited by the
+      // time the news arrived and once for the exit. Neither is a state the
+      // player held, and a trace that prints both reads as a lock that was
+      // released without ever engaging.
+      await announceLock(page, false);
+      await announceLock(page, false);
+
+      await expectTrace(page).toContain("pointer lock released");
+      const rows = await traceText(page);
+      expect(rows.match(/pointer lock engaged/gu)?.length ?? 0).toBe(1);
+      expect(rows.match(/pointer lock released/gu)?.length ?? 0).toBe(1);
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
+  test("carries no coordinate into the text it copies", async () => {
+    const fixture = await launchOffline("gw-input-trace-privacy-");
+    try {
+      const { page } = fixture;
+      await startGameInput(page);
+      await toggleTrace(page);
+      const box = await boxOf(page.locator("#canvas"));
+      // Press and release far apart, so a leaked coordinate would be a large
+      // number no other field could produce.
+      await page.mouse.move(box.x + 40, box.y + 40);
+      await page.mouse.down();
+      await page.mouse.move(box.x + 640, box.y + 440);
+      await page.mouse.up();
+
+      await expectTrace(page).toContain("release");
+      const rows = await traceText(page);
+      // Travel is a distance and is allowed; the endpoints are not present.
+      for (const coordinate of [40, 640, 440, box.x, box.y]) {
+        expect(rows).not.toContain(`=${Math.round(coordinate)},`);
+      }
+      expect(rows).not.toMatch(/x=|y=|client|screen/i);
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+});

--- a/tests/policy/source-wasm-host.test.ts
+++ b/tests/policy/source-wasm-host.test.ts
@@ -366,6 +366,7 @@ test("the WASM section codec has exactly one home", async () => {
     ["src/main/certification/enhancement-transform.ts", '../core/wasm-binary.js'],
     ["src/main/certification/template-save-compat.ts", '../core/wasm-binary.js'],
     ["src/main/certification/template-save-verifier.ts", '../core/wasm-binary.js'],
+    ["src/main/certification/native-double-click.ts", '../core/wasm-binary.js'],
   ];
   for (const [file, specifier] of sharers) {
     const source = await readFile(path.join(root, file), "utf8");

--- a/tests/unit/client-module.test.ts
+++ b/tests/unit/client-module.test.ts
@@ -293,6 +293,7 @@ async function fixture() {
     enhancementBuild: enhancement,
     compatibilityCacheRoot: join(root, "compatibility"),
     enhancementCacheRoot: join(root, "enhancement"),
+    nativeDoubleClickCacheRoot: join(root, "double-click"),
   };
 }
 
@@ -310,6 +311,7 @@ function options(
     enhancementCapabilities,
     compatibilityCacheRoot: value.compatibilityCacheRoot,
     enhancementCacheRoot: value.enhancementCacheRoot,
+    nativeDoubleClickCacheRoot: value.nativeDoubleClickCacheRoot,
   };
 }
 
@@ -418,6 +420,10 @@ describe("client module preparation", () => {
       wasmPath: value.officialWasmPath,
       state: "uncertified",
       enhancementBuild: null,
+      // An unrecognised client is served exactly as downloaded, so it also
+      // never reaches the double-click stage: the renderer keeps synthesising
+      // taps rather than being handed a module nothing certified.
+      nativeDoubleClick: false,
       failure: null,
     });
     await Promise.all([

--- a/tests/unit/native-double-click-transform.test.ts
+++ b/tests/unit/native-double-click-transform.test.ts
@@ -1,0 +1,182 @@
+// The transform that gives the client's mouse double-click flag its missing
+// byte. `internal/upstream/mouse-double-click.md` records why the flag exists
+// and why nothing writes it.
+//
+// Every module here is built in the test rather than read from a downloaded
+// client: game binaries are not committed, and the guards are what this file
+// is about. What it proves is that the rewrite is refused unless the callback
+// it is about to edit is byte-for-byte the one that was certified — the whole
+// safety argument, since the inserted store depends on local 3 being the frame
+// pointer and on the record sitting at a known offset from it.
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import test from "node:test";
+import {
+  DOUBLE_CLICK_FLAG_EXPORT,
+  NATIVE_DOUBLE_CLICK_BUILDS,
+  rewriteWithBuild,
+  type NativeDoubleClickBuild,
+} from "../../src/main/certification/native-double-click.ts";
+import { indexOfBytes, parseExports, sectionById, splitSections }
+  from "../../src/main/core/wasm-binary.ts";
+
+const sha256 = (bytes: Uint8Array) =>
+  createHash("sha256").update(bytes).digest("hex");
+
+const section = (id: number, body: number[]) => [id, body.length, ...body];
+
+/**
+ * A module shaped like the part of the client this transform touches: one
+ * function reachable through an active table slot, a global section, and an
+ * export section. The body ends in `local.get 3` so the insertion point has
+ * something recognisable behind it.
+ */
+function buildModule(): { bytes: Uint8Array; body: Uint8Array } {
+  // (func (result i32)) — the callback's own signature is irrelevant here;
+  // what matters is that the body is a body and the slot resolves to it.
+  const types = section(1, [0x01, 0x60, 0x00, 0x01, 0x7f]);
+  // One function import, so the defined function is index 1 and the transform
+  // has to subtract the import count the way it does against the real client.
+  const imports = section(2, [0x01, 0x01, 0x65, 0x01, 0x66, 0x00, 0x00]);
+  const functions = section(3, [0x01, 0x00]);
+  const table = section(4, [0x01, 0x70, 0x00, 0x01]);
+  // The inserted instruction stores to linear memory and reads local 3, so a
+  // module without both would fail validation for reasons the transform is not
+  // responsible for.
+  const memory = section(5, [0x01, 0x00, 0x01]);
+  const globals = section(6, [0x01, 0x7f, 0x01, 0x41, 0x00, 0x0b]);
+  const exportName = [...new TextEncoder().encode("existing")];
+  const exports = section(7, [
+    0x01, exportName.length, ...exportName, 0x00, 0x00,
+  ]);
+  const elements = section(9, [0x01, 0x00, 0x41, 0x00, 0x0b, 0x01, 0x01]);
+  // four i32 locals, so local 3 exists; then `i32.const 7`, `drop`,
+  // `i32.const 0`, `end`.
+  const bodyBytes = [0x01, 0x04, 0x7f, 0x41, 0x07, 0x1a, 0x41, 0x00, 0x0b];
+  const code = section(10, [0x01, bodyBytes.length, ...bodyBytes]);
+  return {
+    bytes: Uint8Array.from([
+      0, 97, 115, 109, 1, 0, 0, 0,
+      ...types, ...imports, ...functions, ...table, ...memory, ...globals,
+      ...exports,
+      ...elements, ...code,
+    ]),
+    body: Uint8Array.from(bodyBytes),
+  };
+}
+
+const entryFor = (
+  body: Uint8Array,
+  overrides: Partial<NativeDoubleClickBuild> = {},
+): NativeDoubleClickBuild => ({
+  derivations: {},
+  callbackTableSlot: 0,
+  callbackFunctionIndex: 1,
+  callbackBodySha256: sha256(body),
+  // After the locals declaration and `i32.const 7; drop`, which is where the
+  // record store goes in the real callback: before the enqueue and after the
+  // fields it fills.
+  flagStoreOffset: 6,
+  flagStoreFrameOffset: 24,
+  ...overrides,
+});
+
+test("appends one exported mutable global and writes it into the record", () => {
+  const { bytes, body } = buildModule();
+  // The transform validates its own output and throws when it does not hold,
+  // so reaching the next line is the validity assertion.
+  const output = rewriteWithBuild(bytes, entryFor(body));
+
+  const sections = splitSections(output);
+  const names = parseExports(sectionById(sections, 7));
+  const flag = names.find((entry) => entry.name === DOUBLE_CLICK_FLAG_EXPORT);
+  assert.ok(flag, "the flag global must be exported");
+  assert.equal(flag.kind, 0x03, "the export must be a global, not a function");
+  assert.equal(flag.index, 1, "it must be the global appended after the first");
+  assert.equal(names.length, 2, "the module's own export must survive");
+
+  // `local.get 3; global.get 1; i32.store align=2 offset=24`, inserted whole.
+  const code = sectionById(sections, 10);
+  assert.notEqual(
+    indexOfBytes(
+      code,
+      Uint8Array.of(0x20, 0x03, 0x23, 0x01, 0x36, 0x02, 0x18),
+      0,
+    ),
+    -1,
+    "the flag store must appear in the rewritten body",
+  );
+});
+
+test("refuses a callback whose body is not the certified one", () => {
+  const { bytes, body } = buildModule();
+  const wrong = entryFor(body, {
+    callbackBodySha256: sha256(Uint8Array.of(1, 2, 3)),
+  });
+  assert.throws(
+    () => rewriteWithBuild(bytes, wrong),
+    /not the certified body/,
+    "a body that changed by any byte must not be edited",
+  );
+});
+
+test("refuses a table slot that no longer holds the certified function", () => {
+  const { bytes, body } = buildModule();
+  assert.throws(
+    () => rewriteWithBuild(bytes, entryFor(body, { callbackFunctionIndex: 0 })),
+    /holds function/,
+  );
+  assert.throws(
+    () => rewriteWithBuild(bytes, entryFor(body, { callbackTableSlot: 9 })),
+    /holds function/,
+  );
+});
+
+test("refuses to insert past the end of the body", () => {
+  const { bytes, body } = buildModule();
+  assert.throws(
+    () => rewriteWithBuild(bytes, entryFor(body, { flagStoreOffset: 999 })),
+    /outside the callback body/,
+  );
+});
+
+test("refuses a module that already carries the flag export", () => {
+  const { bytes, body } = buildModule();
+  const once = rewriteWithBuild(bytes, entryFor(body));
+  // The second pass sees its own output: the body hash has moved on, so the
+  // body guard fires first. Re-certifying the moved body must still not let a
+  // second flag global in.
+  const sections = splitSections(once);
+  const movedBody = sectionById(sections, 10).subarray(2);
+  assert.throws(
+    () => rewriteWithBuild(once, entryFor(movedBody)),
+    /already exists/,
+  );
+});
+
+test("the shipped entry describes one build and states its own offsets", () => {
+  assert.equal(NATIVE_DOUBLE_CLICK_BUILDS.length, 1);
+  for (const build of NATIVE_DOUBLE_CLICK_BUILDS) {
+    assert.match(build.callbackBodySha256, /^[0-9a-f]{64}$/);
+    // One predecessor per certified capability profile, plus the one where the
+    // Enhancement is off. A missing entry is a launch that silently keeps the
+    // synthetic taps; a stray one is a module nothing produces.
+    const pairs = Object.entries(build.derivations);
+    assert.equal(pairs.length, 5);
+    for (const [input, output] of pairs) {
+      assert.match(input, /^[0-9a-f]{64}$/);
+      assert.match(output, /^[0-9a-f]{64}$/);
+      assert.notEqual(input, output);
+    }
+    assert.equal(
+      new Set(pairs.map(([, output]) => output)).size,
+      pairs.length,
+      "each predecessor must derive a distinct module",
+    );
+    assert.ok(build.flagStoreOffset > 0);
+    // The record base sits eight bytes above the frame pointer and the flag is
+    // the fifth word of the record, so the store lands at frame+24. A different
+    // value here would write over a field the client reads.
+    assert.equal(build.flagStoreFrameOffset, 24);
+  }
+});

--- a/tests/unit/paths.test.ts
+++ b/tests/unit/paths.test.ts
@@ -35,6 +35,7 @@ describe("resolved profile paths", () => {
       certificateFeed: `${root}/game/certificate-feed.json`,
       compatibility: `${root}/game/compatibility`,
       enhancements: `${root}/game/enhancements`,
+      nativeDoubleClick: `${root}/game/double-click`,
       chunks: `${root}/game/chunks`,
       bootChunks: `${root}/game/boot-chunks.json`,
       cacheClearRequest: `${root}/clear-cache-on-start`,

--- a/tests/unit/quit-cleanup-cannot-outlast-the-quit.test.ts
+++ b/tests/unit/quit-cleanup-cannot-outlast-the-quit.test.ts
@@ -1,0 +1,81 @@
+// A quit request is answered by cancelling the quit and running cleanup, so
+// for as long as cleanup runs the application is still on screen and the Cmd+Q
+// that started it has already been consumed. Two of the registered tasks are
+// bounded by nothing of their own — the renderer filesystem sync and the client
+// shutdown's in-flight game update — and the field record in
+// `internal/upstream/memory-exhaustion-log.md` says the sync fails on every
+// observed quit. This executes the real pass to prove a stuck task cannot hold
+// the process, and that a quit which ran out of time says so instead of
+// leaving the next launch to read the missing completion as a crash.
+//
+// `lifecycle.ts` imports Electron and the diagnostics entry point, neither of
+// which `node --test` has, so the loader below answers both. The diagnostics
+// stub is what the assertions read: the events are the contract, not a return
+// value.
+import assert from "node:assert/strict";
+import { register } from "node:module";
+import test, { mock } from "node:test";
+
+const recorded: string[] = [];
+(globalThis as { __quitEvents?: string[] }).__quitEvents = recorded;
+
+register(
+  `data:text/javascript,${encodeURIComponent(
+    `export function resolve(specifier, context, next) {
+       if (specifier === "electron") {
+         return {
+           url: "data:text/javascript,export const app = { on(){}, exit(){}, quit(){}, enableSandbox(){} };",
+           format: "module",
+           shortCircuit: true,
+         };
+       }
+       if (specifier.endsWith("/diagnostics.js")) {
+         return {
+           url: "data:text/javascript," + encodeURIComponent(
+             "export const logEvent = (e) => { globalThis.__quitEvents.push(e.k); };" +
+             "export const flushDiagnostics = async () => {};",
+           ),
+           format: "module",
+           shortCircuit: true,
+         };
+       }
+       return next(specifier, context);
+     }`,
+  )}`,
+);
+
+const { onAppQuit, runQuitCleanup, QUIT_CLEANUP_DEADLINE_MS, isQuitting } =
+  await import("../../src/main/lifecycle.ts");
+
+test("a cleanup task that never settles cannot hold the quit", async () => {
+  const ran: string[] = [];
+  // Registration order is reversed at run time, so this one runs last —
+  // the position the renderer filesystem sync actually occupies.
+  onAppQuit(() => new Promise<void>(() => { ran.push("stuck"); }));
+  onAppQuit(() => { ran.push("first"); });
+
+  // The deadline is the production one; only the clock is faked, so the test
+  // costs nothing and still asserts against the value that ships.
+  mock.timers.enable({ apis: ["setTimeout"] });
+  const pass = runQuitCleanup();
+  let settled = false;
+  void pass.then(() => { settled = true; });
+
+  mock.timers.tick(QUIT_CLEANUP_DEADLINE_MS - 1);
+  await Promise.resolve();
+  assert.equal(settled, false, "the pass waits for its tasks up to the deadline");
+
+  mock.timers.tick(1);
+  await pass;
+  mock.timers.reset();
+
+  assert.deepEqual(ran, ["first", "stuck"], "every task still gets its turn");
+  assert.deepEqual(
+    recorded,
+    ["quit.cleanupStarted", "quit.cleanupTimedOut"],
+    "a quit that ran out of time is recorded as that, not as a completion",
+  );
+  assert.ok(!recorded.includes("quit.cleanupCompleted"),
+    "the crash heuristic reads the completion, so a timeout must not claim one");
+  assert.equal(isQuitting(), true);
+});


### PR DESCRIPTION
## What this fixes for players

Double-clicking in the game did the wrong thing, in ways that cost real items and real attribute points:

- Identification and Salvage Kits could not be double-clicked to use.
- Double-clicking an inventory item moved it to a random slot instead of using it.
- A single click at a vendor sometimes sold several items.
- Distributing attribute points spent more than was clicked.

All of it came from one cause, and all of it is addressed by one change.

## What was actually wrong

The client's double-click channel is complete from the input record through `FrMouse` to the widget — and it was structurally always zero. The Emscripten glue never marshals `MouseEvent.detail`, so the last 16 bytes of the mouse event struct, where the double-click flag lives, are never written. No amount of clicking could set it.

The host worked around that by sending a synthetic touch tap pair, using the client's *touch* double-tap detector instead. That workaround is not a smaller version of a double-click. Each tap is a full click, so one double-click cost **four clicks**, plus a cursor warp, a forced button release, a pointer-mode switch, and drag entry. That is exactly the shape of every symptom above: the vendor sees four clicks and sells four items, the attribute panel sees four and spends four, the inventory slot sees a drag and moves the item.

It also cost about 360 ms, because the taps had to be held back and timed to satisfy the detector.

## How it works now

The served module carries one exported mutable global. The client's own mousedown callback copies it into the input record's flag word — the path the client already had and already reads. The only thing missing was something to write the global.

The renderer writes it from Chromium's own click run, so the player's macOS double-click speed and distance settings decide what counts as a double-click, and Windows' every-even-click semantics are preserved. The write is unconditional on every trusted press, which keeps it stateless: the client reads the global exactly once per press, so a press that never reached the client cannot leave a stale flag behind.

Latency drops from ~360 ms to zero — the flag rides on the press itself. The synthetic tap path is deleted rather than reduced.

## Also in this branch

- **An in-game input trace** (bottom-left overlay, off by default) that records presses, releases, modifiers, pointer-lock transitions and flag decisions, and copies out coordinate-free text. This is the instrument the diagnosis above was built from.
- **A bounded quit cleanup**, so Cmd-Q cannot hang behind an unfinished task. Cleanup races a deadline and logs either completion or timeout, never both.
- **A pointer-lock trace fix**: a right-click shorter than the lock's round trip used to be reported as released twice with no engage, because the exit runs before the browser delivers the news that the lock was acquired.

## What deliberately did not change

- **No new double-click policy.** The host decides nothing about what a double-click is; Chromium's click run already applies the player's own OS preferences.
- **No fallback path.** An unrecognised client build is served untransformed and simply has no double-click, rather than silently reverting to the tap workaround. One behaviour, not two.
- **No coordinates leave the renderer.** The trace records travel distance, never positions.

## Review focus

- **Chain placement.** The transform is last in the certification chain. The callback body is byte-identical through template-save and all four Enhancement profiles, so one proof covers five predecessors and neither existing certified table needed re-keying.
- **Every-even-click.** A run of six clicks flags presses 2, 4 and 6. This matches Windows raising its double-click message on every even click. It is safe now in a way the tap pair was not, because a flag is not an extra click.
- **Listener order.** The flag writer registers after the input host; both are window-capture, which always precedes the client's own canvas listener.

## Verification

- `pnpm verify` — green end to end
- Unit 759 pass, policy 156 pass, integration 29 pass, release 21 pass
- Electron 108 passed, including a new spec that the trace never emits a touch event whatever the click run
- Packaged smoke and Enhancement runtime proofs pass
- Confirmed live in-game from a player trace: flag delivered on every even press at 0 ms, no touch events, drags correctly unflagged

## Known follow-ups

- The four in-game behaviours above want a confirming pass from a player: kits, inventory slots, vendor Sell, attribute points.
- Ctrl+click for calling out targets is unresolved and untouched here. It is a keyboard-path question — the client derives click modifiers from a keydown-maintained global — and needs a trace showing whether the Control press arrives.
- Portrait rotation does not lock the cursor. Deliberately not attempted: the certified cursor ABI's single `hidden` boolean reads the wrong way for a portrait drag, and it needs measurement before code.
