### PR TITLE
Stop the crash detail collapsing the dock it sits under

### DIFF
--- a/src/renderer/loading.css
+++ b/src/renderer/loading.css
@@ -161,7 +161,13 @@
                       font:11px/1.5 ui-monospace, Menlo, monospace;
                       white-space:pre-wrap; overflow-wrap:anywhere;
                       user-select:text; -webkit-user-select:text; }
+/* Both rows claim a whole flex line. Without the second rule the boot row
+   keeps `flex:1`'s zero flex-basis, so it "fits" beside a 100%-basis sibling,
+   wins none of the zero free space, and collapses to 0px — the label then
+   wraps one word per line behind a full-width detail block. */
 #loading-dock:has(#loading-crash-detail:not([hidden])) { flex-wrap:wrap; }
+#loading-dock:has(#loading-crash-detail:not([hidden])) #loading-boot {
+  flex-basis:100%; }
 
 #loading-label { font-size:17px; letter-spacing:.02em; color:#f2e8d2;
                  text-shadow:0 1px 6px #000c; }


### PR DESCRIPTION
## What this ships to users

The crash overlay in 2026.8.4 renders broken — the label wraps one word per line, the buttons squeeze into a sliver, and the technical-details block covers them. A player who has just crashed cannot read what happened or reliably hit **Report a Problem**. Reported from a live 2026.8.4 crash (screenshot below the fold in the linked thread).

## The defect

`#loading-crash-detail` claimed `flex-basis:100%` as a sibling of `#loading-boot`, whose `flex:1` expands to `flex: 1 1 0%` — a **zero** flex basis.

Flex line-breaking sums hypothetical main sizes: `0 + 100% = 100%`, which "fits" the line, so both items landed on the **same** flex line. Free space was then exactly zero, so `#loading-boot`'s `flex-grow:1` had nothing to grow into and it computed to `0px`. `min-width:0` (correct, and load-bearing elsewhere) let it actually collapse rather than holding min-content width.

`flex-wrap:wrap` was already set and did not help — wrapping only breaks a line when items *don't* fit, and a zero-basis item always fits.

## The fix

One rule: when the detail row is visible, the boot row claims a full line too, so each occupies its own.

```css
#loading-dock:has(#loading-crash-detail:not([hidden])) #loading-boot { flex-basis:100%; }
```

The comment above it states the constraint, because the failure mode is invisible in the markup and a future reader deleting the rule would reintroduce it.

## Verification

Measured against the shipped stylesheet with Playwright at a 1512px viewport, crash state with the disclosure open:

| | `#loading-boot` width | label lines |
| --- | --- | --- |
| before | **0px** | 6 |
| after | 1460px | 1 |

Also confirmed by screenshot: one-line label, buttons right-aligned at their natural width, detail as a full-width drawer beneath. `pnpm lint`, `pnpm typecheck`, and the renderer failure-copy unit tests pass.

The narrow-viewport breakpoint is unaffected — the new rule is outside the media query and more specific than the `#loading-boot { width:100% }` there, so the same one-line-each layout holds at every width.

## Review focus

- The `:has()` pair is now two rules that must stay together; the comment says so. If you would rather the detail live inside `.dock-info` (deleting both rules, detail then 946px wide rather than 1460px), that variant was measured too and also fixes the collapse — I chose full width because the content is a wrapped assertion path.

## Known follow-ups

- Unrelated to layout: this crash carried the first captured assertion text — `ASSERTION FAILED: Out of memory!` at `Engine/Gr/Gles3/GlTex.cpp:397`, heap at 2048/2048 MiB. That names the texture allocator as the consumer and belongs in the upstream memory-exhaustion log, separately.
