### PR TITLE
Report the printable-key label offset upstream

### DIFF
--- a/internal/upstream/README.md
+++ b/internal/upstream/README.md
@@ -28,6 +28,7 @@ hash, that routes the broken routines back into the host.
 | [recertify.md](recertify.md) | us | The procedure when ArenaNet publishes a new client. Every index and offset below is build-specific. |
 | [investigation-log.md](investigation-log.md) | us | The chronology, including every wrong turn and what corrected it. Read this before re-deriving anything. |
 | [memory-exhaustion-log.md](memory-exhaustion-log.md) | us | Open: long-session `wasm.abort`s with the heap pegged at the client's compiled-in 2 GiB cap. The heap-staircase instrumentation and what the next crash bundle must answer. |
+| [keyboard-label-offset.md](keyboard-label-offset.md) | us | Open: every printable key is labelled one position too high in the Controls panel and the menus, while input is correct. The key descriptor table, the measurement that isolates the render path, and the two readings a probe still has to choose between. |
 | [investigation-template.md](investigation-template.md) | us | The shape a round takes — hypothesis, what was built, the measurement that killed it, the lesson. Copy it to start the next log. |
 
 ## The build this describes

--- a/internal/upstream/README.md
+++ b/internal/upstream/README.md
@@ -28,6 +28,7 @@ hash, that routes the broken routines back into the host.
 | [recertify.md](recertify.md) | us | The procedure when ArenaNet publishes a new client. Every index and offset below is build-specific. |
 | [investigation-log.md](investigation-log.md) | us | The chronology, including every wrong turn and what corrected it. Read this before re-deriving anything. |
 | [memory-exhaustion-log.md](memory-exhaustion-log.md) | us | Open: long-session `wasm.abort`s with the heap pegged at the client's compiled-in 2 GiB cap. The heap-staircase instrumentation and what the next crash bundle must answer. |
+| [upstream-keyboard-labels.md](upstream-keyboard-labels.md) | **ArenaNet** | Every printable key is labelled one position too high, while input is correct. Self-contained; states plainly which parts are observed and which are inferred. |
 | [keyboard-label-offset.md](keyboard-label-offset.md) | us | Open: every printable key is labelled one position too high in the Controls panel and the menus, while input is correct. The key descriptor table, the measurement that isolates the render path, and the two readings a probe still has to choose between. |
 | [investigation-template.md](investigation-template.md) | us | The shape a round takes — hypothesis, what was built, the measurement that killed it, the lesson. Copy it to start the next log. |
 

--- a/internal/upstream/keyboard-label-offset.md
+++ b/internal/upstream/keyboard-label-offset.md
@@ -80,6 +80,45 @@ Anchors tried and exhausted:
   suggestive rather than decisive. Best candidates by that score: #7154
   (16,590 bytes), #12320, #10382, #13674, #12328, #15906.
 
+## What calling their functions established, and what it could not
+
+The module instantiates standalone in Node: all 219 imports are functions, so
+a stub returning zero for each is enough, and `memory`, `malloc` and `free`
+are already exported. Appending export entries for candidate functions and
+calling them works exactly as the templates investigation describes.
+
+It found **#9718**, which writes a key id as a character:
+
+```
+47:/  48:0  49:1  50:2  …  72:H  73:I  74:J  75:K  76:L  77:M  …  90:Z  91:[
+```
+
+A plain cast, no offset. That is the operation the labels are wrong about —
+but #9718 is not the key renderer. Dozens of functions scattered through the
+binary do the byte-identical thing (they are generic one-character string
+helpers, template instantiations of the same formatting code), so "writes L
+when handed 76" does not distinguish the one the Controls panel calls from
+any of the others. The property that makes one of them the renderer lives in
+its caller.
+
+And the callers cannot be reached cold. The eight functions that call #9718,
+and every pointer-returning candidate tried, return zero without writing
+anything — they early-out on uninitialised state. That is the difference
+from the templates work: `Path::RemoveExtension` and `_wsplitpath` are pure
+helpers that need no game state, and a label renderer needs a live text
+subsystem and an initialised UI.
+
+So the technique that ended the guessing there does not end it here. Locating
+this function needs **live instrumentation** — patching the module to record
+which function produced the string while the real Controls panel draws it —
+not a cold call.
+
+One cheap probe is still unrun: sweeping for the *name → id* direction, which
+does not need UI state. Writing `"k"` into memory and finding the function
+that answers 75 or 76 settles the framing question below outright. It was
+started and killed by a timeout while the broad sweep was still competing for
+the machine; it should be re-run on its own.
+
 ## The open question
 
 Two readings survive every static observation, and they need different

