### PR TITLE
Warn before the Guild Wars WASM heap fills

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -272,11 +272,40 @@ known patterns, so treat it as strong rather than absolute. The export is an
 ordinary ZIP you can open and read before attaching it. GitHub issues are
 public, so review the bug form’s privacy notice as well.
 
+## If the game warns that memory is running out
+
+ArenaNet's current game client is capped at 2 GB of WebAssembly memory. During
+long sessions that visit new content, its memory can keep growing instead of
+settling. At the cap, the next large allocation stops the client. This app
+cannot safely discard objects owned by the game, but it can measure the heap
+and warn before the client reaches its cap.
+
+A notice appears over the game at two points: once with roughly twenty minutes
+of play left, and again with about five. Those points are worked out from how
+fast memory has been filling in this session, so in areas that load a lot of
+new scenery the warning comes sooner in wall-clock terms, which is the whole
+idea — the same notice used to mean half an hour in the open world and two
+minutes inside a mission.
+
+The notice does not print a countdown. It could be worked out, but replayed
+against a real crash it was wrong by enough to matter in both directions, and
+a number on a banner is a promise. What is worth acting on is that the warning
+appeared.
+
+**Reload Now** restarts the client with fresh memory. It takes under a minute,
+and Guild Wars puts you back where you were — the same way it handles a
+dropped connection. That was tested from inside an instance on every way this
+app can reload the game, and progress survived each time; a town or outpost is
+still the one place with nothing at all to lose. **Later** leaves a small
+reminder in the corner rather than going quiet; the full notice returns if time
+runs short. **Why is this happening?** explains it in the game.
+
 ## If the game crashes
 
 When the running game client stops unexpectedly, the launcher screen returns
 with **Retry** and **Report a Problem…**. Retry starts the client again; a
-single crash is usually transient.
+single crash is usually transient. A crash that ran out of memory says so
+under **Technical details**, with the heap size it reached.
 
 If the client crashes again in the same app run, the message changes to say
 so and leads with reporting: **Report a Problem…** on the launcher is the

--- a/internal/upstream/memory-exhaustion-log.md
+++ b/internal/upstream/memory-exhaustion-log.md
@@ -121,3 +121,279 @@ survivable failure). Shipped instead:
    rollup in the bundle), quit-time `filesystem.sync` failing on every
    observed quit (no error code recorded yet), and quit-teardown aborts
    (`a6311932`, 10 ms after `sockets.closeAll()`) being counted as crashes.
