### PR TITLE
Release 2026.8.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "guild-wars",
   "productName": "Guild Wars Reforged",
-  "version": "2026.8.3",
+  "version": "2026.8.4",
   "private": true,
   "packageManager": "pnpm@11.13.1",
   "type": "module",


### PR DESCRIPTION
## What ships in 2026.8.4

Version bump only — everything below is already merged to `main`. The release notes text is at the bottom, ready for the GitHub release.

## Double-clicking now works properly

This is the big one. Double-clicking has been subtly broken since the start, and it was behind a whole cluster of problems that looked unrelated:

- **Identification and Salvage Kits** can be double-clicked to use, like they should be.
- **Inventory items stay put.** Double-clicking an item no longer sends it to a random slot.
- **Vendors sell one item per click.** A single click on Sell sometimes sold several items at once.
- **Attribute points spend what you actually clicked**, instead of several at a time.

It is also instant now. There used to be a delay of roughly a third of a second before a double-click did anything, and that delay is gone — the game responds on the click itself.

**What was going on.** The game never actually told itself that a double-click had happened, because the piece of the browser code that reports "this was the second click" was never wired up. Instead, the app faked it by pretending you had tapped the screen twice, like on a phone. The trouble is that a fake tap is a *whole click*, so every double-click was arriving as four clicks, plus a bit of cursor movement. That is exactly why a vendor sold four items and an attribute panel spent four points.

Now the game is told directly, using the same signal it already understood. Your Mac's own double-click speed and distance settings decide what counts as a double-click, so it matches the rest of your system.

## A warning before the game runs out of memory

The game has a hard memory limit it cannot exceed, and long sessions could hit it. Until now the first sign was the crash itself, usually hours in, and usually mid-mission.

The app now watches the memory and warns you before it becomes a problem — an amber notice while there is still plenty of room to finish what you are doing and get back to a town, and a red one when a crash is likely soon. There is a **Reload Now** button that saves what it can and restarts the client, so you can take a quick relog at a moment you choose instead of losing a run.

If a crash does happen anyway, the crash screen now has a **Technical details** section showing what actually went wrong and how much memory was in use. That is worth screenshotting if you report it.

## Smaller things

- **Cmd-Q always quits.** Quitting could hang behind unfinished background work. Cleanup now has a time limit.
- **A built-in input trace** for bug reports. It records what your mouse and keyboard actually did and copies out as text, with no cursor positions in it. Most people will never need it, but it turns "clicking feels wrong" into something that can be diagnosed.

## Known issues, not fixed here

- **The keyboard shortcuts shown in menus are wrong by one letter.** The menu says Hero is `I`, but the key that works is `H`. Skills says `L`, the key is `K`. Skill 1 says `2`. **The real key is always the one before the one shown.** Arrow keys, Escape, Tab and the F-keys are labelled correctly. This is a bug in ArenaNet's game client, not in this app — it happens in their web client anywhere — and it has been reported to them. Your keys all work correctly; only the labels lie.
- **Ctrl+click does not call out targets** yet. Still being looked at.
- **Rotating your character portrait does not lock the cursor**, so the pointer can run off the window mid-drag.

## Everything in this release

| PR | Player-facing? |
| --- | --- |
| #104 Give the client its own double-click flag and delete the synthetic taps | Yes — the headline |
| #101 Watch the WASM heap and warn before the 2 GiB cap kills the client | Yes |
| #105 Report the printable-key label offset upstream | No — investigation and an upstream report |
| #99 Serve the website download buttons already pointing at the DMG | No — website |
| #102 Pin the unhead 3.x family | No — website build |
| #100 Patch high-severity transitive dependencies via pnpm overrides | No — dependencies |

## Verification

Full `pnpm verify` on this branch, at the released version:

- Unit 759, policy 156, integration 29, release 21 — all pass, zero failures
- Electron end-to-end: 108 passed
- Package, packaged smoke, and Enhancement runtime proofs pass

Both game-relevant fixes confirmed present on `main`, and the old synthetic tap path confirmed gone from the source rather than merely disabled.

## Before publishing

The double-click change is verified end to end by CI and by a live player trace showing the flag delivered on every even press at zero latency, with no touch events. What CI cannot check is that each widget then does the right thing with it — kits, inventory slots, vendor Sell, attribute points. A quick in-game pass on a vendor and the attribute panel is worth doing first, since the every-even-click behaviour is the part of the design that was reasoned about rather than observed.

Release is published by dispatching the release workflow by hand; it reads the version from `package.json` and refuses a tag that already shipped.
