### PR TITLE
Add an opt-in 4 GiB research profile

### DIFF
--- a/apps/website/content/en/1.docs/3.upstream/5.runtime/1.heap-maximum.md
+++ b/apps/website/content/en/1.docs/3.upstream/5.runtime/1.heap-maximum.md
@@ -193,9 +193,11 @@ Qualification completed so far:
 
 This proves the core approach across the former boundary. It does not prove
 every rare WebGL or host callback path, and it does not bound the underlying
-memory demand. The current profile remains a developer experiment while we
-certify every supported Enhancement variant, package it, test system-memory
-pressure, and expose an explicit user setting.
+memory demand. The current profile remains a developer experiment. All five
+variants the production chain can emit—including Enhancements disabled—are
+hash-pinned. It still needs packaged high-address gameplay coverage,
+system-memory testing, and an explicit user setting before an experimental
+player release.
 
 If released before an ArenaNet update, it will be labelled **Experimental 4 GB
 memory mode**, disabled by default, restricted to exact certified builds, easy

--- a/apps/website/content/en/1.docs/3.upstream/7.reference/1.our-workarounds.md
+++ b/apps/website/content/en/1.docs/3.upstream/7.reference/1.our-workarounds.md
@@ -137,10 +137,10 @@ maximum would hand negative pointer values to JavaScript and is refused.
 
 The exact pair has passed ArenaNet-allocator qualification above 3 GiB and a
 live Electron string-glue test at 2,625 MiB. It remains a research profile, not
-a default player setting. Before an experimental release it still needs every
-supported Enhancement variant certified, packaged high-address gameplay
-coverage, system-memory testing, explicit opt-in copy, and diagnostics that
-record the effective mode.
+a default player setting. All five variants the production chain can emit are
+hash-pinned. Before an experimental release it still needs packaged
+high-address gameplay coverage, system-memory testing, and explicit opt-in
+copy. Diagnostics record the effective mode and cap.
 
 **Cost per client build.** Both official artifact hashes, every accepted
 predecessor hash, both derived hashes, and the generated-glue pointer audit.

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -265,6 +265,14 @@ artifact before assigning a source symbol. A capture can conclusively show a
 client request being refused at its compiled limit; assigning ownership still
 requires controlled runs of the same client build.
 
+The opt-in 4 GiB research profile records `wasm.extendedMemory` with its
+closed mode, exact post-double-click profile, and effective cap. The summary's
+heap denominator comes from the same runtime cap gauge. `unsupported` means an
+explicit research request did not match the pinned JS/WASM pair and the
+ordinary 2 GiB artifacts were served; `disabled` means the research profile
+was not requested. A preparation fault is additionally recorded as
+`wasm.extendedMemoryPrepareFailed` without exposing its free-text exception.
+
 ## Verification boundaries
 
 ### Claims and the tests that prove them

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "postinstall": "install-electron",
     "build": "node scripts/build.mjs",
     "dev": "pnpm build && electron-forge start",
+    "dev:memory:4gb": "GWONMAC_EXTENDED_MEMORY_RESEARCH=1 pnpm dev",
     "dev:signed": "node --import ./scripts/ts-hook.mjs --experimental-strip-types scripts/run-signed-dev.ts",
     "test:signed-dev": "node --import ./scripts/ts-hook.mjs --experimental-strip-types scripts/run-signed-dev.ts --test-keychain",
     "typecheck": "tsc --noEmit && tsc -p tsconfig.renderer.json --noEmit && tsc -p tsconfig.tests.json",
@@ -51,6 +52,7 @@
     "diagnostics:compare": "tsc && node build/tools/diagnostics/compare.js",
     "diagnostics:attribute-stalls": "tsc && node build/tools/diagnostics/attribute-stalls.js",
     "diagnostics:attribute-frames": "tsc && node build/tools/diagnostics/attribute-frames.js",