--- a/internal/upstream/keyboard-label-offset.md
+++ b/internal/upstream/keyboard-label-offset.md
@@ -1,0 +1,113 @@
+# Every printable key is labelled one position too high
+
+The Controls panel and the in-game menus name the wrong key. Not a
+translation, not a layout: the label is the *next* character. A control on
+`K` reads `L`, one on `M` reads `N`, one on `1` reads `2`.
+
+Nothing is misrouted. `K` opens Skills and Attributes exactly as it does on
+the Windows client, and the bindings on the account agree with the Windows
+client. The only defective thing is the code that renders a key id as text.
+
+## The measurement that settles it
+
+Build 38,797. One row of the Controls panel, two keys bound to the same
+action:
+
+| Action | Bound key | Rendered |
+| --- | --- | --- |
+| Movement: Move Forward | Up Arrow | `Up Arrow` |
+| Movement: Move Forward | W | `X` |
+
+Same action, same record, same panel, same draw call — and one of the two is
+right. That single row rules out the binding data, the keyboard layout, the
+account, and any theory about the web port shipping a different default
+scheme. Whatever is wrong happens after the binding is read.
+
+The split is exactly: **keys with a name render correctly; keys that are a
+printable character render one too high.**
+
+| Action | Bound | Rendered | id | as a character |
+| --- | --- | --- | --- | --- |
+| Panel: Open Skills and Attributes | K | `L` | 76 | `L` |
+| Panel: Open World Map | M | `N` | 78 | `N` |
+| Action: Use Skill 1 | 1 | `2` | 50 | `2` |
+| Movement: Move Forward | W | `X` | 88 | `X` |
+| Movement: Move Forward | Up Arrow | `Up Arrow` | 32 | not printable |
+
+`Up Arrow` survives because it is not in the module at all — it comes from
+the localized text, so it cannot be produced by casting a number.
+
+## The key descriptor table
+
+`0x1456c0`, 20-byte records, `{ int32 id; char name[16] }`. The data is
+clean and in order; the defect is not here.
+
+```
+id  0..43   Alt Control Shift CapsLock Escape NumLock … ArrowUp F1..F12
+id 48..57   0..9        + a parallel table of shifted names  ) ! @ # $ % ^ & * (
+id 65..90   A..Z        + a parallel table of lowercase names  a..z
+```
+
+The names are DOM `KeyboardEvent.key` values — `ArrowUp`, `PageDown`,
+`HangulMode`, and `Unidentified` as the fallback — so this is the table the
+input side uses to turn a DOM key into an id.
+
+Read the same bytes framed from `0x1456c4` (name first, id at +16) and the
+printable ids come out **one above ASCII**: `A=66`, `H=73`, `0=49`. Which
+framing is real decides the shape of the patch, and the two are not
+distinguishable from the data alone — see the open question below.
+
+## Where the search stands
+
+Exactly one function references the table: **#2441**, the Emscripten input
+callback registration. It carries `"#canvas"` and the callback slots
+899–909, including 903, the mouse callback already patched for
+[the double-click flag](mouse-double-click.md). It *stores* the table
+pointer rather than indexing it in place, which is why no other function
+carries a constant into the table and why the consumers cannot be found by
+searching for one.
+
+Anchors tried and exhausted:
+
+- **Table references.** One function, above.
+- **The rendered names.** `Up Arrow`, `Page Up`, `Num Lock` and friends do
+  not appear anywhere in the module. They are localized text, so they give
+  no address to search from.
+- **Range-check constants.** If the ids really are ASCII+1, a printable
+  test would use bounds ordinary ASCII code never uses — `92` for the
+  letters, `59` for the digits. That ranks the 17,603 bodies down to a
+  handful, but `>= 65 && < 91` is also the normal idiom, so the ranking is
+  suggestive rather than decisive. Best candidates by that score: #7154
+  (16,590 bytes), #12320, #10382, #13674, #12328, #15906.
+
+## The open question
+
+Two readings survive every static observation, and they need different
+patches:
+
+1. **The ids are ASCII+1 and the display casts.** Fix: subtract one before
+   the character conversion.
+2. **The ids are ASCII and the display indexes the descriptor table one
+   record too far.** Fix: correct the index.
+
+Both produce every symptom above, including `Up Arrow` staying correct.
+
+## What settles it
+
+Not more static analysis — that produced two confident, plausible readings
+and no way to choose. The technique that ended the guessing during the
+templates investigation applies here unchanged: **append export entries for
+the candidate functions, instantiate the module in Node with stub imports,
+and call them with a key id.** A function that answers `L` to 76 is the one,
+and the value it was given says which reading is true.
+
+## Whether to ship a fix at all
+
+Worth stating plainly, because the answer is not obviously yes. The patch
+would be one instruction. Against it: a second transform to re-derive and
+re-pin against every ArenaNet build, permanently, for a wrong letter on a
+label — and a hazard to rule out first, that the function is not shared with
+the input path, where the same off-by-one is load-bearing and correct.
+
+The report is worth writing either way. It is specific enough for someone
+with symbols to fix in minutes.