+
+## Round 4 — wrong: bytes remaining was the unit (2026-08-04)
+
+**Hypothesis.** Warning at a fixed distance from the cap — 256 MiB, then
+128 MiB — gives the player enough room to reach somewhere safe.
+
+**Built.** The watermark notice shipped in 2026.8.4 with exactly those two
+thresholds, and copy that told the player to travel to a town or outpost.
+
+**Wrong because** the same headroom is not the same amount of time. Measured
+on the same client build:
+
+| Session | Rate | What 256 MiB bought |
+| --- | --- | --- |
+| Open world, 2 h 16 m | 555 MiB/h | ~28 min |
+| Eye of the North mission | fast enough to hit the cap in ~30 min | ~2–3 min |
+
+The second player reported "multiple warnings" and crashed anyway. Both saw
+the same sentence, and neither could tell which of those two it meant. The
+copy compounded it: an instruction to travel to an outpost is one a player
+inside a dungeon reads as "abandon the run", so it was rational to ignore.
+
+**Kept anyway.** The byte thresholds survive as the fallback for when a rate
+cannot be measured — the first two minutes of a session, and any stretch where
+growth has stalled. They are conditional now: left unconditional, 128 MiB is
+nearly fourteen minutes at the open-world rate and would pre-empt the time rule
+every session, rebuilding the defect.
+
+**Lesson.** A threshold is a claim about the player's situation, and the unit
+has to be the one the player is in. Bytes were what we could measure most
+easily; time was what the sentence was actually promising.
+
+**A number the test corrected.** The replacement kept a hard byte floor as a
+never-silent backstop, first set at 64 MiB. Driven over the measured
+open-world session it raised `critical` at seven minutes — ahead of the
+five-minute time rule, i.e. the same defect in miniature. It is 32 MiB, which
+sits below where the time rule fires at every rate observed so far. That
+threshold had no session behind it until the test supplied one.
+
+## Round 5 — wrong: the heap is a staircase, and we measured it with a ruler shorter than the stair (2026-08-05)
+
+**Hypothesis.** With the unit fixed, a trailing window over recent samples
+gives the rate: five minutes to catch a session that has started spending, and
+fifteen so a lull inside that spending cannot erase it.
+
+**Wrong because** `Module.HEAPU8.buffer` is *reserved* memory, and WebAssembly
+reserves it in jumps. Emscripten's glue grows by a fifth of the current size
+capped at 96 MiB, so at the measured 555 MiB/h the heap steps about once every
+ten minutes and is perfectly flat in between — which the instrumentation
+already said in Round 3 (`wasm.heapGrew`: "growth is discrete and rare") and
+the debug panel repeated on the way in ("a short window reads as either zero or
+enormous depending on where the sample landed").
+
+A five-minute window over a ten-minute tread holds either no step or one.
+Simulated against the measured open-world session, the estimator read:
+
+| | measured | true |
+| --- | --- | --- |
+| Rate | alternating 384 and 1,152 MiB/h | 555 MiB/h |
+| Shown to the player | 15 → 45 → 10 → 30 minutes | a smooth count down |
+| `low` fired | claiming 15 minutes | 41 minutes remained |
+
+The level still landed in roughly the right place, because the steep arm of the
+sawtooth dominates. The *number* — the entire point of Round 4 — swung by three
+times its own value every five minutes, on the chip, which is the one surface
+that updates live.
+
+**Why it survived review and a test suite.** Every test drove smooth linear
+growth. The sessions we measured were staircases; the sessions we tested were
+ramps, so the tests agreed with the code about a shape no client produces.
+
+**Built.** Both ends of a measurement now sit on a growth step, at least ten
+minutes apart, and the module keeps steps rather than samples. Step-to-step is
+what makes the figure stand still: anchoring the far end to *now* puts a whole
+tread in the denominator and none of its rise in the numerator. Ten minutes is
+what tells a burst from a trend, and it was bought rather than guessed — a
+300 MiB zone load at minute 30 of an ordinary session says "about 20 minutes of
+play left" over a four-minute span with 77 minutes truly left, and escalates to
+critical over an eight-minute span with 30 minutes left. Over ten it says
+nothing and the real warning arrives on time.
+
+The cost is knowingly accepted: a mission spending 3,500 MiB/h dies around
+minute 23 and cannot be spoken about until minute 18, where an eight-minute
+span would have warned at 15. There is no shorter honest answer — ten minutes
+into a mission, a ten-minute-old zone load and a sustained spend look alike in
+every window, and a "is it still going?" test costs exactly the latency it
+saves. The byte floors remain the backstop for the fast case.
+
+**Two more the same simulation found.**
+
+*The warm-up ran on the wrong clock.* It excluded the startup ramp for five
+minutes after page load. The page stays open through the client download, so a
+slow first run boots after the exclusion has expired and the ramp is measured
+as ordinary play: 38% of the cap, "about 8 minutes of play left", two hours of
+real headroom. It runs from the client's first allocation now.
+
+*Headroom was read off the reserve.* The client dies when what it has *filled*
+reaches the cap, and the reserve leads that by up to one step — ten minutes of
+open-world play. Taking headroom off the reserve made every step look like ten
+minutes vanishing at once and read a session as a third shorter than it was.
+Growth fires when a request no longer fits, so at the instant of a step the
+filled bytes are what the reserve was before it; between steps they climb at
+the rate just measured. The residual error is one allocation request rather
+than one step.
+
+**Lesson.** Round 4's lesson was that a threshold is a claim about the player's
+situation. This one is narrower and sharper: a test that drives a shape the
+system never produces will confirm whatever the code believes. The measured
+sessions were on disk the whole time — `wasm.heapGrew` events, fourteen of them
+in 2 h 16 m — and no test read one.
+
+## Round 6 — right: every reload path reconnects (2026-08-05)
+
+**The question.** Guild Wars restores a player's instance after a dropped
+connection; that was never in doubt. What was unknown is whether *our* reload
+looks like a dropped connection to its server — and the copy could not say
+"you come back where you were" until somebody had checked. A unit test held
+the hedge in place so nobody could firm the wording by assertion.
+
+**Run.** All five paths in `docs/diagnostics.md`, from inside an instance:
+(d) drop sockets, (c1) orphan + reload, (c2) crash the renderer process,
+(b) View → Reload Game, (a) sync + reload.
+
+**Result.** Every one reconnected, with progress intact, in under thirty
+seconds. Including (c1), which sends no FIN at all and forces the server to
+time the connection out — the path most likely to fail, and the one whose
+passing generalises to a real crash.
+
+**What changed.** The notice now states the reconnect instead of hedging it,
+and the outpost moved out of the notice into the explanation. It is still true
+that an outpost risks nothing, but leading with it is what made the shipped
+sentence easy to ignore from inside a dungeon, and repeating a caveat against
+a measured fact argues with the measurement. The guard test turned around: it
+used to fail if the hedge disappeared, and now fails if the measured claim
+disappears or if the copy grows past the evidence into "guaranteed" or
+"never lose".
+
+**What it does not cover.** One tester, one account. Nothing about a full
+party, a timed mission, or a loaded server. Enough to state the reconnect;
+not enough to promise it cannot go wrong.
+
+**Lesson.** The instrument was worth building. Five paths in one sitting
+answered a question that hours of ordinary play would not have, because
+ordinary play never produces (c1) on purpose — and (c1) is the one that
+mattered.
+
+## Round 7 — wrong: the figure was a diagnostic, printed as a promise (2026-08-05)
+
+**The bundle.** A player's Eye of the North session, 2026-08-04, app 2026.8.4,
+complete from start. Two client runs, two aborts, and 33 `wasm.heapGrew`
+events — the first real staircase we have had rather than a modelled one.
+
+**What it confirmed.**
+
+- The final growth step is clamped to the cap: 1990 → 2048 MiB, 58 MiB rather
+  than the usual 96. The client then died at exactly `2147483648` bytes,
+  `reasonKind: assertion`, fingerprint `8f57c5d5`, **forty-two seconds** after
+  that last step. The reserve does reach the cap exactly, which is what the
+  headroom model assumes.
+- The tread is 96 MiB and the gaps run from 0.9 to 14.3 minutes, which is the
+  shape Round 5 was built for.
+
+**What it broke.** Replayed against that run, the *levels* landed well:
+
+| | this build | shipped 2026.8.4 |
+| --- | --- | --- |
+| `low` | 31.5 min of real play left | 10.9 min |
+| `critical` | 7.0 min | 7.4 min |
+
+The *figure* did not. It read 10 → 15 → 20 → **75** → 40 → 20 → 15 → 10 → 3,
+and at minute 49 offered "about 75 minutes" to a player with 18 left. A
+thirteen-minute lull had drifted into the measurement window just before the
+player went back into heavy loading. Earlier, at minute 34, it said "10
+minutes" with 31 left — wrong the other way, behind a rate that looked stable.
+
+**Why the tests did not catch it.** They drove constant rates. Round 5's
+lesson was that a test driving a shape the system never produces will confirm
+whatever the code believes; the fix for that round replaced ramps with
+staircases and then held the rate constant along them. Real play varies about
+tenfold between lulls and mission loading. The same lesson, one level down.
+
+**Built.** The thresholds still count in time — that is what tripled the
+warning and it is not in question. The figure is gone from every player-facing
+string. The estimate still exists, still sets the level, and is still shown in
+the debug panel and the log, where being approximately right is useful and
+being precisely wrong costs nothing. The client run that reached the cap is
+now a test fixture, replayed step by step against the abort that ended it.
+
+**Also observed, unexplained.** The session's *first* abort came at 1899 MiB —
+149 MiB of headroom left — with `reasonKind: other` and fingerprint
+`a6311932`, the same fingerprint as both crashes in the 2026-08-03 bundle. Our
+model cannot predict a death below the cap. Two observed deaths, one at the
+cap and one short of it, is not enough to say what that is.
+
+**Lesson.** An estimate can be good enough to decide something and not good
+enough to say out loud. The level is a decision the app makes and can defend;
+the figure was a claim the player would check against their own clock.
+
+## Round 8 — correcting our own reading of the cap, and widening the repro (2026-08-06)
+
+**We misread ArenaNet's glue.** Round 3 and the "Open" list say the comment
+above `getHeapMax` shows the 2 GiB cap "only exists to stay clear of 4 GB
+wraparound". It does not. The full text in `Gw.jspi.js` is:
+
+```js
+var getHeapMax = () =>
+    // Stay one Wasm page short of 4GB: while e.g. Chrome is able to allocate
+    // full 4GB Wasm memories, the size will wrap back to 0 bytes in Wasm side
+    // for any code that deals with heap sizes, which would require special
+    // casing all heap size related code to treat 0 specially.
+    2147483648;
+```
+
+2147483648 is **not** one page short of 4 GB — that would be 4294901760. The
+comment is Emscripten's stock text, emitted above whatever `MAXIMUM_MEMORY`
+was configured, and 2147483648 is Emscripten's *default* (2 GB). So the
+correct reading is narrower and, for the report, stronger: the ceiling looks
+like a default nobody changed rather than a constraint anybody chose. We must
+not tell ArenaNet their own comment says something it doesn't.
+
+The ceiling is declared twice, and both agree — the glue constant above, and
+the wasm binary's own memory section:
+
+| artifact | initial | maximum |
+| --- | --- | --- |
+| `Gw.wasm` (27 MiB) | 256 MiB | **2048 MiB** |
+| `Gw.jspi.wasm` (8 MiB) | 256 MiB | **2048 MiB** |
+
+**The causal chain, end to end.** `wasmMemory.grow()` throws once the module's
+declared maximum is reached; `growMemory` catches it, logs
+`growMemory: Attempted to grow heap from … but got error: …` and returns
+undefined, which the caller reads as 0; `_emscripten_resize_heap` fails; the
+allocator returns null; and ArenaNet's own texture path asserts. The recorded
+death is `ASSERTION FAILED: Out of memory!` at `Engine/Gr/Gles3/GlTex.cpp:397`
+with `heapBytes` exactly 2147483648. Which assertion trips first is incidental
+— at the cap, whichever allocation lands next fails.
+
+**It is not an Eye of the North problem.** Two further player reports, neither
+in EotN:
+
+- Vanquishing **Resplendent Makuun** (Nightfall, Vabbi) — crashed ~25 minutes in.
+- **Dunes of Despair** in Hard Mode with a consumable set — crashed ~20 minutes in.
+
+Both are long runs through a lot of an area's content, which is what the
+2026-08-04 staircase already implied: the heap tracks *novel* content, not map
+changes. Five map connections in that bundle cost zero growth because the
+player was revisiting. Vanquishing is the maximal case by definition — clearing
+an explorable area means loading all of it — and it is reachable from every
+campaign, on any account.
+
+**The ask, stated precisely, and what it is not.** `-sMAXIMUM_MEMORY=4GB` is
+one build flag, and wasm32 addresses up to 4 GB, so it is cheap. It is
+mitigation and not a cure, and the report must say so or the first engineer to
+read it will say it for us.
+
+Boot costs a fixed ~700 MiB, so the usable budget goes from ~1,348 MiB to
+~3,396 MiB: about **2.5x**. On the measured session that turns a death at 66
+minutes into one at roughly two and a half hours, and a 25-minute vanquish
+death into about 65 minutes. Useful, and still bounded.
+
+The heap does not converge under continuous new content. It grew steadily to
+the cap across 65 minutes with no plateau, and the only flat stretches were
+the player standing still. So a bigger ceiling buys time proportional to the
+ceiling and nothing else.
+
+What we cannot say is *why* it grows without bound. Round 3 already framed this
+as leak vs. fragmentation vs. per-zone accumulation, and nothing since has
+separated them. We do know `malloc`/`free` work normally — 500 rounds of
+8 MiB alloc/free against the real wasm kept the heap flat — so it is not a
+stubbed allocator. Beyond that: revisiting a zone costs no growth, which is
+equally consistent with content being cached deliberately and with it being
+freed and the blocks reused. From outside the client those look the same.
+
+So the report asks for the flag as breathing room, and reports the growth
+itself as the defect. wasm32 has no ceiling above 4 GB, which is the argument
+for treating the flag as time bought rather than the answer.

--- a/src/renderer/failure-messages.ts
+++ b/src/renderer/failure-messages.ts
@@ -188,17 +188,70 @@ export interface MemoryPressurePresentation {
   detail: string;
   reloadButton: string;
   dismissButton: string;
+  whyLink: string;
+}
+
+export interface MemoryPressureChip {
+  text: string;
+  /** The whole sentence, for the button's accessible name. */
+  label: string;
+}
+
+export interface MemoryExplanationBlock {
+  title: string;
+  body: string;
+}
+
+export interface MemoryExplanation {
+  title: string;
+  blocks: readonly MemoryExplanationBlock[];
+  closeButton: string;
 }
 
 /**
  * The game client's WASM heap is approaching its hard 2 GiB cap; once it gets
  * there the next big allocation kills the client wherever the player happens
  * to be standing. These sentences exist so the player spends that death at a
- * moment of their choosing: reloading from a town or outpost is a quick relog
- * that loses nothing, while an uncontrolled crash mid-mission loses the run.
+ * moment of their choosing.
+ *
+ * They state a condition and not a deadline, which is where they ended up
+ * rather than where they started. "Running low" meant half an hour in the open
+ * world and about two minutes in a mission, and a player could not tell which —
+ * so the *thresholds* count in time now, and that is the fix. It is only the
+ * printed figure that is gone, and a real crash bundle is why.
+ *
+ * Replayed against the Eye of the North session of 2026-08-04 — the player's
+ * own `wasm.heapGrew` staircase, ending at exactly 2 GiB — the levels arrived
+ * where they should: `low` with 31 minutes of real play left against the
+ * shipped rule's 11, `critical` with 7. The figure did not. It read
+ * 10 → 15 → 20 → 75 → 40 → 20 → 15 → 10 → 3, and at one point offered "about
+ * 75 minutes" to a player with 18 left, because a quiet stretch sat in the
+ * measurement window just before they went back into heavy loading.
+ *
+ * No rate can see a player about to zone into a dungeon. The estimate still
+ * exists — the thresholds are computed from it and the log records it — but
+ * it is a diagnostic, and a diagnostic printed on a
+ * banner is a promise. The level is the part that survived contact with a
+ * real session, so the level is the part the player is told.
+ *
+ * They state the reconnect rather than hedging it, which they did not always.
+ * The uncertainty was never whether Guild Wars gives a player their instance
+ * back after a dropped connection — it does — but whether *our* reload looks
+ * like a dropped connection to its server. Tested 2026-08-05 across all five
+ * reload paths this app can take, from inside an instance: every one came back
+ * with progress intact, in under thirty seconds. That is the specific question
+ * the hedge existed for, so the hedge is gone.
+ *
+ * The outpost is no longer in the notice. It is still true that an outpost
+ * risks nothing at all, and the explanation says so — but leading with it is
+ * what made the shipped sentence easy to ignore from inside a dungeon, and now
+ * that the reconnect is measured, repeating the caveat argues against a fact.
  */
 const MEMORY_RELOAD = 'Reload Now';
 const MEMORY_DISMISS = 'Later';
+const MEMORY_WHY = 'Why is this happening?';
+const MEMORY_REJOIN =
+  'Guild Wars puts you back where you were, in under a minute.';
 
 export function memoryPressurePresentation(
   level: 'low' | 'critical',
@@ -209,15 +262,78 @@ export function memoryPressurePresentation(
       ? 'Guild Wars is almost out of memory.'
       : 'Guild Wars is running low on memory.',
     detail: critical
-      ? 'A crash is likely soon. Head to a town or outpost at the next '
-        + 'safe moment and choose Reload Now — that is a quick relog, and '
-        + 'from an outpost you lose nothing.'
-      : 'After long sessions the game can crash when memory runs out. To '
-        + 'pick the moment yourself, finish what you are doing, return to a '
-        + 'town or outpost, and choose Reload Now — it works like a quick '
-        + 'relog.',
+      ? `Reload soon — ${MEMORY_REJOIN}`
+      : `Reload when it suits you — ${MEMORY_REJOIN}`,
     reloadButton: MEMORY_RELOAD,
     dismissButton: MEMORY_DISMISS,
+    whyLink: MEMORY_WHY,
+  };
+}
+
+/**
+ * What `Later` leaves behind: the thing that stops a dismissal meaning silence
+ * until the crash, which is what the shipped build did. It carried a live
+ * countdown until the Eye of the North bundle showed that countdown reading
+ * "75 min" to a player with eighteen minutes left — a figure that moves is
+ * only worth more than a word if it moves the right way.
+ */
+export function memoryPressureChip(
+  level: 'low' | 'critical',
+): MemoryPressureChip {
+  return level === 'critical'
+    ? {
+        text: 'Memory almost full',
+        label:
+          'Guild Wars is almost out of memory. Open the memory warning again.',
+      }
+    : {
+        text: 'Low memory',
+        label: 'Guild Wars is low on memory. Open the memory warning again.',
+      };
+}
+
+/**
+ * The four things a player asks once they have read the warning twice. The
+ * third block says what is true today — measured, documented, published. It
+ * must not claim we are in contact with ArenaNet until someone has actually
+ * written to them.
+ */
+export function memoryExplanation(): MemoryExplanation {
+  return {
+    title: 'Why this memory warning appears',
+    closeButton: 'Close',
+    blocks: [
+      {
+        title: 'What this is',
+        body:
+          "ArenaNet's current game client is capped at 2 GB of WebAssembly "
+          + 'memory. During long sessions that visit new content, its memory '
+          + 'can keep growing instead of settling. At the cap, the next large '
+          + 'allocation stops the game.',
+      },
+      {
+        title: 'Why the app cannot clear it',
+        body:
+          "The memory and its objects belong to ArenaNet's game client. This "
+          + 'app cannot safely discard objects it does not own. It can measure '
+          + 'the heap and warn before the client reaches its cap.',
+      },
+      {
+        title: 'Where it stands',
+        body:
+          'We have measured it, documented it in detail, and published the '
+          + 'findings for ArenaNet.',
+      },
+      {
+        title: 'What to do',
+        body:
+          'Reloading gives the game a fresh 2 GB. It takes under a minute, '
+          + 'and Guild Wars puts you back where you were — the same way it '
+          + 'handles a dropped connection. We tested that from inside an '
+          + 'instance, on every way this app can reload the game. A town or '
+          + 'outpost is still the one place with nothing at all to lose.',
+      },
+    ],
   };
 }
 

--- a/src/renderer/harness.css
+++ b/src/renderer/harness.css
@@ -1,4 +1,11 @@
-:root { color-scheme: dark; }
+:root {
+  color-scheme: dark;
+  /* A critically damped spring, response 0.4s, sampled rather than guessed at
+     with a bezier. No overshoot: bounce belongs to motion a gesture threw, and
+     nothing here was thrown. */
+  --spring: linear(0, .186, .465, .682, .821, .903, .949, .973, .986, .993,
+                   .997, .999, 1);
+}
 html,body { width:100%; height:100%; margin:0; overflow:hidden;
             background:#000; color:#fe0000; font:14px Tahoma,sans-serif; }
 #canvas { display:block; width:100%; height:100%; }
@@ -49,52 +56,244 @@ html,body { width:100%; height:100%; margin:0; overflow:hidden;
 }
 #capture-status[hidden] { display: none; }
 
-/* The heap watermark notice. Top-centred over the running game; amber while
-   there is headroom, red once the next growth step would hit the 2 GiB cap.
-   Buttons are the only interactive surface — the div itself must not feel
-   like a dialog that blocks play. */
+/* The memory warning. Top-centred over the running game, translucent so the
+   game reads through it, and never scrimmed — it is a message running beside
+   play, not a dialog that stops it. It enters down from the edge it lives on
+   and leaves the same way, and blur and scale animate together so it arrives
+   as a surface rather than cross-fading as a picture. */
 #memory-notice {
   position: fixed;
   top: 14px;
   left: 50%;
-  transform: translateX(-50%);
   z-index: 9;
   display: flex;
   align-items: center;
-  gap: 14px;
-  max-width: min(90vw, 680px);
+  gap: 16px;
+  max-width: min(92vw, 540px);
   box-sizing: border-box;
-  padding: 8px 12px;
-  border: 1px solid #8a6d3b;
-  border-radius: 6px;
+  padding: 11px 13px;
+  border: 1px solid #ffffff1f;
+  border-radius: 12px;
   color: #f5ead9;
-  background: #1c1408ee;
-  font: 13px/1.45 Tahoma, sans-serif;
-  box-shadow: 0 2px 10px #0008;
+  background: #241d13b8;
+  backdrop-filter: blur(20px) saturate(170%);
+  -webkit-backdrop-filter: blur(20px) saturate(170%);
+  /* The bright top edge is light catching the material. */
+  box-shadow: inset 0 1px 0 #ffffff1c, 0 2px 8px #000c;
+  transform: translateX(-50%) translateY(0) scale(1);
+  opacity: 1;
+  transition: transform .4s var(--spring), opacity .28s ease-out,
+              backdrop-filter .4s var(--spring), border-color .3s ease-out,
+              background-color .3s ease-out;
 }
 #memory-notice[hidden] { display: none; }
-#memory-notice.critical {
-  border-color: #945b4f;
-  background: #1b0c0bee;
-  color: #fff1e9;
+#memory-notice.entering,
+#memory-notice.leaving {
+  transform: translateX(-50%) translateY(-14px) scale(.97);
+  opacity: 0;
+  backdrop-filter: blur(0) saturate(100%);
+  -webkit-backdrop-filter: blur(0) saturate(100%);
 }
