### PR TITLE
Add a memory debug panel and the triggers a reconnect test needs

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -222,6 +222,60 @@ process when its event loop actually blocked, and otherwise to the renderer.
 Captures recorded before window-state tracking say so rather than claiming the
 window was steady.
 
+## The memory debug panel
+
+Help → Diagnostics → **Show Memory Debug Panel** (⌘⇧D), or the panel's own
+toggle. It appears on a development build, and on any build launched with the
+switch:
+
+```
+open -a "Guild Wars Reforged.app" --args --gw-debug-panel
+```
+
+Not a setting, so nothing about it persists and a player cannot reach it by
+clicking. Not the performance overlay either: that one is a shipped, closed-
+schema readout drawn from the main process's summary, while the heap curve is
+renderer-local and these controls are destructive.
+
+The panel reads the heap, the growth rate, the estimated time to the client's
+2 GiB cap, the growth-step count, open sockets, and the uptime of the current
+page load. It renders the notice and the crash overlay through the same
+functions the real paths use, so a simulation shows the sentence a player would
+actually read. It has no thresholds and no copy of its own, and it never writes
+the watcher's escalation — the readout prints the real level beside the
+simulated one so that stays visible.
+
+Two simulation divergences worth knowing: a simulated crash leaves the memory
+watcher running (a real abort stops it), and the overlay covers a client that is
+still allocating underneath — hence **Dismiss**.
+
+### The reload paths, and why they differ
+
+Whether a reload lets Guild Wars offer the player their instance back is a
+question about what the *server* observes, so the paths are worth telling
+apart. They do not differ at the TCP level — every one of them ends in the same
+`destroy()` — but they differ in ordering, in whether the client learns it was
+disconnected, and in whether anything is sent at all.
+
+| | Path | Filesystem sync | Client sees the close | What the server sees |
+| --- | --- | --- | --- | --- |
+| a | Panel: sync + reload — also the notice's own Reload Now | yes, ≤1.5 s | no | FIN at navigation |
+| b | View → Reload Game (⌘R) | no | **yes** — main closes first | FIN before navigation |
+| c1 | Panel: orphan + reload | no | no | **nothing** — no FIN; the server must time out |
+| c2 | Help → Diagnostics → Crash Renderer Process | no | no | FIN from `render-process-gone` |
+| d | Panel: drop sockets, keep running | no | **yes**, and the client stays alive | FIN |
+| e | Crash overlay → Retry | no | no | FIN at navigation |
+
+Run **(d) first**: it is the only one that does not restart the client, so the
+re-login is fastest, and if reconnecting works from there every reload path
+inherits the answer. **(c1)** is the only silence, which makes it the closest
+imitation of a real crash.
+
+Record the uptime and socket count before each run and how long the re-login
+took — otherwise a server-side timeout gets attributed to a teardown
+difference. (c1) leaves orphaned handles in the main process until the app
+quits, so quit after using it. (c2) recovers only once per launch.
+
 ## Verification boundaries
 
 ### Claims and the tests that prove them

--- a/src/main/window-menu.ts
+++ b/src/main/window-menu.ts
@@ -22,6 +22,9 @@ import { resetGameInput, sendRendererCommand } from "./renderer-commands.js";
 import { isDevBuild } from "./protocol.js";
 import type { WindowHost } from "./window.js";
 