--- a/internal/upstream/keyboard-label-offset.md
+++ b/internal/upstream/keyboard-label-offset.md
@@ -61,8 +61,9 @@ distinguishable from the data alone — see the open question below.
 
 Exactly one function references the table: **#2441**, the Emscripten input
 callback registration. It carries `"#canvas"` and the callback slots
-899–909, including 903, the mouse callback already patched for
-[the double-click flag](mouse-double-click.md). It *stores* the table
+899–909, including 903, the mouse callback the native double-click work
+patches on its own branch — deliberately not linked, because these two
+lines of work are independent and either may land first. It *stores* the table
 pointer rather than indexing it in place, which is why no other function
 carries a constant into the table and why the consumers cannot be found by
 searching for one.

--- a/internal/upstream/upstream-keyboard-labels.md
+++ b/internal/upstream/upstream-keyboard-labels.md
@@ -1,0 +1,148 @@
+# Guild Wars WebAssembly client: every printable key is labelled one position too high
+
+A report for ArenaNet. Nothing in it depends on our project.
+
+## Summary
+
+In the published WebAssembly client, the Controls panel and the in-game menus
+name the wrong key for any binding whose key is a printable character. The
+label shown is the **next character in ASCII order**: a control bound to `K`
+reads `L`, one bound to `M` reads `N`, one bound to `1` reads `2`.
+
+Input is not affected. The key that works is the correct one and matches the
+Windows client, and the bindings held against the account are correct. The
+defect is confined to the code that renders a key id as text.
+
+Keys that have a name rather than a character — `Up Arrow`, `Escape`, `Tab`,
+the function keys — are labelled correctly.
+
+Client examined:
+
+| | |
+| --- | --- |
+| Artifact | `Gw.jspi.wasm` |
+| SHA-256 | `3229678d3fd7d2f0e309530086a614d97f02e7eeb3ca12650ababfd2eb360817` |
+| Size | 8,196,702 bytes |
+| Build reported in-client | 38,797 (internal) |
+
+## User-visible symptoms
+
+Observed with default bindings, in Options → Control:
+
+| Action | Key that works | Label shown |
+| --- | --- | --- |
+| Panel: Open Hero | H | `I` |
+| Panel: Open Inventory | I | `J` |
+| Panel: Open Skills and Attributes | K | `L` |
+| Panel: Open Quest Log | L | `M` |
+| Panel: Open World Map | M | `N` |
+| Action: Use Skill 1 | 1 | `2` |
+| Movement: Move Forward | W | `X` |
+
+The practical consequence is that a player who reads the menu and presses the
+key it names gets the *adjacent* action. "Hero (I)" opens the Inventory,
+because `I` is genuinely the Inventory key and Inventory's own label reads
+`J`.
+
+## The measurement that isolates it
+
+One row of the Controls panel, with two keys bound to the same action:
+
+| Action | Bound key | Rendered |
+| --- | --- | --- |
+| Movement: Move Forward | Up Arrow | `Up Arrow` |
+| Movement: Move Forward | W | `X` |
+
+Same action, same binding record, same panel, same draw. One of the two is
+correct.
+
+This rules out the binding data, the stored configuration, the keyboard
+layout and any difference between the web and Windows binding sets — none of
+those can differ between two keys inside a single record. Whatever is wrong
+happens after the binding is read, in rendering, and only for keys that are
+rendered as a character rather than by name.
+
+## Scope
+
+- **Letters and digits are both affected**, by the same one position.
+- **Named keys are not** — `Up Arrow`, `Escape`, `Tab`, `F1`–`F12` read
+  correctly. Those names are not present in the module and come from the
+  localized text, so they cannot be produced by converting a number.
+- **Independent of keyboard layout.** Reproduced on US QWERTY and on German
+  QWERTZ, identically. A layout fault would diverge where the layouts
+  diverge.
+- **Independent of the host.** We ship a macOS Electron host for this client,
+  and it forwards key events unmodified; nothing on our side participates in
+  drawing these labels.
+
+## The key descriptor table
+
+At `0x1456c0` in the data segment, 20-byte records:
+
+```
+{ int32 id; char name[16] }
+
+id  0..43   Alt Control Shift CapsLock Escape NumLock … ArrowUp F1..F12
+id 48..57   0..9    + a parallel table of shifted names  ) ! @ # $ % ^ & * (
+id 65..90   A..Z    + a parallel table of lowercase names  a..z
+```
+
+The names are DOM `KeyboardEvent.key` values — `ArrowUp`, `PageDown`,
+`HangulMode`, with `Unidentified` as the fallback — so this is the table that
+turns a browser key event into an internal id.
+
+The table's contents are correct and correctly ordered. The defect is not in
+this data.
+
+## What we could not determine
+
+We did not locate the function that renders the label, and two readings of
+the table remain consistent with every observation above. They imply
+different fixes, so we are stating both rather than guessing:
+
+1. **The ids are ASCII+1 and the label is produced by casting the id to a
+   character.** Read the records framed from `0x1456c4` — name first, id at
+   +16 — and the printable ids come out one above ASCII: `A=66`, `H=73`,
+   `0=49`. A cast then yields the observed labels exactly.
+2. **The ids are ASCII and the renderer indexes the descriptor table one
+   record too far.** Read the records framed from `0x1456c0` — id first — and
+   they are exactly ASCII. Reading `name` from the following record yields
+   the observed labels exactly.
+
+Both explain every case in this report, including `Up Arrow` remaining
+correct. With symbols and source this should be immediate; from a stripped
+module it is not.
+
+We did establish that **function #9718** converts a key id to a character
+with no offset (`75` gives `K`, `76` gives `L`, `48` gives `0`), and that many
+functions in the module perform that identical conversion as generic
+one-character string helpers. That means the conversion itself is not
+where the extra one is introduced.
+
+## Expected behaviour
+
+The Controls panel and the in-game menus should name the key that actually
+triggers the action, for printable keys as they already do for named ones.
+
+## Reproduction
+
+1. Log in and open Options → Control.
+2. Select **Movement: Move Forward**. It shows `Up Arrow` and `X`.
+3. Press `X` in game. Nothing moves.
+4. Press `W`. The character moves forward.
+5. Select **Action: Use Skill 1**. It shows `2`; skill 1 fires on `1`.
+
+No configuration change is required and the defect is present with default
+bindings.
+
+## Method, and its limits
+
+Unlike our report on template file management, the claims here were **not**
+verified by executing the functions involved. The label renderer depends on
+an initialised UI and text subsystem, so it cannot be called from a cold
+instance the way the pure path helpers could.
+
+What is directly observed: the rendered labels, the keys that actually work,
+and the contents and layout of the descriptor table. What is inferred: which
+of the two readings above is the real one. We have marked the boundary
+between the two deliberately.


