### PR TITLE
Attribute WASM heap growth in diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ coverage/
 
 plans/*
 !plans/research-tool-architecture.md
+!plans/memory-bug.md

--- a/apps/website/content/en/1.docs/3.upstream/2.request-summary.md
+++ b/apps/website/content/en/1.docs/3.upstream/2.request-summary.md
@@ -3,7 +3,7 @@ title: Request summary and priority
 ref: docs/upstream/request-summary
 description: All twelve upstream requests in one table, with priority, estimated effort, blast radius, and the host workaround that each fix removes.
 icon: lucide:list-checks
-updated: 2026-08-04
+updated: 2026-08-08
 navigation:
   title: Request summary
 ---
@@ -12,7 +12,7 @@ Six of these fixes live in two translation units in `Base/Os/Emscripten`, plus
 `Base/Rtl/Path.cpp` and the `File::Open` mode table. Together they bring back
 template save, list, rename, and delete — and screenshots and chat logs with
 them. One engineer can do all six in a session, and one test covers them. The
-rest of the list is smaller wins, one build flag, and two proposals.
+rest of the list is smaller wins, one runtime investigation, and two proposals.
 
 Every row links to a page with the evidence, repro steps, and acceptance
 criteria.
@@ -30,7 +30,7 @@ criteria.
 | `UR-07` | Marshal `MouseEvent.detail` into the input record | 1 | Low | Small |
 | `UR-08` | Correct the printable-key label off-by-one | 2 | Low | Small |
 | `UR-09` | Re-test the pointer after a mode change | 2 | Low | Small |
-| `UR-10` | Raise the maximum heap size | 2 | Low | Medium |
+| `UR-10` | Profile heap ownership and raise the wasm32 maximum | 2 | Medium | Medium |
 | `UR-11` | Publish build identity and a symbol map | 2 | Low | None |
 | `UR-12` | Add a small platform-host interface | 3 | High | Medium |
 
@@ -39,8 +39,12 @@ information, hits a small defect, or loses progress in a way they can work
 around. Priority 3: nothing is lost today, but the platform improves.
 
 `UR-10` moved from 3 to 2 on 2026-08-04. We first saw it as a limit only very
-long sessions reached; a third report then reached the same cap in about half
-an hour of instanced content, which costs the player that run.
+long sessions reached; another report then reached the same cap in about half
+an hour of instanced content, which costs the player that run. Newer
+instrumentation proves the compiled ceiling and identifies several large
+allocation owners, but does not yet distinguish cache retention,
+fragmentation, or legitimate referenced working set. Raising the maximum buys
+time; the ownership profile is the corrective work.
 
 The effort and blast-radius estimates are ours, made from outside the codebase.
 Read them as a rough size, not a commitment.
@@ -55,7 +59,7 @@ Read them as a rough size, not a commitment.
 | `UR-07` | Double-click works, with no extra clicks | We delete one module transform |
 | `UR-08` | The Controls panel names the correct key | Nothing. We ship no workaround |
 | `UR-09` | The cursor changes at once | We delete one pointer replay |
-| `UR-10` | Long sessions do not stop | We delete one heap warning |
+| `UR-10` | Memory use is bounded; a larger maximum adds headroom | We delete the experimental transform and retire emergency reload guidance |
 | `UR-11` | No direct result | Our update work drops by hours per build |
 | `UR-12` | No direct result | We delete our cursor memory addresses |
 
@@ -68,7 +72,7 @@ Read them as a rough size, not a commitment.
 :::card{title="Input" description="Three defects in mouse, cursor, and keyboard handling." icon="lucide:mouse-pointer-click" to="$docs/upstream/input/double-click-flag"}
 `UR-07` to `UR-09`
 :::
-:::card{title="Runtime" description="Sessions stop at the heap cap. A build flag buys time; the texture path is the cause." icon="lucide:cpu" to="$docs/upstream/runtime/heap-maximum"}
+:::card{title="Runtime" description="Sessions can stop at the 2 GiB cap. A paired 4 GB build buys time; a heap profile must classify retention, fragmentation, or live ownership." icon="lucide:cpu" to="$docs/upstream/runtime/heap-maximum"}
 `UR-10`
 :::
 :::card{title="Interface proposals" description="Two proposals. They do not correct a defect." icon="lucide:plug" to="$docs/upstream/proposals/build-identification"}

--- a/apps/website/content/en/1.docs/3.upstream/5.runtime/1.heap-maximum.md
+++ b/apps/website/content/en/1.docs/3.upstream/5.runtime/1.heap-maximum.md
@@ -1,26 +1,36 @@
 ---
 title: "UR-10: long sessions stop at the 2 GiB heap cap"
 ref: docs/upstream/runtime/heap-maximum
-description: Three players stopped with the WebAssembly heap at exactly 2,147,483,648 bytes. The failing allocation is in the texture path, growth does not level off, and the cap is compiled in.
+description: Build 38797 has a fixed 2 GiB WebAssembly heap. We can prove the ceiling and the failed allocation, but cache retention, fragmentation, and live working set still require an ArenaNet heap profile.
 icon: lucide:cpu
-updated: 2026-08-04
+updated: 2026-08-08
 navigation:
   title: Heap maximum (UR-10)
 ---
 
-Long play sessions end with an assertion abort. At the abort, the WebAssembly
-heap stands at exactly 2,147,483,648 bytes — 2^31, the client's compiled-in
-maximum. The abort text names the texture allocator, and a measured session
-shows heap use rising for as long as the player keeps playing.
+Some content-heavy sessions end when the WebAssembly heap reaches exactly
+2,147,483,648 bytes. That maximum is declared in both artifacts ArenaNet ships:
+the WASM memory section and its generated JavaScript glue. The next allocation
+that needs more capacity is refused and the client aborts.
 
-**Fix:** low effort for the build flag; unknown for the growth itself, which
-we cannot attribute to a call site from outside the module. Medium blast
-radius — a larger address space changes allocator behaviour and memory use on
-small machines, so test on a machine with 8 GB.
+**What we are asking ArenaNet to do:** profile settled live ownership across a
+short multi-zone route, correct the responsible lifecycle, cache budget, or
+allocation pattern, and raise the wasm32 maximum to 4 GiB minus one page as
+additional headroom. The larger maximum must be built with the matching
+unsigned JavaScript pointer support; changing only the WASM declaration is not
+safe.
+
+::warning{title="The ceiling is proven; the underlying leak is not"}
+The 2 GiB ceiling and the allocation refused at that ceiling are properties of
+ArenaNet's build 38797. We cannot yet classify the preceding memory use as a
+leak, cache retention, fragmentation, or legitimate referenced working set.
+The allocation that loses at the boundary does not necessarily own the memory
+allocated before it.
+::
 
 ## What the client says when it stops
 
-A third player's crash, on app 2026.8.4, showed the abort text on screen:
+One captured failure showed:
 
 ```text
 WASM heap at crash: 2048 MiB of 2048 MiB
@@ -28,79 +38,18 @@ ASSERTION FAILED: Out of memory!
 ../../../Engine/Gr/Gles3/GlTex.cpp:397
 ```
 
-This is the client's own assertion, not our interpretation. It gives the
-request its two most useful facts: the heap was at the cap, and **the
-allocation that failed was in the GLES3 texture path**.
+This proves that the final failed request was in ArenaNet's GLES3 texture path.
+It does **not** prove that textures retained the entire heap. At the limit,
+whichever allocation asks for the next block raises its own assertion.
 
-It also explains a detail from the first two crashes. Those reported different
-abort fingerprints, which we read as exhaustion rather than one defect: at the
-cap, whichever allocation runs next raises its own assertion. A texture
-allocation is simply the most likely one to run next.
+## The cap is compiled into both artifacts
 
-## What we measured
+Build 38797's `Gw.jspi.wasm` declares one memory:
 
-Three players. The first two ran client build 38797 on an M1 Pro with 16 GB
-and played together, stopping within six minutes of each other. The third
-reported from app 2026.8.4; we did not collect their machine details, and
-their heap figure is the one their crash view displayed:
+- initial: 4,096 pages, or 256 MiB;
+- maximum: 32,768 pages, or 2 GiB.
 
-| Session      | Length at abort | Heap at abort   | Notes                    |
-| ------------ | --------------- | --------------- | ------------------------ |
-| `5eb4a64e`   | 3 h 18 m        | 2,147,483,648   | Open-world play          |
-| `9ae56272`   | 2 h 23 m        | 2,147,483,648   | Same evening, same party |
-| third player | ~30 m           | 2048 MiB shown  | Eye of the North mission |
-
-The third session is the one that matters most for scale. It reached the same
-cap in about half an hour, in a texture-dense instanced mission — so the limit
-is reached by how much distinct art a session loads, not by elapsed time.
-Players report that this puts speed clears and vanquishes at risk.
-
-## The growth curve
-
-On 2026-08-04 we recorded a full session that did **not** crash, with the
-heap-growth instrumentation running. 136 minutes, app 2026.8.4, 18 map-server
-connections, ordinary open-world play:
-
-| Elapsed | Heap after step | Elapsed | Heap after step |
-| ------- | --------------- | ------- | --------------- |
-| 0.1 m   | 256 MiB         | 84.8 m  | 1124 MiB        |
-| 1.4 m   | 442 MiB         | 94.5 m  | 1220 MiB        |
-| 13.1 m  | 627 MiB         | 97.7 m  | 1316 MiB        |
-| 46.6 m  | 724 MiB         | 109.5 m | 1427 MiB        |
-| 67.5 m  | 930 MiB         | 127.2 m | 1523 MiB        |
-| 82.5 m  | 1027 MiB        | 128.7 m | **1619 MiB**    |
-
-Fourteen growth steps. The player quit at 1619 MiB — 79 % of the cap — and at
-the observed rate would have reached the maximum at about three hours.
-
-Three readings, in decreasing order of confidence:
-
-**Growth does not level off.** The first half of the session averaged
-7.3 MiB/min; the second half averaged 10.1 MiB/min. A cache with a bound would
-flatten as it filled. This one was consuming faster after two hours than in
-its first hour. Overall: **555 MiB per hour**.
-
-**Growth is bursty in time but never stops.** The longest stretch with no
-growth was 34 minutes, and growth resumed after every one of them.
-
-**Per-map attribution is inconclusive from where we stand.** Eight of the
-fourteen steps landed within 11 seconds of a new map-server connection; six
-landed 10 to 27 minutes after one. We do not treat that as evidence either
-way, because a connection is not the same as a map load — the client reuses
-connections across zones, so our count of 18 undercounts the real number. This
-is a limit of observing from outside the module, and one you can settle
-internally in minutes.
-
-::info{title="Reading the step sizes"}
-Six of the fourteen steps are exactly 96 MiB, which is Emscripten's maximum
-growth step. Past roughly 480 MiB every growth request takes the largest chunk
-the runtime allows, so the number of steps is a direct measure of demand. One
-206 MiB step is two growths inside a single 2-second sampling window.
-::
-
-## The cap is compiled in
-
-The client's glue states the cap and the reason for it:
+The matching `Gw.jspi.js` contains:
 
 ```js
 var getHeapMax = () =>
@@ -108,93 +57,182 @@ var getHeapMax = () =>
   2147483648;
 ```
 
-We read this from the artifact on disk, `Gw.jspi.js`, that the client itself
-downloaded.
+The host does not impose a smaller ceiling. Growth succeeds until the declared
+maximum is reached. wasm32 cannot provide more than a 4 GiB address space, so a
+larger maximum buys headroom but cannot make unbounded growth safe.
 
-The build has assertions enabled, so `assert()` calls `abort()` with a text
-reason, and the abort reason our classifier sees is reliable. The two machines
-reported different assertion fingerprints — which points to exhaustion rather
-than one specific defect: at the cap, whichever allocation fails first raises
-its own assertion.
+## Reports and measured sessions
 
-## What the client could do
+Reported failures include open-world sessions lasting several hours and
+texture-dense instanced content reaching the same boundary in roughly half an
+hour. Players have also reported shorter failures in a Resplendent Makuun
+vanquish and Dunes of Despair Hard Mode.
 
-The comment in the glue says the cap exists to stay clear of the 4 GB
-wraparound. Emscripten supports a 4 GB heap on wasm32 with
-`-sMAXIMUM_MEMORY=4GB`.
+Our longest recorded non-crashing staircase reached 1,619 MiB after 136
+minutes:
 
-We're asking you to consider that flag — not claiming it removes the cause. It
-moves the limit and buys a long session more time.
+| Elapsed | Heap after step | Elapsed | Heap after step |
+| --- | --- | --- | --- |
+| 0.1 m | 256 MiB | 84.8 m | 1,124 MiB |
+| 1.4 m | 442 MiB | 94.5 m | 1,220 MiB |
+| 13.1 m | 627 MiB | 97.7 m | 1,316 MiB |
+| 46.6 m | 724 MiB | 109.5 m | 1,427 MiB |
+| 67.5 m | 930 MiB | 127.2 m | 1,523 MiB |
+| 82.5 m | 1,027 MiB | 128.7 m | **1,619 MiB** |
 
-::info{title="A larger heap is not a substitute for the real cause"}
-A 4 GB cap roughly doubles the time to the abort; it doesn't remove the abort.
-Our curve shows consumption still rising after two hours, and the third
-session reached the cap in half an hour — for that player a larger cap buys an
-hour, not a fix. Treat the flag as relief while the texture path is looked at,
-not as the answer.
-::
+That session did not converge before the player quit. Newer short sessions do
+sometimes converge: one multi-zone run reached 733 MiB and stayed there while
+the host processed substantial additional image traffic. Both results are
+real. The route, cache warmth, and allocator reuse affect whether a particular
+session reproduces the growth.
 
-## What we cannot see, and what you can
+WASM memory capacity never shrinks within a process. A flat heap means current
+allocations fit into existing capacity; a rising heap means they did not. A
+rising capacity alone cannot distinguish retained live bytes from
+fragmentation.
 
-We can measure the heap's size, not its contents. From outside the module,
-`malloc` and `free` are not reachable for the client's internal calls, so we
-cannot say whether this is a leak, an unbounded cache, or fragmentation — only
-that consumption rises without levelling off, and that the failing allocation
-is a texture.
+## What allocation attribution found
 
-We considered a heap walker over the allocator's structures and a transform
-around `malloc` and `free`, and rejected both: all three causes need the same
-thing from us, which is evidence for you. Inside the source tree the question
-is much cheaper to answer — the texture cache's eviction policy, if it has
-one, is where we would look first.
+Our first allocator experiment was too expensive to keep: it added about 47%
+steady-state overhead. Its useful historical snapshots identified several
+large ArenaNet allocation owners rather than one texture-only explanation:
 
-## Acceptance criteria
+| Exact build-38797 function | Reverse-engineered owner | Observed retained large bytes |
+| --- | --- | --- |
+| `2797` | `GlTex` | 117–148 MiB |
+| `1586` | `ImgMem` | 46–96 MiB |
+| `4491` | model loading | 29–129 MiB |
+| `3421` | unresolved secondary owner | 24–49 MiB |
 
-- A three-hour session with several map changes does not reach the heap
-  maximum.
-- Repeatedly entering and leaving one texture-dense instanced area returns
-  heap use to roughly its earlier level, rather than adding to it each time.
-- If you raise the cap, `getHeapMax()` returns the new value, and the client
-  does not fault at the old boundary.
-- The client keeps a clear abort message when it does reach the maximum.
+The replacement research probe wraps only exact lifecycle functions for
+`ImgMem`, models, and `GlTex`. It exports aggregates rather than pointers or
+per-allocation events.
 
-## What we built to measure it
+Static analysis found a complete reference-safe model lifecycle already in the
+client:
 
-So the request carries evidence rather than a guess, our host now records:
+1. release function `4629` moves zero-reference models to an unused list with a
+   one-second expiry;
+2. acquire function `4628` removes a reused model from that list;
+3. sweep function `4649` destroys expired unused entries through the normal
+   virtual destructor;
+4. the normal model update calls that sweep approximately every ten seconds.
 
-- A heap-growth event, so the growth staircase is visible per session.
-- The heap size on abort, plus peak gauges.
-- A technical-details view for the player, with the abort text — this is where
-  the `GlTex.cpp` line above came from.
-- A warning at 1.75 GiB and at 1.875 GiB, with a reload at a safe moment.
+A corrected short capture observed 6,092 normal model evictions and only
+1.9 MiB in the zero-reference aggregate, but its bootstrap completeness flag
+was false. That data cannot authorize an external trim. It does show that the
+normal model sweep is active.
 
-The warning lets the player pick the moment of the reload. It doesn't prevent
-the cause.
+We found no certified standalone unused check for the image or texture
+destruction paths. Calling a destructor, raw `free`, or `glDeleteTexture` from
+the host would risk stale lookup entries and use-after-free defects.
 
-## How to reproduce
+## The short internal reproduction ArenaNet can run
 
-We can't give a short reproduction — the abort needs a long session. The
-fastest route we know is texture-dense content:
+ArenaNet does not need to wait hours for the public abort. Source symbols and a
+heap profiler turn this into a short ownership test:
 
 ::steps{mode="numbered"}
 
-### Play a long session
+### Record a settled baseline
 
-Play for two to four hours. Change maps often. Play with other players.
-Instanced Eye of the North content reaches the cap fastest — one player got
-there in about half an hour.
+Use build 38797 with allocation/free stacks. Record live bytes, the largest
+free block, free-bin distribution, and image/model/texture ownership.
 
-### Watch the heap
+### Travel through ten distinct zones
 
-Read `getHeapMax()` and the current heap size at intervals.
+Pause after transitions 3, 6, and 9 so unload work and the model sweep can
+finish. Revisit three earlier zones, then remain idle for 30 seconds.
 
-### Observe the abort
+### Compare capacity with live ownership
 
-The client aborts with an assertion when the heap reaches the maximum.
+- Capacity rises while live bytes return near baseline: fragmentation.
+- Settled live bytes rise across unloads: retention or legitimate working set.
+- Zero-reference bytes remain high: cache budget or sweep issue.
+- Referenced bytes remain high: follow the retaining reference; do not destroy
+  the object externally.
+- Both capacity and live bytes plateau: normal warm-up for that route.
+
+### Repeat with a warm cache
+
+Use the same build, route, account, and settings. A controlled comparison must
+change only one variable.
 ::
 
-## Our workaround today
+The first source paths worth inspecting are `ImgMem` allocation `1586`, model
+load `4491`, and `GlTex` allocation `2797`, plus their existing cache budgets
+and normal release paths.
 
-We warn the player at 1.75 GiB and at 1.875 GiB, then offer a reload, syncing
-the file system first where possible. A fix retires the warning and the reload
-path.
+## Our interim mitigation
+
+### Safe reload warning
+
+GWonMac's production warning monitors the effective heap capacity while there
+is still room to return to a town or outpost, then lets the player choose when
+to reload. Reloading resets the WASM heap. It is recovery, not a memory fix.
+
+### Exact-build 4 GB research profile
+
+We have also built an off-by-default research profile for build 38797. It
+changes the WASM maximum to 65,535 pages—4 GiB minus one 64 KiB page—and
+transforms the exact generated JavaScript to treat high wasm32 pointers as
+unsigned addresses.
+
+The pair is hash-gated and fails closed: an unknown JS or WASM artifact runs
+untouched. Raising only the WASM maximum is explicitly refused.
+
+Qualification completed so far:
+
+- ArenaNet's real allocator grew to 3,025,928,192 bytes offline;
+- it returned and reused allocations above 2 GiB;
+- the live Electron client grew to 2,625 MiB;
+- live `malloc` returned raw signed pointer `-2078907408`, unsigned address
+  `2216059888`;
+- the transformed generated string glue wrote and read `GW4G` through that
+  high pointer without trapping.
+
+This proves the core approach across the former boundary. It does not prove
+every rare WebGL or host callback path, and it does not bound the underlying
+memory demand. The current profile remains a developer experiment while we
+certify every supported Enhancement variant, package it, test system-memory
+pressure, and expose an explicit user setting.
+
+If released before an ArenaNet update, it will be labelled **Experimental 4 GB
+memory mode**, disabled by default, restricted to exact certified builds, easy
+to turn off, and recommended only on Macs with at least 16 GB of RAM.
+
+## What we will not do
+
+- Change only the WASM maximum.
+- Exceed wasm32's 4 GiB address space.
+- Call raw `free`, direct destructors, or `glDeleteTexture`.
+- Guess a cache function or context pointer.
+- Replace ArenaNet's allocator.
+- Automatically reload a player during a mission.
+- Present the 4 GB profile as a fix for unbounded retention.
+
+## Acceptance criteria
+
+For ArenaNet's corrective build:
+
+- settled live ownership and heap capacity plateau across repeated content
+  transitions;
+- zero-reference cache entries leave through normal reference-safe eviction;
+- freed large blocks are reusable when fragmentation was the cause;
+- a three-hour content-diverse session does not approach the effective maximum;
+- if the maximum is raised, generated JS and WASM agree and ordinary game paths
+  work above 2 GiB;
+- the client retains a clear failure reason if it exhausts the new maximum.
+
+For our optional mitigation, every accepted JS/WASM pair must be pinned to an
+exact ArenaNet build, unknown builds must remain untouched, the mode must be
+visible in diagnostics, and disabling it must restore ordinary client behavior
+after restart.
+
+## Current conclusion
+
+The 2 GiB limit and final failed allocation are in ArenaNet's shipped client.
+The reason some sessions consume the available address space still needs an
+ArenaNet source-level heap profile. Until that is fixed, a safe reload remains
+the conservative mitigation and an exact-build 4 GB mode can provide optional
+headroom for informed testers.

--- a/apps/website/content/en/1.docs/3.upstream/7.reference/1.our-workarounds.md
+++ b/apps/website/content/en/1.docs/3.upstream/7.reference/1.our-workarounds.md
@@ -3,7 +3,7 @@ title: Our workarounds, and what each fix removes
 ref: docs/upstream/reference/our-workarounds
 description: What GWonMac does to the client today, why each workaround exists, what it costs us per client build, and exactly what we delete after each upstream fix.
 icon: lucide:wrench
-updated: 2026-08-04
+updated: 2026-08-08
 navigation:
   title: Our workarounds
 ---
@@ -114,14 +114,42 @@ either.
 
 **Deleted after the fix:** the whole retry path.
 
-## Workaround 6 — the heap warning
+## Workaround 6 — the heap warning and safe reload
 
 **Removed by:** `UR-10`.
 
-The host warns the player at 1.75 GiB and at 1.875 GiB of heap use, then
-offers a reload at a moment the player chooses.
+The host monitors the effective heap cap, warns while the player still has
+room to return somewhere safe, then offers a user-controlled reload. WASM
+memory capacity cannot shrink inside one process; reload starts a new heap.
 
-**Deleted after the fix:** the warning and the reload path.
+**Deleted after the fix:** emergency reload guidance can go once ArenaNet's
+ownership policy is bounded and long content-diverse sessions remain well
+below the effective cap. The general crash-recovery path remains.
+
+## Research profile — paired 4 GB JS/WASM transform
+
+**Reduced or removed by:** `UR-10`.
+
+An off-by-default developer profile raises build 38797's WASM maximum to 4 GiB
+minus one page and transforms the matching generated JavaScript to normalize
+wasm32 pointers above 2 GiB. It is a paired transform: changing only the WASM
+maximum would hand negative pointer values to JavaScript and is refused.
+
+The exact pair has passed ArenaNet-allocator qualification above 3 GiB and a
+live Electron string-glue test at 2,625 MiB. It remains a research profile, not
+a default player setting. Before an experimental release it still needs every
+supported Enhancement variant certified, packaged high-address gameplay
+coverage, system-memory testing, explicit opt-in copy, and diagnostics that
+record the effective mode.
+
+**Cost per client build.** Both official artifact hashes, every accepted
+predecessor hash, both derived hashes, and the generated-glue pointer audit.
+Any ArenaNet update disables the profile until it is re-certified.
+
+**Deleted after the fix:** the whole transform and its certification table. A
+source-built 4 GB client already has the compiler's matching unsigned-pointer
+support; a bounded cache/lifecycle fix removes the reason for our emergency
+headroom.
 
 ## What our workarounds never do
 
@@ -135,6 +163,7 @@ offers a reload at a moment the player chooses.
 ## The bottom line
 
 Six of the twelve requests exist because of file handling; one exists because
-of a single unwritten byte. Fix `UR-01` to `UR-07` and three of our six
-workarounds disappear outright, leaving certification work on the cursor
-feature alone.
+of a single unwritten byte. Fix `UR-01` to `UR-07` and three production
+workarounds disappear outright. A source-level `UR-10` correction also avoids
+turning the research-only 4 GB profile into another permanent certification
+burden.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -222,6 +222,49 @@ process when its event loop actually blocked, and otherwise to the renderer.
 Captures recorded before window-state tracking say so rather than claiming the
 window was steady.
 
+### Attributing WASM memory exhaustion
+
+The renderer wraps the official client's imported `emscripten_resize_heap`
+function before instantiation. It does not change the requested size or the
+result. A `wasm.memoryProbe` event first records whether that import was
+available, so silence cannot be mistaken for an active probe. Every call then
+records `wasm.growthRequested` with the requested, before, and after heap
+sizes; whether the request grew, stayed unchanged, was refused, or threw; and
+the first four numeric WASM function indices and code offsets. The event
+therefore includes failed growth attempts that the two-second `wasm.heapGrew`
+capacity staircase cannot see. Stack prose never crosses IPC. An eight-hex
+fingerprint groups identical numeric call chains.
+
+At the same boundary the recorder snapshots bounded WebGL texture aggregates:
+generated, deleted, live, and tracked texture counts; estimated bytes for
+known sized formats; estimated cumulative upload bytes; unknown allocations;
+and whether the 4,096-texture tracking bound was reached. No texture contents,
+WebGL object, pointer, or per-texture history is retained. When
+`unknownTextureAllocations` is non-zero or `textureTrackingSaturated` is true,
+the known byte figure is a lower bound, not total GPU memory.
+
+Run `pnpm diagnostics:summarize <capture.gwdiag>` first. Its **WASM memory
+attribution** section reports the outcome counts, last request, growth trigger,
+and texture state at that request. The growth trigger is the allocation path
+that crossed the current heap capacity; it is not presented as the owner of
+the whole growth step.
+
+| Evidence | What it establishes | What it does not establish |
+| --- | --- | --- |
+| `refused`, unchanged heap, request at or above the compiled cap | The official WASM asked its Emscripten host to exceed the memory available to this build | Which client subsystem retained the earlier allocations |
+| One repeated stack fingerprint while texture counts and estimated bytes stay flat | One stable WASM allocation path is triggering growth, with no measured texture-lifetime correlation | The source symbol without exact-build symbolication |
+| Texture live/known bytes rise with successive requests | Texture allocation or staging is correlated with heap pressure | That GPU storage itself occupies WASM linear memory, or that the host leaked it |
+| Many upload bytes but stable live/known bytes | Texture data is being streamed, while measured retained texture storage is stable | Whether temporary client-side upload buffers are retained elsewhere |
+| Probe `installed`, but no `wasm.growthRequested` before an abort | No call crossed the imported resize boundary before the abort | That the failure was not memory-related; check the abort kind |
+| Probe `resizeImportMissing` | The client build no longer exposes this observation boundary | Anything about growth ownership |
+
+Function indices and offsets are meaningful only for the exact official client
+build recorded in the capture. Run
+`python3 tools/gensyms.py "<path>/Gw.jspi.wasm" build/` against that exact
+artifact before assigning a source symbol. A capture can conclusively show a
+client request being refused at its compiled limit; assigning ownership still
+requires controlled runs of the same client build.
+
 ## Verification boundaries
 
 ### Claims and the tests that prove them

--- a/plans/memory-bug.md
+++ b/plans/memory-bug.md
@@ -1,0 +1,536 @@
+# Guild Wars WASM memory exhaustion: investigation, ArenaNet handoff, and interim mitigation
+
+Last updated: 2026-08-08  
+ArenaNet client target: build `38797`  
+
+## Executive summary
+
+Guild Wars build 38797 ships as a wasm32 client whose linear memory starts at
+256 MiB and has a declared maximum of exactly 2 GiB. The matching generated
+JavaScript returns the same 2 GiB maximum from `getHeapMax()`. Once the
+monotonically growing WASM heap reaches that boundary, the next allocation that
+requires growth is refused and the client aborts. A captured failure reached
+exactly `2,147,483,648` bytes and reported an ArenaNet assertion in
+`Engine/Gr/Gles3/GlTex.cpp:397`.
+
+The 2 GiB ceiling is conclusively part of ArenaNet's shipped JS/WASM artifact,
+not a smaller limit imposed by gwonmac. The allocation and assertion also occur
+inside the shipped client. That does **not** prove that every byte below the
+ceiling is an ArenaNet leak: the unresolved cause can still be legitimate live
+working set, cache retention, allocator fragmentation, or a lifecycle problem.
+The assertion site is the allocation that finally lost, not necessarily the
+owner of all previously retained memory.
+
+We have not found a safe client-side cache purge. Static analysis proves that
+the model cache already has a reference-safe one-second expiry and a normal
+sweep approximately every ten seconds. The available live lifecycle capture
+is incomplete and does not justify invoking any destructor or eviction path.
+Raw `free`, direct `glDeleteTexture`, and guessed cache calls remain prohibited.
+
+As an interim measure, we built an opt-in, research-only 4 GB profile. It
+changes the exact WASM memory maximum to 65,535 pages (4 GiB minus one 64 KiB
+page) and applies the corresponding unsigned-pointer transformation to the
+exact generated JavaScript. Raising only the WASM limit is unsafe. The paired
+profile has passed offline qualification with ArenaNet's real allocator at
+3,025,928,192 bytes and a live browser test at 2,625 MiB with a real pointer
+above 2 GiB. It is suitable for a narrowly gated experimental release after
+the remaining release checklist is completed; it is not a root fix and should
+not be enabled by default.
+
+## What users experience
+
+Observed reports include:
+
+- two client deaths within a 97-minute session, with the second heap reaching
+  exactly 2 GiB;
+- content-dense instanced play reaching the limit in roughly 20–70 minutes in
+  reported cases;
+- a Resplendent Makuun vanquish ending after about 25 minutes;
+- Dunes of Despair Hard Mode with consumables ending after about 20 minutes;
+- an Emscripten `Out of memory!` abort with an ArenaNet `GlTex.cpp:397`
+  assertion;
+- sessions that do not reproduce the growth and instead plateau around
+  700–900 MiB.
+
+The variability matters. The failure is not simply “time in the game.” It is
+affected by content, route, cache warmth, and allocation reuse. A short session
+can exercise several gigabytes of image traffic while the WASM capacity stays
+flat.
+
+## Facts established with high confidence
+
+### The compiled ceiling
+
+- `Gw.jspi.wasm` declares one memory with:
+  - initial: 4,096 pages = 256 MiB;
+  - maximum: 32,768 pages = 2 GiB.
+- `Gw.jspi.js` contains `getHeapMax = () => 2147483648`.
+- The comment immediately above that value is Emscripten's stock explanation
+  for staying one page below 4 GiB, while the value itself is 2 GiB.
+- The host does not impose a smaller limit. Growth succeeds until the module's
+  declared maximum is reached.
+- wasm32 cannot provide memory above the 4 GiB address space. Raising the
+  maximum buys headroom; it cannot make an unbounded retention problem safe.
+
+### Heap behavior
+
+- WASM linear memory capacity only grows during a process. Freeing allocations
+  makes blocks reusable but does not shrink `memory.buffer.byteLength`.
+- Repeated growth therefore does not by itself prove a leak. The relevant
+  comparison is settled live ownership versus heap capacity after unloads.
+- A 500-round, 8 MiB allocate/free test against the real allocator kept heap
+  capacity flat, showing that ordinary `malloc`/`free` reuse works.
+- Revisiting previously loaded content can avoid growth. That is consistent
+  with a cache, and also with freed blocks being reused.
+- In the latest natural travel test the heap reached 733 MiB and stayed there
+  while image cache counters rose from roughly 2,500 to 3,700 native chunks.
+  This was a genuine plateau, not a failed measurement.
+
+### Growth and texture correlation
+
+One valid short archive (`guild-wars-diagnostics_ceck.zip`) recorded:
+
+- build 38797;
+- 397 seconds;
+- heap growth from 819 MiB to 916 MiB on the last step;
+- 868 live textures;
+- an estimated 423 MiB of known texture storage;
+- complete texture tracking;
+- no refused growth request during that short run.
+
+Other valid or historically useful captures showed retained large allocations
+associated with these ArenaNet functions:
+
+| Exact function | Reverse-engineered owner | Example retained large bytes |
+| --- | --- | ---: |
+| `2797` | `GlTex` allocation | 117–148 MiB |
+| `1586` | `ImgMem` allocation | 46–96 MiB |
+| `4491` | model loading | 29–129 MiB |
+| `3421` | unresolved secondary owner | 24–49 MiB |
+
+These figures are attribution evidence, not proof of a leak. Texture estimates
+also include GPU-correlated state and must not be presented as WASM ownership
+without the allocator evidence.
+
+### What the assertion means
+
+`GlTex.cpp:397` identifies the allocation path that crossed the remaining
+capacity. It does not establish that `GlTex` retained the preceding 2 GiB. A
+texture allocation can be the final request after models, images, fragmented
+free blocks, and other caches consumed the available address space.
+
+## What remains unknown
+
+We do not yet have complete evidence to distinguish among:
+
+1. **Cache retention:** referenced or reusable image/model/texture content is
+   retained without a sufficiently low budget.
+2. **Lifecycle defect:** objects that should reach zero references do not.
+3. **Fragmentation:** live bytes return near baseline but large free blocks
+   cannot satisfy later requests.
+4. **Large legitimate working set:** the route really needs close to 2 GiB of
+   simultaneous live state.
+5. **A mixture:** caching plus fragmentation is entirely plausible.
+
+It would be inaccurate to state that the root cause is “100% an ArenaNet
+leak.” What is safe to state is:
+
+> ArenaNet's build 38797 contains the 2 GiB limit and performs the allocation
+> that is refused at that limit. gwonmac has reproduced and instrumented the
+> boundary. The ownership policy that makes some sessions approach the limit
+> has not yet been classified as leak, cache, fragmentation, or legitimate
+> working set.
+
+Enhancements have not been proven to cause the problem. Controlled comparisons
+should keep the same ArenaNet build, route, account, and cache state while
+changing only the Enhancement profile.
+
+## Reverse-engineering results
+
+### `ImgMem`
+
+- creation/allocation: function `1586`;
+- resize/reallocation: function `1592`;
+- destruction: function `1589`.
+
+`ImgMem` storage belongs to higher `GrTex2d` objects. Function `1592` is a
+resize path, not an eviction operation. We have not certified a standalone
+reference-safe cache trim for this owner.
+
+### `GlTex`
+
+- allocation: function `2797`;
+- complete normal teardown: function `2798`;
+- observed callers: `2805`, `2810`, `2811`, and `2812`;
+- single-object callable path considered during research: `2814`.
+
+Normal teardown removes the object from the context array, deletes the GL
+texture, frees its CPU upload buffer, releases dependencies, and unlinks it.
+That proves how normal destruction works. It does not prove that calling the
+path externally is safe: `2814` does not provide a certified unused/reference
+check. It must not be used as a pressure purge.
+
+### Model cache
+
+- parse/load: `4491`;
+- cache insertion: `4507`;
+- reference acquisition: `4628`;
+- release: `4629`;
+- destructor: `4632`;
+- unused sweep: `4649`;
+- normal update caller: `4263`.
+
+The exact build already implements a coherent lifecycle:
+
+1. `4629` decrements refcount `+0x0c`.
+2. At zero, the deferred path links the model into global `s_unused` through
+   link `+0x1c` and writes `Time() + 1000` at `+0x18`.
+3. `4628` unlinks a reused model before incrementing its reference count.
+4. `4649` walks expired unused entries and calls their normal virtual
+   destructor.
+5. `4263` invokes the sweep about every ten seconds.
+6. `4632` cleans the payload, removes hash/list membership, and uses the normal
+   sized-delete path.
+
+Calling `4649` more often would be redundant unless complete live telemetry
+proved expired zero-reference objects were accumulating. Current data does not
+meet that gate.
+
+### Lifecycle telemetry limitation
+
+The first universal allocator probe was rejected because it added about 47%
+steady-state overhead. It has been removed.
+
+The replacement probe wraps only eleven exact lifecycle functions and exports
+aggregate counters. It does not export pointers or per-allocation events. An
+early run reported implausibly high model zero-reference totals; the tracker
+explicitly marked itself `INCOMPLETE`. The corrected short capture reported:
+
+| Owner | Owned | Zero-reference | Normal evictions | Completeness |
+| --- | ---: | ---: | ---: | --- |
+| `ImgMem` | 45.7 MiB | 0 MiB | 0 | incomplete |
+| model | 0 MiB | 1.9 MiB | 6,092 | incomplete |
+| `GlTex` | 123.2 MiB | 0 MiB | 0 | incomplete |
+
+Because completeness failed, these values cannot authorize a production trim.
+They do show the normal model sweep actively evicting thousands of objects.
+
+## How ArenaNet can reproduce and classify it quickly
+
+ArenaNet does not need to wait for a public crash. With source symbols and an
+internal allocator profiler, the ownership question should take minutes rather
+than hours.
+
+### Recommended internal reproduction
+
+1. Use the exact source and Emscripten configuration for build 38797.
+2. Record the emitted JS and WASM maximum-memory settings.
+3. Enable ArenaNet's normal allocation profiler or a low-overhead sampled heap
+   profiler with allocating and freeing C++ stacks.
+4. Start after login in a town/outpost and record a settled baseline.
+5. Visit ten distinct content-heavy zones, pausing after transitions 3, 6,
+   and 9 so asynchronous unload work and the model sweep can complete.
+6. Revisit three earlier zones.
+7. Remain idle for 30 seconds.
+8. At every settled point record:
+   - linear-memory capacity;
+   - total live allocator bytes;
+   - largest free block and free-bin distribution;
+   - live bytes and object counts by allocation stack;
+   - zero-reference cache bytes for image, model, and texture owners;
+   - normal destruction/eviction counts.
+9. Repeat the same route once with the same cache warmed.
+
+### Decision table for ArenaNet
+
+| Result | Classification | Correct direction |
+| --- | --- | --- |
+| Capacity rises by at least 128 MiB while settled live bytes return within 10% or 32 MiB of baseline | fragmentation | reshape/isolate the large allocation pattern or allocator arenas; verify freed blocks are reused |
+| Settled live bytes rise by at least 64 MiB across two unloads and one or more owners explain at least half the retained large bytes | retention/lifecycle | inspect that owner's reference transitions and normal eviction policy |
+| Zero-reference cached ownership stays high across two unloads | cache budget or sweep issue | use the existing lookup removal and destructor path; add budget/hysteresis |
+| Referenced ownership remains high | live working set or missing release | find the retaining reference chain; do not forcibly destroy it |
+| Heap and live bytes plateau across ten transitions | normal warm-up | do not ship a speculative purge |
+
+### Fast boundary reproduction
+
+To test the compiled ceiling independently of the natural route, ArenaNet can:
+
+- temporarily compile a diagnostic build with a lower maximum and run the same
+  content route; or
+- retain a large debug allocation, then perform ordinary game loads so later
+  allocations cross the signed 2 GiB address boundary; or
+- compile with 4 GiB minus one page and run the client above 2 GiB with the
+  generated unsigned-pointer support enabled.
+
+The diagnostic allocation must be research-only and released through the
+normal allocator. It is not a proposed product workaround.
+
+### Source areas worth inspecting first
+
+- `ImgMem` ownership from `1586` through `1592` and `1589`;
+- model owners corresponding to `4491`, `4505`, and `4506`;
+- `GlTex` ownership from `2797` through `2805`, `2810`, `2811`, and `2812`;
+- cache budgets and eviction hysteresis around these owners;
+- fragmentation around the recurring large allocation shapes;
+- mobile builds, if they share the same artifact or memory policy.
+
+## What to send ArenaNet
+
+### Attachments
+
+Prefer complete, validator-clean archives and the exact client artifacts:
+
+1. The original archive containing the exact 2 GiB abort and
+   `GlTex.cpp:397` assertion.
+2. `guild-wars-diagnostics_ceck.zip` for the clean growth staircase and
+   texture correlation.
+3. `guild-wars-diagnostics_research.zip` for historical allocator ownership,
+   clearly labelled as coming from the retired high-overhead probe.
+4. `guild-wars-diagnostics_investige.zip` for the corrected targeted lifecycle
+   schema, clearly labelled incomplete.
+5. The SHA-256 hashes of `Gw.jspi.js` and `Gw.jspi.wasm` from the affected
+   installation.
+6. This document, which includes the lifecycle findings and decision gates.
+
+Do not lead with archives marked `SUSPECT` by the current validator. They can
+be retained as historical evidence, but schema mismatch must not be mistaken
+for a clean capture.
+
+### Developer-facing message
+
+> We are seeing build 38797 abort when its wasm32 linear memory reaches the
+> exact compiled maximum of 2,147,483,648 bytes. The value is present both in
+> the WASM memory declaration (256 MiB initial, 2 GiB maximum) and in
+> `Gw.jspi.js`'s `getHeapMax()`. One captured abort reports
+> `Engine/Gr/Gles3/GlTex.cpp:397` at the boundary.
+>
+> Short instrumented runs identify retained large allocations under the exact
+> functions corresponding to `GlTex` (`2797`), `ImgMem` (`1586`), and model
+> loading (`4491`), but we cannot distinguish cache retention from
+> fragmentation or legitimate referenced ownership from outside the client.
+> The growth-trigger stack is the allocation that crossed capacity, not proof
+> that it owns the prior growth.
+>
+> Could you run build 38797 with your heap profiler across ten distinct zone
+> transitions, three revisits, and a 30-second settle, recording live bytes,
+> largest free block, and ownership/refcount state for those three paths? The
+> existing model unused sweep appears to run normally about every ten seconds.
+>
+> Raising `MAXIMUM_MEMORY` to 4 GiB minus one page works in our research build
+> only when paired with Emscripten's unsigned JS pointer handling. We have
+> validated the real allocator and generated string glue above 2 GiB. This
+> delays the failure but does not replace an ownership or cache-budget fix.
+> We can provide the clean diagnostic archives, exact hashes, growth stacks,
+> and reproduction route.
+
+### Short management-level message
+
+> The web client shipped with a fixed 2 GiB memory ceiling. Some content-heavy
+> sessions reach it and terminate. We have confirmed the ceiling and built a
+> temporary 4 GiB experimental mode, but only ArenaNet can determine whether
+> the underlying growth is cache policy, fragmentation, or a missing release.
+> A short internal heap-profiled zone route should identify the owner. We can
+> provide exact build hashes and diagnostic captures.
+
+### Information to include with every report
+
+- ArenaNet build number;
+- SHA-256 of both JS and WASM artifacts;
+- gwonmac version;
+- whether Enhancements were enabled and which profile;
+- whether experimental 4 GB mode was enabled;
+- route/mission and approximate transition sequence;
+- heap capacity at failure;
+- exact abort text and first numeric WASM frames;
+- whether the diagnostic validator marked the archive valid;
+- machine RAM and macOS version.
+
+## Interim gwonmac mitigation
+
+### Existing safe recovery
+
+Keep the heap watermark and user-controlled reload path. A reload resets linear
+memory and is much safer from a town/outpost than an allocation abort during a
+mission. Automatic mid-mission reload is not a corrective memory fix and must
+not be introduced silently.
+
+### Research-only 4 GB transform
+
+The implemented chain is:
+
+```text
+official WASM
+  -> template compatibility
+  -> optional Enhancement
+  -> native double-click
+  -> targeted lifecycle telemetry
+  -> paired 4 GB JS/WASM transform
+```
+
+The final stage runs only with:
+
+```text
+GWONMAC_MEMORY_ATTRIBUTION_RESEARCH=1
+GWONMAC_EXTENDED_MEMORY_RESEARCH=1
+```
+
+Launch command:
+
+```bash
+cd /path/to/gwonmac-memory-investigation
+pnpm dev:memory:4gb
+```
+
+The normal `pnpm dev` path remains unchanged.
+
+### Why the JS and WASM must change together
+
+wasm32 function results arrive in JavaScript as signed i32 values. A pointer
+above `0x7fffffff` therefore appears negative. Merely changing the WASM maximum
+would make generated heap indexing and host byte offsets use negative values.
+That can corrupt data or trap.
+
+The exact generated-glue transform:
+
+- changes `getHeapMax()` to `4,294,901,760`;
+- converts the audited signed pointer shifts to unsigned shifts;
+- normalizes byte-heap indices;
+- normalizes typed-array byte offsets;
+- normalizes UTF-8 input/output pointers;
+- normalizes image-read and heap-copy destinations;
+- publishes the active cap to the host watermark.
+
+The transform is exact-input hash-gated. It is not a general JavaScript
+rewriter.
+
+### Current certified research pair
+
+| Artifact | SHA-256 |
+| --- | --- |
+| Official JS input | `58ecc6377397f01919d8def58e802e19fbfd6ce13f421dbf14123a667e34f7d0` |
+| Transformed JS output | `1dd5d798b1491f46a7c128c641053c8488211bbc193fe40bdf1d7a886517993d` |
+| ABI-11 WASM input, widest Enhancement profile | `3f7ec5ab3a957103bd3ac3068e6e2cb6d5203b4ccb0afc08dfd4329ff150a9c6` |
+| 4 GB WASM output | `20f36cf63dd0082fc3e888d66d63cfafd73b99aa4e5e937dc446f2aea52f0ec5` |
+
+WASM maximum: 65,535 pages = 4 GiB minus 64 KiB.
+
+### Qualification already completed
+
+Offline, using build 38797's real `malloc` and `free`:
+
+- heap reached `3,025,928,192` bytes;
+- a returned pointer had unsigned address `2,522,561,664`;
+- high-address read/write passed;
+- freed capacity was reused without another heap-growth request.
+
+Live in Electron:
+
+- the transformed cap reported `4,294,901,760`;
+- heap grew to 2,625 MiB;
+- `malloc` returned raw pointer `-2,078,907,408`;
+- the same pointer normalized to unsigned address `2,216,059,888`;
+- generated `stringToUTF8` wrote through the signed high pointer;
+- generated `UTF8ToString` read back `GW4G`;
+- cleanup completed without a trap.
+
+This proves the live engine, memory growth, allocator, and core generated string
+glue can cross the former boundary. It does not prove every rare WebGL or host
+callback path under all gameplay conditions.
+
+### Offline qualification command
+
+```bash
+pnpm memory:qualify:4gb \
+  "/path/to/Gw.jspi.js" \
+  "/path/to/certified/ABI11/Gw.jspi.wasm"
+```
+
+### Proposed experimental product shape
+
+If released before ArenaNet ships a correction:
+
+- setting name: **Experimental 4 GB memory mode**;
+- default: off;
+- scope: exact certified ArenaNet build only;
+- unknown build behavior: refuse the transform and run the untouched client;
+- recommended hardware: at least 16 GB system RAM;
+- warning: this adds headroom and may delay an abort; it does not repair
+  unbounded retention;
+- rollback: disable the setting and restart;
+- diagnostics: record a closed boolean/mode value and the effective heap cap;
+- keep the reload warning near the effective cap;
+- never silently enable it during an update or after a crash.
+
+### Work remaining before an experimental release
+
+The current implementation is a research profile, not yet a user-facing
+setting. Before release:
+
+1. Certify every supported post-double-click/Enhancement variant intended for
+   the option, including Enhancements disabled. The current 4 GB output is
+   pinned only for the widest ABI-11 research predecessor.
+2. Add the explicit persisted opt-in and clear explanatory copy.
+3. Record the effective mode and cap in the closed diagnostics schema.
+4. Test one content-heavy zone transition while allocations above 2 GiB remain
+   live, covering image upload, WebGL, sockets, filesystem, and UI strings.
+5. Test representative 8 GB, 16 GB, and 32 GB Macs. The option should be
+   discouraged or refused where system pressure makes it counterproductive.
+6. Verify warning thresholds and the reload path against the effective 4 GB
+   cap.
+7. Verify transform refusal and cache deletion after a one-byte JS or WASM
+   change.
+8. Package and smoke-test, rather than relying only on the development host.
+9. Keep the offline >2 GiB qualification in the release checklist.
+
+Default activation should require substantially more live coverage and a clear
+understanding of system-memory behavior. ArenaNet's source-level fix remains
+preferable.
+
+## Approaches explicitly rejected
+
+- **Raise only the WASM maximum:** unsafe because JavaScript sees high wasm32
+  pointers as negative.
+- **Raise beyond 4 GiB:** impossible with this wasm32 client.
+- **Raw `free`:** bypasses owner invariants and creates use-after-free risk.
+- **Direct `glDeleteTexture`:** leaves ArenaNet's objects and lookup structures
+  inconsistent.
+- **Call a destructor directly:** skips reference checks, list removal, and
+  dependent cleanup.
+- **Call `GlTex` path `2814` as a purge:** no certified unused check.
+- **Replace the allocator:** far broader than the evidence and likely ABI
+  incompatible.
+- **Keep the universal allocator interceptor:** measured roughly 47% overhead.
+- **Assume the growth-trigger caller owns the growth:** it is only the request
+  that crossed capacity.
+- **Automatically reload during missions:** avoids one abort by introducing
+  predictable session loss.
+- **Ship an unbounded generic transform:** every accepted input and output must
+  be pinned to an exact ArenaNet build.
+
+## Interpreting common console messages
+
+These observed messages are not evidence of the memory failure:
+
+- `image.open ChatFilter.ini -> 0 (not in the image)`: optional file not present
+  in the snapshot;
+- `socket error reset` followed by `socket.connect ...:6112`: game connection
+  reset/reconnect;
+- pointer-lock refusal: focus or user-gesture requirement;
+- a native Electron abort in macOS `HIServices::_RegisterApplication`: app
+  registration/launch failure before the renderer or WASM starts.
+
+## Current decision
+
+1. Continue asking ArenaNet for a source-level heap profile and correction.
+2. Do not ship a guessed cache/destructor patch.
+3. Keep safe reload recovery.
+4. Complete the remaining release gates for an off-by-default, exact-build 4 GB
+   experimental mode if users need an interim option.
+5. Remove or disable the research lifecycle probe once it no longer answers an
+   active question.
+6. Re-certify from zero after every ArenaNet artifact update.
+
+The simplest correct long-term outcome is an ArenaNet build with an intentional
+memory maximum and a bounded, reference-safe content cache. The 4 GB profile is
+useful breathing room while that work is pending; it is not a substitute for
+it.

--- a/src/main/diagnostics/renderer.ts
+++ b/src/main/diagnostics/renderer.ts
@@ -18,6 +18,7 @@ import {
   type RendererMetrics,
   type RendererMilestone,
   type RendererMilestoneFields,
+  type WasmMemoryProbeStatus,
 } from "../../shared/diagnostics.js";
 import { activeCaptureLevel } from "./capture.js";
 import { logEvent, recordEvent, recorder } from "./recorder.js";
@@ -287,6 +288,58 @@ export function recordRendererMilestone(
         clockSynchronized: rendererClockSynchronized,
         code: fields.code,
         heapBytes: fields.heapBytes,
+      },
+      { timestampUs },
+    );
+    return;
+  }
+  if (name === "wasm.memoryProbe") {
+    if (!fields || !("status" in fields)) return;
+    recorder.setLatest("wasm.memoryProbe.status", fields.status);
+    recordEvent(
+      {
+        k: "wasm.memoryProbe",
+        clockSynchronized: rendererClockSynchronized,
+        status: fields.status as WasmMemoryProbeStatus,
+      },
+      { timestampUs },
+    );
+    return;
+  }
+  if (name === "wasm.growthRequested") {
+    if (!fields || !("requestedBytes" in fields)) return;
+    recorder.count("wasm.growthRequests");
+    recorder.count(`wasm.growthRequests.${fields.outcome}`);
+    recorder.setLatest("wasm.growth.outcome", fields.outcome);
+    recorder.setLatest("wasm.growth.stackFingerprint", fields.stackFingerprint);
+    recorder.setLatest("wasm.growth.requestedBytes", fields.requestedBytes);
+    recorder.setLatest("wasm.growth.beforeBytes", fields.beforeBytes);
+    recorder.setLatest("wasm.growth.afterBytes", fields.afterBytes);
+    recorder.setLatest("wasm.growth.stackDepth", fields.stackDepth);
+    recorder.setLatest("wasm.growth.frame0Function", fields.frame0Function);
+    recorder.setLatest("wasm.growth.frame0Offset", fields.frame0Offset);
+    recorder.setLatest("wasm.growth.frame1Function", fields.frame1Function);
+    recorder.setLatest("wasm.growth.frame1Offset", fields.frame1Offset);
+    recorder.setLatest("wasm.textures.live", fields.liveTextures);
+    recorder.setLatest("wasm.textures.tracked", fields.trackedTextures);
+    recorder.setLatest("wasm.textures.knownBytes", fields.knownTextureBytes);
+    recorder.setLatest("wasm.textures.uploadBytes", fields.textureUploadBytes);
+    recorder.setLatest(
+      "wasm.textures.unknownAllocations",
+      fields.unknownTextureAllocations,
+    );
+    recorder.setLatest(
+      "wasm.textures.trackingSaturated",
+      fields.textureTrackingSaturated,
+    );
+    recorder.setPeak("wasm.textures.peakLive", fields.liveTextures);
+    recorder.setPeak("wasm.textures.peakKnownBytes", fields.knownTextureBytes);
+    recordEvent(
+      {
+        k: "wasm.growthRequested",
+        clockSynchronized: rendererClockSynchronized,
+        ...fields,
+        stackFingerprint: asRendererFingerprint(fields.stackFingerprint),
       },
       { timestampUs },
     );

--- a/src/main/diagnostics/schema.ts
+++ b/src/main/diagnostics/schema.ts
@@ -25,6 +25,8 @@ import {
 } from "../../shared/digest.js";
 import {
   WASM_ABORT_REASON_KINDS,
+  WASM_GROWTH_OUTCOMES,
+  WASM_MEMORY_PROBE_STATUSES,
   type DiagnosticFields,
   type DiagnosticLevel,
   type DiagnosticScalar,
@@ -1252,6 +1254,47 @@ export const DIAGNOSTIC_EVENT_SCHEMA = {
     subsystem: "renderer",
     level: "info",
     fields: { fromBytes: finiteNumber, toBytes: finiteNumber },
+  },
+  "wasm.memoryProbe": {
+    subsystem: "wasm",
+    level: "info",
+    fields: {
+      clockSynchronized: boolean,
+      status: literal(WASM_MEMORY_PROBE_STATUSES),
+    },
+  },
+  // Exact heap-growth-boundary observation. Unlike `heapGrew`, this records
+  // refused requests and preserves the numeric WASM call chain which caused
+  // the request. Texture figures are bounded aggregates, never object names
+  // or pixel data.
+  "wasm.growthRequested": {
+    subsystem: "wasm",
+    level: "info",
+    fields: {
+      clockSynchronized: boolean,
+      requestedBytes: finiteNumber,
+      beforeBytes: finiteNumber,
+      afterBytes: finiteNumber,
+      outcome: literal(WASM_GROWTH_OUTCOMES),
+      stackFingerprint: isRendererFingerprint,
+      stackDepth: finiteNumber,
+      frame0Function: finiteNumber,
+      frame0Offset: finiteNumber,
+      frame1Function: finiteNumber,
+      frame1Offset: finiteNumber,
+      frame2Function: finiteNumber,
+      frame2Offset: finiteNumber,
+      frame3Function: finiteNumber,
+      frame3Offset: finiteNumber,
+      generatedTextures: finiteNumber,
+      deletedTextures: finiteNumber,
+      liveTextures: finiteNumber,
+      trackedTextures: finiteNumber,
+      knownTextureBytes: finiteNumber,
+      textureUploadBytes: finiteNumber,
+      unknownTextureAllocations: finiteNumber,
+      textureTrackingSaturated: boolean,
+    },
   },
   // The renderer's Enhancement installation lifecycle. `clientPrepared` above
   // says a transformed module was served; only these say whether the hook was

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -45,6 +45,8 @@ import {
   isRendererMetrics,
   RENDERER_MILESTONES,
   WASM_ABORT_REASON_KINDS,
+  WASM_GROWTH_OUTCOMES,
+  WASM_MEMORY_PROBE_STATUSES,
 } from "../shared/diagnostics.js";
 import { DEFAULT_SETTINGS, EXTERNAL_URLS, IPC } from "../shared/contracts.js";
 import { isDigest } from "../shared/digest.js";
@@ -427,6 +429,60 @@ const asMilestone: Parser<ParsedMilestone> = (args) => {
     milestoneFields = {
       code: record.code as number,
       heapBytes: record.heapBytes as number,
+    };
+  } else if (name === "wasm.memoryProbe") {
+    const valid =
+      recordIsObject
+      && Object.keys(record).length === 1
+      && typeof record.status === "string"
+      && (WASM_MEMORY_PROBE_STATUSES as readonly string[]).includes(record.status);
+    if (!valid) throw new ValidationError("invalid renderer milestone");
+    milestoneFields = {
+      status: record.status as (typeof WASM_MEMORY_PROBE_STATUSES)[number],
+    };
+  } else if (name === "wasm.growthRequested") {
+    const numericFields = [
+      "requestedBytes", "beforeBytes", "afterBytes", "stackDepth",
+      "frame0Function", "frame0Offset", "frame1Function", "frame1Offset",
+      "frame2Function", "frame2Offset", "frame3Function", "frame3Offset",
+      "generatedTextures", "deletedTextures", "liveTextures",
+      "trackedTextures", "knownTextureBytes", "textureUploadBytes",
+      "unknownTextureAllocations",
+    ] as const;
+    const valid =
+      recordIsObject
+      && Object.keys(record).length === numericFields.length + 3
+      && numericFields.every((field) => isByteCount(record[field]))
+      && (record.stackDepth as number) <= 4
+      && (record.trackedTextures as number) <= 4_096
+      && typeof record.outcome === "string"
+      && (WASM_GROWTH_OUTCOMES as readonly string[]).includes(record.outcome)
+      && isRendererFingerprint(record.stackFingerprint)
+      && typeof record.textureTrackingSaturated === "boolean";
+    if (!valid) throw new ValidationError("invalid renderer milestone");
+    milestoneFields = {
+      requestedBytes: record.requestedBytes as number,
+      beforeBytes: record.beforeBytes as number,
+      afterBytes: record.afterBytes as number,
+      outcome: record.outcome as (typeof WASM_GROWTH_OUTCOMES)[number],
+      stackFingerprint: record.stackFingerprint as string,
+      stackDepth: record.stackDepth as number,
+      frame0Function: record.frame0Function as number,
+      frame0Offset: record.frame0Offset as number,
+      frame1Function: record.frame1Function as number,
+      frame1Offset: record.frame1Offset as number,
+      frame2Function: record.frame2Function as number,
+      frame2Offset: record.frame2Offset as number,
+      frame3Function: record.frame3Function as number,
+      frame3Offset: record.frame3Offset as number,
+      generatedTextures: record.generatedTextures as number,
+      deletedTextures: record.deletedTextures as number,
+      liveTextures: record.liveTextures as number,
+      trackedTextures: record.trackedTextures as number,
+      knownTextureBytes: record.knownTextureBytes as number,
+      textureUploadBytes: record.textureUploadBytes as number,
+      unknownTextureAllocations: record.unknownTextureAllocations as number,
+      textureTrackingSaturated: record.textureTrackingSaturated as boolean,
     };
   } else if (name === "enhancement.installed") {
     const valid =

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -18,6 +18,9 @@ type GwClientImports = Parameters<
   typeof import('./client-exit.js').installClientExit
 >[0]['imports'] &
   Parameters<
+    typeof import('./wasm-memory-attribution.js').installWasmMemoryAttribution
+  >[0]['imports'] &
+  Parameters<
   typeof import('./gl-program-cache.js').installGlProgramCache
 >[0]['imports'] &
   Parameters<
@@ -665,6 +668,7 @@ let gamepadImportsAvailable = false;
 // TypeError, not a silently skipped installation.
 let host: typeof import('./graphics.js') &
   typeof import('./client-exit.js') &
+  typeof import('./wasm-memory-attribution.js') &
   typeof import('./gl-program-cache.js') &
   typeof import('./filesystem.js') &
   typeof import('./input.js') &
@@ -733,6 +737,15 @@ Module = {
 
   // Take over instantiation so the EGL imports can be patched first.
   instantiateWasm(imports, success) {
+    const memoryAttribution = host.installWasmMemoryAttribution({
+      imports,
+      module: Module,
+      recordGrowth: (fields) => milestone('wasm.growthRequested', fields),
+      log,
+    });
+    milestone('wasm.memoryProbe', {
+      status: memoryAttribution ? 'installed' : 'resizeImportMissing',
+    });
     host.installClientExit({
       imports,
       instance: () => gameWasmInstance,
@@ -1275,6 +1288,7 @@ function loadGlue() {
       { unavailablePlatformCapabilities },
       { createSocketHost },
       clientExit,
+      memoryAttribution,
       graphics,
       glProgramCache,
       filesystem,
@@ -1289,6 +1303,7 @@ function loadGlue() {
       import('./platform-capabilities.js'),
       import('./socket-host.js'),
       import('./client-exit.js'),
+      import('./wasm-memory-attribution.js'),
       import('./graphics.js'),
       import('./gl-program-cache.js'),
       import('./filesystem.js'),
@@ -1302,6 +1317,7 @@ function loadGlue() {
     ]);
     host = {
       ...clientExit,
+      ...memoryAttribution,
       ...graphics,
       ...glProgramCache,
       ...filesystem,

--- a/src/renderer/wasm-memory-attribution.ts
+++ b/src/renderer/wasm-memory-attribution.ts
@@ -1,0 +1,596 @@
+/**
+ * Observes the two client boundaries that can explain WASM heap exhaustion:
+ * heap-growth requests and WebGL texture lifetime. It owns bounded numeric
+ * evidence only; it neither changes an allocation decision nor retains pixel
+ * data, pointers, stack prose, or an unbounded per-texture history.
+ */
+
+import type { RendererMilestoneFieldsByName } from "../shared/diagnostics.js";
+
+type GrowthFields = RendererMilestoneFieldsByName["wasm.growthRequested"];
+
+type AttributionImports = {
+  env?: {
+    emscripten_resize_heap?: (requestedBytes: number) => unknown;
+    glBindTexture?: (target: number, texture: number) => unknown;
+    glGenTextures?: (count: number, textures: number) => unknown;
+    glDeleteTextures?: (count: number, textures: number) => unknown;
+    glTexStorage2D?: (
+      target: number,
+      levels: number,
+      internalFormat: number,
+      width: number,
+      height: number,
+    ) => unknown;
+    glTexImage2D?: (
+      target: number,
+      level: number,
+      internalFormat: number,
+      width: number,
+      height: number,
+      border: number,
+      format: number,
+      type: number,
+      pixels: number,
+    ) => unknown;
+    glTexSubImage2D?: (
+      target: number,
+      level: number,
+      x: number,
+      y: number,
+      width: number,
+      height: number,
+      format: number,
+      type: number,
+      pixels: number,
+    ) => unknown;
+    glCompressedTexSubImage2D?: (
+      target: number,
+      level: number,
+      x: number,
+      y: number,
+      width: number,
+      height: number,
+      format: number,
+      imageBytes: number,
+      data: number,
+    ) => unknown;
+  };
+};
+
+type ClientMemory = { HEAPU8?: Uint8Array };
+
+export interface WasmStackFrame {
+  readonly functionIndex: number;
+  readonly codeOffset: number;
+}
+
+interface TextureRecord {
+  levelBytes: Float64Array | null;
+  bytes: number;
+}
+
+const MAX_TRACKED_TEXTURES = 4_096;
+const MAX_TEXTURE_IDS_PER_CALL = 4_096;
+const MAX_STACK_FRAMES = 4;
+const MAX_TEXTURE_LEVEL_SLOTS = 6 * 32;
+const MAX_SAFE = Number.MAX_SAFE_INTEGER;
+
+const GL_TEXTURE_CUBE_MAP = 0x8513;
+const GL_TEXTURE_CUBE_MAP_POSITIVE_X = 0x8515;
+const GL_TEXTURE_CUBE_MAP_NEGATIVE_Z = 0x851a;
+
+function saturatingAdd(value: number, increment: number): number {
+  if (!Number.isFinite(increment) || increment <= 0) return value;
+  return Math.min(MAX_SAFE, value + increment);
+}
+
+function finiteDimension(value: number): number | null {
+  return Number.isSafeInteger(value) && value > 0 ? value : null;
+}
+
+function textureBindingTarget(target: number): number {
+  return target >= GL_TEXTURE_CUBE_MAP_POSITIVE_X
+    && target <= GL_TEXTURE_CUBE_MAP_NEGATIVE_Z
+    ? GL_TEXTURE_CUBE_MAP
+    : target;
+}
+
+function textureLevelSlot(target: number, level: number): number | null {
+  if (!Number.isSafeInteger(level) || level < 0 || level > 31) return null;
+  const face = target >= GL_TEXTURE_CUBE_MAP_POSITIVE_X
+    && target <= GL_TEXTURE_CUBE_MAP_NEGATIVE_Z
+    ? target - GL_TEXTURE_CUBE_MAP_POSITIVE_X
+    : 0;
+  return face * 32 + level;
+}
+
+function blockBytes(
+  width: number,
+  height: number,
+  blockWidth: number,
+  blockHeight: number,
+  bytes: number,
+): number {
+  return Math.ceil(width / blockWidth) * Math.ceil(height / blockHeight) * bytes;
+}
+
+/** Estimated storage for the sized formats the shipped client can hand WebGL. */
+export function textureLevelBytes(
+  internalFormat: number,
+  widthValue: number,
+  heightValue: number,
+): number | null {
+  const width = finiteDimension(widthValue);
+  const height = finiteDimension(heightValue);
+  if (width === null || height === null) return null;
+  const pixels = width * height;
+  const bytesPerPixel: Readonly<Record<number, number>> = {
+    0x8229: 1, // R8
+    0x8f94: 1, // R8_SNORM
+    0x822d: 2, // R16F
+    0x822e: 4, // R32F
+    0x822b: 2, // RG8
+    0x8f95: 2, // RG8_SNORM
+    0x822f: 4, // RG16F
+    0x8230: 8, // RG32F
+    0x8051: 3, // RGB8
+    0x8c41: 3, // SRGB8
+    0x8d62: 2, // RGB565
+    0x8c3a: 4, // R11F_G11F_B10F
+    0x8c3d: 4, // RGB9_E5
+    0x881b: 6, // RGB16F
+    0x8815: 12, // RGB32F
+    0x8058: 4, // RGBA8
+    0x8c43: 4, // SRGB8_ALPHA8
+    0x8056: 2, // RGBA4
+    0x8057: 2, // RGB5_A1
+    0x8059: 4, // RGB10_A2
+    0x881a: 8, // RGBA16F
+    0x8814: 16, // RGBA32F
+    0x81a5: 2, // DEPTH_COMPONENT16
+    0x81a6: 3, // DEPTH_COMPONENT24
+    0x8cac: 4, // DEPTH_COMPONENT32F
+    0x88f0: 4, // DEPTH24_STENCIL8
+    0x8cad: 8, // DEPTH32F_STENCIL8
+  };
+  const direct = bytesPerPixel[internalFormat];
+  if (direct !== undefined) return pixels * direct;
+
+  // S3TC/ETC families use fixed 4x4 blocks. These values are storage, not
+  // upload traffic, so mip levels below one block still occupy one block.
+  if ([0x83f0, 0x83f1, 0x8c4c, 0x8c4d, 0x9274, 0x9275].includes(internalFormat)) {
+    return blockBytes(width, height, 4, 4, 8);
+  }
+  if ([0x83f2, 0x83f3, 0x8c4e, 0x8c4f, 0x9278, 0x9279].includes(internalFormat)) {
+    return blockBytes(width, height, 4, 4, 16);
+  }
+  return null;
+}
+
+function uploadBytes(
+  format: number,
+  type: number,
+  widthValue: number,
+  heightValue: number,
+): number | null {
+  const width = finiteDimension(widthValue);
+  const height = finiteDimension(heightValue);
+  if (width === null || height === null) return null;
+  // Packed types already describe the complete pixel.
+  if ([0x8033, 0x8034, 0x8363].includes(type)) return width * height * 2;
+  if ([0x8368, 0x8c3b, 0x8c3e].includes(type)) return width * height * 4;
+  const components: Readonly<Record<number, number>> = {
+    0x1903: 1, // RED
+    0x8227: 2, // RG
+    0x1907: 3, // RGB
+    0x1908: 4, // RGBA
+    0x1902: 1, // DEPTH_COMPONENT
+    0x84f9: 1, // DEPTH_STENCIL (packed type supplies the byte width)
+  };
+  const scalarBytes: Readonly<Record<number, number>> = {
+    0x1401: 1, // UNSIGNED_BYTE
+    0x1400: 1, // BYTE
+    0x1403: 2, // UNSIGNED_SHORT
+    0x1402: 2, // SHORT
+    0x1405: 4, // UNSIGNED_INT
+    0x1404: 4, // INT
+    0x1406: 4, // FLOAT
+    0x140b: 2, // HALF_FLOAT
+  };
+  const componentCount = components[format];
+  const componentBytes = scalarBytes[type];
+  return componentCount === undefined || componentBytes === undefined
+    ? null
+    : width * height * componentCount * componentBytes;
+}
+
+/** Parses only numeric WASM frames; module hashes and JavaScript prose stay local. */
+export function parseWasmStack(stack: string): WasmStackFrame[] {
+  const frames: WasmStackFrame[] = [];
+  const pattern = /wasm-function\[(\d+)\]:0x([0-9a-f]+)/gi;
+  for (const match of stack.matchAll(pattern)) {
+    const functionIndex = Number(match[1]);
+    const codeOffset = Number.parseInt(match[2]!, 16);
+    if (Number.isSafeInteger(functionIndex) && Number.isSafeInteger(codeOffset)) {
+      frames.push({ functionIndex, codeOffset });
+      if (frames.length === MAX_STACK_FRAMES) break;
+    }
+  }
+  return frames;
+}
+
+function fingerprintFrames(frames: readonly WasmStackFrame[]): string {
+  const input = frames
+    .map(({ functionIndex, codeOffset }) => `${functionIndex}:${codeOffset}`)
+    .join(";");
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < input.length; index++) {
+    hash ^= input.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+export function installWasmMemoryAttribution({
+  imports,
+  module,
+  recordGrowth,
+  captureStack = () => new Error("WASM heap growth").stack ?? "",
+  log,
+}: {
+  imports: AttributionImports;
+  module: ClientMemory;
+  recordGrowth: (fields: GrowthFields) => void;
+  captureStack?: () => string;
+  log: (...values: unknown[]) => void;
+}) {
+  const env = imports.env;
+  const resizeHeap = env?.emscripten_resize_heap;
+  if (!env || typeof resizeHeap !== "function") {
+    log("[warn] memory attribution unavailable — heap resize import missing");
+    return null;
+  }
+
+  const textures = new Map<number, TextureRecord>();
+  const bindings = new Map<number, number>();
+  let generatedTextures = 0;
+  let deletedTextures = 0;
+  let knownTextureBytes = 0;
+  let textureUploadBytes = 0;
+  let unknownTextureAllocations = 0;
+  let textureTrackingSaturated = false;
+  let observationFailureReported = false;
+
+  const observe = (callback: () => void) => {
+    try {
+      callback();
+    } catch (error) {
+      if (observationFailureReported) return;
+      observationFailureReported = true;
+      try {
+        log("[warn] memory attribution observation failed", error);
+      } catch {
+        // Diagnostics must never alter the client's call path, including when
+        // its own logger is unavailable.
+      }
+    }
+  };
+
+  const readTextureIds = (pointer: number, countValue: number): number[] => {
+    const heap = module.HEAPU8;
+    if (
+      !heap
+      || !Number.isSafeInteger(pointer)
+      || pointer < 0
+      || !Number.isSafeInteger(countValue)
+      || countValue < 0
+      || countValue > MAX_TEXTURE_IDS_PER_CALL
+      || pointer + countValue * 4 > heap.buffer.byteLength
+    ) return [];
+    const view = new DataView(heap.buffer);
+    return Array.from(
+      { length: countValue },
+      (_unused, index) => view.getUint32(pointer + index * 4, true),
+    );
+  };
+
+  const ensureTexture = (texture: number): TextureRecord | null => {
+    const existing = textures.get(texture);
+    if (existing) return existing;
+    if (textures.size >= MAX_TRACKED_TEXTURES) {
+      textureTrackingSaturated = true;
+      return null;
+    }
+    const created = { levelBytes: null, bytes: 0 };
+    textures.set(texture, created);
+    return created;
+  };
+
+  const setLevelBytes = (
+    target: number,
+    level: number,
+    bytes: number | null,
+  ) => {
+    const texture = bindings.get(textureBindingTarget(target));
+    const slot = textureLevelSlot(target, level);
+    if (!texture || slot === null || bytes === null) {
+      unknownTextureAllocations = saturatingAdd(unknownTextureAllocations, 1);
+      return;
+    }
+    const record = ensureTexture(texture);
+    if (!record) {
+      unknownTextureAllocations = saturatingAdd(unknownTextureAllocations, 1);
+      return;
+    }
+    const levels = record.levelBytes ??= new Float64Array(MAX_TEXTURE_LEVEL_SLOTS);
+    const previous = levels[slot] ?? 0;
+    levels[slot] = bytes;
+    record.bytes += bytes - previous;
+    knownTextureBytes += bytes - previous;
+  };
+
+  const bindTexture = env.glBindTexture;
+  if (typeof bindTexture === "function") {
+    env.glBindTexture = function (this: unknown, target, texture) {
+      const result = bindTexture.call(this, target, texture);
+      observe(() => bindings.set(textureBindingTarget(target), texture));
+      return result;
+    };
+  }
+
+  const genTextures = env.glGenTextures;
+  if (typeof genTextures === "function") {
+    env.glGenTextures = function (this: unknown, count, pointer) {
+      const result = genTextures.call(this, count, pointer);
+      observe(() => {
+        generatedTextures = saturatingAdd(generatedTextures, count);
+        for (const texture of readTextureIds(pointer, count)) ensureTexture(texture);
+      });
+      return result;
+    };
+  }
+
+  const deleteTextures = env.glDeleteTextures;
+  if (typeof deleteTextures === "function") {
+    env.glDeleteTextures = function (this: unknown, count, pointer) {
+      const result = deleteTextures.call(this, count, pointer);
+      observe(() => {
+        const ids = readTextureIds(pointer, count);
+        deletedTextures = saturatingAdd(deletedTextures, count);
+        for (const texture of ids) {
+          const record = textures.get(texture);
+          if (record) knownTextureBytes -= record.bytes;
+          textures.delete(texture);
+          for (const [target, bound] of bindings) {
+            if (bound === texture) bindings.delete(target);
+          }
+        }
+      });
+      return result;
+    };
+  }
+
+  const texStorage2D = env.glTexStorage2D;
+  if (typeof texStorage2D === "function") {
+    env.glTexStorage2D = function (
+      this: unknown,
+      target,
+      levels,
+      internalFormat,
+      width,
+      height,
+    ) {
+      const result = texStorage2D.call(
+        this,
+        target,
+        levels,
+        internalFormat,
+        width,
+        height,
+      );
+      observe(() => {
+        const levelCount = Number.isSafeInteger(levels) && levels > 0
+          ? Math.min(levels, 32)
+          : 0;
+        const faces = target === GL_TEXTURE_CUBE_MAP ? 6 : 1;
+        for (let face = 0; face < faces; face++) {
+          const levelTarget = faces === 1
+            ? target
+            : GL_TEXTURE_CUBE_MAP_POSITIVE_X + face;
+          for (let level = 0; level < levelCount; level++) {
+            setLevelBytes(
+              levelTarget,
+              level,
+              textureLevelBytes(
+                internalFormat,
+                Math.max(1, width >> level),
+                Math.max(1, height >> level),
+              ),
+            );
+          }
+        }
+      });
+      return result;
+    };
+  }
+
+  const texImage2D = env.glTexImage2D;
+  if (typeof texImage2D === "function") {
+    env.glTexImage2D = function (
+      this: unknown,
+      target,
+      level,
+      internalFormat,
+      width,
+      height,
+      border,
+      format,
+      type,
+      pixels,
+    ) {
+      const result = texImage2D.call(
+        this,
+        target,
+        level,
+        internalFormat,
+        width,
+        height,
+        border,
+        format,
+        type,
+        pixels,
+      );
+      observe(() => {
+        const bytes = textureLevelBytes(internalFormat, width, height)
+          ?? uploadBytes(format, type, width, height);
+        setLevelBytes(target, level, bytes);
+        if (pixels !== 0 && bytes !== null) {
+          textureUploadBytes = saturatingAdd(textureUploadBytes, bytes);
+        }
+      });
+      return result;
+    };
+  }
+
+  const texSubImage2D = env.glTexSubImage2D;
+  if (typeof texSubImage2D === "function") {
+    env.glTexSubImage2D = function (
+      this: unknown,
+      target,
+      level,
+      x,
+      y,
+      width,
+      height,
+      format,
+      type,
+      pixels,
+    ) {
+      const result = texSubImage2D.call(
+        this,
+        target,
+        level,
+        x,
+        y,
+        width,
+        height,
+        format,
+        type,
+        pixels,
+      );
+      observe(() => {
+        const bytes = uploadBytes(format, type, width, height);
+        if (pixels !== 0 && bytes !== null) {
+          textureUploadBytes = saturatingAdd(textureUploadBytes, bytes);
+        }
+      });
+      return result;
+    };
+  }
+
+  const compressedTexSubImage2D = env.glCompressedTexSubImage2D;
+  if (typeof compressedTexSubImage2D === "function") {
+    env.glCompressedTexSubImage2D = function (
+      this: unknown,
+      target,
+      level,
+      x,
+      y,
+      width,
+      height,
+      format,
+      imageBytes,
+      data,
+    ) {
+      const result = compressedTexSubImage2D.call(
+        this,
+        target,
+        level,
+        x,
+        y,
+        width,
+        height,
+        format,
+        imageBytes,
+        data,
+      );
+      observe(() => {
+        textureUploadBytes = saturatingAdd(textureUploadBytes, imageBytes);
+      });
+      return result;
+    };
+  }
+
+  const textureSnapshot = () => ({
+    generatedTextures,
+    deletedTextures,
+    liveTextures: Math.max(0, generatedTextures - deletedTextures),
+    trackedTextures: textures.size,
+    knownTextureBytes: Math.max(0, knownTextureBytes),
+    textureUploadBytes,
+    unknownTextureAllocations,
+    textureTrackingSaturated,
+  });
+
+  const growthFields = (
+    requestedBytes: number,
+    beforeBytes: number,
+    afterBytes: number,
+    outcome: GrowthFields["outcome"],
+    frames: readonly WasmStackFrame[],
+  ): GrowthFields => ({
+    requestedBytes,
+    beforeBytes,
+    afterBytes,
+    outcome,
+    stackFingerprint: fingerprintFrames(frames),
+    stackDepth: frames.length,
+    frame0Function: frames[0]?.functionIndex ?? 0,
+    frame0Offset: frames[0]?.codeOffset ?? 0,
+    frame1Function: frames[1]?.functionIndex ?? 0,
+    frame1Offset: frames[1]?.codeOffset ?? 0,
+    frame2Function: frames[2]?.functionIndex ?? 0,
+    frame2Offset: frames[2]?.codeOffset ?? 0,
+    frame3Function: frames[3]?.functionIndex ?? 0,
+    frame3Offset: frames[3]?.codeOffset ?? 0,
+    ...textureSnapshot(),
+  });
+
+  env.emscripten_resize_heap = function (this: unknown, requestedValue) {
+    const requestedBytes = Number(requestedValue) >>> 0;
+    const beforeBytes = module.HEAPU8?.buffer.byteLength ?? 0;
+    let frames: WasmStackFrame[] = [];
+    observe(() => {
+      frames = parseWasmStack(captureStack());
+    });
+    try {
+      const result = resizeHeap.call(this, requestedValue);
+      const afterBytes = module.HEAPU8?.buffer.byteLength ?? beforeBytes;
+      const outcome = afterBytes > beforeBytes
+        ? "grown"
+        : result ? "unchanged" : "refused";
+      observe(() => recordGrowth(growthFields(
+          requestedBytes,
+          beforeBytes,
+          afterBytes,
+          outcome,
+          frames,
+        )));
+      return result;
+    } catch (error) {
+      observe(() => recordGrowth(growthFields(
+          requestedBytes,
+          beforeBytes,
+          module.HEAPU8?.buffer.byteLength ?? beforeBytes,
+          "threw",
+          frames,
+        )));
+      throw error;
+    }
+  };
+
+  return Object.freeze({
+    snapshot: () => Object.freeze(textureSnapshot()),
+  });
+}

--- a/src/shared/diagnostics.ts
+++ b/src/shared/diagnostics.ts
@@ -205,6 +205,8 @@ export const RENDERER_MILESTONES = [
   "snapshot.fatalRead",
   "wasm.abort",
   "wasm.exit",
+  "wasm.memoryProbe",
+  "wasm.growthRequested",
   // The renderer half of the Enhancement story: whether our code was actually
   // live in the game's call path. Main records that a transformed module was
   // *prepared*; only these say the hook was installed, refused, or withdrawn —
@@ -235,6 +237,21 @@ export const WASM_ABORT_REASON_KINDS = [
 ] as const;
 export type WasmAbortReasonKind = (typeof WASM_ABORT_REASON_KINDS)[number];
 
+export const WASM_GROWTH_OUTCOMES = [
+  "grown",
+  "unchanged",
+  "refused",
+  "threw",
+] as const;
+export type WasmGrowthOutcome = (typeof WASM_GROWTH_OUTCOMES)[number];
+
+export const WASM_MEMORY_PROBE_STATUSES = [
+  "installed",
+  "resizeImportMissing",
+] as const;
+export type WasmMemoryProbeStatus =
+  (typeof WASM_MEMORY_PROBE_STATUSES)[number];
+
 export interface RendererMilestoneFieldsByName {
   "build.info": { programId: string | number; buildId: string | number };
   /**
@@ -249,6 +266,37 @@ export interface RendererMilestoneFieldsByName {
   };
   /** A non-zero client exit: the other way the running game dies. */
   "wasm.exit": { code: number; heapBytes: number };
+  /** Whether this build can observe the official client's resize boundary. */
+  "wasm.memoryProbe": { status: WasmMemoryProbeStatus };
+  /**
+   * One call through the client's imported heap-growth boundary. Four bounded
+   * numeric WASM frames preserve attribution without exporting stack prose;
+   * texture fields are aggregate lifetime evidence at the same instant.
+   */
+  "wasm.growthRequested": {
+    requestedBytes: number;
+    beforeBytes: number;
+    afterBytes: number;
+    outcome: WasmGrowthOutcome;
+    stackFingerprint: string;
+    stackDepth: number;
+    frame0Function: number;
+    frame0Offset: number;
+    frame1Function: number;
+    frame1Offset: number;
+    frame2Function: number;
+    frame2Offset: number;
+    frame3Function: number;
+    frame3Offset: number;
+    generatedTextures: number;
+    deletedTextures: number;
+    liveTextures: number;
+    trackedTextures: number;
+    knownTextureBytes: number;
+    textureUploadBytes: number;
+    unknownTextureAllocations: number;
+    textureTrackingSaturated: boolean;
+  };
   /**
    * The hook went live. `capabilityProfile` is the closed profile vocabulary
    * from contracts — typed as string here because contracts imports this file;

--- a/src/tools/diagnostics/summarize.ts
+++ b/src/tools/diagnostics/summarize.ts
@@ -179,5 +179,45 @@ if (!input) {
     // wasm.abort is memory exhaustion, whatever the abort's reason kind says.
     console.log(`  wasm heap peak   ${((Number(summary.latest["renderer.peakWasmHeapBytes"]) || 0) / 1048576).toFixed(0)} MiB of ${(WASM_HEAP_CAP_BYTES / 1048576).toFixed(0)} MiB`);
     console.log(`  GPU RSS peak     ${((Number(summary.latest["process.gpu.peakRssBytes"]) || 0) / 1048576).toFixed(0)} MB`);
+    const memoryProbe = summary.latest["wasm.memoryProbe.status"];
+    if (memoryProbe) console.log(`  memory probe     ${String(memoryProbe)}`);
+    const mebibytes = (value: unknown) =>
+      `${(Number(value) / 1_048_576).toFixed(1)} MiB`;
+    const growthRequests = c["wasm.growthRequests"] ?? 0;
+    if (growthRequests) {
+      console.log("");
+      console.log("WASM memory attribution");
+      console.log(
+        `  growth requests ${growthRequests} `
+          + `(grown ${c["wasm.growthRequests.grown"] ?? 0}, `
+          + `unchanged ${c["wasm.growthRequests.unchanged"] ?? 0}, `
+          + `refused ${c["wasm.growthRequests.refused"] ?? 0}, `
+          + `threw ${c["wasm.growthRequests.threw"] ?? 0})`,
+      );
+      console.log(
+        `  last request    ${mebibytes(summary.latest["wasm.growth.requestedBytes"])} `
+          + `${String(summary.latest["wasm.growth.outcome"])}; heap `
+          + `${mebibytes(summary.latest["wasm.growth.beforeBytes"])} -> `
+          + mebibytes(summary.latest["wasm.growth.afterBytes"]),
+      );
+      console.log(
+        `  growth trigger  ${String(summary.latest["wasm.growth.stackFingerprint"])} `
+          + `fn ${Number(summary.latest["wasm.growth.frame0Function"])} `
+          + `@ 0x${Number(summary.latest["wasm.growth.frame0Offset"]).toString(16)}, `
+          + `fn ${Number(summary.latest["wasm.growth.frame1Function"])} `
+          + `@ 0x${Number(summary.latest["wasm.growth.frame1Offset"]).toString(16)}`,
+      );
+      console.log(
+        `  textures live  ${summary.latest["wasm.textures.live"]} `
+          + `(peak ${summary.latest["wasm.textures.peakLive"]}), estimated `
+          + `${mebibytes(summary.latest["wasm.textures.knownBytes"])} `
+          + `(peak ${mebibytes(summary.latest["wasm.textures.peakKnownBytes"])})`,
+      );
+      console.log(
+        `  uploads        ${mebibytes(summary.latest["wasm.textures.uploadBytes"])}; `
+          + `unknown allocations ${summary.latest["wasm.textures.unknownAllocations"]}; `
+          + `tracker ${summary.latest["wasm.textures.trackingSaturated"] ? "SATURATED" : "complete"}`,
+      );
+    }
   });
 }

--- a/tests/policy/markdown-links.test.ts
+++ b/tests/policy/markdown-links.test.ts
@@ -220,11 +220,15 @@ test("the file list covers tracked docs and excludes gitignored scratch", () => 
   assert.ok(files.includes("PRODUCT.md"));
   assert.ok(files.includes("docs/process-model.md"));
   assert.ok(files.includes("plans/research-tool-architecture.md"));
+  assert.ok(files.includes("plans/memory-bug.md"));
   assert.ok(
     files.every((file) =>
       (
         !file.startsWith("plans/")
-        || file === "plans/research-tool-architecture.md"
+        || [
+          "plans/research-tool-architecture.md",
+          "plans/memory-bug.md",
+        ].includes(file)
       )
       && !file.startsWith("node_modules/")),
     "gitignored paths must not be scanned",

--- a/tests/unit/wasm-abort-reason.test.ts
+++ b/tests/unit/wasm-abort-reason.test.ts
@@ -106,6 +106,22 @@ describe("the recorded abort event", () => {
 });
 
 describe("the recorded heap staircase", () => {
+  it("records whether heap-growth observation is active", () => {
+    assert.deepEqual(
+      diagnosticEventRecord({
+        k: "wasm.memoryProbe",
+        clockSynchronized: true,
+        status: "installed",
+      }),
+      {
+        subsystem: "wasm",
+        level: "info",
+        name: "wasm.memoryProbe",
+        fields: { clockSynchronized: true, status: "installed" },
+      },
+    );
+  });
+
   it("is an info-level renderer event carrying both sides of a growth step", () => {
     assert.deepEqual(
       diagnosticEventRecord({
@@ -118,6 +134,43 @@ describe("the recorded heap staircase", () => {
         level: "info",
         name: "wasm.heapGrew",
         fields: { fromBytes: 1_879_048_192, toBytes: 1_979_711_488 },
+      },
+    );
+  });
+
+  it("records the growth trigger as a separate closed event", () => {
+    const fields = {
+      clockSynchronized: true,
+      requestedBytes: 2_147_483_648,
+      beforeBytes: 2_013_265_920,
+      afterBytes: 2_013_265_920,
+      outcome: "refused" as const,
+      stackFingerprint: asRendererFingerprint("211ffc96"),
+      stackDepth: 2,
+      frame0Function: 17_792,
+      frame0Offset: 0x643e6f,
+      frame1Function: 17_784,
+      frame1Offset: 0x641dc5,
+      frame2Function: 0,
+      frame2Offset: 0,
+      frame3Function: 0,
+      frame3Offset: 0,
+      generatedTextures: 9_000,
+      deletedTextures: 8_750,
+      liveTextures: 250,
+      trackedTextures: 250,
+      knownTextureBytes: 268_435_456,
+      textureUploadBytes: 4_294_967_296,
+      unknownTextureAllocations: 0,
+      textureTrackingSaturated: false,
+    };
+    assert.deepEqual(
+      diagnosticEventRecord({ k: "wasm.growthRequested", ...fields }),
+      {
+        subsystem: "wasm",
+        level: "info",
+        name: "wasm.growthRequested",
+        fields,
       },
     );
   });

--- a/tests/unit/wasm-memory-attribution.test.ts
+++ b/tests/unit/wasm-memory-attribution.test.ts
@@ -1,0 +1,250 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  installWasmMemoryAttribution,
+  parseWasmStack,
+  textureLevelBytes,
+} from "../../src/renderer/wasm-memory-attribution.ts";
+
+const GL_TEXTURE_2D = 0x0de1;
+const GL_RGBA = 0x1908;
+const GL_RGBA8 = 0x8058;
+const GL_UNSIGNED_BYTE = 0x1401;
+
+describe("WASM growth provenance", () => {
+  it("keeps only the first four numeric WASM frames", () => {
+    assert.deepEqual(
+      parseWasmStack([
+        "Error: growth",
+        "    at wrapper (memory-investigation.js:10:2)",
+        "    at wasm-function[17792]:0x643e6f",
+        "    at wasm-function[17784]:0x641dc5",
+        "    at wasm-function[7]:0xaa",
+        "    at wasm-function[8]:0xbb",
+        "    at wasm-function[9]:0xcc",
+      ].join("\n")),
+      [
+        { functionIndex: 17_792, codeOffset: 0x643e6f },
+        { functionIndex: 17_784, codeOffset: 0x641dc5 },
+        { functionIndex: 7, codeOffset: 0xaa },
+        { functionIndex: 8, codeOffset: 0xbb },
+      ],
+    );
+  });
+
+  it("records the request, result, call stack, and current texture state", () => {
+    const module = { HEAPU8: new Uint8Array(128) };
+    new DataView(module.HEAPU8.buffer).setUint32(0, 7, true);
+    const observations: Array<Record<string, unknown>> = [];
+    const noop = (...values: number[]) => { void values; };
+    const imports = {
+      env: {
+        emscripten_resize_heap(requestedBytes: number) {
+          module.HEAPU8 = new Uint8Array(requestedBytes);
+          return true;
+        },
+        glGenTextures: noop,
+        glDeleteTextures: noop,
+        glBindTexture: noop,
+        glTexStorage2D: noop,
+        glTexSubImage2D: noop,
+      },
+    };
+    const investigation = installWasmMemoryAttribution({
+      imports,
+      module,
+      recordGrowth: (fields) => observations.push(fields),
+      captureStack: () => [
+        "Error: growth",
+        "    at wasm-function[17792]:0x643e6f",
+        "    at wasm-function[17784]:0x641dc5",
+      ].join("\n"),
+      log: () => {},
+    });
+
+    imports.env.glGenTextures(1, 0);
+    imports.env.glBindTexture(GL_TEXTURE_2D, 7);
+    imports.env.glTexStorage2D(GL_TEXTURE_2D, 2, GL_RGBA8, 4, 4);
+    imports.env.glTexSubImage2D(
+      GL_TEXTURE_2D,
+      0,
+      0,
+      0,
+      2,
+      2,
+      GL_RGBA,
+      GL_UNSIGNED_BYTE,
+      16,
+    );
+    assert.equal(imports.env.emscripten_resize_heap(256), true);
+
+    assert.equal(observations.length, 1);
+    assert.deepEqual(observations[0], {
+      requestedBytes: 256,
+      beforeBytes: 128,
+      afterBytes: 256,
+      outcome: "grown",
+      stackFingerprint: "211ffc96",
+      stackDepth: 2,
+      frame0Function: 17_792,
+      frame0Offset: 0x643e6f,
+      frame1Function: 17_784,
+      frame1Offset: 0x641dc5,
+      frame2Function: 0,
+      frame2Offset: 0,
+      frame3Function: 0,
+      frame3Offset: 0,
+      generatedTextures: 1,
+      deletedTextures: 0,
+      liveTextures: 1,
+      trackedTextures: 1,
+      knownTextureBytes: 80,
+      textureUploadBytes: 16,
+      unknownTextureAllocations: 0,
+      textureTrackingSaturated: false,
+    });
+    assert.deepEqual(investigation?.snapshot(), {
+      generatedTextures: 1,
+      deletedTextures: 0,
+      liveTextures: 1,
+      trackedTextures: 1,
+      knownTextureBytes: 80,
+      textureUploadBytes: 16,
+      unknownTextureAllocations: 0,
+      textureTrackingSaturated: false,
+    });
+  });
+
+  it("distinguishes a refused resize from one that throws", () => {
+    const refused: Array<Record<string, unknown>> = [];
+    const refusedImports = {
+      env: {
+        emscripten_resize_heap(requestedBytes: number) {
+          void requestedBytes;
+          return false;
+        },
+      },
+    };
+    installWasmMemoryAttribution({
+      imports: refusedImports,
+      module: { HEAPU8: new Uint8Array(64) },
+      recordGrowth: (fields) => refused.push(fields),
+      captureStack: () => "",
+      log: () => {},
+    });
+    assert.equal(refusedImports.env.emscripten_resize_heap(128), false);
+    assert.equal(refused[0]?.outcome, "refused");
+    assert.equal(refused[0]?.beforeBytes, 64);
+    assert.equal(refused[0]?.afterBytes, 64);
+
+    const thrown: Array<Record<string, unknown>> = [];
+    const failure = new Error("resize failed");
+    const thrownImports = {
+      env: {
+        emscripten_resize_heap(requestedBytes: number): never {
+          void requestedBytes;
+          throw failure;
+        },
+      },
+    };
+    installWasmMemoryAttribution({
+      imports: thrownImports,
+      module: { HEAPU8: new Uint8Array(64) },
+      recordGrowth: (fields) => thrown.push(fields),
+      captureStack: () => "",
+      log: () => {},
+    });
+    assert.throws(
+      () => thrownImports.env.emscripten_resize_heap(128),
+      (error) => error === failure,
+    );
+    assert.equal(thrown[0]?.outcome, "threw");
+  });
+
+  it("preserves the allocator contract when observation itself fails", () => {
+    const receiver = { marker: "original receiver" };
+    const seen: unknown[][] = [];
+    const warnings: unknown[][] = [];
+    const imports = {
+      env: {
+        emscripten_resize_heap(this: unknown, requestedBytes: number) {
+          seen.push([this, requestedBytes]);
+          return "original result";
+        },
+      },
+    };
+    installWasmMemoryAttribution({
+      imports,
+      module: { HEAPU8: new Uint8Array(64) },
+      recordGrowth: () => {
+        throw new Error("recorder unavailable");
+      },
+      captureStack: () => {
+        throw new Error("stack unavailable");
+      },
+      log: (...values) => warnings.push(values),
+    });
+
+    assert.equal(
+      imports.env.emscripten_resize_heap.call(receiver, 123),
+      "original result",
+    );
+    assert.deepEqual(seen, [[receiver, 123]]);
+    assert.equal(warnings.length, 1);
+  });
+
+  it("does not alter imports when the shipped client lacks the resize boundary", () => {
+    const warnings: unknown[][] = [];
+    const imports = { env: {} };
+    assert.equal(installWasmMemoryAttribution({
+      imports,
+      module: { HEAPU8: new Uint8Array(0) },
+      recordGrowth: () => assert.fail("growth must not be recorded"),
+      log: (...values) => warnings.push(values),
+    }), null);
+    assert.equal("emscripten_resize_heap" in imports.env, false);
+    assert.equal(warnings.length, 1);
+  });
+
+  it("stops retaining texture identities at the documented bound", () => {
+    const module = { HEAPU8: new Uint8Array(4_096 * 4) };
+    let nextTexture = 1;
+    const imports = {
+      env: {
+        emscripten_resize_heap(requestedBytes: number) {
+          void requestedBytes;
+          return false;
+        },
+        glGenTextures(count: number, pointer: number) {
+          const view = new DataView(module.HEAPU8.buffer);
+          for (let index = 0; index < count; index++) {
+            view.setUint32(pointer + index * 4, nextTexture++, true);
+          }
+        },
+      },
+    };
+    const investigation = installWasmMemoryAttribution({
+      imports,
+      module,
+      recordGrowth: () => {},
+      captureStack: () => "",
+      log: () => {},
+    });
+
+    imports.env.glGenTextures(4_096, 0);
+    imports.env.glGenTextures(1, 0);
+
+    assert.equal(investigation?.snapshot().generatedTextures, 4_097);
+    assert.equal(investigation?.snapshot().trackedTextures, 4_096);
+    assert.equal(investigation?.snapshot().textureTrackingSaturated, true);
+  });
+});
+
+describe("texture storage estimates", () => {
+  it("covers direct and block-compressed formats without guessing unknown ones", () => {
+    assert.equal(textureLevelBytes(GL_RGBA8, 8, 4), 128);
+    assert.equal(textureLevelBytes(0x83f0, 3, 3), 8);
+    assert.equal(textureLevelBytes(0x83f3, 5, 5), 64);
+    assert.equal(textureLevelBytes(0xdead, 8, 8), null);
+  });
+});


### PR DESCRIPTION
## Summary

- observe the official client's imported `emscripten_resize_heap` boundary without changing allocation decisions
- record bounded numeric WASM frames and bounded texture-lifetime aggregates in the closed diagnostic schema
- make the observer fail open so stack capture, logging, or diagnostic recording cannot change the client call path
- document what the evidence proves, what remains unknown, ArenaNet's short heap-profile route, and the interim mitigation choices

## Safety boundaries

- no allocator interception, pointer table, cache purge, raw `free`, direct destructor, or WebGL deletion
- no pointer, texture content, stack prose, or unbounded per-object history crosses IPC
- unknown or missing resize imports leave the client import untouched and record an explicit unavailable status
- summaries call the captured stack the growth trigger, never the owner of the whole growth step

## Verification

- `pnpm check` (787 unit tests and 158 policy tests)
- `pnpm build`
- `pnpm test:website` (typecheck, full prerender, smoke tests)
- `git diff --check`

## Merge order

1. #112 — dependency/CI prerequisite
2. #113 — production heap warning and safe reload
3. this PR

The branch contains the exact commits from #112 and #113 so it is testable now; the diff against `main` will shrink as those land.
