### PR TITLE
fix: keep release smoke independent of signing secrets

### DIFF
--- a/forge.config.ts
+++ b/forge.config.ts
@@ -5,6 +5,7 @@ import { flipFuses, FuseV1Options, FuseVersion } from "@electron/fuses";
 import { readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { macOSBundleVersions } from "./scripts/macos-version.js";
+import { ignorePackageFile } from "./scripts/package-ignore.js";
 import { resolvePackageMode } from "./scripts/package-mode.js";
 import {
   distributionEntitlementsPath,
@@ -85,30 +86,7 @@ const config: ForgeConfig = {
       NSAppTransportSecurity: { NSAllowsArbitraryLoads: false },
     },
     // Forge's own packaged output is out/; compiled JS lives in build/.
-    ignore: (file) => {
-      if (!file || file === "/") return false;
-      const p = file.startsWith("/") ? file : `/${file}`;
-      if (p === "/package.json") return false;
-      if (p === "/build" || p === "/build/main" || p === "/build/shared")
-        return false;
-      if (p.startsWith("/build/main/") || p.startsWith("/build/shared/")) {
-        return (
-          p.endsWith(".map") || p.endsWith(".d.ts") || p.endsWith(".d.ts.map")
-        );
-      }
-      if (p === "/build/renderer") return false;
-      if (p.startsWith("/build/renderer/")) return p.endsWith(".d.ts");
-      if (p === "/build/preload" || p === "/build/preload/preload.cjs")
-        return false;
-      if (
-        p === "/build/native"
-        || p === "/build/native/keychain.node"
-        || p === "/build/native/gw-dat-decode"
-      ) {
-        return false;
-      }
-      return true;
-    },
+    ignore: ignorePackageFile,
   },
   rebuildConfig: {},
   makers: [

--- a/scripts/package-ignore.ts
+++ b/scripts/package-ignore.ts
@@ -1,0 +1,23 @@
+/** The one copy filter used by Forge and the packaged-app inventory proof. */
+export function ignorePackageFile(file: string): boolean {
+  if (!file || file === "/") return false;
+  const p = file.startsWith("/") ? file : `/${file}`;
+  if (p === "/package.json") return false;
+  if (p === "/build" || p === "/build/main" || p === "/build/shared") {
+    return false;
+  }
+  if (p.startsWith("/build/main/") || p.startsWith("/build/shared/")) {
+    return p.endsWith(".map") || p.endsWith(".d.ts") || p.endsWith(".d.ts.map");
+  }
+  if (p === "/build/renderer") return false;
+  if (p.startsWith("/build/renderer/")) return p.endsWith(".d.ts");
+  if (p === "/build/preload" || p === "/build/preload/preload.cjs") return false;
+  if (
+    p === "/build/native"
+    || p === "/build/native/keychain.node"
+    || p === "/build/native/gw-dat-decode"
+  ) {
+    return false;
+  }
+  return true;
+}

--- a/tests/helpers/package-inventory.ts
+++ b/tests/helpers/package-inventory.ts
@@ -6,10 +6,6 @@ import ts from "typescript";
 /** Archive-rooted paths: the leading "/" is the packaged app's root. */
 type PackageInventory = ReadonlySet<string>;
 
-// Derived from Forge's own option rather than restated, because the callers
-// hand this straight through from `forgeConfig.packagerConfig?.ignore` and the
-// guard below is what turns the wider option into the copy filter this walk
-// needs.
 type PackagerIgnore = NonNullable<ForgeConfig["packagerConfig"]>["ignore"];
 
 export const PRELOAD_ENTRY = "/build/preload/preload.cjs";

--- a/tests/packaged-smoke.ts
+++ b/tests/packaged-smoke.ts
@@ -8,8 +8,8 @@ import path from "node:path";
 import { promisify } from "node:util";
 import { FuseState, FuseV1Options, getCurrentFuseWire } from "@electron/fuses";
 import { extractFile, listPackage, statFile } from "@electron/asar";
-import forgeConfig from "../forge.config.ts";
 import { macOSBundleVersions } from "../scripts/macos-version.js";
+import { ignorePackageFile } from "../scripts/package-ignore.ts";
 import {
   assertNoDeveloperPackageFiles,
   assertRequiredPackageFiles,
@@ -65,8 +65,7 @@ const actualPackageFiles = new Set(
     (file) => !("files" in statFile(asarPath, file.slice(1))),
   ),
 );
-const ignore = forgeConfig.packagerConfig?.ignore;
-const expectedPackageFiles = new Set(forgePackageFiles(root, ignore));
+const expectedPackageFiles = new Set(forgePackageFiles(root, ignorePackageFile));
 assert.deepEqual(
   [...actualPackageFiles].sort(),
   [...expectedPackageFiles].sort(),

--- a/tests/policy/source-native-keychain.test.ts
+++ b/tests/policy/source-native-keychain.test.ts
@@ -88,6 +88,7 @@ test("the canonical build emits one host-only Node-API 8 addon", () => {
 // glob, so adding a third is an edit here as well as there.
 test("Forge unpacks only the two executables from ASAR", () => {
   const forge = read("forge.config.ts");
+  const packageIgnore = read("scripts/package-ignore.ts");
   assert.match(
     forge,
     /asar: \{ unpack: "\*\*\/build\/native\/\{keychain\.node,gw-dat-decode\}" \}/u,
@@ -97,7 +98,7 @@ test("Forge unpacks only the two executables from ASAR", () => {
     /p === "\/build\/native\/keychain\.node"/u,
     /p === "\/build\/native\/gw-dat-decode"/u,
   ]) {
-    assert.match(forge, kept);
+    assert.match(packageIgnore, kept);
   }
   assert.doesNotMatch(forge, /unpackDir|asarUnpack/u);
 });

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -268,6 +268,11 @@ test("release workflow stages and publishes one tested, attested package version
     workflow,
     /name: Smoke-test signed release candidate[\s\S]*?GW_PACKAGE_INTENT: release[\s\S]*?run: pnpm test:packaged/,
   );
+  assert.doesNotMatch(
+    read("tests/packaged-smoke.ts"),
+    /forge\.config/,
+    "post-signing smoke must not reload credential-bearing packaging config",
+  );
   assert.match(
     workflow,
     /name: Prove signed Data Protection Keychain continuity without signing secrets[\s\S]*?GW_SIGNED_APP_PATH: \$\{\{ steps\.assets\.outputs\.app \}\}[\s\S]*?GW_SIGNED_REPLACEMENT_APP_PATH: \$\{\{ steps\.runtime-fixture\.outputs\.replacement \}\}[\s\S]*?run: pnpm test:signed-keychain/,


### PR DESCRIPTION
## Outcome

- moves the package copy filter into one pure owner shared by Forge and the packaged-app inventory proof
- prevents the post-signing smoke test from reloading credential-bearing Forge configuration
- preserves the release invariant that signing material is removed before packaged runtime tests

## Verification

- `pnpm exec eslint forge.config.ts scripts/package-ignore.ts tests/packaged-smoke.ts tests/helpers/package-inventory.ts tests/policy/source-release-pipeline.test.ts`
- `pnpm exec tsc --noEmit -p tsconfig.tests.json`
- `node --import ./scripts/ts-hook.mjs --test tests/policy/source-release-pipeline.test.ts` (17/17)
- `git diff --check`

This fixes the failure exposed by non-publishing release dry run 31475542247. No Apple environment or release publication behavior changes.