### PR TITLE
fix: recreate the release marker before replacement signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,6 +256,7 @@ jobs:
           test -d "$app"
           mkdir -p "$(dirname "$replacement")"
           ditto "$app" "$replacement"
+          rm "$replacement/Contents/Resources/distribution-channel.json"
           printf 'newly signed replacement\n' > \
             "$replacement/Contents/Resources/upgrade-proof"
           GW_SIGN_APP_PATH="$replacement" \

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -324,6 +324,10 @@ test("release workflow stages and publishes one tested, attested package version
     releaseBuild.indexOf("name: Prepare signed Keychain replacement fixture")
       < signingMaterialRemovedAt,
   );
+  assert.match(
+    releaseBuild,
+    /ditto "\$app" "\$replacement"[\s\S]*?rm "\$replacement\/Contents\/Resources\/distribution-channel\.json"[\s\S]*?scripts\/sign-distribution-app\.ts/,
+  );
   assert.ok(
     signingMaterialRemovedAt
       < releaseBuild.indexOf("name: Prepare checksum-pinned release assets"),


### PR DESCRIPTION
## Root cause

The release workflow copied the already-signed candidate to create the Keychain replacement fixture. That copy already contained the canonical `distribution-channel.json` marker. The fail-closed signer uses exclusive creation for that marker and correctly refused to overwrite it with `EEXIST`.

## Fix

- Remove the marker only from the copied replacement fixture before invoking the signer.
- Keep exclusive marker creation unchanged for every signing caller.
- Pin the copy → marker removal → signing order in the existing release-policy test.

No application runtime behavior, Apple environment, secret, package identity, or release publication condition changes.

## Verification

- `tests/policy/source-release-pipeline.test.ts`: 17/17 passed
- scoped ESLint passed
- `git diff --check` passed
- The failed dry run had already passed app/DMG signing, notarization, stapling, and distribution verification before reaching this fixture step.