+    "memory:qualify:4gb": "GWONMAC_EXTENDED_MEMORY_RESEARCH=1 node --import ./scripts/ts-hook.mjs --experimental-strip-types scripts/qualify-extended-memory.ts",
     "verify": "pnpm check && pnpm build && node scripts/verify-companion-kernel.mjs && pnpm test:integration && pnpm test:release && pnpm test:electron && pnpm package && pnpm test:packaged"
   },
   "devDependencies": {

--- a/plans/memory-bug.md
+++ b/plans/memory-bug.md
@@ -363,21 +363,19 @@ official WASM
   -> template compatibility
   -> optional Enhancement
   -> native double-click
-  -> targeted lifecycle telemetry
   -> paired 4 GB JS/WASM transform
 ```
 
 The final stage runs only with:
 
 ```text
-GWONMAC_MEMORY_ATTRIBUTION_RESEARCH=1
 GWONMAC_EXTENDED_MEMORY_RESEARCH=1
 ```
 
 Launch command:
 
 ```bash
-cd /path/to/gwonmac-memory-investigation
+cd /path/to/gwonmac-memory-4gb
 pnpm dev:memory:4gb
 ```
 
@@ -403,14 +401,22 @@ The exact generated-glue transform:
 The transform is exact-input hash-gated. It is not a general JavaScript
 rewriter.
 
-### Current certified research pair
+### Current certified research pairs
 
 | Artifact | SHA-256 |
 | --- | --- |
 | Official JS input | `58ecc6377397f01919d8def58e802e19fbfd6ce13f421dbf14123a667e34f7d0` |
 | Transformed JS output | `1dd5d798b1491f46a7c128c641053c8488211bbc193fe40bdf1d7a886517993d` |
-| ABI-11 WASM input, widest Enhancement profile | `3f7ec5ab3a957103bd3ac3068e6e2cb6d5203b4ccb0afc08dfd4329ff150a9c6` |
-| 4 GB WASM output | `20f36cf63dd0082fc3e888d66d63cfafd73b99aa4e5e937dc446f2aea52f0ec5` |
+| WASM input, Enhancements off | `e7d86cfcf7b09abbedd3afca758dbf4a3f3c6e1aa4d44e53b31e45e886d7f250` |
+| 4 GB output, Enhancements off | `862f97fc87267e3b4d342ea01f15834cc60a7be982fd9741cf0ae31b8a18a00b` |
+| WASM input, cursor | `2c03fb7ac535508d99bc96212d2e087d4322ef7d11cf3e0049f4019035326d50` |
+| 4 GB output, cursor | `c65ba2c246e45a1c013f32e51451537775bb2ae6d5a5ae3a9f3240b2594efb91` |
+| WASM input, target | `e69c026e942496b2fbd6bef056fb1eeb0b6ff5e51fed02846fb37a27c53a49f7` |
+| 4 GB output, target | `da872c47a3846427a5c00685d99064a02b7ce809aca6ea2073c92d84f891d8cc` |
+| WASM input, cursor + target | `ee642435a41221dd8d2db1dd326d650c1a86e00cd823743d867505a4246bfdc9` |
+| 4 GB output, cursor + target | `d5f4b161124cc1829c7a1f23859da2a1f9290c668c8fad1d9d316428034c1190` |
+| WASM input, cursor + Toolbox | `35d258f8373ccf3eb0321a48b98c0ace61a304683d3295b1712a5a71102d1da6` |
+| 4 GB output, cursor + Toolbox | `a0bd482dda0476f36feed1104033041057e10062775424088c4961a142fac8e1` |
 
 WASM maximum: 65,535 pages = 4 GiB minus 64 KiB.
 
@@ -442,7 +448,7 @@ callback path under all gameplay conditions.
 ```bash
 pnpm memory:qualify:4gb \
   "/path/to/Gw.jspi.js" \
-  "/path/to/certified/ABI11/Gw.jspi.wasm"
+  "/path/to/official/Gw.jspi.wasm"
 ```
 
 ### Proposed experimental product shape
@@ -466,21 +472,18 @@ If released before ArenaNet ships a correction:
 The current implementation is a research profile, not yet a user-facing
 setting. Before release:
 
-1. Certify every supported post-double-click/Enhancement variant intended for
-   the option, including Enhancements disabled. The current 4 GB output is
-   pinned only for the widest ABI-11 research predecessor.
-2. Add the explicit persisted opt-in and clear explanatory copy.
-3. Record the effective mode and cap in the closed diagnostics schema.
-4. Test one content-heavy zone transition while allocations above 2 GiB remain
+1. Add an explicit persisted user opt-in and clear explanatory copy if the
+   developer-only environment switch is promoted into a packaged feature.
+2. Test one content-heavy zone transition while allocations above 2 GiB remain
    live, covering image upload, WebGL, sockets, filesystem, and UI strings.
-5. Test representative 8 GB, 16 GB, and 32 GB Macs. The option should be
+3. Test representative 8 GB, 16 GB, and 32 GB Macs. The option should be
    discouraged or refused where system pressure makes it counterproductive.
-6. Verify warning thresholds and the reload path against the effective 4 GB
+4. Verify warning thresholds and the reload path against the effective 4 GB
    cap.
-7. Verify transform refusal and cache deletion after a one-byte JS or WASM
+5. Verify transform refusal and cache deletion after a one-byte JS or WASM
    change.
-8. Package and smoke-test, rather than relying only on the development host.
-9. Keep the offline >2 GiB qualification in the release checklist.
+6. Package and smoke-test, rather than relying only on the development host.
+7. Keep the offline >2 GiB qualification in the release checklist.
 
 Default activation should require substantially more live coverage and a clear
 understanding of system-memory behavior. ArenaNet's source-level fix remains

--- a/scripts/qualify-extended-memory.ts
+++ b/scripts/qualify-extended-memory.ts
@@ -1,0 +1,231 @@
+/** Offline proof that build 38797's complete production chain crosses 2 GiB. */
+import { createHash } from "node:crypto";
+import {
+  mkdtemp,
+  mkdir,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  EXTENDED_MEMORY_JS_BUILD,
+  EXTENDED_MEMORY_MAX_BYTES,
+  EXTENDED_MEMORY_WASM_BUILDS,
+  prepareExtendedMemoryArtifacts,
+  rewriteExtendedMemoryJs,
+  rewriteExtendedMemoryWasm,
+} from "../src/main/certification/extended-memory.js";
+import {
+  findTemplateSaveBuild,
+  rewriteTemplateSaveWasm,
+} from "../src/main/certification/template-save-compat.js";
+import { findEnhancementBuild } from "../src/main/certification/enhancement-builds.js";
+import { transformEnhancementWasm } from "../src/main/certification/enhancement-transform.js";
+import { rewriteNativeDoubleClickWasm } from "../src/main/certification/native-double-click.js";
+import { ENHANCEMENT_CAPABILITY_PROFILES } from "../src/shared/contracts.js";
+import { certifyClientBuild } from "../src/main/certification/client-certification.js";
+import { prepareClientModule } from "../src/main/certification/client-module.js";
+
+const [jsPath, wasmPath] = process.argv.slice(2);
+if (!jsPath || !wasmPath) {
+  throw new Error(
+    "usage: qualify-extended-memory.ts <official Gw.jspi.js> <official Gw.jspi.wasm>",
+  );
+}
+
+const sha256 = (bytes: Uint8Array | string): string =>
+  createHash("sha256").update(bytes).digest("hex");
+const [officialJs, officialWasm] = await Promise.all([
+  readFile(jsPath, "utf8"),
+  readFile(wasmPath),
+]);
+const transformedJs = rewriteExtendedMemoryJs(officialJs);
+if (sha256(transformedJs) !== EXTENDED_MEMORY_JS_BUILD.outputSha256) {
+  throw new Error("transformed JavaScript does not match its certified hash");
+}
+new Function(transformedJs);
+
+const templateBuild = findTemplateSaveBuild(sha256(officialWasm));
+if (!templateBuild) throw new Error("official WASM is not template-save certified");
+const templateWasm = rewriteTemplateSaveWasm(officialWasm, templateBuild);
+const enhancementBuild = findEnhancementBuild(sha256(templateWasm));
+if (!enhancementBuild) throw new Error("template output is not Enhancement certified");
+
+const predecessors = new Map<string, Uint8Array>();
+predecessors.set("off", rewriteNativeDoubleClickWasm(templateWasm));
+for (const [profile, capabilities] of Object.entries(
+  ENHANCEMENT_CAPABILITY_PROFILES,
+)) {
+  predecessors.set(
+    profile,
+    rewriteNativeDoubleClickWasm(
+      transformEnhancementWasm(templateWasm, enhancementBuild, capabilities),
+    ),
+  );
+}
+
+const scratch = await mkdtemp(join(tmpdir(), "gwonmac-4gb-qualification-"));
+try {
+  const predecessorPath = join(scratch, "Gw.jspi.wasm");
+  const cacheRoot = join(scratch, "cache");
+  const predecessor = predecessors.get("off");
+  if (!predecessor) throw new Error("Enhancements-off predecessor is missing");
+  await writeFile(predecessorPath, predecessor);
+  const first = await prepareExtendedMemoryArtifacts(
+    jsPath,
+    predecessorPath,
+    cacheRoot,
+  );
+  const cached = await prepareExtendedMemoryArtifacts(
+    jsPath,
+    predecessorPath,
+    cacheRoot,
+  );
+  if (
+    first?.profile !== "off"
+    || cached?.jsPath !== first.jsPath
+    || cached?.wasmPath !== first.wasmPath
+  ) throw new Error("paired artifact cache did not reproduce its exact output");
+
+  const changed = Uint8Array.from(predecessor);
+  changed[changed.byteLength - 1] = changed[changed.byteLength - 1]! ^ 1;
+  await writeFile(predecessorPath, changed);
+  if (
+    await prepareExtendedMemoryArtifacts(jsPath, predecessorPath, cacheRoot)
+    !== null
+  ) throw new Error("changed WASM pair was not refused");
+  if (await stat(cacheRoot).then(() => true, () => false)) {
+    throw new Error("refused pair left a stale derived cache");
+  }
+} finally {
+  await rm(scratch, { recursive: true, force: true });
+}
+
+const variants = [];
+let allocatorModule: Uint8Array | null = null;
+for (const build of EXTENDED_MEMORY_WASM_BUILDS) {
+  const predecessor = predecessors.get(build.profile);
+  if (!predecessor || sha256(predecessor) !== build.inputSha256) {
+    throw new Error(`${build.profile} predecessor does not match certification`);
+  }
+  const output = rewriteExtendedMemoryWasm(predecessor);
+  if (
+    sha256(output) !== build.outputSha256
+    || !WebAssembly.validate(Uint8Array.from(output))
+  ) {
+    throw new Error(`${build.profile} output does not match certification`);
+  }
+  if (build.profile === "cursorToolbox") allocatorModule = output;
+  variants.push({
+    profile: build.profile,
+    inputSha256: build.inputSha256,
+    outputSha256: build.outputSha256,
+  });
+}
+if (!allocatorModule) throw new Error("allocator qualification variant is missing");
+
+const selectionScratch = await mkdtemp(join(tmpdir(), "gwonmac-4gb-selection-"));
+try {
+  const officialJsPath = join(selectionScratch, "official", "Gw.jspi.js");
+  const officialWasmPath = join(selectionScratch, "official", "Gw.jspi.wasm");
+  await mkdir(join(selectionScratch, "official"), { recursive: true });
+  await Promise.all([
+    writeFile(officialJsPath, officialJs),
+    writeFile(officialWasmPath, officialWasm),
+  ]);
+  const officialSha256 = sha256(officialWasm);
+  const selected = await prepareClientModule({
+    officialJsPath,
+    officialWasmPath,
+    officialSha256,
+    certification: certifyClientBuild(officialSha256),
+    enhancementCapabilities: {
+      nativeCursor: false,
+      targetObservation: false,
+      toolbox: false,
+    },
+    compatibilityCacheRoot: join(selectionScratch, "compatibility"),
+    enhancementCacheRoot: join(selectionScratch, "enhancements"),
+    nativeDoubleClickCacheRoot: join(selectionScratch, "double-click"),
+    extendedMemoryCacheRoot: join(selectionScratch, "extended-memory"),
+  });
+  if (
+    selected.extendedMemory.status !== "active"
+    || selected.extendedMemory.profile !== "off"
+    || sha256(await readFile(selected.jsPath)) !== EXTENDED_MEMORY_JS_BUILD.outputSha256
+    || sha256(await readFile(selected.wasmPath))
+      !== EXTENDED_MEMORY_WASM_BUILDS[0]!.outputSha256
+  ) throw new Error("production client selection did not publish the certified pair");
+} finally {
+  await rm(selectionScratch, { recursive: true, force: true });
+}
+
+const module = new WebAssembly.Module(Uint8Array.from(allocatorModule));
+const state: { memory?: WebAssembly.Memory } = {};
+const imports: WebAssembly.Imports = {};
+for (const entry of WebAssembly.Module.imports(module)) {
+  const namespace = (imports[entry.module] ??= {}) as Record<string, unknown>;
+  if (entry.kind !== "function") {
+    throw new Error(`unsupported ${entry.kind} import ${entry.module}.${entry.name}`);
+  }
+  namespace[entry.name] = entry.name === "emscripten_resize_heap"
+    ? (requested: number) => {
+        const memory = state.memory;
+        if (!memory) throw new Error("heap growth requested during instantiation");
+        const target = requested >>> 0;
+        if (target > EXTENDED_MEMORY_MAX_BYTES) return 0;
+        const current = memory.buffer.byteLength;
+        if (target <= current) return 1;
+        memory.grow(Math.ceil((target - current) / 65_536));
+        return 1;
+      }
+    : () => 0;
+}
+const instance = await WebAssembly.instantiate(module, imports);
+const exports = instance.exports as {
+  memory: WebAssembly.Memory;
+  malloc(bytes: number): number;
+  free(pointer: number): void;
+};
+const memory = exports.memory;
+state.memory = memory;
+
+const allocationBytes = 480 * 1_024 * 1_024;
+const pointers: number[] = [];
+let highPointer: number | undefined;
+for (let index = 0; index < 6; index += 1) {
+  const raw = exports.malloc(allocationBytes);
+  if (raw === 0) throw new Error(`allocation ${index + 1} failed`);
+  pointers.push(raw);
+  if ((raw >>> 0) >= 0x8000_0000) highPointer ??= raw;
+}
+if (highPointer === undefined || memory.buffer.byteLength <= 0x8000_0000) {
+  throw new Error("allocator did not cross 2 GiB");
+}
+
+const highAddress = highPointer >>> 0;
+const view = new DataView(memory.buffer);
+view.setUint32(highAddress, 0x4757_3447, true);
+if (view.getUint32(highAddress, true) !== 0x4757_3447) {
+  throw new Error("high-address read/write failed");
+}
+const capacityBeforeFree = memory.buffer.byteLength;
+for (const pointer of pointers) exports.free(pointer);
+const reused = exports.malloc(allocationBytes);
+if (reused === 0 || memory.buffer.byteLength !== capacityBeforeFree) {
+  throw new Error("freed allocation was not reused without heap growth");
+}
+exports.free(reused);
+
+console.log(JSON.stringify({
+  jsInputSha256: EXTENDED_MEMORY_JS_BUILD.inputSha256,
+  jsOutputSha256: EXTENDED_MEMORY_JS_BUILD.outputSha256,
+  variants,
+  heapBytes: capacityBeforeFree,
+  highPointerUnsigned: highAddress,
+  crossed2GiB: true,
+  freedBlockReusedWithoutGrowth: true,
+}, null, 2));

--- a/src/main/active-client.ts
+++ b/src/main/active-client.ts
@@ -19,6 +19,7 @@ export interface ActiveClient {
   readonly store: ChunkStore;
   readonly snapshotMeta: SnapshotMetadata;
   readonly wasmPath: string;
+  readonly jsPath: string;
   readonly enhancementBuild: KnownEnhancementBuild | null;
 }
 

--- a/src/main/certification/client-module.ts
+++ b/src/main/certification/client-module.ts
@@ -41,6 +41,11 @@ import {
   NATIVE_DOUBLE_CLICK_TRANSFORM_ABI,
   rewriteNativeDoubleClickWasm,
 } from "./native-double-click.js";
+import {
+  EXTENDED_MEMORY_RESEARCH_ENABLED,
+  prepareExtendedMemoryArtifacts,
+  type ExtendedMemoryProfile,
+} from "./extended-memory.js";
 
 /**
  * The exact records matched while certifying the official client hash. The
@@ -60,11 +65,15 @@ export type ClientCertification =
     };
 
 export interface ClientModulePreparationFailure {
-  readonly stage: "template-save" | "enhancement" | "native-double-click";
+  readonly stage:
+    | "template-save"
+    | "enhancement"
+    | "native-double-click"
+    | "extended-memory";
   readonly error: unknown;
 }
 
-export interface PreparedClientModule {
+interface PreparedWasmClientModule {
   readonly wasmPath: string;
   readonly state: ClientCompatibilityState;
   readonly enhancementBuild: KnownEnhancementBuild | null;
@@ -77,14 +86,28 @@ export interface PreparedClientModule {
   readonly nativeDoubleClick: boolean;
 }
 
+export type ExtendedMemoryMode =
+  | { readonly status: "disabled" | "unsupported" }
+  | {
+      readonly status: "active";
+      readonly profile: ExtendedMemoryProfile;
+    };
+
+export interface PreparedClientModule extends PreparedWasmClientModule {
+  readonly jsPath: string;
+  readonly extendedMemory: ExtendedMemoryMode;
+}
+
 export interface PrepareClientModuleOptions {
   readonly officialWasmPath: string;
+  readonly officialJsPath: string;
   readonly officialSha256: string;
   readonly certification: ClientCertification;
   readonly enhancementCapabilities: EnhancementCapabilities;
   readonly compatibilityCacheRoot: string;
   readonly enhancementCacheRoot: string;
   readonly nativeDoubleClickCacheRoot: string;
+  readonly extendedMemoryCacheRoot: string;
 }
 
 function templateSaveCache(
@@ -180,9 +203,9 @@ async function discardEnhancementCache(
  * player the double-click repair's latency, never the client.
  */
 async function withNativeDoubleClick(
-  prepared: PreparedClientModule,
+  prepared: PreparedWasmClientModule,
   cacheRoot: string,
-): Promise<PreparedClientModule> {
+): Promise<PreparedWasmClientModule> {
   const inputSha256 = await sha256File(prepared.wasmPath);
   const build = findNativeDoubleClickBuild(inputSha256);
   const expectedOutputSha256 = build
@@ -219,15 +242,48 @@ async function withNativeDoubleClick(
 export async function prepareClientModule(
   options: PrepareClientModuleOptions,
 ): Promise<PreparedClientModule> {
-  return withNativeDoubleClick(
+  const prepared = await withNativeDoubleClick(
     await prepareCertifiedChain(options),
     options.nativeDoubleClickCacheRoot,
   );
+  if (!EXTENDED_MEMORY_RESEARCH_ENABLED) {
+    return {
+      ...prepared,
+      jsPath: options.officialJsPath,
+      extendedMemory: { status: "disabled" },
+    };
+  }
+  try {
+    const extended = await prepareExtendedMemoryArtifacts(
+      options.officialJsPath,
+      prepared.wasmPath,
+      options.extendedMemoryCacheRoot,
+    );
+    return extended
+      ? {
+          ...prepared,
+          jsPath: extended.jsPath,
+          wasmPath: extended.wasmPath,
+          extendedMemory: { status: "active", profile: extended.profile },
+        }
+      : {
+          ...prepared,
+          jsPath: options.officialJsPath,
+          extendedMemory: { status: "unsupported" },
+        };
+  } catch (error) {
+    return {
+      ...prepared,
+      jsPath: options.officialJsPath,
+      extendedMemory: { status: "unsupported" },
+      failure: prepared.failure ?? { stage: "extended-memory", error },
+    };
+  }
 }
 
 async function prepareCertifiedChain(
   options: PrepareClientModuleOptions,
-): Promise<PreparedClientModule> {
+): Promise<PreparedWasmClientModule> {
   const {
     officialWasmPath,
     officialSha256,

--- a/src/main/certification/extended-memory.ts
+++ b/src/main/certification/extended-memory.ts
@@ -1,0 +1,345 @@
+/**
+ * Opt-in 4 GiB research profile for exact ArenaNet build 38797.
+ *
+ * This is one paired transform. wasm32 addresses above 2 GiB arrive in
+ * JavaScript as negative i32 values, so publishing the larger WASM memory
+ * without the matching unsigned-pointer glue is never allowed.
+ */
+import { createHash } from "node:crypto";
+import { mkdir, readFile, rm, stat } from "node:fs/promises";
+import path from "node:path";
+import { writeAtomic, writeAtomicJson } from "../core/atomic-file.js";
+import {
+  concat,
+  encodeSection,
+  readUleb,
+  splitSections,
+  uleb,
+  WASM_HEADER,
+  type Section,
+} from "../core/wasm-binary.js";
+
+declare const WebAssembly: { validate(bytes: Uint8Array): boolean };
+
+export const EXTENDED_MEMORY_TRANSFORM_ABI = 1;
+export const EXTENDED_MEMORY_RESEARCH_ENABLED =
+  process.env.GWONMAC_EXTENDED_MEMORY_RESEARCH === "1";
+export const EXTENDED_MEMORY_MAX_PAGES = 65_535;
+export const EXTENDED_MEMORY_MAX_BYTES = EXTENDED_MEMORY_MAX_PAGES * 65_536;
+export const EXTENDED_MEMORY_PROFILES = [
+  "off",
+  "cursor",
+  "target",
+  "cursorTarget",
+  "cursorToolbox",
+] as const;
+export type ExtendedMemoryProfile = (typeof EXTENDED_MEMORY_PROFILES)[number];
+
+export interface ExtendedMemoryWasmBuild {
+  readonly buildId: 38_797;
+  readonly profile: ExtendedMemoryProfile;
+  readonly inputSha256: string;
+  readonly outputSha256: string;
+}
+
+/** Every post-double-click variant the current production chain can emit. */
+export const EXTENDED_MEMORY_WASM_BUILDS: readonly ExtendedMemoryWasmBuild[] =
+  Object.freeze([
+    Object.freeze({
+      buildId: 38_797 as const,
+      profile: "off" as const,
+      inputSha256: "e7d86cfcf7b09abbedd3afca758dbf4a3f3c6e1aa4d44e53b31e45e886d7f250",
+      outputSha256: "862f97fc87267e3b4d342ea01f15834cc60a7be982fd9741cf0ae31b8a18a00b",
+    }),
+    Object.freeze({
+      buildId: 38_797 as const,
+      profile: "cursor" as const,
+      inputSha256: "2c03fb7ac535508d99bc96212d2e087d4322ef7d11cf3e0049f4019035326d50",
+      outputSha256: "c65ba2c246e45a1c013f32e51451537775bb2ae6d5a5ae3a9f3240b2594efb91",
+    }),
+    Object.freeze({
+      buildId: 38_797 as const,
+      profile: "target" as const,
+      inputSha256: "e69c026e942496b2fbd6bef056fb1eeb0b6ff5e51fed02846fb37a27c53a49f7",
+      outputSha256: "da872c47a3846427a5c00685d99064a02b7ce809aca6ea2073c92d84f891d8cc",
+    }),
+    Object.freeze({
+      buildId: 38_797 as const,
+      profile: "cursorTarget" as const,
+      inputSha256: "ee642435a41221dd8d2db1dd326d650c1a86e00cd823743d867505a4246bfdc9",
+      outputSha256: "d5f4b161124cc1829c7a1f23859da2a1f9290c668c8fad1d9d316428034c1190",
+    }),
+    Object.freeze({
+      buildId: 38_797 as const,
+      profile: "cursorToolbox" as const,
+      inputSha256: "35d258f8373ccf3eb0321a48b98c0ace61a304683d3295b1712a5a71102d1da6",
+      outputSha256: "a0bd482dda0476f36feed1104033041057e10062775424088c4961a142fac8e1",
+    }),
+  ]);
+
+export const EXTENDED_MEMORY_JS_BUILD = Object.freeze({
+  buildId: 38_797,
+  inputSha256: "58ecc6377397f01919d8def58e802e19fbfd6ce13f421dbf14123a667e34f7d0",
+  outputSha256: "1dd5d798b1491f46a7c128c641053c8488211bbc193fe40bdf1d7a886517993d",
+});
+
+const sha256 = (bytes: Uint8Array | string): string =>
+  createHash("sha256").update(bytes).digest("hex");
+
+function fail(message: string): never {
+  throw new Error(`extended-memory transform: ${message}`);
+}
+
+function replaceExactly(
+  source: string,
+  search: string,
+  replacement: string,
+  expectedCount: number,
+): string {
+  const parts = source.split(search);
+  if (parts.length - 1 !== expectedCount) {
+    fail(`expected ${expectedCount} occurrences of ${JSON.stringify(search)}`);
+  }
+  return parts.join(replacement);
+}
+
+export function findExtendedMemoryWasmBuild(
+  inputSha256: string,
+): ExtendedMemoryWasmBuild | null {
+  return EXTENDED_MEMORY_WASM_BUILDS.find(
+    (build) => build.inputSha256 === inputSha256,
+  ) ?? null;
+}
+
+/** Raise the sole defined memory from 32,768 to 65,535 pages. */
+export function rewriteExtendedMemoryWasm(input: Uint8Array): Uint8Array {
+  const build = findExtendedMemoryWasmBuild(sha256(input));
+  if (!build) fail("uncertified WASM input");
+  const sections = splitSections(input);
+  const memory = sections.find((section) => section.id === 5)
+    ?? fail("missing memory section");
+  const cursor = { offset: 0 };
+  const count = readUleb(memory.body, cursor);
+  const flags = readUleb(memory.body, cursor);
+  const initial = readUleb(memory.body, cursor);
+  const maximum = readUleb(memory.body, cursor);
+  if (
+    count !== 1 || flags !== 1 || initial !== 4_096 || maximum !== 32_768
+    || cursor.offset !== memory.body.byteLength
+  ) {
+    fail("memory declaration is not the certified 256 MiB / 2 GiB shape");
+  }
+  const replacement: Section = {
+    id: 5,
+    body: concat(uleb(1), uleb(1), uleb(initial), uleb(EXTENDED_MEMORY_MAX_PAGES)),
+  };
+  const output = concat(
+    WASM_HEADER,
+    ...sections.map((section) =>
+      encodeSection(section === memory ? replacement : section)),
+  );
+  if (!WebAssembly.validate(output)) fail("rewritten module does not validate");
+  if (sha256(output) !== build.outputSha256) fail("derived WASM hash changed");
+  return output;
+}
+
+/**
+ * Apply Emscripten's CAN_ADDRESS_2GB unsigned-pointer lowering to the pinned
+ * generated glue. The shifts and heap accesses were audited for this exact
+ * input; this function never accepts an arbitrary script.
+ */
+export function rewriteExtendedMemoryJs(input: string): string {
+  if (sha256(input) !== EXTENDED_MEMORY_JS_BUILD.inputSha256) {
+    fail("uncertified JavaScript input");
+  }
+  let output = replaceExactly(input, "      2147483648;", "      4294901760;", 1);
+  output = replaceExactly(
+    output,
+    "      4294901760;\r\n  \r\n  var alignMemory",
+    "      4294901760;\r\n  Module['gwonmacHeapCapBytes'] = 4294901760;\r\n  \r\n  var alignMemory",
+    1,
+  );
+
+  let signedShiftCount = 0;
+  output = output.replace(/(?<!>)>>(?!>)/g, () => {
+    signedShiftCount += 1;
+    return ">>>";
+  });
+  if (signedShiftCount !== 327) fail("signed-shift audit count changed");
+
+  let heapIndexCount = 0;
+  output = output.replace(
+    /\b(HEAP(?:U?8|U?16|U?32|F32|F64))\[([^\]\r\n]+)\]/g,
+    (_whole, heap: string, index: string) => {
+      heapIndexCount += 1;
+      return `${heap}[((${index}) >>> 0)]`;
+    },
+  );
+  if (heapIndexCount !== 341) fail("heap-index audit count changed");
+
+  output = replaceExactly(
+    output,
+    "  var UTF8ArrayToString = (heapOrArray, idx = 0, maxBytesToRead, ignoreNul) => {\r\n  ",
+    "  var UTF8ArrayToString = (heapOrArray, idx = 0, maxBytesToRead, ignoreNul) => {\r\n      idx >>>= 0;\r\n  ",
+    1,
+  );
+  output = replaceExactly(
+    output,
+    "  var stringToUTF8Array = (str, heap, outIdx, maxBytesToWrite) => {\r\n",
+    "  var stringToUTF8Array = (str, heap, outIdx, maxBytesToWrite) => {\r\n      outIdx >>>= 0;\r\n",
+    1,
+  );
+
+  let viewOffsetCount = 0;
+  output = output.replace(
+    /new ((?:Big)?Uint(?:8|16|32|64)Array)\(Module\.HEAPU8\.buffer, ([^,\r\n]+),/g,
+    (_whole, view: string, offset: string) => {
+      viewOffsetCount += 1;
+      return `new ${view}(Module.HEAPU8.buffer, ((${offset}) >>> 0),`;
+    },
+  );
+  if (viewOffsetCount !== 7) fail("typed-array offset audit count changed");
+
+  output = replaceExactly(
+    output,
+    "HEAP8.set(contents, ptr);",
+    "HEAP8.set(contents, ptr >>> 0);",
+    1,
+  );
+  output = replaceExactly(
+    output,
+    "Module.HEAPU8.set(data, dataPtr);",
+    "Module.HEAPU8.set(data, dataPtr >>> 0);",
+    1,
+  );
+  output = replaceExactly(
+    output,
+    "Module.HEAPU8.set(array, responseBody);",
+    "Module.HEAPU8.set(array, responseBody >>> 0);",
+    1,
+  );
+  output = replaceExactly(
+    output,
+    "Module.image.readAsync(imageId, offset, null, buffer, bytes)",
+    "Module.image.readAsync(imageId, offset, null, buffer >>> 0, bytes)",
+    2,
+  );
+  if (sha256(output) !== EXTENDED_MEMORY_JS_BUILD.outputSha256) {
+    fail("derived JavaScript hash changed");
+  }
+  return output;
+}
+
+export interface ExtendedMemoryArtifacts {
+  readonly jsPath: string;
+  readonly wasmPath: string;
+  readonly profile: ExtendedMemoryProfile;
+}
+
+interface ExtendedMemoryMetadata {
+  abi?: unknown;
+  jsInputSha256?: unknown;
+  jsOutputSha256?: unknown;
+  wasmInputSha256?: unknown;
+  wasmOutputSha256?: unknown;
+  profile?: unknown;
+}
+
+function artifactPaths(
+  cacheRoot: string,
+  build: ExtendedMemoryWasmBuild,
+): Omit<ExtendedMemoryArtifacts, "profile"> & {
+  readonly cacheDir: string;
+  readonly metadataPath: string;
+} {
+  const identity = sha256(
+    `${EXTENDED_MEMORY_JS_BUILD.inputSha256}:${build.inputSha256}`,
+  );
+  const cacheDir = path.join(cacheRoot, identity, String(EXTENDED_MEMORY_TRANSFORM_ABI));
+  return {
+    cacheDir,
+    jsPath: path.join(cacheDir, "Gw.jspi.js"),
+    wasmPath: path.join(cacheDir, "Gw.jspi.wasm"),
+    metadataPath: path.join(cacheDir, "metadata.json"),
+  };
+}
+
+async function fileSha256(filePath: string): Promise<string> {
+  return sha256(await readFile(filePath));
+}
+
+async function usable(
+  cacheRoot: string,
+  build: ExtendedMemoryWasmBuild,
+): Promise<boolean> {
+  const files = artifactPaths(cacheRoot, build);
+  try {
+    const metadata = JSON.parse(
+      await readFile(files.metadataPath, "utf8"),
+    ) as ExtendedMemoryMetadata;
+    if (
+      metadata.abi !== EXTENDED_MEMORY_TRANSFORM_ABI
+      || metadata.jsInputSha256 !== EXTENDED_MEMORY_JS_BUILD.inputSha256
+      || metadata.jsOutputSha256 !== EXTENDED_MEMORY_JS_BUILD.outputSha256
+      || metadata.wasmInputSha256 !== build.inputSha256
+      || metadata.wasmOutputSha256 !== build.outputSha256
+      || metadata.profile !== build.profile
+    ) return false;
+    const [jsStat, wasmStat, jsHash, wasmHash] = await Promise.all([
+      stat(files.jsPath),
+      stat(files.wasmPath),
+      fileSha256(files.jsPath),
+      fileSha256(files.wasmPath),
+    ]);
+    return jsStat.isFile() && wasmStat.isFile()
+      && jsHash === EXTENDED_MEMORY_JS_BUILD.outputSha256
+      && wasmHash === build.outputSha256;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Atomically selects a certified JS/WASM pair. `null` means this exact pair is
+ * unsupported and both official artifacts must be served unchanged.
+ */
+export async function prepareExtendedMemoryArtifacts(
+  officialJsPath: string,
+  inputWasmPath: string,
+  cacheRoot: string,
+): Promise<ExtendedMemoryArtifacts | null> {
+  const [jsInput, wasmInput] = await Promise.all([
+    readFile(officialJsPath, "utf8"),
+    readFile(inputWasmPath),
+  ]);
+  const build = findExtendedMemoryWasmBuild(sha256(wasmInput));
+  if (sha256(jsInput) !== EXTENDED_MEMORY_JS_BUILD.inputSha256 || !build) {
+    await rm(cacheRoot, { recursive: true, force: true });
+    return null;
+  }
+  const files = artifactPaths(cacheRoot, build);
+  if (await usable(cacheRoot, build)) {
+    return { jsPath: files.jsPath, wasmPath: files.wasmPath, profile: build.profile };
+  }
+
+  const jsOutput = rewriteExtendedMemoryJs(jsInput);
+  const wasmOutput = rewriteExtendedMemoryWasm(wasmInput);
+  await rm(cacheRoot, { recursive: true, force: true });
+  await mkdir(files.cacheDir, { recursive: true });
+  await Promise.all([
+    writeAtomic(files.jsPath, jsOutput),
+    writeAtomic(files.wasmPath, wasmOutput),
+  ]);
+  await writeAtomicJson(files.metadataPath, {
+    abi: EXTENDED_MEMORY_TRANSFORM_ABI,
+    jsInputSha256: EXTENDED_MEMORY_JS_BUILD.inputSha256,
+    jsOutputSha256: EXTENDED_MEMORY_JS_BUILD.outputSha256,
+    wasmInputSha256: build.inputSha256,
+    wasmOutputSha256: build.outputSha256,
+    profile: build.profile,
+  });
+  if (!await usable(cacheRoot, build)) {
+    fail("published artifact pair failed verification");
+  }
+  return { jsPath: files.jsPath, wasmPath: files.wasmPath, profile: build.profile };
+}

--- a/src/main/client-runtime.ts
+++ b/src/main/client-runtime.ts
@@ -35,6 +35,7 @@ import type {
 import {
   enhancementCapabilitiesRequested,
   ENHANCEMENT_TRANSFORM_ABI,
+  WASM_HEAP_CAP_BYTES,
 } from "../shared/contracts.js";
 import { isDigest, type Digest } from "../shared/digest.js";
 import { AppError, NotReadyError, errorCode } from "../shared/errors.js";
@@ -46,6 +47,7 @@ import {
 import type { CertificateFeed } from "./certification/certificate-feed.js";
 import { proveCertificateFeedEntry } from "./certification/certificate-feed-proof.js";
 import type { ClientCertification } from "./certification/client-module.js";
+import { EXTENDED_MEMORY_MAX_BYTES } from "./certification/extended-memory.js";
 import {
   PATCH_REQUEST_HEADERS,
   PATCH_REQUEST_TIMEOUT_MS,
@@ -259,6 +261,7 @@ export class ClientRuntime {
 
   private async selectClientWasm(): Promise<{
     wasmPath: string;
+    jsPath: string;
     build: ActiveClient["enhancementBuild"];
   }> {
     const officialWasm = clientArtifactPath(
@@ -276,7 +279,11 @@ export class ClientRuntime {
       logEvent({ k: "wasm.clientHashUnavailable",
         code: errorCode(error),
       });
-      return { wasmPath: officialWasm, build: null };
+      return {
+        wasmPath: officialWasm,
+        jsPath: clientArtifactPath(this.options.paths.artifacts, "Gw.jspi.js"),
+        build: null,
+      };
     }
 
     let certification = certifyClientBuild(officialSha256);
@@ -305,12 +312,14 @@ export class ClientRuntime {
     }
     const prepared = await prepareClientModule({
       officialWasmPath: officialWasm,
+      officialJsPath: clientArtifactPath(this.options.paths.artifacts, "Gw.jspi.js"),
       officialSha256,
       certification,
       enhancementCapabilities: this.options.enhancementCapabilities,
       compatibilityCacheRoot: this.options.paths.compatibility,
       enhancementCacheRoot: this.options.paths.enhancements,
       nativeDoubleClickCacheRoot: this.options.paths.nativeDoubleClick,
+      extendedMemoryCacheRoot: this.options.paths.extendedMemory,
     });
     const state = prepared.state;
     this.compatibilityValue = {
@@ -350,7 +359,30 @@ export class ClientRuntime {
       logEvent({ k: "enhancement.uncertifiedClientBlocked" });
     }
     gauge("enhancement.supportedBuild", prepared.enhancementBuild !== null);
-    return { wasmPath: prepared.wasmPath, build: prepared.enhancementBuild };
+    const extendedCap = prepared.extendedMemory.status === "active"
+      ? EXTENDED_MEMORY_MAX_BYTES
+      : WASM_HEAP_CAP_BYTES;
+    gauge("wasm.extendedMemoryMode", prepared.extendedMemory.status);
+    gauge("wasm.heapCapBytes", extendedCap);
+    logEvent({
+      k: "wasm.extendedMemory",
+      mode: prepared.extendedMemory.status,
+      profile: prepared.extendedMemory.status === "active"
+        ? prepared.extendedMemory.profile
+        : "none",
+      capBytes: extendedCap,
+    });
+    if (prepared.failure?.stage === "extended-memory") {
+      logEvent({
+        k: "wasm.extendedMemoryPrepareFailed",
+        code: errorCode(prepared.failure.error),
+      });
+    }
+    return {
+      wasmPath: prepared.wasmPath,
+      jsPath: prepared.jsPath,
+      build: prepared.enhancementBuild,
+    };
   }
 
   private async snapshotFor(store: ChunkStore): Promise<SnapshotMetadata> {
@@ -392,6 +424,7 @@ export class ClientRuntime {
       store,
       snapshotMeta,
       wasmPath: enhancement.wasmPath,
+      jsPath: enhancement.jsPath,
       enhancementBuild: enhancement.build,
     });
     this.candidateHealthToken = candidateFingerprint

--- a/src/main/core/paths.ts
+++ b/src/main/core/paths.ts
@@ -29,6 +29,7 @@ export interface GamePaths {
   compatibility: string;
   enhancements: string;
   nativeDoubleClick: string;
+  extendedMemory: string;
   chunks: string;
   bootChunks: string;
   cacheClearRequest: string;
@@ -55,6 +56,7 @@ export function gamePaths(userData: string): GamePaths {
     compatibility: path.join(game, "compatibility"),
     enhancements: path.join(game, "enhancements"),
     nativeDoubleClick: path.join(game, "double-click"),
+    extendedMemory: path.join(game, "extended-memory"),
     chunks: path.join(game, "chunks"),
     bootChunks: path.join(game, "boot-chunks.json"),
     cacheClearRequest: path.join(userData, "clear-cache-on-start"),

--- a/src/main/diagnostics/schema.ts
+++ b/src/main/diagnostics/schema.ts
@@ -43,6 +43,7 @@ import {
   CERTIFICATE_FEED_SOURCES,
 } from "../certification/certificate-feed-delivery.js";
 import { LOCAL_VERIFICATION_REASONS } from "../certification/local-client-verifier.js";
+import { EXTENDED_MEMORY_PROFILES } from "../certification/extended-memory.js";
 import {
   isProxyRoute,
   type ProxyRoute,
@@ -809,6 +810,20 @@ export const DIAGNOSTIC_EVENT_SCHEMA = {
     subsystem: "wasm",
     level: "info",
     fields: none,
+  },
+  "wasm.extendedMemory": {
+    subsystem: "wasm",
+    level: "info",
+    fields: {
+      mode: literal(["disabled", "unsupported", "active"] as const),
+      profile: literal(["none", ...EXTENDED_MEMORY_PROFILES] as const),
+      capBytes: finiteNumber,
+    },
+  },
+  "wasm.extendedMemoryPrepareFailed": {
+    subsystem: "wasm",
+    level: "warn",
+    fields: { code },
   },
   "enhancement.prepareFailed": {
     subsystem: "wasm",

--- a/src/main/protocol.ts
+++ b/src/main/protocol.ts
@@ -72,6 +72,7 @@ export interface ProtocolDeps {
     store: ChunkStore;
     snapshotMeta: SnapshotMetadata;
     wasmPath: string;
+    jsPath: string;
   } | null;
 }
 
@@ -436,6 +437,9 @@ export async function handleGwRequest(request: Request): Promise<Response> {
       artifactName === "Gw.jspi.wasm"
         ? active?.wasmPath ??
           clientArtifactPath(gamePaths().artifacts, "Gw.jspi.wasm")
+        : artifactName === "Gw.jspi.js"
+          ? active?.jsPath ??
+            clientArtifactPath(gamePaths().artifacts, "Gw.jspi.js")
         : clientArtifactPath(
             active?.artifactsDir ?? gamePaths().artifacts,
             artifactName,

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -109,6 +109,7 @@ type GwGameModule = {
 
   // Published by the generated glue, so absent until it has run.
   HEAPU8?: Uint8Array;
+  gwonmacHeapCapBytes?: number;
   SDL2?: { audioContext?: AudioContext };
   audioContext?: AudioContext;
   oskIsActive?: boolean;
@@ -303,8 +304,9 @@ function requestHeapCap() {
     import('./heap-pressure.js'),
   ])
     .then(([{ WASM_HEAP_CAP_BYTES }, { createHeapPressureWatch }]) => {
-      heapCapBytes = WASM_HEAP_CAP_BYTES;
-      heapWatch = createHeapPressureWatch({ capBytes: WASM_HEAP_CAP_BYTES });
+      const capBytes = Module.gwonmacHeapCapBytes ?? WASM_HEAP_CAP_BYTES;
+      heapCapBytes = capBytes;
+      heapWatch = createHeapPressureWatch({ capBytes });
     })
     // A failed load retries on the next tick rather than silencing the
     // warning for the whole session.
@@ -1394,7 +1396,8 @@ function loadGlue() {
     const source = createImageSource({
       metadata: meta,
       fetchRange: fetchSnapshotRange,
-      writeBytes: (data, address) => clientRuntime().HEAPU8.set(data, address),
+      writeBytes: (data, address) =>
+        clientRuntime().HEAPU8.set(data, address >>> 0),
       diagnostics: window.gwDiagnostics,
       log,
     });

--- a/src/renderer/wasm-memory-attribution.ts
+++ b/src/renderer/wasm-memory-attribution.ts
@@ -279,19 +279,19 @@ export function installWasmMemoryAttribution({
 
   const readTextureIds = (pointer: number, countValue: number): number[] => {
     const heap = module.HEAPU8;
+    const address = pointer >>> 0;
     if (
       !heap
       || !Number.isSafeInteger(pointer)
-      || pointer < 0
       || !Number.isSafeInteger(countValue)
       || countValue < 0
       || countValue > MAX_TEXTURE_IDS_PER_CALL
-      || pointer + countValue * 4 > heap.buffer.byteLength
+      || address + countValue * 4 > heap.buffer.byteLength
     ) return [];
     const view = new DataView(heap.buffer);
     return Array.from(
       { length: countValue },
-      (_unused, index) => view.getUint32(pointer + index * 4, true),
+      (_unused, index) => view.getUint32(address + index * 4, true),
     );
   };
 

--- a/src/tools/diagnostics/summarize.ts
+++ b/src/tools/diagnostics/summarize.ts
@@ -177,7 +177,12 @@ if (!input) {
     console.log(`  renderer RSS peak ${((Number(summary.latest["process.tab.peakRssBytes"]) || 0) / 1048576).toFixed(0)} MB`);
     // Against the client's compiled-in cap: a peak at the cap plus a
     // wasm.abort is memory exhaustion, whatever the abort's reason kind says.
-    console.log(`  wasm heap peak   ${((Number(summary.latest["renderer.peakWasmHeapBytes"]) || 0) / 1048576).toFixed(0)} MiB of ${(WASM_HEAP_CAP_BYTES / 1048576).toFixed(0)} MiB`);
+    const heapCapBytes = Number(summary.latest["wasm.heapCapBytes"])
+      || WASM_HEAP_CAP_BYTES;
+    console.log(`  wasm heap peak   ${((Number(summary.latest["renderer.peakWasmHeapBytes"]) || 0) / 1048576).toFixed(0)} MiB of ${(heapCapBytes / 1048576).toFixed(0)} MiB`);
+    console.log(
+      `  memory mode      ${String(summary.latest["wasm.extendedMemoryMode"] ?? "disabled")}`,
+    );
     console.log(`  GPU RSS peak     ${((Number(summary.latest["process.gpu.peakRssBytes"]) || 0) / 1048576).toFixed(0)} MB`);
     const memoryProbe = summary.latest["wasm.memoryProbe.status"];
     if (memoryProbe) console.log(`  memory probe     ${String(memoryProbe)}`);

--- a/tests/electron/client-runtime-concurrency.spec.ts
+++ b/tests/electron/client-runtime-concurrency.spec.ts
@@ -328,6 +328,7 @@ test.describe("client generation coordination", () => {
             store,
             snapshotMeta: {},
             wasmPath: path.join(paths.artifacts, "Gw.jspi.wasm"),
+            jsPath: path.join(paths.artifacts, "Gw.jspi.js"),
             enhancementBuild: null,
           });
           const token = Object.freeze({
@@ -356,6 +357,7 @@ test.describe("client generation coordination", () => {
             store,
             snapshotMeta: {},
             wasmPath: path.join(paths.artifacts, "Gw.jspi.wasm"),
+            jsPath: path.join(paths.artifacts, "Gw.jspi.js"),
             enhancementBuild: null,
           });
           await fs.writeFile(
@@ -465,6 +467,7 @@ test.describe("client generation coordination", () => {
             store,
             snapshotMeta: {},
             wasmPath: path.join(paths.artifacts, "Gw.jspi.wasm"),
+            jsPath: path.join(paths.artifacts, "Gw.jspi.js"),
             enhancementBuild: null,
           });
           const token = Object.freeze({

--- a/tests/electron/enhancement-runtime.spec.ts
+++ b/tests/electron/enhancement-runtime.spec.ts
@@ -97,6 +97,7 @@ test.describe("Enhancement runtime selection", () => {
       expect(settings).toMatchObject(init.enhancementSelection);
       const selected = await prepareClientModule({
         officialWasmPath: path.join(paths.artifacts, "Gw.jspi.wasm"),
+        officialJsPath: path.join(paths.artifacts, "Gw.jspi.js"),
         officialSha256: OFFICIAL_SHA256,
         certification: {
           state: "certified",
@@ -116,6 +117,7 @@ test.describe("Enhancement runtime selection", () => {
         compatibilityCacheRoot: paths.compatibility,
         enhancementCacheRoot: paths.enhancements,
         nativeDoubleClickCacheRoot: paths.nativeDoubleClick,
+        extendedMemoryCacheRoot: paths.extendedMemory,
       });
       const bytes = await readFile(selected.wasmPath);
       const module = new WebAssembly.Module(bytes);

--- a/tests/unit/active-client.test.ts
+++ b/tests/unit/active-client.test.ts
@@ -24,6 +24,7 @@ function generation(
     store: { size } as ClientGeneration["store"],
     snapshotMeta: snapshot(size),
     wasmPath,
+    jsPath: wasmPath.replace(/\.wasm$/, ".js"),
     enhancementBuild: null,
   };
 }

--- a/tests/unit/client-module.test.ts
+++ b/tests/unit/client-module.test.ts
@@ -280,7 +280,9 @@ async function fixture() {
   scratchDirs.push(root);
   const official = officialFixture();
   const officialWasmPath = join(root, "official.wasm");
+  const officialJsPath = join(root, "official.js");
   await writeFile(officialWasmPath, official);
+  await writeFile(officialJsPath, "official glue");
   const templateSaveBuild = certifyTemplate(official);
   const templateOutput = rewriteTemplateSaveWasm(official, templateSaveBuild);
   const enhancement = enhancementBuild(templateOutput);
@@ -288,12 +290,14 @@ async function fixture() {
     root,
     official,
     officialWasmPath,
+    officialJsPath,
     officialSha256: sha256(official),
     templateSaveBuild,
     enhancementBuild: enhancement,
     compatibilityCacheRoot: join(root, "compatibility"),
     enhancementCacheRoot: join(root, "enhancement"),
     nativeDoubleClickCacheRoot: join(root, "double-click"),
+    extendedMemoryCacheRoot: join(root, "extended-memory"),
   };
 }
 
@@ -306,12 +310,14 @@ function options(
 ) {
   return {
     officialWasmPath: value.officialWasmPath,
+    officialJsPath: value.officialJsPath,
     officialSha256: value.officialSha256,
     certification,
     enhancementCapabilities,
     compatibilityCacheRoot: value.compatibilityCacheRoot,
     enhancementCacheRoot: value.enhancementCacheRoot,
     nativeDoubleClickCacheRoot: value.nativeDoubleClickCacheRoot,
+    extendedMemoryCacheRoot: value.extendedMemoryCacheRoot,
   };
 }
 
@@ -418,6 +424,8 @@ describe("client module preparation", () => {
 
     assert.deepEqual(prepared, {
       wasmPath: value.officialWasmPath,
+      jsPath: value.officialJsPath,
+      extendedMemory: { status: "disabled" },
       state: "uncertified",
       enhancementBuild: null,
       // An unrecognised client is served exactly as downloaded, so it also

--- a/tests/unit/extended-memory.test.ts
+++ b/tests/unit/extended-memory.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  EXTENDED_MEMORY_JS_BUILD,
+  EXTENDED_MEMORY_MAX_BYTES,
+  EXTENDED_MEMORY_MAX_PAGES,
+  EXTENDED_MEMORY_PROFILES,
+  EXTENDED_MEMORY_RESEARCH_ENABLED,
+  EXTENDED_MEMORY_WASM_BUILDS,
+  findExtendedMemoryWasmBuild,
+  rewriteExtendedMemoryJs,
+  rewriteExtendedMemoryWasm,
+} from "../../src/main/certification/extended-memory.js";
+import { NATIVE_DOUBLE_CLICK_BUILDS } from "../../src/main/certification/native-double-click.js";
+import { ENHANCEMENT_CAPABILITY_PROFILES } from "../../src/shared/contracts.js";
+import { diagnosticEventRecord } from "../../src/main/diagnostics/schema.js";
+
+describe("research-only extended memory transform", () => {
+  it("requires the explicit research environment and stops one page short of 4 GiB", () => {
+    assert.equal(
+      EXTENDED_MEMORY_RESEARCH_ENABLED,
+      process.env.GWONMAC_EXTENDED_MEMORY_RESEARCH === "1",
+    );
+    assert.equal(EXTENDED_MEMORY_MAX_PAGES, 65_535);
+    assert.equal(EXTENDED_MEMORY_MAX_BYTES, 4_294_901_760);
+  });
+
+  it("certifies every post-double-click variant the production chain emits", () => {
+    const expectedProfiles = [
+      "off",
+      ...Object.keys(ENHANCEMENT_CAPABILITY_PROFILES),
+    ].sort();
+    assert.deepEqual(
+      EXTENDED_MEMORY_WASM_BUILDS.map((build) => build.profile).sort(),
+      expectedProfiles,
+    );
+    assert.deepEqual([...EXTENDED_MEMORY_PROFILES].sort(), expectedProfiles);
+    const doubleClickOutputs = new Set(
+      Object.values(NATIVE_DOUBLE_CLICK_BUILDS[0]!.derivations),
+    );
+    assert.deepEqual(
+      new Set(EXTENDED_MEMORY_WASM_BUILDS.map((build) => build.inputSha256)),
+      doubleClickOutputs,
+    );
+  });
+
+  it("pins unique exact inputs and outputs", () => {
+    const hashes = [
+      EXTENDED_MEMORY_JS_BUILD.inputSha256,
+      EXTENDED_MEMORY_JS_BUILD.outputSha256,
+      ...EXTENDED_MEMORY_WASM_BUILDS.flatMap((build) => [
+        build.inputSha256,
+        build.outputSha256,
+      ]),
+    ];
+    assert.equal(new Set(hashes).size, hashes.length);
+    for (const hash of hashes) assert.match(hash, /^[0-9a-f]{64}$/);
+  });
+
+  it("refuses unknown JavaScript and WASM before rewriting either", () => {
+    assert.throws(
+      () => rewriteExtendedMemoryJs("var getHeapMax = () => 2147483648;"),
+      /uncertified JavaScript input/,
+    );
+    assert.throws(
+      () => rewriteExtendedMemoryWasm(Uint8Array.of(0, 97, 115, 109)),
+      /uncertified WASM input/,
+    );
+    assert.equal(findExtendedMemoryWasmBuild("0".repeat(64)), null);
+  });
+
+  it("records the effective mode and cap with a closed profile", () => {
+    assert.deepEqual(
+      diagnosticEventRecord({
+        k: "wasm.extendedMemory",
+        mode: "active",
+        profile: "cursorToolbox",
+        capBytes: EXTENDED_MEMORY_MAX_BYTES,
+      }),
+      {
+        subsystem: "wasm",
+        level: "info",
+        name: "wasm.extendedMemory",
+        fields: {
+          mode: "active",
+          profile: "cursorToolbox",
+          capBytes: EXTENDED_MEMORY_MAX_BYTES,
+        },
+      },
+    );
+  });
+});

--- a/tests/unit/paths.test.ts
+++ b/tests/unit/paths.test.ts
@@ -36,6 +36,7 @@ describe("resolved profile paths", () => {
       compatibility: `${root}/game/compatibility`,
       enhancements: `${root}/game/enhancements`,
       nativeDoubleClick: `${root}/game/double-click`,
+      extendedMemory: `${root}/game/extended-memory`,
       chunks: `${root}/game/chunks`,
       bootChunks: `${root}/game/boot-chunks.json`,
       cacheClearRequest: `${root}/clear-cache-on-start`,


### PR DESCRIPTION
## Summary

- add an off-by-default `GWONMAC_EXTENDED_MEMORY_RESEARCH=1` profile for exact ArenaNet build 38797
- transform the generated JavaScript and WASM as one indivisible pair: 65,535 WASM pages plus audited unsigned wasm32 pointer handling
- certify every post-double-click variant the current production chain emits: Enhancements off, cursor, target, cursor+target, and cursor+Toolbox
- serve the selected JS and WASM from one verified cache identity and fall back to both ordinary artifacts for an unknown or changed pair
- make the heap warning and diagnostics use the effective runtime cap

## Why research-only

This adds headroom; it does not classify or repair the underlying cache retention, fragmentation, or live working set. It has no settings UI, cannot turn on automatically, and is not a default player feature. A packaged experimental setting still requires high-address gameplay and system-memory-pressure coverage.

## Exact-build qualification

`pnpm memory:qualify:4gb <official-js> <official-wasm>` reconstructs the complete production chain and proved:

- all five predecessor and output hashes match the certification table
- the paired cache publishes and reuses only the exact pair
- a one-byte WASM change is refused and the stale pair is removed
- the actual `prepareClientModule` path selects the paired Enhancements-off artifacts only with the opt-in active
- ArenaNet's real allocator reached 3,025,928,192 bytes
- a pointer reached unsigned address 2,522,561,664
- high-address read/write passed
- freed capacity was reused without another growth request

The earlier live Electron run additionally reached 2,625 MiB and round-tripped `GW4G` through the generated UTF-8 glue above the signed 2 GiB boundary. That evidence is documented, not treated as complete gameplay certification.

## Verification

- `pnpm check` (including 792 unit tests and 158 policy tests)
- `pnpm build`
- `pnpm test:website`
- targeted Electron generation/concurrency and Enhancement-selection tests: 6 passed
- exact installed-artifact 4 GiB qualification
- `git diff --check`

## Merge order

1. #112 — dependency/CI prerequisite
2. #113 — production heap warning and safe reload
3. #114 — bounded growth diagnostics and evidence
4. this PR

The branch contains those exact predecessor commits so every gate can run now; its diff against `main` will shrink as they land.