### PR DESCRIPTION
## What this is

Investigation and an upstream report. **No client changes ship in this branch.**

## The issue

Players reported that the in-game keyboard shortcuts do not match the Windows client — the menus show Hero (I), Inventory (J), Skills and Attributes (L), Quest Log (M) — while the game responds to the Windows keys: H, I, K, L.

There are not two sets of shortcuts. There is one set, and every label for a printable key is printed one position too high. Input is entirely correct and matches the Windows client; only the rendered text is wrong.

| Action | Key that works | Label shown |
| --- | --- | --- |
| Panel: Open Skills and Attributes | K | `L` |
| Panel: Open World Map | M | `N` |
| Action: Use Skill 1 | 1 | `2` |
| Movement: Move Forward | W | `X` |
| Movement: Move Forward | Up Arrow | `Up Arrow` |

## What isolates it

The last two rows are the same action, with two keys bound, in one record, drawn by one call — and one label is right. Nothing before the render can differ between two keys inside a single record, which eliminates the binding data, the stored configuration, the keyboard layout, and any web-versus-Windows binding difference together.

The split is exactly: keys with a name render correctly, keys that are a printable character render one too high. Reproduced identically on US QWERTY and German QWERTZ, so it is not a layout fault.

## What we established

- A key descriptor table at `0x1456c0`, 20-byte records, `{ int32 id; char name[16] }`, holding DOM `KeyboardEvent.key` names. Its contents are correct and correctly ordered — the defect is not in this data.
- The bindings are not stored locally. The client's browser storage holds `Gw.dat`, skill templates and `ChatFilter.ini`, and no controls file, so bindings arrive with the account. That is also why they agree with the Windows client.
- Function #9718 converts a key id to a character with no offset at all, and many functions in the module perform that identical conversion as generic one-character string helpers. So the extra one is not introduced by the conversion.
- Nothing on the host side participates in drawing these labels, so this reproduces in the web client anywhere.

## What we could not determine, and why no fix ships

Two readings of the table survive every observation and imply different fixes: either the ids are ASCII+1 and the label is a cast, or the ids are ASCII and the renderer indexes one record too far. Both explain every case, including `Up Arrow` staying correct.

Standing the module up in Node and calling ArenaNet's functions directly — the technique that resolved the template defects — does not resolve this one. It works, and it is how #9718 was identified, but the label renderer needs an initialised UI and text subsystem and returns nothing when called cold. Locating it would need live instrumentation, which is a different and much larger job for a defect whose entire cost is a wrong letter on a label, and which would add a second transform to re-derive and re-pin against every upstream build.

The notes record this so the next attempt starts from live instrumentation rather than repeating the search.

## What ships

- `internal/upstream/upstream-keyboard-labels.md` — a self-contained report for ArenaNet. It states plainly which claims are observed and which are inferred, and says outright that, unlike the template report, these were not verified by executing the functions.
- `internal/upstream/keyboard-label-offset.md` — our own notes, including the ruled-out approach.

## Verification

- `pnpm check` — typecheck, lint, link check, unit 752, policy 156, all green
- The link check caught a cross-branch link in the first draft; removed, since these two lines of work are independent and either may land first
