### PR TITLE
refactor: move settings decisions out of generic IPC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,8 @@ is meant to inherit the dead ends rather than walk back into them.
 | `src/main/certification/` | the official -> template-save -> Enhancement chain: certified tables, both transforms, the isolated proof, and the Enhancement switches |
 | `certificates/`           | the reviewed ArenaNet client-generation heartbeat used by scheduled recertification |
 | `src/main/protocol.ts`    | secure `gw://app` routing and snapshot ranges                 |
-| `src/main/ipc.ts`         | validated native capability handlers                          |
+| `src/main/ipc.ts`         | validated capability transport and direct forwarding          |
+| `src/main/settings-actions.ts` | settings confirmations, durable reset markers, relaunch, and startup recovery |
 | `src/main/diagnostics.ts` | the diagnostics subsystem's one entry point                   |
 | `src/main/diagnostics/`   | flight recorder, capture, samplers, schema, detector, export  |
 | `src/preload/preload.body.cjs` | frozen sandbox-compatible capability bridge; its channel constants are spliced in by `scripts/generate-preload.ts` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,7 +70,7 @@ is meant to inherit the dead ends rather than walk back into them.
 | `src/main/certification/` | the official -> template-save -> Enhancement chain: certified tables, both transforms, the isolated proof, and the Enhancement switches |
 | `certificates/`           | the reviewed ArenaNet client-generation heartbeat used by scheduled recertification |
 | `src/main/protocol.ts`    | secure `gw://app` routing and snapshot ranges                 |
-| `src/main/ipc.ts`         | validated capability transport and direct forwarding          |
+| `src/main/ipc.ts`         | sender/value validation, channel registration, and direct owner-local operations |
 | `src/main/settings-actions.ts` | settings confirmations, durable reset markers, relaunch, and startup recovery |
 | `src/main/diagnostics.ts` | the diagnostics subsystem's one entry point                   |
 | `src/main/diagnostics/`   | flight recorder, capture, samplers, schema, detector, export  |

--- a/docs/process-model.md
+++ b/docs/process-model.md
@@ -50,7 +50,7 @@ arbitrary filesystem or URL fetch capability.
 | `src/main/core/wasm-binary.ts` | WASM section codec shared by both transforms and the re-certifier |
 | `src/main/certification/` | certified build tables, both transforms, the isolated local proof |
 | `src/main/protocol.ts`    | `gw://app` routing and range responses                            |
-| `src/main/ipc.ts`         | sender/value validation and direct capability forwarding          |
+| `src/main/ipc.ts`         | sender/value validation, channel registration, and direct owner-local operations |
 | `src/main/settings-actions.ts` | settings confirmation, durable reset, relaunch, and recovery |
 | `src/main/diagnostics.ts` | the diagnostics subsystem's one entry point                       |
 | `src/main/diagnostics/`   | flight recorder, capture, samplers, schema, detector, export      |

--- a/docs/process-model.md
+++ b/docs/process-model.md
@@ -50,7 +50,8 @@ arbitrary filesystem or URL fetch capability.
 | `src/main/core/wasm-binary.ts` | WASM section codec shared by both transforms and the re-certifier |
 | `src/main/certification/` | certified build tables, both transforms, the isolated local proof |
 | `src/main/protocol.ts`    | `gw://app` routing and range responses                            |
-| `src/main/ipc.ts`         | validated native capability handlers                              |
+| `src/main/ipc.ts`         | sender/value validation and direct capability forwarding          |
+| `src/main/settings-actions.ts` | settings confirmation, durable reset, relaunch, and recovery |
 | `src/main/diagnostics.ts` | the diagnostics subsystem's one entry point                       |
 | `src/main/diagnostics/`   | flight recorder, capture, samplers, schema, detector, export      |
 | `src/preload/preload.body.cjs` | sandbox-compatible bridge; `scripts/generate-preload.ts` splices the canonical constants above it |

--- a/plans/full-refactor-optimization.md
+++ b/plans/full-refactor-optimization.md
@@ -1,8 +1,8 @@
 # Refactor program: outcome and completion record
 
-Status: accepted and in progress as a six-branch stack. Later stacked PRs
-implement the target outcomes below; the final PR records only what the exact
-stack head has actually proved.
+Status: implemented and locally verified as a six-branch stack. The code and
+deterministic repository gates are complete; merge review and the explicitly
+separate signed/live release operations remain.
 
 Evidence baseline: `main` at `54c6e0806d484fdd6ac4c03b1edf102a16a9bd10`,
 reviewed on 2026-08-10. Workflow steps, contracts, and test inventories belong