-#memory-notice-label { display: block; }
-#memory-notice-actions { display: flex; gap: 8px; flex-shrink: 0; }
-#memory-notice button {
-  font: 12px Tahoma, sans-serif;
-  padding: 5px 12px;
-  border: 1px solid #776a55;
-  border-radius: 4px;
-  background: #2b2a20;
-  color: inherit;
+#memory-notice.critical {
+  background: #2b0f0ab8;
+  border-color: #ff8f6b4d;
+  box-shadow: inset 0 1px 0 #ffb49c26, 0 2px 8px #000c,
+              0 0 0 1px #ff6a4126;
+}
+/* Vibrancy: over a translucent ground text earns contrast, a heavier weight
+   and a little tracking rather than sitting flat and grey. */
+#memory-notice-label {
+  display: block;
+  font: 600 14px/1.3 Tahoma, sans-serif;
+  letter-spacing: .005em;
+  color: #fff6ec;
+}
+#memory-notice.critical #memory-notice-label { color: #ffd9cb; }
+#memory-notice-detail {
+  font: 13px/1.5 Tahoma, sans-serif;
+  letter-spacing: .01em;
+  color: #ece0cf;
+  /* The label above is a block; these two run together inline beneath it, so
+     the gap between them belongs here rather than as padding inside a string
+     the copy module owns. */
+  margin-right: .35em;
+}
+#memory-notice-why {
+  display: inline;
+  padding: 0;
+  border: 0;
+  background: none;
+  color: #ece0cf;
+  opacity: .74;
+  font: 13px/1.5 Tahoma, sans-serif;
+  letter-spacing: .01em;
+  text-decoration: underline;
+  text-underline-offset: 2px;
   cursor: pointer;
 }
-#memory-notice button:hover { border-color: #a99878; }
+#memory-notice-why:hover { opacity: 1; }
+#memory-notice-actions { display: flex; gap: 8px; flex-shrink: 0; }
+#memory-notice-actions button {
+  min-height: 36px;
+  font: 500 12.5px/1 Tahoma, sans-serif;
+  padding: 8px 14px;
+  border: 1px solid #ffffff26;
+  border-radius: 8px;
+  background: #ffffff14;
+  color: #f3e8da;
+  cursor: pointer;
+  transition: background-color .12s ease-out, border-color .12s ease-out,
+              transform .1s ease-out;
+}
+#memory-notice-actions button:hover { background: #ffffff1f; border-color: #ffffff3d; }
+/* Feedback on the press, not the release. */
+#memory-notice button:active { transform: scale(.97); }
 #memory-notice button:focus-visible { outline: 2px solid #ff9d66;
                                       outline-offset: 2px; }
-#memory-notice button:active { transform: scale(.97); }
-#memory-notice.critical button { border-color: #8a5f55; }
-#memory-notice.critical button:hover { border-color: #c08a7c; }
+#memory-notice-actions .primary {
+  background: #c2542e;
+  border-color: #e0714f;
+  color: #fff6f1;
+  font-weight: 600;
+}
+#memory-notice-actions .primary:hover { background: #d15f36; border-color: #ff8a63; }
+
+/* The chip a dismissal leaves. Top right, in the band between the client's own
+   window buttons and the top of its compass — at 118px it sat on the compass
+   itself, over the one piece of UI a player reads constantly. */
+#memory-chip {
+  position: fixed;
+  top: 52px;
+  right: 16px;
+  z-index: 9;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  min-height: 32px;
+  padding: 6px 11px;
+  border: 1px solid #ffffff26;
+  border-radius: 20px;
+  background: #2b0f0ab3;
+  backdrop-filter: blur(14px) saturate(160%);
+  -webkit-backdrop-filter: blur(14px) saturate(160%);
+  color: #ffd9cb;
+  font: 600 11.5px/1 Tahoma, sans-serif;
+  letter-spacing: .02em;
+  cursor: pointer;
+  box-shadow: 0 2px 8px #000b;
+  transition: transform .1s ease-out, background-color .12s ease-out;
+}
+#memory-chip[hidden] { display: none; }
+#memory-chip:hover { background: #421b12d9; }
+#memory-chip:active { transform: scale(.96); }
+#memory-chip:focus-visible { outline: 2px solid #ff9d66; outline-offset: 2px; }
+.memory-chip-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #ff7a55;
+}
+
+/* The explanation is the one modal task here, so it dims what it interrupts.
+   The notice never does — it runs beside play. */
+#memory-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 10;
+  background: #000;
+  opacity: .5;
+  transition: opacity .3s ease-out;
+}
+#memory-scrim[hidden] { display: none; }
+#memory-why {
+  position: fixed;
+  top: 14px;
+  left: 50%;
+  z-index: 11;
+  width: min(92vw, 540px);
+  max-height: calc(100vh - 34px);
+  overflow-y: auto;
+  box-sizing: border-box;
+  padding: 20px 22px;
+  border: 1px solid #ffffff21;
+  border-radius: 14px;
+  background: #1a1610f2;
+  backdrop-filter: blur(24px) saturate(160%);
+  -webkit-backdrop-filter: blur(24px) saturate(160%);
+  color: #f0e6d2;
+  font: 13px/1.6 Tahoma, sans-serif;
+  box-shadow: inset 0 1px 0 #ffffff1a, 0 2px 8px #000d;
+  transform-origin: top center;
+  transform: translateX(-50%) scale(1);
+  opacity: 1;
+  transition: transform .4s var(--spring), opacity .26s ease-out;
+}
+#memory-why[hidden] { display: none; }
+#memory-why.entering, #memory-why.leaving {
+  transform: translateX(-50%) scale(.94);
+  opacity: 0;
+}
+#memory-why h2 {
+  margin: 0 0 14px;
+  color: #fff6ec;
+  font: 600 17px/1.3 Tahoma, sans-serif;
+  text-wrap: balance;
+}
+#memory-why h3 {
+  margin: 16px 0 4px;
+  font: 600 13.5px/1.35 Tahoma, sans-serif;
+  letter-spacing: .005em;
+  color: #efb85b;
+}
+#memory-why h3:first-child { margin-top: 0; }
+#memory-why p { margin: 0; color: #e2d7c2; letter-spacing: .008em; }
+#memory-why-close {
+  margin-top: 18px;
+  min-height: 36px;
+  padding: 8px 16px;
+  border: 1px solid #ffffff26;
+  border-radius: 8px;
+  background: #ffffff14;
+  color: #f0e6d2;
+  font: 500 12.5px/1 Tahoma, sans-serif;
+  cursor: pointer;
+  transition: background-color .12s ease-out, transform .1s ease-out;
+}
+#memory-why-close:hover { background: #ffffff1f; }
+#memory-why-close:active { transform: scale(.97); }
+#memory-why-close:focus-visible { outline: 2px solid #ff9d66; outline-offset: 2px; }
+
+/* Reduced motion keeps the feedback and drops the travel: a cross-fade in
+   place, and no scaling under the finger. */
+@media (prefers-reduced-motion: reduce) {
+  #memory-notice, #memory-why, #memory-scrim,
+  #memory-notice button, #memory-chip, #memory-why-close {
+    transition: opacity .2s ease-out;
+  }
+  #memory-notice.entering, #memory-notice.leaving {
+    transform: translateX(-50%);
+    backdrop-filter: blur(20px) saturate(170%);
+    -webkit-backdrop-filter: blur(20px) saturate(170%);
+  }
+  #memory-why.entering, #memory-why.leaving { transform: translateX(-50%); }
+  #memory-notice button:active, #memory-chip:active,
+  #memory-why-close:active { transform: none; }
+}
+/* Frosted glass is the first thing to go when transparency is refused. */
+@media (prefers-reduced-transparency: reduce) {
+  #memory-notice { background: #241d13; backdrop-filter: none;
+                   -webkit-backdrop-filter: none; }
+  #memory-notice.critical { background: #2b0f0a; }
+  #memory-chip { background: #2b0f0a; backdrop-filter: none;
+                 -webkit-backdrop-filter: none; }
+  #memory-why { background: #1a1610; backdrop-filter: none;
+                -webkit-backdrop-filter: none; }
+}
+@media (prefers-contrast: more) {
+  #memory-notice { background: #1b150d; border-color: #ffd9a8; }
+  #memory-notice.critical { background: #2a0b06; border-color: #ff9f80; }
+  #memory-notice-detail, #memory-notice-why { color: #fff8ee; opacity: 1; }
+}
 
 /* The Steam sign-in status line: quiet, bottom-centred over the client's own
    login screen, and gone on its own — it explains, it never blocks. */

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -269,42 +269,66 @@ window.gwLog = (on = true) => {
 };
 
 /**
- * The heap watermark. The client's WASM memory is capped by its own build
- * (`WASM_HEAP_CAP_BYTES` in the shared contracts), memory only ever grows
- * within one run, and a session that reaches the cap dies on whatever
- * allocation comes next — historically hours in and mid-mission. The watcher
- * moves that death to a moment the player picks: warn while there is headroom
- * to travel somewhere safe, escalate when the next growth step would hit the
- * cap. Reloading is a quick relog; from a town or outpost it loses nothing.
+ * The memory warning. The client's WASM memory is capped by its own build
+ * (`WASM_HEAP_CAP_BYTES` in the shared contracts), it only ever grows within a
+ * run, and a session that reaches the cap dies on whatever allocation comes
+ * next — historically hours in and mid-mission. The watcher moves that death
+ * to a moment the player picks.
+ *
+ * It counts in time, not bytes remaining. `heap-pressure.ts` owns that
+ * arithmetic and the reason for it; what matters here is that the number the
+ * player is shown is measured, and that when it cannot be measured no number
+ * is shown at all.
  *
  * A classic script cannot static-import, so the cap arrives via a dynamic
  * import — on the first watcher tick, not at boot. Boot would work here, but
  * it would also put the canonical contract into the module cache before the
  * Enhancement runtime imports it, and the packaged proof that the runtime
- * resolves the canonical module observes that import as a request. Until the
- * import lands the thresholds are Infinity and the watcher is silent, which
- * costs one 15-second tick and nothing else: no heap reaches a watermark
- * that fast.
+ * resolves the canonical module observes that import as a request. Until it
+ * lands there is no watch and the watcher is silent, which costs one
+ * 15-second tick and nothing else: no heap fills that fast.
  */
 const MIB = 1_048_576;
 let heapCapBytes = 0;
