### PR TITLE
Count the memory warning in time, not in bytes remaining

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -259,11 +259,17 @@ still allocating underneath — hence **Dismiss**.
 
 ### The reload paths, and why they differ
 
-Whether a reload lets Guild Wars offer the player their instance back is a
-question about what the *server* observes, so the paths are worth telling
-apart. They do not differ at the TCP level — every one of them ends in the same
-`destroy()` — but they differ in ordering, in whether the client learns it was
-disconnected, and in whether anything is sent at all.
+**Answered, 2026-08-05: every path below reconnects.** Run from inside an
+instance, all five put the player back where they were with progress intact,
+in under thirty seconds. The question was never whether Guild Wars restores an
+instance after a dropped connection — it does — but whether these reloads look
+like one to its server, and none of the differences in the table turned out to
+matter to it. The notice's copy states the reconnect because of this run.
+
+The table stays because the paths still differ, and the next question about
+them will be a different one. They do not differ at the TCP level — every one
+ends in the same `destroy()` — but they differ in ordering, in whether the
+client learns it was disconnected, and in whether anything is sent at all.
 
 | | Path | Filesystem sync | Client sees the close | What the server sees |
 | --- | --- | --- | --- | --- |
@@ -274,15 +280,20 @@ disconnected, and in whether anything is sent at all.
 | d | Panel: drop sockets, keep running | no | **yes**, and the client stays alive | FIN |
 | e | Crash overlay → Retry | no | no | FIN at navigation |
 
-Run **(d) first**: it is the only one that does not restart the client, so the
-re-login is fastest, and if reconnecting works from there every reload path
-inherits the answer. **(c1)** is the only silence, which makes it the closest
-imitation of a real crash.
+If you are re-running this, take **(d) first**: it is the only one that does
+not restart the client, so the re-login is fastest. **(c1)** is the only
+silence, which makes it the closest imitation of a real crash — and it was the
+one most likely to fail, so it passing is what generalises.
 
 Record the uptime and socket count before each run and how long the re-login
 took — otherwise a server-side timeout gets attributed to a teardown
 difference. (c1) leaves orphaned handles in the main process until the app
 quits, so quit after using it. (c2) recovers only once per launch.
+
+Two limits on what that run proved: one tester on one account, and it says
+nothing about a full party, a timed mission, or a loaded server. It is enough
+to state the reconnect and not enough to promise it can never go wrong, which
+is the line the copy tests hold.
 
 ## Verification boundaries
 

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -245,6 +245,14 @@ actually read. It has no thresholds and no copy of its own, and it never writes
 the watcher's escalation — the readout prints the real level beside the
 simulated one so that stays visible.
 
+Two numbers on it are estimates, and they are deliberately not the same one.
+**to cap** is the panel's own arithmetic over the whole run, which is the right
+figure for reading a session afterwards. **warning** is what the warning itself
+concluded — measured step to step over at least ten minutes, ignoring the
+startup ramp — and it is the number that explains what the player was actually
+told. It reads `not measuring yet` until two growth steps ten minutes apart
+have been seen, which in the open world is around twenty minutes of play.
+
 Two simulation divergences worth knowing: a simulated crash leaves the memory
 watcher running (a real abort stops it), and the overlay covers a client that is
 still allocating underneath — hence **Dismiss**.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -272,11 +272,32 @@ known patterns, so treat it as strong rather than absolute. The export is an
 ordinary ZIP you can open and read before attaching it. GitHub issues are
 public, so review the bug form’s privacy notice as well.
 
+## If the game warns that memory is running out
+
+ArenaNet's game client can only use 2 GB of memory and does not release what
+it loads, so a long session eventually fills it and the client stops. Neither
+the limit nor the memory use is something this app can change; what it can do
+is watch, and warn before it happens.
+
+A notice appears over the game naming roughly how long is left — about twenty
+minutes, then about five. The estimate comes from how fast memory has been
+filling in this session, so it shortens on its own in areas that load a lot of
+new scenery; when there has not yet been enough to measure, the notice says
+memory is running low without claiming a figure.
+
+**Reload Now** restarts the client with fresh memory. It takes a few seconds
+and then you log back in. You should be able to rejoin an instance you were
+in, the same way Guild Wars handles a dropped connection — reloading from a
+town or outpost is the one case with nothing to lose. **Later** leaves a small
+counter in the corner rather than going quiet; the full notice returns if time
+runs short. **Why is this happening?** explains it in the game.
+
 ## If the game crashes
 
 When the running game client stops unexpectedly, the launcher screen returns
 with **Retry** and **Report a Problem…**. Retry starts the client again; a
-single crash is usually transient.
+single crash is usually transient. A crash that ran out of memory says so
+under **Technical details**, with the heap size it reached.
 
 If the client crashes again in the same app run, the message changes to say
 so and leads with reporting: **Report a Problem…** on the launcher is the

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -285,10 +285,11 @@ filling in this session, so it shortens on its own in areas that load a lot of
 new scenery; when there has not yet been enough to measure, the notice says
 memory is running low without claiming a figure.
 
-**Reload Now** restarts the client with fresh memory. It takes a few seconds
-and then you log back in. You should be able to rejoin an instance you were
-in, the same way Guild Wars handles a dropped connection — reloading from a
-town or outpost is the one case with nothing to lose. **Later** leaves a small
+**Reload Now** restarts the client with fresh memory. It takes under a minute,
+and Guild Wars puts you back where you were — the same way it handles a
+dropped connection. That was tested from inside an instance on every way this
+app can reload the game, and progress survived each time; a town or outpost is
+still the one place with nothing at all to lose. **Later** leaves a small
 counter in the corner rather than going quiet; the full notice returns if time
 runs short. **Why is this happening?** explains it in the game.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -279,11 +279,17 @@ it loads, so a long session eventually fills it and the client stops. Neither
 the limit nor the memory use is something this app can change; what it can do
 is watch, and warn before it happens.
 
-A notice appears over the game naming roughly how long is left — about twenty
-minutes, then about five. The estimate comes from how fast memory has been
-filling in this session, so it shortens on its own in areas that load a lot of
-new scenery; when there has not yet been enough to measure, the notice says
-memory is running low without claiming a figure.
+A notice appears over the game at two points: once with roughly twenty minutes
+of play left, and again with about five. Those points are worked out from how
+fast memory has been filling in this session, so in areas that load a lot of
+new scenery the warning comes sooner in wall-clock terms, which is the whole
+idea — the same notice used to mean half an hour in the open world and two
+minutes inside a mission.
+
+The notice does not print a countdown. It could be worked out, but replayed
+against a real crash it was wrong by enough to matter in both directions, and
+a number on a banner is a promise. What is worth acting on is that the warning
+appeared.
 
 **Reload Now** restarts the client with fresh memory. It takes under a minute,
 and Guild Wars puts you back where you were — the same way it handles a

--- a/internal/upstream/memory-exhaustion-log.md
+++ b/internal/upstream/memory-exhaustion-log.md
@@ -231,3 +231,38 @@ situation. This one is narrower and sharper: a test that drives a shape the
 system never produces will confirm whatever the code believes. The measured
 sessions were on disk the whole time — `wasm.heapGrew` events, fourteen of them
 in 2 h 16 m — and no test read one.
+
+## Round 6 — right: every reload path reconnects (2026-08-05)
+
+**The question.** Guild Wars restores a player's instance after a dropped
+connection; that was never in doubt. What was unknown is whether *our* reload
+looks like a dropped connection to its server — and the copy could not say
+"you come back where you were" until somebody had checked. A unit test held
+the hedge in place so nobody could firm the wording by assertion.
+
+**Run.** All five paths in `docs/diagnostics.md`, from inside an instance:
+(d) drop sockets, (c1) orphan + reload, (c2) crash the renderer process,
+(b) View → Reload Game, (a) sync + reload.
+
+**Result.** Every one reconnected, with progress intact, in under thirty
+seconds. Including (c1), which sends no FIN at all and forces the server to
+time the connection out — the path most likely to fail, and the one whose
+passing generalises to a real crash.
+
+**What changed.** The notice now states the reconnect instead of hedging it,
+and the outpost moved out of the notice into the explanation. It is still true
+that an outpost risks nothing, but leading with it is what made the shipped
+sentence easy to ignore from inside a dungeon, and repeating a caveat against
+a measured fact argues with the measurement. The guard test turned around: it
+used to fail if the hedge disappeared, and now fails if the measured claim
+disappears or if the copy grows past the evidence into "guaranteed" or
+"never lose".
+
+**What it does not cover.** One tester, one account. Nothing about a full
+party, a timed mission, or a loaded server. Enough to state the reconnect;
+not enough to promise it cannot go wrong.
+
+**Lesson.** The instrument was worth building. Five paths in one sitting
+answered a question that hours of ordinary play would not have, because
+ordinary play never produces (c1) on purpose — and (c1) is the one that
+mattered.

--- a/internal/upstream/memory-exhaustion-log.md
+++ b/internal/upstream/memory-exhaustion-log.md
@@ -159,3 +159,75 @@ open-world session it raised `critical` at seven minutes — ahead of the
 five-minute time rule, i.e. the same defect in miniature. It is 32 MiB, which
 sits below where the time rule fires at every rate observed so far. That
 threshold had no session behind it until the test supplied one.
+
+## Round 5 — wrong: the heap is a staircase, and we measured it with a ruler shorter than the stair (2026-08-05)
+
+**Hypothesis.** With the unit fixed, a trailing window over recent samples
+gives the rate: five minutes to catch a session that has started spending, and
+fifteen so a lull inside that spending cannot erase it.
+
+**Wrong because** `Module.HEAPU8.buffer` is *reserved* memory, and WebAssembly
+reserves it in jumps. Emscripten's glue grows by a fifth of the current size
+capped at 96 MiB, so at the measured 555 MiB/h the heap steps about once every
+ten minutes and is perfectly flat in between — which the instrumentation
+already said in Round 3 (`wasm.heapGrew`: "growth is discrete and rare") and
+the debug panel repeated on the way in ("a short window reads as either zero or
+enormous depending on where the sample landed").
+
+A five-minute window over a ten-minute tread holds either no step or one.
+Simulated against the measured open-world session, the estimator read:
+
+| | measured | true |
+| --- | --- | --- |
+| Rate | alternating 384 and 1,152 MiB/h | 555 MiB/h |
+| Shown to the player | 15 → 45 → 10 → 30 minutes | a smooth count down |
+| `low` fired | claiming 15 minutes | 41 minutes remained |
+
+The level still landed in roughly the right place, because the steep arm of the
+sawtooth dominates. The *number* — the entire point of Round 4 — swung by three
+times its own value every five minutes, on the chip, which is the one surface
+that updates live.
+
+**Why it survived review and a test suite.** Every test drove smooth linear
+growth. The sessions we measured were staircases; the sessions we tested were
+ramps, so the tests agreed with the code about a shape no client produces.
+
+**Built.** Both ends of a measurement now sit on a growth step, at least ten
+minutes apart, and the module keeps steps rather than samples. Step-to-step is
+what makes the figure stand still: anchoring the far end to *now* puts a whole
+tread in the denominator and none of its rise in the numerator. Ten minutes is
+what tells a burst from a trend, and it was bought rather than guessed — a
+300 MiB zone load at minute 30 of an ordinary session says "about 20 minutes of
+play left" over a four-minute span with 77 minutes truly left, and escalates to
+critical over an eight-minute span with 30 minutes left. Over ten it says
+nothing and the real warning arrives on time.
+
+The cost is knowingly accepted: a mission spending 3,500 MiB/h dies around
+minute 23 and cannot be spoken about until minute 18, where an eight-minute
+span would have warned at 15. There is no shorter honest answer — ten minutes
+into a mission, a ten-minute-old zone load and a sustained spend look alike in
+every window, and a "is it still going?" test costs exactly the latency it
+saves. The byte floors remain the backstop for the fast case.
+
+**Two more the same simulation found.**
+
+*The warm-up ran on the wrong clock.* It excluded the startup ramp for five
+minutes after page load. The page stays open through the client download, so a
+slow first run boots after the exclusion has expired and the ramp is measured
+as ordinary play: 38% of the cap, "about 8 minutes of play left", two hours of
+real headroom. It runs from the client's first allocation now.
+
+*Headroom was read off the reserve.* The client dies when what it has *filled*
+reaches the cap, and the reserve leads that by up to one step — ten minutes of
+open-world play. Taking headroom off the reserve made every step look like ten
+minutes vanishing at once and read a session as a third shorter than it was.
+Growth fires when a request no longer fits, so at the instant of a step the
+filled bytes are what the reserve was before it; between steps they climb at
+the rate just measured. The residual error is one allocation request rather
+than one step.
+
+**Lesson.** Round 4's lesson was that a threshold is a claim about the player's
+situation. This one is narrower and sharper: a test that drives a shape the
+system never produces will confirm whatever the code believes. The measured
+sessions were on disk the whole time — `wasm.heapGrew` events, fourteen of them
+in 2 h 16 m — and no test read one.

--- a/internal/upstream/memory-exhaustion-log.md
+++ b/internal/upstream/memory-exhaustion-log.md
@@ -371,7 +371,29 @@ player was revisiting. Vanquishing is the maximal case by definition — clearin
 an explorable area means loading all of it — and it is reachable from every
 campaign, on any account.
 
-**The ask, stated precisely.** Rebuild with `-sMAXIMUM_MEMORY=4GB`. wasm32
-addresses up to 4 GB, the comment already in their glue is Emscripten's
-guidance for exactly that configuration, and it is one build flag rather than a
-change to how the client allocates.
+**The ask, stated precisely, and what it is not.** `-sMAXIMUM_MEMORY=4GB` is
+one build flag, and wasm32 addresses up to 4 GB, so it is cheap. It is
+mitigation and not a cure, and the report must say so or the first engineer to
+read it will say it for us.
+
+Boot costs a fixed ~700 MiB, so the usable budget goes from ~1,348 MiB to
+~3,396 MiB: about **2.5x**. On the measured session that turns a death at 66
+minutes into one at roughly two and a half hours, and a 25-minute vanquish
+death into about 65 minutes. Useful, and still bounded.
+
+The heap does not converge under continuous new content. It grew steadily to
+the cap across 65 minutes with no plateau, and the only flat stretches were
+the player standing still. So a bigger ceiling buys time proportional to the
+ceiling and nothing else.
+
+What we cannot say is *why* it grows without bound. Round 3 already framed this
+as leak vs. fragmentation vs. per-zone accumulation, and nothing since has
+separated them. We do know `malloc`/`free` work normally — 500 rounds of
+8 MiB alloc/free against the real wasm kept the heap flat — so it is not a
+stubbed allocator. Beyond that: revisiting a zone costs no growth, which is
+equally consistent with content being cached deliberately and with it being
+freed and the blocks reused. From outside the client those look the same.
+
+So the report asks for the flag as breathing room, and reports the growth
+itself as the defect. wasm32 has no ceiling above 4 GB, which is the argument
+for treating the flag as time bought rather than the answer.

--- a/internal/upstream/memory-exhaustion-log.md
+++ b/internal/upstream/memory-exhaustion-log.md
@@ -266,3 +266,55 @@ not enough to promise it cannot go wrong.
 answered a question that hours of ordinary play would not have, because
 ordinary play never produces (c1) on purpose — and (c1) is the one that
 mattered.
+
+## Round 7 — wrong: the figure was a diagnostic, printed as a promise (2026-08-05)
+
+**The bundle.** A player's Eye of the North session, 2026-08-04, app 2026.8.4,
+complete from start. Two client runs, two aborts, and 33 `wasm.heapGrew`
+events — the first real staircase we have had rather than a modelled one.
+
+**What it confirmed.**
+
+- The final growth step is clamped to the cap: 1990 → 2048 MiB, 58 MiB rather
+  than the usual 96. The client then died at exactly `2147483648` bytes,
+  `reasonKind: assertion`, fingerprint `8f57c5d5`, **forty-two seconds** after
+  that last step. The reserve does reach the cap exactly, which is what the
+  headroom model assumes.
+- The tread is 96 MiB and the gaps run from 0.9 to 14.3 minutes, which is the
+  shape Round 5 was built for.
+
+**What it broke.** Replayed against that run, the *levels* landed well:
+
+| | this build | shipped 2026.8.4 |
+| --- | --- | --- |
+| `low` | 31.5 min of real play left | 10.9 min |
+| `critical` | 7.0 min | 7.4 min |
+
+The *figure* did not. It read 10 → 15 → 20 → **75** → 40 → 20 → 15 → 10 → 3,
+and at minute 49 offered "about 75 minutes" to a player with 18 left. A
+thirteen-minute lull had drifted into the measurement window just before the
+player went back into heavy loading. Earlier, at minute 34, it said "10
+minutes" with 31 left — wrong the other way, behind a rate that looked stable.
+
+**Why the tests did not catch it.** They drove constant rates. Round 5's
+lesson was that a test driving a shape the system never produces will confirm
+whatever the code believes; the fix for that round replaced ramps with
+staircases and then held the rate constant along them. Real play varies about
+tenfold between lulls and mission loading. The same lesson, one level down.
+
+**Built.** The thresholds still count in time — that is what tripled the
+warning and it is not in question. The figure is gone from every player-facing
+string. The estimate still exists, still sets the level, and is still shown in
+the debug panel and the log, where being approximately right is useful and
+being precisely wrong costs nothing. The client run that reached the cap is
+now a test fixture, replayed step by step against the abort that ended it.
+
+**Also observed, unexplained.** The session's *first* abort came at 1899 MiB —
+149 MiB of headroom left — with `reasonKind: other` and fingerprint
+`a6311932`, the same fingerprint as both crashes in the 2026-08-03 bundle. Our
+model cannot predict a death below the cap. Two observed deaths, one at the
+cap and one short of it, is not enough to say what that is.
+
+**Lesson.** An estimate can be good enough to decide something and not good
+enough to say out loud. The level is a decision the app makes and can defend;
+the figure was a claim the player would check against their own clock.

--- a/internal/upstream/memory-exhaustion-log.md
+++ b/internal/upstream/memory-exhaustion-log.md
@@ -121,3 +121,41 @@ survivable failure). Shipped instead:
    rollup in the bundle), quit-time `filesystem.sync` failing on every
    observed quit (no error code recorded yet), and quit-teardown aborts
    (`a6311932`, 10 ms after `sockets.closeAll()`) being counted as crashes.
+
+## Round 4 — wrong: bytes remaining was the unit (2026-08-04)
+
+**Hypothesis.** Warning at a fixed distance from the cap — 256 MiB, then
+128 MiB — gives the player enough room to reach somewhere safe.
+
+**Built.** The watermark notice shipped in 2026.8.4 with exactly those two
+thresholds, and copy that told the player to travel to a town or outpost.
+
+**Wrong because** the same headroom is not the same amount of time. Measured
+on the same client build:
+
+| Session | Rate | What 256 MiB bought |
+| --- | --- | --- |
+| Open world, 2 h 16 m | 555 MiB/h | ~28 min |
+| Eye of the North mission | fast enough to hit the cap in ~30 min | ~2–3 min |
+
+The second player reported "multiple warnings" and crashed anyway. Both saw
+the same sentence, and neither could tell which of those two it meant. The
+copy compounded it: an instruction to travel to an outpost is one a player
+inside a dungeon reads as "abandon the run", so it was rational to ignore.
+
+**Kept anyway.** The byte thresholds survive as the fallback for when a rate
+cannot be measured — the first two minutes of a session, and any stretch where
+growth has stalled. They are conditional now: left unconditional, 128 MiB is
+nearly fourteen minutes at the open-world rate and would pre-empt the time rule
+every session, rebuilding the defect.
+
+**Lesson.** A threshold is a claim about the player's situation, and the unit
+has to be the one the player is in. Bytes were what we could measure most
+easily; time was what the sentence was actually promising.
+
+**A number the test corrected.** The replacement kept a hard byte floor as a
+never-silent backstop, first set at 64 MiB. Driven over the measured
+open-world session it raised `critical` at seven minutes — ahead of the
+five-minute time rule, i.e. the same defect in miniature. It is 32 MiB, which
+sits below where the time rule fires at every rate observed so far. That
+threshold had no session behind it until the test supplied one.

--- a/internal/upstream/memory-exhaustion-log.md
+++ b/internal/upstream/memory-exhaustion-log.md
@@ -318,3 +318,60 @@ cap and one short of it, is not enough to say what that is.
 **Lesson.** An estimate can be good enough to decide something and not good
 enough to say out loud. The level is a decision the app makes and can defend;
 the figure was a claim the player would check against their own clock.
+
+## Round 8 — correcting our own reading of the cap, and widening the repro (2026-08-06)
+
+**We misread ArenaNet's glue.** Round 3 and the "Open" list say the comment
+above `getHeapMax` shows the 2 GiB cap "only exists to stay clear of 4 GB
+wraparound". It does not. The full text in `Gw.jspi.js` is:
+
+```js
+var getHeapMax = () =>
+    // Stay one Wasm page short of 4GB: while e.g. Chrome is able to allocate
+    // full 4GB Wasm memories, the size will wrap back to 0 bytes in Wasm side
+    // for any code that deals with heap sizes, which would require special
+    // casing all heap size related code to treat 0 specially.
+    2147483648;
+```
+
+2147483648 is **not** one page short of 4 GB — that would be 4294901760. The
+comment is Emscripten's stock text, emitted above whatever `MAXIMUM_MEMORY`
+was configured, and 2147483648 is Emscripten's *default* (2 GB). So the
+correct reading is narrower and, for the report, stronger: the ceiling looks
+like a default nobody changed rather than a constraint anybody chose. We must
+not tell ArenaNet their own comment says something it doesn't.
+
+The ceiling is declared twice, and both agree — the glue constant above, and
+the wasm binary's own memory section:
+
+| artifact | initial | maximum |
+| --- | --- | --- |
+| `Gw.wasm` (27 MiB) | 256 MiB | **2048 MiB** |
+| `Gw.jspi.wasm` (8 MiB) | 256 MiB | **2048 MiB** |
+
+**The causal chain, end to end.** `wasmMemory.grow()` throws once the module's
+declared maximum is reached; `growMemory` catches it, logs
+`growMemory: Attempted to grow heap from … but got error: …` and returns
+undefined, which the caller reads as 0; `_emscripten_resize_heap` fails; the
+allocator returns null; and ArenaNet's own texture path asserts. The recorded
+death is `ASSERTION FAILED: Out of memory!` at `Engine/Gr/Gles3/GlTex.cpp:397`
+with `heapBytes` exactly 2147483648. Which assertion trips first is incidental
+— at the cap, whichever allocation lands next fails.
+
+**It is not an Eye of the North problem.** Two further player reports, neither
+in EotN:
+
+- Vanquishing **Resplendent Makuun** (Nightfall, Vabbi) — crashed ~25 minutes in.
+- **Dunes of Despair** in Hard Mode with a consumable set — crashed ~20 minutes in.
+
+Both are long runs through a lot of an area's content, which is what the
+2026-08-04 staircase already implied: the heap tracks *novel* content, not map
+changes. Five map connections in that bundle cost zero growth because the
+player was revisiting. Vanquishing is the maximal case by definition — clearing
+an explorable area means loading all of it — and it is reachable from every
+campaign, on any account.
+
+**The ask, stated precisely.** Rebuild with `-sMAXIMUM_MEMORY=4GB`. wasm32
+addresses up to 4 GB, the comment already in their glue is Emscripten's
+guidance for exactly that configuration, and it is one build flag rather than a
+change to how the client allocates.