@@ -30,7 +30,7 @@ The preference throughout is:
 delete > simplify > replace > add
 ```
 
-This is a target outcome, not a second implementation. Exact schemas live in
+This is an outcome record, not a second implementation. Exact schemas live in
 types, exact release steps live in workflows/scripts, and exact behavior lives
 in tests.
 
@@ -115,7 +115,7 @@ in tests.
 - Performance claims name a measurement boundary; unproved public absolutes are
   removed rather than converted into architecture.
 
-## Target owners
+## Canonical owners
 
 | Concern | Owner | Executable proof |
 | --- | --- | --- |
@@ -189,8 +189,8 @@ packaged story.
 - a second patch-day report representation;
 - another generation token/journal abstraction over existing transaction
   owners;
-- generic `GameHost`, coordinator, cancellation framework, registry, ledger,
-  plugin surface, background job, or database;
+- generic `GameHost`, startup coordinator, cancellation framework, generic
+  feature/plugin registry, ledger, background job, or database;
 - Vue shell rewrite without measured player value;
 - duplicate website release version/track policy;
 - source-regex tests that duplicate packaged behavior; and
@@ -233,35 +233,46 @@ second-device hardware matrix.
 5. repeat the data proof for every public beta/RC; and
 6. on final Stable publication, run one owned `B1/RC → S1` updater canary.
 
-No draft-only feed, second updater, automatic downgrade, or custom DMG
+The staged GitHub draft is the checksum-pinned exact release candidate, not a
+second updater feed. No second updater, automatic downgrade, or custom DMG
 downloader is added to make these checks easier.
 
 ## Final completion gate
 
-The refactor program closes when all applicable boxes are evidenced:
+The local refactor program closes when all locally applicable boxes are
+evidenced:
 
-- [ ] full stack is rebased and each PR remains independently reviewable;
-- [ ] user-owned unrelated worktree changes are unchanged;
-- [ ] typecheck, lint, unit, policy, integration, release, Tools,
+- [x] full stack is rebased and each PR remains independently reviewable;
+- [x] user-owned unrelated worktree changes are unchanged;
+- [x] typecheck, lint, unit, policy, integration, release, Tools,
       website, Electron, packaged runtime, and packaged smoke gates pass against
       the exact final stack head;
-- [ ] the mandatory thermonuclear review has no unresolved P1/P2 finding;
-- [ ] unknown and soft-refused ArenaNet modules keep host-only Tools, while
+- [x] the mandatory thermonuclear review has no unresolved P1/P2 finding;
+- [x] unknown and soft-refused ArenaNet modules keep host-only Tools, while
       live observation/Apply remain absent;
-- [ ] Stable/Beta selection has one release-policy source and every candidate
-      is exact, newer than Stable, and Stable-readable;
-- [ ] WebGate remains stateless and no credential or cookie becomes app state;
-- [ ] multi-step settings workflows are outside IPC; direct owner-local IPC
+- [x] Stable/Beta selection has one release-policy source, and its release gate
+      requires every public candidate to be exact, newer than Stable, and
+      Stable-readable;
+- [x] WebGate remains stateless and no credential or cookie becomes app state;
+- [x] multi-step settings workflows are outside IPC; direct owner-local IPC
       operations remain explicit rather than hidden behind another service;
-- [ ] no remote certificate authority, duplicate updater or release
-      version/track policy, generic `GameHost`, second Tools host, coordinator,
-      registry, migration framework, or refactor-only compatibility shim
-      remains. The one existing `ToolsHost` and released-data readers remain
-      intentionally;
-- [ ] active documents describe shipped behavior and distinguish local proof
-      from signed/live release operations; and
-- [ ] the program stops. Further architecture work requires a reproduced player
+- [x] no remote certificate authority, duplicate updater or release
+      version/track policy, generic `GameHost`, second Tools host, startup
+      coordinator, generic feature/plugin registry, migration framework, or
+      refactor-only compatibility shim remains. The one existing `ToolsHost`
+      and released-data readers remain intentionally;
+- [x] active documents describe the implemented stack and distinguish local
+      proof from signed/live release operations; and
+- [x] the program stops. Further architecture work requires a reproduced player
       or maintainer defect, or a measured performance decision.
+
+Public Beta promotion remains a release operation, not unfinished architecture:
+
+- [ ] the Stable enabler is published and adopted before the first public Beta;
+- [ ] the exact signed `Stable → candidate → same Stable` proof passes for
+      each public beta/RC; and
+- [ ] the bounded production-updater canaries and one owned live hardware check are
+      recorded in the matching release notes.
 
 Passing this gate is “dream enough”: not a claim that software will never
 change, but proof that this architecture program has no unfinished cleanup or

--- a/src/main/diagnostics/schema-app-update.ts
+++ b/src/main/diagnostics/schema-app-update.ts
@@ -46,6 +46,18 @@ export const APP_AND_UPDATE_EVENT_SCHEMA = {
     level: "error",
     fields: { code },
   },
+  "app.relaunchFailed": {
+    subsystem: "app",
+    level: "error",
+    fields: {
+      action: literal([
+        "toolsEnable",
+        "cacheClear",
+        "gameStorageReset",
+      ] as const),
+      code,
+    },
+  },
   "app.beforeQuit": { subsystem: "app", level: "info", fields: none },
   "app.unexpectedUserData": {
     subsystem: "app",

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -9,12 +9,12 @@
  * window, its main frame, the canonical renderer URL — because a page that
  * navigated away is no longer the renderer the capability was granted to.
  *
- * Transport, not policy. What a socket, a secret, a setting or a chunk means is
- * decided behind these handlers; this file validates arguments, names the
- * subsystem that answers, and returns codes rather than inventing prose.
+ * Multi-step feature policy lives behind these handlers. This file validates
+ * arguments and either forwards one owner-local capability directly or calls
+ * the workflow owner; it returns codes rather than inventing prose.
  */
-import { BrowserWindow, clipboard, dialog, ipcMain, shell, app } from "electron";
-import { statfs, writeFile } from "node:fs/promises";
+import { BrowserWindow, clipboard, ipcMain, shell, app } from "electron";
+import { statfs } from "node:fs/promises";
 import type {
   AppSettings,
   AppSettingsPatch,
@@ -95,8 +95,13 @@ import { gamePaths } from "./paths.js";
 import { isCanonicalRendererUrl } from "./core/renderer-trust.js";
 import { MAX_QUEUED_BYTES_PER_SOCKET } from "./core/sockets.js";
 import { isQuitting } from "./lifecycle.js";
-import { getMainWindow, resetWindowState } from "./window.js";
-import { resetGameInput } from "./renderer-commands.js";
+import { getMainWindow } from "./window.js";
+import {
+  applySettingsChange,
+  confirmSettingsReset,
+  requestCacheClear,
+  requestGameStorageReset,
+} from "./settings-actions.js";
 
 export interface IpcContext {
   sockets: SocketManager;
@@ -523,20 +528,6 @@ const asMilestone: Parser<ParsedMilestone> = (args) => {
   };
 };
 
-async function confirmToolsRestart(win: BrowserWindow): Promise<boolean> {
-  await resetGameInput(win);
-  const { response } = await dialog.showMessageBox(win, {
-    type: "warning",
-    buttons: ["Enable and Restart", "Cancel"],
-    defaultId: 1,
-    cancelId: 1,
-    message: "Enable GWonMac Tools Beta?",
-    detail:
-      "The optional Tools capability is prepared when the app starts, so the first enable needs one restart and closes any game in progress. After that, individual tools can be changed live.",
-  });
-  return response === 0;
-}
-
 async function chunkStoreInfo(
   store: ChunkStore | null,
   volumeDir: string,
@@ -673,57 +664,19 @@ export function registerIpcHandlers(ctx: IpcContext): {
       }
     }),
 
-    settingsSet: channel(one(parseSettingsPatch), async (win, patch) => {
-      try {
-        const previous = await ctx.getSettings();
-        const restartForTools = patch.gwonmacTools === true
-          && !ctx.toolsCapableAtLaunch;
-        if (restartForTools && !(await confirmToolsRestart(win))) return previous;
-        const saved = await ctx.updateSettings(patch);
-        if (previous.dataStrategy !== saved.dataStrategy) {
-          logEvent({ k: "launcher.strategyChanged",
-            strategy: saved.dataStrategy ?? "unselected",
-          });
-        }
-        if (restartForTools) {
-          app.relaunch();
-          app.quit();
-        }
-        return saved;
-      } catch (error) {
-        logEvent({ k: "settings.saveFailed", code: errorCode(error) });
-        throw error;
-      }
-    }),
+    settingsSet: channel(one(parseSettingsPatch), (win, patch) =>
+      applySettingsChange(
+        win,
+        patch,
+        ctx.toolsCapableAtLaunch,
+        ctx.getSettings,
+        ctx.updateSettings,
+      ),
+    ),
 
-    settingsReset: channel(nothing, async (win) => {
-      await resetGameInput(win);
-      try {
-        const { response } = await dialog.showMessageBox(win, {
-          type: "warning",
-          buttons: ["Reset GWonMac Settings", "Cancel"],
-          defaultId: 1,
-          cancelId: 1,
-          message: "Reset GWonMac settings?",
-          detail: "Display, tools, window size and position, diagnostics, and launcher choices return to their defaults. Downloaded game data and your saved login stay untouched.",
-        });
-        if (response !== 0) return null;
-        const settings = await ctx.resetSettings();
-        try {
-          await resetWindowState(win);
-        } catch {
-          // The settings file is already durably reset. Window geometry is a
-          // separate document, so its failure must not turn that committed
-          // result into a false "settings reset failed" answer.
-          logEvent({ k: "window.stateResetFailed" });
-        }
-        logEvent({ k: "settings.reset" });
-        return settings;
-      } catch (error) {
-        logEvent({ k: "settings.resetFailed", code: errorCode(error) });
-        throw error;
-      }
-    }),
+    settingsReset: channel(nothing, (win) =>
+      confirmSettingsReset(win, ctx.resetSettings),
+    ),
 
     credentialsLoad: channel(nothing, async () => {
       try {
@@ -766,57 +719,17 @@ export function registerIpcHandlers(ctx: IpcContext): {
       }
     }),
 
-    cacheClear: channel(nothing, async (win) => {
-      await resetGameInput(win);
-      const { response } = await dialog.showMessageBox(win, {
-        type: "warning",
-        buttons: ["Clear and Restart", "Cancel"],
-        defaultId: 1,
-        cancelId: 1,
-        message: "Clear downloaded game data?",
-        detail:
-          "The app will restart. Client files stay installed, but game data will download again.",
-      });
-      if (response !== 0) return false;
-      try {
-        await writeFile(paths.cacheClearRequest, "", { mode: 0o600 });
-        logEvent({ k: "cache.clearRequested" });
-        app.relaunch();
-        app.quit();
-        return true;
-      } catch (error) {
-        logEvent({ k: "cache.clearRequestFailed", code: errorCode(error) });
-        throw error;
-      }
-    }),
+    cacheClear: channel(nothing, (win) =>
+      requestCacheClear(win, paths.cacheClearRequest),
+    ),
 
     cacheDownloadAll: channel(nothing, () => ctx.downloadFullGame()),
 
     cacheStopDownload: channel(nothing, () => ctx.stopFullDownload()),
 
-    gameStorageReset: channel(nothing, async (win) => {
-      await resetGameInput(win);
-      const { response } = await dialog.showMessageBox(win, {
-        type: "warning",
-        buttons: ["Reset and Restart", "Cancel"],
-        defaultId: 1,
-        cancelId: 1,
-        message: "Reset saved Guild Wars files?",
-        detail:
-          "This removes local Guild Wars settings, build templates, screenshots, and chat logs. Downloaded game data and your saved login stay untouched.",
-      });
-      if (response !== 0) return false;
-      try {
-        await writeFile(paths.gameStorageClearRequest, "", { mode: 0o600 });
-        logEvent({ k: "filesystem.resetRequested" });
-        app.relaunch();
-        app.quit();
-        return true;
-      } catch (error) {
-        logEvent({ k: "filesystem.resetFailed", code: errorCode(error) });
-        throw error;
-      }
-    }),
+    gameStorageReset: channel(nothing, (win) =>
+      requestGameStorageReset(win, paths.gameStorageClearRequest),
+    ),
 
     diagnosticsGraphics: channel(asGraphics, (_win, value) => {
       recordGraphics(value);

--- a/src/main/lifecycle.ts
+++ b/src/main/lifecycle.ts
@@ -69,7 +69,6 @@ export async function runQuitCleanup(): Promise<void> {
     }
   })();
   const outcome = await Promise.race([pass.then(() => "completed" as const), expired]);
-  clearTimeout(deadline);
   // A task still running past the deadline keeps running; nothing here can
   // cancel it. What the deadline buys is that the process no longer waits for
   // it, and that the record says which of the two happened.
@@ -78,7 +77,19 @@ export async function runQuitCleanup(): Promise<void> {
       ? { k: "quit.cleanupCompleted" }
       : { k: "quit.cleanupTimedOut" },
   );
-  await flushDiagnostics();
+  try {
+    // The final write is part of cleanup, not an operation after it. Reuse the
+    // same deadline so a recorder blocked on the filesystem cannot strand the
+    // process after every registered task has already been bounded.
+    await Promise.race([flushDiagnostics(), expired]);
+  } catch (err) {
+    // There is nowhere durable left to report a recorder failure. Keep the
+    // developer console useful without making diagnostics a prerequisite for
+    // quitting or installing an already-downloaded update.
+    console.error("quit diagnostics flush failed", err);
+  } finally {
+    clearTimeout(deadline);
+  }
 }
 
 /** Call before ready. Enables Chromium renderer sandboxing. */

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -16,7 +16,7 @@ import {
   session,
 } from "electron";
 import { readFileSync } from "node:fs";
-import { mkdir, rm, stat } from "node:fs/promises";
+import { mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import {
   EXTERNAL_URLS,
@@ -103,6 +103,10 @@ import {
   parseDistributionMarker,
   type DistributionChannel,
 } from "../shared/distribution-channel.js";
+import {
+  applyPendingCacheClear,
+  applyPendingGameStorageReset,
+} from "./settings-actions.js";
 
 // The public app name changed after alpha profiles already existed. Keep that
 // one profile as the canonical home so the rename cannot strand saved login,
@@ -299,36 +303,6 @@ async function clearBrowserNetworkCache(): Promise<void> {
   }
 }
 
-async function applyPendingCacheClear(): Promise<void> {
-  const paths = gamePaths();
-  try {
-    await stat(paths.cacheClearRequest);
-  } catch {
-    return;
-  }
-  await rm(paths.chunks, { recursive: true, force: true });
-  await rm(paths.bootChunks, { force: true });
-  await rm(paths.cacheClearRequest, { force: true });
-  logEvent({ k: "cache.clearedAtStartup" });
-}
-
-async function applyPendingGameStorageClear(): Promise<void> {
-  const paths = gamePaths();
-  try {
-    await stat(paths.gameStorageClearRequest);
-  } catch {
-    return;
-  }
-  // Run before a renderer can mount IDBFS, otherwise auto-persisting game
-  // writes can race the destructive clear and recreate entries before quit.
-  await session.defaultSession.clearStorageData({
-    origin: "gw://app",
-    storages: ["indexdb"],
-  });
-  await rm(paths.gameStorageClearRequest, { force: true });
-  logEvent({ k: "filesystem.resetCompleted" });
-}
-
 function buildWindowHost(
   clientRuntime: ClientRuntime,
   sockets: SocketManager,
@@ -375,8 +349,9 @@ if (primaryInstance) void app.whenReady().then(async () => {
       "Mat4m0/gwonmac · App icon artwork © ArenaNet LLC · QT Friz Quad © 1992 QualiType (SIL OFL 1.1) · Not affiliated with ArenaNet or NCSOFT.",
     website: EXTERNAL_URLS.github,
   });
-  await applyPendingCacheClear();
-  await applyPendingGameStorageClear();
+  const paths = gamePaths();
+  await applyPendingCacheClear(paths);
+  await applyPendingGameStorageReset(paths);
   await ensureDirs();
   await startDiagnostics();
   const distributionChannel = packagedDistributionChannel();
@@ -402,7 +377,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
   await clearBrowserCookies("startup");
   await clearBrowserNetworkCache();
   logEvent({ k: "electron.ready" });
-  const settings = await loadSettings(gamePaths().settings, async () => {
+  const settings = await loadSettings(paths.settings, async () => {
     logEvent({ k: "settings.corruptRecovered" });
     await dialog.showMessageBox({
       type: "warning",
@@ -419,7 +394,6 @@ if (primaryInstance) void app.whenReady().then(async () => {
     enhancementProgram,
   );
   await prepareWindowState();
-  const paths = gamePaths();
   const keychain: NativeKeychain = persistentSecrets
     ? loadNativeKeychain({
         packaged: true,
@@ -503,7 +477,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
     steamSessionStore,
     getProgress: () => clientRuntime.progress,
     getChunkStore: () => clientRuntime.active?.store ?? null,
-    getSettings: () => loadSettings(gamePaths().settings),
+    getSettings: () => loadSettings(paths.settings),
     updateSettings: updateAppSettings,
     resetSettings: resetAppSettings,
     toolsCapableAtLaunch: settings.gwonmacTools,
@@ -596,7 +570,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
   // so a due tick during a download or a ready update is a no-op.
   const periodicCheckTick = setInterval(() => {
     void (async () => {
-      const current = await loadSettings(gamePaths().settings);
+      const current = await loadSettings(paths.settings);
       if (!periodicCheckDue({
         capable: distribution.automaticUpdates,
         autoCheckUpdates: current.autoCheckUpdates,

--- a/src/main/settings-actions.ts
+++ b/src/main/settings-actions.ts
@@ -187,12 +187,18 @@ export async function requestGameStorageReset(
   return true;
 }
 
-export async function applyPendingCacheClear(paths: GamePaths): Promise<void> {
+async function pendingMarkerExists(markerPath: string): Promise<boolean> {
   try {
-    await stat(paths.cacheClearRequest);
-  } catch {
-    return;
+    await stat(markerPath);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
   }
+}
+
+export async function applyPendingCacheClear(paths: GamePaths): Promise<void> {
+  if (!(await pendingMarkerExists(paths.cacheClearRequest))) return;
   await rm(paths.chunks, { recursive: true, force: true });
   await rm(paths.bootChunks, { force: true });
   await rm(paths.cacheClearRequest, { force: true });
@@ -202,11 +208,7 @@ export async function applyPendingCacheClear(paths: GamePaths): Promise<void> {
 export async function applyPendingGameStorageReset(
   paths: GamePaths,
 ): Promise<void> {
-  try {
-    await stat(paths.gameStorageClearRequest);
-  } catch {
-    return;
-  }
+  if (!(await pendingMarkerExists(paths.gameStorageClearRequest))) return;
   // This runs before a renderer can mount IDBFS. Clearing it later would race
   // the game's auto-persist and could recreate files before quit.
   await session.defaultSession.clearStorageData({

--- a/src/main/settings-actions.ts
+++ b/src/main/settings-actions.ts
@@ -42,13 +42,31 @@ async function confirmAction(
   return response === 0;
 }
 
-/** The durable action already succeeded; relaunch failure is diagnostic only. */
-function requestRelaunch(action: RelaunchAction): void {
+/** The durable action already succeeded; relaunch failure cannot undo it. */
+function requestRelaunch(win: BrowserWindow, action: RelaunchAction): void {
   try {
     app.relaunch();
     app.quit();
   } catch (error) {
     logEvent({ k: "app.relaunchFailed", action, code: errorCode(error) });
+    // Keep the successful durable result, but do not tell the player a restart
+    // happened when Electron refused it. This stays native because the failure
+    // occurs after the IPC result is already determined and applies equally to
+    // settings, cache, and game-storage actions.
+    try {
+      void dialog.showMessageBox(win, {
+        type: "warning",
+        buttons: ["OK"],
+        defaultId: 0,
+        cancelId: 0,
+        message: "Restart did not start",
+        detail:
+          "Your change is saved. Quit and reopen GWonMac to apply it.",
+      }).catch(() => {});
+    } catch {
+      // A warning failure must not turn the already-durable action into a
+      // rejected settings response.
+    }
   }
 }
 
@@ -80,7 +98,7 @@ export async function applySettingsChange(
         strategy: saved.dataStrategy ?? "unselected",
       });
     }
-    if (restartForTools) requestRelaunch("toolsEnable");
+    if (restartForTools) requestRelaunch(win, "toolsEnable");
     return saved;
   } catch (error) {
     logEvent({ k: "settings.saveFailed", code: errorCode(error) });
@@ -140,7 +158,7 @@ export async function requestCacheClear(
     throw error;
   }
   logEvent({ k: "cache.clearRequested" });
-  requestRelaunch("cacheClear");
+  requestRelaunch(win, "cacheClear");
   return true;
 }
 
@@ -165,7 +183,7 @@ export async function requestGameStorageReset(
     throw error;
   }
   logEvent({ k: "filesystem.resetRequested" });
-  requestRelaunch("gameStorageReset");
+  requestRelaunch(win, "gameStorageReset");
   return true;
 }
 

--- a/src/main/settings-actions.ts
+++ b/src/main/settings-actions.ts
@@ -1,0 +1,200 @@
+/**
+ * Settings-screen actions whose meaning is larger than one settings-file
+ * read or write.
+ *
+ * IPC owns sender validation and parsing. This module owns the confirmation,
+ * durable boundary, and relaunch ordering: a refusal writes nothing, and once
+ * a settings value or reset marker is durable, a failed relaunch cannot turn
+ * that completed write into a false failure response.
+ */
+import { app, dialog, session } from "electron";
+import type { BrowserWindow } from "electron";
+import { rm, stat, writeFile } from "node:fs/promises";
+import type {
+  AppSettings,
+  AppSettingsPatch,
+} from "../shared/contracts.js";
+import { errorCode } from "../shared/errors.js";
+import { logEvent } from "./diagnostics.js";
+import type { GamePaths } from "./paths.js";
+import { resetGameInput } from "./renderer-commands.js";
+import { resetWindowState } from "./window.js";
+
+type RelaunchAction = "toolsEnable" | "cacheClear" | "gameStorageReset";
+
+async function confirmAction(
+  win: BrowserWindow,
+  copy: {
+    readonly confirmLabel: string;
+    readonly message: string;
+    readonly detail: string;
+  },
+): Promise<boolean> {
+  await resetGameInput(win);
+  const { response } = await dialog.showMessageBox(win, {
+    type: "warning",
+    buttons: [copy.confirmLabel, "Cancel"],
+    defaultId: 1,
+    cancelId: 1,
+    message: copy.message,
+    detail: copy.detail,
+  });
+  return response === 0;
+}
+
+/** The durable action already succeeded; relaunch failure is diagnostic only. */
+function requestRelaunch(action: RelaunchAction): void {
+  try {
+    app.relaunch();
+    app.quit();
+  } catch (error) {
+    logEvent({ k: "app.relaunchFailed", action, code: errorCode(error) });
+  }
+}
+
+export async function applySettingsChange(
+  win: BrowserWindow,
+  patch: AppSettingsPatch,
+  toolsCapableAtLaunch: boolean,
+  read: () => Promise<AppSettings>,
+  write: (patch: AppSettingsPatch) => Promise<AppSettings>,
+): Promise<AppSettings> {
+  try {
+    const previous = await read();
+    const restartForTools = patch.gwonmacTools === true && !toolsCapableAtLaunch;
+    if (
+      restartForTools
+      && !(await confirmAction(win, {
+        confirmLabel: "Enable and Restart",
+        message: "Enable GWonMac Tools Beta?",
+        detail:
+          "The optional Tools capability is prepared when the app starts, so the first enable needs one restart and closes any game in progress. After that, individual tools can be changed live.",
+      }))
+    ) {
+      return previous;
+    }
+    const saved = await write(patch);
+    if (previous.dataStrategy !== saved.dataStrategy) {
+      logEvent({
+        k: "launcher.strategyChanged",
+        strategy: saved.dataStrategy ?? "unselected",
+      });
+    }
+    if (restartForTools) requestRelaunch("toolsEnable");
+    return saved;
+  } catch (error) {
+    logEvent({ k: "settings.saveFailed", code: errorCode(error) });
+    throw error;
+  }
+}
+
+export async function confirmSettingsReset(
+  win: BrowserWindow,
+  reset: () => Promise<AppSettings>,
+): Promise<AppSettings | null> {
+  if (
+    !(await confirmAction(win, {
+      confirmLabel: "Reset GWonMac Settings",
+      message: "Reset GWonMac settings?",
+      detail:
+        "Display, tools, window size and position, diagnostics, and launcher choices return to their defaults. Downloaded game data and your saved login stay untouched.",
+    }))
+  ) {
+    return null;
+  }
+  try {
+    const settings = await reset();
+    try {
+      await resetWindowState(win);
+    } catch {
+      // The settings document is already durable. Window geometry is a
+      // separate document and cannot roll that result back.
+      logEvent({ k: "window.stateResetFailed" });
+    }
+    logEvent({ k: "settings.reset" });
+    return settings;
+  } catch (error) {
+    logEvent({ k: "settings.resetFailed", code: errorCode(error) });
+    throw error;
+  }
+}
+
+export async function requestCacheClear(
+  win: BrowserWindow,
+  markerPath: string,
+): Promise<boolean> {
+  if (
+    !(await confirmAction(win, {
+      confirmLabel: "Clear and Restart",
+      message: "Clear downloaded game data?",
+      detail:
+        "The app will restart. Client files stay installed, but game data will download again.",
+    }))
+  ) {
+    return false;
+  }
+  try {
+    await writeFile(markerPath, "", { mode: 0o600 });
+  } catch (error) {
+    logEvent({ k: "cache.clearRequestFailed", code: errorCode(error) });
+    throw error;
+  }
+  logEvent({ k: "cache.clearRequested" });
+  requestRelaunch("cacheClear");
+  return true;
+}
+
+export async function requestGameStorageReset(
+  win: BrowserWindow,
+  markerPath: string,
+): Promise<boolean> {
+  if (
+    !(await confirmAction(win, {
+      confirmLabel: "Reset and Restart",
+      message: "Reset saved Guild Wars files?",
+      detail:
+        "This removes local Guild Wars settings, build templates, screenshots, and chat logs. Downloaded game data and your saved login stay untouched.",
+    }))
+  ) {
+    return false;
+  }
+  try {
+    await writeFile(markerPath, "", { mode: 0o600 });
+  } catch (error) {
+    logEvent({ k: "filesystem.resetFailed", code: errorCode(error) });
+    throw error;
+  }
+  logEvent({ k: "filesystem.resetRequested" });
+  requestRelaunch("gameStorageReset");
+  return true;
+}
+
+export async function applyPendingCacheClear(paths: GamePaths): Promise<void> {
+  try {
+    await stat(paths.cacheClearRequest);
+  } catch {
+    return;
+  }
+  await rm(paths.chunks, { recursive: true, force: true });
+  await rm(paths.bootChunks, { force: true });
+  await rm(paths.cacheClearRequest, { force: true });
+  logEvent({ k: "cache.clearedAtStartup" });
+}
+
+export async function applyPendingGameStorageReset(
+  paths: GamePaths,
+): Promise<void> {
+  try {
+    await stat(paths.gameStorageClearRequest);
+  } catch {
+    return;
+  }
+  // This runs before a renderer can mount IDBFS. Clearing it later would race
+  // the game's auto-persist and could recreate files before quit.
+  await session.defaultSession.clearStorageData({
+    origin: "gw://app",
+    storages: ["indexdb"],
+  });
+  await rm(paths.gameStorageClearRequest, { force: true });
+  logEvent({ k: "filesystem.resetCompleted" });
+}

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -70,6 +70,8 @@ let restoredWindowState: WindowState | null = null;
 let lastNormalBounds: WindowBounds | null = null;
 let windowStateTimer: ReturnType<typeof setTimeout> | null = null;
 let windowStateWrite: Promise<void> = Promise.resolve();
+let windowStateReset: Promise<void> = Promise.resolve();
+let windowStateResetDepth = 0;
 let downloadPowerBlockerId: number | null = null;
 
 export function updateLongRunningTaskFeedback(
@@ -152,6 +154,10 @@ async function persistWindowState(win: BrowserWindow): Promise<void> {
 }
 
 function scheduleWindowStateSave(win: BrowserWindow): void {
+  // Leaving fullscreen/maximized and applying the default bounds emits several
+  // intermediate events. Persisting one of those after the explicit reset
+  // write can resurrect the old placement.
+  if (windowStateResetDepth > 0) return;
   if (windowStateTimer) clearTimeout(windowStateTimer);
   windowStateTimer = setTimeout(() => {
     windowStateTimer = null;
@@ -162,6 +168,7 @@ function scheduleWindowStateSave(win: BrowserWindow): void {
 }
 
 export async function flushWindowState(): Promise<void> {
+  await windowStateReset;
   if (windowStateTimer) {
     clearTimeout(windowStateTimer);
     windowStateTimer = null;
@@ -172,54 +179,65 @@ export async function flushWindowState(): Promise<void> {
   await windowStateWrite;
 }
 
-export async function resetWindowState(win = mainWindow): Promise<void> {
-  if (windowStateTimer) {
-    clearTimeout(windowStateTimer);
-    windowStateTimer = null;
-  }
-  const reset = defaultWindowState(primaryWorkArea());
-  restoredWindowState = reset;
-  lastNormalBounds = reset.bounds;
-  if (win && !win.isDestroyed()) {
-    if (win.isFullScreen()) {
-      await new Promise<void>((resolve, reject) => {
-        const completed = () => {
-          clearTimeout(timeout);
-          resolve();
-        };
-        const timeout = setTimeout(() => {
-          win.removeListener("leave-full-screen", completed);
-          reject(new Error("window did not leave full screen"));
-        }, 5_000);
-        win.once("leave-full-screen", completed);
-        win.setFullScreen(false);
+export function resetWindowState(win = mainWindow): Promise<void> {
+  const reset = windowStateReset.then(async () => {
+    windowStateResetDepth += 1;
+    try {
+      if (windowStateTimer) {
+        clearTimeout(windowStateTimer);
+        windowStateTimer = null;
+      }
+      const requested = defaultWindowState(primaryWorkArea());
+      let settled = requested;
+      if (win && !win.isDestroyed()) {
+        if (win.isFullScreen()) {
+          await new Promise<void>((resolve, reject) => {
+            const completed = () => {
+              clearTimeout(timeout);
+              resolve();
+            };
+            const timeout = setTimeout(() => {
+              win.removeListener("leave-full-screen", completed);
+              reject(new Error("window did not leave full screen"));
+            }, 5_000);
+            win.once("leave-full-screen", completed);
+            win.setFullScreen(false);
+          });
+        }
+        if (win.isMaximized()) {
+          await new Promise<void>((resolve, reject) => {
+            const completed = () => {
+              clearTimeout(timeout);
+              resolve();
+            };
+            const timeout = setTimeout(() => {
+              win.removeListener("unmaximize", completed);
+              reject(new Error("window did not leave maximized mode"));
+            }, 5_000);
+            win.once("unmaximize", completed);
+            win.unmaximize();
+          });
+        }
+        win.setBounds(requested.bounds);
+        settled = { bounds: { ...win.getBounds() }, mode: "normal" };
+      }
+      restoredWindowState = settled;
+      lastNormalBounds = settled.bounds;
+      const write = windowStateWrite.then(() =>
+        saveWindowState(gamePaths().windowState, settled),
+      );
+      windowStateWrite = write.catch(() => undefined);
+      await write;
+      logEvent({ k: "window.stateReset",
+        width: settled.bounds.width,
+        height: settled.bounds.height,
       });
+    } finally {
+      windowStateResetDepth -= 1;
     }
-    if (win.isMaximized()) {
-      await new Promise<void>((resolve, reject) => {
-        const completed = () => {
-          clearTimeout(timeout);
-          resolve();
-        };
-        const timeout = setTimeout(() => {
-          win.removeListener("unmaximize", completed);
-          reject(new Error("window did not leave maximized mode"));
-        }, 5_000);
-        win.once("unmaximize", completed);
-        win.unmaximize();
-      });
-    }
-    win.setBounds(reset.bounds);
-  }
-  const write = windowStateWrite.then(() =>
-    saveWindowState(gamePaths().windowState, reset),
-  );
-  windowStateWrite = write.catch(() => undefined);
-  await write;
-  logEvent({ k: "window.stateReset",
-    width: reset.bounds.width,
-    height: reset.bounds.height,
   });
+  windowStateReset = reset.catch(() => undefined);
+  return reset;
 }
 
 export function getMainWindow(): BrowserWindow | null {
@@ -290,13 +308,18 @@ export function createMainWindow(host: WindowHost): BrowserWindow {
   });
 
   const rememberNormalBounds = (): void => {
-    if (win.isFullScreen() || win.isMaximized()) return;
+    if (
+      windowStateResetDepth > 0 ||
+      win.isFullScreen() ||
+      win.isMaximized()
+    ) return;
     lastNormalBounds = { ...win.getBounds() };
     scheduleWindowStateSave(win);
   };
   win.on("move", rememberNormalBounds);
   win.on("resize", rememberNormalBounds);
   const persistMode = (): void => {
+    if (windowStateResetDepth > 0) return;
     void persistWindowState(win).catch(() => {
       logEvent({ k: "window.stateSaveFailed" });
     });

--- a/tests/electron/launcher.spec.ts
+++ b/tests/electron/launcher.spec.ts
@@ -1,6 +1,5 @@
 import { expect, test } from "@playwright/test";
 import { existsSync } from "node:fs";
-import { writeFile } from "node:fs/promises";
 import path from "node:path";
 import {
   closeOffline,
@@ -23,6 +22,14 @@ declare global {
   var __clientRetryRestart: {
     quit: number;
     relaunch: number;
+    originalQuit: Electron.App["quit"];
+    originalRelaunch: Electron.App["relaunch"];
+  };
+  var __gameStorageReset: {
+    accept: boolean;
+    quit: number;
+    relaunch: number;
+    originalDialog: Electron.Dialog["showMessageBox"];
     originalQuit: Electron.App["quit"];
     originalRelaunch: Electron.App["relaunch"];
   };
@@ -319,9 +326,10 @@ test.describe("launcher recovery", () => {
     }
   });
 
-  test("clears saved files before the replacement renderer can mount IDBFS", async () => {
+  test("confirms, persists, and applies a saved-files reset before replacement startup", async () => {
     let fixture = await launchOffline("gw-filesystem-reset-e2e-");
     const { userData } = fixture;
+    const marker = path.join(userData, "clear-game-storage-on-start");
     try {
       await fixture.page.evaluate(
         () =>
@@ -340,11 +348,63 @@ test.describe("launcher recovery", () => {
             };
           }),
       );
+
+      await fixture.app.evaluate(({ app: electronApp, dialog }) => {
+        globalThis.__gameStorageReset = {
+          accept: false,
+          quit: 0,
+          relaunch: 0,
+          originalDialog: dialog.showMessageBox,
+          originalQuit: electronApp.quit,
+          originalRelaunch: electronApp.relaunch,
+        };
+        dialog.showMessageBox = async () => ({
+          response: globalThis.__gameStorageReset.accept ? 0 : 1,
+          checkboxChecked: false,
+        });
+        electronApp.relaunch = () => {
+          globalThis.__gameStorageReset.relaunch += 1;
+        };
+        electronApp.quit = () => {
+          globalThis.__gameStorageReset.quit += 1;
+        };
+      });
+
+      expect(
+        await fixture.page.evaluate(() =>
+          window.gwNative.gameStorage.resetAndRestart(),
+        ),
+      ).toBe(false);
+      expect(existsSync(marker)).toBe(false);
+      expect(
+        await fixture.app.evaluate(() => ({
+          quit: globalThis.__gameStorageReset.quit,
+          relaunch: globalThis.__gameStorageReset.relaunch,
+        })),
+      ).toEqual({ quit: 0, relaunch: 0 });
+
+      await fixture.app.evaluate(() => {
+        globalThis.__gameStorageReset.accept = true;
+      });
+      expect(
+        await fixture.page.evaluate(() =>
+          window.gwNative.gameStorage.resetAndRestart(),
+        ),
+      ).toBe(true);
+      expect(existsSync(marker)).toBe(true);
+      expect(
+        await fixture.app.evaluate(() => ({
+          quit: globalThis.__gameStorageReset.quit,
+          relaunch: globalThis.__gameStorageReset.relaunch,
+        })),
+      ).toEqual({ quit: 1, relaunch: 1 });
+
+      await fixture.app.evaluate(({ app: electronApp, dialog }) => {
+        dialog.showMessageBox = globalThis.__gameStorageReset.originalDialog;
+        electronApp.quit = globalThis.__gameStorageReset.originalQuit;
+        electronApp.relaunch = globalThis.__gameStorageReset.originalRelaunch;
+      });
       await fixture.app.close();
-      await writeFile(
-        path.join(userData, "clear-game-storage-on-start"),
-        "",
-      );
 
       fixture = await launchOfflineAt(userData);
       expect(
@@ -355,7 +415,7 @@ test.describe("launcher recovery", () => {
         ),
       ).toBe(false);
       expect(
-        existsSync(path.join(userData, "clear-game-storage-on-start")),
+        existsSync(marker),
       ).toBe(false);
     } finally {
       await closeOffline(fixture);

--- a/tests/electron/launcher.spec.ts
+++ b/tests/electron/launcher.spec.ts
@@ -19,17 +19,17 @@ declare global {
   // in the renderer. They exist only while it runs.
   var __failLauncherDownloadTest: ((result: DownloadOutcome) => void) | undefined;
   var __fullGameVerificationCalls: number | undefined;
-  var __clientRetryRestart: {
-    quit: number;
-    relaunch: number;
-    originalQuit: Electron.App["quit"];
-    originalRelaunch: Electron.App["relaunch"];
-  };
   var __gameStorageReset: {
     accept: boolean;
     quit: number;
     relaunch: number;
     originalDialog: Electron.Dialog["showMessageBox"];
+    originalQuit: Electron.App["quit"];
+    originalRelaunch: Electron.App["relaunch"];
+  };
+  var __clientRetryRestart: {
+    quit: number;
+    relaunch: number;
     originalQuit: Electron.App["quit"];
     originalRelaunch: Electron.App["relaunch"];
   };

--- a/tests/electron/settings-test-fixture.mts
+++ b/tests/electron/settings-test-fixture.mts
@@ -12,6 +12,7 @@ declare global {
     quit: boolean;
     relaunch: boolean;
     options: Electron.MessageBoxOptions | null;
+    messages?: Electron.MessageBoxOptions[];
     originalQuit: Electron.App["quit"];
     originalRelaunch: Electron.App["relaunch"];
   };

--- a/tests/electron/settings-tools-updates.spec.ts
+++ b/tests/electron/settings-tools-updates.spec.ts
@@ -223,7 +223,7 @@ test.describe("tools and update settings", () => {
     }
   });
 
-  test("the first Tools enable can be declined, then saves and restarts atomically", async () => {
+  test("the first Tools enable can be declined and a saved enable survives relaunch refusal", async () => {
     const fixture = await launchOffline("gw-tools-enable-restart-e2e-");
     try {
       const { app, page } = fixture;
@@ -281,6 +281,7 @@ test.describe("tools and update settings", () => {
         dialog.showMessageBox = record as typeof dialog.showMessageBox;
         electronApp.relaunch = () => {
           globalThis.__resetRestart.relaunch = true;
+          throw new Error("injected relaunch refusal");
         };
         electronApp.quit = () => {
           globalThis.__resetRestart.quit = true;
@@ -295,7 +296,7 @@ test.describe("tools and update settings", () => {
         if (!options) throw new Error("no message box was shown");
         return { quit, relaunch, buttons: options.buttons };
       })).toEqual({
-        quit: true,
+        quit: false,
         relaunch: true,
         buttons: ["Enable and Restart", "Cancel"],
       });

--- a/tests/electron/settings-tools-updates.spec.ts
+++ b/tests/electron/settings-tools-updates.spec.ts
@@ -268,6 +268,7 @@ test.describe("tools and update settings", () => {
           quit: false,
           relaunch: false,
           options: null,
+          messages: [],
           originalQuit: electronApp.quit,
           originalRelaunch: electronApp.relaunch,
         };
@@ -276,6 +277,7 @@ test.describe("tools and update settings", () => {
           options: Electron.MessageBoxOptions,
         ): Promise<Electron.MessageBoxReturnValue> => {
           globalThis.__resetRestart.options = options;
+          globalThis.__resetRestart.messages?.push(options);
           return { response: 0, checkboxChecked: false };
         };
         dialog.showMessageBox = record as typeof dialog.showMessageBox;
@@ -291,14 +293,31 @@ test.describe("tools and update settings", () => {
       await page.locator('input[name="gwonmacTools"]').click();
       await expect.poll(() => page.evaluate(async () =>
         (await window.gwNative.settings.get()).gwonmacTools)).toBe(true);
+      await expect.poll(() => app.evaluate(() =>
+        globalThis.__resetRestart.messages?.length ?? 0)).toBe(2);
       expect(await app.evaluate(() => {
-        const { quit, relaunch, options } = globalThis.__resetRestart;
-        if (!options) throw new Error("no message box was shown");
-        return { quit, relaunch, buttons: options.buttons };
+        const { quit, relaunch, messages } = globalThis.__resetRestart;
+        const [confirmation, warning] = messages ?? [];
+        if (!confirmation || !warning) throw new Error("both restart dialogs were not shown");
+        return {
+          quit,
+          relaunch,
+          confirmation: confirmation.buttons,
+          warning: {
+            buttons: warning.buttons,
+            detail: warning.detail,
+            message: warning.message,
+          },
+        };
       })).toEqual({
         quit: false,
         relaunch: true,
-        buttons: ["Enable and Restart", "Cancel"],
+        confirmation: ["Enable and Restart", "Cancel"],
+        warning: {
+          buttons: ["OK"],
+          detail: "Your change is saved. Quit and reopen GWonMac to apply it.",
+          message: "Restart did not start",
+        },
       });
       await app.evaluate(({ app: electronApp }) => {
         electronApp.quit = globalThis.__resetRestart.originalQuit;

--- a/tests/policy/source-wasm-host.test.ts
+++ b/tests/policy/source-wasm-host.test.ts
@@ -389,32 +389,6 @@ test("the WASM section codec has exactly one home", async () => {
   }
 });
 
-test("saved-file recovery defers IndexedDB deletion until before renderer startup", async () => {
-  const ipc = await readFile(path.join(root, "src/main/ipc.ts"), "utf8");
-  const main = await readFile(path.join(root, "src/main/main.ts"), "utf8");
-  // The handlers live in a registry keyed by channel name.
-  const resetHandler = ipc.slice(
-    ipc.indexOf("gameStorageReset: channel("),
-    ipc.indexOf("diagnosticsGraphics: channel("),
-  );
-  assert.ok(resetHandler.length > 0, "the gameStorageReset handler was not found");
-
-  assert.match(resetHandler, /resetGameInput\(win\)/);
-  assert.match(resetHandler, /paths\.gameStorageClearRequest/);
-  assert.doesNotMatch(resetHandler, /clearStorageData/);
-  assert.doesNotMatch(resetHandler, /credentials|cacheClearRequest|recursive/);
-  assert.match(
-    main,
-    /applyPendingGameStorageClear[\s\S]*origin:\s*"gw:\/\/app"[\s\S]*storages:\s*\["indexdb"\]/,
-  );
-  const firstWindow = main.indexOf("createMainWindow(buildWindowHost(");
-  assert.notEqual(firstWindow, -1, "no window is created from a window host");
-  assert.ok(
-    main.indexOf("await applyPendingGameStorageClear()") < firstWindow,
-    "the pending IndexedDB clear must run before the first window exists",
-  );
-});
-
 test("the served module decides whether Enhancement imports", async () => {
   const harness = await readFile(
     path.join(root, "src/renderer/harness.ts"),

--- a/tests/unit/diagnostic-schema.test.ts
+++ b/tests/unit/diagnostic-schema.test.ts
@@ -86,6 +86,17 @@ describe("diagnosticEventRecord", () => {
     assert.deepEqual(quit.fields, { phase: "quit", code: "unknown" });
   });
 
+  it("names the durable action whose relaunch was refused", () => {
+    assert.deepEqual(
+      diagnosticEventRecord({
+        k: "app.relaunchFailed",
+        action: "gameStorageReset",
+        code: "unknown",
+      }).fields,
+      { action: "gameStorageReset", code: "unknown" },
+    );
+  });
+
   it("keeps the socket event name closed and the payload declared", () => {
     // `socket.${event.type}` was a templated name whose error branch carried
     // libuv's message; both parts are now fields of a fixed name.

--- a/tests/unit/quit-cleanup-cannot-outlast-the-quit.test.ts
+++ b/tests/unit/quit-cleanup-cannot-outlast-the-quit.test.ts
@@ -17,7 +17,12 @@ import { register } from "node:module";
 import test, { mock } from "node:test";
 
 const recorded: string[] = [];
-(globalThis as { __quitEvents?: string[] }).__quitEvents = recorded;
+const flushes: string[] = [];
+(globalThis as {
+  __quitEvents?: string[];
+  __quitFlushes?: string[];
+}).__quitEvents = recorded;
+(globalThis as { __quitFlushes?: string[] }).__quitFlushes = flushes;
 
 register(
   `data:text/javascript,${encodeURIComponent(
@@ -33,7 +38,7 @@ register(
          return {
            url: "data:text/javascript," + encodeURIComponent(
              "export const logEvent = (e) => { globalThis.__quitEvents.push(e.k); };" +
-             "export const flushDiagnostics = async () => {};",
+             "export const flushDiagnostics = () => new Promise(() => { globalThis.__quitFlushes.push('started'); });",
            ),
            format: "module",
            shortCircuit: true,
@@ -47,7 +52,7 @@ register(
 const { onAppQuit, runQuitCleanup, QUIT_CLEANUP_DEADLINE_MS, isQuitting } =
   await import("../../src/main/lifecycle.ts");
 
-test("a cleanup task that never settles cannot hold the quit", async () => {
+test("neither a stuck cleanup task nor a stuck final flush can hold the quit", async () => {
   const ran: string[] = [];
   // Registration order is reversed at run time, so this one runs last —
   // the position the renderer filesystem sync actually occupies.
@@ -77,5 +82,10 @@ test("a cleanup task that never settles cannot hold the quit", async () => {
   );
   assert.ok(!recorded.includes("quit.cleanupCompleted"),
     "the crash heuristic reads the completion, so a timeout must not claim one");
+  assert.deepEqual(
+    flushes,
+    ["started"],
+    "the final diagnostic write is attempted without escaping the deadline",
+  );
   assert.equal(isQuitting(), true);
 });

--- a/tests/unit/settings-actions-pending-markers.test.ts
+++ b/tests/unit/settings-actions-pending-markers.test.ts
@@ -1,0 +1,76 @@
+// A missing reset marker is the normal no-op startup path. Any other stat
+// failure means startup cannot know whether a durable destructive request is
+// pending, so it must stay visible instead of being misclassified as absent.
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { register } from "node:module";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { after, test } from "node:test";
+import type { GamePaths } from "../../src/main/paths.js";
+
+register(
+  `data:text/javascript,${encodeURIComponent(
+    `const module = (source) => ({
+       url: "data:text/javascript," + encodeURIComponent(source),
+       format: "module",
+       shortCircuit: true,
+     });
+     export function resolve(specifier, context, next) {
+       if (specifier === "electron") {
+         return module(
+           "export const app = {}; export const dialog = {};" +
+           "export const session = { defaultSession: { clearStorageData: async () => {} } };",
+         );
+       }
+       if (specifier.endsWith("/diagnostics.js")) {
+         return module("export const logEvent = () => {};");
+       }
+       if (specifier.endsWith("/renderer-commands.js")) {
+         return module("export const resetGameInput = async () => {};");
+       }
+       if (specifier.endsWith("/window.js")) {
+         return module("export const resetWindowState = async () => {};");
+       }
+       return next(specifier, context);
+     }`,
+  )}`,
+);
+
+const { applyPendingCacheClear, applyPendingGameStorageReset } =
+  await import("../../src/main/settings-actions.ts");
+
+const root = await mkdtemp(path.join(tmpdir(), "gw-pending-markers-"));
+after(() => rm(root, { recursive: true, force: true }));
+
+function pathsWithMarkers(
+  cacheClearRequest: string,
+  gameStorageClearRequest: string,
+): GamePaths {
+  return {
+    cacheClearRequest,
+    gameStorageClearRequest,
+    chunks: path.join(root, "chunks"),
+    bootChunks: path.join(root, "boot-chunks.json"),
+  } as GamePaths;
+}
+
+test("ENOENT means no destructive startup action is pending", async () => {
+  const paths = pathsWithMarkers(
+    path.join(root, "missing-cache-marker"),
+    path.join(root, "missing-storage-marker"),
+  );
+
+  await applyPendingCacheClear(paths);
+  await applyPendingGameStorageReset(paths);
+});
+
+test("marker inspection failures other than ENOENT remain visible", async () => {
+  const notDirectory = path.join(root, "ordinary-file");
+  await writeFile(notDirectory, "not a directory");
+  const brokenMarkerPath = path.join(notDirectory, "marker");
+  const paths = pathsWithMarkers(brokenMarkerPath, brokenMarkerPath);
+
+  await assert.rejects(applyPendingCacheClear(paths), { code: "ENOTDIR" });
+  await assert.rejects(applyPendingGameStorageReset(paths), { code: "ENOTDIR" });
+});


### PR DESCRIPTION
## Outcome

Completes the six-PR program without adding a service container, startup coordinator, generic registry, or compatibility shim.

- Moves multi-step settings dialogs, durable action markers, reset/recovery decisions, and relaunch-refusal presentation out of the generic IPC registrar.
- IPC retains sender validation, parsing, registration, and direct owner-local forwarding.
- Durable settings changes remain committed when relaunch is refused, with truthful recovery guidance.
- Bounds final diagnostics flush by the existing quit deadline and keeps flush failure best-effort.
- Treats only `ENOENT` as an absent destructive-action marker; real filesystem failures remain visible.
- Closes the window-state reset race.
- Records local completion separately from still-pending signed/live Beta promotion gates.

## Exact local proof

Final head: `daa75864c3732db5e882f7c6846aab51175e0926`

Final tree: `e3dcbb0f29436fbefa5d318f95aeb0cb4f4e9b67`

- `pnpm verify` passed: 987 unit, 161 policy, 71 Tools unit, 40 integration, 21 release, 31 Tools browser, 108 Electron stories plus 1 intentional live-only skip, build/package, packaged smoke, and packaged Enhancement runtime.
- The embedded Tools focus story passed 20/20 repetitions, and the fullscreen/reset story passed 10/10 after binding focus and persistence to their settled owners.
- Website build and served-route smoke passed separately.
- Frozen install passed the supply-chain policy; `pnpm audit --json` reported no non-ignored advisories.
- Every PR delta passes `git diff --check`; the six exact heads have valid linear ancestry.
- Independent architecture, security/KISS, dependency, and test/operations reviews report no unresolved P1/P2 or high-confidence P3.

Required GitHub verification and applicable Website/CodeQL checks must be green on every rewritten PR head before merge. Signed/live Stable/Beta release operations are intentionally not claimed as completed.