-let heapWarnBytes = Infinity; // cap − 256 MiB — time to finish up.
-let heapCriticalBytes = Infinity; // cap − 128 MiB — go now.
+let heapWatch: import('./heap-pressure.js').HeapPressureWatch | null = null;
 let heapCapRequested = false;
 function requestHeapCap() {
   if (heapCapRequested) return;
   heapCapRequested = true;
-  void import('../shared/contracts.js')
-    .then(({ WASM_HEAP_CAP_BYTES }) => {
+  void Promise.all([
+    import('../shared/contracts.js'),
+    import('./heap-pressure.js'),
+  ])
+    .then(([{ WASM_HEAP_CAP_BYTES }, { createHeapPressureWatch }]) => {
       heapCapBytes = WASM_HEAP_CAP_BYTES;
-      heapWarnBytes = WASM_HEAP_CAP_BYTES - 256 * MIB;
-      heapCriticalBytes = WASM_HEAP_CAP_BYTES - 128 * MIB;
+      heapWatch = createHeapPressureWatch({ capBytes: WASM_HEAP_CAP_BYTES });
     })
     // A failed load retries on the next tick rather than silencing the
-    // watermark for the whole session.
+    // warning for the whole session.
     .catch(() => { heapCapRequested = false; });
 }
 let heapNoticeLevel: 'none' | 'low' | 'critical' = 'none';
+/** What is on screen, so a dismissal can be a deferral rather than silence. */
+let heapSurface: 'hidden' | 'notice' | 'chip' = 'hidden';
+let heapLeaveTimer: ReturnType<typeof setTimeout> | null = null;
+let heapWhyLeaveTimer: ReturnType<typeof setTimeout> | null = null;
+const prefersReducedMotion = () =>
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+/**
+ * How long to leave an element in the DOM while it animates out, read from the
+ * element itself rather than restated here. A number copied out of the
+ * stylesheet is a second source of truth that drifts silently — and this one
+ * also inherits the shorter durations the reduced-motion block sets, which a
+ * constant could not.
+ */
+const exitMs = (element: HTMLElement) =>
+  Math.max(
+    0,
+    ...getComputedStyle(element)
+      .transitionDuration.split(',')
+      .map((value) => Number.parseFloat(value) * 1_000)
+      .filter(Number.isFinite),
+  );
 
 const wasmHeapBytes = () => Module.HEAPU8?.buffer.byteLength ?? 0;
 window.gwWasmHeapBytes = wasmHeapBytes;
@@ -329,18 +353,92 @@ const crashTechnicalDetail = (reason: unknown, heapBytes: number): string => {
 // Static markup, and this script loads at the end of <body>, so the elements
 // exist here; a missing id degrades to a watcher that never presents.
 const heapNoticeRoot = document.getElementById('memory-notice');
+const heapNoticeText = document.getElementById('memory-notice-text');
 const heapNoticeLabel = document.getElementById('memory-notice-label');
 const heapNoticeDetail = document.getElementById('memory-notice-detail');
 const heapNoticeReload = document.getElementById('memory-notice-reload');
 const heapNoticeLater = document.getElementById('memory-notice-later');
+const heapNoticeWhy = document.getElementById('memory-notice-why');
+const heapChip = document.getElementById('memory-chip');
+const heapChipText = document.getElementById('memory-chip-text');
+const heapScrim = document.getElementById('memory-scrim');
+const heapWhyRoot = document.getElementById('memory-why');
+const heapWhyTitle = document.getElementById('memory-why-title');
+const heapWhyBlocks = document.getElementById('memory-why-blocks');
+const heapWhyClose = document.getElementById('memory-why-close');
+
+/**
+ * The client listens on the window for the events these surfaces generate, so
+ * a click on Later used to reach the game as well. Stopping them at the
+ * overlay root is the same boundary `toolbox-foundation.ts` draws.
+ */
+for (const root of [heapNoticeRoot, heapChip, heapScrim, heapWhyRoot]) {
+  for (const name of [
+    'keydown', 'keyup', 'pointerdown', 'pointerup', 'pointermove',
+    'mousedown', 'mouseup', 'mousemove', 'click', 'wheel', 'contextmenu',
+  ]) {
+    root?.addEventListener(name, (event) => event.stopPropagation());
+  }
+}
+
 heapNoticeReload?.addEventListener('click', () => {
-  hideHeapNotice();
+  hideHeapNotice({ instant: true });
   reloadClientSafely();
 });
-heapNoticeLater?.addEventListener('click', hideHeapNotice);
+heapNoticeLater?.addEventListener('click', () => {
+  // Later is a deferral, not a dismissal: the watcher keeps measuring, the
+  // chip remains visible, and a rise to critical raises the banner again.
+  hideHeapNotice({ after: showHeapChip });
+});
+heapNoticeWhy?.addEventListener('click', () => void openHeapWhy());
+heapChip?.addEventListener('click', () => {
+  hideHeapChip();
+  void presentHeapNotice(heapNoticeLevel === 'critical' ? 'critical' : 'low');
+});
+heapWhyClose?.addEventListener('click', () => closeHeapWhy());
+heapScrim?.addEventListener('click', () => closeHeapWhy());
+/**
+ * The explanation claims `aria-modal`, which tells a screen reader everything
+ * behind it is inert — so the keyboard has to agree. It holds exactly one
+ * control, which makes the trap the whole of it: Tab has nowhere else to go.
+ * Listening on the document rather than on the panel is what makes Escape
+ * work from a click that landed on the panel's own prose.
+ */
+document.addEventListener('keydown', (event) => {
+  if (!heapWhyRoot || heapWhyRoot.hidden) return;
+  if (event.key === 'Escape') {
+    event.preventDefault();
+    closeHeapWhy();
+  } else if (event.key === 'Tab') {
+    event.preventDefault();
+    heapWhyClose?.focus();
+  }
+}, true);
 
-function hideHeapNotice() {
-  if (heapNoticeRoot) heapNoticeRoot.hidden = true;
+function hideHeapNotice(options?: { instant?: boolean; after?: () => void }) {
+  if (!heapNoticeRoot || heapNoticeRoot.hidden) return;
+  if (heapLeaveTimer !== null) clearTimeout(heapLeaveTimer);
+  if (heapSurface === 'notice') heapSurface = 'hidden';
+  if (options?.instant || prefersReducedMotion()) {
+    heapNoticeRoot.hidden = true;
+    heapNoticeRoot.classList.remove('leaving', 'entering');
+    options?.after?.();
+    return;
+  }
+  // It leaves the way it came, back up past the edge it lives on.
+  heapNoticeRoot.classList.add('leaving');
+  heapLeaveTimer = setTimeout(() => {
+    heapLeaveTimer = null;
+    if (!heapNoticeRoot.classList.contains('leaving')) return;
+    heapNoticeRoot.hidden = true;
+    heapNoticeRoot.classList.remove('leaving');
+    options?.after?.();
+  }, exitMs(heapNoticeRoot));
+}
+
+function hideHeapChip() {
+  if (heapChip) heapChip.hidden = true;
+  if (heapSurface === 'chip') heapSurface = 'hidden';
 }
 
 /**
@@ -365,32 +463,150 @@ function reloadClientSafely() {
 
 async function presentHeapNotice(level: 'low' | 'critical') {
   if (
-    !heapNoticeRoot || !heapNoticeLabel || !heapNoticeDetail
-    || !heapNoticeReload || !heapNoticeLater
+    !heapNoticeRoot || !heapNoticeText || !heapNoticeLabel || !heapNoticeDetail
+    || !heapNoticeReload || !heapNoticeLater || !heapNoticeWhy
   ) return;
+  // The explanation owns the screen until it closes. A level may escalate
+  // while the player is reading it; closeHeapWhy restores the latest level.
+  if (heapWhyRoot && !heapWhyRoot.hidden) return;
   const { memoryPressurePresentation } = await import('./failure-messages.js');
+  // The import can yield on its first call, so repeat the ownership check to
+  // keep a notice from appearing over a modal opened in the meantime.
+  if (heapWhyRoot && !heapWhyRoot.hidden) return;
   const copy = memoryPressurePresentation(level);
   heapNoticeLabel.textContent = copy.label;
   heapNoticeDetail.textContent = copy.detail;
   heapNoticeReload.textContent = copy.reloadButton;
   heapNoticeLater.textContent = copy.dismissButton;
+  heapNoticeWhy.textContent = copy.whyLink;
   heapNoticeRoot.classList.toggle('critical', level === 'critical');
+  // A surface already on screen changing state does not leave and re-enter;
+  // the colour transition and the re-announcement carry the escalation.
+  const wasShowing = heapSurface === 'notice' && !heapNoticeRoot.hidden;
+  heapNoticeText.setAttribute('role', level === 'critical' ? 'alert' : 'status');
+  heapNoticeText.setAttribute(
+    'aria-live', level === 'critical' ? 'assertive' : 'polite',
+  );
+  heapSurface = 'notice';
+  hideHeapChip();
+  if (heapLeaveTimer !== null) {
+    clearTimeout(heapLeaveTimer);
+    heapLeaveTimer = null;
+  }
+  heapNoticeRoot.classList.remove('leaving');
+  if (wasShowing || prefersReducedMotion()) {
+    heapNoticeRoot.classList.remove('entering');
+    heapNoticeRoot.hidden = false;
+    return;
+  }
+  heapNoticeRoot.classList.add('entering');
   heapNoticeRoot.hidden = false;
+  void heapNoticeRoot.offsetWidth;
+  requestAnimationFrame(() => heapNoticeRoot.classList.remove('entering'));
+}
+
+function showHeapChip() {
+  if (!heapChip || !heapChipText || heapNoticeLevel === 'none') return;
+  void (async () => {
+    const { memoryPressureChip } = await import('./failure-messages.js');
+    if (heapSurface !== 'hidden') return;
+    const chip = memoryPressureChip(heapNoticeLevel as 'low' | 'critical');
+    // Only touch the DOM when the rendered string actually changes: this runs
+    // on every tick, over a game drawing at sixty frames a second.
+    if (heapChipText.textContent !== chip.text) heapChipText.textContent = chip.text;
+    heapChip.setAttribute('aria-label', chip.label);
+    heapChip.hidden = false;
+    heapSurface = 'chip';
+  })().catch(() => {});
+}
+
+/**
+ * The explanation is the one modal task here, so it dims the game and takes
+ * focus — and it opens in the notice's place rather than over it, because two
+ * translucent surfaces stacked stop being readable.
+ */
+async function openHeapWhy() {
+  if (!heapWhyRoot || !heapWhyBlocks || !heapWhyClose || !heapWhyTitle) return;
+  const { memoryExplanation } = await import('./failure-messages.js');
+  const copy = memoryExplanation();
+  heapWhyTitle.textContent = copy.title;
+  heapWhyClose.textContent = copy.closeButton;
+  heapWhyBlocks.replaceChildren(
+    ...copy.blocks.flatMap((block) => {
+      const heading = document.createElement('h3');
+      heading.textContent = block.title;
+      const body = document.createElement('p');
+      body.textContent = block.body;
+      return [heading, body];
+    }),
+  );
+  // The game may hold the pointer; without this the panel cannot be reached.
+  document.exitPointerLock?.();
+  if (heapWhyLeaveTimer !== null) {
+    clearTimeout(heapWhyLeaveTimer);
+    heapWhyLeaveTimer = null;
+  }
+  hideHeapNotice({ instant: true });
+  hideHeapChip();
+  if (heapScrim) heapScrim.hidden = false;
+  heapWhyRoot.classList.remove('leaving');
+  if (!prefersReducedMotion()) {
+    heapWhyRoot.classList.add('entering');
+    heapWhyRoot.hidden = false;
+    void heapWhyRoot.offsetWidth;
+    requestAnimationFrame(() => heapWhyRoot.classList.remove('entering'));
+  } else {
+    heapWhyRoot.hidden = false;
+  }
+  heapWhyClose.focus();
+}
+
+function closeHeapWhy(options?: { instant?: boolean }) {
+  if (!heapWhyRoot || heapWhyRoot.hidden) return;
+  const restoreWarning = () => {
+    if (options?.instant) return;
+    if (heapNoticeLevel !== 'none') {
+      void presentHeapNotice(heapNoticeLevel as 'low' | 'critical').then(() => {
+        heapNoticeWhy?.focus();
+      });
+    } else {
+      document.getElementById('canvas')?.focus();
+    }
+  };
+  const finish = () => {
+    heapWhyLeaveTimer = null;
+    heapWhyRoot.hidden = true;
+    heapWhyRoot.classList.remove('leaving');
+    if (heapScrim) heapScrim.hidden = true;
+    restoreWarning();
+  };
+  if (options?.instant || prefersReducedMotion()) finish();
+  else {
+    heapWhyRoot.classList.add('leaving');
+    heapWhyLeaveTimer = setTimeout(finish, exitMs(heapWhyRoot));
+  }
 }
 
 setInterval(() => {
   if (crashRecorded) return;
   requestHeapCap();
-  const bytes = wasmHeapBytes();
-  const level = bytes >= heapCriticalBytes
-    ? 'critical'
-    : bytes >= heapWarnBytes ? 'low' : 'none';
-  // Escalation is one-way and each level presents once: the heap cannot
-  // shrink within a client run, and a reload resets this whole script.
-  if (level === 'none' || level === heapNoticeLevel) return;
-  heapNoticeLevel = level;
-  log(`[memory] wasm heap at ${Math.round(bytes / MIB)} MiB — ${level} notice`);
-  presentHeapNotice(level).catch(() => {});
+  if (!heapWatch) return;
+  const reading = heapWatch.sample(wasmHeapBytes(), performance.now());
+  if (reading.level === 'none') return;
+  if (reading.level !== heapNoticeLevel) {
+    heapNoticeLevel = reading.level;
+    log(
+      `[memory] wasm heap at ${Math.round(reading.bytes / MIB)} MiB`
+      + ` — ${reading.minutes ?? '?'} min left`
+      + ` at ${Math.round((reading.bytesPerMinute ?? 0) / MIB)} MiB/min`
+      + ` — ${reading.level} notice (${reading.raisedBy ?? 'held'})`,
+    );
+    // A rise always shows the banner, including out of a dismissal: Later
+    // means later, and the level only ever rises when time is running out.
+    void presentHeapNotice(reading.level);
+    return;
+  }
+  if (heapSurface === 'chip') showHeapChip();
 }, 15_000);
 
 const STARTUP_LABELS = {
@@ -796,7 +1012,11 @@ Module = {
     // fingerprint, and stays readable on the overlay's disclosure.
     if (crashRecorded) return;
     crashRecorded = true;
-    hideHeapNotice();
+    // The crash overlay is taking the screen; nothing animates out from under
+    // it.
+    hideHeapNotice({ instant: true });
+    hideHeapChip();
+    closeHeapWhy({ instant: true });
     const heapBytes = wasmHeapBytes();
     // The overlay first, with the first-crash presentation; the recorded
     // count upgrades it below once main has counted this crash.
@@ -831,7 +1051,9 @@ Module = {
       // first-crash and count the same death twice.
       if (crashRecorded) return;
       crashRecorded = true;
-      hideHeapNotice();
+      hideHeapNotice({ instant: true });
+      hideHeapChip();
+      closeHeapWhy({ instant: true });
       // `code` is declared unknown at the Module boundary; anything the
       // glue passes that is not a plain integer records as the -1 the
       // schema can still account for.
@@ -1014,7 +1236,8 @@ function loadGlue() {
     const target = event.relatedTarget;
     if (
       oskInputs.has(target) ||
-      (target instanceof Element && target.closest('#toolbox-foundation'))
+      (target instanceof Element
+        && target.closest('#toolbox-foundation, #memory-notice, #memory-chip, #memory-why'))
     ) {
       event.stopImmediatePropagation();
     }

--- a/src/renderer/heap-pressure.ts
+++ b/src/renderer/heap-pressure.ts
@@ -1,0 +1,302 @@
+/**
+ * How long the client has left before its heap fills, and which warning that
+ * earns. The unit is time, not bytes remaining: the same 256 MiB of headroom
+ * was half an hour of open-world play and about two minutes inside a
+ * texture-dense mission, and a player has no way to tell those apart from a
+ * sentence that names neither.
+ *
+ * It owns the rate estimate and the threshold policy. It owns no DOM, no
+ * timer, and not one word the player reads — the harness drives it and
+ * `failure-messages.ts` says it. It also imports nothing from `../shared/`:
+ * the client's compiled-in cap arrives as an argument, because a second
+ * importer of the canonical contract disturbs the packaged proof that the
+ * Enhancement runtime is what requested it.
+ *
+ * What it measures is a staircase, not a slope. `Module.HEAPU8.buffer` is the
+ * memory the runtime has *reserved*, and WebAssembly reserves it in discrete
+ * jumps — Emscripten's glue grows by a fifth of the current size, capped at
+ * 96 MiB, so a session spending 555 MiB an hour takes one step roughly every
+ * ten minutes and is perfectly flat in between. That shape decides the whole
+ * design below, and getting it wrong is not subtle: a fixed five-minute
+ * window contains either no step or one, and reports 0 or 1,152 MiB an hour
+ * for a session actually spending 555.
+ */
+
+export type HeapPressureLevel = 'none' | 'low' | 'critical';
+
+export interface HeapPressureReading {
+  /** Monotonic within a client run: once critical, always critical. */
+  level: HeapPressureLevel;
+  /** Hedged and display-ready; null when no rate could be measured. */
+  minutes: number | null;
+  /** Unhedged, for the log line. Null when unmeasurable. */
+  bytesPerMinute: number | null;
+  /**
+   * The step-to-step span the rate was measured over; null when no rate could
+   * be measured. This is what tells "nothing has grown twice yet" apart from
+   * "the reading is broken" — a distinction a bare log placeholder cannot
+   * draw, and the reason it is on the reading rather than inferred.
+   */
+  measuredOverMs: number | null;
+  bytes: number;
+  /** Which rule raised the level. For the log; the copy never branches on it. */
+  raisedBy: 'time' | 'bytes' | null;
+}
+
+export interface HeapPressurePolicy {
+  /** Shortest step-to-step span a rate may be measured over. See DEFAULTS. */
+  minSpanMs?: number;
+  /** No step counts until this long after the client first allocated. */
+  warmupMs?: number;
+  lowMinutes?: number;
+  criticalMinutes?: number;
+  blindLowBytes?: number;
+  blindCriticalBytes?: number;
+  hardCriticalBytes?: number;
+  minRateBytesPerMinute?: number;
+  /** How many consecutive readings must agree before a level is raised. */
+  confirmations?: number;
+}
+
+export interface HeapPressureWatch {
+  sample(bytes: number, atMs: number): HeapPressureReading;
+}
+
+const MIB = 1_048_576;
+
+const DEFAULTS = {
+  /**
+   * Both ends of a measurement sit on a growth step, and they must be at
+   * least this far apart.
+   *
+   * Step-to-step is what makes the estimate stand still. Measuring from a
+   * step to *now* puts a whole tread in the denominator and none of its rise
+   * in the numerator, so the figure sags between steps and jumps back when
+   * the next one lands — a third of its own value, every ten minutes, on a
+   * session whose rate never changed. Measuring step to step reads the same
+   * number wherever in the tread the sample falls.
+   *
+   * The span is what tells a burst from a trend, and ten minutes is bought
+   * rather than guessed. Loading a zone reserves a couple of hundred MiB in
+   * seconds; a sustained 3,500 MiB an hour reserves about the same amount
+   * over ten minutes. Inside a window shorter than that the two are the same
+   * measurement, and the level never falls, so getting it wrong is permanent.
+   * Simulated against the sessions we have measured — a 300 MiB zone load at
+   * minute 30 of an ordinary 555 MiB/h session:
+   *
+   *     span   what the load makes the warning say
+   *      4 m   "about 20 minutes of play left", 77 minutes truly left
+   *      8 m   escalates to critical with 30 minutes truly left
+   *     10 m   nothing; the real warning arrives on time at minute 95
+   *
+   * The cost is paid by the fastest sessions. A mission spending 3,500 MiB an
+   * hour dies around minute 23, and nothing can be said about it until minute
+   * 18 — five minutes of warning where an eight-minute span would have given
+   * eight. That is the worse error to accept, and it is accepted knowingly:
+   * the alternative mis-warns every player who walks into a large zone, every
+   * time, and leaves the warning up for the hour afterwards. The byte floors
+   * below are the backstop for the fast case.
+   *
+   * There is no shorter honest answer. Ten minutes into a mission, a
+   * ten-minute-old zone load and a sustained spend look alike in every
+   * window; a "is it still going?" test costs exactly the latency it saves.
+   */
+  minSpanMs: 10 * 60_000,
+  /**
+   * Measured from the client's first allocation, not from page load.
+   *
+   * Starting the client is the heaviest allocating a session ever does —
+   * observed at roughly 4,500 MiB/h against a steady-state 555 — so a
+   * measurement anchored inside that ramp reads a startup as a session with a
+   * quarter of an hour to live, and every player is warned a minute after
+   * logging in. Anchoring the exclusion to page load instead looks equivalent
+   * and is not: the page is open through the client download, so a slow first
+   * run boots after the warm-up has already expired and the ramp is measured
+   * as ordinary play.
+   */
+  warmupMs: 5 * 60_000,
+  lowMinutes: 20,
+  criticalMinutes: 5,
+  // The bytes the shipped build warned on, kept for when time is unmeasurable.
+  blindLowBytes: 256 * MIB,
+  blindCriticalBytes: 128 * MIB,
+  // The never-silent backstop: this much headroom is critical whatever any
+  // estimate claims. It has to sit *below* where the time rule fires in an
+  // ordinary session or it pre-empts it — at the measured 555 MiB/h the five
+  // minute rule fires at about 46 MiB, and a 64 MiB floor took the warning
+  // over at seven minutes, which is the defect this module exists to remove.
+  hardCriticalBytes: 32 * MIB,
+  minRateBytesPerMinute: MIB,
+  /**
+   * How many consecutive readings must agree before the level is raised. The
+   * level never falls, so a single unlucky sample would be permanent — this is
+   * what makes "we measured it twice" the price of a warning that cannot be
+   * taken back. The hard byte floor is exempt: at that point the heap really
+   * is nearly full and there is nothing left to corroborate.
+   */
+  confirmations: 2,
+};
+
+const RANK: Record<HeapPressureLevel, number> = {
+  none: 0,
+  low: 1,
+  critical: 2,
+};
+
+/**
+ * Round the estimate the way the sentence reads it: to five minutes once
+ * there is a quarter of an hour to spend, to the minute when there is not.
+ *
+ * Nearest, not down. At the moment the twenty-minute rule fires the estimate
+ * sits just under twenty, and flooring would print "about 15 minutes" —
+ * understating by a quarter exactly when the number is supposed to sound
+ * deliberate. Rounding up costs at most two and a half minutes against an
+ * estimate already built to run early, and the sentence says "about".
+ */
+export function hedgeMinutes(minutes: number): number {
+  if (!Number.isFinite(minutes) || minutes <= 0) return 0;
+  return minutes >= 10 ? Math.round(minutes / 5) * 5 : Math.round(minutes);
+}
+
+export function createHeapPressureWatch(
+  options: { capBytes: number } & HeapPressurePolicy,
+): HeapPressureWatch {
+  const policy = { ...DEFAULTS, ...options };
+  const capBytes = options.capBytes;
+  /** Growth steps, oldest first; `bytes` is the heap the step arrived at. */
+  const steps: { atMs: number; bytes: number; grewBy: number }[] = [];
+  let previousBytes: number | null = null;
+  let previousAtMs = -Infinity;
+  /** When the client first held any memory — the clock the warm-up runs on. */
+  let allocatingSinceMs: number | null = null;
+  let raised: HeapPressureLevel = 'none';
+  let pending: HeapPressureLevel = 'none';
+  let streak = 0;
+
+  return {
+    sample(bytes, atMs) {
+      // A repeated or backwards timestamp would divide by zero or by a
+      // negative; the sample is dropped rather than allowed to produce a rate.
+      if (atMs > previousAtMs) {
+        if (allocatingSinceMs === null && bytes > 0) allocatingSinceMs = atMs;
+        const settled =
+          allocatingSinceMs !== null
+          && atMs >= allocatingSinceMs + policy.warmupMs;
+        if (settled && previousBytes !== null && bytes > previousBytes) {
+          steps.push({ atMs, bytes, grewBy: bytes - previousBytes });
+          // Only the newest step old enough to be a base is ever read again,
+          // so everything before it goes. Pruning against the newest *step*
+          // rather than against now is what keeps the base from being thrown
+          // away during a plateau, when nothing newer can replace it.
+          const oldestUseful = atMs - policy.minSpanMs;
+          while (steps.length > 2 && steps[1]!.atMs <= oldestUseful) {
+            steps.shift();
+          }
+        }
+        previousBytes = bytes;
+        previousAtMs = atMs;
+      }
+
+      let bytesPerMinute: number | null = null;
+      let measuredOverMs: number | null = null;
+      const last = steps.at(-1);
+      let baseIndex = -1;
+      if (last) {
+        const cutoff = last.atMs - policy.minSpanMs;
+        for (let i = steps.length - 1; i >= 0; i -= 1) {
+          if (steps[i]!.atMs <= cutoff) {
+            baseIndex = i;
+            break;
+          }
+        }
+      }
+      const base = baseIndex >= 0 ? steps[baseIndex] : undefined;
+      if (last && base) {
+        const spanMs = last.atMs - base.atMs;
+        // How long the heap has stood still since the last step. On a regular
+        // staircase this only ever climbs to one tread's width and resets, so
+        // it changes nothing; past that width it is evidence the spending has
+        // slowed, and it stretches the denominator rather than leaving a stale
+        // rate in place for a player who has walked back into town.
+        const meanStepMs = spanMs / (steps.length - 1 - baseIndex);
+        const overdueMs = Math.max(0, atMs - last.atMs - meanStepMs);
+        const minutes = (spanMs + overdueMs) / 60_000;
+        if (minutes > 0) {
+          bytesPerMinute = Math.max(0, (last.bytes - base.bytes) / minutes);
+          measuredOverMs = spanMs + overdueMs;
+        }
+      }
+      if (
+        bytesPerMinute !== null
+        && bytesPerMinute < policy.minRateBytesPerMinute
+      ) {
+        bytesPerMinute = null;
+        measuredOverMs = null;
+      }
+
+      // What the client has actually filled, as against what it has reserved
+      // for itself. Growth fires when a request no longer fits, so at the
+      // instant of a step the filled bytes are what the reserve was *before*
+      // it, and between steps they climb at the rate just measured. Taking
+      // headroom off the reserve instead makes every step look like ten
+      // minutes of play disappearing at once: the figure sits still for a
+      // tread and then lurches, and it reads a session as a third shorter
+      // than it is. The error here is one allocation request, not one step.
+      let filled = bytes;
+      if (last && bytesPerMinute !== null) {
+        const spentSinceStep = (bytesPerMinute * (atMs - last.atMs)) / 60_000;
+        filled = Math.min(bytes, bytes - last.grewBy + spentSinceStep);
+      }
+      const headroom = capBytes > 0 ? Math.max(0, capBytes - filled) : null;
+      const rawMinutes =
+        headroom !== null && bytesPerMinute !== null && bytesPerMinute > 0
+          ? headroom / bytesPerMinute
+          : null;
+
+      let fromTime: HeapPressureLevel = 'none';
+      if (rawMinutes !== null) {
+        if (rawMinutes <= policy.criticalMinutes) fromTime = 'critical';
+        else if (rawMinutes <= policy.lowMinutes) fromTime = 'low';
+      }
+
+      let fromBytes: HeapPressureLevel = 'none';
+      if (headroom !== null) {
+        if (headroom <= policy.hardCriticalBytes) fromBytes = 'critical';
+        else if (rawMinutes === null) {
+          // Only while time is unmeasurable. Left unconditional, the 128 MiB
+          // floor is nearly fourteen minutes at the measured open-world rate —
+          // it would pre-empt the five-minute rule every session and rebuild
+          // the defect this module exists to remove.
+          if (headroom <= policy.blindCriticalBytes) fromBytes = 'critical';
+          else if (headroom <= policy.blindLowBytes) fromBytes = 'low';
+        }
+      }
+
+      const proposed = RANK[fromTime] >= RANK[fromBytes] ? fromTime : fromBytes;
+      let raisedBy: 'time' | 'bytes' | null = null;
+      if (RANK[proposed] > RANK[raised]) {
+        streak = proposed === pending ? streak + 1 : 1;
+        pending = proposed;
+        // The floor answers for itself; everything else is corroborated first,
+        // because a level that cannot fall must not be set by one sample.
+        const forced = headroom !== null && headroom <= policy.hardCriticalBytes;
+        if (forced || streak >= policy.confirmations) {
+          raised = proposed;
+          raisedBy = RANK[fromTime] >= RANK[fromBytes] ? 'time' : 'bytes';
+        }
+      } else {
+        streak = 0;
+        pending = 'none';
+      }
+
+      return {
+        level: raised,
+        minutes: rawMinutes === null ? null : hedgeMinutes(rawMinutes),
+        bytesPerMinute,
+        measuredOverMs,
+        bytes,
+        raisedBy,
+      };
+    },
+  };
+}

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -200,19 +200,37 @@
 
 <div id="log"></div>
 <output id="diagnostics" aria-live="off"></output>
-<!-- The heap watermark notice: shown over the running game when WASM memory
-     nears its 2 GiB cap, so the player can reload from a safe place instead
-     of crashing mid-mission. harness.ts owns when; failure-messages.ts owns
-     the words. -->
-<div id="memory-notice" role="status" aria-live="polite" hidden>
-  <div id="memory-notice-text">
+<!-- The memory warning: shown over the running game when the client's heap is
+     running out, so the player can reload at a moment they choose instead of
+     crashing at one they did not. harness.ts owns when and how many minutes;
+     failure-messages.ts owns every word. -->
+<div id="memory-notice" hidden>
+  <div id="memory-notice-text" role="status" aria-live="polite"
+       aria-atomic="true">
     <strong id="memory-notice-label"></strong>
     <span id="memory-notice-detail"></span>
+    <button type="button" id="memory-notice-why"></button>
   </div>
   <div id="memory-notice-actions">
     <button type="button" id="memory-notice-later"></button>
-    <button type="button" id="memory-notice-reload"></button>
+    <button type="button" id="memory-notice-reload" class="primary"></button>
   </div>
+</div>
+<!-- What Later leaves behind. The banner's figure is frozen when it is shown,
+     so this is the surface that keeps counting — a dismissal is a deferral,
+     not the silence that preceded the crashes this warning exists for. -->
+<button type="button" id="memory-chip" hidden>
+  <span class="memory-chip-dot" aria-hidden="true"></span>
+  <span id="memory-chip-text"></span>
+</button>
+<!-- The explanation is a modal task, so unlike the notice it dims the game.
+     It opens in the notice's place: two translucent surfaces never stack. -->
+<div id="memory-scrim" hidden></div>
+<div id="memory-why" role="dialog" aria-modal="true"
+     aria-labelledby="memory-why-title" hidden>
+  <h2 id="memory-why-title"></h2>
+  <div id="memory-why-blocks"></div>
+  <button type="button" id="memory-why-close"></button>
 </div>
 <output id="capture-status" hidden aria-live="off">
   <span class="capture-dot" aria-hidden="true"></span>

--- a/tests/policy/source-wasm-host.test.ts
+++ b/tests/policy/source-wasm-host.test.ts
@@ -467,3 +467,119 @@ test("a completed client main loop closes the host application", async () => {
   assert.match(harness, /onExit\(code\)/);
   assert.match(harness, /code === 0[\s\S]*native\(\)\.app\.requestQuit\(\)/);
 });
+
+test("the memory warning measures time and keeps its one contract import", async () => {
+  const [harness, pressure, css, html] = await Promise.all([
+    readFile(path.join(root, "src/renderer/harness.ts"), "utf8"),
+    readFile(path.join(root, "src/renderer/heap-pressure.ts"), "utf8"),
+    readFile(path.join(root, "src/renderer/harness.css"), "utf8"),
+    readFile(path.join(root, "src/renderer/index.html"), "utf8"),
+  ]);
+
+  // The packaged Enhancement-runtime proof observes the runtime's own request
+  // for the canonical contract. A second importer, or this one moved to boot,
+  // resolves it from the module cache and the proof stops proving anything.
+  //
+  // Only a runtime import counts. `import('…').SomeType` is a type position,
+  // erased before anything is fetched, and harness.ts names several — the
+  // negative lookahead is what tells the two apart in source text.
+  assert.equal(
+    harness.match(/import\('\.\.\/shared\/contracts\.js'\)(?!\s*\.)/gu)?.length,
+    1,
+    "harness.ts must import the canonical contract exactly once at runtime",
+  );
+  assert.match(
+    harness,
+    /function requestHeapCap\(\)[\s\S]{0,400}import\('\.\.\/shared\/contracts\.js'\)/u,
+    "the contract import must stay inside requestHeapCap",
+  );
+  assert.doesNotMatch(
+    pressure,
+    /from ['"]\.\.\/shared\//u,
+    "heap-pressure.ts must take the cap as an argument, not import it",
+  );
+
+  // The estimator is what makes the warning mean the same thing in an outpost
+  // and in a mission; a byte-only watcher is the defect it replaced.
+  assert.match(harness, /heapWatch\.sample\(wasmHeapBytes\(\), performance\.now\(\)\)/u);
+
+  // A warning drawn over a live game has to survive the three preferences that
+  // change how it may be drawn at all.
+  for (const query of [
+    "prefers-reduced-motion",
+    "prefers-reduced-transparency",
+    "prefers-contrast",
+  ]) {
+    const block = css.slice(css.indexOf(`@media (${query}`));
+    assert.ok(
+      block.slice(0, 600).includes("#memory-notice"),
+      `${query} must cover the memory notice`,
+    );
+  }
+
+  // The explanation is modal and the notice is not: one dims the game and
+  // takes focus, the other runs beside play.
+  assert.match(html, /id="memory-why"[^>]*role="dialog"[^>]*aria-modal="true"/u);
+  assert.doesNotMatch(
+    html,
+    /id="memory-notice"[^>]*aria-modal/u,
+    "the notice must not block the game it is drawn over",
+  );
+  assert.match(
+    html,
+    /id="memory-notice-text"[^>]*role="status"[^>]*aria-live="polite"[^>]*aria-atomic="true"/u,
+    "only the warning text, not its interactive controls, may be a live region",
+  );
+  assert.doesNotMatch(
+    html,
+    /id="memory-notice"[^>]*role=/u,
+    "interactive warning controls must sit outside the status live region",
+  );
+  // `aria-modal` tells a screen reader the game behind it is not there. Half
+  // that contract — the attribute without a keyboard that agrees — describes
+  // an app the player is not using.
+  assert.match(
+    harness,
+    /heapWhyRoot\.hidden\) return;[\s\S]{0,400}'Tab'[\s\S]{0,200}focus\(\)/u,
+    "an aria-modal explanation must trap the keyboard inside itself",
+  );
+  assert.match(
+    harness,
+    /\[heapNoticeRoot, heapChip, heapScrim, heapWhyRoot\]/u,
+    "every warning surface must stop input before it reaches the game",
+  );
+});
+
+test("the memory warning measures a staircase step to step", async () => {
+  const pressure = await readFile(
+    path.join(root, "src/renderer/heap-pressure.ts"),
+    "utf8",
+  );
+
+  // `Module.HEAPU8.buffer` is *reserved* memory and WebAssembly reserves it in
+  // jumps — about one 96 MiB step every ten minutes at the measured open-world
+  // rate, and flat in between. A fixed-duration window over that shape holds
+  // either no step or one, and reads a steady 555 MiB/h session as alternating
+  // between 384 and 1,152. Both ends of a measurement belong on a step, which
+  // is why the module keeps the steps rather than the samples.
+  assert.match(
+    pressure,
+    /const steps: \{ atMs: number; bytes: number; grewBy: number \}\[\]/u,
+    "the estimator must measure growth steps, not raw samples",
+  );
+  assert.doesNotMatch(
+    pressure,
+    /windowsMs/u,
+    "a fixed-duration window cannot measure a staircase",
+  );
+
+  // The warm-up excludes the startup ramp, and where its clock starts is the
+  // whole of whether it works: the page stays open through the client
+  // download, so a slow first run boots after a page-load-anchored warm-up has
+  // already expired and the ramp is measured as ordinary play.
+  assert.match(
+    pressure,
+    /allocatingSinceMs === null && bytes > 0\) allocatingSinceMs = atMs/u,
+    "the warm-up must run from the first allocation, not from page load",
+  );
+});

--- a/tests/unit/failure-codes-become-sentences-in-the-renderer.test.ts
+++ b/tests/unit/failure-codes-become-sentences-in-the-renderer.test.ts
@@ -14,6 +14,8 @@ import {
   describeSnapshotReadFailure as snapshotRead,
   describeSteamRefusal,
   failureDetail,
+  memoryExplanation,
+  memoryPressureChip,
   memoryPressurePresentation,
   suggestReport,
 } from "../../src/renderer/failure-messages.js";
@@ -191,21 +193,124 @@ describe("renderer failure messages", () => {
         notice.detail,
         notice.reloadButton,
         notice.dismissButton,
+        notice.whyLink,
       ]) {
         assert.ok(text.length > 0, "memory notice has empty prose");
       }
-      // The whole point of the notice: the player picks a safe place first.
-      assert.match(notice.detail, /town or outpost/);
-      // The detail must name the button it tells the player to press.
-      assert.ok(notice.detail.includes(notice.reloadButton));
+      // The outpost belongs to the explanation now, not to the notice. It is
+      // still the one place that risks nothing, but the reconnect is measured,
+      // and repeating a caveat against a measured fact is what made the
+      // shipped sentence easy to ignore from inside a dungeon.
+      assert.doesNotMatch(notice.detail, /town or outpost/);
+      assert.match(memoryExplanation().blocks[3]!.body, /town or outpost/);
+      // The detail opens with the action. Derived from the button so it
+      // survives a rename, and it pins the ordering the redesign is about:
+      // what to do first, why it is happening behind a link.
+      assert.ok(
+        notice.detail.startsWith(notice.reloadButton.split(" ")[0]!),
+        `detail does not open with the action: ${notice.detail}`,
+      );
     }
-    // Low reads as headroom; critical reads as imminent.
-    assert.match(low.label, /running low/);
-    assert.match(critical.label, /almost out of memory/);
-    assert.match(critical.detail, /^A crash is likely soon/);
+    // Escalation lives in the urgency of the instruction, not in a fear
+    // sentence: the deadline shrinks and "when it suits you" becomes "soon".
+    assert.match(low.detail, /^Reload when it suits you/);
+    assert.match(critical.detail, /^Reload soon/);
+    assert.match(critical.label, /out of memory/);
     // Buttons are identical across levels: escalation changes the words,
     // not the actions.
     assert.equal(low.reloadButton, critical.reloadButton);
     assert.equal(low.dismissButton, critical.dismissButton);
+  });
+
+  it("names no figure the player could check against a clock", () => {
+    // The thresholds count in time; the sentences do not print the time. That
+    // split was decided by the Eye of the North crash bundle of 2026-08-04:
+    // replayed against the client run that reached the cap, the levels landed
+    // where they should — `low` with 31 real minutes left where the shipped
+    // byte rule gave 11 — and the figure read 10 → 15 → 20 → 75 → 40 → 20 →
+    // 15 → 10 → 3, offering "about 75 minutes" to a player with 18 left. A
+    // quiet stretch had drifted into the measurement window just before they
+    // went back into heavy loading, and no rate can see that coming.
+    //
+    // The estimate still exists and still sets the level. The log records it
+    // as a diagnostic, but a diagnostic on a banner is a promise, so nothing
+    // here may carry one.
+    for (const level of ["low", "critical"] as const) {
+      const notice = memoryPressurePresentation(level);
+      for (const text of [notice.label, notice.detail, notice.whyLink]) {
+        assert.doesNotMatch(text, /\d/, text);
+      }
+      assert.doesNotMatch(memoryPressureChip(level).text, /\d/);
+      assert.doesNotMatch(memoryPressureChip(level).label, /\d/);
+    }
+    // Low reads as headroom, critical as imminent — the escalation the figure
+    // used to carry has to live in the words instead.
+    assert.match(memoryPressurePresentation("low").label, /running low/);
+    assert.match(memoryPressurePresentation("critical").label, /almost out of/);
+    assert.notEqual(
+      memoryPressureChip("low").text,
+      memoryPressureChip("critical").text,
+      "the chip says the same thing at both levels",
+    );
+  });
+
+  it("states the reconnect that was measured, and claims nothing past it", () => {
+    // This test used to require the hedge — "should be able to rejoin" — and
+    // fail if anyone firmed the wording before the experiment had been run.
+    // It has been run: 2026-08-05, all five reload paths, from inside an
+    // instance, progress intact every time and back inside thirty seconds.
+    // The uncertainty was never whether Guild Wars restores an instance after
+    // a dropped connection; it was whether our reload looks like one to the
+    // server. That is answered, so the assertion turns around and guards the
+    // opposite failure: a promise wider than the evidence.
+    const strings = [
+      memoryPressurePresentation("low"),
+      memoryPressurePresentation("critical"),
+    ].flatMap((notice) => [notice.label, notice.detail]);
+    const explanation = memoryExplanation();
+    strings.push(...explanation.blocks.map((block) => block.body));
+
+    assert.ok(
+      strings.some((text) => /puts you back where you were/.test(text)),
+      "the measured reconnect stopped being stated",
+    );
+    assert.ok(
+      strings.every((text) => !/should be able to/.test(text)),
+      "a hedge the experiment retired came back",
+    );
+    // What was tested is one tester, one account, five paths. It says the
+    // reconnect works and how long it took; it must not promise that nothing
+    // can ever go wrong, which no session count would earn.
+    for (const text of strings) {
+      assert.doesNotMatch(text, /\b(guarantee\w*|never lose|always works?)\b/i, text);
+    }
+  });
+
+  it("explains the memory limit without claiming ArenaNet has been contacted", () => {
+    const explanation = memoryExplanation();
+    assert.equal(explanation.blocks.length, 4);
+    for (const block of explanation.blocks) {
+      assert.ok(block.title.length > 0, "block has no title");
+      assert.ok(block.body.length > 40, `${block.title} is not an explanation`);
+    }
+    const stands = explanation.blocks[2]!;
+    for (const claim of [/measured/, /documented/, /published/]) {
+      assert.match(stands.body, claim);
+    }
+    // What is true today is that the findings are published. Saying more than
+    // that in the app would be a claim nobody could back.
+    const joined = explanation.blocks.map((block) => block.body).join(" ");
+    assert.doesNotMatch(joined, /in contact with|reported to ArenaNet/i);
+  });
+
+  it("leaves something behind when a warning is dismissed", () => {
+    // `Later` used to mean silence until the crash. The chip is what stops
+    // that, and its accessible name has to say what it will do when clicked.
+    for (const level of ["low", "critical"] as const) {
+      const chip = memoryPressureChip(level);
+      assert.ok(chip.text.length > 0 && chip.text.length < 24, chip.text);
+      assert.match(chip.label, /memory/i);
+      assert.match(chip.label, /again/);
+    }
   });
 });

--- a/tests/unit/the-memory-warning-counts-time-not-bytes.test.ts
+++ b/tests/unit/the-memory-warning-counts-time-not-bytes.test.ts
@@ -1,0 +1,447 @@
+// The estimator, driven over the two sessions that were actually measured on
+// 2026-08-04. The shipped build warned on bytes remaining, which meant the same
+// sentence bought half an hour in the open world and about two minutes inside a
+// mission — the second row here is the whole reason this module exists.
+//
+// Every session below is a staircase, not a ramp, because that is what the
+// runtime presents: `Module.HEAPU8.buffer` is *reserved* memory and WebAssembly
+// reserves it in jumps. An earlier version of this file drove smooth linear
+// growth and passed while the shipped estimator read a steady 555 MiB/h session
+// as alternating between 384 and 1,152 — the test was measuring a shape no
+// client produces. `simulate` below is the fix: it models the allocator, works
+// out when the client really dies, and every assertion is what the player was
+// told against what was true at that moment.
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  createHeapPressureWatch,
+  hedgeMinutes,
+  type HeapPressurePolicy,
+  type HeapPressureLevel,
+  type HeapPressureReading,
+} from "../../src/renderer/heap-pressure.js";
+
+const MIB = 1_048_576;
+const CAP = 2048 * MIB;
+const TICK_MS = 15_000;
+const TICK_MINUTES = TICK_MS / 60_000;
+
+interface Tick extends HeapPressureReading {
+  atMinutes: number;
+  /** Minutes until this session really ends, known from the whole run. */
+  trulyLeft: number;
+}
+
+interface Session {
+  diesAtMinutes: number;
+  ticks: readonly Tick[];
+  /** The first tick at each level, which is all the player ever experiences. */
+  raised: Map<HeapPressureLevel, Tick>;
+}
+
+/**
+ * A session as the runtime actually presents it.
+ *
+ * The client fills memory smoothly and the runtime reserves it in steps:
+ * Emscripten's glue grows by a fifth of the current size, capped at 96 MiB,
+ * and never by less than the allocation needs. At the measured open-world rate
+ * that is one step roughly every ten minutes with a flat heap in between —
+ * which is the entire difficulty this module exists to handle.
+ *
+ * The physics run first and to the end, so the death is known before the
+ * watcher is asked about it. Nothing here asserts against the watcher's own
+ * arithmetic; every claim is checked against the session that really happened.
+ */
+function simulate(options: {
+  /** MiB per hour of real spending, constant or per-minute. */
+  rate: number | ((minute: number) => number);
+  startMib?: number;
+  /** Minutes the page is open before the client allocates anything. */
+  bootAtMinutes?: number;
+  /** One-off reservations — a zone load is a couple of hundred MiB in seconds. */
+  loads?: readonly { atMinutes: number; mib: number }[];
+  policy?: HeapPressurePolicy;
+  capBytes?: number;
+}): Session {
+  const capBytes = options.capBytes ?? CAP;
+  const boot = options.bootAtMinutes ?? 0;
+  const rateAt = (minute: number) =>
+    typeof options.rate === "function" ? options.rate(minute) : options.rate;
+
+  const frames: { atMinutes: number; reservedMib: number }[] = [];
+  let usedMib = 0;
+  let reservedMib = 0;
+  let diesAtMinutes = Infinity;
+  for (let minute = 0; minute < 600; minute += TICK_MINUTES) {
+    if (minute >= boot) {
+      if (usedMib === 0) usedMib = options.startMib ?? 690;
+      usedMib += (rateAt(minute) / 60) * TICK_MINUTES;
+      for (const load of options.loads ?? []) {
+        if (Math.abs(minute - load.atMinutes) < TICK_MINUTES / 2) {
+          usedMib += load.mib;
+        }
+      }
+      // The glue's own growth rule, and it repeats until the ask fits.
+      while (usedMib > reservedMib) {
+        reservedMib += Math.max(16, Math.min(96, reservedMib * 0.2));
+      }
+    }
+    if (usedMib * MIB >= capBytes) {
+      diesAtMinutes = minute;
+      break;
+    }
+    frames.push({ atMinutes: minute, reservedMib });
+  }
+
+  const watch = createHeapPressureWatch({ capBytes, ...options.policy });
+  const raised = new Map<HeapPressureLevel, Tick>();
+  const ticks = frames.map((frame) => {
+    const reading = watch.sample(frame.reservedMib * MIB, frame.atMinutes * 60_000);
+    const tick: Tick = {
+      ...reading,
+      atMinutes: frame.atMinutes,
+      trulyLeft: diesAtMinutes - frame.atMinutes,
+    };
+    if (!raised.has(reading.level)) raised.set(reading.level, tick);
+    return tick;
+  });
+  return { diesAtMinutes, ticks, raised };
+}
+
+/**
+ * Every tick where a rate could be measured. The figure never reaches the
+ * player — the Eye of the North bundle retired that — but the estimate still
+ * decides the level, so the sessions below check it is measured at all.
+ */
+const claims = (session: Session) =>
+  session.ticks.filter((tick) => tick.minutes !== null);
+
+describe("the memory warning counts time, not bytes", () => {
+  it("warns an open-world session with the headroom it claims", () => {
+    // 555 MiB/h, measured over 2 h 16 m.
+    const session = simulate({ rate: 555 });
+    const low = session.raised.get("low");
+    const critical = session.raised.get("critical");
+    assert.ok(low && critical, "the session ended without warning");
+
+    // The claim has to be true, not merely present.
+    assert.ok(
+      low.trulyLeft > 15 && low.trulyLeft < 26,
+      `low arrived with ${low.trulyLeft.toFixed(1)} real minutes left`,
+    );
+    assert.ok(
+      critical.trulyLeft > 3 && critical.trulyLeft < 9,
+      `critical arrived with ${critical.trulyLeft.toFixed(1)} real minutes left`,
+    );
+    assert.equal(critical.raisedBy, "time");
+  });
+
+  it("gives a texture-dense mission a real warning, not ninety seconds", () => {
+    // The Eye of the North report: the cap in about half an hour. Under the
+    // shipped byte thresholds this player got "low" with three minutes left
+    // and "critical" with ninety seconds — and crashed anyway.
+    const session = simulate({ rate: 3_500 });
+    const low = session.raised.get("low");
+    assert.ok(low, "the fast session was never warned at all");
+    assert.ok(
+      low.trulyLeft >= 4,
+      `only ${low.trulyLeft.toFixed(1)} minutes of warning`,
+    );
+
+    // What the shipped build could not do: warn while there is still headroom
+    // to walk somewhere. Its 256 MiB rule fires about 3 minutes before death
+    // at this rate.
+    const headroomMib = (CAP - low.bytes) / MIB;
+    assert.ok(
+      headroomMib > 180,
+      `${headroomMib.toFixed(0)} MiB left — inside the shipped rule's reach`,
+    );
+  });
+
+  it("reads the rate that was actually spent, not the shape of the staircase", () => {
+    // The defect this test exists for. Reserved memory moves in ~96 MiB jumps
+    // about ten minutes apart at this rate, so a five-minute window contains
+    // either no step or one and reports 0 or 1,152 MiB/h for a session
+    // spending 555. Both ends of a measurement sit on a step for this reason.
+    for (const rate of [555, 3_500]) {
+      const measured = simulate({ rate })
+        .ticks.map((tick) => tick.bytesPerMinute)
+        .filter((value): value is number => value !== null)
+        .map((value) => (value * 60) / MIB);
+      assert.ok(measured.length > 0, `${rate} MiB/h was never measured at all`);
+      for (const value of measured) {
+        assert.ok(
+          Math.abs(value - rate) / rate < 0.1,
+          `read ${value.toFixed(0)} MiB/h for a session spending ${rate}`,
+        );
+      }
+    }
+  });
+
+  it("puts the levels of a real crash where they belong", () => {
+    // The Eye of the North session of 2026-08-04, replayed from the player's
+    // own bundle: every `wasm.heapGrew` event of the client run that reached
+    // the cap, against the abort that ended it. The last step is clamped —
+    // 1990 to 2048 MiB rather than the usual 96 — and the client dies forty
+    // seconds later at exactly 2 GiB.
+    //
+    // This is the fixture the simulations could not be: the rate swings about
+    // tenfold between quiet stretches and mission loading, including a
+    // thirteen-minute lull at minute 34. What has to survive that is the
+    // level, because the level is the only thing the player is told.
+    const diedAtMinutes = 66.02;
+    const steps: readonly (readonly [number, number])[] = [
+      [0.12, 531], [0.16, 627], [1.76, 723], [16.06, 820], [22.82, 916],
+      [24.82, 1013], [26.69, 1110], [28.36, 1206], [30.69, 1302],
+      [32.56, 1398], [34.16, 1495], [47.72, 1593], [51.82, 1690],
+      [53.16, 1786], [55.12, 1894], [58.62, 1990], [65.32, 2048],
+    ];
+    const watch = createHeapPressureWatch({ capBytes: CAP });
+    const raised = new Map<HeapPressureLevel, number>();
+    for (let minute = 0; minute <= diedAtMinutes; minute += TICK_MINUTES) {
+      let mib = 0;
+      for (const [at, value] of steps) if (at <= minute) mib = value;
+      const { level } = watch.sample(mib * MIB, minute * 60_000);
+      if (!raised.has(level)) raised.set(level, diedAtMinutes - minute);
+    }
+
+    const low = raised.get("low");
+    const critical = raised.get("critical");
+    assert.ok(low !== undefined, "the session that hit the cap was never warned");
+    assert.ok(critical !== undefined, "it never escalated");
+
+    // The shipped byte thresholds gave this player 10.9 minutes at 256 MiB and
+    // 7.4 at 128 MiB. Beating the first is the whole reason for the change.
+    assert.ok(low > 20, `low arrived with ${low.toFixed(1)} min left`);
+    assert.ok(
+      critical > 5 && critical < 12,
+      `critical arrived with ${critical.toFixed(1)} min left`,
+    );
+  });
+
+  it("does not read the cost of starting the game as the cost of playing it", () => {
+    // Observed on a real launch: 734 MiB and climbing at ~4,500 MiB/h less
+    // than three minutes in, against a steady-state 555 MiB/h. Measured from
+    // inside that ramp the session looks a quarter of an hour from death, and
+    // the warning fired at 36% of the cap — every player, every login.
+    const session = simulate({
+      startMib: 40,
+      rate: (minute) => (minute < 3 ? 15_000 : 555),
+    });
+    for (const tick of session.ticks) {
+      if (tick.atMinutes > 60) break;
+      assert.equal(
+        tick.level,
+        "none",
+        `warned ${tick.atMinutes} min in, at ${Math.round(tick.bytes / MIB)} MiB`,
+      );
+    }
+    // Once the ramp is behind it, ordinary play is read as ordinary play.
+    const settled = claims(session).at(-1);
+    assert.ok(settled?.bytesPerMinute, "the ramp silenced the whole session");
+    const perHour = (settled.bytesPerMinute * 60) / MIB;
+    assert.ok(
+      Math.abs(perHour - 555) / 555 < 0.1,
+      `read ${perHour.toFixed(0)} MiB/h after a 15,000 MiB/h launch`,
+    );
+  });
+
+  it("survives a first run whose download outlasts the warm-up", () => {
+    // The warm-up excludes the startup ramp, so where its clock starts decides
+    // whether it works. Anchored to page load it looks equivalent and is not:
+    // the page stays open through the client download, so a slow first run
+    // boots after the exclusion has already expired and the ramp is measured
+    // as ordinary play — 38% of the cap, "about 8 minutes of play left", two
+    // hours of real headroom. The clock starts at the first allocation.
+    const session = simulate({
+      bootAtMinutes: 12,
+      startMib: 40,
+      rate: (minute) => (minute < 15 ? 15_000 : 555),
+    });
+    for (const tick of session.ticks) {
+      if (tick.atMinutes > 70) break;
+      assert.equal(
+        tick.level,
+        "none",
+        `warned ${tick.atMinutes} min in, at ${Math.round(tick.bytes / MIB)} MiB`,
+      );
+    }
+  });
+
+  it("starts measuring when the player starts playing, not when they log in", () => {
+    // Ten minutes parked in Kamadan, then out into the world. Nothing about
+    // the idling should either warn or be averaged into what follows.
+    const session = simulate({ rate: (minute) => (minute < 15 ? 0 : 555) });
+    for (const tick of session.ticks) {
+      if (tick.atMinutes > 40) break;
+      assert.equal(tick.level, "none", `warned while idle at ${tick.atMinutes}`);
+    }
+    const late = claims(session).at(-1);
+    assert.ok(late && Math.abs((late.bytesPerMinute! * 60) / MIB - 555) < 60);
+  });
+
+  it("does not let one map load latch a warning that cannot be taken back", () => {
+    // A zone load reserves a couple of hundred MiB in seconds. Measured over a
+    // window short enough it reads as thousands of MiB an hour, and since the
+    // level never falls it would be permanent — this session is warned when it
+    // deserves it, not thirty-eight minutes early because the player walked
+    // through a door.
+    const session = simulate({
+      rate: 555,
+      loads: [{ atMinutes: 30, mib: 300 }],
+    });
+    const low = session.raised.get("low");
+    assert.ok(low, "the load swallowed the real warning too");
+    assert.ok(
+      low.trulyLeft < 26,
+      `the load warned ${low.trulyLeft.toFixed(0)} minutes before it mattered`,
+    );
+    assert.ok(
+      session.ticks.some((tick) => tick.atMinutes > 30 && tick.bytes > 1_100 * MIB),
+      "the load did happen",
+    );
+  });
+
+  it("says nothing through an hour with only one growth step in it", () => {
+    // An observed session, 2026-08-05: ramp to ~740 MiB, then flat for an hour,
+    // then a single 96 MiB step to 833 — 191 MiB/h, a third of the rate this
+    // was designed around, with the cap six hours away. One step is not a rate
+    // and the panel showed a bare dash for it, which read as a broken
+    // instrument rather than as the correct answer. It reports the span it
+    // measured over now, so the two cases are told apart.
+    const session = simulate({ rate: (minute) => (minute < 4 ? 11_000 : 191) });
+    for (const tick of session.ticks) {
+      if (tick.atMinutes > 74) break;
+      assert.equal(tick.level, "none", `warned at ${tick.atMinutes} min`);
+    }
+    const late = session.ticks.find((tick) => tick.atMinutes === 74)!;
+    assert.ok(
+      late.bytesPerMinute === null || late.measuredOverMs !== null,
+      "a rate was reported without the span it came from",
+    );
+
+    // And it wakes up: the estimate exists well before this session could die.
+    const measured = claims(session)[0];
+    assert.ok(measured, "the session never produced an estimate at all");
+    assert.ok(
+      measured.trulyLeft > 60,
+      `first estimate arrived with only ${measured.trulyLeft.toFixed(0)} min left`,
+    );
+  });
+
+  it("shows the span behind every rate it reports", () => {
+    // The panel prints this, and a rate with no span behind it is the shape of
+    // the reading that used to be indistinguishable from a broken one.
+    for (const rate of [555, 3_500]) {
+      for (const tick of simulate({ rate }).ticks) {
+        if (tick.bytesPerMinute === null) {
+          assert.equal(tick.measuredOverMs, null, "a span with no rate");
+        } else {
+          assert.ok(
+            tick.measuredOverMs !== null
+              && tick.measuredOverMs >= 10 * 60_000,
+            `${rate} MiB/h: rate measured over ${tick.measuredOverMs} ms`,
+          );
+        }
+      }
+    }
+  });
+
+  it("falls back to bytes only while there is no rate to read", () => {
+    // A page that opens already near the cap has no staircase to read, so the
+    // shipped thresholds are what still warns it.
+    const watch = createHeapPressureWatch({ capBytes: CAP });
+    const first = watch.sample(CAP - 100 * MIB, 0);
+    // Corroborated first: the level can never be taken back, so no single
+    // reading sets it. One tick later is the whole cost.
+    assert.equal(first.level, "none", "raised on a single reading");
+    const cold = watch.sample(CAP - 100 * MIB, TICK_MS);
+    assert.equal(cold.level, "critical");
+    assert.equal(cold.minutes, null, "no number was measured, so none is offered");
+    assert.equal(cold.raisedBy, "bytes");
+
+    // Except at the floor, where there is nothing left to corroborate.
+    const dying = createHeapPressureWatch({ capBytes: CAP });
+    assert.equal(dying.sample(CAP - 8 * MIB, 0).level, "critical");
+  });
+
+  it("keeps warning a stalled heap that is nearly full", () => {
+    // A player idling in an outpost at 1.8 GiB has no recent steps, so the
+    // time rule has nothing to say. Bytes are what is left to speak.
+    const watch = createHeapPressureWatch({ capBytes: CAP });
+    let atMs = 0;
+    let last = watch.sample(1_820 * MIB, atMs);
+    for (let i = 0; i < 80; i += 1) {
+      atMs += TICK_MS;
+      last = watch.sample(1_820 * MIB, atMs);
+    }
+    assert.equal(last.minutes, null, "a flat heap has no time to give");
+    assert.equal(last.level, "low");
+  });
+
+  it("lets a rate go stale rather than believing it forever", () => {
+    // Step-to-step measurement is what stops the figure sagging between steps,
+    // but it also means a player who stops spending would otherwise keep the
+    // last rate they earned. A tread wider than the ones it was measured over
+    // is evidence, and it stretches the estimate out.
+    const session = simulate({ rate: (minute) => (minute < 45 ? 555 : 0) });
+    const spending = session.ticks.find((tick) => tick.atMinutes === 44)!;
+    const idle = session.ticks.find((tick) => tick.atMinutes === 90);
+    assert.ok(spending.bytesPerMinute !== null);
+    assert.ok(
+      idle === undefined
+        || idle.bytesPerMinute === null
+        || idle.bytesPerMinute < spending.bytesPerMinute / 4,
+      "an hour of standing still still read as open-world spending",
+    );
+  });
+
+  it("never lowers a warning it has already raised", () => {
+    const watch = createHeapPressureWatch({ capBytes: CAP });
+    let atMs = 0;
+    for (let i = 0; i < 40; i += 1) {
+      watch.sample((300 + i * 45) * MIB, atMs);
+      atMs += TICK_MS;
+    }
+    let last = watch.sample(2_000 * MIB, atMs);
+    assert.equal(last.level, "critical");
+    for (let i = 0; i < 80; i += 1) {
+      atMs += TICK_MS;
+      last = watch.sample(2_000 * MIB, atMs);
+    }
+    assert.equal(last.level, "critical", "the heap did not shrink, so nor does the warning");
+  });
+
+  it("rounds the estimate without ever flattering it by much", () => {
+    assert.equal(hedgeMinutes(19.7), 20);
+    assert.equal(hedgeMinutes(12), 10);
+    assert.equal(hedgeMinutes(4.4), 4);
+    assert.equal(hedgeMinutes(0.2), 0);
+    assert.equal(hedgeMinutes(-5), 0);
+    for (let m = 0; m <= 180; m += 0.1) {
+      assert.ok(
+        hedgeMinutes(m) <= m + 2.5,
+        `hedge(${m}) = ${hedgeMinutes(m)} overstates by more than 2.5`,
+      );
+    }
+  });
+
+  it("produces no NaN, no infinity and no negative minutes", () => {
+    for (const capBytes of [0, CAP]) {
+      const watch = createHeapPressureWatch({ capBytes });
+      for (const [bytes, atMs] of [
+        [300 * MIB, 0],
+        [400 * MIB, 0], // same instant
+        [500 * MIB, -1_000], // backwards
+        [4_000 * MIB, 60_000], // past the cap
+        [4_000 * MIB, 200_000],
+      ] as const) {
+        const reading = watch.sample(bytes, atMs);
+        for (const value of [reading.minutes, reading.bytesPerMinute]) {
+          assert.ok(value === null || Number.isFinite(value), String(value));
+        }
+        assert.ok((reading.minutes ?? 0) >= 0);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- measure WebAssembly heap growth step-to-step and warn from the observed consumption rate
- offer a safe reload, a non-silent Later reminder, and an in-app explanation
- record bounded heap-growth and abort diagnostics without retaining raw crash text
- document the player recovery path and the live-session evidence behind the thresholds

This is the clean production replacement for #110 and #111. It starts from `main`, contains no memory debug panel or test-only reconnect controls, and keeps the research instrumentation out of the shipped renderer.

## Evidence

The warning policy was replayed against the captured 2 GiB failure session and exercised live in the earlier research branch. The production UI was separately reviewed at 1280×800 and 800×600, including low, critical, reminder, explanation, keyboard focus, reduced motion, reduced transparency, and increased contrast behavior.

## Verification

- `pnpm typecheck`
- `pnpm test:unit` — 779 passed
- `pnpm test:policy` — 158 passed
- `pnpm lint`
- `pnpm build`
- `pnpm test:website`
- `git diff --check`

## Merge order

#112 fixes the repository-wide audit gate and is already green. This branch includes that exact commit so its own CI can pass before #112 lands; GitHub will reduce this PR to the single warning commit after #112 merges.