--- a/src/renderer/dev-panel.ts
+++ b/src/renderer/dev-panel.ts
@@ -223,7 +223,12 @@ export interface DevPanelHost {
    * arithmetic. They measure over different windows on purpose, and when they
    * disagree it is the warning's number that explains what the player saw.
    */
-  pressure(): { minutes: number | null; bytesPerMinute: number | null } | null;
+  pressure(): {
+    minutes: number | null;
+    bytesPerMinute: number | null;
+    /** The span the rate was measured over; null while there is no rate. */
+    measuredOverMs: number | null;
+  } | null;
   /** Draws the notice without touching the watcher's own state. */
   previewNotice(level: 'low' | 'critical'): void;
   hideNotice(): void;
@@ -396,10 +401,22 @@ export function createDevPanel(host: DevPanelHost): DevPanel {
     // the player was told — and a disagreement with the line above is
     // information, not a bug in either.
     const pressure = host.pressure();
-    warningCell.textContent = pressure === null
-      ? 'not measuring yet'
-      : `${pressure.minutes === null ? '—' : `~${pressure.minutes} m`}`
-        + ` at ${perHour(pressure.bytesPerMinute)}`;
+    if (pressure === null) {
+      warningCell.textContent = 'no reading yet';
+    } else if (pressure.measuredOverMs === null) {
+      // It has a reading and no rate, which is a different thing from having
+      // no reading — and on a quiet session it is the state the panel sits in
+      // for an hour. A bare dash here read as a broken instrument, so it says
+      // what it is waiting for. The steps row above counts this panel's own
+      // samples, including the boot-ramp rises the warning excludes, so the
+      // two numbers are not meant to agree.
+      warningCell.textContent = 'waiting for two steps 10 min apart';
+    } else {
+      warningCell.textContent =
+        `${pressure.minutes === null ? '—' : `~${pressure.minutes} m`}`
+        + ` at ${perHour(pressure.bytesPerMinute)}`
+        + ` over ${Math.round(pressure.measuredOverMs / 60_000)} m`;
+    }
     stepsCell.textContent = summary.lastStepBytes === null
       ? String(summary.steps)
       : `${summary.steps} · last +${Math.round(summary.lastStepBytes / MIB)} MiB`;

--- a/src/renderer/dev-panel.ts
+++ b/src/renderer/dev-panel.ts
@@ -218,6 +218,12 @@ export interface DevPanelHost {
   capBytes(): number;
   /** The escalation the real watcher has reached. Read only. */
   realNoticeLevel(): string;
+  /**
+   * What the warning itself last concluded, as against this panel's own
+   * arithmetic. They measure over different windows on purpose, and when they
+   * disagree it is the warning's number that explains what the player saw.
+   */
+  pressure(): { minutes: number | null; bytesPerMinute: number | null } | null;
   /** Draws the notice without touching the watcher's own state. */
   previewNotice(level: 'low' | 'critical'): void;
   hideNotice(): void;
@@ -270,6 +276,7 @@ export function createDevPanel(host: DevPanelHost): DevPanel {
       <dt>notice</dt><dd data-role="notice"></dd>
       <dt>growth</dt><dd data-role="growth"></dd>
       <dt>to cap</dt><dd data-role="tocap"></dd>
+      <dt>warning</dt><dd data-role="warning"></dd>
       <dt>steps</dt><dd data-role="steps"></dd>
       <dt>sockets</dt><dd data-role="sockets"></dd>
       <dt>uptime</dt><dd data-role="uptime"></dd>
@@ -310,6 +317,7 @@ export function createDevPanel(host: DevPanelHost): DevPanel {
   const noticeCell = cell('notice');
   const growthCell = cell('growth');
   const toCapCell = cell('tocap');
+  const warningCell = cell('warning');
   const stepsCell = cell('steps');
   const socketsCell = cell('sockets');
   const uptimeCell = cell('uptime');
@@ -382,7 +390,16 @@ export function createDevPanel(host: DevPanelHost): DevPanel {
     growthCell.textContent =
       `${perHour(summary.recentBytesPerMinute)} 30m`
       + ` · ${perHour(summary.runBytesPerMinute)} since open`;
-    toCapCell.textContent = minutesText(summary.minutesToCap);
+    toCapCell.textContent = `${minutesText(summary.minutesToCap)}  (since open)`;
+    // The warning's own reading. It measures step to step over a longer span
+    // and ignores the startup ramp, so this is the number that explains what
+    // the player was told — and a disagreement with the line above is
+    // information, not a bug in either.
+    const pressure = host.pressure();
+    warningCell.textContent = pressure === null
+      ? 'not measuring yet'
+      : `${pressure.minutes === null ? '—' : `~${pressure.minutes} m`}`
+        + ` at ${perHour(pressure.bytesPerMinute)}`;
     stepsCell.textContent = summary.lastStepBytes === null
       ? String(summary.steps)
       : `${summary.steps} · last +${Math.round(summary.lastStepBytes / MIB)} MiB`;

--- a/src/renderer/failure-messages.ts
+++ b/src/renderer/failure-messages.ts
@@ -220,18 +220,24 @@ export interface MemoryExplanation {
  * growth rate could be measured, and then the label states no number at all: a
  * figure we did not measure is worse than none.
  *
- * They also say "should be able to rejoin" rather than promising it. Guild
- * Wars offers a player their instance back after a dropped connection, but
- * whether our reload triggers that offer has not been tested yet, and a player
- * who loses a run to our confidence would be right to be angry. The outpost is
- * named as the safe option, not demanded — demanding it is what made the old
- * sentence easy to ignore from inside a dungeon.
+ * They state the reconnect rather than hedging it, which they did not always.
+ * The uncertainty was never whether Guild Wars gives a player their instance
+ * back after a dropped connection — it does — but whether *our* reload looks
+ * like a dropped connection to its server. Tested 2026-08-05 across all five
+ * reload paths this app can take, from inside an instance: every one came back
+ * with progress intact, in under thirty seconds. That is the specific question
+ * the hedge existed for, so the hedge is gone.
+ *
+ * The outpost is no longer in the notice. It is still true that an outpost
+ * risks nothing at all, and the explanation says so — but leading with it is
+ * what made the shipped sentence easy to ignore from inside a dungeon, and now
+ * that the reconnect is measured, repeating the caveat argues against a fact.
  */
 const MEMORY_RELOAD = 'Reload Now';
 const MEMORY_DISMISS = 'Later';
 const MEMORY_WHY = 'Why is this happening?';
 const MEMORY_REJOIN =
-  'you should be able to rejoin where you were. Safest from a town or outpost.';
+  'Guild Wars puts you back where you were, in under a minute.';
 
 export function memoryPressurePresentation(
   level: 'low' | 'critical',
@@ -329,11 +335,11 @@ export function memoryExplanation(): MemoryExplanation {
       {
         title: 'What to do',
         body:
-          'Reloading gives the game a fresh 2 GB — it takes a few seconds, '
-          + 'then you log back in. You should be able to rejoin an instance '
-          + 'you were in, the same way Guild Wars handles a dropped '
-          + 'connection. Reloading from a town or outpost is the one case '
-          + 'with nothing to lose.',
+          'Reloading gives the game a fresh 2 GB. It takes under a minute, '
+          + 'and Guild Wars puts you back where you were — the same way it '
+          + 'handles a dropped connection. We tested that from inside an '
+          + 'instance, on every way this app can reload the game. A town or '
+          + 'outpost is still the one place with nothing at all to lose.',
       },
     ],
   };

--- a/src/renderer/failure-messages.ts
+++ b/src/renderer/failure-messages.ts
@@ -214,11 +214,25 @@ export interface MemoryExplanation {
  * to be standing. These sentences exist so the player spends that death at a
  * moment of their choosing.
  *
- * They lead with a deadline because the old wording led with a condition —
- * "running low" meant half an hour in the open world and about two minutes in
- * a mission, and a player could not tell which. `minutes` is null when no
- * growth rate could be measured, and then the label states no number at all: a
- * figure we did not measure is worse than none.
+ * They state a condition and not a deadline, which is where they ended up
+ * rather than where they started. "Running low" meant half an hour in the open
+ * world and about two minutes in a mission, and a player could not tell which —
+ * so the *thresholds* count in time now, and that is the fix. It is only the
+ * printed figure that is gone, and a real crash bundle is why.
+ *
+ * Replayed against the Eye of the North session of 2026-08-04 — the player's
+ * own `wasm.heapGrew` staircase, ending at exactly 2 GiB — the levels arrived
+ * where they should: `low` with 31 minutes of real play left against the
+ * shipped rule's 11, `critical` with 7. The figure did not. It read
+ * 10 → 15 → 20 → 75 → 40 → 20 → 15 → 10 → 3, and at one point offered "about
+ * 75 minutes" to a player with 18 left, because a quiet stretch sat in the
+ * measurement window just before they went back into heavy loading.
+ *
+ * No rate can see a player about to zone into a dungeon. The estimate still
+ * exists — the thresholds are computed from it, the debug panel shows it and
+ * the log records it — but it is a diagnostic, and a diagnostic printed on a
+ * banner is a promise. The level is the part that survived contact with a
+ * real session, so the level is the part the player is told.
  *
  * They state the reconnect rather than hedging it, which they did not always.
  * The uncertainty was never whether Guild Wars gives a player their instance
@@ -241,27 +255,12 @@ const MEMORY_REJOIN =
 
 export function memoryPressurePresentation(
   level: 'low' | 'critical',
-  minutes: number | null = null,
 ): MemoryPressurePresentation {
   const critical = level === 'critical';
-  const unit = minutes === 1 ? 'minute' : 'minutes';
-  let label: string;
-  if (minutes === null) {
-    label = critical
-      ? 'Guild Wars is almost out of memory.'
-      : 'Guild Wars is running low on memory.';
-  } else if (minutes < 1) {
-    // The estimate rounds to whole minutes, so the last half-minute would
-    // otherwise read "About 0 minutes" — a sentence that sounds like a bug at
-    // the one moment the player has to believe it.
-    label = 'Under a minute before Guild Wars runs out of memory.';
-  } else {
-    label = critical
-      ? `About ${minutes} ${unit} before Guild Wars runs out of memory.`
-      : `About ${minutes} ${unit} of play left before a crash.`;
-  }
   return {
-    label,
+    label: critical
+      ? 'Guild Wars is almost out of memory.'
+      : 'Guild Wars is running low on memory.',
     detail: critical
       ? `Reload soon — ${MEMORY_REJOIN}`
       : `Reload when it suits you — ${MEMORY_REJOIN}`,
@@ -272,31 +271,25 @@ export function memoryPressurePresentation(
 }
 
 /**
- * What `Later` leaves behind. The banner's number is frozen when it is shown,
- * so this is the one live surface — it is also what stops a dismissal meaning
- * silence until the crash, which is what the shipped build did.
+ * What `Later` leaves behind: the thing that stops a dismissal meaning silence
+ * until the crash, which is what the shipped build did. It carried a live
+ * countdown until the Eye of the North bundle showed that countdown reading
+ * "75 min" to a player with eighteen minutes left — a figure that moves is
+ * only worth more than a word if it moves the right way.
  */
 export function memoryPressureChip(
   level: 'low' | 'critical',
-  minutes: number | null,
 ): MemoryPressureChip {
-  if (minutes === null) {
-    return {
-      text: 'Low memory',
-      label: 'Guild Wars is low on memory. Open the memory warning again.',
-    };
-  }
-  if (minutes < 1) {
-    return {
-      text: 'Under a minute',
-      label: 'Under a minute before Guild Wars runs out of memory.',
-    };
-  }
-  const unit = minutes === 1 ? 'minute' : 'minutes';
-  return {
-    text: `${minutes} min`,
-    label: `About ${minutes} ${unit} before Guild Wars runs out of memory.`,
-  };
+  return level === 'critical'
+    ? {
+        text: 'Memory almost full',
+        label:
+          'Guild Wars is almost out of memory. Open the memory warning again.',
+      }
+    : {
+        text: 'Low memory',
+        label: 'Guild Wars is low on memory. Open the memory warning again.',
+      };
 }
 
 /**

--- a/src/renderer/failure-messages.ts
+++ b/src/renderer/failure-messages.ts
@@ -244,6 +244,11 @@ export function memoryPressurePresentation(
     label = critical
       ? 'Guild Wars is almost out of memory.'
       : 'Guild Wars is running low on memory.';
+  } else if (minutes < 1) {
+    // The estimate rounds to whole minutes, so the last half-minute would
+    // otherwise read "About 0 minutes" — a sentence that sounds like a bug at
+    // the one moment the player has to believe it.
+    label = 'Under a minute before Guild Wars runs out of memory.';
   } else {
     label = critical
       ? `About ${minutes} ${unit} before Guild Wars runs out of memory.`

--- a/src/renderer/failure-messages.ts
+++ b/src/renderer/failure-messages.ts
@@ -188,36 +188,149 @@ export interface MemoryPressurePresentation {
   detail: string;
   reloadButton: string;
   dismissButton: string;
+  whyLink: string;
+}
+
+export interface MemoryPressureChip {
+  text: string;
+  /** The whole sentence, for the button's accessible name. */
+  label: string;
+}
+
+export interface MemoryExplanationBlock {
+  title: string;
+  body: string;
+}
+
+export interface MemoryExplanation {
+  title: string;
+  blocks: readonly MemoryExplanationBlock[];
+  closeButton: string;
 }
 
 /**
  * The game client's WASM heap is approaching its hard 2 GiB cap; once it gets
  * there the next big allocation kills the client wherever the player happens
  * to be standing. These sentences exist so the player spends that death at a
- * moment of their choosing: reloading from a town or outpost is a quick relog
- * that loses nothing, while an uncontrolled crash mid-mission loses the run.
+ * moment of their choosing.
+ *
+ * They lead with a deadline because the old wording led with a condition —
+ * "running low" meant half an hour in the open world and about two minutes in
+ * a mission, and a player could not tell which. `minutes` is null when no
+ * growth rate could be measured, and then the label states no number at all: a
+ * figure we did not measure is worse than none.
+ *
+ * They also say "should be able to rejoin" rather than promising it. Guild
+ * Wars offers a player their instance back after a dropped connection, but
+ * whether our reload triggers that offer has not been tested yet, and a player
+ * who loses a run to our confidence would be right to be angry. The outpost is
+ * named as the safe option, not demanded — demanding it is what made the old
+ * sentence easy to ignore from inside a dungeon.
  */
 const MEMORY_RELOAD = 'Reload Now';
 const MEMORY_DISMISS = 'Later';
+const MEMORY_WHY = 'Why is this happening?';
+const MEMORY_REJOIN =
+  'you should be able to rejoin where you were. Safest from a town or outpost.';
 
 export function memoryPressurePresentation(
   level: 'low' | 'critical',
+  minutes: number | null = null,
 ): MemoryPressurePresentation {
   const critical = level === 'critical';
-  return {
-    label: critical
+  const unit = minutes === 1 ? 'minute' : 'minutes';
+  let label: string;
+  if (minutes === null) {
+    label = critical
       ? 'Guild Wars is almost out of memory.'
-      : 'Guild Wars is running low on memory.',
+      : 'Guild Wars is running low on memory.';
+  } else {
+    label = critical
+      ? `About ${minutes} ${unit} before Guild Wars runs out of memory.`
+      : `About ${minutes} ${unit} of play left before a crash.`;
+  }
+  return {
+    label,
     detail: critical
-      ? 'A crash is likely soon. Head to a town or outpost at the next '
-        + 'safe moment and choose Reload Now — that is a quick relog, and '
-        + 'from an outpost you lose nothing.'
-      : 'After long sessions the game can crash when memory runs out. To '
-        + 'pick the moment yourself, finish what you are doing, return to a '
-        + 'town or outpost, and choose Reload Now — it works like a quick '
-        + 'relog.',
+      ? `Reload soon — ${MEMORY_REJOIN}`
+      : `Reload when it suits you — ${MEMORY_REJOIN}`,
     reloadButton: MEMORY_RELOAD,
     dismissButton: MEMORY_DISMISS,
+    whyLink: MEMORY_WHY,
+  };
+}
+
+/**
+ * What `Later` leaves behind. The banner's number is frozen when it is shown,
+ * so this is the one live surface — it is also what stops a dismissal meaning
+ * silence until the crash, which is what the shipped build did.
+ */
+export function memoryPressureChip(
+  level: 'low' | 'critical',
+  minutes: number | null,
+): MemoryPressureChip {
+  if (minutes === null) {
+    return {
+      text: 'Low memory',
+      label: 'Guild Wars is low on memory. Open the memory warning again.',
+    };
+  }
+  if (minutes < 1) {
+    return {
+      text: 'Under a minute',
+      label: 'Under a minute before Guild Wars runs out of memory.',
+    };
+  }
+  const unit = minutes === 1 ? 'minute' : 'minutes';
+  return {
+    text: `${minutes} min`,
+    label: `About ${minutes} ${unit} before Guild Wars runs out of memory.`,
+  };
+}
+
+/**
+ * The four things a player asks once they have read the warning twice. The
+ * third block says what is true today — measured, documented, published. It
+ * must not claim we are in contact with ArenaNet until someone has actually
+ * written to them.
+ */
+export function memoryExplanation(): MemoryExplanation {
+  return {
+    title: 'Why Guild Wars runs out of memory',
+    closeButton: 'Close',
+    blocks: [
+      {
+        title: 'What this is',
+        body:
+          'The game client can only use 2 GB of memory. It does not release '
+          + 'what it loads, so a long session gradually fills that up and the '
+          + 'game stops — usually after two to three hours, and faster in '
+          + 'dungeons and missions with a lot of new scenery.',
+      },
+      {
+        title: 'Why we cannot fix it',
+        body:
+          "The limit and the memory use are both inside ArenaNet's game "
+          + 'client. This app only hosts that client on macOS — it cannot '
+          + 'change how the game allocates memory. What it can do is watch it '
+          + 'and warn you before it runs out, which is what this is.',
+      },
+      {
+        title: 'Where it stands',
+        body:
+          'We have measured it, documented it in detail, and published the '
+          + 'findings for ArenaNet.',
+      },
+      {
+        title: 'What to do',
+        body:
+          'Reloading gives the game a fresh 2 GB — it takes a few seconds, '
+          + 'then you log back in. You should be able to rejoin an instance '
+          + 'you were in, the same way Guild Wars handles a dropped '
+          + 'connection. Reloading from a town or outpost is the one case '
+          + 'with nothing to lose.',
+      },
+    ],
   };
 }
 

--- a/src/renderer/harness.css
+++ b/src/renderer/harness.css
@@ -153,10 +153,12 @@ html,body { width:100%; height:100%; margin:0; overflow:hidden;
 }
 #memory-notice-actions .primary:hover { background: #d15f36; border-color: #ff8a63; }
 
-/* The chip a dismissal leaves. Right edge, clear of the notice's own centre. */
+/* The chip a dismissal leaves. Top right, in the band between the client's own
+   window buttons and the top of its compass — at 118px it sat on the compass
+   itself, over the one piece of UI a player reads constantly. */
 #memory-chip {
   position: fixed;
-  top: 118px;
+  top: 52px;
   right: 16px;
   z-index: 9;
   display: flex;

--- a/src/renderer/harness.css
+++ b/src/renderer/harness.css
@@ -1,4 +1,11 @@
-:root { color-scheme: dark; }
+:root {
+  color-scheme: dark;
+  /* A critically damped spring, response 0.4s, sampled rather than guessed at
+     with a bezier. No overshoot: bounce belongs to motion a gesture threw, and
+     nothing here was thrown. */
+  --spring: linear(0, .186, .465, .682, .821, .903, .949, .973, .986, .993,
+                   .997, .999, 1);
+}
 html,body { width:100%; height:100%; margin:0; overflow:hidden;
             background:#000; color:#fe0000; font:14px Tahoma,sans-serif; }
 #canvas { display:block; width:100%; height:100%; }
@@ -49,52 +56,231 @@ html,body { width:100%; height:100%; margin:0; overflow:hidden;
 }
 #capture-status[hidden] { display: none; }
 
-/* The heap watermark notice. Top-centred over the running game; amber while
-   there is headroom, red once the next growth step would hit the 2 GiB cap.
-   Buttons are the only interactive surface — the div itself must not feel
-   like a dialog that blocks play. */
+/* The memory warning. Top-centred over the running game, translucent so the
+   game reads through it, and never scrimmed — it is a message running beside
+   play, not a dialog that stops it. It enters down from the edge it lives on
+   and leaves the same way, and blur and scale animate together so it arrives
+   as a surface rather than cross-fading as a picture. */
 #memory-notice {
   position: fixed;
   top: 14px;
   left: 50%;
-  transform: translateX(-50%);
   z-index: 9;
   display: flex;
   align-items: center;
-  gap: 14px;
-  max-width: min(90vw, 680px);
+  gap: 16px;
+  max-width: min(92vw, 540px);
   box-sizing: border-box;
-  padding: 8px 12px;
-  border: 1px solid #8a6d3b;
-  border-radius: 6px;
+  padding: 11px 13px;
+  border: 1px solid #ffffff1f;
+  border-radius: 12px;
   color: #f5ead9;
-  background: #1c1408ee;
-  font: 13px/1.45 Tahoma, sans-serif;
-  box-shadow: 0 2px 10px #0008;
+  background: #241d13b8;
+  backdrop-filter: blur(20px) saturate(170%);
+  -webkit-backdrop-filter: blur(20px) saturate(170%);
+  /* The bright top edge is light catching the material. */
+  box-shadow: inset 0 1px 0 #ffffff1c, 0 8px 28px #000000a6;
+  transform: translateX(-50%) translateY(0) scale(1);
+  opacity: 1;
+  transition: transform .4s var(--spring), opacity .28s ease-out,
+              backdrop-filter .4s var(--spring), border-color .3s ease-out,
+              background-color .3s ease-out;
 }
 #memory-notice[hidden] { display: none; }
-#memory-notice.critical {
-  border-color: #945b4f;
-  background: #1b0c0bee;
-  color: #fff1e9;
+#memory-notice.entering,
+#memory-notice.leaving {
+  transform: translateX(-50%) translateY(-14px) scale(.97);
+  opacity: 0;
+  backdrop-filter: blur(0) saturate(100%);
+  -webkit-backdrop-filter: blur(0) saturate(100%);
 }
-#memory-notice-label { display: block; }
-#memory-notice-actions { display: flex; gap: 8px; flex-shrink: 0; }
-#memory-notice button {
-  font: 12px Tahoma, sans-serif;
-  padding: 5px 12px;
-  border: 1px solid #776a55;
-  border-radius: 4px;
-  background: #2b2a20;
-  color: inherit;
+#memory-notice.critical {
+  background: #2b0f0ab8;
+  border-color: #ff8f6b4d;
+  box-shadow: inset 0 1px 0 #ffb49c26, 0 10px 34px #000000b8,
+              0 0 0 1px #ff6a4126;
+}
+/* Vibrancy: over a translucent ground text earns contrast, a heavier weight
+   and a little tracking rather than sitting flat and grey. */
+#memory-notice-label {
+  display: block;
+  font: 600 14px/1.3 Tahoma, sans-serif;
+  letter-spacing: .005em;
+  color: #fff6ec;
+}
+#memory-notice.critical #memory-notice-label { color: #ffd9cb; }
+#memory-notice-detail {
+  font: 13px/1.5 Tahoma, sans-serif;
+  letter-spacing: .01em;
+  color: #ece0cf;
+}
+#memory-notice-why {
+  display: inline;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: #ece0cf;
+  opacity: .74;
+  font: 13px/1.5 Tahoma, sans-serif;
+  letter-spacing: .01em;
+  text-decoration: underline;
+  text-underline-offset: 2px;
   cursor: pointer;
 }
-#memory-notice button:hover { border-color: #a99878; }
+#memory-notice-why:hover { opacity: 1; }
+#memory-notice-actions { display: flex; gap: 8px; flex-shrink: 0; }
+#memory-notice-actions button {
+  font: 500 12.5px/1 Tahoma, sans-serif;
+  padding: 8px 14px;
+  border: 1px solid #ffffff26;
+  border-radius: 8px;
+  background: #ffffff14;
+  color: #f3e8da;
+  cursor: pointer;
+  transition: background-color .12s ease-out, border-color .12s ease-out,
+              transform .1s ease-out;
+}
+#memory-notice-actions button:hover { background: #ffffff1f; border-color: #ffffff3d; }
+/* Feedback on the press, not the release. */
+#memory-notice button:active { transform: scale(.97); }
 #memory-notice button:focus-visible { outline: 2px solid #ff9d66;
                                       outline-offset: 2px; }
-#memory-notice button:active { transform: scale(.97); }
-#memory-notice.critical button { border-color: #8a5f55; }
-#memory-notice.critical button:hover { border-color: #c08a7c; }
+#memory-notice-actions .primary {
+  background: #c2542e;
+  border-color: #e0714f;
+  color: #fff6f1;
+  font-weight: 600;
+}
+#memory-notice-actions .primary:hover { background: #d15f36; border-color: #ff8a63; }
+
+/* The chip a dismissal leaves. Right edge, clear of the notice's own centre. */
+#memory-chip {
+  position: fixed;
+  top: 118px;
+  right: 16px;
+  z-index: 9;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 6px 11px;
+  border: 1px solid #ffffff26;
+  border-radius: 20px;
+  background: #2b0f0ab3;
+  backdrop-filter: blur(14px) saturate(160%);
+  -webkit-backdrop-filter: blur(14px) saturate(160%);
+  color: #ffd9cb;
+  font: 600 11.5px/1 Tahoma, sans-serif;
+  letter-spacing: .02em;
+  cursor: pointer;
+  box-shadow: 0 4px 14px #0009;
+  transition: transform .1s ease-out, background-color .12s ease-out;
+}
+#memory-chip[hidden] { display: none; }
+#memory-chip:active { transform: scale(.96); }
+#memory-chip:focus-visible { outline: 2px solid #ff9d66; outline-offset: 2px; }
+.memory-chip-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #ff7a55;
+}
+
+/* The explanation is the one modal task here, so it dims what it interrupts.
+   The notice never does — it runs beside play. */
+#memory-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 10;
+  background: #000;
+  opacity: .5;
+  transition: opacity .3s ease-out;
+}
+#memory-scrim[hidden] { display: none; }
+#memory-why {
+  position: fixed;
+  top: 14px;
+  left: 50%;
+  z-index: 11;
+  width: min(92vw, 540px);
+  max-height: calc(100vh - 34px);
+  overflow-y: auto;
+  box-sizing: border-box;
+  padding: 20px 22px;
+  border: 1px solid #ffffff21;
+  border-radius: 14px;
+  background: #1a1610f2;
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  color: #f0e6d2;
+  font: 13px/1.6 Tahoma, sans-serif;
+  box-shadow: inset 0 1px 0 #ffffff1a, 0 18px 50px #000000c4;
+  /* Anchored to the link that opened it; harness.ts computes the origin from
+     the link's own box, because a constant drifts the first time the copy
+     changes length. */
+  transform: translateX(-50%) scale(1);
+  opacity: 1;
+  transition: transform .4s var(--spring), opacity .26s ease-out;
+}
+#memory-why[hidden] { display: none; }
+#memory-why.entering, #memory-why.leaving {
+  transform: translateX(-50%) scale(.94);
+  opacity: 0;
+}
+#memory-why h3 {
+  margin: 18px 0 4px;
+  font: 600 11px/1.3 Tahoma, sans-serif;
+  letter-spacing: .09em;
+  text-transform: uppercase;
+  color: #e0a94b;
+}
+#memory-why h3:first-child { margin-top: 0; }
+#memory-why p { margin: 0; color: #e2d7c2; letter-spacing: .008em; }
+#memory-why-close {
+  margin-top: 18px;
+  padding: 8px 16px;
+  border: 1px solid #ffffff26;
+  border-radius: 8px;
+  background: #ffffff14;
+  color: #f0e6d2;
+  font: 500 12.5px/1 Tahoma, sans-serif;
+  cursor: pointer;
+  transition: background-color .12s ease-out, transform .1s ease-out;
+}
+#memory-why-close:hover { background: #ffffff1f; }
+#memory-why-close:active { transform: scale(.97); }
+#memory-why-close:focus-visible { outline: 2px solid #ff9d66; outline-offset: 2px; }
+
+/* Reduced motion keeps the feedback and drops the travel: a cross-fade in
+   place, and no scaling under the finger. */
+@media (prefers-reduced-motion: reduce) {
+  #memory-notice, #memory-why, #memory-scrim,
+  #memory-notice button, #memory-chip, #memory-why-close {
+    transition: opacity .2s ease;
+  }
+  #memory-notice.entering, #memory-notice.leaving {
+    transform: translateX(-50%);
+    backdrop-filter: blur(20px) saturate(170%);
+    -webkit-backdrop-filter: blur(20px) saturate(170%);
+  }
+  #memory-why.entering, #memory-why.leaving { transform: translateX(-50%); }
+  #memory-notice button:active, #memory-chip:active,
+  #memory-why-close:active { transform: none; }
+}
+/* Frosted glass is the first thing to go when transparency is refused. */
+@media (prefers-reduced-transparency: reduce) {
+  #memory-notice { background: #241d13; backdrop-filter: none;
+                   -webkit-backdrop-filter: none; }
+  #memory-notice.critical { background: #2b0f0a; }
+  #memory-chip { background: #2b0f0a; backdrop-filter: none;
+                 -webkit-backdrop-filter: none; }
+  #memory-why { background: #1a1610; backdrop-filter: none;
+                -webkit-backdrop-filter: none; }
+}
+@media (prefers-contrast: more) {
+  #memory-notice { background: #1b150d; border-color: #ffd9a8; }
+  #memory-notice.critical { background: #2a0b06; border-color: #ff9f80; }
+  #memory-notice-detail, #memory-notice-why { color: #fff8ee; opacity: 1; }
+}
 
 /* The Steam sign-in status line: quiet, bottom-centred over the client's own
    login screen, and gone on its own — it explains, it never blocks. */

