### PR TITLE
chore: prepare 2026.8.6 stable enabler

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "guild-wars",
   "productName": "Guild Wars Reforged",
-  "version": "2026.8.5",
+  "version": "2026.8.6",
   "private": true,
   "packageManager": "pnpm@11.13.1",
   "type": "module",


### PR DESCRIPTION
## What changed

- Advances the release version from `2026.8.5` to `2026.8.6`.
- Makes the merged Stable/Beta selector, patch-survival, and architecture program eligible for the existing versioned-release workflow.

## Why

`v2026.8.5` is already published, so the release workflow correctly refuses another build with that version. `2026.8.6` is the Stable enabler (`S0`): it ships the update-track and persistence contract before any public Beta uses it.

This does not introduce another signing environment or updater. Stable, Beta, and RC continue to use the existing protected `release` environment and existing Apple secrets.

## Player impact

Stable remains the default. Existing release identity, profile, Keychain authority, game data, settings, Builds, Teams, templates, and updater ownership remain unchanged.

## Verification

- `git diff --check`
- 50 focused updater, release selection, manifest, and macOS build-order tests
- The required PR verification must pass before merge.

## Release handoff

After merge, run the existing **Versioned release** workflow from `main` with `dry_run: true`. Approve only the existing `release` environment. Do not configure or run the separate Preview snapshot workflows.