+/** Launch with `--gw-debug-panel` to reveal the memory panel on any build. */
+export const DEBUG_PANEL_SWITCH = "gw-debug-panel";
+
 const USER_GUIDE_URL = `${EXTERNAL_URLS.github}/blob/main/docs/user-guide.md`;
 
 export interface ApplicationMenuActions {
@@ -38,6 +41,12 @@ export function installApplicationMenu({
 }: ApplicationMenuActions): void {
   const isMac = process.platform === "darwin";
   const dev = isDevBuild();
+  // The memory panel's own gate, deliberately not `dev` alone. The sessions
+  // worth measuring are hours long on a real account, and a dev build refuses
+  // persistent secrets — so the build that needs these controls is the
+  // packaged one, launched with the switch. Nothing about it persists, and a
+  // player cannot reach it by clicking.
+  const debugPanel = dev || app.commandLine.hasSwitch(DEBUG_PANEL_SWITCH);
 
   const template: MenuItemConstructorOptions[] = [
     ...(isMac
@@ -208,6 +217,30 @@ export function installApplicationMenu({
                 void sendRendererCommand(win, { type: "input.trace" });
               },
             },
+            // The memory panel and the one trigger main owns. Crashing the
+            // renderer is here rather than in the panel because it is the one
+            // path with no renderer involvement at all, which is exactly what
+            // makes it the most faithful imitation of a real crash.
+            ...(debugPanel
+              ? ([
+                  { type: "separator" },
+                  {
+                    id: "toggle-dev-panel",
+                    label: "Show Memory Debug Panel",
+                    accelerator: "CmdOrCtrl+Shift+D",
+                    click: () => {
+                      void sendRendererCommand(win, { type: "dev.panel" });
+                    },
+                  },
+                  {
+                    id: "crash-renderer-process",
+                    label: "Crash Renderer Process (test reconnect)",
+                    click: () => {
+                      win.webContents.forcefullyCrashRenderer();
+                    },
+                  },
+                ] as MenuItemConstructorOptions[])
+              : []),
             {
               id: "stop-capture",
               label: "Stop Capture",

--- a/src/renderer/commands.ts
+++ b/src/renderer/commands.ts
@@ -68,6 +68,9 @@
       case 'input.trace':
         dispatch('gw:input-trace');
         break;
+      case 'dev.panel':
+        dispatch('gw:dev-panel');
+        break;
       case 'diagnostics.toggle':
         dispatch('gw:diagnostics-toggle');
         break;

--- a/src/renderer/dev-panel.ts
+++ b/src/renderer/dev-panel.ts
@@ -1,0 +1,435 @@
+/**
+ * The memory debug panel: a live reading of the client's WASM heap, and the
+ * triggers that let one person answer questions about it in minutes instead of
+ * hours of play.
+ *
+ * It owns the sample ring, the readout, the sparkline and its own buttons. It
+ * owns no thresholds, no notice copy and no escalation state — those belong to
+ * the harness and to `failure-messages.ts`, and this module reaches them only
+ * through the callbacks it is constructed with. A simulated notice therefore
+ * renders the sentence the player would really read; a panel with its own copy
+ * would be rehearsing the wrong words.
+ *
+ * Deliberately not the diagnostics overlay: that one is a shipped, closed-schema
+ * performance readout bound to a player setting, drawn from the main process's
+ * summary. The heap curve is renderer-local and these controls are destructive,
+ * so they get their own surface and their own gate.
+ */
+
+/**
+ * A cap of zero means the harness has not yet resolved the client's compiled-in
+ * maximum. The panel must render that as unknown rather than dividing by it —
+ * and it must never import the contract itself, because a second importer of
+ * `shared/contracts.js` disturbs the packaged proof that the Enhancement
+ * runtime is what requested it. The cap arrives by callback.
+ */
+export interface HeapSample {
+  atMs: number;
+  bytes: number;
+}
+
+export interface HeapSummary {
+  bytes: number;
+  capBytes: number;
+  /** Null when the cap is unknown. */
+  fractionOfCap: number | null;
+  /** Growth over the whole run, bytes per minute; null when unmeasurable. */
+  runBytesPerMinute: number | null;
+  /** Growth over the trailing window; null when the window is not covered. */
+  recentBytesPerMinute: number | null;
+  /** Minutes until the cap at the run rate; null when unmeasurable. */
+  minutesToCap: number | null;
+  /** Samples where the heap grew. Two steps inside one interval coalesce. */
+  steps: number;
+  lastStepBytes: number | null;
+  lastStepAtMs: number | null;
+}
+
+const RECENT_WINDOW_MS = 30 * 60_000;
+const MIB = 1_048_576;
+
+/**
+ * The run rate, not the recent one, drives the estimate. Heap growth is a step
+ * function — the client takes the runtime's largest allowed chunk at a time —
+ * so a short window reads as either zero or enormous depending on where the
+ * sample landed. Both are shown, each labelled with its window, and the reader
+ * decides.
+ */
+export function summarizeHeap(
+  samples: readonly HeapSample[],
+  capBytes: number,
+  nowMs: number,
+): HeapSummary {
+  const latest = samples.at(-1);
+  const bytes = latest?.bytes ?? 0;
+  const summary: HeapSummary = {
+    bytes,
+    capBytes,
+    fractionOfCap: capBytes > 0 ? bytes / capBytes : null,
+    runBytesPerMinute: null,
+    recentBytesPerMinute: null,
+    minutesToCap: null,
+    steps: 0,
+    lastStepBytes: null,
+    lastStepAtMs: null,
+  };
+  if (samples.length === 0) return summary;
+
+  // A decrease is a reloaded client rather than a shrinking heap — WASM memory
+  // never gives pages back — so it restarts the count instead of subtracting.
+  let previous = samples[0]!.bytes;
+  for (const sample of samples.slice(1)) {
+    if (sample.bytes > previous) {
+      summary.steps += 1;
+      summary.lastStepBytes = sample.bytes - previous;
+      summary.lastStepAtMs = sample.atMs;
+    }
+    previous = sample.bytes;
+  }
+
+  const slope = (from: HeapSample | undefined) => {
+    if (!from || !latest) return null;
+    const minutes = (latest.atMs - from.atMs) / 60_000;
+    if (minutes <= 0) return null;
+    return (latest.bytes - from.bytes) / minutes;
+  };
+
+  summary.runBytesPerMinute = slope(samples[0]);
+  summary.recentBytesPerMinute = slope(
+    [...samples].reverse().find((s) => s.atMs <= nowMs - RECENT_WINDOW_MS),
+  );
+
+  const rate = summary.runBytesPerMinute;
+  if (capBytes > 0 && rate !== null && rate > 0) {
+    summary.minutesToCap = Math.max(0, (capBytes - bytes) / rate);
+  }
+  return summary;
+}
+
+/**
+ * Halve a full ring by dropping every second sample, keeping the first and the
+ * last. Paired with a doubling interval this keeps the sparkline spanning the
+ * whole run at a fixed cost, rather than showing an ever-shorter tail of a
+ * session whose length is the interesting part.
+ */
+export function decimate(samples: readonly HeapSample[]): HeapSample[] {
+  if (samples.length < 3) return [...samples];
+  const kept = samples.filter((_, index) => index % 2 === 0);
+  const last = samples.at(-1)!;
+  if (kept.at(-1) !== last) kept.push(last);
+  return kept;
+}
+
+const CAPACITY = 240;
+const FIRST_INTERVAL_MS = 5_000;
+
+const PANEL_CSS = `
+/*
+ * The right edge, vertically centred: the four corners are taken
+ * (#capture-status, #diagnostics, #input-trace, Tools) and it must not cover
+ * #memory-notice at the top centre, which is one of the things it exists to
+ * judge. Only the buttons take the pointer.
+ *
+ * Above the launcher rather than below it, unlike every other overlay here.
+ * The launcher covers the whole window, and it is what a simulated crash
+ * raises — so a panel underneath it would hide its own Dismiss button at the
+ * one moment that button is the way out.
+ */
+#dev-panel {
+  position: fixed;
+  top: 50%;
+  right: 12px;
+  transform: translateY(-50%);
+  z-index: 11;
+  width: 310px;
+  max-height: calc(100vh - 24px);
+  overflow-y: auto;
+  box-sizing: border-box;
+  padding: 10px 12px;
+  border: 1px solid #4a4740;
+  border-radius: 3px;
+  background: rgba(8, 8, 10, 0.97);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.55);
+  color: #e8e4d8;
+  font: 11px/1.55 ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-variant-numeric: tabular-nums;
+  pointer-events: none;
+  user-select: none;
+  -webkit-user-select: none;
+}
+#dev-panel[hidden] { display: none; }
+#dev-panel h2 {
+  margin: 0 0 6px;
+  color: #c8aa6e;
+  font: inherit;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+#dev-panel dl {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1px 10px;
+  margin: 0;
+}
+#dev-panel dt { color: #8d8a82; }
+#dev-panel dd { margin: 0; white-space: pre; }
+#dev-panel dd[data-warn="true"] { color: #ffb488; }
+#dev-panel svg { display: block; width: 100%; height: 44px; margin: 8px 0 4px; }
+#dev-panel svg .cap { stroke: #6b4a3a; stroke-dasharray: 2 3; }
+#dev-panel svg .curve { fill: none; stroke: #c8aa6e; stroke-width: 1.5; }
+#dev-panel section {
+  margin-top: 8px;
+  padding-top: 7px;
+  border-top: 1px solid #332f29;
+}
+#dev-panel section h3 {
+  margin: 0 0 5px;
+  color: #8d8a82;
+  font: inherit;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+#dev-panel section[data-danger="true"] h3 { color: #d98a6a; }
+#dev-panel .row { display: flex; flex-wrap: wrap; gap: 4px; }
+#dev-panel button {
+  pointer-events: auto;
+  padding: 3px 8px;
+  border: 1px solid #524e44;
+  border-radius: 2px;
+  background: #1d1c19;
+  color: #e8e4d8;
+  font: inherit;
+  cursor: default;
+}
+#dev-panel button:hover { background: #2a2823; border-color: #6b6557; }
+#dev-panel button:active { transform: scale(0.97); }
+#dev-panel button:focus-visible { outline: 1px solid #c8aa6e; outline-offset: 1px; }
+#dev-panel section[data-danger="true"] button { border-color: #6b4438; }
+#dev-panel section[data-danger="true"] button:hover { border-color: #a3634a; }
+#dev-panel p { margin: 5px 0 0; color: #8d8a82; white-space: normal; }
+`;
+
+export interface DevPanelHost {
+  parent: HTMLElement;
+  log(...values: unknown[]): void;
+  /** Current WASM linear memory, in bytes. */
+  heapBytes(): number;
+  /** The client's compiled-in maximum; 0 until the harness has resolved it. */
+  capBytes(): number;
+  /** The escalation the real watcher has reached. Read only. */
+  realNoticeLevel(): string;
+  /** Draws the notice without touching the watcher's own state. */
+  previewNotice(level: 'low' | 'critical'): void;
+  hideNotice(): void;
+  /** Draws the crash overlay without recording a crash. */
+  previewCrash(count: number): void;
+  dismissOverlay(): void;
+  openSockets(): number;
+  /** Path (d): drop the connections, leave the client running. */
+  dropSockets(): void;
+  /** Path (a): sync the filesystem, then reload. */
+  reloadSafely(): void;
+  /** Path (c1): reload without closing anything, so no FIN is ever sent. */
+  reloadOrphaning(): void;
+}
+
+export interface DevPanel {
+  toggle(): boolean;
+  visible(): boolean;
+}
+
+const minutesText = (minutes: number | null): string => {
+  if (minutes === null) return '—';
+  if (minutes < 60) return `~${Math.round(minutes)} m`;
+  const hours = Math.floor(minutes / 60);
+  return `~${hours} h ${String(Math.round(minutes % 60)).padStart(2, '0')} m`;
+};
+
+const clockText = (ms: number): string => {
+  const total = Math.max(0, Math.floor(ms / 1000));
+  const pad = (value: number) => String(value).padStart(2, '0');
+  return `${pad(Math.floor(total / 3600))}:${pad(Math.floor(total / 60) % 60)}:${pad(total % 60)}`;
+};
+
+const perHour = (bytesPerMinute: number | null): string =>
+  bytesPerMinute === null
+    ? '—'
+    : `${bytesPerMinute >= 0 ? '+' : ''}${Math.round((bytesPerMinute * 60) / MIB)} MiB/h`;
+
+export function createDevPanel(host: DevPanelHost): DevPanel {
+  const style = document.createElement('style');
+  style.textContent = PANEL_CSS;
+  const root = document.createElement('div');
+  root.id = 'dev-panel';
+  root.hidden = true;
+  root.innerHTML = `
+    <h2>Memory debug</h2>
+    <dl>
+      <dt>heap</dt><dd data-role="heap"></dd>
+      <dt>notice</dt><dd data-role="notice"></dd>
+      <dt>growth</dt><dd data-role="growth"></dd>
+      <dt>to cap</dt><dd data-role="tocap"></dd>
+      <dt>steps</dt><dd data-role="steps"></dd>
+      <dt>sockets</dt><dd data-role="sockets"></dd>
+      <dt>uptime</dt><dd data-role="uptime"></dd>
+    </dl>
+    <svg data-role="spark" viewBox="0 0 100 30" preserveAspectRatio="none" aria-hidden="true">
+      <line class="cap" x1="0" y1="0.75" x2="100" y2="0.75"></line>
+      <polyline class="curve" data-role="curve" points=""></polyline>
+    </svg>
+    <section>
+      <h3>Simulate</h3>
+      <div class="row">
+        <button type="button" data-role="low">Low notice</button>
+        <button type="button" data-role="critical">Critical notice</button>
+        <button type="button" data-role="hide">Hide</button>
+      </div>
+      <div class="row" style="margin-top:4px">
+        <button type="button" data-role="crash1">Crash 1st</button>
+        <button type="button" data-role="crash2">Crash repeat</button>
+        <button type="button" data-role="dismiss">Dismiss</button>
+      </div>
+    </section>
+    <section data-danger="true">
+      <h3>Reconnect triggers</h3>
+      <div class="row">
+        <button type="button" data-role="drop">d · drop sockets</button>
+        <button type="button" data-role="reload-safe">a · sync + reload</button>
+        <button type="button" data-role="reload-orphan">c1 · orphan + reload</button>
+      </div>
+      <p>b is View → Reload Game. c2 is Help → Diagnostics → Crash Renderer Process.
+         Note uptime and sockets before each, and how long the re-login took.</p>
+    </section>
+  `;
+  host.parent.append(style, root);
+
+  const cell = (role: string) =>
+    root.querySelector<HTMLElement>(`dd[data-role="${role}"]`)!;
+  const heapCell = cell('heap');
+  const noticeCell = cell('notice');
+  const growthCell = cell('growth');
+  const toCapCell = cell('tocap');
+  const stepsCell = cell('steps');
+  const socketsCell = cell('sockets');
+  const uptimeCell = cell('uptime');
+  const curve = root.querySelector<SVGPolylineElement>('[data-role="curve"]')!;
+
+  const on = (role: string, run: () => void) => {
+    root
+      .querySelector<HTMLButtonElement>(`button[data-role="${role}"]`)!
+      .addEventListener('click', run);
+  };
+
+  const startedAt = performance.now();
+  let samples: HeapSample[] = [];
+  let intervalMs = FIRST_INTERVAL_MS;
+  let nextSampleAt = startedAt;
+  let simulated: string | null = null;
+  let visible = false;
+
+  const sample = (nowMs: number) => {
+    if (nowMs < nextSampleAt) return;
+    nextSampleAt = nowMs + intervalMs;
+    samples.push({ atMs: nowMs, bytes: host.heapBytes() });
+    if (samples.length > CAPACITY) {
+      samples = decimate(samples);
+      intervalMs *= 2;
+    }
+  };
+
+  const paintCurve = (summary: HeapSummary) => {
+    if (samples.length < 2 || summary.capBytes <= 0) {
+      curve.setAttribute('points', '');
+      return;
+    }
+    const first = samples[0]!.atMs;
+    const span = Math.max(1, samples.at(-1)!.atMs - first);
+    curve.setAttribute(
+      'points',
+      samples
+        .map((s) => {
+          const x = ((s.atMs - first) / span) * 100;
+          const y = 30 - Math.min(1, s.bytes / summary.capBytes) * 30;
+          return `${x.toFixed(1)},${y.toFixed(1)}`;
+        })
+        .join(' '),
+    );
+  };
+
+  const paint = (nowMs: number) => {
+    const summary = summarizeHeap(samples, host.capBytes(), nowMs);
+    const cap = summary.capBytes > 0
+      ? `${Math.round(summary.capBytes / MIB)}`
+      : '?';
+    const pct = summary.fractionOfCap === null
+      ? ''
+      : `  ${(summary.fractionOfCap * 100).toFixed(1)}%`;
+    heapCell.textContent = `${Math.round(summary.bytes / MIB)} / ${cap} MiB${pct}`;
+    heapCell.dataset.warn = String((summary.fractionOfCap ?? 0) > 0.85);
+
+    // The real escalation is shown beside the simulated one precisely so a
+    // preview can be seen not to have moved it.
+    noticeCell.textContent = simulated === null
+      ? `real ${host.realNoticeLevel()}`
+      : `real ${host.realNoticeLevel()} · showing ${simulated} (sim)`;
+    noticeCell.dataset.warn = String(simulated !== null);
+
+    growthCell.textContent =
+      `${perHour(summary.recentBytesPerMinute)} 30m · ${perHour(summary.runBytesPerMinute)} run`;
+    toCapCell.textContent = minutesText(summary.minutesToCap);
+    stepsCell.textContent = summary.lastStepBytes === null
+      ? String(summary.steps)
+      : `${summary.steps} · last +${Math.round(summary.lastStepBytes / MIB)} MiB`;
+    socketsCell.textContent = String(host.openSockets());
+    uptimeCell.textContent = clockText(nowMs - startedAt);
+    paintCurve(summary);
+  };
+
+  // Sampling runs whether or not anyone is looking — the curve is worth having
+  // for the whole session, and the panel is usually opened after something has
+  // already gone wrong. Only the painting is conditional.
+  setInterval(() => {
+    const nowMs = performance.now();
+    sample(nowMs);
+    if (visible) paint(nowMs);
+  }, 1_000);
+  sample(startedAt);
+
+  const preview = (level: 'low' | 'critical') => {
+    simulated = level;
+    host.previewNotice(level);
+    host.log(`[dev] simulated ${level} notice — real level ${host.realNoticeLevel()}`);
+  };
+
+  on('low', () => preview('low'));
+  on('critical', () => preview('critical'));
+  on('hide', () => {
+    simulated = null;
+    host.hideNotice();
+  });
+  on('crash1', () => host.previewCrash(1));
+  on('crash2', () => host.previewCrash(2));
+  on('dismiss', () => host.dismissOverlay());
+  on('drop', () => {
+    host.log(`[dev] dropping ${host.openSockets()} socket(s), client stays running`);
+    host.dropSockets();
+  });
+  on('reload-safe', () => {
+    host.log('[dev] reload: filesystem sync, then reload');
+    host.reloadSafely();
+  });
+  on('reload-orphan', () => {
+    host.log('[dev] reload: orphaning sockets, no close sent');
+    host.reloadOrphaning();
+  });
+
+  return Object.freeze({
+    visible: () => visible,
+    toggle() {
+      visible = !visible;
+      root.hidden = !visible;
+      if (visible) paint(performance.now());
+      return visible;
+    },
+  });
+}

--- a/src/renderer/dev-panel.ts
+++ b/src/renderer/dev-panel.ts
@@ -375,14 +375,23 @@ export function createDevPanel(host: DevPanelHost): DevPanel {
       : `real ${host.realNoticeLevel()} · showing ${simulated} (sim)`;
     noticeCell.dataset.warn = String(simulated !== null);
 
+    // "since open", not "run": the slope starts at this panel's first sample,
+    // and the panel did not exist for the boot ramp. Calling it the run rate
+    // claimed a window it cannot see, and on a session where the panel opened
+    // during startup that claim is mostly ramp.
     growthCell.textContent =
-      `${perHour(summary.recentBytesPerMinute)} 30m · ${perHour(summary.runBytesPerMinute)} run`;
+      `${perHour(summary.recentBytesPerMinute)} 30m`
+      + ` · ${perHour(summary.runBytesPerMinute)} since open`;
     toCapCell.textContent = minutesText(summary.minutesToCap);
     stepsCell.textContent = summary.lastStepBytes === null
       ? String(summary.steps)
       : `${summary.steps} · last +${Math.round(summary.lastStepBytes / MIB)} MiB`;
     socketsCell.textContent = String(host.openSockets());
-    uptimeCell.textContent = clockText(nowMs - startedAt);
+    // Since page load, not since this panel opened. `performance.now()` is
+    // already measured from the time origin, and the subtraction that used to
+    // be here made uptime mean "time since ⌘⇧D" — while the panel's own footer
+    // asks the reader to record it as time-since-relaunch.
+    uptimeCell.textContent = clockText(nowMs);
     paintCurve(summary);
   };
 

--- a/src/renderer/dev-panel.ts
+++ b/src/renderer/dev-panel.ts
@@ -240,9 +240,10 @@ export interface DevPanel {
 
 const minutesText = (minutes: number | null): string => {
   if (minutes === null) return '—';
-  if (minutes < 60) return `~${Math.round(minutes)} m`;
-  const hours = Math.floor(minutes / 60);
-  return `~${hours} h ${String(Math.round(minutes % 60)).padStart(2, '0')} m`;
+  // Round once, then split. Rounding each part separately prints "1 h 60 m".
+  const whole = Math.round(minutes);
+  if (whole < 60) return `~${whole} m`;
+  return `~${Math.floor(whole / 60)} h ${String(whole % 60).padStart(2, '0')} m`;
 };
 
 const clockText = (ms: number): string => {

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -197,6 +197,10 @@ async function escalateRepeatedCrash(): Promise<void> {
   if (count > 1) window.gwLoading?.failCrash(count);
 }
 let disposeSocketHost = () => {};
+let socketHost: ReturnType<
+  typeof import('./socket-host.js').createSocketHost
+> | null = null;
+let devPanel: import('./dev-panel.js').DevPanel | null = null;
 const native = () => window.gwNative;
 const milestone = <
   N extends import('../shared/diagnostics.js').RendererMilestone,
@@ -392,6 +396,59 @@ setInterval(() => {
   log(`[memory] wasm heap at ${Math.round(bytes / MIB)} MiB — ${level} notice`);
   presentHeapNotice(level).catch(() => {});
 }, 15_000);
+
+/**
+ * The memory debug panel, built on first use. The menu entry that sends this
+ * is gated, so most runs never pay for it — and it is wired here rather than
+ * inside boot() because a client that failed to start is exactly when the
+ * heap reading is worth having.
+ *
+ * The panel is handed callbacks, never state: it has no thresholds and no copy
+ * of its own, so a simulated notice is the sentence a player would really read
+ * and a preview cannot move the real escalation.
+ */
+window.addEventListener('gw:dev-panel', () => {
+  void (async () => {
+    if (!devPanel) {
+      const { createDevPanel } = await import('./dev-panel.js');
+      devPanel = createDevPanel({
+        parent: document.body,
+        log,
+        heapBytes: wasmHeapBytes,
+        capBytes: () => heapCapBytes,
+        realNoticeLevel: () => heapNoticeLevel,
+        previewNotice: (level) => void presentHeapNotice(level).catch(() => {}),
+        hideNotice: hideHeapNotice,
+        previewCrash: (count) => {
+          // No `crashRecorded`, no `wasm.abort` milestone: the overlay is
+          // drawn, the diagnostics record stays truthful, and the marker
+          // keeps a screenshot of this from being read as a real crash.
+          window.gwLoading?.failCrash(
+            count,
+            `SIMULATED crash overlay — no client abort occurred\n`
+              + `WASM heap: ${Math.round(wasmHeapBytes() / 1048576)} MiB`,
+          );
+        },
+        dismissOverlay: () => window.gwLoading?.done(),
+        openSockets: () => socketHost?.openCount() ?? 0,
+        dropSockets: () => socketHost?.closeAll(),
+        reloadSafely: reloadClientSafely,
+        reloadOrphaning: () => {
+          // Reassigns the same binding boot assigns, so the production
+          // teardown at `beforeunload` keeps one path and no debug branch.
+          // Nothing closes the sockets, so the server sees silence rather
+          // than a FIN — the closest thing to a real crash we can stage.
+          disposeSocketHost = () => {};
+          window.location.reload();
+        },
+      });
+    }
+    log(`dev panel: ${devPanel.toggle() ? 'on' : 'off'}`);
+  })().catch((error: unknown) => {
+    log('[err] dev panel failed to load:',
+      error instanceof Error ? error.message : String(error));
+  });
+});
 
 const STARTUP_LABELS = {
   connecting: 'Starting Guild Wars',
@@ -1092,7 +1149,7 @@ function loadGlue() {
     createClientHealthConfirmation =
       clientHealth.createClientHealthConfirmation;
     Object.assign(Module, unavailablePlatformCapabilities(log));
-    const socketHost = createSocketHost({
+    socketHost = createSocketHost({
       native: native().sockets,
       diagnostics: window.gwDiagnostics,
       socketOpened: () => {

--- a/src/renderer/socket-host.ts
+++ b/src/renderer/socket-host.ts
@@ -149,6 +149,26 @@ export function createSocketHost({
 
   return {
     socket: { connect: makeSocket },
+
+    /** How many connections the client currently holds. */
+    openCount: () => sockets.size,
+
+    /**
+     * Drop every connection but stay subscribed, so the client can reconnect
+     * on this same page — which is what tells a disconnect apart from a
+     * teardown. `dispose` is the teardown; this is not, and unsubscribing here
+     * would silently break the reconnection it exists to allow.
+     *
+     * Only the close is requested. Each socket leaves the map and calls the
+     * client's `onclose` when main confirms it, exactly as a reset from the
+     * far end does — clearing the map here would strand those confirmations as
+     * events for sockets nobody knows, and the client would never learn it had
+     * been disconnected.
+     */
+    closeAll() {
+      for (const socket of sockets.values()) socket.close();
+    },
+
     dispose() {
       unsubscribe();
       earlyEvents.clear();

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -672,6 +672,7 @@ export type RendererCommand =
     }
   | { type: "filesystem.sync" }
   | { type: "input.trace" }
+  | { type: "dev.panel" }
   | { type: "diagnostics.toggle" }
   | {
       type: "diagnostics.capture";

--- a/tests/electron/dev-panel.spec.ts
+++ b/tests/electron/dev-panel.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "@playwright/test";
+import { closeOffline, launchOffline } from "./fixtures.mjs";
+import { memoryPressurePresentation } from "../../src/renderer/failure-messages.js";
+
+/**
+ * The panel is a measuring instrument for a question that gets answered once,
+ * so what has to be proved is that it does not disturb what it measures: a
+ * simulated notice must render the sentence a player would really read, and it
+ * must leave the real escalation exactly where it was. The reload triggers are
+ * deliberately not exercised — driving one would end the session under test.
+ */
+const togglePanel = (page: import("@playwright/test").Page) =>
+  page.evaluate(() =>
+    window.dispatchEvent(new globalThis.CustomEvent("gw:dev-panel")),
+  );
+
+const readout = (page: import("@playwright/test").Page, role: string) =>
+  page.locator(`#dev-panel dd[data-role="${role}"]`);
+
+test.describe("memory debug panel", () => {
+  test("stays out of the way until it is asked for", async () => {
+    const fixture = await launchOffline("gw-dev-panel-off-");
+    try {
+      await expect(fixture.page.locator("#dev-panel")).toHaveCount(0);
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
+  test("previews the real notice without moving the real escalation", async () => {
+    const fixture = await launchOffline("gw-dev-panel-preview-");
+    try {
+      const { page } = fixture;
+      await togglePanel(page);
+      await expect(page.locator("#dev-panel")).toBeVisible();
+
+      // Nothing has filled the heap, so the watcher is still at rest — which is
+      // the state the preview must not disturb.
+      await expect(readout(page, "notice")).toHaveText(/real none/);
+
+      await page.locator('#dev-panel button[data-role="critical"]').click();
+      const notice = page.locator("#memory-notice");
+      await expect(notice).toBeVisible();
+      await expect(notice).toHaveClass(/critical/);
+
+      // The copy is the catalogue's, not the panel's: a simulation with its own
+      // words would be rehearsing sentences no player ever sees.
+      const critical = memoryPressurePresentation("critical");
+      await expect(page.locator("#memory-notice-label")).toHaveText(critical.label);
+      await expect(page.locator("#memory-notice-detail")).toContainText(
+        critical.detail,
+      );
+
+      // The point of the whole test: the preview drew the notice and left the
+      // watcher alone, so the real warning still arrives at its real threshold.
+      await expect(readout(page, "notice")).toHaveText(/real none · showing critical/);
+
+      await page.locator('#dev-panel button[data-role="hide"]').click();
+      await expect(notice).toBeHidden();
+      await expect(readout(page, "notice")).toHaveText(/real none$/);
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
+  test("marks a simulated crash so a screenshot of it cannot be misread", async () => {
+    const fixture = await launchOffline("gw-dev-panel-crash-");
+    try {
+      const { page } = fixture;
+      await togglePanel(page);
+      await page.locator('#dev-panel button[data-role="crash2"]').click();
+
+      // The repeat-crash copy, so the escalation is exercised too.
+      await expect(page.locator("#loading-label")).toHaveText(/keeps stopping/);
+      await expect(page.locator("#loading-crash-text")).toContainText("SIMULATED");
+
+      // No abort happened, so nothing may have been recorded as one.
+      const crashes = await page.evaluate(async () => {
+        const summary = await window.gwNative.diagnostics.current();
+        return summary.counters["wasm.crashes"] ?? 0;
+      });
+      expect(crashes).toBe(0);
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
+  test("lets a click through everywhere except its own controls", async () => {
+    const fixture = await launchOffline("gw-dev-panel-pointer-");
+    try {
+      const { page } = fixture;
+      await togglePanel(page);
+      const panel = page.locator("#dev-panel");
+      await expect(panel).toBeVisible();
+      // The panel sits over a live game; only the buttons may take the pointer,
+      // or a player judging a notice would be clicking a wall.
+      await expect(panel).toHaveCSS("pointer-events", "none");
+      await expect(
+        page.locator('#dev-panel button[data-role="low"]'),
+      ).toHaveCSS("pointer-events", "auto");
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+});

--- a/tests/unit/dev-panel.test.ts
+++ b/tests/unit/dev-panel.test.ts
@@ -1,0 +1,123 @@
+// The panel's arithmetic, executed rather than asserted about. The readout is
+// the instrument a reconnect experiment is recorded against, so a number it
+// prints wrong is a wrong finding — these run the real functions over the
+// shapes a real session produces: a monotone climb, a reload, a stalled heap,
+// and a cap the harness has not resolved yet.
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  decimate,
+  summarizeHeap,
+  type HeapSample,
+} from "../../src/renderer/dev-panel.js";
+
+const MIB = 1_048_576;
+const CAP = 2048 * MIB;
+
+/** Minutes-since-start into the shape the panel stores. */
+const at = (minutes: number, mib: number): HeapSample => ({
+  atMs: minutes * 60_000,
+  bytes: mib * MIB,
+});
+
+describe("the memory panel's readout", () => {
+  it("reports the climb of a real session in the units the panel prints", () => {
+    // The measured open-world session: 555 MiB/h from 300 MiB.
+    const samples: HeapSample[] = [];
+    for (let minute = 0; minute <= 120; minute += 5) {
+      samples.push(at(minute, 300 + (555 / 60) * minute));
+    }
+    const summary = summarizeHeap(samples, CAP, 120 * 60_000);
+
+    assert.ok(summary.runBytesPerMinute !== null);
+    assert.equal(Math.round((summary.runBytesPerMinute * 60) / MIB), 555);
+    assert.ok(summary.fractionOfCap !== null);
+    assert.ok(summary.fractionOfCap > 0.6 && summary.fractionOfCap < 0.7);
+
+    // Time to the cap, at that rate, from ~1410 MiB.
+    assert.ok(summary.minutesToCap !== null);
+    assert.ok(
+      summary.minutesToCap > 60 && summary.minutesToCap < 80,
+      `${summary.minutesToCap} minutes`,
+    );
+  });
+
+  it("counts a growth step per rise, and treats a fall as a reloaded client", () => {
+    // WASM memory never returns pages, so a smaller reading is a new client on
+    // the same page — the count restarts rather than going negative.
+    const summary = summarizeHeap(
+      [at(0, 300), at(1, 400), at(2, 400), at(3, 500), at(4, 260), at(5, 350)],
+      CAP,
+      5 * 60_000,
+    );
+    assert.equal(summary.steps, 3);
+    assert.equal(summary.lastStepBytes, 90 * MIB);
+    assert.equal(summary.lastStepAtMs, 5 * 60_000);
+  });
+
+  it("says nothing rather than guessing when there is nothing to measure", () => {
+    const empty = summarizeHeap([], CAP, 0);
+    assert.equal(empty.runBytesPerMinute, null);
+    assert.equal(empty.minutesToCap, null);
+    assert.equal(empty.steps, 0);
+
+    const one = summarizeHeap([at(0, 300)], CAP, 0);
+    assert.equal(one.runBytesPerMinute, null);
+    assert.equal(one.minutesToCap, null);
+
+    // A heap that has not moved has no rate, so no estimate — not "forever".
+    const flat = summarizeHeap([at(0, 900), at(10, 900), at(20, 900)], CAP, 20 * 60_000);
+    assert.equal(flat.runBytesPerMinute, 0);
+    assert.equal(flat.minutesToCap, null);
+  });
+
+  it("renders an unresolved cap as unknown instead of dividing by it", () => {
+    // `capBytes` is 0 until the harness's deferred contract import lands, and
+    // the panel can be opened before then.
+    const summary = summarizeHeap([at(0, 300), at(10, 400)], 0, 10 * 60_000);
+    assert.equal(summary.fractionOfCap, null);
+    assert.equal(summary.minutesToCap, null);
+    assert.ok(summary.runBytesPerMinute !== null, "the rate is still knowable");
+    assert.equal(Number.isFinite(summary.runBytesPerMinute), true);
+  });
+
+  it("keeps the ends of the run when the ring is halved", () => {
+    // The sparkline has to span the whole session, so the oldest and newest
+    // samples are the two that must survive every decimation.
+    const samples = Array.from({ length: 41 }, (_, i) => at(i, 300 + i));
+    const halved = decimate(samples);
+    assert.ok(halved.length <= 22, `${halved.length} kept`);
+    assert.deepEqual(halved[0], samples[0]);
+    assert.deepEqual(halved.at(-1), samples.at(-1));
+
+    // Repeated halving stays stable and never drops below the two ends.
+    let ring = samples;
+    for (let round = 0; round < 8; round += 1) ring = decimate(ring);
+    assert.ok(ring.length >= 2);
+    assert.deepEqual(ring[0], samples[0]);
+    assert.deepEqual(ring.at(-1), samples.at(-1));
+
+    // Too short to thin is returned as it is, not emptied.
+    assert.deepEqual(decimate([]), []);
+    assert.deepEqual(decimate([at(0, 300)]), [at(0, 300)]);
+  });
+
+  it("produces no NaN or negative from degenerate input", () => {
+    for (const samples of [
+      [at(0, 300), at(0, 400)], // no elapsed time
+      [at(5, 300), at(0, 400)], // out of order
+      [at(0, 4000)], // already past the cap
+    ]) {
+      const summary = summarizeHeap(samples, CAP, 5 * 60_000);
+      for (const value of [
+        summary.runBytesPerMinute,
+        summary.recentBytesPerMinute,
+        summary.minutesToCap,
+        summary.fractionOfCap,
+      ]) {
+        assert.ok(value === null || Number.isFinite(value), String(value));
+      }
+      assert.ok((summary.minutesToCap ?? 0) >= 0);
+    }
+  });
+});

--- a/tests/unit/socket-host.test.ts
+++ b/tests/unit/socket-host.test.ts
@@ -163,6 +163,50 @@ describe("renderer socket host", () => {
     assert.equal(secondClosed, 0);
     host.dispose();
   });
+
+  it("tells dropping the connections apart from tearing the host down", async () => {
+    // The difference is what the client is allowed to do next. `closeAll`
+    // imitates a lost connection, so the client must be able to reconnect on
+    // this same page; `dispose` is the page going away. An unsubscribe in the
+    // first would look identical here and break only in a live session.
+    const native = fakeNative();
+    const host = createSocketHost({ native: native.api, log: () => undefined });
+    const first = host.socket.connect("one");
+    let firstClosed = 0;
+    first.onclose = () => {
+      firstClosed += 1;
+    };
+    native.connects[0]!(51);
+    await turn();
+    native.emit({ type: "open", socketId: 51, port: 6112 });
+    assert.equal(host.openCount(), 1);
+
+    host.closeAll();
+    assert.deepEqual(native.closes, [51]);
+    // The close is requested, not assumed: the client learns it was
+    // disconnected when main confirms, the same way a reset from the far end
+    // reaches it.
+    assert.equal(firstClosed, 0, "not before main confirms");
+    native.emit({ type: "close", socketId: 51, reason: "owner" });
+    assert.equal(firstClosed, 1);
+    assert.equal(host.openCount(), 0);
+    assert.equal(native.counts().unsubscribes, 0, "still listening");
+
+    // The reconnection the client makes after the drop still arrives.
+    const second = host.socket.connect("two");
+    let secondOpened = 0;
+    second.onopen = () => {
+      secondOpened += 1;
+    };
+    native.connects[1]!(52);
+    await turn();
+    native.emit({ type: "open", socketId: 52, port: 6112 });
+    assert.equal(secondOpened, 1, "reconnect after closeAll");
+    assert.equal(host.openCount(), 1);
+
+    host.dispose();
+    assert.equal(native.counts().unsubscribes, 1);
+  });
 });
 
 /**


### PR DESCRIPTION
**Stack 1 of 2.** Base: `main`. Followed by the time-based memory warning, which is written against whatever this PR's experiment finds.

## What this ships

A developer panel for the one question blocking the memory-warning redesign: **does reloading let Guild Wars offer the player their instance back?** That decides whether the warning can say "reload, you'll be right back" or has to say "travel to an outpost first" — and it cannot be answered by reading code.

It is also the live heap reading every future memory report will want: heap against the 2 GiB cap, growth rate over 30 min and over the run, estimated time to the cap, growth-step count, open sockets, page uptime, and a sparkline spanning the whole session.

Reachable via Help → Diagnostics → **Show Memory Debug Panel** (⌘⇧D) on a dev build, or any build launched with:

```bash
open -a "Guild Wars Reforged.app" --args --gw-debug-panel
```

## The reload paths, and why there are five

The paths do **not** differ at the TCP level — every one ends in the same `destroy()`. They differ in ordering, in whether the client learns it was disconnected, and in whether anything is sent at all. That last one is what a reconnect offer probably turns on.

| | Path | Sync | Client sees close | Server sees | Trigger |
|---|---|---|---|---|---|
| a | sync + reload — also the notice's own Reload Now | yes, ≤1.5 s | no | FIN at navigation | panel |
| b | View → Reload Game | no | **yes** — main closes first | FIN before navigation | existing ⌘R |
| c1 | orphan + reload | no | no | **nothing** — no FIN; server must time out | panel |
| c2 | Crash Renderer Process | no | no | FIN from `render-process-gone` | menu |
| d | drop sockets, keep running | no | **yes**, client stays alive | FIN | panel |
| e | crash overlay → Retry | no | no | FIN at navigation | existing |

**Run (d) first** — it is the only one that does not restart the client, so the re-login is fastest, and if reconnect works from there every path inherits the answer. (c1) is the only silence, so it is the closest imitation of a real crash. The matrix and the recording protocol are in `docs/diagnostics.md`.

## Simulation cannot corrupt what it measures

The seam already existed, so no "simulated mode" flag was needed anywhere:

- `presentHeapNotice` writes DOM only; the watcher is the sole writer of the escalation level. A preview draws the notice and the real warning still fires later at its real threshold. The readout prints **`real none · showing critical (sim)`** so that stays visible — and the Electron spec asserts it.
- A simulated crash calls `failCrash` without setting `crashRecorded` and without recording a `wasm.abort` milestone, so the diagnostics record stays truthful. The detail text opens with a literal `SIMULATED` marker, and the spec asserts `wasm.crashes` is still 0 afterwards.
- Every simulated surface renders the **real** copy from `failure-messages.ts`. A simulation with its own words would be rehearsing sentences no player ever sees.

## Two things found while building it

**`closeAll()` had to keep the subscription.** My first version cleared the socket map, which orphaned the native close confirmations — the client would never have learned it was disconnected, silently invalidating path (d), the one I most want to run. `finish()` already removes each socket and fires `onclose`; `closeAll` now only requests. The regression is pinned in `tests/unit/socket-host.test.ts`.

**The panel had to sit above the launcher.** At z-index 5 it was under `#loading` (10), so a simulated crash covered the panel's own **Dismiss** button — the way out was behind the thing it dismisses. Caught by the Electron spec timing out on a click, not by review.

## Verification

- `pnpm check` — 766 unit, 156 policy, typecheck, lint, links: all pass
- `pnpm build && pnpm test:electron` — 112 passed, 1 skipped
- New: `tests/unit/dev-panel.test.ts` (the readout arithmetic over a real session shape, a reload, a stalled heap, an unresolved cap, degenerate input), `tests/electron/dev-panel.spec.ts` (4 tests)
- Not exercised in tests: the reload triggers. Driving one ends the session under test; they are for the manual matrix.

## Review focus

- **Gating.** `isDevBuild() || app.commandLine.hasSwitch("gw-debug-panel")`, precedent `gw-volatile-secrets`. Deliberately not an `AppSettings` key: that would cost contract + parse + form + tests and leave a persistent, player-discoverable "crash the game" switch.
- **`reloadOrphaning`** reassigns the same `disposeSocketHost` binding boot already assigns, so the production `beforeunload` teardown keeps one path and gains no debug branch.
- **The panel never imports `shared/contracts.js`** — a second importer disturbs the packaged proof that the Enhancement runtime is what requested it. The cap arrives by callback, and renders as `?` until the harness resolves it.
- The `gw:dev-panel` listener is at module scope, not inside `boot()`: a client that failed to start is exactly when the heap reading is worth having.

## Known follow-ups

- (c1) leaves orphaned handles in main until quit, and the new page queues packets for unknown socket ids into an unbounded `earlyEvents` map. Quit after using it. The unbounded map is pre-existing and worth its own small fix.
- (c2) recovers only once per app launch (`rendererRecoveryUsed` is one-shot).