--- a/src/renderer/harness.css
+++ b/src/renderer/harness.css
@@ -113,6 +113,10 @@ html,body { width:100%; height:100%; margin:0; overflow:hidden;
   font: 13px/1.5 Tahoma, sans-serif;
   letter-spacing: .01em;
   color: #ece0cf;
+  /* The label above is a block; these two run together inline beneath it, so
+     the gap between them belongs here rather than as padding inside a string
+     the copy module owns. */
+  margin-right: .35em;
 }
 #memory-notice-why {
   display: inline;

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -441,6 +441,8 @@ function reloadClientSafely() {
  * while they are reading it; the chip is the live one.
  */
 let heapMinutes: number | null = null;
+/** The last thing the estimator concluded, for the debug panel to read back. */
+let heapReading: import('./heap-pressure.js').HeapPressureReading | null = null;
 
 async function presentHeapNotice(level: 'low' | 'critical') {
   if (
@@ -569,6 +571,7 @@ setInterval(() => {
   requestHeapCap();
   if (!heapWatch) return;
   const reading = heapWatch.sample(wasmHeapBytes(), performance.now());
+  heapReading = reading;
   heapMinutes = reading.minutes;
   if (reading.level === 'none') return;
   if (reading.level !== heapNoticeLevel) {
@@ -607,6 +610,10 @@ window.addEventListener('gw:dev-panel', () => {
         heapBytes: wasmHeapBytes,
         capBytes: () => heapCapBytes,
         realNoticeLevel: () => heapNoticeLevel,
+        pressure: () => heapReading && {
+          minutes: heapReading.minutes,
+          bytesPerMinute: heapReading.bytesPerMinute,
+        },
         previewNotice: (level) => void presentHeapNotice(level).catch(() => {}),
         hideNotice: hideHeapNotice,
         previewCrash: (count) => {

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -463,12 +463,12 @@ function reloadClientSafely() {
 }
 
 /**
- * The estimate the banner carries is frozen when it is shown. A figure ticking
- * down under the player's cursor is noise, and it would reflow the surface
- * while they are reading it; the chip is the live one.
+ * The last thing the estimator concluded. It is a diagnostic — the debug panel
+ * reads it back and the log line records it — and deliberately never reaches
+ * the player: replayed against a real crash bundle the level held up and the
+ * minute figure did not, so `failure-messages.ts` states the condition and no
+ * number. See the memory block there for the session that decided it.
  */
-let heapMinutes: number | null = null;
-/** The last thing the estimator concluded, for the debug panel to read back. */
 let heapReading: import('./heap-pressure.js').HeapPressureReading | null = null;
 
 async function presentHeapNotice(level: 'low' | 'critical') {
@@ -477,7 +477,7 @@ async function presentHeapNotice(level: 'low' | 'critical') {
     || !heapNoticeReload || !heapNoticeLater || !heapNoticeWhy
   ) return;
   const { memoryPressurePresentation } = await import('./failure-messages.js');
-  const copy = memoryPressurePresentation(level, heapMinutes);
+  const copy = memoryPressurePresentation(level);
   heapNoticeLabel.textContent = copy.label;
   heapNoticeDetail.textContent = copy.detail;
   heapNoticeReload.textContent = copy.reloadButton;
@@ -513,7 +513,7 @@ function showHeapChip() {
   if (!heapChip || !heapChipText || heapNoticeLevel === 'none') return;
   void (async () => {
     const { memoryPressureChip } = await import('./failure-messages.js');
-    const chip = memoryPressureChip(heapNoticeLevel as 'low' | 'critical', heapMinutes);
+    const chip = memoryPressureChip(heapNoticeLevel as 'low' | 'critical');
     // Only touch the DOM when the rendered string actually changes: this runs
     // on every tick, over a game drawing at sixty frames a second.
     if (heapChipText.textContent !== chip.text) heapChipText.textContent = chip.text;
@@ -599,7 +599,6 @@ setInterval(() => {
   if (!heapWatch) return;
   const reading = heapWatch.sample(wasmHeapBytes(), performance.now());
   heapReading = reading;
-  heapMinutes = reading.minutes;
   if (reading.level === 'none') return;
   if (reading.level !== heapNoticeLevel) {
     heapNoticeLevel = reading.level;

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -273,42 +273,50 @@ window.gwLog = (on = true) => {
 };
 
 /**
- * The heap watermark. The client's WASM memory is capped by its own build
- * (`WASM_HEAP_CAP_BYTES` in the shared contracts), memory only ever grows
- * within one run, and a session that reaches the cap dies on whatever
- * allocation comes next — historically hours in and mid-mission. The watcher
- * moves that death to a moment the player picks: warn while there is headroom
- * to travel somewhere safe, escalate when the next growth step would hit the
- * cap. Reloading is a quick relog; from a town or outpost it loses nothing.
+ * The memory warning. The client's WASM memory is capped by its own build
+ * (`WASM_HEAP_CAP_BYTES` in the shared contracts), it only ever grows within a
+ * run, and a session that reaches the cap dies on whatever allocation comes
+ * next — historically hours in and mid-mission. The watcher moves that death
+ * to a moment the player picks.
+ *
+ * It counts in time, not bytes remaining. `heap-pressure.ts` owns that
+ * arithmetic and the reason for it; what matters here is that the number the
+ * player is shown is measured, and that when it cannot be measured no number
+ * is shown at all.
  *
  * A classic script cannot static-import, so the cap arrives via a dynamic
  * import — on the first watcher tick, not at boot. Boot would work here, but
  * it would also put the canonical contract into the module cache before the
  * Enhancement runtime imports it, and the packaged proof that the runtime
- * resolves the canonical module observes that import as a request. Until the
- * import lands the thresholds are Infinity and the watcher is silent, which
- * costs one 15-second tick and nothing else: no heap reaches a watermark
- * that fast.
+ * resolves the canonical module observes that import as a request. Until it
+ * lands there is no watch and the watcher is silent, which costs one
+ * 15-second tick and nothing else: no heap fills that fast.
  */
 const MIB = 1_048_576;
 let heapCapBytes = 0;
-let heapWarnBytes = Infinity; // cap − 256 MiB — time to finish up.
-let heapCriticalBytes = Infinity; // cap − 128 MiB — go now.
+let heapWatch: import('./heap-pressure.js').HeapPressureWatch | null = null;
 let heapCapRequested = false;
 function requestHeapCap() {
   if (heapCapRequested) return;
   heapCapRequested = true;
-  void import('../shared/contracts.js')
-    .then(({ WASM_HEAP_CAP_BYTES }) => {
+  void Promise.all([
+    import('../shared/contracts.js'),
+    import('./heap-pressure.js'),
+  ])
+    .then(([{ WASM_HEAP_CAP_BYTES }, { createHeapPressureWatch }]) => {
       heapCapBytes = WASM_HEAP_CAP_BYTES;
-      heapWarnBytes = WASM_HEAP_CAP_BYTES - 256 * MIB;
-      heapCriticalBytes = WASM_HEAP_CAP_BYTES - 128 * MIB;
+      heapWatch = createHeapPressureWatch({ capBytes: WASM_HEAP_CAP_BYTES });
     })
     // A failed load retries on the next tick rather than silencing the
-    // watermark for the whole session.
+    // warning for the whole session.
     .catch(() => { heapCapRequested = false; });
 }
 let heapNoticeLevel: 'none' | 'low' | 'critical' = 'none';
+/** What is on screen, so a dismissal can be a deferral rather than silence. */
+let heapSurface: 'hidden' | 'notice' | 'chip' = 'hidden';
+let heapLeaveTimer: ReturnType<typeof setTimeout> | null = null;
+const prefersReducedMotion = () =>
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
 const wasmHeapBytes = () => Module.HEAPU8?.buffer.byteLength ?? 0;
 window.gwWasmHeapBytes = wasmHeapBytes;
@@ -337,14 +345,74 @@ const heapNoticeLabel = document.getElementById('memory-notice-label');
 const heapNoticeDetail = document.getElementById('memory-notice-detail');
 const heapNoticeReload = document.getElementById('memory-notice-reload');
 const heapNoticeLater = document.getElementById('memory-notice-later');
+const heapNoticeWhy = document.getElementById('memory-notice-why');
+const heapChip = document.getElementById('memory-chip');
+const heapChipText = document.getElementById('memory-chip-text');
+const heapScrim = document.getElementById('memory-scrim');
+const heapWhyRoot = document.getElementById('memory-why');
+const heapWhyTitle = document.getElementById('memory-why-title');
+const heapWhyBlocks = document.getElementById('memory-why-blocks');
+const heapWhyClose = document.getElementById('memory-why-close');
+
+/**
+ * The client listens on the window for the events these surfaces generate, so
+ * a click on Later used to reach the game as well. Stopping them at the
+ * overlay root is the same boundary `toolbox-foundation.ts` draws.
+ */
+for (const root of [heapNoticeRoot, heapChip, heapWhyRoot]) {
+  for (const name of [
+    'keydown', 'keyup', 'pointerdown', 'pointerup', 'pointermove',
+    'mousedown', 'mouseup', 'mousemove', 'click', 'wheel', 'contextmenu',
+  ]) {
+    root?.addEventListener(name, (event) => event.stopPropagation());
+  }
+}
+
 heapNoticeReload?.addEventListener('click', () => {
-  hideHeapNotice();
+  hideHeapNotice({ instant: true });
   reloadClientSafely();
 });
-heapNoticeLater?.addEventListener('click', hideHeapNotice);
+heapNoticeLater?.addEventListener('click', () => {
+  // Later is a deferral, not a dismissal: the chip keeps the estimate on
+  // screen and keeps counting, and a rise to critical raises the banner again.
+  hideHeapNotice();
+  showHeapChip();
+});
+heapNoticeWhy?.addEventListener('click', () => void openHeapWhy());
+heapChip?.addEventListener('click', () => {
+  hideHeapChip();
+  void presentHeapNotice(heapNoticeLevel === 'critical' ? 'critical' : 'low');
+});
+heapWhyClose?.addEventListener('click', () => closeHeapWhy());
+heapScrim?.addEventListener('click', () => closeHeapWhy());
+heapWhyRoot?.addEventListener('keydown', (event) => {
+  if ((event as KeyboardEvent).key !== 'Escape') return;
+  event.preventDefault();
+  closeHeapWhy();
+});
 
-function hideHeapNotice() {
-  if (heapNoticeRoot) heapNoticeRoot.hidden = true;
+function hideHeapNotice(options?: { instant?: boolean }) {
+  if (!heapNoticeRoot || heapNoticeRoot.hidden) return;
+  if (heapLeaveTimer !== null) clearTimeout(heapLeaveTimer);
+  if (heapSurface === 'notice') heapSurface = 'hidden';
+  if (options?.instant || prefersReducedMotion()) {
+    heapNoticeRoot.hidden = true;
+    heapNoticeRoot.classList.remove('leaving', 'entering');
+    return;
+  }
+  // It leaves the way it came, back up past the edge it lives on.
+  heapNoticeRoot.classList.add('leaving');
+  heapLeaveTimer = setTimeout(() => {
+    heapLeaveTimer = null;
+    if (!heapNoticeRoot.classList.contains('leaving')) return;
+    heapNoticeRoot.hidden = true;
+    heapNoticeRoot.classList.remove('leaving');
+  }, 300);
+}
+
+function hideHeapChip() {
+  if (heapChip) heapChip.hidden = true;
+  if (heapSurface === 'chip') heapSurface = 'hidden';
 }
 
 /**
@@ -367,34 +435,156 @@ function reloadClientSafely() {
   else reload();
 }
 
+/**
+ * The estimate the banner carries is frozen when it is shown. A figure ticking
+ * down under the player's cursor is noise, and it would reflow the surface
+ * while they are reading it; the chip is the live one.
+ */
+let heapMinutes: number | null = null;
+
 async function presentHeapNotice(level: 'low' | 'critical') {
   if (
     !heapNoticeRoot || !heapNoticeLabel || !heapNoticeDetail
-    || !heapNoticeReload || !heapNoticeLater
+    || !heapNoticeReload || !heapNoticeLater || !heapNoticeWhy
   ) return;
   const { memoryPressurePresentation } = await import('./failure-messages.js');
-  const copy = memoryPressurePresentation(level);
+  const copy = memoryPressurePresentation(level, heapMinutes);
   heapNoticeLabel.textContent = copy.label;
-  heapNoticeDetail.textContent = copy.detail;
+  heapNoticeDetail.textContent = ` ${copy.detail} `;
   heapNoticeReload.textContent = copy.reloadButton;
   heapNoticeLater.textContent = copy.dismissButton;
+  heapNoticeWhy.textContent = copy.whyLink;
   heapNoticeRoot.classList.toggle('critical', level === 'critical');
+  // A surface already on screen changing state does not leave and re-enter;
+  // the colour transition and the re-announcement carry the escalation.
+  const wasShowing = heapSurface === 'notice' && !heapNoticeRoot.hidden;
+  heapNoticeRoot.setAttribute('role', level === 'critical' ? 'alert' : 'status');
+  heapNoticeRoot.setAttribute(
+    'aria-live', level === 'critical' ? 'assertive' : 'polite',
+  );
+  heapSurface = 'notice';
+  hideHeapChip();
+  if (heapLeaveTimer !== null) {
+    clearTimeout(heapLeaveTimer);
+    heapLeaveTimer = null;
+  }
+  heapNoticeRoot.classList.remove('leaving');
+  if (wasShowing || prefersReducedMotion()) {
+    heapNoticeRoot.classList.remove('entering');
+    heapNoticeRoot.hidden = false;
+    return;
+  }
+  heapNoticeRoot.classList.add('entering');
   heapNoticeRoot.hidden = false;
+  void heapNoticeRoot.offsetWidth;
+  requestAnimationFrame(() => heapNoticeRoot.classList.remove('entering'));
+}
+
+function showHeapChip() {
+  if (!heapChip || !heapChipText || heapNoticeLevel === 'none') return;
+  void (async () => {
+    const { memoryPressureChip } = await import('./failure-messages.js');
+    const chip = memoryPressureChip(heapNoticeLevel as 'low' | 'critical', heapMinutes);
+    // Only touch the DOM when the rendered string actually changes: this runs
+    // on every tick, over a game drawing at sixty frames a second.
+    if (heapChipText.textContent !== chip.text) heapChipText.textContent = chip.text;
+    heapChip.setAttribute('aria-label', chip.label);
+    heapChip.hidden = false;
+    heapSurface = 'chip';
+  })().catch(() => {});
+}
+
+/**
+ * The explanation is the one modal task here, so it dims the game and takes
+ * focus — and it opens in the notice's place rather than over it, because two
+ * translucent surfaces stacked stop being readable.
+ */
+async function openHeapWhy() {
+  if (!heapWhyRoot || !heapWhyBlocks || !heapWhyClose || !heapWhyTitle) return;
+  const { memoryExplanation } = await import('./failure-messages.js');
+  const copy = memoryExplanation();
+  heapWhyTitle.textContent = copy.title;
+  heapWhyClose.textContent = copy.closeButton;
+  heapWhyBlocks.replaceChildren(
+    ...copy.blocks.flatMap((block) => {
+      const heading = document.createElement('h3');
+      heading.textContent = block.title;
+      const body = document.createElement('p');
+      body.textContent = block.body;
+      return [heading, body];
+    }),
+  );
+  // The game may hold the pointer; without this the panel cannot be reached.
+  document.exitPointerLock?.();
+  // Anchored to the link that opened it, measured rather than assumed: the
+  // link moves with the length of the copy above it.
+  if (heapNoticeWhy) {
+    const link = heapNoticeWhy.getBoundingClientRect();
+    const panel = heapWhyRoot.getBoundingClientRect();
+    heapWhyRoot.style.transformOrigin =
+      `${link.left + link.width / 2 - panel.left}px `
+      + `${link.top + link.height / 2 - panel.top}px`;
+  }
+  hideHeapNotice({ instant: true });
+  hideHeapChip();
+  if (heapScrim) heapScrim.hidden = false;
+  heapWhyRoot.classList.remove('leaving');
+  if (!prefersReducedMotion()) {
+    heapWhyRoot.classList.add('entering');
+    heapWhyRoot.hidden = false;
+    void heapWhyRoot.offsetWidth;
+    requestAnimationFrame(() => heapWhyRoot.classList.remove('entering'));
+  } else {
+    heapWhyRoot.hidden = false;
+  }
+  heapWhyClose.focus();
+}
+
+function closeHeapWhy(options?: { instant?: boolean }) {
+  if (!heapWhyRoot || heapWhyRoot.hidden) return;
+  if (heapScrim) heapScrim.hidden = true;
+  const finish = () => {
+    heapWhyRoot.hidden = true;
+    heapWhyRoot.classList.remove('leaving');
+  };
+  if (options?.instant || prefersReducedMotion()) finish();
+  else {
+    heapWhyRoot.classList.add('leaving');
+    setTimeout(finish, 280);
+  }
+  if (options?.instant) return;
+  // The notice comes back where it was, and focus with it; if the warning is
+  // over, the keys belong to the game again.
+  if (heapNoticeLevel !== 'none') {
+    void presentHeapNotice(heapNoticeLevel as 'low' | 'critical').then(() => {
+      heapNoticeWhy?.focus();
+    });
+  } else {
+    document.getElementById('canvas')?.focus();
+  }
 }
 
 setInterval(() => {
   if (crashRecorded) return;
   requestHeapCap();
-  const bytes = wasmHeapBytes();
-  const level = bytes >= heapCriticalBytes
-    ? 'critical'
-    : bytes >= heapWarnBytes ? 'low' : 'none';
-  // Escalation is one-way and each level presents once: the heap cannot
-  // shrink within a client run, and a reload resets this whole script.
-  if (level === 'none' || level === heapNoticeLevel) return;
-  heapNoticeLevel = level;
-  log(`[memory] wasm heap at ${Math.round(bytes / MIB)} MiB — ${level} notice`);
-  presentHeapNotice(level).catch(() => {});
+  if (!heapWatch) return;
+  const reading = heapWatch.sample(wasmHeapBytes(), performance.now());
+  heapMinutes = reading.minutes;
+  if (reading.level === 'none') return;
+  if (reading.level !== heapNoticeLevel) {
+    heapNoticeLevel = reading.level;
+    log(
+      `[memory] wasm heap at ${Math.round(reading.bytes / MIB)} MiB`
+      + ` — ${reading.minutes ?? '?'} min left`
+      + ` at ${Math.round((reading.bytesPerMinute ?? 0) / MIB)} MiB/min`
+      + ` — ${reading.level} notice (${reading.raisedBy ?? 'held'})`,
+    );
+    // A rise always shows the banner, including out of a dismissal: Later
+    // means later, and the level only ever rises when time is running out.
+    void presentHeapNotice(reading.level);
+    return;
+  }
+  if (heapSurface === 'chip') showHeapChip();
 }, 15_000);
 
 /**
@@ -853,7 +1043,11 @@ Module = {
     // fingerprint, and stays readable on the overlay's disclosure.
     if (crashRecorded) return;
     crashRecorded = true;
-    hideHeapNotice();
+    // The crash overlay is taking the screen; nothing animates out from under
+    // it.
+    hideHeapNotice({ instant: true });
+    hideHeapChip();
+    closeHeapWhy({ instant: true });
     const heapBytes = wasmHeapBytes();
     // The overlay first, with the first-crash presentation; the recorded
     // count upgrades it below once main has counted this crash.
@@ -888,7 +1082,9 @@ Module = {
       // first-crash and count the same death twice.
       if (crashRecorded) return;
       crashRecorded = true;
-      hideHeapNotice();
+      hideHeapNotice({ instant: true });
+      hideHeapChip();
+      closeHeapWhy({ instant: true });
       // `code` is declared unknown at the Module boundary; anything the
       // glue passes that is not a plain integer records as the -1 the
       // schema can still account for.
@@ -1071,7 +1267,8 @@ function loadGlue() {
     const target = event.relatedTarget;
     if (
       oskInputs.has(target) ||
-      (target instanceof Element && target.closest('#toolbox-foundation'))
+      (target instanceof Element
+        && target.closest('#toolbox-foundation, #memory-notice, #memory-chip, #memory-why'))
     ) {
       event.stopImmediatePropagation();
     }

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -640,6 +640,7 @@ window.addEventListener('gw:dev-panel', () => {
         pressure: () => heapReading && {
           minutes: heapReading.minutes,
           bytesPerMinute: heapReading.bytesPerMinute,
+          measuredOverMs: heapReading.measuredOverMs,
         },
         previewNotice: (level) => void presentHeapNotice(level).catch(() => {}),
         hideNotice: hideHeapNotice,

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -317,6 +317,21 @@ let heapSurface: 'hidden' | 'notice' | 'chip' = 'hidden';
 let heapLeaveTimer: ReturnType<typeof setTimeout> | null = null;
 const prefersReducedMotion = () =>
   window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+/**
+ * How long to leave an element in the DOM while it animates out, read from the
+ * element itself rather than restated here. A number copied out of the
+ * stylesheet is a second source of truth that drifts silently — and this one
+ * also inherits the shorter durations the reduced-motion block sets, which a
+ * constant could not.
+ */
+const exitMs = (element: HTMLElement) =>
+  Math.max(
+    0,
+    ...getComputedStyle(element)
+      .transitionDuration.split(',')
+      .map((value) => Number.parseFloat(value) * 1_000)
+      .filter(Number.isFinite),
+  );
 
 const wasmHeapBytes = () => Module.HEAPU8?.buffer.byteLength ?? 0;
 window.gwWasmHeapBytes = wasmHeapBytes;
@@ -385,11 +400,23 @@ heapChip?.addEventListener('click', () => {
 });
 heapWhyClose?.addEventListener('click', () => closeHeapWhy());
 heapScrim?.addEventListener('click', () => closeHeapWhy());
-heapWhyRoot?.addEventListener('keydown', (event) => {
-  if ((event as KeyboardEvent).key !== 'Escape') return;
-  event.preventDefault();
-  closeHeapWhy();
-});
+/**
+ * The explanation claims `aria-modal`, which tells a screen reader everything
+ * behind it is inert — so the keyboard has to agree. It holds exactly one
+ * control, which makes the trap the whole of it: Tab has nowhere else to go.
+ * Listening on the document rather than on the panel is what makes Escape
+ * work from a click that landed on the panel's own prose.
+ */
+document.addEventListener('keydown', (event) => {
+  if (!heapWhyRoot || heapWhyRoot.hidden) return;
+  if (event.key === 'Escape') {
+    event.preventDefault();
+    closeHeapWhy();
+  } else if (event.key === 'Tab') {
+    event.preventDefault();
+    heapWhyClose?.focus();
+  }
+}, true);
 
 function hideHeapNotice(options?: { instant?: boolean }) {
   if (!heapNoticeRoot || heapNoticeRoot.hidden) return;
@@ -407,7 +434,7 @@ function hideHeapNotice(options?: { instant?: boolean }) {
     if (!heapNoticeRoot.classList.contains('leaving')) return;
     heapNoticeRoot.hidden = true;
     heapNoticeRoot.classList.remove('leaving');
-  }, 300);
+  }, exitMs(heapNoticeRoot));
 }
 
 function hideHeapChip() {
@@ -452,7 +479,7 @@ async function presentHeapNotice(level: 'low' | 'critical') {
   const { memoryPressurePresentation } = await import('./failure-messages.js');
   const copy = memoryPressurePresentation(level, heapMinutes);
   heapNoticeLabel.textContent = copy.label;
-  heapNoticeDetail.textContent = ` ${copy.detail} `;
+  heapNoticeDetail.textContent = copy.detail;
   heapNoticeReload.textContent = copy.reloadButton;
   heapNoticeLater.textContent = copy.dismissButton;
   heapNoticeWhy.textContent = copy.whyLink;
@@ -552,7 +579,7 @@ function closeHeapWhy(options?: { instant?: boolean }) {
   if (options?.instant || prefersReducedMotion()) finish();
   else {
     heapWhyRoot.classList.add('leaving');
-    setTimeout(finish, 280);
+    setTimeout(finish, exitMs(heapWhyRoot));
   }
   if (options?.instant) return;
   // The notice comes back where it was, and focus with it; if the warning is

--- a/src/renderer/heap-pressure.ts
+++ b/src/renderer/heap-pressure.ts
@@ -29,6 +29,8 @@ export interface HeapPressureReading {
 
 export interface HeapPressurePolicy {
   windowsMs?: readonly number[];
+  /** No slope is measured from a sample older than this. See DEFAULTS. */
+  warmupMs?: number;
   lowMinutes?: number;
   criticalMinutes?: number;
   blindLowBytes?: number;
@@ -52,6 +54,18 @@ const MIB = 1_048_576;
  */
 const DEFAULTS = {
   windowsMs: [2 * 60_000, 10 * 60_000] as readonly number[],
+  /**
+   * Nothing measured before this counts as a baseline. Starting the client is
+   * the heaviest allocating a session ever does — observed at roughly
+   * 4,500 MiB/h against a steady-state 555 — so a window whose base sits in
+   * the ramp reads a startup as a session with a quarter of an hour to live,
+   * and every player would be warned a minute after logging in.
+   *
+   * Samples from the ramp are still recorded; they are just never the point a
+   * slope is measured from. The cost is that the first estimate arrives about
+   * seven minutes in, and until then the byte floors are what warn.
+   */
+  warmupMs: 5 * 60_000,
   lowMinutes: 20,
   criticalMinutes: 5,
   // The bytes the shipped build warned on, kept for when time is unmeasurable.
@@ -108,11 +122,15 @@ export function createHeapPressureWatch(
 
       let bytesPerMinute: number | null = null;
       for (const windowMs of policy.windowsMs) {
-        // A window with no sample old enough is not usable. Extrapolating a
-        // partial window is how a cold start invents a rate it never saw.
+        // A window with no sample old enough is not usable, and one whose base
+        // is still inside the startup ramp is worse than unusable — it reports
+        // the cost of launching the game as the cost of playing it.
+        // Extrapolating either is how a young session invents a rate it never
+        // saw.
         const base = [...history]
           .reverse()
-          .find((entry) => entry.atMs <= atMs - windowMs);
+          .find((entry) =>
+            entry.atMs <= atMs - windowMs && entry.atMs >= policy.warmupMs);
         if (!base) continue;
         const elapsed = (atMs - base.atMs) / 60_000;
         if (elapsed <= 0) continue;

--- a/src/renderer/heap-pressure.ts
+++ b/src/renderer/heap-pressure.ts
@@ -46,14 +46,23 @@ export interface HeapPressureWatch {
 const MIB = 1_048_576;
 
 /**
- * Two trailing windows, and the steepest wins. The short one makes a mission
- * that eats memory visible about two minutes after the player zones into it;
- * the long one stops a lull inside that mission from erasing a rate we just
- * measured. There is no session-average window: under a steepest-wins rule it
- * could only ever win by keeping an hour-old burst alive forever.
+ * Two trailing windows, and the steepest wins. The short one catches a session
+ * that has started spending heavily; the long one stops a lull inside that
+ * spending from erasing a rate we just measured. There is no session-average
+ * window: under a steepest-wins rule it could only ever win by keeping an
+ * hour-old burst alive forever.
+ *
+ * Five minutes is the floor for the short one, not two. Loading a zone
+ * allocates a couple of hundred MiB in seconds, which over two minutes reads
+ * as thousands of MiB an hour — and since the level never falls, one map
+ * change would have latched a warning for the rest of the session. Five
+ * minutes dilutes a single load to something a real trend can still beat, and
+ * costs nothing that matters: the fastest session we have measured took half
+ * an hour to fill, so being told at minute ten instead of minute eight
+ * changes nothing a player would do.
  */
 const DEFAULTS = {
-  windowsMs: [2 * 60_000, 10 * 60_000] as readonly number[],
+  windowsMs: [5 * 60_000, 15 * 60_000] as readonly number[],
   /**
    * Nothing measured before this counts as a baseline. Starting the client is
    * the heaviest allocating a session ever does — observed at roughly
@@ -78,6 +87,14 @@ const DEFAULTS = {
   // over at seven minutes, which is the defect this module exists to remove.
   hardCriticalBytes: 32 * MIB,
   minRateBytesPerMinute: MIB,
+  /**
+   * How many consecutive readings must agree before the level is raised. The
+   * level never falls, so a single unlucky sample would be permanent — this is
+   * what makes "we measured it twice" the price of a warning that cannot be
+   * taken back. The hard byte floor is exempt: at that point the heap really
+   * is nearly full and there is nothing left to corroborate.
+   */
+  confirmations: 2,
 };
 
 const RANK: Record<HeapPressureLevel, number> = {
@@ -109,6 +126,8 @@ export function createHeapPressureWatch(
   const longestWindowMs = Math.max(...policy.windowsMs);
   const history: { atMs: number; bytes: number }[] = [];
   let raised: HeapPressureLevel = 'none';
+  let pending: HeapPressureLevel = 'none';
+  let streak = 0;
 
   return {
     sample(bytes, atMs) {
@@ -172,8 +191,18 @@ export function createHeapPressureWatch(
       const proposed = RANK[fromTime] >= RANK[fromBytes] ? fromTime : fromBytes;
       let raisedBy: 'time' | 'bytes' | null = null;
       if (RANK[proposed] > RANK[raised]) {
-        raised = proposed;
-        raisedBy = RANK[fromTime] >= RANK[fromBytes] ? 'time' : 'bytes';
+        streak = proposed === pending ? streak + 1 : 1;
+        pending = proposed;
+        // The floor answers for itself; everything else is corroborated first,
+        // because a level that cannot fall must not be set by one sample.
+        const forced = headroom !== null && headroom <= policy.hardCriticalBytes;
+        if (forced || streak >= policy.confirmations) {
+          raised = proposed;
+          raisedBy = RANK[fromTime] >= RANK[fromBytes] ? 'time' : 'bytes';
+        }
+      } else {
+        streak = 0;
+        pending = 'none';
       }
 
       return {

--- a/src/renderer/heap-pressure.ts
+++ b/src/renderer/heap-pressure.ts
@@ -1,0 +1,170 @@
+/**
+ * How long the client has left before its heap fills, and which warning that
+ * earns. The unit is time, not bytes remaining: the same 256 MiB of headroom
+ * was half an hour of open-world play and about two minutes inside a
+ * texture-dense mission, and a player has no way to tell those apart from a
+ * sentence that names neither.
+ *
+ * It owns the rate estimate and the threshold policy. It owns no DOM, no
+ * timer, and not one word the player reads — the harness drives it and
+ * `failure-messages.ts` says it. It also imports nothing from `../shared/`:
+ * the client's compiled-in cap arrives as an argument, because a second
+ * importer of the canonical contract disturbs the packaged proof that the
+ * Enhancement runtime is what requested it.
+ */
+
+export type HeapPressureLevel = 'none' | 'low' | 'critical';
+
+export interface HeapPressureReading {
+  /** Monotonic within a client run: once critical, always critical. */
+  level: HeapPressureLevel;
+  /** Hedged and display-ready; null when no rate could be measured. */
+  minutes: number | null;
+  /** Unhedged, for the log line. Null when unmeasurable. */
+  bytesPerMinute: number | null;
+  bytes: number;
+  /** Which rule raised the level. For the log; the copy never branches on it. */
+  raisedBy: 'time' | 'bytes' | null;
+}
+
+export interface HeapPressurePolicy {
+  windowsMs?: readonly number[];
+  lowMinutes?: number;
+  criticalMinutes?: number;
+  blindLowBytes?: number;
+  blindCriticalBytes?: number;
+  hardCriticalBytes?: number;
+  minRateBytesPerMinute?: number;
+}
+
+export interface HeapPressureWatch {
+  sample(bytes: number, atMs: number): HeapPressureReading;
+}
+
+const MIB = 1_048_576;
+
+/**
+ * Two trailing windows, and the steepest wins. The short one makes a mission
+ * that eats memory visible about two minutes after the player zones into it;
+ * the long one stops a lull inside that mission from erasing a rate we just
+ * measured. There is no session-average window: under a steepest-wins rule it
+ * could only ever win by keeping an hour-old burst alive forever.
+ */
+const DEFAULTS = {
+  windowsMs: [2 * 60_000, 10 * 60_000] as readonly number[],
+  lowMinutes: 20,
+  criticalMinutes: 5,
+  // The bytes the shipped build warned on, kept for when time is unmeasurable.
+  blindLowBytes: 256 * MIB,
+  blindCriticalBytes: 128 * MIB,
+  // The never-silent backstop: this much headroom is critical whatever any
+  // estimate claims. It has to sit *below* where the time rule fires in an
+  // ordinary session or it pre-empts it — at the measured 555 MiB/h the five
+  // minute rule fires at about 46 MiB, and a 64 MiB floor took the warning
+  // over at seven minutes, which is the defect this module exists to remove.
+  hardCriticalBytes: 32 * MIB,
+  minRateBytesPerMinute: MIB,
+};
+
+const RANK: Record<HeapPressureLevel, number> = {
+  none: 0,
+  low: 1,
+  critical: 2,
+};
+
+/**
+ * Round the estimate the way the sentence reads it: to five minutes once
+ * there is a quarter of an hour to spend, to the minute when there is not.
+ *
+ * Nearest, not down. At the moment the twenty-minute rule fires the estimate
+ * sits just under twenty, and flooring would print "about 15 minutes" —
+ * understating by a quarter exactly when the number is supposed to sound
+ * deliberate. Rounding up costs at most two and a half minutes against an
+ * estimate already built to run early, and the sentence says "about".
+ */
+export function hedgeMinutes(minutes: number): number {
+  if (!Number.isFinite(minutes) || minutes <= 0) return 0;
+  return minutes >= 10 ? Math.round(minutes / 5) * 5 : Math.round(minutes);
+}
+
+export function createHeapPressureWatch(
+  options: { capBytes: number } & HeapPressurePolicy,
+): HeapPressureWatch {
+  const policy = { ...DEFAULTS, ...options };
+  const capBytes = options.capBytes;
+  const longestWindowMs = Math.max(...policy.windowsMs);
+  const history: { atMs: number; bytes: number }[] = [];
+  let raised: HeapPressureLevel = 'none';
+
+  return {
+    sample(bytes, atMs) {
+      const previous = history.at(-1);
+      // A repeated or backwards timestamp would divide by zero or by a
+      // negative; the sample is dropped rather than allowed to produce a rate.
+      if (!previous || atMs > previous.atMs) history.push({ atMs, bytes });
+      while (history.length > 1 && history[0]!.atMs < atMs - longestWindowMs * 2) {
+        history.shift();
+      }
+
+      let bytesPerMinute: number | null = null;
+      for (const windowMs of policy.windowsMs) {
+        // A window with no sample old enough is not usable. Extrapolating a
+        // partial window is how a cold start invents a rate it never saw.
+        const base = [...history]
+          .reverse()
+          .find((entry) => entry.atMs <= atMs - windowMs);
+        if (!base) continue;
+        const elapsed = (atMs - base.atMs) / 60_000;
+        if (elapsed <= 0) continue;
+        const slope = Math.max(0, (bytes - base.bytes) / elapsed);
+        bytesPerMinute = Math.max(bytesPerMinute ?? 0, slope);
+      }
+      if (
+        bytesPerMinute !== null
+        && bytesPerMinute < policy.minRateBytesPerMinute
+      ) {
+        bytesPerMinute = null;
+      }
+
+      const headroom = capBytes > 0 ? Math.max(0, capBytes - bytes) : null;
+      const rawMinutes =
+        headroom !== null && bytesPerMinute !== null && bytesPerMinute > 0
+          ? headroom / bytesPerMinute
+          : null;
+
+      let fromTime: HeapPressureLevel = 'none';
+      if (rawMinutes !== null) {
+        if (rawMinutes <= policy.criticalMinutes) fromTime = 'critical';
+        else if (rawMinutes <= policy.lowMinutes) fromTime = 'low';
+      }
+
+      let fromBytes: HeapPressureLevel = 'none';
+      if (headroom !== null) {
+        if (headroom <= policy.hardCriticalBytes) fromBytes = 'critical';
+        else if (rawMinutes === null) {
+          // Only while time is unmeasurable. Left unconditional, the 128 MiB
+          // floor is nearly fourteen minutes at the measured open-world rate —
+          // it would pre-empt the five-minute rule every session and rebuild
+          // the defect this module exists to remove.
+          if (headroom <= policy.blindCriticalBytes) fromBytes = 'critical';
+          else if (headroom <= policy.blindLowBytes) fromBytes = 'low';
+        }
+      }
+
+      const proposed = RANK[fromTime] >= RANK[fromBytes] ? fromTime : fromBytes;
+      let raisedBy: 'time' | 'bytes' | null = null;
+      if (RANK[proposed] > RANK[raised]) {
+        raised = proposed;
+        raisedBy = RANK[fromTime] >= RANK[fromBytes] ? 'time' : 'bytes';
+      }
+
+      return {
+        level: raised,
+        minutes: rawMinutes === null ? null : hedgeMinutes(rawMinutes),
+        bytesPerMinute,
+        bytes,
+        raisedBy,
+      };
+    },
+  };
+}

--- a/src/renderer/heap-pressure.ts
+++ b/src/renderer/heap-pressure.ts
@@ -31,6 +31,13 @@ export interface HeapPressureReading {
   minutes: number | null;
   /** Unhedged, for the log line. Null when unmeasurable. */
   bytesPerMinute: number | null;
+  /**
+   * The step-to-step span the rate was measured over; null when no rate could
+   * be measured. This is what tells "nothing has grown twice yet" apart from
+   * "the reading is broken" — a distinction the debug panel could not draw
+   * from a bare dash, and the reason it is on the reading rather than inferred.
+   */
+  measuredOverMs: number | null;
   bytes: number;
   /** Which rule raised the level. For the log; the copy never branches on it. */
   raisedBy: 'time' | 'bytes' | null;
@@ -191,6 +198,7 @@ export function createHeapPressureWatch(
       }
 
       let bytesPerMinute: number | null = null;
+      let measuredOverMs: number | null = null;
       const last = steps.at(-1);
       let baseIndex = -1;
       if (last) {
@@ -215,6 +223,7 @@ export function createHeapPressureWatch(
         const minutes = (spanMs + overdueMs) / 60_000;
         if (minutes > 0) {
           bytesPerMinute = Math.max(0, (last.bytes - base.bytes) / minutes);
+          measuredOverMs = spanMs + overdueMs;
         }
       }
       if (
@@ -222,6 +231,7 @@ export function createHeapPressureWatch(
         && bytesPerMinute < policy.minRateBytesPerMinute
       ) {
         bytesPerMinute = null;
+        measuredOverMs = null;
       }
 
       // What the client has actually filled, as against what it has reserved
@@ -283,6 +293,7 @@ export function createHeapPressureWatch(
         level: raised,
         minutes: rawMinutes === null ? null : hedgeMinutes(rawMinutes),
         bytesPerMinute,
+        measuredOverMs,
         bytes,
         raisedBy,
       };

--- a/src/renderer/heap-pressure.ts
+++ b/src/renderer/heap-pressure.ts
@@ -11,6 +11,15 @@
  * the client's compiled-in cap arrives as an argument, because a second
  * importer of the canonical contract disturbs the packaged proof that the
  * Enhancement runtime is what requested it.
+ *
+ * What it measures is a staircase, not a slope. `Module.HEAPU8.buffer` is the
+ * memory the runtime has *reserved*, and WebAssembly reserves it in discrete
+ * jumps — Emscripten's glue grows by a fifth of the current size, capped at
+ * 96 MiB, so a session spending 555 MiB an hour takes one step roughly every
+ * ten minutes and is perfectly flat in between. That shape decides the whole
+ * design below, and getting it wrong is not subtle: a fixed five-minute
+ * window contains either no step or one, and reports 0 or 1,152 MiB an hour
+ * for a session actually spending 555.
  */
 
 export type HeapPressureLevel = 'none' | 'low' | 'critical';
@@ -28,8 +37,9 @@ export interface HeapPressureReading {
 }
 
 export interface HeapPressurePolicy {
-  windowsMs?: readonly number[];
-  /** No slope is measured from a sample older than this. See DEFAULTS. */
+  /** Shortest step-to-step span a rate may be measured over. See DEFAULTS. */
+  minSpanMs?: number;
+  /** No step counts until this long after the client first allocated. */
   warmupMs?: number;
   lowMinutes?: number;
   criticalMinutes?: number;
@@ -37,6 +47,8 @@ export interface HeapPressurePolicy {
   blindCriticalBytes?: number;
   hardCriticalBytes?: number;
   minRateBytesPerMinute?: number;
+  /** How many consecutive readings must agree before a level is raised. */
+  confirmations?: number;
 }
 
 export interface HeapPressureWatch {
@@ -45,34 +57,55 @@ export interface HeapPressureWatch {
 
 const MIB = 1_048_576;
 
-/**
- * Two trailing windows, and the steepest wins. The short one catches a session
- * that has started spending heavily; the long one stops a lull inside that
- * spending from erasing a rate we just measured. There is no session-average
- * window: under a steepest-wins rule it could only ever win by keeping an
- * hour-old burst alive forever.
- *
- * Five minutes is the floor for the short one, not two. Loading a zone
- * allocates a couple of hundred MiB in seconds, which over two minutes reads
- * as thousands of MiB an hour — and since the level never falls, one map
- * change would have latched a warning for the rest of the session. Five
- * minutes dilutes a single load to something a real trend can still beat, and
- * costs nothing that matters: the fastest session we have measured took half
- * an hour to fill, so being told at minute ten instead of minute eight
- * changes nothing a player would do.
- */
 const DEFAULTS = {
-  windowsMs: [5 * 60_000, 15 * 60_000] as readonly number[],
   /**
-   * Nothing measured before this counts as a baseline. Starting the client is
-   * the heaviest allocating a session ever does — observed at roughly
-   * 4,500 MiB/h against a steady-state 555 — so a window whose base sits in
-   * the ramp reads a startup as a session with a quarter of an hour to live,
-   * and every player would be warned a minute after logging in.
+   * Both ends of a measurement sit on a growth step, and they must be at
+   * least this far apart.
    *
-   * Samples from the ramp are still recorded; they are just never the point a
-   * slope is measured from. The cost is that the first estimate arrives about
-   * seven minutes in, and until then the byte floors are what warn.
+   * Step-to-step is what makes the estimate stand still. Measuring from a
+   * step to *now* puts a whole tread in the denominator and none of its rise
+   * in the numerator, so the figure sags between steps and jumps back when
+   * the next one lands — a third of its own value, every ten minutes, on a
+   * session whose rate never changed. Measuring step to step reads the same
+   * number wherever in the tread the sample falls.
+   *
+   * The span is what tells a burst from a trend, and ten minutes is bought
+   * rather than guessed. Loading a zone reserves a couple of hundred MiB in
+   * seconds; a sustained 3,500 MiB an hour reserves about the same amount
+   * over ten minutes. Inside a window shorter than that the two are the same
+   * measurement, and the level never falls, so getting it wrong is permanent.
+   * Simulated against the sessions we have measured — a 300 MiB zone load at
+   * minute 30 of an ordinary 555 MiB/h session:
+   *
+   *     span   what the load makes the warning say
+   *      4 m   "about 20 minutes of play left", 77 minutes truly left
+   *      8 m   escalates to critical with 30 minutes truly left
+   *     10 m   nothing; the real warning arrives on time at minute 95
+   *
+   * The cost is paid by the fastest sessions. A mission spending 3,500 MiB an
+   * hour dies around minute 23, and nothing can be said about it until minute
+   * 18 — five minutes of warning where an eight-minute span would have given
+   * eight. That is the worse error to accept, and it is accepted knowingly:
+   * the alternative mis-warns every player who walks into a large zone, every
+   * time, and leaves the warning up for the hour afterwards. The byte floors
+   * below are the backstop for the fast case.
+   *
+   * There is no shorter honest answer. Ten minutes into a mission, a
+   * ten-minute-old zone load and a sustained spend look alike in every
+   * window; a "is it still going?" test costs exactly the latency it saves.
+   */
+  minSpanMs: 10 * 60_000,
+  /**
+   * Measured from the client's first allocation, not from page load.
+   *
+   * Starting the client is the heaviest allocating a session ever does —
+   * observed at roughly 4,500 MiB/h against a steady-state 555 — so a
+   * measurement anchored inside that ramp reads a startup as a session with a
+   * quarter of an hour to live, and every player is warned a minute after
+   * logging in. Anchoring the exclusion to page load instead looks equivalent
+   * and is not: the page is open through the client download, so a slow first
+   * run boots after the warm-up has already expired and the ramp is measured
+   * as ordinary play.
    */
   warmupMs: 5 * 60_000,
   lowMinutes: 20,
@@ -123,38 +156,66 @@ export function createHeapPressureWatch(
 ): HeapPressureWatch {
   const policy = { ...DEFAULTS, ...options };
   const capBytes = options.capBytes;
-  const longestWindowMs = Math.max(...policy.windowsMs);
-  const history: { atMs: number; bytes: number }[] = [];
+  /** Growth steps, oldest first; `bytes` is the heap the step arrived at. */
+  const steps: { atMs: number; bytes: number; grewBy: number }[] = [];
+  let previousBytes: number | null = null;
+  let previousAtMs = -Infinity;
+  /** When the client first held any memory — the clock the warm-up runs on. */
+  let allocatingSinceMs: number | null = null;
   let raised: HeapPressureLevel = 'none';
   let pending: HeapPressureLevel = 'none';
   let streak = 0;
 
   return {
     sample(bytes, atMs) {
-      const previous = history.at(-1);
       // A repeated or backwards timestamp would divide by zero or by a
       // negative; the sample is dropped rather than allowed to produce a rate.
-      if (!previous || atMs > previous.atMs) history.push({ atMs, bytes });
-      while (history.length > 1 && history[0]!.atMs < atMs - longestWindowMs * 2) {
-        history.shift();
+      if (atMs > previousAtMs) {
+        if (allocatingSinceMs === null && bytes > 0) allocatingSinceMs = atMs;
+        const settled =
+          allocatingSinceMs !== null
+          && atMs >= allocatingSinceMs + policy.warmupMs;
+        if (settled && previousBytes !== null && bytes > previousBytes) {
+          steps.push({ atMs, bytes, grewBy: bytes - previousBytes });
+          // Only the newest step old enough to be a base is ever read again,
+          // so everything before it goes. Pruning against the newest *step*
+          // rather than against now is what keeps the base from being thrown
+          // away during a plateau, when nothing newer can replace it.
+          const oldestUseful = atMs - policy.minSpanMs;
+          while (steps.length > 2 && steps[1]!.atMs <= oldestUseful) {
+            steps.shift();
+          }
+        }
+        previousBytes = bytes;
+        previousAtMs = atMs;
       }
 
       let bytesPerMinute: number | null = null;
-      for (const windowMs of policy.windowsMs) {
-        // A window with no sample old enough is not usable, and one whose base
-        // is still inside the startup ramp is worse than unusable — it reports
-        // the cost of launching the game as the cost of playing it.
-        // Extrapolating either is how a young session invents a rate it never
-        // saw.
-        const base = [...history]
-          .reverse()
-          .find((entry) =>
-            entry.atMs <= atMs - windowMs && entry.atMs >= policy.warmupMs);
-        if (!base) continue;
-        const elapsed = (atMs - base.atMs) / 60_000;
-        if (elapsed <= 0) continue;
-        const slope = Math.max(0, (bytes - base.bytes) / elapsed);
-        bytesPerMinute = Math.max(bytesPerMinute ?? 0, slope);
+      const last = steps.at(-1);
+      let baseIndex = -1;
+      if (last) {
+        const cutoff = last.atMs - policy.minSpanMs;
+        for (let i = steps.length - 1; i >= 0; i -= 1) {
+          if (steps[i]!.atMs <= cutoff) {
+            baseIndex = i;
+            break;
+          }
+        }
+      }
+      const base = baseIndex >= 0 ? steps[baseIndex] : undefined;
+      if (last && base) {
+        const spanMs = last.atMs - base.atMs;
+        // How long the heap has stood still since the last step. On a regular
+        // staircase this only ever climbs to one tread's width and resets, so
+        // it changes nothing; past that width it is evidence the spending has
+        // slowed, and it stretches the denominator rather than leaving a stale
+        // rate in place for a player who has walked back into town.
+        const meanStepMs = spanMs / (steps.length - 1 - baseIndex);
+        const overdueMs = Math.max(0, atMs - last.atMs - meanStepMs);
+        const minutes = (spanMs + overdueMs) / 60_000;
+        if (minutes > 0) {
+          bytesPerMinute = Math.max(0, (last.bytes - base.bytes) / minutes);
+        }
       }
       if (
         bytesPerMinute !== null
@@ -163,7 +224,20 @@ export function createHeapPressureWatch(
         bytesPerMinute = null;
       }
 
-      const headroom = capBytes > 0 ? Math.max(0, capBytes - bytes) : null;
+      // What the client has actually filled, as against what it has reserved
+      // for itself. Growth fires when a request no longer fits, so at the
+      // instant of a step the filled bytes are what the reserve was *before*
+      // it, and between steps they climb at the rate just measured. Taking
+      // headroom off the reserve instead makes every step look like ten
+      // minutes of play disappearing at once: the figure sits still for a
+      // tread and then lurches, and it reads a session as a third shorter
+      // than it is. The error here is one allocation request, not one step.
+      let filled = bytes;
+      if (last && bytesPerMinute !== null) {
+        const spentSinceStep = (bytesPerMinute * (atMs - last.atMs)) / 60_000;
+        filled = Math.min(bytes, bytes - last.grewBy + spentSinceStep);
+      }
+      const headroom = capBytes > 0 ? Math.max(0, capBytes - filled) : null;
       const rawMinutes =
         headroom !== null && bytesPerMinute !== null && bytesPerMinute > 0
           ? headroom / bytesPerMinute

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -200,19 +200,36 @@
 
 <div id="log"></div>
 <output id="diagnostics" aria-live="off"></output>
-<!-- The heap watermark notice: shown over the running game when WASM memory
-     nears its 2 GiB cap, so the player can reload from a safe place instead
-     of crashing mid-mission. harness.ts owns when; failure-messages.ts owns
-     the words. -->
+<!-- The memory warning: shown over the running game when the client's heap is
+     running out, so the player can reload at a moment they choose instead of
+     crashing at one they did not. harness.ts owns when and how many minutes;
+     failure-messages.ts owns every word. -->
 <div id="memory-notice" role="status" aria-live="polite" hidden>
   <div id="memory-notice-text">
     <strong id="memory-notice-label"></strong>
     <span id="memory-notice-detail"></span>
+    <button type="button" id="memory-notice-why"></button>
   </div>
   <div id="memory-notice-actions">
     <button type="button" id="memory-notice-later"></button>
-    <button type="button" id="memory-notice-reload"></button>
+    <button type="button" id="memory-notice-reload" class="primary"></button>
   </div>
+</div>
+<!-- What Later leaves behind. The banner's figure is frozen when it is shown,
+     so this is the surface that keeps counting — a dismissal is a deferral,
+     not the silence that preceded the crashes this warning exists for. -->
+<button type="button" id="memory-chip" hidden>
+  <span class="memory-chip-dot" aria-hidden="true"></span>
+  <span id="memory-chip-text"></span>
+</button>
+<!-- The explanation is a modal task, so unlike the notice it dims the game.
+     It opens in the notice's place: two translucent surfaces never stack. -->
+<div id="memory-scrim" hidden></div>
+<div id="memory-why" role="dialog" aria-modal="true"
+     aria-labelledby="memory-why-title" hidden>
+  <h2 id="memory-why-title" class="sr-only"></h2>
+  <div id="memory-why-blocks"></div>
+  <button type="button" id="memory-why-close"></button>
 </div>
 <output id="capture-status" hidden aria-live="off">
   <span class="capture-dot" aria-hidden="true"></span>

--- a/tests/electron/dev-panel.spec.ts
+++ b/tests/electron/dev-panel.spec.ts
@@ -102,4 +102,72 @@ test.describe("memory debug panel", () => {
       await closeOffline(fixture);
     }
   });
+
+  test("keeps the warning's own clicks off the game behind it", async () => {
+    const fixture = await launchOffline("gw-notice-events-");
+    try {
+      const { page } = fixture;
+      await togglePanel(page);
+      await page.locator('#dev-panel button[data-role="low"]').click();
+      await expect(page.locator("#memory-notice")).toBeVisible();
+
+      // The client listens on the window, so without a boundary at the notice
+      // root, dismissing the warning also hands the game a click — in the
+      // middle of whatever the player was doing when it appeared.
+      const reached = await page.evaluate(async () => {
+        let seen = 0;
+        const count = () => {
+          seen += 1;
+        };
+        for (const name of ["click", "pointerdown", "mousedown", "keydown"]) {
+          window.addEventListener(name, count);
+        }
+        document.getElementById("memory-notice-later")?.click();
+        return seen;
+      });
+      expect(reached).toBe(0);
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
+  test("holds the keyboard inside the explanation it says is modal", async () => {
+    const fixture = await launchOffline("gw-notice-modal-");
+    try {
+      const { page } = fixture;
+      await togglePanel(page);
+      // The warning is drawn over a running game, and this fixture never gets
+      // one — the launcher is still up, and it is meant to cover the notice.
+      // The panel's own Dismiss is how the launcher goes away.
+      await page.locator('#dev-panel button[data-role="dismiss"]').click();
+      await page.locator('#dev-panel button[data-role="critical"]').click();
+      // The notice's copy arrives with a deferred import, so its own controls
+      // have no box until it does.
+      await expect(page.locator("#memory-notice")).toBeVisible();
+      await page.locator("#memory-notice-why").click();
+
+      const why = page.locator("#memory-why");
+      await expect(why).toBeVisible();
+      await expect(why).toHaveAttribute("aria-modal", "true");
+      // aria-modal tells a screen reader the game behind this is not there.
+      // The keyboard has to agree, or the two describe different apps.
+      const focused = () => page.evaluate(() => document.activeElement?.id ?? "");
+      expect(await focused()).toBe("memory-why-close");
+      for (const key of ["Tab", "Tab", "Shift+Tab"]) {
+        await page.keyboard.press(key);
+        expect(await focused()).toBe("memory-why-close");
+      }
+
+      // And Escape closes it, which is the only way out that does not need a
+      // pointer the game may be holding. The dimming goes with it — a scrim
+      // left over a live game is the worst thing this surface could leave
+      // behind. (The notice does not return here: this one was the panel's
+      // preview, so there is no real escalation to come back to.)
+      await page.keyboard.press("Escape");
+      await expect(why).toBeHidden();
+      await expect(page.locator("#memory-scrim")).toBeHidden();
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
 });

--- a/tests/policy/source-wasm-host.test.ts
+++ b/tests/policy/source-wasm-host.test.ts
@@ -525,4 +525,46 @@ test("the memory warning measures time and keeps its one contract import", async
     /id="memory-notice"[^>]*aria-modal/u,
     "the notice must not block the game it is drawn over",
   );
+  // `aria-modal` tells a screen reader the game behind it is not there. Half
+  // that contract — the attribute without a keyboard that agrees — describes
+  // an app the player is not using.
+  assert.match(
+    harness,
+    /heapWhyRoot\.hidden\) return;[\s\S]{0,400}'Tab'[\s\S]{0,200}focus\(\)/u,
+    "an aria-modal explanation must trap the keyboard inside itself",
+  );
+});
+
+test("the memory warning measures a staircase step to step", async () => {
+  const pressure = await readFile(
+    path.join(root, "src/renderer/heap-pressure.ts"),
+    "utf8",
+  );
+
+  // `Module.HEAPU8.buffer` is *reserved* memory and WebAssembly reserves it in
+  // jumps — about one 96 MiB step every ten minutes at the measured open-world
+  // rate, and flat in between. A fixed-duration window over that shape holds
+  // either no step or one, and reads a steady 555 MiB/h session as alternating
+  // between 384 and 1,152. Both ends of a measurement belong on a step, which
+  // is why the module keeps the steps rather than the samples.
+  assert.match(
+    pressure,
+    /const steps: \{ atMs: number; bytes: number; grewBy: number \}\[\]/u,
+    "the estimator must measure growth steps, not raw samples",
+  );
+  assert.doesNotMatch(
+    pressure,
+    /windowsMs/u,
+    "a fixed-duration window cannot measure a staircase",
+  );
+
+  // The warm-up excludes the startup ramp, and where its clock starts is the
+  // whole of whether it works: the page stays open through the client
+  // download, so a slow first run boots after a page-load-anchored warm-up has
+  // already expired and the ramp is measured as ordinary play.
+  assert.match(
+    pressure,
+    /allocatingSinceMs === null && bytes > 0\) allocatingSinceMs = atMs/u,
+    "the warm-up must run from the first allocation, not from page load",
+  );
 });

--- a/tests/policy/source-wasm-host.test.ts
+++ b/tests/policy/source-wasm-host.test.ts
@@ -467,3 +467,62 @@ test("a completed client main loop closes the host application", async () => {
   assert.match(harness, /onExit\(code\)/);
   assert.match(harness, /code === 0[\s\S]*native\(\)\.app\.requestQuit\(\)/);
 });
+
+test("the memory warning measures time and keeps its one contract import", async () => {
+  const [harness, pressure, css, html] = await Promise.all([
+    readFile(path.join(root, "src/renderer/harness.ts"), "utf8"),
+    readFile(path.join(root, "src/renderer/heap-pressure.ts"), "utf8"),
+    readFile(path.join(root, "src/renderer/harness.css"), "utf8"),
+    readFile(path.join(root, "src/renderer/index.html"), "utf8"),
+  ]);
+
+  // The packaged Enhancement-runtime proof observes the runtime's own request
+  // for the canonical contract. A second importer, or this one moved to boot,
+  // resolves it from the module cache and the proof stops proving anything.
+  //
+  // Only a runtime import counts. `import('…').SomeType` is a type position,
+  // erased before anything is fetched, and harness.ts names several — the
+  // negative lookahead is what tells the two apart in source text.
+  assert.equal(
+    harness.match(/import\('\.\.\/shared\/contracts\.js'\)(?!\s*\.)/gu)?.length,
+    1,
+    "harness.ts must import the canonical contract exactly once at runtime",
+  );
+  assert.match(
+    harness,
+    /function requestHeapCap\(\)[\s\S]{0,400}import\('\.\.\/shared\/contracts\.js'\)/u,
+    "the contract import must stay inside requestHeapCap",
+  );
+  assert.doesNotMatch(
+    pressure,
+    /from ['"]\.\.\/shared\//u,
+    "heap-pressure.ts must take the cap as an argument, not import it",
+  );
+
+  // The estimator is what makes the warning mean the same thing in an outpost
+  // and in a mission; a byte-only watcher is the defect it replaced.
+  assert.match(harness, /heapWatch\.sample\(wasmHeapBytes\(\), performance\.now\(\)\)/u);
+
+  // A warning drawn over a live game has to survive the three preferences that
+  // change how it may be drawn at all.
+  for (const query of [
+    "prefers-reduced-motion",
+    "prefers-reduced-transparency",
+    "prefers-contrast",
+  ]) {
+    const block = css.slice(css.indexOf(`@media (${query}`));
+    assert.ok(
+      block.slice(0, 600).includes("#memory-notice"),
+      `${query} must cover the memory notice`,
+    );
+  }
+
+  // The explanation is modal and the notice is not: one dims the game and
+  // takes focus, the other runs beside play.
+  assert.match(html, /id="memory-why"[^>]*role="dialog"[^>]*aria-modal="true"/u);
+  assert.doesNotMatch(
+    html,
+    /id="memory-notice"[^>]*aria-modal/u,
+    "the notice must not block the game it is drawn over",
+  );
+});

--- a/tests/unit/failure-codes-become-sentences-in-the-renderer.test.ts
+++ b/tests/unit/failure-codes-become-sentences-in-the-renderer.test.ts
@@ -185,8 +185,8 @@ describe("renderer failure messages", () => {
   });
 
   it("escalates the memory watermark words, not its actions", () => {
-    const low = memoryPressurePresentation("low", 20);
-    const critical = memoryPressurePresentation("critical", 5);
+    const low = memoryPressurePresentation("low");
+    const critical = memoryPressurePresentation("critical");
     for (const notice of [low, critical]) {
       for (const text of [
         notice.label,
@@ -222,41 +222,36 @@ describe("renderer failure messages", () => {
     assert.equal(low.dismissButton, critical.dismissButton);
   });
 
-  it("claims a number only when one was measured, and never in the detail", () => {
-    const measured = memoryPressurePresentation("low", 20);
-    assert.match(measured.label, /About 20 minutes/);
-
-    // No rate, no figure. An estimate we did not measure is worse than none,
-    // so the label falls back to the sentence that states only the condition.
-    const blind = memoryPressurePresentation("low", null);
-    assert.doesNotMatch(blind.label, /\d/);
-    assert.match(blind.label, /running low/);
-    assert.doesNotMatch(memoryPressurePresentation("critical", null).label, /\d/);
-
-    // The number is injected, not baked in, and it agrees with itself.
-    assert.match(memoryPressurePresentation("critical", 3).label, /About 3 minutes/);
-    assert.match(memoryPressurePresentation("critical", 1).label, /About 1 minute\b/);
-
-    // The estimate rounds to whole minutes, so the last half-minute reaches
-    // here as a zero. "About 0 minutes" reads as a broken app at the one
-    // moment the sentence has to be believed. Reachable from the chip, which
-    // re-opens the banner against a live figure.
+  it("names no figure the player could check against a clock", () => {
+    // The thresholds count in time; the sentences do not print the time. That
+    // split was decided by the Eye of the North crash bundle of 2026-08-04:
+    // replayed against the client run that reached the cap, the levels landed
+    // where they should — `low` with 31 real minutes left where the shipped
+    // byte rule gave 11 — and the figure read 10 → 15 → 20 → 75 → 40 → 20 →
+    // 15 → 10 → 3, offering "about 75 minutes" to a player with 18 left. A
+    // quiet stretch had drifted into the measurement window just before they
+    // went back into heavy loading, and no rate can see that coming.
+    //
+    // The estimate still exists and still sets the level. It is a diagnostic:
+    // the debug panel shows it and the log records it. A diagnostic on a
+    // banner is a promise, so nothing here may carry one.
     for (const level of ["low", "critical"] as const) {
-      const expiring = memoryPressurePresentation(level, 0);
-      assert.match(expiring.label, /^Under a minute/);
-      assert.doesNotMatch(expiring.label, /\b0\b/);
-    }
-
-    // Never in the detail: the banner's number is frozen when shown, and a
-    // stale figure in a sentence that outlives it would be a lie.
-    for (const minutes of [null, 1, 5, 20] as const) {
-      for (const level of ["low", "critical"] as const) {
-        assert.doesNotMatch(
-          memoryPressurePresentation(level, minutes).detail,
-          /\d/,
-        );
+      const notice = memoryPressurePresentation(level);
+      for (const text of [notice.label, notice.detail, notice.whyLink]) {
+        assert.doesNotMatch(text, /\d/, text);
       }
+      assert.doesNotMatch(memoryPressureChip(level).text, /\d/);
+      assert.doesNotMatch(memoryPressureChip(level).label, /\d/);
     }
+    // Low reads as headroom, critical as imminent — the escalation the figure
+    // used to carry has to live in the words instead.
+    assert.match(memoryPressurePresentation("low").label, /running low/);
+    assert.match(memoryPressurePresentation("critical").label, /almost out of/);
+    assert.notEqual(
+      memoryPressureChip("low").text,
+      memoryPressureChip("critical").text,
+      "the chip says the same thing at both levels",
+    );
   });
 
   it("states the reconnect that was measured, and claims nothing past it", () => {
@@ -269,8 +264,8 @@ describe("renderer failure messages", () => {
     // server. That is answered, so the assertion turns around and guards the
     // opposite failure: a promise wider than the evidence.
     const strings = [
-      memoryPressurePresentation("low", 20),
-      memoryPressurePresentation("critical", 5),
+      memoryPressurePresentation("low"),
+      memoryPressurePresentation("critical"),
     ].flatMap((notice) => [notice.label, notice.detail]);
     const explanation = memoryExplanation();
     strings.push(...explanation.blocks.map((block) => block.body));
@@ -308,12 +303,14 @@ describe("renderer failure messages", () => {
     assert.doesNotMatch(joined, /in contact with|reported to ArenaNet/i);
   });
 
-  it("keeps counting on the chip a dismissal leaves behind", () => {
-    assert.match(memoryPressureChip("critical", 4).text, /4/);
-    assert.ok(memoryPressureChip("critical", 4).label.length > 20);
-    // Below a minute it must not round up to "1 min" and read as reassurance.
-    assert.match(memoryPressureChip("critical", 0).text, /Under a minute/);
-    // And with no measurement it states the condition rather than a figure.
-    assert.doesNotMatch(memoryPressureChip("low", null).text, /\d/);
+  it("leaves something behind when a warning is dismissed", () => {
+    // `Later` used to mean silence until the crash. The chip is what stops
+    // that, and its accessible name has to say what it will do when clicked.
+    for (const level of ["low", "critical"] as const) {
+      const chip = memoryPressureChip(level);
+      assert.ok(chip.text.length > 0 && chip.text.length < 24, chip.text);
+      assert.match(chip.label, /memory/i);
+      assert.match(chip.label, /again/);
+    }
   });
 });

--- a/tests/unit/failure-codes-become-sentences-in-the-renderer.test.ts
+++ b/tests/unit/failure-codes-become-sentences-in-the-renderer.test.ts
@@ -197,8 +197,12 @@ describe("renderer failure messages", () => {
       ]) {
         assert.ok(text.length > 0, "memory notice has empty prose");
       }
-      // The safe place is named, so a player who wants certainty has it.
-      assert.match(notice.detail, /town or outpost/);
+      // The outpost belongs to the explanation now, not to the notice. It is
+      // still the one place that risks nothing, but the reconnect is measured,
+      // and repeating a caveat against a measured fact is what made the
+      // shipped sentence easy to ignore from inside a dungeon.
+      assert.doesNotMatch(notice.detail, /town or outpost/);
+      assert.match(memoryExplanation().blocks[3]!.body, /town or outpost/);
       // The detail opens with the action. Derived from the button so it
       // survives a rename, and it pins the ordering the redesign is about:
       // what to do first, why it is happening behind a link.
@@ -255,10 +259,15 @@ describe("renderer failure messages", () => {
     }
   });
 
-  it("hedges the reconnect until somebody has actually tested it", () => {
-    // Guild Wars offers an instance back after a dropped connection, but
-    // whether our reload triggers that offer is unverified. This test is what
-    // stops the wording being firmed up before the experiment is run.
+  it("states the reconnect that was measured, and claims nothing past it", () => {
+    // This test used to require the hedge — "should be able to rejoin" — and
+    // fail if anyone firmed the wording before the experiment had been run.
+    // It has been run: 2026-08-05, all five reload paths, from inside an
+    // instance, progress intact every time and back inside thirty seconds.
+    // The uncertainty was never whether Guild Wars restores an instance after
+    // a dropped connection; it was whether our reload looks like one to the
+    // server. That is answered, so the assertion turns around and guards the
+    // opposite failure: a promise wider than the evidence.
     const strings = [
       memoryPressurePresentation("low", 20),
       memoryPressurePresentation("critical", 5),
@@ -267,11 +276,18 @@ describe("renderer failure messages", () => {
     strings.push(...explanation.blocks.map((block) => block.body));
 
     assert.ok(
-      strings.some((text) => /should be able to rejoin/.test(text)),
-      "the hedge disappeared",
+      strings.some((text) => /puts you back where you were/.test(text)),
+      "the measured reconnect stopped being stated",
     );
+    assert.ok(
+      strings.every((text) => !/should be able to/.test(text)),
+      "a hedge the experiment retired came back",
+    );
+    // What was tested is one tester, one account, five paths. It says the
+    // reconnect works and how long it took; it must not promise that nothing
+    // can ever go wrong, which no session count would earn.
     for (const text of strings) {
-      assert.doesNotMatch(text, /\b(will|can) (put|place|return) you back\b/i, text);
+      assert.doesNotMatch(text, /\b(guarantee\w*|never lose|always works?)\b/i, text);
     }
   });
 

--- a/tests/unit/failure-codes-become-sentences-in-the-renderer.test.ts
+++ b/tests/unit/failure-codes-become-sentences-in-the-renderer.test.ts
@@ -233,6 +233,16 @@ describe("renderer failure messages", () => {
     assert.match(memoryPressurePresentation("critical", 3).label, /About 3 minutes/);
     assert.match(memoryPressurePresentation("critical", 1).label, /About 1 minute\b/);
 
+    // The estimate rounds to whole minutes, so the last half-minute reaches
+    // here as a zero. "About 0 minutes" reads as a broken app at the one
+    // moment the sentence has to be believed. Reachable from the chip, which
+    // re-opens the banner against a live figure.
+    for (const level of ["low", "critical"] as const) {
+      const expiring = memoryPressurePresentation(level, 0);
+      assert.match(expiring.label, /^Under a minute/);
+      assert.doesNotMatch(expiring.label, /\b0\b/);
+    }
+
     // Never in the detail: the banner's number is frozen when shown, and a
     // stale figure in a sentence that outlives it would be a lie.
     for (const minutes of [null, 1, 5, 20] as const) {

--- a/tests/unit/failure-codes-become-sentences-in-the-renderer.test.ts
+++ b/tests/unit/failure-codes-become-sentences-in-the-renderer.test.ts
@@ -14,6 +14,8 @@ import {
   describeSnapshotReadFailure as snapshotRead,
   describeSteamRefusal,
   failureDetail,
+  memoryExplanation,
+  memoryPressureChip,
   memoryPressurePresentation,
   suggestReport,
 } from "../../src/renderer/failure-messages.js";
@@ -183,29 +185,109 @@ describe("renderer failure messages", () => {
   });
 
   it("escalates the memory watermark words, not its actions", () => {
-    const low = memoryPressurePresentation("low");
-    const critical = memoryPressurePresentation("critical");
+    const low = memoryPressurePresentation("low", 20);
+    const critical = memoryPressurePresentation("critical", 5);
     for (const notice of [low, critical]) {
       for (const text of [
         notice.label,
         notice.detail,
         notice.reloadButton,
         notice.dismissButton,
+        notice.whyLink,
       ]) {
         assert.ok(text.length > 0, "memory notice has empty prose");
       }
-      // The whole point of the notice: the player picks a safe place first.
+      // The safe place is named, so a player who wants certainty has it.
       assert.match(notice.detail, /town or outpost/);
-      // The detail must name the button it tells the player to press.
-      assert.ok(notice.detail.includes(notice.reloadButton));
+      // The detail opens with the action. Derived from the button so it
+      // survives a rename, and it pins the ordering the redesign is about:
+      // what to do first, why it is happening behind a link.
+      assert.ok(
+        notice.detail.startsWith(notice.reloadButton.split(" ")[0]!),
+        `detail does not open with the action: ${notice.detail}`,
+      );
     }
-    // Low reads as headroom; critical reads as imminent.
-    assert.match(low.label, /running low/);
-    assert.match(critical.label, /almost out of memory/);
-    assert.match(critical.detail, /^A crash is likely soon/);
+    // Escalation lives in the urgency of the instruction, not in a fear
+    // sentence: the deadline shrinks and "when it suits you" becomes "soon".
+    assert.match(low.detail, /^Reload when it suits you/);
+    assert.match(critical.detail, /^Reload soon/);
+    assert.match(critical.label, /out of memory/);
     // Buttons are identical across levels: escalation changes the words,
     // not the actions.
     assert.equal(low.reloadButton, critical.reloadButton);
     assert.equal(low.dismissButton, critical.dismissButton);
+  });
+
+  it("claims a number only when one was measured, and never in the detail", () => {
+    const measured = memoryPressurePresentation("low", 20);
+    assert.match(measured.label, /About 20 minutes/);
+
+    // No rate, no figure. An estimate we did not measure is worse than none,
+    // so the label falls back to the sentence that states only the condition.
+    const blind = memoryPressurePresentation("low", null);
+    assert.doesNotMatch(blind.label, /\d/);
+    assert.match(blind.label, /running low/);
+    assert.doesNotMatch(memoryPressurePresentation("critical", null).label, /\d/);
+
+    // The number is injected, not baked in, and it agrees with itself.
+    assert.match(memoryPressurePresentation("critical", 3).label, /About 3 minutes/);
+    assert.match(memoryPressurePresentation("critical", 1).label, /About 1 minute\b/);
+
+    // Never in the detail: the banner's number is frozen when shown, and a
+    // stale figure in a sentence that outlives it would be a lie.
+    for (const minutes of [null, 1, 5, 20] as const) {
+      for (const level of ["low", "critical"] as const) {
+        assert.doesNotMatch(
+          memoryPressurePresentation(level, minutes).detail,
+          /\d/,
+        );
+      }
+    }
+  });
+
+  it("hedges the reconnect until somebody has actually tested it", () => {
+    // Guild Wars offers an instance back after a dropped connection, but
+    // whether our reload triggers that offer is unverified. This test is what
+    // stops the wording being firmed up before the experiment is run.
+    const strings = [
+      memoryPressurePresentation("low", 20),
+      memoryPressurePresentation("critical", 5),
+    ].flatMap((notice) => [notice.label, notice.detail]);
+    const explanation = memoryExplanation();
+    strings.push(...explanation.blocks.map((block) => block.body));
+
+    assert.ok(
+      strings.some((text) => /should be able to rejoin/.test(text)),
+      "the hedge disappeared",
+    );
+    for (const text of strings) {
+      assert.doesNotMatch(text, /\b(will|can) (put|place|return) you back\b/i, text);
+    }
+  });
+
+  it("explains the memory limit without claiming ArenaNet has been contacted", () => {
+    const explanation = memoryExplanation();
+    assert.equal(explanation.blocks.length, 4);
+    for (const block of explanation.blocks) {
+      assert.ok(block.title.length > 0, "block has no title");
+      assert.ok(block.body.length > 40, `${block.title} is not an explanation`);
+    }
+    const stands = explanation.blocks[2]!;
+    for (const claim of [/measured/, /documented/, /published/]) {
+      assert.match(stands.body, claim);
+    }
+    // What is true today is that the findings are published. Saying more than
+    // that in the app would be a claim nobody could back.
+    const joined = explanation.blocks.map((block) => block.body).join(" ");
+    assert.doesNotMatch(joined, /in contact with|reported to ArenaNet/i);
+  });
+
+  it("keeps counting on the chip a dismissal leaves behind", () => {
+    assert.match(memoryPressureChip("critical", 4).text, /4/);
+    assert.ok(memoryPressureChip("critical", 4).label.length > 20);
+    // Below a minute it must not round up to "1 min" and read as reassurance.
+    assert.match(memoryPressureChip("critical", 0).text, /Under a minute/);
+    // And with no measurement it states the condition rather than a figure.
+    assert.doesNotMatch(memoryPressureChip("low", null).text, /\d/);
   });
 });

--- a/tests/unit/the-memory-warning-counts-time-not-bytes.test.ts
+++ b/tests/unit/the-memory-warning-counts-time-not-bytes.test.ts
@@ -2,11 +2,21 @@
 // 2026-08-04. The shipped build warned on bytes remaining, which meant the same
 // sentence bought half an hour in the open world and about two minutes inside a
 // mission — the second row here is the whole reason this module exists.
+//
+// Every session below is a staircase, not a ramp, because that is what the
+// runtime presents: `Module.HEAPU8.buffer` is *reserved* memory and WebAssembly
+// reserves it in jumps. An earlier version of this file drove smooth linear
+// growth and passed while the shipped estimator read a steady 555 MiB/h session
+// as alternating between 384 and 1,152 — the test was measuring a shape no
+// client produces. `simulate` below is the fix: it models the allocator, works
+// out when the client really dies, and every assertion is what the player was
+// told against what was true at that moment.
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   createHeapPressureWatch,
   hedgeMinutes,
+  type HeapPressurePolicy,
   type HeapPressureLevel,
   type HeapPressureReading,
 } from "../../src/renderer/heap-pressure.js";
@@ -14,71 +24,186 @@ import {
 const MIB = 1_048_576;
 const CAP = 2048 * MIB;
 const TICK_MS = 15_000;
+const TICK_MINUTES = TICK_MS / 60_000;
+
+interface Tick extends HeapPressureReading {
+  atMinutes: number;
+  /** Minutes until this session really ends, known from the whole run. */
+  trulyLeft: number;
+}
+
+interface Session {
+  diesAtMinutes: number;
+  ticks: readonly Tick[];
+  /** The first tick at each level, which is all the player ever experiences. */
+  raised: Map<HeapPressureLevel, Tick>;
+}
 
 /**
- * A session at a constant rate, sampled on the watcher's own 15-second tick.
- * Returns the reading at which each level was first raised, which is the only
- * thing the player ever experiences.
+ * A session as the runtime actually presents it.
+ *
+ * The client fills memory smoothly and the runtime reserves it in steps:
+ * Emscripten's glue grows by a fifth of the current size, capped at 96 MiB,
+ * and never by less than the allocation needs. At the measured open-world rate
+ * that is one step roughly every ten minutes with a flat heap in between —
+ * which is the entire difficulty this module exists to handle.
+ *
+ * The physics run first and to the end, so the death is known before the
+ * watcher is asked about it. Nothing here asserts against the watcher's own
+ * arithmetic; every claim is checked against the session that really happened.
  */
-function play(mibPerHour: number, startMib = 300, capBytes = CAP) {
-  const watch = createHeapPressureWatch({ capBytes });
-  const first = new Map<HeapPressureLevel, { atMinutes: number; reading: HeapPressureReading }>();
-  let atMs = 0;
-  for (let step = 0; step < 4 * 60 * 4; step += 1) {
-    const minutes = atMs / 60_000;
-    const bytes = (startMib + (mibPerHour / 60) * minutes) * MIB;
-    if (bytes >= capBytes) break;
-    const reading = watch.sample(bytes, atMs);
-    if (!first.has(reading.level)) {
-      first.set(reading.level, { atMinutes: minutes, reading });
+function simulate(options: {
+  /** MiB per hour of real spending, constant or per-minute. */
+  rate: number | ((minute: number) => number);
+  startMib?: number;
+  /** Minutes the page is open before the client allocates anything. */
+  bootAtMinutes?: number;
+  /** One-off reservations — a zone load is a couple of hundred MiB in seconds. */
+  loads?: readonly { atMinutes: number; mib: number }[];
+  policy?: HeapPressurePolicy;
+  capBytes?: number;
+}): Session {
+  const capBytes = options.capBytes ?? CAP;
+  const boot = options.bootAtMinutes ?? 0;
+  const rateAt = (minute: number) =>
+    typeof options.rate === "function" ? options.rate(minute) : options.rate;
+
+  const frames: { atMinutes: number; reservedMib: number }[] = [];
+  let usedMib = 0;
+  let reservedMib = 0;
+  let diesAtMinutes = Infinity;
+  for (let minute = 0; minute < 600; minute += TICK_MINUTES) {
+    if (minute >= boot) {
+      if (usedMib === 0) usedMib = options.startMib ?? 690;
+      usedMib += (rateAt(minute) / 60) * TICK_MINUTES;
+      for (const load of options.loads ?? []) {
+        if (Math.abs(minute - load.atMinutes) < TICK_MINUTES / 2) {
+          usedMib += load.mib;
+        }
+      }
+      // The glue's own growth rule, and it repeats until the ask fits.
+      while (usedMib > reservedMib) {
+        reservedMib += Math.max(16, Math.min(96, reservedMib * 0.2));
+      }
     }
-    atMs += TICK_MS;
+    if (usedMib * MIB >= capBytes) {
+      diesAtMinutes = minute;
+      break;
+    }
+    frames.push({ atMinutes: minute, reservedMib });
   }
-  return first;
+
+  const watch = createHeapPressureWatch({ capBytes, ...options.policy });
+  const raised = new Map<HeapPressureLevel, Tick>();
+  const ticks = frames.map((frame) => {
+    const reading = watch.sample(frame.reservedMib * MIB, frame.atMinutes * 60_000);
+    const tick: Tick = {
+      ...reading,
+      atMinutes: frame.atMinutes,
+      trulyLeft: diesAtMinutes - frame.atMinutes,
+    };
+    if (!raised.has(reading.level)) raised.set(reading.level, tick);
+    return tick;
+  });
+  return { diesAtMinutes, ticks, raised };
 }
+
+/** Every figure the player was shown, and what was true when they saw it. */
+const claims = (session: Session) =>
+  session.ticks.filter((tick) => tick.minutes !== null);
 
 describe("the memory warning counts time, not bytes", () => {
   it("warns an open-world session with the headroom it claims", () => {
-    // 555 MiB/h, measured over 2 h 16 m. The cap arrives at about 3 h 09 m.
-    const run = play(555);
-    const low = run.get("low");
-    const critical = run.get("critical");
-    assert.ok(low && critical);
+    // 555 MiB/h, measured over 2 h 16 m.
+    const session = simulate({ rate: 555 });
+    const low = session.raised.get("low");
+    const critical = session.raised.get("critical");
+    assert.ok(low && critical, "the session ended without warning");
 
+    // The claim has to be true, not merely present.
     assert.ok(
-      low.reading.minutes !== null && low.reading.minutes >= 15 && low.reading.minutes <= 20,
-      `low claimed ${low.reading.minutes} minutes`,
+      low.trulyLeft > 15 && low.trulyLeft < 26,
+      `low arrived with ${low.trulyLeft.toFixed(1)} real minutes left`,
     );
     assert.ok(
-      critical.reading.minutes !== null && critical.reading.minutes <= 5,
-      `critical claimed ${critical.reading.minutes} minutes`,
+      critical.trulyLeft > 3 && critical.trulyLeft < 9,
+      `critical arrived with ${critical.trulyLeft.toFixed(1)} real minutes left`,
     );
-    // The claim has to be true, not just present: the remaining headroom at
-    // the measured rate must be near the number the player was shown.
-    const remaining = (CAP - critical.reading.bytes) / MIB / (555 / 60);
-    assert.ok(remaining > 3 && remaining < 9, `${remaining} real minutes left`);
-    assert.equal(critical.reading.raisedBy, "time");
+    assert.equal(critical.raisedBy, "time");
   });
 
-  it("gives a texture-dense mission the same warning, not two minutes", () => {
+  it("gives a texture-dense mission a real warning, not ninety seconds", () => {
     // The Eye of the North report: the cap in about half an hour. Under the
     // shipped byte thresholds this player got "low" with three minutes left
     // and "critical" with ninety seconds — and crashed anyway.
-    const run = play(3_500);
-    const low = run.get("low");
-    const critical = run.get("critical");
-    assert.ok(low && critical);
-
-    assert.ok(low.atMinutes < 15, `low arrived at ${low.atMinutes} min`);
-    const lowHeadroomMib = (CAP - low.reading.bytes) / MIB;
+    const session = simulate({ rate: 3_500 });
+    const low = session.raised.get("low");
+    assert.ok(low, "the fast session was never warned at all");
     assert.ok(
-      lowHeadroomMib > 256,
-      `${lowHeadroomMib} MiB left — the shipped rule would not have fired yet`,
+      low.trulyLeft >= 4,
+      `only ${low.trulyLeft.toFixed(1)} minutes of warning`,
     );
 
-    // What the shipped build could not do: leave real minutes on the clock.
-    const remaining = (CAP - critical.reading.bytes) / MIB / (3_500 / 60);
-    assert.ok(remaining > 3, `${remaining} real minutes left at critical`);
+    // What the shipped build could not do: warn while there is still headroom
+    // to walk somewhere. Its 256 MiB rule fires about 3 minutes before death
+    // at this rate.
+    const headroomMib = (CAP - low.bytes) / MIB;
+    assert.ok(
+      headroomMib > 180,
+      `${headroomMib.toFixed(0)} MiB left — inside the shipped rule's reach`,
+    );
+  });
+
+  it("reads the rate that was actually spent, not the shape of the staircase", () => {
+    // The defect this test exists for. Reserved memory moves in ~96 MiB jumps
+    // about ten minutes apart at this rate, so a five-minute window contains
+    // either no step or one and reports 0 or 1,152 MiB/h for a session
+    // spending 555. Both ends of a measurement sit on a step for this reason.
+    for (const rate of [555, 3_500]) {
+      const measured = simulate({ rate })
+        .ticks.map((tick) => tick.bytesPerMinute)
+        .filter((value): value is number => value !== null)
+        .map((value) => (value * 60) / MIB);
+      assert.ok(measured.length > 0, `${rate} MiB/h was never measured at all`);
+      for (const value of measured) {
+        assert.ok(
+          Math.abs(value - rate) / rate < 0.1,
+          `read ${value.toFixed(0)} MiB/h for a session spending ${rate}`,
+        );
+      }
+    }
+  });
+
+  it("counts down instead of standing still and lurching", () => {
+    // Each step reserves about ten minutes of play at once. Read off the
+    // reserve, the estimate would sit through a whole tread and then drop ten
+    // minutes in one tick; the figure the player watches has to move the way
+    // time does. The five-minute granularity of the wording is the floor.
+    for (const rate of [555, 3_500]) {
+      const shown = claims(simulate({ rate })).map((tick) => tick.minutes!);
+      for (let i = 1; i < shown.length; i += 1) {
+        assert.ok(
+          Math.abs(shown[i]! - shown[i - 1]!) <= 5,
+          `${rate} MiB/h: the figure jumped ${shown[i - 1]} → ${shown[i]}`,
+        );
+      }
+    }
+  });
+
+  it("never names a number that is not close to true", () => {
+    // The whole premise. Anywhere a figure is shown, in either session, it has
+    // to be near the time that was really left — a warning nobody can check is
+    // worth as much as the "running low" it replaced.
+    for (const rate of [555, 3_500]) {
+      for (const tick of claims(simulate({ rate }))) {
+        const slack = Math.max(2.5, tick.trulyLeft * 0.35);
+        assert.ok(
+          Math.abs(tick.minutes! - tick.trulyLeft) <= slack,
+          `${rate} MiB/h at ${tick.atMinutes} min: said ${tick.minutes}`
+            + `, truly ${tick.trulyLeft.toFixed(1)}`,
+        );
+      }
+    }
   });
 
   it("does not read the cost of starting the game as the cost of playing it", () => {
@@ -86,93 +211,93 @@ describe("the memory warning counts time, not bytes", () => {
     // than three minutes in, against a steady-state 555 MiB/h. Measured from
     // inside that ramp the session looks a quarter of an hour from death, and
     // the warning fired at 36% of the cap — every player, every login.
-    const watch = createHeapPressureWatch({ capBytes: CAP });
-    let atMs = 0;
-    let last = watch.sample(0, atMs);
-    for (let minute = 0; minute <= 4; minute += 0.25) {
-      atMs = minute * 60_000;
-      last = watch.sample(Math.min(760, 260 * minute + 40) * MIB, atMs);
+    const session = simulate({
+      startMib: 40,
+      rate: (minute) => (minute < 3 ? 15_000 : 555),
+    });
+    for (const tick of session.ticks) {
+      if (tick.atMinutes > 60) break;
       assert.equal(
-        last.level,
+        tick.level,
         "none",
-        `warned ${minute} minutes in, at ${Math.round(last.bytes / MIB)} MiB`,
+        `warned ${tick.atMinutes} min in, at ${Math.round(tick.bytes / MIB)} MiB`,
       );
-      assert.equal(last.minutes, null, "claimed a figure measured from startup");
     }
-
     // Once the ramp is behind it, ordinary play is read as ordinary play.
-    const settledAt = atMs;
-    for (let minute = 5; minute <= 30; minute += 0.25) {
-      atMs = minute * 60_000;
-      const mib = 760 + (555 / 60) * (minute - settledAt / 60_000);
-      last = watch.sample(mib * MIB, atMs);
-    }
-    assert.equal(last.level, "none", "still quiet with two hours of headroom");
+    const settled = claims(session).at(-1);
+    assert.ok(settled?.bytesPerMinute, "the ramp silenced the whole session");
+    const perHour = (settled.bytesPerMinute * 60) / MIB;
     assert.ok(
-      last.bytesPerMinute !== null
-        && Math.round((last.bytesPerMinute * 60) / MIB) === 555,
-      `read ${Math.round(((last.bytesPerMinute ?? 0) * 60) / MIB)} MiB/h`,
+      Math.abs(perHour - 555) / 555 < 0.1,
+      `read ${perHour.toFixed(0)} MiB/h after a 15,000 MiB/h launch`,
     );
+  });
+
+  it("survives a first run whose download outlasts the warm-up", () => {
+    // The warm-up excludes the startup ramp, so where its clock starts decides
+    // whether it works. Anchored to page load it looks equivalent and is not:
+    // the page stays open through the client download, so a slow first run
+    // boots after the exclusion has already expired and the ramp is measured
+    // as ordinary play — 38% of the cap, "about 8 minutes of play left", two
+    // hours of real headroom. The clock starts at the first allocation.
+    const session = simulate({
+      bootAtMinutes: 12,
+      startMib: 40,
+      rate: (minute) => (minute < 15 ? 15_000 : 555),
+    });
+    for (const tick of session.ticks) {
+      if (tick.atMinutes > 70) break;
+      assert.equal(
+        tick.level,
+        "none",
+        `warned ${tick.atMinutes} min in, at ${Math.round(tick.bytes / MIB)} MiB`,
+      );
+    }
   });
 
   it("starts measuring when the player starts playing, not when they log in", () => {
-    // Ten minutes parked in Kamadan, then out into the world. The rate that
-    // matters begins at minute ten, and nothing about the idling before it
-    // should either warn or be averaged into what follows.
-    const watch = createHeapPressureWatch({ capBytes: CAP });
-    let atMs = 0;
-    let last = watch.sample(700 * MIB, atMs);
-    for (let minute = 0; minute <= 10; minute += 0.25) {
-      atMs = minute * 60_000;
-      last = watch.sample(700 * MIB, atMs);
-      assert.equal(last.level, "none", `warned while idle at ${minute} min`);
+    // Ten minutes parked in Kamadan, then out into the world. Nothing about
+    // the idling should either warn or be averaged into what follows.
+    const session = simulate({ rate: (minute) => (minute < 15 ? 0 : 555) });
+    for (const tick of session.ticks) {
+      if (tick.atMinutes > 40) break;
+      assert.equal(tick.level, "none", `warned while idle at ${tick.atMinutes}`);
     }
-    // Now playing, at the measured open-world rate.
-    for (let minute = 10.25; minute <= 25; minute += 0.25) {
-      atMs = minute * 60_000;
-      last = watch.sample((700 + (555 / 60) * (minute - 10)) * MIB, atMs);
-    }
-    assert.equal(last.level, "none", "still an hour of headroom");
-    // The idle stretch is behind the window by now, so the rate is the one the
-    // player is actually spending at — not a tenth of it.
-    assert.ok(
-      last.bytesPerMinute !== null
-        && Math.round((last.bytesPerMinute * 60) / MIB) === 555,
-      `read ${Math.round(((last.bytesPerMinute ?? 0) * 60) / MIB)} MiB/h`,
-    );
+    const late = claims(session).at(-1);
+    assert.ok(late && Math.abs((late.bytesPerMinute! * 60) / MIB - 555) < 60);
   });
 
   it("does not let one map load latch a warning that cannot be taken back", () => {
-    // A zone load allocates a couple of hundred MiB in seconds. Measured over
-    // a short enough window that reads as thousands of MiB an hour, and since
-    // the level never falls it would have been permanent — a player who then
-    // played quietly for an hour would keep a warning that had already been
-    // wrong for fifty minutes.
-    const watch = createHeapPressureWatch({ capBytes: CAP });
-    let heap = 900;
-    watch.sample(heap * MIB, 0);
-    for (let minute = 0.25; minute <= 20; minute += 0.25) {
-      // One 220 MiB load at minute twelve, quiet either side of it.
-      if (Math.abs(minute - 12) < 0.13) heap += 220;
-      const last = watch.sample(heap * MIB, minute * 60_000);
-      assert.equal(
-        last.level,
-        "none",
-        `a single map load warned at ${minute} min`,
-      );
-    }
-    assert.equal(heap, 1120, "the load did happen");
+    // A zone load reserves a couple of hundred MiB in seconds. Measured over a
+    // window short enough it reads as thousands of MiB an hour, and since the
+    // level never falls it would be permanent — this session is warned when it
+    // deserves it, not thirty-eight minutes early because the player walked
+    // through a door.
+    const session = simulate({
+      rate: 555,
+      loads: [{ atMinutes: 30, mib: 300 }],
+    });
+    const low = session.raised.get("low");
+    assert.ok(low, "the load swallowed the real warning too");
+    assert.ok(
+      low.trulyLeft < 26,
+      `the load warned ${low.trulyLeft.toFixed(0)} minutes before it mattered`,
+    );
+    assert.ok(
+      session.ticks.some((tick) => tick.atMinutes > 30 && tick.bytes > 1_100 * MIB),
+      "the load did happen",
+    );
   });
 
   it("falls back to bytes only while there is no rate to read", () => {
-    // A page that opens already near the cap has no history to slope, so the
+    // A page that opens already near the cap has no staircase to read, so the
     // shipped thresholds are what still warns it.
     const watch = createHeapPressureWatch({ capBytes: CAP });
     const first = watch.sample(CAP - 100 * MIB, 0);
     // Corroborated first: the level can never be taken back, so no single
     // reading sets it. One tick later is the whole cost.
     assert.equal(first.level, "none", "raised on a single reading");
-    const cold = watch.sample(CAP - 100 * MIB, 15_000);
+    const cold = watch.sample(CAP - 100 * MIB, TICK_MS);
     assert.equal(cold.level, "critical");
     assert.equal(cold.minutes, null, "no number was measured, so none is offered");
     assert.equal(cold.raisedBy, "bytes");
@@ -183,10 +308,8 @@ describe("the memory warning counts time, not bytes", () => {
   });
 
   it("keeps warning a stalled heap that is nearly full", () => {
-    // A player idling in an outpost at 1.8 GiB has a near-zero recent rate, so
-    // the time rule goes quiet. Bytes are what is left to speak. The heap is
-    // flat from the first sample on purpose: a step into it would be a real
-    // burst, and reading that as imminent would be correct.
+    // A player idling in an outpost at 1.8 GiB has no recent steps, so the
+    // time rule has nothing to say. Bytes are what is left to speak.
     const watch = createHeapPressureWatch({ capBytes: CAP });
     let atMs = 0;
     let last = watch.sample(1_820 * MIB, atMs);
@@ -198,15 +321,30 @@ describe("the memory warning counts time, not bytes", () => {
     assert.equal(last.level, "low");
   });
 
+  it("lets a rate go stale rather than believing it forever", () => {
+    // Step-to-step measurement is what stops the figure sagging between steps,
+    // but it also means a player who stops spending would otherwise keep the
+    // last rate they earned. A tread wider than the ones it was measured over
+    // is evidence, and it stretches the estimate out.
+    const session = simulate({ rate: (minute) => (minute < 45 ? 555 : 0) });
+    const spending = session.ticks.find((tick) => tick.atMinutes === 44)!;
+    const idle = session.ticks.find((tick) => tick.atMinutes === 90);
+    assert.ok(spending.bytesPerMinute !== null);
+    assert.ok(
+      idle === undefined
+        || idle.bytesPerMinute === null
+        || idle.bytesPerMinute < spending.bytesPerMinute / 4,
+      "an hour of standing still still read as open-world spending",
+    );
+  });
+
   it("never lowers a warning it has already raised", () => {
     const watch = createHeapPressureWatch({ capBytes: CAP });
     let atMs = 0;
-    // Climb hard into critical.
     for (let i = 0; i < 40; i += 1) {
       watch.sample((300 + i * 45) * MIB, atMs);
       atMs += TICK_MS;
     }
-    // Then stop allocating entirely for twenty minutes.
     let last = watch.sample(2_000 * MIB, atMs);
     assert.equal(last.level, "critical");
     for (let i = 0; i < 80; i += 1) {

--- a/tests/unit/the-memory-warning-counts-time-not-bytes.test.ts
+++ b/tests/unit/the-memory-warning-counts-time-not-bytes.test.ts
@@ -115,14 +115,71 @@ describe("the memory warning counts time, not bytes", () => {
     );
   });
 
+  it("starts measuring when the player starts playing, not when they log in", () => {
+    // Ten minutes parked in Kamadan, then out into the world. The rate that
+    // matters begins at minute ten, and nothing about the idling before it
+    // should either warn or be averaged into what follows.
+    const watch = createHeapPressureWatch({ capBytes: CAP });
+    let atMs = 0;
+    let last = watch.sample(700 * MIB, atMs);
+    for (let minute = 0; minute <= 10; minute += 0.25) {
+      atMs = minute * 60_000;
+      last = watch.sample(700 * MIB, atMs);
+      assert.equal(last.level, "none", `warned while idle at ${minute} min`);
+    }
+    // Now playing, at the measured open-world rate.
+    for (let minute = 10.25; minute <= 25; minute += 0.25) {
+      atMs = minute * 60_000;
+      last = watch.sample((700 + (555 / 60) * (minute - 10)) * MIB, atMs);
+    }
+    assert.equal(last.level, "none", "still an hour of headroom");
+    // The idle stretch is behind the window by now, so the rate is the one the
+    // player is actually spending at — not a tenth of it.
+    assert.ok(
+      last.bytesPerMinute !== null
+        && Math.round((last.bytesPerMinute * 60) / MIB) === 555,
+      `read ${Math.round(((last.bytesPerMinute ?? 0) * 60) / MIB)} MiB/h`,
+    );
+  });
+
+  it("does not let one map load latch a warning that cannot be taken back", () => {
+    // A zone load allocates a couple of hundred MiB in seconds. Measured over
+    // a short enough window that reads as thousands of MiB an hour, and since
+    // the level never falls it would have been permanent — a player who then
+    // played quietly for an hour would keep a warning that had already been
+    // wrong for fifty minutes.
+    const watch = createHeapPressureWatch({ capBytes: CAP });
+    let heap = 900;
+    watch.sample(heap * MIB, 0);
+    for (let minute = 0.25; minute <= 20; minute += 0.25) {
+      // One 220 MiB load at minute twelve, quiet either side of it.
+      if (Math.abs(minute - 12) < 0.13) heap += 220;
+      const last = watch.sample(heap * MIB, minute * 60_000);
+      assert.equal(
+        last.level,
+        "none",
+        `a single map load warned at ${minute} min`,
+      );
+    }
+    assert.equal(heap, 1120, "the load did happen");
+  });
+
   it("falls back to bytes only while there is no rate to read", () => {
     // A page that opens already near the cap has no history to slope, so the
     // shipped thresholds are what still warns it.
     const watch = createHeapPressureWatch({ capBytes: CAP });
-    const cold = watch.sample(CAP - 100 * MIB, 0);
+    const first = watch.sample(CAP - 100 * MIB, 0);
+    // Corroborated first: the level can never be taken back, so no single
+    // reading sets it. One tick later is the whole cost.
+    assert.equal(first.level, "none", "raised on a single reading");
+    const cold = watch.sample(CAP - 100 * MIB, 15_000);
     assert.equal(cold.level, "critical");
     assert.equal(cold.minutes, null, "no number was measured, so none is offered");
     assert.equal(cold.raisedBy, "bytes");
+
+    // Except at the floor, where there is nothing left to corroborate.
+    const dying = createHeapPressureWatch({ capBytes: CAP });
+    assert.equal(dying.sample(CAP - 8 * MIB, 0).level, "critical");
   });
 
   it("keeps warning a stalled heap that is nearly full", () => {

--- a/tests/unit/the-memory-warning-counts-time-not-bytes.test.ts
+++ b/tests/unit/the-memory-warning-counts-time-not-bytes.test.ts
@@ -289,6 +289,51 @@ describe("the memory warning counts time, not bytes", () => {
     );
   });
 
+  it("says nothing through an hour with only one growth step in it", () => {
+    // An observed session, 2026-08-05: ramp to ~740 MiB, then flat for an hour,
+    // then a single 96 MiB step to 833 — 191 MiB/h, a third of the rate this
+    // was designed around, with the cap six hours away. One step is not a rate
+    // and the panel showed a bare dash for it, which read as a broken
+    // instrument rather than as the correct answer. It reports the span it
+    // measured over now, so the two cases are told apart.
+    const session = simulate({ rate: (minute) => (minute < 4 ? 11_000 : 191) });
+    for (const tick of session.ticks) {
+      if (tick.atMinutes > 74) break;
+      assert.equal(tick.level, "none", `warned at ${tick.atMinutes} min`);
+    }
+    const late = session.ticks.find((tick) => tick.atMinutes === 74)!;
+    assert.ok(
+      late.bytesPerMinute === null || late.measuredOverMs !== null,
+      "a rate was reported without the span it came from",
+    );
+
+    // And it wakes up: the estimate exists well before this session could die.
+    const measured = claims(session)[0];
+    assert.ok(measured, "the session never produced an estimate at all");
+    assert.ok(
+      measured.trulyLeft > 60,
+      `first estimate arrived with only ${measured.trulyLeft.toFixed(0)} min left`,
+    );
+  });
+
+  it("shows the span behind every rate it reports", () => {
+    // The panel prints this, and a rate with no span behind it is the shape of
+    // the reading that used to be indistinguishable from a broken one.
+    for (const rate of [555, 3_500]) {
+      for (const tick of simulate({ rate }).ticks) {
+        if (tick.bytesPerMinute === null) {
+          assert.equal(tick.measuredOverMs, null, "a span with no rate");
+        } else {
+          assert.ok(
+            tick.measuredOverMs !== null
+              && tick.measuredOverMs >= 10 * 60_000,
+            `${rate} MiB/h: rate measured over ${tick.measuredOverMs} ms`,
+          );
+        }
+      }
+    }
+  });
+
   it("falls back to bytes only while there is no rate to read", () => {
     // A page that opens already near the cap has no staircase to read, so the
     // shipped thresholds are what still warns it.

--- a/tests/unit/the-memory-warning-counts-time-not-bytes.test.ts
+++ b/tests/unit/the-memory-warning-counts-time-not-bytes.test.ts
@@ -1,0 +1,160 @@
+// The estimator, driven over the two sessions that were actually measured on
+// 2026-08-04. The shipped build warned on bytes remaining, which meant the same
+// sentence bought half an hour in the open world and about two minutes inside a
+// mission — the second row here is the whole reason this module exists.
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  createHeapPressureWatch,
+  hedgeMinutes,
+  type HeapPressureLevel,
+  type HeapPressureReading,
+} from "../../src/renderer/heap-pressure.js";
+
+const MIB = 1_048_576;
+const CAP = 2048 * MIB;
+const TICK_MS = 15_000;
+
+/**
+ * A session at a constant rate, sampled on the watcher's own 15-second tick.
+ * Returns the reading at which each level was first raised, which is the only
+ * thing the player ever experiences.
+ */
+function play(mibPerHour: number, startMib = 300, capBytes = CAP) {
+  const watch = createHeapPressureWatch({ capBytes });
+  const first = new Map<HeapPressureLevel, { atMinutes: number; reading: HeapPressureReading }>();
+  let atMs = 0;
+  for (let step = 0; step < 4 * 60 * 4; step += 1) {
+    const minutes = atMs / 60_000;
+    const bytes = (startMib + (mibPerHour / 60) * minutes) * MIB;
+    if (bytes >= capBytes) break;
+    const reading = watch.sample(bytes, atMs);
+    if (!first.has(reading.level)) {
+      first.set(reading.level, { atMinutes: minutes, reading });
+    }
+    atMs += TICK_MS;
+  }
+  return first;
+}
+
+describe("the memory warning counts time, not bytes", () => {
+  it("warns an open-world session with the headroom it claims", () => {
+    // 555 MiB/h, measured over 2 h 16 m. The cap arrives at about 3 h 09 m.
+    const run = play(555);
+    const low = run.get("low");
+    const critical = run.get("critical");
+    assert.ok(low && critical);
+
+    assert.ok(
+      low.reading.minutes !== null && low.reading.minutes >= 15 && low.reading.minutes <= 20,
+      `low claimed ${low.reading.minutes} minutes`,
+    );
+    assert.ok(
+      critical.reading.minutes !== null && critical.reading.minutes <= 5,
+      `critical claimed ${critical.reading.minutes} minutes`,
+    );
+    // The claim has to be true, not just present: the remaining headroom at
+    // the measured rate must be near the number the player was shown.
+    const remaining = (CAP - critical.reading.bytes) / MIB / (555 / 60);
+    assert.ok(remaining > 3 && remaining < 9, `${remaining} real minutes left`);
+    assert.equal(critical.reading.raisedBy, "time");
+  });
+
+  it("gives a texture-dense mission the same warning, not two minutes", () => {
+    // The Eye of the North report: the cap in about half an hour. Under the
+    // shipped byte thresholds this player got "low" with three minutes left
+    // and "critical" with ninety seconds — and crashed anyway.
+    const run = play(3_500);
+    const low = run.get("low");
+    const critical = run.get("critical");
+    assert.ok(low && critical);
+
+    assert.ok(low.atMinutes < 15, `low arrived at ${low.atMinutes} min`);
+    const lowHeadroomMib = (CAP - low.reading.bytes) / MIB;
+    assert.ok(
+      lowHeadroomMib > 256,
+      `${lowHeadroomMib} MiB left — the shipped rule would not have fired yet`,
+    );
+
+    // What the shipped build could not do: leave real minutes on the clock.
+    const remaining = (CAP - critical.reading.bytes) / MIB / (3_500 / 60);
+    assert.ok(remaining > 3, `${remaining} real minutes left at critical`);
+  });
+
+  it("falls back to bytes only while there is no rate to read", () => {
+    // A page that opens already near the cap has no history to slope, so the
+    // shipped thresholds are what still warns it.
+    const watch = createHeapPressureWatch({ capBytes: CAP });
+    const cold = watch.sample(CAP - 100 * MIB, 0);
+    assert.equal(cold.level, "critical");
+    assert.equal(cold.minutes, null, "no number was measured, so none is offered");
+    assert.equal(cold.raisedBy, "bytes");
+  });
+
+  it("keeps warning a stalled heap that is nearly full", () => {
+    // A player idling in an outpost at 1.8 GiB has a near-zero recent rate, so
+    // the time rule goes quiet. Bytes are what is left to speak. The heap is
+    // flat from the first sample on purpose: a step into it would be a real
+    // burst, and reading that as imminent would be correct.
+    const watch = createHeapPressureWatch({ capBytes: CAP });
+    let atMs = 0;
+    let last = watch.sample(1_820 * MIB, atMs);
+    for (let i = 0; i < 80; i += 1) {
+      atMs += TICK_MS;
+      last = watch.sample(1_820 * MIB, atMs);
+    }
+    assert.equal(last.minutes, null, "a flat heap has no time to give");
+    assert.equal(last.level, "low");
+  });
+
+  it("never lowers a warning it has already raised", () => {
+    const watch = createHeapPressureWatch({ capBytes: CAP });
+    let atMs = 0;
+    // Climb hard into critical.
+    for (let i = 0; i < 40; i += 1) {
+      watch.sample((300 + i * 45) * MIB, atMs);
+      atMs += TICK_MS;
+    }
+    // Then stop allocating entirely for twenty minutes.
+    let last = watch.sample(2_000 * MIB, atMs);
+    assert.equal(last.level, "critical");
+    for (let i = 0; i < 80; i += 1) {
+      atMs += TICK_MS;
+      last = watch.sample(2_000 * MIB, atMs);
+    }
+    assert.equal(last.level, "critical", "the heap did not shrink, so nor does the warning");
+  });
+
+  it("rounds the estimate without ever flattering it by much", () => {
+    assert.equal(hedgeMinutes(19.7), 20);
+    assert.equal(hedgeMinutes(12), 10);
+    assert.equal(hedgeMinutes(4.4), 4);
+    assert.equal(hedgeMinutes(0.2), 0);
+    assert.equal(hedgeMinutes(-5), 0);
+    for (let m = 0; m <= 180; m += 0.1) {
+      assert.ok(
+        hedgeMinutes(m) <= m + 2.5,
+        `hedge(${m}) = ${hedgeMinutes(m)} overstates by more than 2.5`,
+      );
+    }
+  });
+
+  it("produces no NaN, no infinity and no negative minutes", () => {
+    for (const capBytes of [0, CAP]) {
+      const watch = createHeapPressureWatch({ capBytes });
+      for (const [bytes, atMs] of [
+        [300 * MIB, 0],
+        [400 * MIB, 0], // same instant
+        [500 * MIB, -1_000], // backwards
+        [4_000 * MIB, 60_000], // past the cap
+        [4_000 * MIB, 200_000],
+      ] as const) {
+        const reading = watch.sample(bytes, atMs);
+        for (const value of [reading.minutes, reading.bytesPerMinute]) {
+          assert.ok(value === null || Number.isFinite(value), String(value));
+        }
+        assert.ok((reading.minutes ?? 0) >= 0);
+      }
+    }
+  });
+});

--- a/tests/unit/the-memory-warning-counts-time-not-bytes.test.ts
+++ b/tests/unit/the-memory-warning-counts-time-not-bytes.test.ts
@@ -81,6 +81,40 @@ describe("the memory warning counts time, not bytes", () => {
     assert.ok(remaining > 3, `${remaining} real minutes left at critical`);
   });
 
+  it("does not read the cost of starting the game as the cost of playing it", () => {
+    // Observed on a real launch: 734 MiB and climbing at ~4,500 MiB/h less
+    // than three minutes in, against a steady-state 555 MiB/h. Measured from
+    // inside that ramp the session looks a quarter of an hour from death, and
+    // the warning fired at 36% of the cap — every player, every login.
+    const watch = createHeapPressureWatch({ capBytes: CAP });
+    let atMs = 0;
+    let last = watch.sample(0, atMs);
+    for (let minute = 0; minute <= 4; minute += 0.25) {
+      atMs = minute * 60_000;
+      last = watch.sample(Math.min(760, 260 * minute + 40) * MIB, atMs);
+      assert.equal(
+        last.level,
+        "none",
+        `warned ${minute} minutes in, at ${Math.round(last.bytes / MIB)} MiB`,
+      );
+      assert.equal(last.minutes, null, "claimed a figure measured from startup");
+    }
+
+    // Once the ramp is behind it, ordinary play is read as ordinary play.
+    const settledAt = atMs;
+    for (let minute = 5; minute <= 30; minute += 0.25) {
+      atMs = minute * 60_000;
+      const mib = 760 + (555 / 60) * (minute - settledAt / 60_000);
+      last = watch.sample(mib * MIB, atMs);
+    }
+    assert.equal(last.level, "none", "still quiet with two hours of headroom");
+    assert.ok(
+      last.bytesPerMinute !== null
+        && Math.round((last.bytesPerMinute * 60) / MIB) === 555,
+      `read ${Math.round(((last.bytesPerMinute ?? 0) * 60) / MIB)} MiB/h`,
+    );
+  });
+
   it("falls back to bytes only while there is no rate to read", () => {
     // A page that opens already near the cap has no history to slope, so the
     // shipped thresholds are what still warns it.

--- a/tests/unit/the-memory-warning-counts-time-not-bytes.test.ts
+++ b/tests/unit/the-memory-warning-counts-time-not-bytes.test.ts
@@ -108,7 +108,11 @@ function simulate(options: {
   return { diesAtMinutes, ticks, raised };
 }
 
-/** Every figure the player was shown, and what was true when they saw it. */
+/**
+ * Every tick where a rate could be measured. The figure never reaches the
+ * player — the Eye of the North bundle retired that — but the estimate still
+ * decides the level, so the sessions below check it is measured at all.
+ */
 const claims = (session: Session) =>
   session.ticks.filter((tick) => tick.minutes !== null);
 
@@ -174,36 +178,45 @@ describe("the memory warning counts time, not bytes", () => {
     }
   });
 
-  it("counts down instead of standing still and lurching", () => {
-    // Each step reserves about ten minutes of play at once. Read off the
-    // reserve, the estimate would sit through a whole tread and then drop ten
-    // minutes in one tick; the figure the player watches has to move the way
-    // time does. The five-minute granularity of the wording is the floor.
-    for (const rate of [555, 3_500]) {
-      const shown = claims(simulate({ rate })).map((tick) => tick.minutes!);
-      for (let i = 1; i < shown.length; i += 1) {
-        assert.ok(
-          Math.abs(shown[i]! - shown[i - 1]!) <= 5,
-          `${rate} MiB/h: the figure jumped ${shown[i - 1]} → ${shown[i]}`,
-        );
-      }
+  it("puts the levels of a real crash where they belong", () => {
+    // The Eye of the North session of 2026-08-04, replayed from the player's
+    // own bundle: every `wasm.heapGrew` event of the client run that reached
+    // the cap, against the abort that ended it. The last step is clamped —
+    // 1990 to 2048 MiB rather than the usual 96 — and the client dies forty
+    // seconds later at exactly 2 GiB.
+    //
+    // This is the fixture the simulations could not be: the rate swings about
+    // tenfold between quiet stretches and mission loading, including a
+    // thirteen-minute lull at minute 34. What has to survive that is the
+    // level, because the level is the only thing the player is told.
+    const diedAtMinutes = 66.02;
+    const steps: readonly (readonly [number, number])[] = [
+      [0.12, 531], [0.16, 627], [1.76, 723], [16.06, 820], [22.82, 916],
+      [24.82, 1013], [26.69, 1110], [28.36, 1206], [30.69, 1302],
+      [32.56, 1398], [34.16, 1495], [47.72, 1593], [51.82, 1690],
+      [53.16, 1786], [55.12, 1894], [58.62, 1990], [65.32, 2048],
+    ];
+    const watch = createHeapPressureWatch({ capBytes: CAP });
+    const raised = new Map<HeapPressureLevel, number>();
+    for (let minute = 0; minute <= diedAtMinutes; minute += TICK_MINUTES) {
+      let mib = 0;
+      for (const [at, value] of steps) if (at <= minute) mib = value;
+      const { level } = watch.sample(mib * MIB, minute * 60_000);
+      if (!raised.has(level)) raised.set(level, diedAtMinutes - minute);
     }
-  });
 
-  it("never names a number that is not close to true", () => {
-    // The whole premise. Anywhere a figure is shown, in either session, it has
-    // to be near the time that was really left — a warning nobody can check is
-    // worth as much as the "running low" it replaced.
-    for (const rate of [555, 3_500]) {
-      for (const tick of claims(simulate({ rate }))) {
-        const slack = Math.max(2.5, tick.trulyLeft * 0.35);
-        assert.ok(
-          Math.abs(tick.minutes! - tick.trulyLeft) <= slack,
-          `${rate} MiB/h at ${tick.atMinutes} min: said ${tick.minutes}`
-            + `, truly ${tick.trulyLeft.toFixed(1)}`,
-        );
-      }
-    }
+    const low = raised.get("low");
+    const critical = raised.get("critical");
+    assert.ok(low !== undefined, "the session that hit the cap was never warned");
+    assert.ok(critical !== undefined, "it never escalated");
+
+    // The shipped byte thresholds gave this player 10.9 minutes at 256 MiB and
+    // 7.4 at 128 MiB. Beating the first is the whole reason for the change.
+    assert.ok(low > 20, `low arrived with ${low.toFixed(1)} min left`);
+    assert.ok(
+      critical > 5 && critical < 12,
+      `critical arrived with ${critical.toFixed(1)} min left`,
+    );
   });
 
   it("does not read the cost of starting the game as the cost of playing it", () => {


### PR DESCRIPTION
**Stack 2 of 2.** Base: `memory-debug-panel` (#110). Review that one first — the diff below is only this PR's own changes.

## What this ships to players

The memory warning stops counting in bytes and starts counting in time. The *thresholds* count in time; the sentence does not print a figure — see "A real crash corrected this" below, which is why.

> **Guild Wars is running low on memory.**
> Reload when it suits you — Guild Wars puts you back where you were, in under a minute. <ins>Why is this happening?</ins>
> `[Later]` `[**Reload Now**]`

**Later** now leaves a chip that keeps counting instead of going silent, and a rise to critical raises the banner again. **Why is this happening?** explains the limit in four short blocks, in the game.

## The defect

The shipped thresholds fired at a fixed distance from the cap — 256 MiB, then 128 MiB. Measured on the same client build:

| Session | Rate | What 256 MiB bought |
|---|---|---|
| Open world, 2 h 16 m | 555 MiB/h | ~28 min |
| Eye of the North mission | cap in ~30 min | ~2–3 min |

Same sentence, and no way for the player to tell which one they had. The player who got the two-minute version reported "multiple warnings" and crashed anyway.

The copy compounded it: telling someone inside a dungeon to travel to an outpost reads as "abandon the run", so ignoring it was rational.

## How the estimate works

`heap-pressure.ts` — pure, clock-injected, DOM-free, unit-tested.

**It measures a staircase, not a slope.** `Module.HEAPU8.buffer` is *reserved* memory, and WebAssembly reserves it in jumps: Emscripten grows by a fifth of the current size capped at 96 MiB, so at 555 MiB/h the heap steps about once every ten minutes and is flat in between. That shape decides the whole design.

- **Rate** — both ends of a measurement sit on a growth step, at least **10 minutes** apart. Step to step is what makes the figure stand still: anchoring the far end to *now* puts a whole tread in the denominator and none of its rise in the numerator, so the estimate sags across the tread and jumps back when the next step lands. A plateau wider than the treads it was measured over stretches the denominator, so a player who walks back into town does not keep the rate they earned in the field.
- **Headroom** — measured against what the client has *filled*, not what it has reserved. Growth fires when a request no longer fits, so at the instant of a step the filled bytes are what the reserve was before it. Reading headroom off the reserve makes every step look like ten minutes vanishing at once.
- **Warm-up** — no step counts until five minutes after the client's **first allocation**. Starting the client is the heaviest allocating a session ever does (~4,500 MiB/h against a steady-state 555).
- **Warn** at `minutes <= 20` and `minutes <= 5`, corroborated across two readings. Level is monotonic, so a single unlucky sample must not be permanent.
- **Fallback** — the old byte thresholds still fire, but only while no rate can be read. Left unconditional, 128 MiB is nearly fourteen minutes at the measured rate and would pre-empt the time rule every session, rebuilding the defect.
- **Hedging** — `>= 10 min` rounds to five, below that to the minute. Nearest, not floor. Pinned by a property test: never overstates by more than 2.5 min.
- **No measurement, no number.** The label falls back to today's wording rather than printing a figure we did not measure.

Simulated against the allocator, on the sessions we measured:

| | shipped low / critical | this PR |
|---|---|---|
| Open world 555 MiB/h (dies at 147 min) | 28 min / 14 min left | low at 127 min saying 20 (19.3 truly), critical saying 5 (4.8 truly) |
| EotN 3,500 MiB/h (dies at 23 min) | 3 min / 1.5 min left | warned at 18 min saying 5 (5.0 truly) |
| Rate read for a steady 555 MiB/h session | — | 549–562 MiB/h |

## Why ten minutes, and what it costs

The span is what tells a zone load from a trend, and it was bought rather than guessed. A 300 MiB load at minute 30 of an ordinary session:

| span | what the load makes the warning say |
|---|---|
| 4 min | "about 20 minutes of play left" — **77 minutes truly left** |
| 8 min | escalates to **critical** — 30 minutes truly left |
| 10 min | nothing; the real warning arrives on time at minute 95 |

The cost lands on the fastest sessions and is accepted knowingly: a mission spending 3,500 MiB/h dies around minute 23 and cannot be spoken about until minute 18, where an eight-minute span would have warned at 15. There is no shorter honest answer — ten minutes into a mission, a ten-minute-old zone load and a sustained spend look alike in every window, and a "is it still going?" test costs exactly the latency it saves. The byte floors are the backstop for the fast case.

## Two thresholds and a clock the tests corrected

- **The hard byte floor** was 64 MiB by judgement. Driven over the measured open-world session it raised `critical` at seven minutes — ahead of the five-minute time rule, the same defect in miniature. It is 32 MiB now.
- **The warm-up ran from page load.** The page stays open through the client download, so a first run whose download outlasts it boots into a measured startup ramp: 38% of the cap, "about 8 minutes of play left", two hours of real headroom. It runs from the first allocation now.
- **The rate windows were fixed durations** (5 and 15 minutes). Over a ten-minute tread that reads a steady 555 MiB/h session as alternating between 384 and 1,152, and the chip — the surface that updates live — showed 15 → 45 → 10 → 30 for a rate that never changed.

Every test in this file drove smooth linear growth, which is why none of that failed. They drive the allocator now, and each one checks what the player was told against when the session really ended. Recorded as Rounds 4–7 in `internal/upstream/memory-exhaustion-log.md`.

## Presentation

Ported from the prototype that was reviewed, not re-derived: a sampled critically damped spring (`--spring`, response 0.4 s, no overshoot — bounce belongs to motion a gesture threw); enter and exit along the same path; blur and scale together so it materialises rather than fades; press feedback on pointer-down; translucent material with a bright top edge.

The notice **never scrims the game** — it runs beside play. The explanation is the one modal task, so it dims, takes focus, releases pointer lock, traps the keyboard, and **opens in the notice's place** so two translucent surfaces never stack. Its transform-origin is measured from the link that opened it rather than hardcoded. Exit timings are read from the element's own computed `transition-duration` rather than restated in TypeScript, so the reduced-motion block shortens them for free.

Deliberately **not** ported: the prototype's canvas push-back. A CSS `filter` on a live WebGL canvas forces a full-frame composite and interacts with the offscreen path in `graphics.ts` and with pointer-lock mapping. Scrim only.

Also fixes a live defect: events now stop at the overlay roots, so clicking **Later** no longer also reaches the game.

## Verification

- `pnpm check` — 785 unit, 158 policy, typecheck, lint, links: pass
- `pnpm build && pnpm test:electron` — 114 passed, 1 skipped
- Rendered the **shipped** stylesheet in a browser and measured it (540 px wide, chip clear of the notice) rather than trusting the port — a CSS bug I shipped unrendered last week is why
- New policy assertions: the canonical contract is imported exactly once **at runtime** and still inside `requestHeapCap` (the packaged Enhancement-runtime proof depends on it); `heap-pressure.ts` imports nothing from `shared/`; all three accessibility preferences cover the notice; the estimator keeps growth steps rather than samples and no fixed-duration window survives; the warm-up runs from the first allocation; an `aria-modal` explanation traps the keyboard

## Review focus

- **The trade-off in "why ten minutes"** is the one judgement call here that a reviewer might make differently. It is written down at `DEFAULTS.minSpanMs` with the numbers behind it.
- **Two broken assertions replaced, not deleted.** `detail.includes(reloadButton)` became "the detail opens with the action" (derived from the button, so it survives a rename); `/^A crash is likely soon/` became the escalation living in the instruction — `Reload when it suits you` → `Reload soon`.
- **The reconnect guard turned around rather than being deleted.** It used to fail if the hedge disappeared before the experiment ran. The experiment ran (below), so it now fails if the measured claim disappears, or if the copy grows past one tester into "guaranteed" / "never lose". Another guards the ArenaNet claim: measured, documented, published — not "in contact with".
- **`backdrop-filter` over a live 60 fps canvas is still unmeasured.** `loading.css` uses it only over static artwork. The notice is small and the `prefers-reduced-transparency` path is the fallback, but this deserves a performance capture before release.

## A real crash corrected this

A player's Eye of the North bundle (2026-08-04, app 2026.8.4, complete from start) arrived with 33 `wasm.heapGrew` events — the first real staircase rather than a modelled one. It confirmed the shape and the endgame: the final growth step clamps to the cap (1990 → 2048 MiB, 58 MiB not 96), and the client dies at exactly `2147483648` bytes **forty-two seconds later**.

Replayed against that run, the **levels landed well**:

| | this PR | shipped 2026.8.4 |
|---|---|---|
| `low` | **31.5 min** of real play left | 10.9 min |
| `critical` | 7.0 min | 7.4 min |

The **figure did not**. It read 10 → 15 → 20 → **75** → 40 → 20 → 15 → 10 → 3, and at minute 49 offered "about 75 minutes" to a player with 18 left — a thirteen-minute lull had drifted into the measurement window just before they went back into heavy loading. Earlier it said "10 minutes" with 31 left, behind a rate that looked perfectly stable.

The tests missed it the same way they missed the staircase: they drove constant rates, and real play varies about tenfold between lulls and loading.

So the thresholds keep counting in time — that is the fix, and it is what tripled the warning — and the sentences stop printing the number. The estimate still exists, still sets the level, and is still shown in the debug panel and the log, where being approximately right is useful and being precisely wrong costs nothing. **That client run is now a test fixture**, replayed step by step against the abort that ended it.

Unexplained and recorded: the session's *first* abort came at 1899 MiB — 149 MiB of headroom left — with `reasonKind: other` and the same fingerprint as both crashes in the 2026-08-03 bundle. Our model cannot predict a death below the cap, and two deaths is not enough to say what that is.

## The reconnect experiment: answered

Run 2026-08-05 with #110's panel, from inside an instance, on all five reload paths — drop sockets, orphan + reload, crash the renderer process, ⌘R, and sync + reload. **Every one reconnected with progress intact, in under thirty seconds.** Including the orphan path, which sends no FIN at all and forces the server to time the connection out: the one most likely to fail, and the one whose passing generalises to a real crash.

So the copy states the reconnect instead of hedging it, and the outpost moves from the notice into the explanation — it is still the one place that risks nothing, but leading with it is what made the shipped sentence easy to ignore from inside a dungeon.

Limits, recorded in the log and in `docs/diagnostics.md`: one tester, one account, nothing about a full party, a timed mission, or a loaded server. Enough to state the reconnect; not enough to promise it cannot go wrong.

## Known follow-ups
- The estimator cannot resolve better than one allocation request, and the client's own last growth step may or may not be usable — no bundle has recorded heap-at-abort yet. It errs early either way.


