### PR TITLE
feat(accounts): add production-ready multiple accounts

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,38 @@
+# Guild Wars Reforged Interface
+
+The interface has one visual contract: Guild Wars supplies atmosphere and
+macOS supplies interaction.
+
+## Visual system
+
+- Use the reviewed static Reforged landscape as environmental key art. Do not
+  load the launcher video in utility windows.
+- Use the existing Reforged logo as the only ornamental brand element.
+- Use the macOS system font for application controls, labels, forms, and status.
+- Use one ember tint (`#b84618`) for selection and primary action. Reserve red
+  for destructive actions and green for an already-open account.
+- Prefer native hierarchy: system-sized controls, semantic checkboxes, sheets,
+  menus, concise labels, and visible keyboard focus.
+- Use translucent material only where it improves separation from key art.
+  Reduced-transparency mode replaces it with an opaque warm-dark surface.
+- Keep motion short and functional. Reduced-motion mode removes nonessential
+  transitions and animation.
+
+## Multiple Accounts Hub
+
+The Hub uses a 960×700 hidden-inset window with a 640×560 minimum. Its chooser
+is content-sized and anchored at bottom-right; compact widths turn it into a
+bottom sheet. Account rows scroll within the chooser, so many accounts do not
+move the primary action off-screen.
+
+The launch surface answers one question: which accounts should open? Account
+administration uses progressive disclosure:
+
+1. The chooser shows selection, launch state, Retry, and the primary action.
+2. A row's More menu exposes Edit Account and Archive Account.
+3. Modal sheets handle creation and editing.
+4. Hub Settings handles archived accounts, permanent deletion, and account-mode
+   switching.
+
+Player text says **account**. Internal code may retain **profile** for stable
+IDs, paths, partitions, and existing domain types.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -25,6 +25,10 @@ is content-sized and anchored at bottom-right; compact widths turn it into a
 bottom sheet. Account rows scroll within the chooser, so many accounts do not
 move the primary action off-screen.
 
+Game Settings only enables or leaves Multiple Accounts mode. The Hub is the
+single account-management surface, including the empty **Create First Account**
+flow and its optional one-time copy from Single Account data.
+
 The launch surface answers one question: which accounts should open? Account
 administration uses progressive disclosure:
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -23,6 +23,10 @@ wants the official game without Windows, Wine, or a browser tab.
 Some returning players also want a small set of familiar tools. They do not
 need a plugin platform.
 
+Some players use more than one Guild Wars account. They can explicitly enable
+**Multiple Accounts** mode to open independently controlled accounts in
+separate windows. The normal Single Account mode stays the default.
+
 ## Product promise
 
 - Keep the official game playable after an unknown ArenaNet update.
@@ -31,6 +35,8 @@ need a plugin platform.
 - Keep host-owned Builds and Teams available without live Tools.
 - Give players clear Stable and Beta application-update behavior.
 - Keep local data and diagnostics under the player's control.
+- Keep Single Account data unchanged when a player enters or leaves Multiple
+  Accounts mode.
 - Keep the project understandable for one new contributor.
 
 ## Tools
@@ -67,7 +73,9 @@ See [Release verification](docs/release-verification.md).
 - No Windows or Linux version.
 - No redistribution of ArenaNet game binaries.
 - No autonomous gameplay.
-- No bots, macros, multiboxing support, or trading tools.
+- No bots, macros, input broadcasting, synchronized control, or trading tools.
+- No cloned application installations or duplicated ArenaNet game downloads
+  for Multiple Accounts mode.
 - No generic memory, packet, command, or plugin API.
 - No port of the Windows plugin ABI.
 - No gwonmac telemetry from the Mac app.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,7 @@ its rules.
 | --- | --- |
 | How does a player use or recover the app? | [User guide](user-guide.md) |
 | Which process owns this work? | [Process model](process-model.md) |
+| How do Single and Multiple Accounts mode isolate player data? | [Multiple Accounts](multiple-accounts.md) |
 | How do ArenaNet client files and game data update? | [Content pipeline](content-pipeline.md) |
 | How does the official client host and certification work? | [WASM host](wasm-host.md) |
 | What can diagnostics record and export? | [Diagnostics](diagnostics.md) |

--- a/docs/multiple-accounts.md
+++ b/docs/multiple-accounts.md
@@ -1,0 +1,113 @@
+# Multiple Accounts
+
+This document owns the player-data boundary between Single Account mode and
+Multiple Accounts mode.
+
+## Product boundary
+
+Single Account mode is the default. It starts Guild Wars directly and keeps
+the existing saved login, Guild Wars files, builds, settings, and window state.
+
+Multiple Accounts mode is an explicit opt-in workspace. It starts at the
+Account Picker. The player can open one or more independently controlled Guild
+Wars accounts. The app does not broadcast input or automate gameplay.
+
+The active mode is fixed for the lifetime of the app process. A mode change
+takes effect after a restart.
+
+## Canonical data owners
+
+| Data | Owner |
+| --- | --- |
+| Verified client, chunks, compatibility artifacts, and skill assets | Shared app infrastructure |
+| Application updater and update preferences | Shared app infrastructure |
+| Active account mode | Launcher-mode document |
+| Single saved login | Existing fixed Keychain items |
+| Single Guild Wars files and templates | Default Electron session |
+| Single builds and teams | Existing root build library |
+| Single window state | Existing root window state |
+| Multiple Accounts profile registry | Multiple Accounts workspace |
+| Profile saved login | Profile-scoped Keychain items |
+| Profile Guild Wars files | Profile persistent Electron session |
+| Profile window state | Profile window-state document |
+| Shared Multiple Accounts templates | Multiple Accounts shared template library |
+| Private Multiple Accounts templates | Profile template library |
+| Shared Multiple Accounts builds | Multiple Accounts shared build library |
+| Private Multiple Accounts builds | Profile build library |
+| Running, queued, failed, and crashed status | Live window registry |
+
+Single Account mode is not a Multiple Accounts profile. No Multiple Accounts
+game window uses the default Electron session or the fixed Single Account
+Keychain items.
+
+## Setup and mode transitions
+
+Settings shows **Set Up Multiple Accounts…** only in the Advanced pane until
+the player enables the mode.
+
+Setup creates a staged Multiple Accounts workspace and at least one profile.
+The player signs in separately for every profile. Setup can copy templates,
+builds, and teams from Single Account mode. This import reads a stable snapshot
+and writes a new Multiple Accounts destination. It never moves, links, mirrors,
+or later synchronizes the Single Account source.
+
+The app publishes the workspace before it publishes the selected mode. A
+cancelled or failed setup leaves Single Account mode selected. An import failure
+does not change its source or the previous destination revision.
+
+Returning to Single Account mode preserves the complete Multiple Accounts
+workspace. Re-enabling it restores the profiles and libraries. Neither
+transition copies data automatically.
+
+## Multiple Accounts sharing
+
+Sharing applies only among Multiple Accounts profiles. Each profile selects
+**Shared** or **Private** independently for templates and for builds and teams.
+
+Build libraries are main-process documents with revisions. A stale renderer
+cannot replace a newer shared library without an explicit conflict result.
+
+Every profile keeps an isolated IDBFS mount. A profile that uses Shared
+templates receives a working projection of the canonical Multiple Accounts
+template library. The app reconciles that projection before launch and after a
+clean close. It does not mutate another running renderer's filesystem.
+
+Template reconciliation preserves both contents when two different templates
+use the same normalized path. A deletion cannot silently discard a concurrent
+edit. The canonical library and each profile checkpoint use revisions, so a
+projection can be rebuilt.
+
+## Lifecycle and recovery
+
+Every cold Multiple Accounts launch opens the Account Picker with no profile
+selected. One profile ID maps to at most one live game window. A duplicate
+launch request focuses that window.
+
+The app starts selected profiles in a bounded queue. It confirms a new client
+generation with one canary renderer before it starts the remaining profiles.
+One profile failure does not close another profile.
+
+Closing a profile flushes its filesystem and closes only its sockets. Quitting
+the app flushes all live profile filesystems in parallel. After an application
+update or process crash, Multiple Accounts mode returns to the Account Picker.
+It does not reopen profiles automatically.
+
+Archive is the normal profile-removal action. It preserves the profile session,
+private libraries, and Keychain items. Permanent deletion is a separate,
+confirmed action. It never removes a shared library or Single Account data.
+
+Reset actions name their scope. A Single Account saved-files reset clears only
+the default session. A profile reset clears only the selected persistent
+session. Clearing downloaded game data affects the shared app infrastructure
+and does not clear player files or saved login.
+
+## Security and privacy
+
+The window registry derives profile authority from the trusted sender. A
+renderer cannot choose a profile ID, native path, Electron partition, Keychain
+item, or socket owner.
+
+The Account Picker cannot access game sockets, saved login, player files, or
+build writes. Diagnostics use ephemeral window identifiers. They do not record
+profile names, stable profile IDs, account identifiers, credentials, template
+contents, or game traffic.

--- a/docs/multiple-accounts.md
+++ b/docs/multiple-accounts.md
@@ -94,6 +94,13 @@ the app flushes all live profile filesystems in parallel. After an application
 update or process crash, Multiple Accounts mode returns to the Account Picker.
 It does not reopen profiles automatically.
 
+If the selected mode or profile registry is missing, corrupt, or from an
+unsupported future format, startup does not guess at its contents. It offers to
+preserve the unreadable document and restart in Single Account mode. This
+recovery quarantines the unreadable document and changes the launcher-mode
+document only; it does not open, copy, or clear either mode's player data or
+Keychain items.
+
 Archive is the normal profile-removal action. It preserves the profile session,
 private libraries, and Keychain items. Permanent deletion is a separate,
 confirmed action. It never removes a shared library or Single Account data.

--- a/docs/multiple-accounts.md
+++ b/docs/multiple-accounts.md
@@ -34,7 +34,7 @@ takes effect after a restart.
 | Private Multiple Accounts templates | Profile template library |
 | Shared Multiple Accounts builds | Multiple Accounts shared build library |
 | Private Multiple Accounts builds | Profile build library |
-| Running, queued, failed, and crashed status | Live window registry |
+| Ready, queued, opening, checking, running, and failed status | Main-process runtime store and live window registry |
 
 Single Account mode is not a Multiple Accounts profile. No Multiple Accounts
 game window uses the default Electron session or the fixed Single Account
@@ -81,13 +81,28 @@ format but never reconcile with another profile.
 
 ## Lifecycle and recovery
 
-Every cold Multiple Accounts launch opens the Account Picker with no profile
-selected. One profile ID maps to at most one live game window. A duplicate
-launch request focuses that window.
+Every cold Multiple Accounts launch opens the Account Picker with no account
+selected. One profile ID maps to at most one live game window. The Hub shows
+only bounded runtime language: **Ready**, **Waiting**, **Starting**, **Checking
+updated client**, **Open**, and **Needs Attention**. It never describes a loaded
+renderer as game-ready.
 
-The app starts selected profiles in a bounded queue. It confirms a new client
-generation with one canary renderer before it starts the remaining profiles.
-One profile failure does not close another profile.
+The app starts selected accounts in a bounded queue and presents every new game
+window inactive. It confirms a new client generation with one canary renderer
+before it starts the remaining accounts. A canary failure stops the unopened
+queue and returns those rows to Ready. An ordinary account failure does not
+close or stop another account.
+
+After complete success, the Hub hides and focuses the first selected account
+once. Selecting an already-open account shows its existing window. If any
+account fails, the Hub stays visible for recovery and successful accounts stay
+open. Brand-new windows cascade by 32 pixels where display space permits;
+saved window positions take precedence after the first launch.
+
+A renderer gets one automatic recovery per deliberate launch. Recovery keeps
+the same profile ownership and does not affect other accounts. A second crash
+becomes a persistent Needs Attention row with Retry. The Hub remains
+recoverable from Dock activation, and Settings is available with Command-,.
 
 Closing a profile flushes its filesystem and closes only its sockets. Quitting
 the app flushes all live profile filesystems in parallel. After an application
@@ -101,9 +116,27 @@ recovery quarantines the unreadable document and changes the launcher-mode
 document only; it does not open, copy, or clear either mode's player data or
 Keychain items.
 
-Archive is the normal profile-removal action. It preserves the profile session,
+Archive is the normal account-removal action. It preserves the profile session,
 private libraries, and Keychain items. Permanent deletion is a separate,
-confirmed action. It never removes a shared library or Single Account data.
+confirmed action in Hub Settings. It never removes a shared library or Single
+Account data.
+
+## Hub interaction
+
+The Hub is a focused chooser, not an account dashboard. Rows use native
+checkbox semantics and the entire non-action area is clickable. The primary
+action reflects the selection: Open, Open _Account_, Show _Account_, Retry
+_Account_, or Open _n_ Accounts. Edit and Archive live in each row's More menu.
+
+New and Edit Account are modal sheets. Player-facing sharing choices are
+**Builds and teams** and **In-game templates**, each either **Shared between
+Multiple Accounts** or **Separate for this account**. Shared is the default.
+The sheet states that login, game settings, screenshots, chat logs, and Single
+Account data are never shared.
+
+Mode switching, archived-account restoration, and permanent deletion live in
+Settings rather than the launch surface. Game Settings → Accounts carries the
+same mode explanation and Return to Single Account action.
 
 Reset actions name their scope. A Single Account saved-files reset clears only
 the default session. A profile reset clears only the selected persistent

--- a/docs/multiple-accounts.md
+++ b/docs/multiple-accounts.md
@@ -42,7 +42,7 @@ Keychain items.
 
 ## Setup and mode transitions
 
-Settings shows **Set Up Multiple Accounts…** only in the Advanced pane until
+Settings shows Multiple Accounts setup only in the Accounts pane until
 the player enables the mode.
 
 Setup creates a staged Multiple Accounts workspace and at least one profile.
@@ -64,18 +64,20 @@ transition copies data automatically.
 Sharing applies only among Multiple Accounts profiles. Each profile selects
 **Shared** or **Private** independently for templates and for builds and teams.
 
-Build libraries are main-process documents with revisions. A stale renderer
-cannot replace a newer shared library without an explicit conflict result.
+Build libraries remain main-process documents. Main serializes writes per
+library and refuses a save whose last-read baseline is stale, so one profile
+cannot silently replace another profile's newer shared library.
 
 Every profile keeps an isolated IDBFS mount. A profile that uses Shared
 templates receives a working projection of the canonical Multiple Accounts
 template library. The app reconciles that projection before launch and after a
-clean close. It does not mutate another running renderer's filesystem.
+clean close or reload. It does not mutate another running renderer's filesystem.
 
 Template reconciliation preserves both contents when two different templates
 use the same normalized path. A deletion cannot silently discard a concurrent
 edit. The canonical library and each profile checkpoint use revisions, so a
-projection can be rebuilt.
+projection can be rebuilt. Private template libraries use the same snapshot
+format but never reconcile with another profile.
 
 ## Lifecycle and recovery
 

--- a/docs/multiple-accounts.md
+++ b/docs/multiple-accounts.md
@@ -42,18 +42,20 @@ Keychain items.
 
 ## Setup and mode transitions
 
-Settings shows Multiple Accounts setup only in the Accounts pane until
-the player enables the mode.
+Settings shows one Multiple Accounts enable action in the Accounts pane until
+the player enables the mode. Settings never creates or edits accounts.
 
-Setup creates a staged Multiple Accounts workspace and at least one profile.
-The player signs in separately for every profile. Setup can copy templates,
+Enabling publishes an empty Multiple Accounts workspace and restarts into the
+Account Picker. Its empty state owns **Create First Account**. The player signs
+in separately for every account. Creating the first account can copy templates,
 builds, and teams from Single Account mode. This import reads a stable snapshot
 and writes a new Multiple Accounts destination. It never moves, links, mirrors,
-or later synchronizes the Single Account source.
+or later synchronizes the Single Account source. Later accounts cannot import
+from Single Account mode.
 
 The app publishes the workspace before it publishes the selected mode. A
-cancelled or failed setup leaves Single Account mode selected. An import failure
-does not change its source or the previous destination revision.
+cancelled or failed enable action leaves Single Account mode selected. A failed
+first-account import does not change its source or publish the account.
 
 Returning to Single Account mode preserves the complete Multiple Accounts
 workspace. Re-enabling it restores the profiles and libraries. Neither
@@ -128,7 +130,8 @@ checkbox semantics and the entire non-action area is clickable. The primary
 action reflects the selection: Open, Open _Account_, Show _Account_, Retry
 _Account_, or Open _n_ Accounts. Edit and Archive live in each row's More menu.
 
-New and Edit Account are modal sheets. Player-facing sharing choices are
+The Account Picker is the only account-management surface. New and Edit Account
+are modal sheets. Player-facing sharing choices are
 **Builds and teams** and **In-game templates**, each either **Shared between
 Multiple Accounts** or **Separate for this account**. Shared is the default.
 The sheet states that login, game settings, screenshots, chat logs, and Single

--- a/docs/process-model.md
+++ b/docs/process-model.md
@@ -14,6 +14,8 @@ those facts.
 ```text
 Electron main process
   application lifecycle
+  active Single or Multiple Accounts mode
+  game-window registry
   ArenaNet client and content updates
   verified client generations and rollback
   native chunk storage
@@ -30,7 +32,7 @@ Sandboxed preload
           | frozen window.gwNative capabilities
           v
 Chromium renderer
-  launcher and settings
+  account picker, launcher, and settings
   Guild Wars Module host
   input and presentation
   required Core features
@@ -46,6 +48,23 @@ routes.
 
 The preload exposes one frozen `window.gwNative` object. It transports
 capabilities. It does not own game rules or persistence rules.
+
+## Account modes
+
+The process captures one account mode at startup. It does not switch storage
+owners while it runs.
+
+Single Account mode uses the existing default Electron session, saved-login
+items, build library, and window state. Multiple Accounts mode does not treat
+Single Account mode as a profile. Each Multiple Accounts profile uses a
+non-default persistent Electron session and profile-scoped native stores.
+
+Both modes use the same verified client generation, chunk store, derived
+client artifacts, and application updater. These stores contain rebuildable
+client infrastructure. They do not contain player account state.
+
+[Multiple Accounts](multiple-accounts.md) owns the complete data and transition
+contract.
 
 ## Client generation ownership
 
@@ -163,10 +182,12 @@ The main process owns these native stores:
 - verified ArenaNet client generations;
 - the content-addressed chunk store;
 - bounded diagnostics files;
-- two saved-login items in Apple's Data Protection Keychain.
+- Single Account and profile-scoped saved-login items in Apple's Data
+  Protection Keychain.
 
-The renderer owns the Guild Wars IDBFS mount under the `gw://app` origin. This
-mount contains game preferences, templates, screenshots, and chat logs.
+Each game renderer owns one Guild Wars IDBFS mount under its isolated
+`gw://app` session. The mount contains game preferences, templates,
+screenshots, and chat logs. Two renderers do not mount the same browser store.
 
 Derived WASM modules and caches are rebuildable. They are never certification
 authority.
@@ -176,9 +197,10 @@ authority.
 The Release, Preview, and signed Development identities use separate Keychain
 authority. Each identity can read only its own provisioned items.
 
-One item stores the ArenaNet user name and password. One item stores the Steam
-access token and expiry. A read failure does not delete an item. The game can
-continue to its login screen when an item is unavailable.
+Each account scope has one item for the ArenaNet user name and password and one
+item for the Steam access token and expiry. The existing fixed items belong
+only to Single Account mode. A read failure does not delete an item. The game
+can continue to its login screen when an item is unavailable.
 
 Unpackaged and ordinary local builds use volatile storage. They do not claim a
 provisioned Keychain item. There is no file or `safeStorage` fallback.
@@ -209,11 +231,13 @@ rollback procedures.
 ## Application lifecycle
 
 The app acquires a single-instance lock before it reads or cleans profile-owned
-files. A second launch focuses the existing window and exits.
+files. In Single Account mode, a second launch focuses the game. In Multiple
+Accounts mode, it opens or focuses the Account Picker.
 
-Closing the game window quits the application. Quit follows one bounded cleanup
-path. It saves the renderer filesystem, closes sockets, stops background work,
-flushes diagnostics, and exits.
+Closing the Single Account game window quits the application. Closing one
+Multiple Accounts game window closes only that profile. Application quit saves
+all live renderer filesystems in parallel, closes sockets, stops background
+work, flushes diagnostics, and exits through one bounded cleanup path.
 
 Main-to-renderer events stop after the window or its `webContents` is destroyed.
 The app attempts renderer recovery only after unexpected renderer loss. It does

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -30,9 +30,11 @@ ArenaNet.
 Single Account mode is the default. It starts Guild Wars directly and keeps
 the login, templates, builds, settings, and window state that you already use.
 
-Open **Settings → Advanced → Set Up Multiple Accounts…** to create a separate
+Open **Settings → Accounts**, name the first profile, choose its Shared or
+Private libraries, and select **Enable and Restart…** to create a separate
 Multiple Accounts workspace. Every later Multiple Accounts start opens the
-Account Picker. Select one or more profiles and choose **Open Accounts**.
+Account Picker with nothing preselected. Select one or more profiles and choose
+**Open selected**.
 
 Each profile signs in separately and keeps separate Guild Wars preferences,
 screenshots, chat logs, saved login, and window position. Profiles can use the
@@ -42,10 +44,17 @@ Setup can copy templates, builds, and teams from Single Account mode. This is a
 one-time copy. The originals remain in Single Account mode. Later changes do
 not synchronize between the two modes.
 
-Use **Settings → Accounts → Return to Single Account Mode** to change the next
-launch. Your Multiple Accounts profiles stay available if you enable the mode
-again. The modes share verified game downloads, so creating a profile does not
-download another complete copy of Guild Wars.
+Use **Return to Single Account mode…** at the bottom of the Account Picker to
+change the next launch. Your Multiple Accounts profiles and saved logins stay
+available if you restore the mode from **Settings → Accounts** later. The modes
+share verified game downloads, so creating a profile does not download another
+complete copy of Guild Wars.
+
+Use **New profile…** in the Account Picker to add profiles. **Edit…** changes a
+profile's name or library choices; close its game window before changing
+sharing. Archive hides a profile but keeps all its data and saved login. The
+Archived profiles section can restore it or permanently delete it after a
+native confirmation.
 
 Every account window is independently controlled. The app does not broadcast
 keyboard, mouse, or controller input between windows.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -25,6 +25,31 @@ the client files, asks how to store game data, and starts Guild Wars. Later
 starts use verified cached data when possible. Login and online play still need
 ArenaNet.
 
+## Single and Multiple Accounts
+
+Single Account mode is the default. It starts Guild Wars directly and keeps
+the login, templates, builds, settings, and window state that you already use.
+
+Open **Settings → Advanced → Set Up Multiple Accounts…** to create a separate
+Multiple Accounts workspace. Every later Multiple Accounts start opens the
+Account Picker. Select one or more profiles and choose **Open Accounts**.
+
+Each profile signs in separately and keeps separate Guild Wars preferences,
+screenshots, chat logs, saved login, and window position. Profiles can use the
+shared Multiple Accounts template and build libraries or private libraries.
+
+Setup can copy templates, builds, and teams from Single Account mode. This is a
+one-time copy. The originals remain in Single Account mode. Later changes do
+not synchronize between the two modes.
+
+Use **Settings → Accounts → Return to Single Account Mode** to change the next
+launch. Your Multiple Accounts profiles stay available if you enable the mode
+again. The modes share verified game downloads, so creating a profile does not
+download another complete copy of Guild Wars.
+
+Every account window is independently controlled. The app does not broadcast
+keyboard, mouse, or controller input between windows.
+
 A local source build has a temporary identity. It does not share saved-login
 access with the published Release app.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -30,13 +30,13 @@ ArenaNet.
 Single Account mode is the default. It starts Guild Wars directly and keeps
 the login, templates, builds, settings, and window state that you already use.
 
-Open **Settings → Accounts**, name the first profile, choose its Shared or
+Open **Settings → Accounts**, name the first account, choose its Shared or
 Private libraries, and select **Enable and Restart…** to create a separate
 Multiple Accounts workspace. Every later Multiple Accounts start opens the
-Account Picker with nothing preselected. Select one or more profiles and choose
-**Open selected**.
+Account Picker with nothing preselected. Select one or more accounts and choose
+**Open**. If an account is already running, the action changes to **Show**.
 
-Each profile signs in separately and keeps separate Guild Wars preferences,
+Each account signs in separately and keeps separate Guild Wars preferences,
 screenshots, chat logs, saved login, and window position. Profiles can use the
 shared Multiple Accounts template and build libraries or private libraries.
 
@@ -44,17 +44,16 @@ Setup can copy templates, builds, and teams from Single Account mode. This is a
 one-time copy. The originals remain in Single Account mode. Later changes do
 not synchronize between the two modes.
 
-Use **Return to Single Account mode…** at the bottom of the Account Picker to
-change the next launch. Your Multiple Accounts profiles and saved logins stay
-available if you restore the mode from **Settings → Accounts** later. The modes
-share verified game downloads, so creating a profile does not download another
+Use Command-, in the Account Picker to open Settings, then choose **Return to
+Single Account…** to change the next launch. Your accounts and saved logins stay
+available if you restore Multiple Accounts from **Settings → Accounts** later. The modes
+share verified game downloads, so creating an account does not download another
 complete copy of Guild Wars.
 
-Use **New profile…** in the Account Picker to add profiles. **Edit…** changes a
-profile's name or library choices; close its game window before changing
-sharing. Archive hides a profile but keeps all its data and saved login. The
-Archived profiles section can restore it or permanently delete it after a
-native confirmation.
+Use **New Account…** in the Account Picker to add accounts. The row's More menu
+contains **Edit Account…** and **Archive Account**; close its game window before
+changing sharing. Archive keeps all account data and saved login. Hub Settings
+can restore it or permanently delete it after a native confirmation.
 
 Every account window is independently controlled. The app does not broadcast
 keyboard, mouse, or controller input between windows.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -30,9 +30,10 @@ ArenaNet.
 Single Account mode is the default. It starts Guild Wars directly and keeps
 the login, templates, builds, settings, and window state that you already use.
 
-Open **Settings → Accounts**, name the first account, choose its Shared or
-Private libraries, and select **Enable and Restart…** to create a separate
-Multiple Accounts workspace. Every later Multiple Accounts start opens the
+Open **Settings → Accounts** and select **Enable and Restart…**. Settings only
+switches the mode; it does not create or manage accounts. GWonMac restarts into
+the Account Picker, where **Create First Account** sets up the first account and
+its Shared or Separate libraries. Every later Multiple Accounts start opens the
 Account Picker with nothing preselected. Select one or more accounts and choose
 **Open**. If an account is already running, the action changes to **Show**.
 
@@ -40,9 +41,10 @@ Each account signs in separately and keeps separate Guild Wars preferences,
 screenshots, chat logs, saved login, and window position. Profiles can use the
 shared Multiple Accounts template and build libraries or private libraries.
 
-Setup can copy templates, builds, and teams from Single Account mode. This is a
-one-time copy. The originals remain in Single Account mode. Later changes do
-not synchronize between the two modes.
+Creating the first account can copy templates, builds, and teams from Single
+Account mode. This is a one-time copy. The originals remain in Single Account
+mode. Later changes do not synchronize between the two modes. All later account
+creation and management also stays in the Account Picker.
 
 Use Command-, in the Account Picker to open Settings, then choose **Return to
 Single Account…** to change the next launch. Your accounts and saved logins stay

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -37,11 +37,6 @@ auditConfig:
     - GHSA-jmr9-qjv8-65gv
     - GHSA-w3rx-r6r6-pgpr
     - GHSA-5p2g-fcmc-qvqq
-    # Electron Forge 7 reaches extract-zip only through Electron Packager's
-    # extraction of the trusted Electron distribution during packaging. The
-    # application never passes user-controlled archives to this dependency,
-    # and no patched extract-zip release currently exists.
-    - GHSA-jmr9-qjv8-65gv
     # The affected esbuild serve-directory path exists only on Windows. Owned
     # automation runs on macOS/Linux, and fontless invokes only transform.
     - GHSA-g7r4-m6w7-qqqr

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,6 +33,11 @@ auditConfig:
   ignoreGhsas:
     - GHSA-w3rx-r6r6-pgpr
     - GHSA-5p2g-fcmc-qvqq
+    # Electron Forge 7 reaches extract-zip only through Electron Packager's
+    # extraction of the trusted Electron distribution during packaging. The
+    # application never passes user-controlled archives to this dependency,
+    # and no patched extract-zip release currently exists.
+    - GHSA-jmr9-qjv8-65gv
     # The affected esbuild serve-directory path exists only on Windows. Owned
     # automation runs on macOS/Linux, and fontless invokes only transform.
     - GHSA-g7r4-m6w7-qqqr

--- a/scripts/copy-renderer.mjs
+++ b/scripts/copy-renderer.mjs
@@ -35,6 +35,9 @@ const ASSETS = [
 const SHARED_ASSETS = [
   ["src/shared/ui/tokens.css", "ui/tokens.css"],
   ["src/shared/ui/components.css", "ui/components.css"],
+  // The website and Hub use one reviewed static painting. Keep it canonical in
+  // the website package and copy it into the renderer at build time.
+  ["apps/website/public/bg-reforged.jpg", "images/bg-reforged.jpg"],
 ];
 
 const dest = path.resolve("build/renderer");

--- a/scripts/copy-renderer.mjs
+++ b/scripts/copy-renderer.mjs
@@ -12,6 +12,8 @@ import path from "node:path";
 // editor and OS files part of the build, so two clean checkouts could package
 // different applications. A new asset must be reviewed here.
 const ASSETS = [
+  "accounts.css",
+  "accounts.html",
   "favicon.ico",
   "favicon.png",
   "fonts/COPYING-QUALITYPE",

--- a/src/main/accounts-ipc-values.ts
+++ b/src/main/accounts-ipc-values.ts
@@ -1,0 +1,87 @@
+/**
+ * Pure validation for the Multiple Accounts IPC surface.
+ * The Electron boundary owns argument counts; this module owns account values.
+ */
+import type {
+  AccountProfileCreateRequest,
+  AccountProfileRequest,
+  AccountProfileUpdateRequest,
+  AccountsSetupRequest,
+} from "../shared/contracts.js";
+import {
+  MULTI_PROFILE_MAX_COUNT,
+  parseProfileId,
+  parseProfileName,
+  type LibraryScope,
+  type ProfileId,
+} from "../shared/multiple-accounts.js";
+import { ValidationError } from "../shared/errors.js";
+import { parseExportEntries } from "./template-export.js";
+
+function parseLibraryScope(value: unknown, field: string): LibraryScope {
+  if (value !== "shared" && value !== "private") {
+    throw new ValidationError(`${field} must be shared or private`);
+  }
+  return value;
+}
+
+export function parseAccountsSetup(value: unknown): AccountsSetupRequest {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new ValidationError("account setup must be an object");
+  }
+  const input = value as Record<string, unknown>;
+  return { templateEntries: parseExportEntries(input.templateEntries) };
+}
+
+function parseAccountProfile(value: unknown): AccountProfileRequest {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new ValidationError("account profile must be an object");
+  }
+  const input = value as Record<string, unknown>;
+  return {
+    name: parseProfileName(input.name),
+    templates: parseLibraryScope(input.templates, "templates"),
+    builds: parseLibraryScope(input.builds, "builds"),
+  };
+}
+
+export function parseAccountProfileCreate(value: unknown): AccountProfileCreateRequest {
+  const profile = parseAccountProfile(value);
+  const input = value as Record<string, unknown>;
+  if (
+    typeof input.copySingleBuilds !== "boolean"
+    || typeof input.copySingleTemplates !== "boolean"
+  ) {
+    throw new ValidationError("account copy choices must be booleans");
+  }
+  return {
+    ...profile,
+    copySingleBuilds: input.copySingleBuilds,
+    copySingleTemplates: input.copySingleTemplates,
+  };
+}
+
+export function parseAccountProfileUpdate(value: unknown): AccountProfileUpdateRequest {
+  const profile = parseAccountProfile(value);
+  return {
+    id: parseProfileId((value as Record<string, unknown>).id),
+    ...profile,
+  };
+}
+
+export function parseProfileIds(value: unknown): readonly ProfileId[] {
+  if (
+    !Array.isArray(value)
+    || value.length === 0
+    || value.length > MULTI_PROFILE_MAX_COUNT
+  ) {
+    throw new ValidationError(
+      `select between 1 and ${MULTI_PROFILE_MAX_COUNT} account profiles`,
+    );
+  }
+  const ids = value.map(parseProfileId);
+  if (new Set(ids).size !== ids.length) {
+    throw new ValidationError("account profile selection contains duplicates");
+  }
+  return ids;
+}

--- a/src/main/accounts-window.ts
+++ b/src/main/accounts-window.ts
@@ -5,7 +5,7 @@
  * IPC refuses it. Closing it does not close running accounts; a later app
  * activation can reveal the same window again.
  */
-import { BrowserWindow, session } from "electron";
+import { app, BrowserWindow, Menu, session } from "electron";
 import type { ProtocolDeps } from "./protocol.js";
 import { installGwProtocolHandlerForSession } from "./protocol.js";
 import { preloadPath } from "./paths.js";
@@ -14,6 +14,34 @@ import { windowRegistry } from "./window-registry.js";
 const HUB_URL = "gw://app/accounts.html";
 let hubWindow: BrowserWindow | null = null;
 let protocolInstalled = false;
+
+function installAccountsMenu(): void {
+  Menu.setApplicationMenu(Menu.buildFromTemplate([
+    ...(process.platform === "darwin"
+      ? [{
+          label: app.name,
+          submenu: [
+            { role: "about" as const },
+            { type: "separator" as const },
+            { role: "hide" as const },
+            { role: "hideOthers" as const },
+            { role: "unhide" as const },
+            { type: "separator" as const },
+            { role: "quit" as const },
+          ],
+        }]
+      : []),
+    {
+      label: "Edit",
+      submenu: [
+        { role: "cut" as const },
+        { role: "copy" as const },
+        { role: "paste" as const },
+        { role: "selectAll" as const },
+      ],
+    },
+  ]));
+}
 
 export function getAccountsWindow(): BrowserWindow | null {
   return hubWindow && !hubWindow.isDestroyed() ? hubWindow : null;
@@ -69,6 +97,8 @@ export function createAccountsWindow(deps: ProtocolDeps): BrowserWindow {
   });
   win.webContents.on("will-attach-webview", (event) => event.preventDefault());
   win.once("ready-to-show", () => win.show());
+  win.on("focus", installAccountsMenu);
+  installAccountsMenu();
   win.on("close", (event) => {
     if (windowRegistry.gameWindows().length > 0) {
       event.preventDefault();

--- a/src/main/accounts-window.ts
+++ b/src/main/accounts-window.ts
@@ -9,6 +9,7 @@ import { app, BrowserWindow, Menu, session } from "electron";
 import type { ProtocolDeps } from "./protocol.js";
 import { installGwProtocolHandlerForSession } from "./protocol.js";
 import { preloadPath } from "./paths.js";
+import { sendRendererCommand } from "./renderer-commands.js";
 import { windowRegistry } from "./window-registry.js";
 
 const HUB_URL = "gw://app/accounts.html";
@@ -22,6 +23,17 @@ function installAccountsMenu(): void {
           label: app.name,
           submenu: [
             { role: "about" as const },
+            { type: "separator" as const },
+            {
+              id: "accounts-settings-menu",
+              label: "Settings…",
+              accelerator: "CommandOrControl+,",
+              click: () => {
+                void sendRendererCommand(getAccountsWindow(), {
+                  type: "accounts.settings.open",
+                });
+              },
+            },
             { type: "separator" as const },
             { role: "hide" as const },
             { role: "hideOthers" as const },
@@ -70,11 +82,13 @@ export function createAccountsWindow(deps: ProtocolDeps): BrowserWindow {
   owner.setPermissionRequestHandler((_contents, _permission, callback) => callback(false));
   owner.setPermissionCheckHandler(() => false);
   const win = new BrowserWindow({
-    width: 700,
-    height: 620,
-    minWidth: 560,
-    minHeight: 480,
+    width: 960,
+    height: 700,
+    minWidth: 640,
+    minHeight: 560,
     title: "Guild Wars Reforged — Accounts",
+    titleBarStyle: "hiddenInset",
+    backgroundColor: "#0a0806",
     show: false,
     webPreferences: {
       session: owner,

--- a/src/main/accounts-window.ts
+++ b/src/main/accounts-window.ts
@@ -1,0 +1,84 @@
+/**
+ * The Multiple Accounts picker window and its non-game security boundary.
+ *
+ * The Hub uses a dedicated session and is registered with role `hub`, so game
+ * IPC refuses it. Closing it does not close running accounts; a later app
+ * activation can reveal the same window again.
+ */
+import { BrowserWindow, session } from "electron";
+import type { ProtocolDeps } from "./protocol.js";
+import { installGwProtocolHandlerForSession } from "./protocol.js";
+import { preloadPath } from "./paths.js";
+import { windowRegistry } from "./window-registry.js";
+
+const HUB_URL = "gw://app/accounts.html";
+let hubWindow: BrowserWindow | null = null;
+let protocolInstalled = false;
+
+export function getAccountsWindow(): BrowserWindow | null {
+  return hubWindow && !hubWindow.isDestroyed() ? hubWindow : null;
+}
+
+export function revealAccountsWindow(): boolean {
+  const win = getAccountsWindow();
+  if (!win) return false;
+  if (win.isMinimized()) win.restore();
+  win.show();
+  win.focus();
+  return true;
+}
+
+export function createAccountsWindow(deps: ProtocolDeps): BrowserWindow {
+  const existing = getAccountsWindow();
+  if (existing) {
+    revealAccountsWindow();
+    return existing;
+  }
+  const owner = session.fromPartition("persist:gw-multi-hub", { cache: false });
+  if (!protocolInstalled) {
+    installGwProtocolHandlerForSession(owner, deps);
+    protocolInstalled = true;
+  }
+  owner.setPermissionRequestHandler((_contents, _permission, callback) => callback(false));
+  owner.setPermissionCheckHandler(() => false);
+  const win = new BrowserWindow({
+    width: 700,
+    height: 620,
+    minWidth: 560,
+    minHeight: 480,
+    title: "Guild Wars Reforged — Accounts",
+    show: false,
+    webPreferences: {
+      session: owner,
+      preload: preloadPath(),
+      nodeIntegration: false,
+      contextIsolation: true,
+      sandbox: true,
+      webSecurity: true,
+      webviewTag: false,
+      spellcheck: false,
+      allowRunningInsecureContent: false,
+      experimentalFeatures: false,
+    },
+  });
+  hubWindow = win;
+  windowRegistry.register(win, { mode: "multi", role: "hub" });
+  win.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+  win.webContents.on("will-navigate", (event, url) => {
+    if (url !== HUB_URL) event.preventDefault();
+  });
+  win.webContents.on("will-attach-webview", (event) => event.preventDefault());
+  win.once("ready-to-show", () => win.show());
+  win.on("close", (event) => {
+    if (windowRegistry.gameWindows().length > 0) {
+      event.preventDefault();
+      win.hide();
+    }
+  });
+  win.on("closed", () => {
+    windowRegistry.unregister(win);
+    if (hubWindow === win) hubWindow = null;
+  });
+  void win.loadURL(HUB_URL);
+  return win;
+}

--- a/src/main/core/account-template-library.ts
+++ b/src/main/core/account-template-library.ts
@@ -1,0 +1,116 @@
+/**
+ * The canonical Multiple Accounts template library and its three-way merge.
+ *
+ * Each shared profile receives a checkpoint at launch. On close, its current
+ * projection is compared with that checkpoint and the latest canonical
+ * library. Unrelated edits combine; a concurrent edit beats a stale deletion;
+ * and two different edits to one path are both retained under stable conflict
+ * names. Single Account data never enters this owner except as an explicit
+ * setup snapshot.
+ */
+import { readFile } from "node:fs/promises";
+import type {
+  AccountTemplateLibrary,
+  TemplateExportEntry,
+} from "../../shared/contracts.js";
+import { AppError } from "../../shared/errors.js";
+import { parseTemplateEntries } from "../../shared/template-entries.js";
+import { writeAtomicJson } from "./atomic-file.js";
+
+const DOCUMENT_MODE = 0o600;
+
+function parseLibrary(value: unknown): AccountTemplateLibrary {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new AppError("bad_multi_workspace", "template library must be an object");
+  }
+  const source = value as Record<string, unknown>;
+  if (
+    source.formatVersion !== 1
+    || !Number.isSafeInteger(source.revision)
+    || (source.revision as number) < 0
+  ) {
+    throw new AppError("bad_multi_workspace", "template library format is invalid");
+  }
+  return {
+    revision: source.revision as number,
+    entries: parseTemplateEntries(source.entries),
+  };
+}
+
+export async function loadAccountTemplateLibrary(
+  filePath: string,
+): Promise<AccountTemplateLibrary> {
+  try {
+    return parseLibrary(JSON.parse(await readFile(filePath, "utf8")) as unknown);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return { revision: 0, entries: [] };
+    }
+    throw error;
+  }
+}
+
+export async function saveAccountTemplateLibrary(
+  filePath: string,
+  library: AccountTemplateLibrary,
+): Promise<AccountTemplateLibrary> {
+  const entries = parseTemplateEntries(library.entries);
+  const value = { formatVersion: 1, revision: library.revision, entries };
+  await writeAtomicJson(filePath, value, DOCUMENT_MODE);
+  return { revision: value.revision, entries: value.entries };
+}
+
+const pathKey = (filePath: string) => filePath.normalize("NFC").toLowerCase();
+const entriesByPath = (entries: readonly TemplateExportEntry[]) =>
+  new Map(entries.map((entry) => [pathKey(entry.path), entry]));
+
+function conflictPath(path: string, occupied: ReadonlySet<string>): string {
+  const suffix = " (conflict)";
+  const extension = path.toLowerCase().endsWith(".txt") ? ".txt" : "";
+  const cut = path.lastIndexOf("/");
+  const directory = path.slice(0, cut + 1);
+  const file = path.slice(cut + 1, extension ? -extension.length : undefined);
+  for (let number = 1; number <= 99; number += 1) {
+    const tag = `${suffix}${number === 1 ? "" : ` ${number}`}`;
+    const maxStem = 259 - extension.length - tag.length;
+    const candidate = `${directory}${file.slice(0, maxStem)}${tag}${extension}`;
+    if (!occupied.has(pathKey(candidate))) return candidate;
+  }
+  throw new AppError("bad_multi_workspace", "too many template conflicts");
+}
+
+/** Merge one profile projection against the checkpoint it was launched with. */
+export function reconcileAccountTemplates(
+  baseEntries: readonly TemplateExportEntry[],
+  latestEntries: readonly TemplateExportEntry[],
+  profileEntries: readonly TemplateExportEntry[],
+): TemplateExportEntry[] {
+  const base = entriesByPath(parseTemplateEntries(baseEntries));
+  const latest = entriesByPath(parseTemplateEntries(latestEntries));
+  const profile = entriesByPath(parseTemplateEntries(profileEntries));
+  const result = new Map(latest);
+  const paths = new Set([...base.keys(), ...profile.keys()]);
+  for (const key of paths) {
+    const before = base.get(key);
+    const local = profile.get(key);
+    const current = latest.get(key);
+    if (local?.contents === before?.contents) continue;
+    if (local === undefined) {
+      if (current?.contents === before?.contents) result.delete(key);
+      continue;
+    }
+    if (
+      current === undefined
+      || current.contents === before?.contents
+      || current.contents === local.contents
+    ) {
+      result.set(key, local);
+      continue;
+    }
+    const occupied = new Set(result.keys());
+    const conflicted = conflictPath(local.path, occupied);
+    result.set(pathKey(conflicted), { path: conflicted, contents: local.contents });
+  }
+  return [...result.values()]
+    .sort((left, right) => left.path.localeCompare(right.path));
+}

--- a/src/main/core/build-library-coordinator.ts
+++ b/src/main/core/build-library-coordinator.ts
@@ -1,0 +1,65 @@
+/**
+ * Serializes each durable build library and rejects stale writes from another
+ * window. IPC supplies an owned window and path; this owner keeps persistence
+ * and optimistic-concurrency state behind that transport boundary.
+ */
+import type { BuildLibrary } from "../../shared/builds/library.js";
+import { ValidationError } from "../../shared/errors.js";
+import { loadBuildLibrary, saveBuildLibrary } from "./build-library.js";
+import { Mutex } from "./mutex.js";
+
+export class BuildLibraryCoordinator {
+  private readonly baselines = new WeakMap<object, Map<string, string>>();
+  private readonly locks = new Map<string, Mutex>();
+
+  async get(
+    owner: object,
+    libraryPath: string,
+  ): Promise<{ readonly library: BuildLibrary; readonly recovered: boolean }> {
+    return this.lockFor(libraryPath).run(async () => {
+      let recovered = false;
+      const library = await loadBuildLibrary(libraryPath, () => {
+        recovered = true;
+      });
+      this.remember(owner, libraryPath, library);
+      return { library, recovered };
+    });
+  }
+
+  async set(
+    owner: object,
+    libraryPath: string,
+    library: BuildLibrary,
+  ): Promise<BuildLibrary> {
+    return this.lockFor(libraryPath).run(async () => {
+      const current = await loadBuildLibrary(libraryPath);
+      const expected = this.baselines.get(owner)?.get(libraryPath);
+      if (expected === undefined || expected !== JSON.stringify(current)) {
+        throw new ValidationError(
+          "build library changed in another account; reload before saving",
+        );
+      }
+      const saved = await saveBuildLibrary(libraryPath, library);
+      this.remember(owner, libraryPath, saved);
+      return saved;
+    });
+  }
+
+  private lockFor(libraryPath: string): Mutex {
+    let lock = this.locks.get(libraryPath);
+    if (!lock) {
+      lock = new Mutex();
+      this.locks.set(libraryPath, lock);
+    }
+    return lock;
+  }
+
+  private remember(owner: object, libraryPath: string, library: BuildLibrary): void {
+    let values = this.baselines.get(owner);
+    if (!values) {
+      values = new Map();
+      this.baselines.set(owner, values);
+    }
+    values.set(libraryPath, JSON.stringify(library));
+  }
+}

--- a/src/main/core/credentials.ts
+++ b/src/main/core/credentials.ts
@@ -13,7 +13,7 @@
  */
 import type { StoredCredentials } from "../../shared/contracts.js";
 import { AppError } from "../../shared/errors.js";
-import type { NativeKeychain } from "./native-keychain.js";
+import type { NativeKeychain, SecretSlot } from "./native-keychain.js";
 import { KeychainJsonStore, type KeychainSecret } from "./keychain-store.js";
 
 /**
@@ -48,7 +48,10 @@ const CREDENTIALS: KeychainSecret<StoredCredentials> = {
 
 /** The ArenaNet saved login's fixed Data Protection Keychain item. */
 export class CredentialsStore extends KeychainJsonStore<StoredCredentials> {
-  constructor(keychain: NativeKeychain) {
-    super("arenaNetCredentials", keychain, CREDENTIALS);
+  constructor(
+    keychain: NativeKeychain,
+    slot: SecretSlot = "arenaNetCredentials",
+  ) {
+    super(slot, keychain, CREDENTIALS);
   }
 }

--- a/src/main/core/multiple-accounts.ts
+++ b/src/main/core/multiple-accounts.ts
@@ -85,22 +85,10 @@ export async function quarantineAccountDocument(
   }
 }
 
-export function createMultiWorkspace(options: {
-  readonly name: string;
-  readonly templates: LibraryScope;
-  readonly builds: LibraryScope;
-  readonly id?: string;
-}): MultiWorkspace {
-  const id = (options.id ?? randomUUID()) as ProfileId;
+export function createMultiWorkspace(): MultiWorkspace {
   return parseMultiWorkspace({
     formatVersion: 1,
-    profiles: [{
-      id,
-      name: parseProfileName(options.name),
-      archived: false,
-      templates: options.templates,
-      builds: options.builds,
-    }],
+    profiles: [],
   });
 }
 

--- a/src/main/core/multiple-accounts.ts
+++ b/src/main/core/multiple-accounts.ts
@@ -142,3 +142,32 @@ export function archiveMultiProfile(
     ),
   });
 }
+
+export function restoreMultiProfile(
+  workspace: MultiWorkspace,
+  profileId: ProfileId,
+): MultiWorkspace {
+  if (!workspace.profiles.some((profile) => profile.id === profileId)) {
+    throw new AppError("bad_multi_workspace", "profile does not exist");
+  }
+  return parseMultiWorkspace({
+    ...workspace,
+    profiles: workspace.profiles.map((profile) =>
+      profile.id === profileId ? { ...profile, archived: false } : profile,
+    ),
+  });
+}
+
+export function removeArchivedMultiProfile(
+  workspace: MultiWorkspace,
+  profileId: ProfileId,
+): MultiWorkspace {
+  const profile = workspace.profiles.find((candidate) => candidate.id === profileId);
+  if (!profile?.archived) {
+    throw new AppError("bad_multi_workspace", "only an archived profile can be deleted");
+  }
+  return parseMultiWorkspace({
+    ...workspace,
+    profiles: workspace.profiles.filter((candidate) => candidate.id !== profileId),
+  });
+}

--- a/src/main/core/multiple-accounts.ts
+++ b/src/main/core/multiple-accounts.ts
@@ -1,0 +1,90 @@
+/**
+ * The durable Single/Multiple Accounts selection and Multi profile registry.
+ *
+ * A missing launcher-mode document means the legacy Single Account path. An
+ * existing malformed document fails closed. Writes use the repository's one
+ * atomic file publisher so setup cannot expose a partial workspace or mode.
+ */
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import {
+  parseLauncherMode,
+  parseMultiWorkspace,
+  parseProfileName,
+  type AccountMode,
+  type LibraryScope,
+  type MultiWorkspace,
+  type ProfileId,
+} from "../../shared/multiple-accounts.js";
+import { AppError } from "../../shared/errors.js";
+import { writeAtomicJson } from "./atomic-file.js";
+
+const DOCUMENT_MODE = 0o600;
+
+async function readDocument(path: string): Promise<unknown | null> {
+  let text: string;
+  try {
+    text = await readFile(path, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+  try {
+    return JSON.parse(text) as unknown;
+  } catch (error) {
+    throw new AppError(
+      path.endsWith("launcher-mode.json") ? "bad_launcher_mode" : "bad_multi_workspace",
+      "account-mode data is not valid JSON",
+      { cause: error },
+    );
+  }
+}
+
+export async function loadAccountMode(path: string): Promise<AccountMode> {
+  const value = await readDocument(path);
+  return value === null ? "single" : parseLauncherMode(value).mode;
+}
+
+export async function saveAccountMode(
+  path: string,
+  mode: AccountMode,
+): Promise<AccountMode> {
+  const parsed = parseLauncherMode({ formatVersion: 1, mode });
+  await writeAtomicJson(path, parsed, DOCUMENT_MODE);
+  return parsed.mode;
+}
+
+export async function loadMultiWorkspace(
+  path: string,
+): Promise<MultiWorkspace | null> {
+  const value = await readDocument(path);
+  return value === null ? null : parseMultiWorkspace(value);
+}
+
+export async function saveMultiWorkspace(
+  path: string,
+  workspace: MultiWorkspace,
+): Promise<MultiWorkspace> {
+  const parsed = parseMultiWorkspace(workspace);
+  await writeAtomicJson(path, parsed, DOCUMENT_MODE);
+  return parsed;
+}
+
+export function createMultiWorkspace(options: {
+  readonly name: string;
+  readonly templates: LibraryScope;
+  readonly builds: LibraryScope;
+  readonly id?: string;
+}): MultiWorkspace {
+  const id = (options.id ?? randomUUID()) as ProfileId;
+  return parseMultiWorkspace({
+    formatVersion: 1,
+    profiles: [{
+      id,
+      name: parseProfileName(options.name),
+      archived: false,
+      templates: options.templates,
+      builds: options.builds,
+    }],
+  });
+}

--- a/src/main/core/multiple-accounts.ts
+++ b/src/main/core/multiple-accounts.ts
@@ -14,6 +14,7 @@ import {
   type AccountMode,
   type LibraryScope,
   type MultiWorkspace,
+  type MultiProfile,
   type ProfileId,
 } from "../../shared/multiple-accounts.js";
 import { AppError } from "../../shared/errors.js";
@@ -86,5 +87,58 @@ export function createMultiWorkspace(options: {
       templates: options.templates,
       builds: options.builds,
     }],
+  });
+}
+
+export function addMultiProfile(
+  workspace: MultiWorkspace,
+  options: {
+    readonly name: string;
+    readonly templates: LibraryScope;
+    readonly builds: LibraryScope;
+    readonly id?: string;
+  },
+): MultiWorkspace {
+  const profile: MultiProfile = {
+    id: (options.id ?? randomUUID()) as ProfileId,
+    name: parseProfileName(options.name),
+    archived: false,
+    templates: options.templates,
+    builds: options.builds,
+  };
+  return parseMultiWorkspace({
+    ...workspace,
+    profiles: [...workspace.profiles, profile],
+  });
+}
+
+export function updateMultiProfile(
+  workspace: MultiWorkspace,
+  profileId: ProfileId,
+  changes: Pick<MultiProfile, "name" | "templates" | "builds">,
+): MultiWorkspace {
+  if (!workspace.profiles.some((profile) => profile.id === profileId)) {
+    throw new AppError("bad_multi_workspace", "profile does not exist");
+  }
+  return parseMultiWorkspace({
+    ...workspace,
+    profiles: workspace.profiles.map((profile) =>
+      profile.id === profileId ? { ...profile, ...changes } : profile,
+    ),
+  });
+}
+
+export function archiveMultiProfile(
+  workspace: MultiWorkspace,
+  profileId: ProfileId,
+): MultiWorkspace {
+  if (!workspace.profiles.some((profile) => profile.id === profileId)) {
+    throw new AppError("bad_multi_workspace", "profile does not exist");
+  }
+  return parseMultiWorkspace({
+    ...workspace,
+    profiles: workspace.profiles.map((profile) =>
+      profile.id === profileId ? { ...profile, archived: true } : profile,
+    ),
   });
 }

--- a/src/main/core/multiple-accounts.ts
+++ b/src/main/core/multiple-accounts.ts
@@ -89,6 +89,7 @@ export function createMultiWorkspace(): MultiWorkspace {
   return parseMultiWorkspace({
     formatVersion: 1,
     profiles: [],
+    deletingProfileIds: [],
   });
 }
 
@@ -171,5 +172,23 @@ export function removeArchivedMultiProfile(
   return parseMultiWorkspace({
     ...workspace,
     profiles: workspace.profiles.filter((candidate) => candidate.id !== profileId),
+    deletingProfileIds: workspace.deletingProfileIds.filter(
+      (candidate) => candidate !== profileId,
+    ),
+  });
+}
+
+/** Persist this transition before any native resource for the profile is erased. */
+export function beginArchivedProfileDeletion(
+  workspace: MultiWorkspace,
+  profileId: ProfileId,
+): MultiWorkspace {
+  const profile = workspace.profiles.find((candidate) => candidate.id === profileId);
+  if (!profile?.archived) {
+    throw new AppError("bad_multi_workspace", "only an archived profile can be deleted");
+  }
+  return parseMultiWorkspace({
+    ...workspace,
+    deletingProfileIds: [...new Set([...workspace.deletingProfileIds, profileId])],
   });
 }

--- a/src/main/core/multiple-accounts.ts
+++ b/src/main/core/multiple-accounts.ts
@@ -6,7 +6,7 @@
  * atomic file publisher so setup cannot expose a partial workspace or mode.
  */
 import { randomUUID } from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { readFile, rename } from "node:fs/promises";
 import {
   parseLauncherMode,
   parseMultiWorkspace,
@@ -69,6 +69,20 @@ export async function saveMultiWorkspace(
   const parsed = parseMultiWorkspace(workspace);
   await writeAtomicJson(path, parsed, DOCUMENT_MODE);
   return parsed;
+}
+
+/** Preserve an unreadable account document before a player-approved recovery. */
+export async function quarantineAccountDocument(
+  filePath: string,
+): Promise<string | null> {
+  const backupPath = `${filePath}.corrupt-${Date.now()}`;
+  try {
+    await rename(filePath, backupPath);
+    return backupPath;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
 }
 
 export function createMultiWorkspace(options: {

--- a/src/main/core/native-keychain.ts
+++ b/src/main/core/native-keychain.ts
@@ -2,16 +2,26 @@
  * The interface every persistent secret talks to, and the closed set of slots
  * it may name.
  *
- * `SecretSlot` is a union rather than a string, so a new persistent secret is a
- * deliberate edit here instead of an ad-hoc item appearing in a player's
- * Keychain. `VolatileNativeKeychain` is the implementation for builds with no
+ * `SecretSlot` is a closed grammar rather than an arbitrary string. Single
+ * keeps its legacy names; Multi adds the same two kinds under a validated
+ * profile UUID. `VolatileNativeKeychain` is the implementation for builds with no
  * provisioned signing identity: secrets live in memory and are lost at quit.
  * It is not a fallback an entitled build may drop to, and no file, encrypted
  * blob or mock-Keychain implementation stands beside it as one.
  */
-export const SECRET_SLOTS = ["arenaNetCredentials", "steamSession"] as const;
+import type { ProfileId } from "../../shared/multiple-accounts.js";
 
-export type SecretSlot = (typeof SECRET_SLOTS)[number];
+export const SINGLE_SECRET_SLOTS = ["arenaNetCredentials", "steamSession"] as const;
+export type SingleSecretSlot = (typeof SINGLE_SECRET_SLOTS)[number];
+export type MultiSecretSlot = `multi.${ProfileId}.${SingleSecretSlot}`;
+export type SecretSlot = SingleSecretSlot | MultiSecretSlot;
+
+export function multiSecretSlot(
+  profileId: ProfileId,
+  kind: SingleSecretSlot,
+): MultiSecretSlot {
+  return `multi.${profileId}.${kind}`;
+}
 
 export interface NativeKeychain {
   load(slot: SecretSlot): Promise<Buffer | null>;

--- a/src/main/core/paths.ts
+++ b/src/main/core/paths.ts
@@ -86,6 +86,7 @@ export interface MultiProfilePaths {
   readonly templates: string;
   readonly templateSync: string;
   readonly windowState: string;
+  readonly gameStorageClearRequest: string;
 }
 
 /** Resolve stores only after `parseProfileId` has made traversal impossible. */
@@ -100,6 +101,7 @@ export function multiProfilePaths(
     templates: path.join(root, "templates.json"),
     templateSync: path.join(root, "template-sync.json"),
     windowState: path.join(root, "window-state.json"),
+    gameStorageClearRequest: path.join(root, "clear-game-storage-on-start"),
   };
 }
 

--- a/src/main/core/paths.ts
+++ b/src/main/core/paths.ts
@@ -116,7 +116,6 @@ export function multiProfilePaths(
 export function documentDirectories(paths: GamePaths): string[] {
   return [
     paths.userData,
-    paths.multiRoot,
     paths.game,
     paths.diagnostics,
     paths.chunks,

--- a/src/main/core/paths.ts
+++ b/src/main/core/paths.ts
@@ -13,6 +13,7 @@
  */
 import path from "node:path";
 import type { CLIENT_ARTIFACTS } from "./access-key.js";
+import type { ProfileId } from "../../shared/multiple-accounts.js";
 import { clientGenerationPaths } from "./client-compatibility.js";
 
 export interface GamePaths {
@@ -20,6 +21,13 @@ export interface GamePaths {
   settings: string;
   buildLibrary: string;
   windowState: string;
+  launcherMode: string;
+  multiRoot: string;
+  multiWorkspace: string;
+  multiHubWindowState: string;
+  multiSharedBuildLibrary: string;
+  multiSharedTemplates: string;
+  multiProfiles: string;
   diagnostics: string;
   game: string;
   artifacts: string;
@@ -39,11 +47,19 @@ export interface GamePaths {
 export function gamePaths(userData: string): GamePaths {
   const game = path.join(userData, "game");
   const artifacts = path.join(game, "artifacts");
+  const multiRoot = path.join(userData, "multi");
   return {
     userData,
     settings: path.join(userData, "settings.json"),
     buildLibrary: path.join(userData, "build-library.json"),
     windowState: path.join(userData, "window-state.json"),
+    launcherMode: path.join(userData, "launcher-mode.json"),
+    multiRoot,
+    multiWorkspace: path.join(multiRoot, "workspace.json"),
+    multiHubWindowState: path.join(multiRoot, "hub-window-state.json"),
+    multiSharedBuildLibrary: path.join(multiRoot, "shared", "build-library.json"),
+    multiSharedTemplates: path.join(multiRoot, "shared", "templates.json"),
+    multiProfiles: path.join(multiRoot, "profiles"),
     diagnostics: path.join(userData, "diagnostics"),
     game,
     artifacts,
@@ -64,6 +80,29 @@ export function gamePaths(userData: string): GamePaths {
   };
 }
 
+export interface MultiProfilePaths {
+  readonly root: string;
+  readonly buildLibrary: string;
+  readonly templates: string;
+  readonly templateSync: string;
+  readonly windowState: string;
+}
+
+/** Resolve stores only after `parseProfileId` has made traversal impossible. */
+export function multiProfilePaths(
+  paths: GamePaths,
+  profileId: ProfileId,
+): MultiProfilePaths {
+  const root = path.join(paths.multiProfiles, profileId);
+  return {
+    root,
+    buildLibrary: path.join(root, "build-library.json"),
+    templates: path.join(root, "templates.json"),
+    templateSync: path.join(root, "template-sync.json"),
+    windowState: path.join(root, "window-state.json"),
+  };
+}
+
 /**
  * Stable document roots whose direct atomic-write temporaries need the generic
  * boot-time sweep.
@@ -77,6 +116,7 @@ export function gamePaths(userData: string): GamePaths {
 export function documentDirectories(paths: GamePaths): string[] {
   return [
     paths.userData,
+    paths.multiRoot,
     paths.game,
     paths.diagnostics,
     paths.chunks,

--- a/src/main/core/paths.ts
+++ b/src/main/core/paths.ts
@@ -24,7 +24,6 @@ export interface GamePaths {
   launcherMode: string;
   multiRoot: string;
   multiWorkspace: string;
-  multiHubWindowState: string;
   multiSharedBuildLibrary: string;
   multiSharedTemplates: string;
   multiProfiles: string;
@@ -56,7 +55,6 @@ export function gamePaths(userData: string): GamePaths {
     launcherMode: path.join(userData, "launcher-mode.json"),
     multiRoot,
     multiWorkspace: path.join(multiRoot, "workspace.json"),
-    multiHubWindowState: path.join(multiRoot, "hub-window-state.json"),
     multiSharedBuildLibrary: path.join(multiRoot, "shared", "build-library.json"),
     multiSharedTemplates: path.join(multiRoot, "shared", "templates.json"),
     multiProfiles: path.join(multiRoot, "profiles"),

--- a/src/main/core/paths.ts
+++ b/src/main/core/paths.ts
@@ -24,6 +24,7 @@ export interface GamePaths {
   launcherMode: string;
   multiRoot: string;
   multiWorkspace: string;
+  multiSingleTemplateImport: string;
   multiSharedBuildLibrary: string;
   multiSharedTemplates: string;
   multiProfiles: string;
@@ -55,6 +56,7 @@ export function gamePaths(userData: string): GamePaths {
     launcherMode: path.join(userData, "launcher-mode.json"),
     multiRoot,
     multiWorkspace: path.join(multiRoot, "workspace.json"),
+    multiSingleTemplateImport: path.join(multiRoot, "single-template-import.json"),
     multiSharedBuildLibrary: path.join(multiRoot, "shared", "build-library.json"),
     multiSharedTemplates: path.join(multiRoot, "shared", "templates.json"),
     multiProfiles: path.join(multiRoot, "profiles"),

--- a/src/main/core/profile-runtime.ts
+++ b/src/main/core/profile-runtime.ts
@@ -1,3 +1,7 @@
+/**
+ * Process-local launch status for Multiple Accounts. This is the one owner of
+ * the transient state projected into the Hub; nothing here is persisted.
+ */
 import type {
   AccountLaunchIssue,
   MultiProfileRuntimeState,

--- a/src/main/core/profile-runtime.ts
+++ b/src/main/core/profile-runtime.ts
@@ -1,0 +1,56 @@
+import type {
+  AccountLaunchIssue,
+  MultiProfileRuntimeState,
+} from "../../shared/contracts.js";
+import type { ProfileId } from "../../shared/multiple-accounts.js";
+
+export interface ProfileRuntime {
+  readonly state: MultiProfileRuntimeState;
+  readonly launchIssue?: AccountLaunchIssue;
+}
+
+/** The process-local source of truth for every account launch row. */
+export class ProfileRuntimeStore {
+  readonly #profiles = new Map<ProfileId, ProfileRuntime>();
+
+  get(profileId: ProfileId): ProfileRuntime {
+    return this.#profiles.get(profileId) ?? { state: "ready" };
+  }
+
+  set(
+    profileId: ProfileId,
+    state: MultiProfileRuntimeState,
+    launchIssue?: AccountLaunchIssue,
+  ): void {
+    this.#profiles.set(profileId, launchIssue ? { state, launchIssue } : { state });
+  }
+
+  queue(profileIds: readonly ProfileId[], isOpen: (id: ProfileId) => boolean): void {
+    for (const profileId of profileIds) {
+      if (!isOpen(profileId)) this.set(profileId, "queued");
+    }
+  }
+
+  releaseQueued(profileIds: readonly ProfileId[]): void {
+    for (const profileId of profileIds) {
+      if (this.get(profileId).state === "queued") this.set(profileId, "ready");
+    }
+  }
+}
+
+export type ProfileLaunchStage =
+  | "preparing"
+  | "starting"
+  | "validating"
+  | "crashed"
+  | "unknown";
+
+export function launchIssueForStage(stage: ProfileLaunchStage): AccountLaunchIssue {
+  switch (stage) {
+    case "preparing": return "profile-preparation";
+    case "starting": return "window-startup";
+    case "validating": return "client-validation";
+    case "crashed": return "renderer-crash";
+    case "unknown": return "unknown";
+  }
+}

--- a/src/main/core/renderer-trust.ts
+++ b/src/main/core/renderer-trust.ts
@@ -1,5 +1,5 @@
 /**
- * What counts as the renderer document: two paths under `gw://app`, with no
+ * What counts as the game renderer document: two paths under `gw://app`, with no
  * port, credentials, query or fragment.
  *
  * Callers decide from this whether a navigation is the application itself, so
@@ -9,14 +9,9 @@
  * from having to know what any individual setting means.
  */
 const TRUSTED_PATHS = new Set(["/", "/index.html"]);
+const ACCOUNTS_PATH = "/accounts.html";
 
-/**
- * The renderer document, and nothing else. There is no query string to
- * allow-list: launch configuration reaches the renderer through
- * `RENDERER_INIT_ARGUMENT`, so a security boundary no longer has to know what a
- * cursor preference is.
- */
-export function isCanonicalRendererUrl(raw: string): boolean {
+function trustedUrl(raw: string, paths: ReadonlySet<string>): boolean {
   try {
     const url = new URL(raw);
     return (
@@ -27,9 +22,24 @@ export function isCanonicalRendererUrl(raw: string): boolean {
       && !url.password
       && !url.hash
       && !url.search
-      && TRUSTED_PATHS.has(url.pathname)
+      && paths.has(url.pathname)
     );
   } catch {
     return false;
   }
+}
+
+/**
+ * The renderer document, and nothing else. There is no query string to
+ * allow-list: launch configuration reaches the renderer through
+ * `RENDERER_INIT_ARGUMENT`, so a security boundary no longer has to know what a
+ * cursor preference is.
+ */
+export function isCanonicalRendererUrl(raw: string): boolean {
+  return trustedUrl(raw, TRUSTED_PATHS);
+}
+
+/** The Hub document is separate so a game window can never navigate to it. */
+export function isAccountsRendererUrl(raw: string): boolean {
+  return trustedUrl(raw, new Set([ACCOUNTS_PATH]));
 }

--- a/src/main/core/steam-session.ts
+++ b/src/main/core/steam-session.ts
@@ -13,7 +13,7 @@
  */
 import type { SteamRefusalReason } from "../../shared/contracts.js";
 import { AppError, errorCode, type ErrorCode } from "../../shared/errors.js";
-import type { NativeKeychain } from "./native-keychain.js";
+import type { NativeKeychain, SecretSlot } from "./native-keychain.js";
 import { KeychainJsonStore, type KeychainSecret } from "./keychain-store.js";
 import { Mutex } from "./mutex.js";
 
@@ -79,8 +79,11 @@ const STEAM_SESSION: KeychainSecret<StoredSteamSession> = {
 
 /** The Steam token's one persistent home. */
 export class SteamSessionStore extends KeychainJsonStore<StoredSteamSession> {
-  constructor(keychain: NativeKeychain) {
-    super("steamSession", keychain, STEAM_SESSION);
+  constructor(
+    keychain: NativeKeychain,
+    slot: SecretSlot = "steamSession",
+  ) {
+    super(slot, keychain, STEAM_SESSION);
   }
 }
 

--- a/src/main/core/window-state.ts
+++ b/src/main/core/window-state.ts
@@ -197,3 +197,28 @@ export function defaultWindowState(primaryWorkArea: WindowBounds): WindowState {
     mode: "normal",
   };
 }
+
+/**
+ * Offset a brand-new account window without ever placing its title bar outside
+ * the active work area. Persisted bounds bypass this helper entirely.
+ */
+export function cascadeWindowState(
+  state: WindowState,
+  ordinal: number,
+  workArea: WindowBounds,
+  step = 32,
+): WindowState {
+  const offset = Math.max(0, Math.trunc(ordinal)) * step;
+  return fitWindowStateToDisplays(
+    {
+      ...state,
+      bounds: {
+        ...state.bounds,
+        x: state.bounds.x + offset,
+        y: state.bounds.y + offset,
+      },
+    },
+    [workArea],
+    workArea,
+  );
+}

--- a/src/main/ipc-values.ts
+++ b/src/main/ipc-values.ts
@@ -3,6 +3,19 @@
  * No Electron capability or domain policy belongs in this module.
  */
 import type { GraphicsDiagnostics, SocketEvent } from "../shared/contracts.js";
+import type {
+  RendererMilestone,
+  RendererMilestoneFields,
+  WasmAbortReasonKind,
+} from "../shared/diagnostics.js";
+import {
+  RENDERER_MILESTONES,
+  WASM_ABORT_REASON_KINDS,
+  WASM_GROWTH_OUTCOMES,
+  WASM_MEMORY_PROBE_STATUSES,
+} from "../shared/diagnostics.js";
+import { ValidationError } from "../shared/errors.js";
+import { isRendererFingerprint } from "./diagnostics/schema-fields.js";
 
 export function toWireSocketEvent(event: SocketEvent): SocketEvent {
   if (event.type !== "data") return event;
@@ -48,4 +61,119 @@ export function isGraphicsDiagnostics(value: unknown): value is GraphicsDiagnost
     && (record.devicePixelRatio as number) <= 16
     && (record.renderScale === 1 || record.renderScale === 1.5 || record.renderScale === 2)
   );
+}
+
+export interface ParsedMilestone {
+  readonly name: RendererMilestone;
+  readonly rendererTimestampUs: number;
+  readonly fields: RendererMilestoneFields | undefined;
+}
+
+const isByteCount = (value: unknown): value is number =>
+  typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+
+/** Validates the complete renderer milestone tuple before diagnostics sees it. */
+export function parseRendererMilestoneArgs(args: readonly unknown[]): ParsedMilestone {
+  if (args.length !== 3) throw new ValidationError("expected 3 IPC argument(s)");
+  const [name, rendererTimestampUs, fields] = args;
+  if (
+    typeof name !== "string"
+    || !RENDERER_MILESTONES.includes(name as RendererMilestone)
+    || typeof rendererTimestampUs !== "number"
+    || !Number.isFinite(rendererTimestampUs)
+    || rendererTimestampUs < 0
+    || rendererTimestampUs > Number.MAX_SAFE_INTEGER
+  ) throw new ValidationError("invalid renderer milestone");
+
+  const record = fields as Record<string, unknown> | undefined;
+  const recordIsObject = record !== undefined && record !== null
+    && typeof record === "object" && !Array.isArray(record);
+  let milestoneFields: RendererMilestoneFields | undefined;
+  if (name === "build.info") {
+    const valid = recordIsObject && Object.keys(record).length === 2
+      && (typeof record.programId === "string" || typeof record.programId === "number")
+      && (typeof record.buildId === "string" || typeof record.buildId === "number")
+      && [record.programId, record.buildId].every((value) =>
+        (typeof value === "string" && value.length <= 128)
+        || (typeof value === "number" && Number.isSafeInteger(value) && value >= 0));
+    if (!valid) throw new ValidationError("invalid renderer milestone");
+    milestoneFields = {
+      programId: record.programId as string | number,
+      buildId: record.buildId as string | number,
+    };
+  } else if (name === "wasm.abort") {
+    const valid = recordIsObject && Object.keys(record).length === 3
+      && typeof record.reasonKind === "string"
+      && (WASM_ABORT_REASON_KINDS as readonly string[]).includes(record.reasonKind)
+      && isRendererFingerprint(record.fingerprint) && isByteCount(record.heapBytes);
+    if (!valid) throw new ValidationError("invalid renderer milestone");
+    milestoneFields = {
+      reasonKind: record.reasonKind as WasmAbortReasonKind,
+      fingerprint: record.fingerprint as string,
+      heapBytes: record.heapBytes as number,
+    };
+  } else if (name === "wasm.exit") {
+    const valid = recordIsObject && Object.keys(record).length === 2
+      && typeof record.code === "number" && Number.isSafeInteger(record.code)
+      && isByteCount(record.heapBytes);
+    if (!valid) throw new ValidationError("invalid renderer milestone");
+    milestoneFields = { code: record.code as number, heapBytes: record.heapBytes as number };
+  } else if (name === "wasm.memoryProbe") {
+    const valid = recordIsObject && Object.keys(record).length === 1
+      && typeof record.status === "string"
+      && (WASM_MEMORY_PROBE_STATUSES as readonly string[]).includes(record.status);
+    if (!valid) throw new ValidationError("invalid renderer milestone");
+    milestoneFields = { status: record.status as (typeof WASM_MEMORY_PROBE_STATUSES)[number] };
+  } else if (name === "wasm.growthRequested") {
+    const numericFields = [
+      "requestedBytes", "beforeBytes", "afterBytes", "stackDepth",
+      "frame0Function", "frame0Offset", "frame1Function", "frame1Offset",
+      "frame2Function", "frame2Offset", "frame3Function", "frame3Offset",
+      "generatedTextures", "deletedTextures", "liveTextures", "trackedTextures",
+      "knownTextureBytes", "textureUploadBytes", "unknownTextureAllocations",
+    ] as const;
+    const valid = recordIsObject && Object.keys(record).length === numericFields.length + 3
+      && numericFields.every((field) => isByteCount(record[field]))
+      && (record.stackDepth as number) <= 4 && (record.trackedTextures as number) <= 4_096
+      && typeof record.outcome === "string"
+      && (WASM_GROWTH_OUTCOMES as readonly string[]).includes(record.outcome)
+      && isRendererFingerprint(record.stackFingerprint)
+      && typeof record.textureTrackingSaturated === "boolean";
+    if (!valid) throw new ValidationError("invalid renderer milestone");
+    milestoneFields = {
+      requestedBytes: record.requestedBytes as number, beforeBytes: record.beforeBytes as number,
+      afterBytes: record.afterBytes as number,
+      outcome: record.outcome as (typeof WASM_GROWTH_OUTCOMES)[number],
+      stackFingerprint: record.stackFingerprint as string, stackDepth: record.stackDepth as number,
+      frame0Function: record.frame0Function as number, frame0Offset: record.frame0Offset as number,
+      frame1Function: record.frame1Function as number, frame1Offset: record.frame1Offset as number,
+      frame2Function: record.frame2Function as number, frame2Offset: record.frame2Offset as number,
+      frame3Function: record.frame3Function as number, frame3Offset: record.frame3Offset as number,
+      generatedTextures: record.generatedTextures as number, deletedTextures: record.deletedTextures as number,
+      liveTextures: record.liveTextures as number, trackedTextures: record.trackedTextures as number,
+      knownTextureBytes: record.knownTextureBytes as number, textureUploadBytes: record.textureUploadBytes as number,
+      unknownTextureAllocations: record.unknownTextureAllocations as number,
+      textureTrackingSaturated: record.textureTrackingSaturated as boolean,
+    };
+  } else if (name === "enhancement.installed") {
+    const valid = recordIsObject && Object.keys(record).length === 3
+      && typeof record.companionAbi === "number" && Number.isSafeInteger(record.companionAbi) && record.companionAbi >= 0
+      && typeof record.installation === "number" && Number.isSafeInteger(record.installation) && record.installation >= 1
+      && typeof record.capabilityProfile === "string" && record.capabilityProfile.length <= 32;
+    if (!valid) throw new ValidationError("invalid renderer milestone");
+    milestoneFields = {
+      companionAbi: record.companionAbi as number,
+      installation: record.installation as number,
+      capabilityProfile: record.capabilityProfile as string,
+    };
+  } else if (name === "enhancement.uninstalled") {
+    const valid = recordIsObject && Object.keys(record).length === 1
+      && typeof record.installation === "number" && Number.isSafeInteger(record.installation)
+      && record.installation >= 1;
+    if (!valid) throw new ValidationError("invalid renderer milestone");
+    milestoneFields = { installation: record.installation as number };
+  } else if (fields !== undefined) {
+    throw new ValidationError("invalid renderer milestone");
+  }
+  return { name: name as RendererMilestone, rendererTimestampUs, fields: milestoneFields };
 }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -74,11 +74,8 @@ import {
   ValidationError,
 } from "../shared/errors.js";
 import { parseCredentials, type CredentialsStore } from "./core/credentials.js";
-import {
-  loadBuildLibrary,
-  saveBuildLibrary,
-} from "./core/build-library.js";
 import { parseBuildLibrary } from "../shared/builds/parse-library.js";
+import type { BuildLibrary } from "../shared/builds/library.js";
 import { isGraphicsDiagnostics, toWireSocketEvent } from "./ipc-values.js";
 import { resolveDns } from "./core/dns.js";
 import { exportTemplates, parseExportEntries } from "./template-export.js";
@@ -94,7 +91,6 @@ import type {
 } from "./steam-acquire.js";
 import { parseSettingsPatch } from "./core/settings.js";
 import type { SocketManager } from "./core/sockets.js";
-import { Mutex } from "./core/mutex.js";
 import { FREE_MARGIN, type ChunkStore } from "./core/chunk-store.js";
 import {
   count,
@@ -129,7 +125,10 @@ export interface IpcContext {
   windows: WindowRegistry;
   credentialsStoreFor: (win: BrowserWindow) => CredentialsStore;
   steamSessionStoreFor: (win: BrowserWindow) => SteamSessionStore;
-  buildLibraryPathFor: (win: BrowserWindow) => string;
+  getBuildLibrary: (
+    win: BrowserWindow,
+  ) => Promise<{ readonly library: BuildLibrary; readonly recovered: boolean }>;
+  setBuildLibrary: (win: BrowserWindow, library: BuildLibrary) => Promise<BuildLibrary>;
   gameStorageResetMarkerFor: (win: BrowserWindow) => string;
   getProgress: () => DownloadProgress;
   getChunkStore: () => ChunkStore | null;
@@ -723,28 +722,6 @@ export function registerIpcHandlers(ctx: IpcContext): {
 } {
   const paths = gamePaths();
   const secretOperations = new Set<Promise<unknown>>();
-  const buildBaselines = new WeakMap<BrowserWindow, Map<string, string>>();
-  const buildLocks = new Map<string, Mutex>();
-  const buildLock = (libraryPath: string): Mutex => {
-    let lock = buildLocks.get(libraryPath);
-    if (!lock) {
-      lock = new Mutex();
-      buildLocks.set(libraryPath, lock);
-    }
-    return lock;
-  };
-  const rememberBuildBaseline = (
-    win: BrowserWindow,
-    libraryPath: string,
-    library: unknown,
-  ): void => {
-    let values = buildBaselines.get(win);
-    if (!values) {
-      values = new Map();
-      buildBaselines.set(win, values);
-    }
-    values.set(libraryPath, JSON.stringify(library));
-  };
   const secretOperation = <T>(operation: () => Promise<T>): Promise<T> => {
     if (isQuitting()) {
       return Promise.reject(new ValidationError("application is quitting"));
@@ -808,33 +785,10 @@ export function registerIpcHandlers(ctx: IpcContext): {
       await ctx.sockets.close(socketId, win.webContents.id);
     }),
 
-    buildLibraryGet: channel(nothing, async (win) => {
-      const libraryPath = ctx.buildLibraryPathFor(win);
-      return buildLock(libraryPath).run(async () => {
-        let recovered = false;
-        const library = await loadBuildLibrary(libraryPath, () => {
-          recovered = true;
-        });
-        rememberBuildBaseline(win, libraryPath, library);
-        return { library, recovered };
-      });
-    }),
+    buildLibraryGet: channel(nothing, (win) => ctx.getBuildLibrary(win)),
 
-    buildLibrarySet: channel(one(parseBuildLibrary), async (win, library) => {
-      const libraryPath = ctx.buildLibraryPathFor(win);
-      return buildLock(libraryPath).run(async () => {
-        const current = await loadBuildLibrary(libraryPath);
-        const expected = buildBaselines.get(win)?.get(libraryPath);
-        if (expected === undefined || expected !== JSON.stringify(current)) {
-          throw new ValidationError(
-            "build library changed in another account; reload before saving",
-          );
-        }
-        const saved = await saveBuildLibrary(libraryPath, library);
-        rememberBuildBaseline(win, libraryPath, saved);
-        return saved;
-      });
-    }),
+    buildLibrarySet: channel(one(parseBuildLibrary), (win, library) =>
+      ctx.setBuildLibrary(win, library)),
 
     settingsGet: channel(nothing, async () => {
       try {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -18,6 +18,8 @@ import { statfs } from "node:fs/promises";
 import type {
   AppSettings,
   AppSettingsPatch,
+  AccountsSetupRequest,
+  AccountsState,
   AppUpdateState,
   CacheInfo,
   ClientHealthToken,
@@ -33,6 +35,12 @@ import type {
   SteamTokenResult,
   StoredCredentials,
 } from "../shared/contracts.js";
+import {
+  parseProfileId,
+  parseProfileName,
+  type LibraryScope,
+  type ProfileId,
+} from "../shared/multiple-accounts.js";
 import type {
   RendererFrameBatch,
   RendererMetrics,
@@ -92,7 +100,10 @@ import {
 } from "./diagnostics.js";
 import { isRendererFingerprint } from "./diagnostics/schema-fields.js";
 import { gamePaths } from "./paths.js";
-import { isCanonicalRendererUrl } from "./core/renderer-trust.js";
+import {
+  isAccountsRendererUrl,
+  isCanonicalRendererUrl,
+} from "./core/renderer-trust.js";
 import { MAX_QUEUED_BYTES_PER_SOCKET } from "./core/sockets.js";
 import { isQuitting } from "./lifecycle.js";
 import { windowRegistry, type WindowRegistry } from "./window-registry.js";
@@ -128,6 +139,10 @@ export interface IpcContext {
     parent: BrowserWindow,
     record: (event: SteamAcquireEvent) => void,
   ) => Promise<SteamAcquireResult>;
+  getAccountsState: () => AccountsState;
+  setupAccounts: (request: AccountsSetupRequest) => Promise<void>;
+  openAccounts: (profileIds: readonly ProfileId[]) => Promise<void>;
+  useSingleAccountMode: () => Promise<void>;
 }
 
 type SteamInvokeChannel = "steamToken" | "steamStore" | "steamClear";
@@ -135,16 +150,20 @@ type SteamInvokeChannel = "steamToken" | "steamStore" | "steamClear";
 function assertSender(
   registry: WindowRegistry,
   event: Electron.IpcMainInvokeEvent,
+  role: "game" | "hub" | "any",
 ): BrowserWindow {
   const win = BrowserWindow.fromWebContents(event.sender);
   const context = registry.contextForWebContents(event.sender.id);
-  if (!win || !context || context.role !== "game") {
+  if (!win || !context || (role !== "any" && context.role !== role)) {
     throw new AllowlistError("unowned ipc sender");
   }
   if (!event.senderFrame || event.senderFrame !== event.sender.mainFrame) {
     throw new AllowlistError("ipc sender is not the main frame");
   }
-  if (!isCanonicalRendererUrl(event.senderFrame.url)) {
+  const trusted = context.role === "hub"
+    ? isAccountsRendererUrl(event.senderFrame.url)
+    : isCanonicalRendererUrl(event.senderFrame.url);
+  if (!trusted) {
     throw new AllowlistError("invalid ipc origin");
   }
   return win;
@@ -173,6 +192,7 @@ type Run<In, Out> = (win: BrowserWindow, input: In) => Out | Promise<Out>;
 interface ChannelDef<In, Out> {
   readonly parse: Parser<In>;
   readonly run: Run<In, Out>;
+  readonly role: "game" | "hub" | "any";
 }
 
 /**
@@ -185,14 +205,16 @@ interface ChannelDef<In, Out> {
 interface AnyChannelDef {
   readonly parse: Parser<unknown>;
   readonly run: Run<never, unknown>;
+  readonly role: "game" | "hub" | "any";
 }
 
 /** You cannot construct a channel without a parser. That is the point. */
 function channel<In, Out>(
   parse: Parser<In>,
   run: Run<In, Out>,
+  role: "game" | "hub" | "any" = "game",
 ): ChannelDef<In, Out> {
-  return { parse, run };
+  return { parse, run, role };
 }
 
 /** For the channels that carry nothing. Still a parser, still explicit. */
@@ -370,6 +392,41 @@ const asExternalLinkKind = one((value: unknown): ExternalLinkKind => {
     throw new ValidationError("invalid external link kind");
   }
   return value;
+});
+
+function parseLibraryScope(value: unknown, field: string): LibraryScope {
+  if (value !== "shared" && value !== "private") {
+    throw new ValidationError(`${field} must be shared or private`);
+  }
+  return value;
+}
+
+const asAccountsSetup = one((value: unknown): AccountsSetupRequest => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new ValidationError("account setup must be an object");
+  }
+  const input = value as Record<string, unknown>;
+  if (typeof input.importTemplates !== "boolean" || typeof input.importBuilds !== "boolean") {
+    throw new ValidationError("account import choices must be booleans");
+  }
+  return {
+    name: parseProfileName(input.name),
+    templates: parseLibraryScope(input.templates, "templates"),
+    builds: parseLibraryScope(input.builds, "builds"),
+    importTemplates: input.importTemplates,
+    importBuilds: input.importBuilds,
+  };
+});
+
+const asProfileIds = one((value: unknown): readonly ProfileId[] => {
+  if (!Array.isArray(value) || value.length === 0 || value.length > 16) {
+    throw new ValidationError("select between 1 and 16 account profiles");
+  }
+  const ids = value.map(parseProfileId);
+  if (new Set(ids).size !== ids.length) {
+    throw new ValidationError("account profile selection contains duplicates");
+  }
+  return ids;
 });
 
 interface ParsedMilestone {
@@ -819,6 +876,25 @@ export function registerIpcHandlers(ctx: IpcContext): {
       nothing,
       (win) => ctx.restartAndInstallUpdate(win),
     ),
+    accountsGet: channel(
+      nothing,
+      () => ctx.getAccountsState(),
+      "any",
+    ),
+    accountsSetup: channel(
+      asAccountsSetup,
+      (_win, request) => ctx.setupAccounts(request),
+    ),
+    accountsOpen: channel(
+      asProfileIds,
+      (_win, profileIds) => ctx.openAccounts(profileIds),
+      "hub",
+    ),
+    accountsUseSingle: channel(
+      nothing,
+      () => ctx.useSingleAccountMode(),
+      "any",
+    ),
   } satisfies Record<Exclude<InvokeChannel, SteamInvokeChannel>, AnyChannelDef>;
 
   registerChannelDefinitions(ctx.windows, handlers);
@@ -856,7 +932,7 @@ function registerChannelDefinitions(
     const def = definition as ChannelDef<unknown, unknown>;
     const name = key as InvokeChannel;
     ipcMain.handle(IPC[name], async (event, ...args: unknown[]) => {
-      const win = assertSender(windows, event);
+      const win = assertSender(windows, event, def.role);
       let input: unknown;
       try {
         input = def.parse(args);

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -21,6 +21,7 @@ import type {
   AccountsSetupRequest,
   AccountProfileRequest,
   AccountProfileUpdateRequest,
+  AccountTemplateLibrary,
   AccountsState,
   AppUpdateState,
   CacheInfo,
@@ -36,10 +37,12 @@ import type {
   SteamRefusalReason,
   SteamTokenResult,
   StoredCredentials,
+  TemplateExportEntry,
 } from "../shared/contracts.js";
 import {
   parseProfileId,
   parseProfileName,
+  MULTI_PROFILE_MAX_COUNT,
   type LibraryScope,
   type ProfileId,
 } from "../shared/multiple-accounts.js";
@@ -87,6 +90,7 @@ import type {
 } from "./steam-acquire.js";
 import { parseSettingsPatch } from "./core/settings.js";
 import type { SocketManager } from "./core/sockets.js";
+import { Mutex } from "./core/mutex.js";
 import { FREE_MARGIN, type ChunkStore } from "./core/chunk-store.js";
 import {
   count,
@@ -122,6 +126,7 @@ export interface IpcContext {
   credentialsStoreFor: (win: BrowserWindow) => CredentialsStore;
   steamSessionStoreFor: (win: BrowserWindow) => SteamSessionStore;
   buildLibraryPathFor: (win: BrowserWindow) => string;
+  gameStorageResetMarkerFor: (win: BrowserWindow) => string;
   getProgress: () => DownloadProgress;
   getChunkStore: () => ChunkStore | null;
   getSettings: () => Promise<AppSettings>;
@@ -147,7 +152,14 @@ export interface IpcContext {
   createAccount: (request: AccountProfileRequest) => Promise<AccountsState>;
   updateAccount: (request: AccountProfileUpdateRequest) => Promise<AccountsState>;
   archiveAccount: (profileId: ProfileId) => Promise<AccountsState>;
+  restoreAccount: (profileId: ProfileId) => Promise<AccountsState>;
+  deleteAccount: (profileId: ProfileId) => Promise<AccountsState>;
   useSingleAccountMode: () => Promise<void>;
+  loadAccountTemplates: (win: BrowserWindow) => Promise<AccountTemplateLibrary | null>;
+  saveAccountTemplates: (
+    win: BrowserWindow,
+    entries: readonly TemplateExportEntry[],
+  ) => Promise<void>;
 }
 
 type SteamInvokeChannel = "steamToken" | "steamStore" | "steamClear";
@@ -419,6 +431,7 @@ const asAccountsSetup = one((value: unknown): AccountsSetupRequest => {
     templates: parseLibraryScope(input.templates, "templates"),
     builds: parseLibraryScope(input.builds, "builds"),
     importTemplates: input.importTemplates,
+    templateEntries: parseExportEntries(input.templateEntries),
     importBuilds: input.importBuilds,
   };
 });
@@ -446,8 +459,14 @@ const asAccountProfileUpdate = one((value: unknown): AccountProfileUpdateRequest
 const asProfileId = one(parseProfileId);
 
 const asProfileIds = one((value: unknown): readonly ProfileId[] => {
-  if (!Array.isArray(value) || value.length === 0 || value.length > 16) {
-    throw new ValidationError("select between 1 and 16 account profiles");
+  if (
+    !Array.isArray(value)
+    || value.length === 0
+    || value.length > MULTI_PROFILE_MAX_COUNT
+  ) {
+    throw new ValidationError(
+      `select between 1 and ${MULTI_PROFILE_MAX_COUNT} account profiles`,
+    );
   }
   const ids = value.map(parseProfileId);
   if (new Set(ids).size !== ids.length) {
@@ -670,6 +689,28 @@ export function registerIpcHandlers(ctx: IpcContext): {
 } {
   const paths = gamePaths();
   const secretOperations = new Set<Promise<unknown>>();
+  const buildBaselines = new WeakMap<BrowserWindow, Map<string, string>>();
+  const buildLocks = new Map<string, Mutex>();
+  const buildLock = (libraryPath: string): Mutex => {
+    let lock = buildLocks.get(libraryPath);
+    if (!lock) {
+      lock = new Mutex();
+      buildLocks.set(libraryPath, lock);
+    }
+    return lock;
+  };
+  const rememberBuildBaseline = (
+    win: BrowserWindow,
+    libraryPath: string,
+    library: unknown,
+  ): void => {
+    let values = buildBaselines.get(win);
+    if (!values) {
+      values = new Map();
+      buildBaselines.set(win, values);
+    }
+    values.set(libraryPath, JSON.stringify(library));
+  };
   const secretOperation = <T>(operation: () => Promise<T>): Promise<T> => {
     if (isQuitting()) {
       return Promise.reject(new ValidationError("application is quitting"));
@@ -734,15 +775,31 @@ export function registerIpcHandlers(ctx: IpcContext): {
     }),
 
     buildLibraryGet: channel(nothing, async (win) => {
-      let recovered = false;
-      const library = await loadBuildLibrary(ctx.buildLibraryPathFor(win), () => {
-        recovered = true;
+      const libraryPath = ctx.buildLibraryPathFor(win);
+      return buildLock(libraryPath).run(async () => {
+        let recovered = false;
+        const library = await loadBuildLibrary(libraryPath, () => {
+          recovered = true;
+        });
+        rememberBuildBaseline(win, libraryPath, library);
+        return { library, recovered };
       });
-      return { library, recovered };
     }),
 
     buildLibrarySet: channel(one(parseBuildLibrary), async (win, library) => {
-      return saveBuildLibrary(ctx.buildLibraryPathFor(win), library);
+      const libraryPath = ctx.buildLibraryPathFor(win);
+      return buildLock(libraryPath).run(async () => {
+        const current = await loadBuildLibrary(libraryPath);
+        const expected = buildBaselines.get(win)?.get(libraryPath);
+        if (expected === undefined || expected !== JSON.stringify(current)) {
+          throw new ValidationError(
+            "build library changed in another account; reload before saving",
+          );
+        }
+        const saved = await saveBuildLibrary(libraryPath, library);
+        rememberBuildBaseline(win, libraryPath, saved);
+        return saved;
+      });
     }),
 
     settingsGet: channel(nothing, async () => {
@@ -818,7 +875,7 @@ export function registerIpcHandlers(ctx: IpcContext): {
     cacheStopDownload: channel(nothing, () => ctx.stopFullDownload()),
 
     gameStorageReset: channel(nothing, (win) =>
-      requestGameStorageReset(win, paths.gameStorageClearRequest),
+      requestGameStorageReset(win, ctx.gameStorageResetMarkerFor(win)),
     ),
 
     diagnosticsGraphics: channel(asGraphics, (_win, value) => {
@@ -932,10 +989,28 @@ export function registerIpcHandlers(ctx: IpcContext): {
       (_win, profileId) => ctx.archiveAccount(profileId),
       "hub",
     ),
+    accountsRestore: channel(
+      asProfileId,
+      (_win, profileId) => ctx.restoreAccount(profileId),
+      "hub",
+    ),
+    accountsDelete: channel(
+      asProfileId,
+      (_win, profileId) => ctx.deleteAccount(profileId),
+      "hub",
+    ),
     accountsUseSingle: channel(
       nothing,
       () => ctx.useSingleAccountMode(),
       "any",
+    ),
+    accountsTemplatesLoad: channel(
+      nothing,
+      (win) => ctx.loadAccountTemplates(win),
+    ),
+    accountsTemplatesSave: channel(
+      one(parseExportEntries),
+      (win, entries) => ctx.saveAccountTemplates(win, entries),
     ),
   } satisfies Record<Exclude<InvokeChannel, SteamInvokeChannel>, AnyChannelDef>;
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -19,7 +19,6 @@ import type {
   AppSettings,
   AppSettingsPatch,
   AccountsSetupRequest,
-  AccountProfileRequest,
   AccountProfileCreateRequest,
   AccountProfileUpdateRequest,
   AccountTemplateLibrary,
@@ -41,27 +40,14 @@ import type {
   StoredCredentials,
   TemplateExportEntry,
 } from "../shared/contracts.js";
-import {
-  parseProfileId,
-  parseProfileName,
-  MULTI_PROFILE_MAX_COUNT,
-  type LibraryScope,
-  type ProfileId,
-} from "../shared/multiple-accounts.js";
+import { parseProfileId, type ProfileId } from "../shared/multiple-accounts.js";
 import type {
   RendererFrameBatch,
   RendererMetrics,
-  RendererMilestone,
-  RendererMilestoneFields,
-  WasmAbortReasonKind,
 } from "../shared/diagnostics.js";
 import {
   isRendererFrameBatch,
   isRendererMetrics,
-  RENDERER_MILESTONES,
-  WASM_ABORT_REASON_KINDS,
-  WASM_GROWTH_OUTCOMES,
-  WASM_MEMORY_PROBE_STATUSES,
 } from "../shared/diagnostics.js";
 import { EXTERNAL_URLS, IPC } from "../shared/contracts.js";
 import { ENHANCEMENT_RUNTIME_FEATURES } from "../shared/contracts.js";
@@ -76,7 +62,17 @@ import {
 import { parseCredentials, type CredentialsStore } from "./core/credentials.js";
 import { parseBuildLibrary } from "../shared/builds/parse-library.js";
 import type { BuildLibrary } from "../shared/builds/library.js";
-import { isGraphicsDiagnostics, toWireSocketEvent } from "./ipc-values.js";
+import {
+  isGraphicsDiagnostics,
+  parseRendererMilestoneArgs,
+  toWireSocketEvent,
+} from "./ipc-values.js";
+import {
+  parseAccountProfileCreate,
+  parseAccountProfileUpdate,
+  parseAccountsSetup,
+  parseProfileIds,
+} from "./accounts-ipc-values.js";
 import { resolveDns } from "./core/dns.js";
 import { exportTemplates, parseExportEntries } from "./template-export.js";
 import {
@@ -104,7 +100,6 @@ import {
   recordClockOffset,
   startDnsResolveSpan,
 } from "./diagnostics.js";
-import { isRendererFingerprint } from "./diagnostics/schema-fields.js";
 import { gamePaths } from "./paths.js";
 import {
   isAccountsRendererUrl,
@@ -438,238 +433,12 @@ const asExternalLinkKind = one((value: unknown): ExternalLinkKind => {
   return value;
 });
 
-function parseLibraryScope(value: unknown, field: string): LibraryScope {
-  if (value !== "shared" && value !== "private") {
-    throw new ValidationError(`${field} must be shared or private`);
-  }
-  return value;
-}
-
-const asAccountsSetup = one((value: unknown): AccountsSetupRequest => {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new ValidationError("account setup must be an object");
-  }
-  const input = value as Record<string, unknown>;
-  return {
-    templateEntries: parseExportEntries(input.templateEntries),
-  };
-});
-
-function parseAccountProfile(value: unknown): AccountProfileRequest {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new ValidationError("account profile must be an object");
-  }
-  const input = value as Record<string, unknown>;
-  return {
-    name: parseProfileName(input.name),
-    templates: parseLibraryScope(input.templates, "templates"),
-    builds: parseLibraryScope(input.builds, "builds"),
-  };
-}
-
-const asAccountProfileCreate = one((value: unknown): AccountProfileCreateRequest => {
-  const profile = parseAccountProfile(value);
-  const input = value as Record<string, unknown>;
-  if (
-    typeof input.copySingleBuilds !== "boolean"
-    || typeof input.copySingleTemplates !== "boolean"
-  ) {
-    throw new ValidationError("account copy choices must be booleans");
-  }
-  return {
-    ...profile,
-    copySingleBuilds: input.copySingleBuilds,
-    copySingleTemplates: input.copySingleTemplates,
-  };
-});
-const asAccountProfileUpdate = one((value: unknown): AccountProfileUpdateRequest => {
-  const profile = parseAccountProfile(value);
-  return {
-    id: parseProfileId((value as Record<string, unknown>).id),
-    ...profile,
-  };
-});
+const asAccountsSetup = one(parseAccountsSetup);
+const asAccountProfileCreate = one(parseAccountProfileCreate);
+const asAccountProfileUpdate = one(parseAccountProfileUpdate);
 const asProfileId = one(parseProfileId);
-
-const asProfileIds = one((value: unknown): readonly ProfileId[] => {
-  if (
-    !Array.isArray(value)
-    || value.length === 0
-    || value.length > MULTI_PROFILE_MAX_COUNT
-  ) {
-    throw new ValidationError(
-      `select between 1 and ${MULTI_PROFILE_MAX_COUNT} account profiles`,
-    );
-  }
-  const ids = value.map(parseProfileId);
-  if (new Set(ids).size !== ids.length) {
-    throw new ValidationError("account profile selection contains duplicates");
-  }
-  return ids;
-});
-
-interface ParsedMilestone {
-  name: RendererMilestone;
-  rendererTimestampUs: number;
-  fields: RendererMilestoneFields | undefined;
-}
-
-/** A byte count as the renderer reports one: a non-negative safe integer. */
-const isByteCount = (value: unknown): value is number =>
-  typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
-
-const asMilestone: Parser<ParsedMilestone> = (args) => {
-  exact(args, 3);
-  const [name, rendererTimestampUs, fields] = args;
-  if (
-    typeof name !== "string" ||
-    !RENDERER_MILESTONES.includes(name as RendererMilestone) ||
-    typeof rendererTimestampUs !== "number" ||
-    !Number.isFinite(rendererTimestampUs) ||
-    rendererTimestampUs < 0 ||
-    rendererTimestampUs > Number.MAX_SAFE_INTEGER
-  ) {
-    throw new ValidationError("invalid renderer milestone");
-  }
-  const record = fields as Record<string, unknown> | undefined;
-  const recordIsObject =
-    record !== undefined
-    && record !== null
-    && typeof record === "object"
-    && !Array.isArray(record);
-  let milestoneFields: RendererMilestoneFields | undefined;
-  if (name === "build.info") {
-    const valid =
-      recordIsObject
-      && Object.keys(record).length === 2
-      && (typeof record.programId === "string" || typeof record.programId === "number")
-      && (typeof record.buildId === "string" || typeof record.buildId === "number")
-      && [record.programId, record.buildId].every(
-        (value) =>
-          (typeof value === "string" && value.length <= 128) ||
-          (typeof value === "number" && Number.isSafeInteger(value) && value >= 0),
-      );
-    if (!valid) throw new ValidationError("invalid renderer milestone");
-    milestoneFields = {
-      programId: record.programId as string | number,
-      buildId: record.buildId as string | number,
-    };
-  } else if (name === "wasm.abort") {
-    const valid =
-      recordIsObject
-      && Object.keys(record).length === 3
-      && typeof record.reasonKind === "string"
-      && (WASM_ABORT_REASON_KINDS as readonly string[]).includes(record.reasonKind)
-      && isRendererFingerprint(record.fingerprint)
-      && isByteCount(record.heapBytes);
-    if (!valid) throw new ValidationError("invalid renderer milestone");
-    milestoneFields = {
-      reasonKind: record.reasonKind as WasmAbortReasonKind,
-      fingerprint: record.fingerprint as string,
-      heapBytes: record.heapBytes as number,
-    };
-  } else if (name === "wasm.exit") {
-    const valid =
-      recordIsObject
-      && Object.keys(record).length === 2
-      && typeof record.code === "number"
-      && Number.isSafeInteger(record.code)
-      && isByteCount(record.heapBytes);
-    if (!valid) throw new ValidationError("invalid renderer milestone");
-    milestoneFields = {
-      code: record.code as number,
-      heapBytes: record.heapBytes as number,
-    };
-  } else if (name === "wasm.memoryProbe") {
-    const valid =
-      recordIsObject
-      && Object.keys(record).length === 1
-      && typeof record.status === "string"
-      && (WASM_MEMORY_PROBE_STATUSES as readonly string[]).includes(record.status);
-    if (!valid) throw new ValidationError("invalid renderer milestone");
-    milestoneFields = {
-      status: record.status as (typeof WASM_MEMORY_PROBE_STATUSES)[number],
-    };
-  } else if (name === "wasm.growthRequested") {
-    const numericFields = [
-      "requestedBytes", "beforeBytes", "afterBytes", "stackDepth",
-      "frame0Function", "frame0Offset", "frame1Function", "frame1Offset",
-      "frame2Function", "frame2Offset", "frame3Function", "frame3Offset",
-      "generatedTextures", "deletedTextures", "liveTextures",
-      "trackedTextures", "knownTextureBytes", "textureUploadBytes",
-      "unknownTextureAllocations",
-    ] as const;
-    const valid =
-      recordIsObject
-      && Object.keys(record).length === numericFields.length + 3
-      && numericFields.every((field) => isByteCount(record[field]))
-      && (record.stackDepth as number) <= 4
-      && (record.trackedTextures as number) <= 4_096
-      && typeof record.outcome === "string"
-      && (WASM_GROWTH_OUTCOMES as readonly string[]).includes(record.outcome)
-      && isRendererFingerprint(record.stackFingerprint)
-      && typeof record.textureTrackingSaturated === "boolean";
-    if (!valid) throw new ValidationError("invalid renderer milestone");
-    milestoneFields = {
-      requestedBytes: record.requestedBytes as number,
-      beforeBytes: record.beforeBytes as number,
-      afterBytes: record.afterBytes as number,
-      outcome: record.outcome as (typeof WASM_GROWTH_OUTCOMES)[number],
-      stackFingerprint: record.stackFingerprint as string,
-      stackDepth: record.stackDepth as number,
-      frame0Function: record.frame0Function as number,
-      frame0Offset: record.frame0Offset as number,
-      frame1Function: record.frame1Function as number,
-      frame1Offset: record.frame1Offset as number,
-      frame2Function: record.frame2Function as number,
-      frame2Offset: record.frame2Offset as number,
-      frame3Function: record.frame3Function as number,
-      frame3Offset: record.frame3Offset as number,
-      generatedTextures: record.generatedTextures as number,
-      deletedTextures: record.deletedTextures as number,
-      liveTextures: record.liveTextures as number,
-      trackedTextures: record.trackedTextures as number,
-      knownTextureBytes: record.knownTextureBytes as number,
-      textureUploadBytes: record.textureUploadBytes as number,
-      unknownTextureAllocations: record.unknownTextureAllocations as number,
-      textureTrackingSaturated: record.textureTrackingSaturated as boolean,
-    };
-  } else if (name === "enhancement.installed") {
-    const valid =
-      recordIsObject
-      && Object.keys(record).length === 3
-      && typeof record.companionAbi === "number"
-      && Number.isSafeInteger(record.companionAbi)
-      && record.companionAbi >= 0
-      && typeof record.installation === "number"
-      && Number.isSafeInteger(record.installation)
-      && record.installation >= 1
-      && typeof record.capabilityProfile === "string"
-      && record.capabilityProfile.length <= 32;
-    if (!valid) throw new ValidationError("invalid renderer milestone");
-    milestoneFields = {
-      companionAbi: record.companionAbi as number,
-      installation: record.installation as number,
-      capabilityProfile: record.capabilityProfile as string,
-    };
-  } else if (name === "enhancement.uninstalled") {
-    const valid =
-      recordIsObject
-      && Object.keys(record).length === 1
-      && typeof record.installation === "number"
-      && Number.isSafeInteger(record.installation)
-      && record.installation >= 1;
-    if (!valid) throw new ValidationError("invalid renderer milestone");
-    milestoneFields = { installation: record.installation as number };
-  } else if (fields !== undefined) {
-    throw new ValidationError("invalid renderer milestone");
-  }
-  return {
-    name: name as RendererMilestone,
-    rendererTimestampUs,
-    fields: milestoneFields,
-  };
-};
+const asProfileIds = one(parseProfileIds);
+const asMilestone = parseRendererMilestoneArgs;
 
 async function chunkStoreInfo(
   store: ChunkStore | null,

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -13,7 +13,7 @@
  * arguments and either forwards one owner-local capability directly or calls
  * the workflow owner; it returns codes rather than inventing prose.
  */
-import { BrowserWindow, clipboard, ipcMain, shell, app } from "electron";
+import { BrowserWindow, clipboard, ipcMain, shell } from "electron";
 import { statfs } from "node:fs/promises";
 import type {
   AppSettings,
@@ -153,8 +153,12 @@ export interface IpcContext {
   updateAccount: (request: AccountProfileUpdateRequest) => Promise<AccountsState>;
   archiveAccount: (profileId: ProfileId) => Promise<AccountsState>;
   restoreAccount: (profileId: ProfileId) => Promise<AccountsState>;
-  deleteAccount: (profileId: ProfileId) => Promise<AccountsState>;
+  deleteAccount: (
+    parent: BrowserWindow,
+    profileId: ProfileId,
+  ) => Promise<AccountsState>;
   useSingleAccountMode: () => Promise<void>;
+  requestQuit: (win: BrowserWindow) => void;
   loadAccountTemplates: (win: BrowserWindow) => Promise<AccountTemplateLibrary | null>;
   saveAccountTemplates: (
     win: BrowserWindow,
@@ -921,9 +925,7 @@ export function registerIpcHandlers(ctx: IpcContext): {
       if (kind === "gameData") shell.showItemInFolder(paths.game);
     }),
 
-    appRequestQuit: channel(nothing, () => {
-      app.quit();
-    }),
+    appRequestQuit: channel(nothing, (win) => ctx.requestQuit(win)),
 
     clipboardWriteText: channel(asClipboardText, (_win, text) => {
       clipboard.writeText(text);
@@ -996,7 +998,7 @@ export function registerIpcHandlers(ctx: IpcContext): {
     ),
     accountsDelete: channel(
       asProfileId,
-      (_win, profileId) => ctx.deleteAccount(profileId),
+      (win, profileId) => ctx.deleteAccount(win, profileId),
       "hub",
     ),
     accountsUseSingle: channel(

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -95,7 +95,7 @@ import { gamePaths } from "./paths.js";
 import { isCanonicalRendererUrl } from "./core/renderer-trust.js";
 import { MAX_QUEUED_BYTES_PER_SOCKET } from "./core/sockets.js";
 import { isQuitting } from "./lifecycle.js";
-import { getMainWindow } from "./window.js";
+import { windowRegistry, type WindowRegistry } from "./window-registry.js";
 import {
   applySettingsChange,
   confirmSettingsReset,
@@ -105,8 +105,10 @@ import {
 
 export interface IpcContext {
   sockets: SocketManager;
-  credentialsStore: CredentialsStore;
-  steamSessionStore: SteamSessionStore;
+  windows: WindowRegistry;
+  credentialsStoreFor: (win: BrowserWindow) => CredentialsStore;
+  steamSessionStoreFor: (win: BrowserWindow) => SteamSessionStore;
+  buildLibraryPathFor: (win: BrowserWindow) => string;
   getProgress: () => DownloadProgress;
   getChunkStore: () => ChunkStore | null;
   getSettings: () => Promise<AppSettings>;
@@ -130,9 +132,13 @@ export interface IpcContext {
 
 type SteamInvokeChannel = "steamToken" | "steamStore" | "steamClear";
 
-function assertSender(event: Electron.IpcMainInvokeEvent): BrowserWindow {
+function assertSender(
+  registry: WindowRegistry,
+  event: Electron.IpcMainInvokeEvent,
+): BrowserWindow {
   const win = BrowserWindow.fromWebContents(event.sender);
-  if (!win || win !== getMainWindow()) {
+  const context = registry.contextForWebContents(event.sender.id);
+  if (!win || !context || context.role !== "game") {
     throw new AllowlistError("unowned ipc sender");
   }
   if (!event.senderFrame || event.senderFrame !== event.sender.mainFrame) {
@@ -579,7 +585,6 @@ export function registerIpcHandlers(ctx: IpcContext): {
   drainSecrets(): Promise<void>;
 } {
   const paths = gamePaths();
-  const credentials = ctx.credentialsStore;
   const secretOperations = new Set<Promise<unknown>>();
   const secretOperation = <T>(operation: () => Promise<T>): Promise<T> => {
     if (isQuitting()) {
@@ -644,16 +649,16 @@ export function registerIpcHandlers(ctx: IpcContext): {
       await ctx.sockets.close(socketId, win.webContents.id);
     }),
 
-    buildLibraryGet: channel(nothing, async () => {
+    buildLibraryGet: channel(nothing, async (win) => {
       let recovered = false;
-      const library = await loadBuildLibrary(paths.buildLibrary, () => {
+      const library = await loadBuildLibrary(ctx.buildLibraryPathFor(win), () => {
         recovered = true;
       });
       return { library, recovered };
     }),
 
-    buildLibrarySet: channel(one(parseBuildLibrary), async (_win, library) => {
-      return saveBuildLibrary(paths.buildLibrary, library);
+    buildLibrarySet: channel(one(parseBuildLibrary), async (win, library) => {
+      return saveBuildLibrary(ctx.buildLibraryPathFor(win), library);
     }),
 
     settingsGet: channel(nothing, async () => {
@@ -679,9 +684,9 @@ export function registerIpcHandlers(ctx: IpcContext): {
       confirmSettingsReset(win, ctx.resetSettings),
     ),
 
-    credentialsLoad: channel(nothing, async () => {
+    credentialsLoad: channel(nothing, async (win) => {
       try {
-        return await secretOperation(() => credentials.load());
+        return await secretOperation(() => ctx.credentialsStoreFor(win).load());
       } catch (error) {
         logEvent({ k: "credentials.loadFailed", code: errorCode(error) });
         throw error;
@@ -692,9 +697,9 @@ export function registerIpcHandlers(ctx: IpcContext): {
     // is that rule, so the boundary is validated without a second opinion.
     credentialsSave: channel(
       one(parseCredentials),
-      async (_win, value: StoredCredentials) => {
+      async (win, value: StoredCredentials) => {
         try {
-          await secretOperation(() => credentials.save(value));
+          await secretOperation(() => ctx.credentialsStoreFor(win).save(value));
         } catch (error) {
           logEvent({ k: "credentials.saveFailed", code: errorCode(error) });
           throw error;
@@ -702,9 +707,9 @@ export function registerIpcHandlers(ctx: IpcContext): {
       },
     ),
 
-    credentialsClear: channel(nothing, async () => {
+    credentialsClear: channel(nothing, async (win) => {
       try {
-        await secretOperation(() => credentials.clear());
+        await secretOperation(() => ctx.credentialsStoreFor(win).clear());
       } catch (error) {
         logEvent({ k: "credentials.clearFailed", code: errorCode(error) });
         throw error;
@@ -816,10 +821,11 @@ export function registerIpcHandlers(ctx: IpcContext): {
     ),
   } satisfies Record<Exclude<InvokeChannel, SteamInvokeChannel>, AnyChannelDef>;
 
-  registerChannelDefinitions(handlers);
+  registerChannelDefinitions(ctx.windows, handlers);
   const steamSettled = registerSteamIpcHandlers(
     ctx.acquireSteamToken,
-    ctx.steamSessionStore,
+    ctx.steamSessionStoreFor,
+    ctx.windows,
   );
   return {
     async drainSecrets() {
@@ -832,6 +838,7 @@ export function registerIpcHandlers(ctx: IpcContext): {
 }
 
 function registerChannelDefinitions(
+  windows: WindowRegistry,
   handlers: Partial<Record<InvokeChannel, AnyChannelDef>>,
 ): void {
   // One registration, uniform and total: `assertSender` first, then the
@@ -849,7 +856,7 @@ function registerChannelDefinitions(
     const def = definition as ChannelDef<unknown, unknown>;
     const name = key as InvokeChannel;
     ipcMain.handle(IPC[name], async (event, ...args: unknown[]) => {
-      const win = assertSender(event);
+      const win = assertSender(windows, event);
       let input: unknown;
       try {
         input = def.parse(args);
@@ -864,9 +871,22 @@ function registerChannelDefinitions(
 
 export function registerSteamIpcHandlers(
   acquireSteamToken: IpcContext["acquireSteamToken"],
-  store: SteamSessionStore,
+  storeOrResolver: SteamSessionStore | ((win: BrowserWindow) => SteamSessionStore),
+  windows?: WindowRegistry,
 ): () => Promise<void> {
-  const steam = new SteamSessionCoordinator(store);
+  const storeFor = typeof storeOrResolver === "function"
+    ? storeOrResolver
+    : () => storeOrResolver;
+  const coordinators = new Map<SteamSessionStore, SteamSessionCoordinator>();
+  const coordinatorFor = (win: BrowserWindow): SteamSessionCoordinator => {
+    const store = storeFor(win);
+    let coordinator = coordinators.get(store);
+    if (!coordinator) {
+      coordinator = new SteamSessionCoordinator(store);
+      coordinators.set(store, coordinator);
+    }
+    return coordinator;
+  };
 
   const runSteamSignIn = async (
     win: BrowserWindow,
@@ -893,6 +913,7 @@ export function registerSteamIpcHandlers(
     // rebuilds its own login screen from a refused credential and a rejection
     // here would only turn "no token" into a launch failure.
     steamToken: channel(asSilentFlag, async (win, silent) => {
+      const steam = coordinatorFor(win);
       if (isQuitting()) throw new ValidationError("application is quitting");
       const resolution = await steam.resolve({
         silent,
@@ -920,14 +941,16 @@ export function registerSteamIpcHandlers(
       } satisfies SteamTokenResult;
     }),
 
-    steamStore: channel(asSteamStoreback, async (_win, { token, expiry }) => {
+    steamStore: channel(asSteamStoreback, async (win, { token, expiry }) => {
       if (isQuitting()) throw new ValidationError("application is quitting");
+      const steam = coordinatorFor(win);
       const outcome = await steam.refresh(token, expiry);
       logEvent({ k: "steam.storeback", outcome });
     }),
 
-    steamClear: channel(nothing, async () => {
+    steamClear: channel(nothing, async (win) => {
       if (isQuitting()) throw new ValidationError("application is quitting");
+      const steam = coordinatorFor(win);
       try {
         await steam.clear();
         logEvent({ k: "steam.tokenCleared" });
@@ -938,8 +961,10 @@ export function registerSteamIpcHandlers(
     }),
   } satisfies Record<SteamInvokeChannel, AnyChannelDef>;
 
-  registerChannelDefinitions(handlers);
-  return () => steam.settled();
+  registerChannelDefinitions(windows ?? windowRegistry, handlers);
+  return async () => {
+    await Promise.all([...coordinators.values()].map((steam) => steam.settled()));
+  };
 }
 
 export function emitSocketEvent(ownerId: number, event: SocketEvent): void {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -20,6 +20,7 @@ import type {
   AppSettingsPatch,
   AccountsSetupRequest,
   AccountProfileRequest,
+  AccountProfileCreateRequest,
   AccountProfileUpdateRequest,
   AccountTemplateLibrary,
   AccountsState,
@@ -155,7 +156,7 @@ export interface IpcContext {
   getAccountsState: () => AccountsState;
   setupAccounts: (request: AccountsSetupRequest) => Promise<void>;
   openAccounts: (profileIds: readonly ProfileId[]) => Promise<void>;
-  createAccount: (request: AccountProfileRequest) => Promise<AccountsState>;
+  createAccount: (request: AccountProfileCreateRequest) => Promise<AccountsState>;
   updateAccount: (request: AccountProfileUpdateRequest) => Promise<AccountsState>;
   archiveAccount: (profileId: ProfileId) => Promise<AccountsState>;
   restoreAccount: (profileId: ProfileId) => Promise<AccountsState>;
@@ -450,16 +451,8 @@ const asAccountsSetup = one((value: unknown): AccountsSetupRequest => {
     throw new ValidationError("account setup must be an object");
   }
   const input = value as Record<string, unknown>;
-  if (typeof input.importTemplates !== "boolean" || typeof input.importBuilds !== "boolean") {
-    throw new ValidationError("account import choices must be booleans");
-  }
   return {
-    name: parseProfileName(input.name),
-    templates: parseLibraryScope(input.templates, "templates"),
-    builds: parseLibraryScope(input.builds, "builds"),
-    importTemplates: input.importTemplates,
     templateEntries: parseExportEntries(input.templateEntries),
-    importBuilds: input.importBuilds,
   };
 });
 
@@ -475,7 +468,21 @@ function parseAccountProfile(value: unknown): AccountProfileRequest {
   };
 }
 
-const asAccountProfile = one(parseAccountProfile);
+const asAccountProfileCreate = one((value: unknown): AccountProfileCreateRequest => {
+  const profile = parseAccountProfile(value);
+  const input = value as Record<string, unknown>;
+  if (
+    typeof input.copySingleBuilds !== "boolean"
+    || typeof input.copySingleTemplates !== "boolean"
+  ) {
+    throw new ValidationError("account copy choices must be booleans");
+  }
+  return {
+    ...profile,
+    copySingleBuilds: input.copySingleBuilds,
+    copySingleTemplates: input.copySingleTemplates,
+  };
+});
 const asAccountProfileUpdate = one((value: unknown): AccountProfileUpdateRequest => {
   const profile = parseAccountProfile(value);
   return {
@@ -1004,7 +1011,7 @@ export function registerIpcHandlers(ctx: IpcContext): {
       "hub",
     ),
     accountsCreate: channel(
-      asAccountProfile,
+      asAccountProfileCreate,
       (_win, request) => ctx.createAccount(request),
       "hub",
     ),

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -19,6 +19,8 @@ import type {
   AppSettings,
   AppSettingsPatch,
   AccountsSetupRequest,
+  AccountProfileRequest,
+  AccountProfileUpdateRequest,
   AccountsState,
   AppUpdateState,
   CacheInfo,
@@ -142,6 +144,9 @@ export interface IpcContext {
   getAccountsState: () => AccountsState;
   setupAccounts: (request: AccountsSetupRequest) => Promise<void>;
   openAccounts: (profileIds: readonly ProfileId[]) => Promise<void>;
+  createAccount: (request: AccountProfileRequest) => Promise<AccountsState>;
+  updateAccount: (request: AccountProfileUpdateRequest) => Promise<AccountsState>;
+  archiveAccount: (profileId: ProfileId) => Promise<AccountsState>;
   useSingleAccountMode: () => Promise<void>;
 }
 
@@ -417,6 +422,28 @@ const asAccountsSetup = one((value: unknown): AccountsSetupRequest => {
     importBuilds: input.importBuilds,
   };
 });
+
+function parseAccountProfile(value: unknown): AccountProfileRequest {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new ValidationError("account profile must be an object");
+  }
+  const input = value as Record<string, unknown>;
+  return {
+    name: parseProfileName(input.name),
+    templates: parseLibraryScope(input.templates, "templates"),
+    builds: parseLibraryScope(input.builds, "builds"),
+  };
+}
+
+const asAccountProfile = one(parseAccountProfile);
+const asAccountProfileUpdate = one((value: unknown): AccountProfileUpdateRequest => {
+  const profile = parseAccountProfile(value);
+  return {
+    id: parseProfileId((value as Record<string, unknown>).id),
+    ...profile,
+  };
+});
+const asProfileId = one(parseProfileId);
 
 const asProfileIds = one((value: unknown): readonly ProfileId[] => {
   if (!Array.isArray(value) || value.length === 0 || value.length > 16) {
@@ -888,6 +915,21 @@ export function registerIpcHandlers(ctx: IpcContext): {
     accountsOpen: channel(
       asProfileIds,
       (_win, profileIds) => ctx.openAccounts(profileIds),
+      "hub",
+    ),
+    accountsCreate: channel(
+      asAccountProfile,
+      (_win, request) => ctx.createAccount(request),
+      "hub",
+    ),
+    accountsUpdate: channel(
+      asAccountProfileUpdate,
+      (_win, request) => ctx.updateAccount(request),
+      "hub",
+    ),
+    accountsArchive: channel(
+      asProfileId,
+      (_win, profileId) => ctx.archiveAccount(profileId),
       "hub",
     ),
     accountsUseSingle: channel(

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -27,7 +27,7 @@ import {
   type AppSettingsPatch,
   type AccountsSetupRequest,
   type AccountsState,
-  type AccountProfileRequest,
+  type AccountProfileCreateRequest,
   type AccountProfileUpdateRequest,
   type DownloadProgress,
   type PrefetchProgress,
@@ -806,29 +806,15 @@ if (primaryInstance) void app.whenReady().then(async () => {
     }
     multiWorkspace ??= await loadMultiWorkspace(paths.multiWorkspace);
     if (!multiWorkspace) {
-      const candidate = createMultiWorkspace(request);
-      const profile = candidate.profiles[0]!;
-      const profilePaths = multiProfilePaths(paths, profile.id);
-      await mkdir(profilePaths.root, { recursive: true });
-      if (request.importBuilds) {
-        await importBuildLibraryIfPresent(
-          paths.buildLibrary,
-          profile.builds === "shared"
-            ? paths.multiSharedBuildLibrary
-            : profilePaths.buildLibrary,
-        );
-      }
-      if (request.importTemplates) {
-        const templatePath = profile.templates === "shared"
-          ? paths.multiSharedTemplates
-          : profilePaths.templates;
-        await saveAccountTemplateLibrary(templatePath, {
-          revision: 1,
-          entries: request.templateEntries,
-        });
-      }
+      const candidate = createMultiWorkspace();
       await saveMultiWorkspace(paths.multiWorkspace, candidate);
       multiWorkspace = candidate;
+    }
+    if (multiWorkspace.profiles.length === 0) {
+      await saveAccountTemplateLibrary(paths.multiSingleTemplateImport, {
+        revision: 1,
+        entries: request.templateEntries,
+      });
     }
     await saveAccountMode(paths.launcherMode, "multi");
     app.relaunch();
@@ -998,15 +984,40 @@ if (primaryInstance) void app.whenReady().then(async () => {
         await focused;
       }
     },
-    createAccount: (request: AccountProfileRequest) => accountsLock.run(async () => {
+    createAccount: (request: AccountProfileCreateRequest) => accountsLock.run(async () => {
       if (activeAccountMode !== "multi" || !multiWorkspace) {
         throw new Error("Multiple Accounts mode is not active");
       }
+      const firstAccount = multiWorkspace.profiles.length === 0;
+      if (!firstAccount && (request.copySingleBuilds || request.copySingleTemplates)) {
+        throw new Error("Single Account data can be copied only into the first account");
+      }
       const next = addMultiProfile(multiWorkspace, request);
       const profile = next.profiles.at(-1)!;
-      await mkdir(multiProfilePaths(paths, profile.id).root, { recursive: true });
+      const profilePaths = multiProfilePaths(paths, profile.id);
+      await mkdir(profilePaths.root, { recursive: true });
+      if (firstAccount && request.copySingleBuilds) {
+        await importBuildLibraryIfPresent(
+          paths.buildLibrary,
+          profile.builds === "shared"
+            ? paths.multiSharedBuildLibrary
+            : profilePaths.buildLibrary,
+        );
+      }
+      if (firstAccount && request.copySingleTemplates) {
+        const source = await loadAccountTemplateLibrary(paths.multiSingleTemplateImport);
+        await saveAccountTemplateLibrary(
+          profile.templates === "shared"
+            ? paths.multiSharedTemplates
+            : profilePaths.templates,
+          { revision: 1, entries: source.entries },
+        );
+      }
       await saveMultiWorkspace(paths.multiWorkspace, next);
       multiWorkspace = next;
+      if (firstAccount) {
+        await rm(paths.multiSingleTemplateImport, { force: true }).catch(() => undefined);
+      }
       return accountsState();
     }),
     updateAccount: (request: AccountProfileUpdateRequest) => accountsLock.run(async () => {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -115,6 +115,7 @@ import {
 import {
   applyPendingCacheClear,
   applyPendingGameStorageReset,
+  applyPendingSessionStorageReset,
 } from "./settings-actions.js";
 import { windowRegistry } from "./window-registry.js";
 import {
@@ -125,6 +126,8 @@ import {
   loadMultiWorkspace,
   saveAccountMode,
   saveMultiWorkspace,
+  removeArchivedMultiProfile,
+  restoreMultiProfile,
   updateMultiProfile,
 } from "./core/multiple-accounts.js";
 import {
@@ -132,6 +135,11 @@ import {
   type ProfileId,
 } from "../shared/multiple-accounts.js";
 import { multiSecretSlot } from "./core/native-keychain.js";
+import {
+  loadAccountTemplateLibrary,
+  reconcileAccountTemplates,
+  saveAccountTemplateLibrary,
+} from "./core/account-template-library.js";
 import {
   createAccountsWindow,
   revealAccountsWindow,
@@ -177,6 +185,7 @@ const HOST_VERSION = (() => {
 /** Every settings write is a read-modify-write of one file. */
 const settingsLock = new Mutex();
 const accountsLock = new Mutex();
+const templatesLock = new Mutex();
 let appUpdaterController: AppUpdater | null = null;
 let updateRestartInFlight: Promise<void> | null = null;
 let secondInstanceRequested = false;
@@ -368,11 +377,17 @@ function buildWindowHost(
     startCapture: startDiagnosticCapture,
     stopCapture: stopDiagnosticCapture,
     reloadGame: (win) => {
-      sockets.closeAll(win.webContents.id);
-      void win.loadURL(RENDERER_URL);
+      void (async () => {
+        await sendRendererCommand(win, { type: "filesystem.sync" });
+        sockets.closeAll(win.webContents.id);
+        await win.loadURL(RENDERER_URL);
+      })();
     },
     prepareRendererRecovery: async () => {
       await clientRuntime.recoverRendererCrash();
+    },
+    gameWindowClosed: () => {
+      if (activeAccountMode === "multi") revealAccountsWindow();
     },
   };
 }
@@ -395,9 +410,9 @@ if (primaryInstance) void app.whenReady().then(async () => {
   });
   const paths = gamePaths();
   activeAccountMode = await loadAccountMode(paths.launcherMode);
-  let multiWorkspace = activeAccountMode === "multi"
-    ? await loadMultiWorkspace(paths.multiWorkspace)
-    : null;
+  // The registry is safe to inspect from Single mode for the explicit Accounts
+  // settings pane. Its sessions, libraries, and Keychain items remain closed.
+  let multiWorkspace = await loadMultiWorkspace(paths.multiWorkspace);
   if (activeAccountMode === "multi" && !multiWorkspace) {
     throw new Error("Multiple Accounts mode has no workspace");
   }
@@ -578,14 +593,13 @@ if (primaryInstance) void app.whenReady().then(async () => {
   };
   const accountsState = (): AccountsState => ({
     mode: activeAccountMode,
-    profiles: (multiWorkspace?.profiles ?? [])
-      .filter((profile) => !profile.archived)
-      .map((profile) => ({
+    profiles: (multiWorkspace?.profiles ?? []).map((profile) => ({
         id: profile.id,
         name: profile.name,
         templates: profile.templates,
         builds: profile.builds,
-        state: windowRegistry.profileWindow(profile.id)
+        archived: profile.archived,
+        state: !profile.archived && windowRegistry.profileWindow(profile.id)
           ? "running"
           : (profileLaunchState.get(profile.id) ?? "ready"),
       })),
@@ -614,6 +628,14 @@ if (primaryInstance) void app.whenReady().then(async () => {
         owner.clearCache(),
       ]);
       const profilePaths = multiProfilePaths(paths, profileId);
+      const reset = await applyPendingSessionStorageReset(
+        owner,
+        profilePaths.gameStorageClearRequest,
+      );
+      if (reset && profile.templates === "private") {
+        await rm(profilePaths.templates, { force: true });
+        await rm(profilePaths.templateSync, { force: true });
+      }
       await mkdir(profilePaths.root, { recursive: true });
       await prepareWindowState(profilePaths.windowState);
       const win = createMainWindow(host, {
@@ -649,7 +671,13 @@ if (primaryInstance) void app.whenReady().then(async () => {
         );
       }
       if (request.importTemplates) {
-        throw new Error("Template import is not available in this build");
+        const templatePath = profile.templates === "shared"
+          ? paths.multiSharedTemplates
+          : profilePaths.templates;
+        await saveAccountTemplateLibrary(templatePath, {
+          revision: 1,
+          entries: request.templateEntries,
+        });
       }
       await saveMultiWorkspace(paths.multiWorkspace, multiWorkspace);
     }
@@ -688,6 +716,12 @@ if (primaryInstance) void app.whenReady().then(async () => {
       return profile.builds === "shared"
         ? paths.multiSharedBuildLibrary
         : multiProfilePaths(paths, profile.id).buildLibrary;
+    },
+    gameStorageResetMarkerFor: (win) => {
+      const context = windowRegistry.contextForWebContents(win.webContents.id);
+      return context?.mode === "multi" && context.role === "game"
+        ? multiProfilePaths(paths, context.profileId).gameStorageClearRequest
+        : paths.gameStorageClearRequest;
     },
     getProgress: () => clientRuntime.progress,
     getChunkStore: () => clientRuntime.active?.store ?? null,
@@ -766,6 +800,13 @@ if (primaryInstance) void app.whenReady().then(async () => {
       if (activeAccountMode !== "multi" || !multiWorkspace) {
         throw new Error("Multiple Accounts mode is not active");
       }
+      const current = profileFor(request.id);
+      if (
+        windowRegistry.profileWindow(request.id)
+        && (current.builds !== request.builds || current.templates !== request.templates)
+      ) {
+        throw new Error("Close this account before changing sharing");
+      }
       const next = updateMultiProfile(multiWorkspace, request.id, request);
       await saveMultiWorkspace(paths.multiWorkspace, next);
       multiWorkspace = next;
@@ -785,6 +826,75 @@ if (primaryInstance) void app.whenReady().then(async () => {
       await saveMultiWorkspace(paths.multiWorkspace, next);
       multiWorkspace = next;
       return accountsState();
+    }),
+    restoreAccount: (profileId: ProfileId) => accountsLock.run(async () => {
+      if (activeAccountMode !== "multi" || !multiWorkspace) {
+        throw new Error("Multiple Accounts mode is not active");
+      }
+      const next = restoreMultiProfile(multiWorkspace, profileId);
+      await saveMultiWorkspace(paths.multiWorkspace, next);
+      multiWorkspace = next;
+      return accountsState();
+    }),
+    deleteAccount: (profileId: ProfileId) => accountsLock.run(async () => {
+      if (activeAccountMode !== "multi" || !multiWorkspace) {
+        throw new Error("Multiple Accounts mode is not active");
+      }
+      const next = removeArchivedMultiProfile(multiWorkspace, profileId);
+      const owner = session.fromPartition(`persist:gw-multi-${profileId}`, {
+        cache: false,
+      });
+      await Promise.all([
+        credentialStoreForProfile(profileId).clear(),
+        steamStoreForProfile(profileId).clear(),
+        owner.clearStorageData(),
+        owner.clearCache(),
+      ]);
+      await rm(multiProfilePaths(paths, profileId).root, {
+        recursive: true,
+        force: true,
+      });
+      await saveMultiWorkspace(paths.multiWorkspace, next);
+      credentialsStores.delete(profileId);
+      steamSessionStores.delete(profileId);
+      multiWorkspace = next;
+      return accountsState();
+    }),
+    loadAccountTemplates: async (win) => {
+      const context = windowRegistry.contextForWebContents(win.webContents.id);
+      if (context?.mode !== "multi" || context.role !== "game") return null;
+      const profile = profileFor(context.profileId);
+      const profilePaths = multiProfilePaths(paths, profile.id);
+      const libraryPath = profile.templates === "shared"
+        ? paths.multiSharedTemplates
+        : profilePaths.templates;
+      const library = await loadAccountTemplateLibrary(libraryPath);
+      await saveAccountTemplateLibrary(profilePaths.templateSync, library);
+      return library;
+    },
+    saveAccountTemplates: (win, entries) => templatesLock.run(async () => {
+      const context = windowRegistry.contextForWebContents(win.webContents.id);
+      if (context?.mode !== "multi" || context.role !== "game") return;
+      const profile = profileFor(context.profileId);
+      const profilePaths = multiProfilePaths(paths, profile.id);
+      if (profile.templates === "private") {
+        const current = await loadAccountTemplateLibrary(profilePaths.templates);
+        await saveAccountTemplateLibrary(profilePaths.templates, {
+          revision: current.revision + 1,
+          entries,
+        });
+        return;
+      }
+      const [base, latest] = await Promise.all([
+        loadAccountTemplateLibrary(profilePaths.templateSync),
+        loadAccountTemplateLibrary(paths.multiSharedTemplates),
+      ]);
+      const merged = {
+        revision: latest.revision + 1,
+        entries: reconcileAccountTemplates(base.entries, latest.entries, entries),
+      };
+      await saveAccountTemplateLibrary(paths.multiSharedTemplates, merged);
+      await saveAccountTemplateLibrary(profilePaths.templateSync, merged);
     }),
     useSingleAccountMode,
   });

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -26,6 +26,8 @@ import {
   type AppSettingsPatch,
   type AccountsSetupRequest,
   type AccountsState,
+  type AccountProfileRequest,
+  type AccountProfileUpdateRequest,
   type DownloadProgress,
   type PrefetchProgress,
   type UpdateTrack,
@@ -117,10 +119,13 @@ import {
 import { windowRegistry } from "./window-registry.js";
 import {
   createMultiWorkspace,
+  addMultiProfile,
+  archiveMultiProfile,
   loadAccountMode,
   loadMultiWorkspace,
   saveAccountMode,
   saveMultiWorkspace,
+  updateMultiProfile,
 } from "./core/multiple-accounts.js";
 import {
   type AccountMode,
@@ -171,6 +176,7 @@ const HOST_VERSION = (() => {
 
 /** Every settings write is a read-modify-write of one file. */
 const settingsLock = new Mutex();
+const accountsLock = new Mutex();
 let appUpdaterController: AppUpdater | null = null;
 let updateRestartInFlight: Promise<void> | null = null;
 let secondInstanceRequested = false;
@@ -745,6 +751,41 @@ if (primaryInstance) void app.whenReady().then(async () => {
     openAccounts: async (profileIds) => {
       for (const profileId of profileIds) await openProfile(profileId);
     },
+    createAccount: (request: AccountProfileRequest) => accountsLock.run(async () => {
+      if (activeAccountMode !== "multi" || !multiWorkspace) {
+        throw new Error("Multiple Accounts mode is not active");
+      }
+      const next = addMultiProfile(multiWorkspace, request);
+      const profile = next.profiles.at(-1)!;
+      await mkdir(multiProfilePaths(paths, profile.id).root, { recursive: true });
+      await saveMultiWorkspace(paths.multiWorkspace, next);
+      multiWorkspace = next;
+      return accountsState();
+    }),
+    updateAccount: (request: AccountProfileUpdateRequest) => accountsLock.run(async () => {
+      if (activeAccountMode !== "multi" || !multiWorkspace) {
+        throw new Error("Multiple Accounts mode is not active");
+      }
+      const next = updateMultiProfile(multiWorkspace, request.id, request);
+      await saveMultiWorkspace(paths.multiWorkspace, next);
+      multiWorkspace = next;
+      windowRegistry.profileWindow(request.id)?.setTitle(
+        `Guild Wars Reforged — ${request.name}`,
+      );
+      return accountsState();
+    }),
+    archiveAccount: (profileId: ProfileId) => accountsLock.run(async () => {
+      if (activeAccountMode !== "multi" || !multiWorkspace) {
+        throw new Error("Multiple Accounts mode is not active");
+      }
+      if (windowRegistry.profileWindow(profileId)) {
+        throw new Error("Close this account before archiving it");
+      }
+      const next = archiveMultiProfile(multiWorkspace, profileId);
+      await saveMultiWorkspace(paths.multiWorkspace, next);
+      multiWorkspace = next;
+      return accountsState();
+    }),
     useSingleAccountMode,
   });
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -15,9 +15,8 @@ import {
   powerMonitor,
   session,
 } from "electron";
-import type { BrowserWindow } from "electron";
 import { readFileSync } from "node:fs";
-import { mkdir, readFile, rm } from "node:fs/promises";
+import { mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import {
   EXTERNAL_URLS,
@@ -25,10 +24,6 @@ import {
   IPC,
   type AppSettings,
   type AppSettingsPatch,
-  type AccountsSetupRequest,
-  type AccountsState,
-  type AccountProfileCreateRequest,
-  type AccountProfileUpdateRequest,
   type DownloadProgress,
   type PrefetchProgress,
   type UpdateTrack,
@@ -42,8 +37,6 @@ import { INITIAL_PROGRESS } from "../shared/progress.js";
 import { AUTOMATION_COMMAND } from "../shared/automation.js";
 import { ClientRuntime } from "./client-runtime.js";
 import { Mutex } from "./core/mutex.js";
-import { saveBuildLibrary } from "./core/build-library.js";
-import { parseBuildLibrary } from "../shared/builds/parse-library.js";
 import { loadSettings, saveSettings } from "./core/settings.js";
 import { SocketManager } from "./core/sockets.js";
 import {
@@ -75,7 +68,6 @@ import {
 } from "./lifecycle.js";
 import { sweepOrphanDirectories } from "./core/atomic-file.js";
 import { documentDirectories } from "./core/paths.js";
-import { multiProfilePaths } from "./core/paths.js";
 import { gamePaths } from "./paths.js";
 import {
   DEVELOPER_ENHANCEMENT_PROGRAM,
@@ -85,18 +77,14 @@ import {
 } from "./certification/enhancement-policy.js";
 import {
   installGwProtocolHandler,
-  installGwProtocolHandlerForSession,
   registerGwScheme,
 } from "./protocol.js";
 import {
   createMainWindow,
-  closeProfileWindow,
   flushWindowState,
   getMainWindow,
   prepareWindowState,
-  resetRendererRecovery,
   RENDERER_URL,
-  setOwnedWindowTitle,
   type WindowHost,
   updateLongRunningTaskFeedback,
 } from "./window.js";
@@ -104,8 +92,6 @@ import { exportDiagnosticsReport } from "./diagnostics-export.js";
 import { resetGameInput, sendRendererCommand } from "./renderer-commands.js";
 import { STEAM_OAUTH } from "./core/steam-oauth.js";
 import { acquireSteamToken } from "./steam-acquire.js";
-import { CredentialsStore } from "./core/credentials.js";
-import { SteamSessionStore } from "./core/steam-session.js";
 import {
   VolatileNativeKeychain,
   type NativeKeychain,
@@ -121,42 +107,21 @@ import {
 import {
   applyPendingCacheClear,
   applyPendingGameStorageReset,
-  applyPendingSessionStorageReset,
 } from "./settings-actions.js";
 import { windowRegistry } from "./window-registry.js";
 import {
-  createMultiWorkspace,
-  addMultiProfile,
-  archiveMultiProfile,
   loadAccountMode,
   loadMultiWorkspace,
-  saveAccountMode,
-  saveMultiWorkspace,
   quarantineAccountDocument,
-  removeArchivedMultiProfile,
-  restoreMultiProfile,
-  updateMultiProfile,
+  saveAccountMode,
 } from "./core/multiple-accounts.js";
-import {
-  type AccountMode,
-  type MultiWorkspace,
-  type ProfileId,
-} from "../shared/multiple-accounts.js";
-import { multiSecretSlot } from "./core/native-keychain.js";
-import {
-  launchIssueForStage,
-  ProfileRuntimeStore,
-} from "./core/profile-runtime.js";
-import {
-  loadAccountTemplateLibrary,
-  reconcileAccountTemplates,
-  saveAccountTemplateLibrary,
-} from "./core/account-template-library.js";
+import type { AccountMode, MultiWorkspace } from "../shared/multiple-accounts.js";
 import {
   createAccountsWindow,
-  getAccountsWindow,
   revealAccountsWindow,
 } from "./accounts-window.js";
+import { MultipleAccountsController } from "./multiple-accounts-controller.js";
+import { BuildLibraryCoordinator } from "./core/build-library-coordinator.js";
 
 // The public app name changed after alpha profiles already existed. Keep that
 // one profile as the canonical home so the rename cannot strand saved login,
@@ -197,8 +162,6 @@ const HOST_VERSION = (() => {
 
 /** Every settings write is a read-modify-write of one file. */
 const settingsLock = new Mutex();
-const accountsLock = new Mutex();
-const templatesLock = new Mutex();
 let appUpdaterController: AppUpdater | null = null;
 let updateRestartInFlight: Promise<void> | null = null;
 let secondInstanceRequested = false;
@@ -362,21 +325,6 @@ async function clearBrowserNetworkCache(): Promise<void> {
       code: errorCode(error),
     });
   }
-}
-
-async function importBuildLibraryIfPresent(
-  source: string,
-  destination: string,
-): Promise<void> {
-  let bytes: string;
-  try {
-    bytes = await readFile(source, "utf8");
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
-    throw error;
-  }
-  const library = parseBuildLibrary(JSON.parse(bytes) as unknown);
-  await saveBuildLibrary(destination, library);
 }
 
 function buildWindowHost(
@@ -558,36 +506,6 @@ if (primaryInstance) void app.whenReady().then(async () => {
         resourcesPath: process.resourcesPath,
       })
     : new VolatileNativeKeychain();
-  const credentialsStores = new Map<string, CredentialsStore>();
-  const steamSessionStores = new Map<string, SteamSessionStore>();
-  const credentialStoreForProfile = (profileId?: ProfileId): CredentialsStore => {
-    const key = profileId ?? "single";
-    let store = credentialsStores.get(key);
-    if (!store) {
-      store = new CredentialsStore(
-        keychain,
-        profileId
-          ? multiSecretSlot(profileId, "arenaNetCredentials")
-          : "arenaNetCredentials",
-      );
-      credentialsStores.set(key, store);
-    }
-    return store;
-  };
-  const steamStoreForProfile = (profileId?: ProfileId): SteamSessionStore => {
-    const key = profileId ?? "single";
-    let store = steamSessionStores.get(key);
-    if (!store) {
-      store = new SteamSessionStore(
-        keychain,
-        profileId
-          ? multiSecretSlot(profileId, "steamSession")
-          : "steamSession",
-      );
-      steamSessionStores.set(key, store);
-    }
-    return store;
-  };
   const expectedUserData = process.env.GW_EXPECT_USER_DATA;
   const profileMatches =
     !expectedUserData ||
@@ -665,199 +583,28 @@ if (primaryInstance) void app.whenReady().then(async () => {
     enhancementSelection,
     enhancementProgram,
   );
-  const profileProtocolSessions = new Set<ProfileId>();
-  const profileRuntime = new ProfileRuntimeStore();
-  const profileFor = (profileId: ProfileId) => {
-    const profile = multiWorkspace?.profiles.find(
-      (candidate) => candidate.id === profileId && !candidate.archived,
-    );
-    if (!profile) throw new Error("Unknown Multiple Accounts profile");
-    return profile;
-  };
-  const accountsState = (): AccountsState => ({
+  const accounts = new MultipleAccountsController({
     mode: activeAccountMode,
-    profiles: (multiWorkspace?.profiles ?? []).map((profile) => ({
-        id: profile.id,
-        name: profile.name,
-        templates: profile.templates,
-        builds: profile.builds,
-        archived: profile.archived,
-        state: profileRuntime.get(profile.id).state,
-        ...(profileRuntime.get(profile.id).launchIssue
-          ? { launchIssue: profileRuntime.get(profile.id).launchIssue }
-          : {}),
-      })),
+    workspace: multiWorkspace,
+    paths,
+    keychain,
+    clientRuntime,
+    protocol: protocolDeps,
+    windowHost: host,
   });
-  const openProfile = async (
-    profileId: ProfileId,
-    newWindowOrdinal: number,
-  ): Promise<{ readonly win: BrowserWindow; readonly opened: boolean }> => {
-    const profile = profileFor(profileId);
-    let existing = windowRegistry.profileWindow(profileId);
-    const previous = profileRuntime.get(profileId);
-    const profilePaths = multiProfilePaths(paths, profileId);
-    if (previous?.state === "failed") {
-      resetRendererRecovery(profilePaths.windowState);
-      if (existing && !existing.isDestroyed()) existing.destroy();
-      existing = null;
-    }
-    if (existing) {
-      if (existing.isMinimized()) existing.restore();
-      return { win: existing, opened: false };
-    }
-    if (previous?.state === "opening" || previous?.state === "checking") {
-      throw new Error("Account is already opening");
-    }
-    profileRuntime.set(profileId, "opening");
-    let failureStage: Parameters<typeof launchIssueForStage>[0] = "preparing";
-    try {
-      const owner = session.fromPartition(`persist:gw-multi-${profileId}`, {
-        cache: false,
-      });
-      if (!profileProtocolSessions.has(profileId)) {
-        installGwProtocolHandlerForSession(owner, protocolDeps);
-        profileProtocolSessions.add(profileId);
-      }
-      await Promise.all([
-        owner.clearStorageData({ storages: ["cookies"] }),
-        owner.clearCache(),
-      ]);
-      const reset = await applyPendingSessionStorageReset(
-        owner,
-        profilePaths.gameStorageClearRequest,
-      );
-      if (reset && profile.templates === "private") {
-        await rm(profilePaths.templates, { force: true });
-        await rm(profilePaths.templateSync, { force: true });
-      }
-      await mkdir(profilePaths.root, { recursive: true });
-      await prepareWindowState(profilePaths.windowState, newWindowOrdinal);
-      failureStage = "starting";
-      let hubWasVisibleBeforeRecovery = false;
-      const win = createMainWindow(host, {
-        context: { mode: "multi", role: "game", profileId },
-        session: owner,
-        title: `Guild Wars Reforged — ${profile.name}`,
-        windowStatePath: profilePaths.windowState,
-        showInactive: true,
-        onRendererRecoveryStart: () => {
-          hubWasVisibleBeforeRecovery = getAccountsWindow()?.isVisible() ?? false;
-        },
-        onRendererRecovered: () => {
-          if (!hubWasVisibleBeforeRecovery) getAccountsWindow()?.hide();
-        },
-        onRendererFailure: () => {
-          profileRuntime.set(profileId, "failed", launchIssueForStage("crashed"));
-          revealAccountsWindow();
-        },
-      });
-      win.on("closed", () => {
-        const replacement = windowRegistry.profileWindow(profileId);
-        if (replacement && replacement !== win) return;
-        if (profileRuntime.get(profileId).state !== "failed") {
-          profileRuntime.set(profileId, "ready");
-        }
-      });
-      await new Promise<void>((resolve, reject) => {
-        const timeout = setTimeout(() => {
-          cleanup();
-          reject(new Error("profile window did not finish loading"));
-        }, 30_000);
-        const cleanup = () => {
-          clearTimeout(timeout);
-          win.webContents.removeListener("did-finish-load", loaded);
-          win.removeListener("closed", closed);
-        };
-        const loaded = () => {
-          cleanup();
-          resolve();
-        };
-        const closed = () => {
-          cleanup();
-          reject(new Error("profile window closed while loading"));
-        };
-        win.webContents.once("did-finish-load", loaded);
-        win.once("closed", closed);
-      });
-      profileRuntime.set(profileId, "running");
-      return { win, opened: true };
-    } catch (error) {
-      profileRuntime.set(profileId, "failed", launchIssueForStage(failureStage));
-      const failedWindow = windowRegistry.profileWindow(profileId);
-      if (failedWindow && !failedWindow.isDestroyed()) failedWindow.destroy();
-      throw error;
-    }
-  };
-  const waitForCandidateCanary = async (): Promise<void> => {
-    const candidate = clientRuntime.healthToken;
-    if (!candidate) return;
-    const deadline = Date.now() + 60_000;
-    while (clientRuntime.healthToken === candidate && Date.now() < deadline) {
-      await new Promise((resolve) => setTimeout(resolve, 100));
-    }
-    if (clientRuntime.healthToken === candidate) {
-      throw new Error("first profile did not confirm the new client generation");
-    }
-  };
-
-  const setupAccounts = async (request: AccountsSetupRequest): Promise<void> => {
-    if (activeAccountMode !== "single") {
-      throw new Error("Multiple Accounts mode is already enabled");
-    }
-    multiWorkspace ??= await loadMultiWorkspace(paths.multiWorkspace);
-    if (!multiWorkspace) {
-      const candidate = createMultiWorkspace();
-      await saveMultiWorkspace(paths.multiWorkspace, candidate);
-      multiWorkspace = candidate;
-    }
-    if (multiWorkspace.profiles.length === 0) {
-      await saveAccountTemplateLibrary(paths.multiSingleTemplateImport, {
-        revision: 1,
-        entries: request.templateEntries,
-      });
-    }
-    await saveAccountMode(paths.launcherMode, "multi");
-    app.relaunch();
-    app.quit();
-  };
-
-  const useSingleAccountMode = async (): Promise<void> => {
-    await saveAccountMode(paths.launcherMode, "single");
-    app.relaunch();
-    app.quit();
-  };
+  await accounts.resumePendingDeletions();
+  const buildLibraries = new BuildLibraryCoordinator();
 
   const ipcCleanup = registerIpcHandlers({
     sockets,
     windows: windowRegistry,
-    credentialsStoreFor: (win) => {
-      const context = windowRegistry.contextForWebContents(win.webContents.id);
-      return context?.mode === "multi" && context.role === "game"
-        ? credentialStoreForProfile(context.profileId)
-        : credentialStoreForProfile();
-    },
-    steamSessionStoreFor: (win) => {
-      const context = windowRegistry.contextForWebContents(win.webContents.id);
-      return context?.mode === "multi" && context.role === "game"
-        ? steamStoreForProfile(context.profileId)
-        : steamStoreForProfile();
-    },
-    buildLibraryPathFor: (win) => {
-      const context = windowRegistry.contextForWebContents(win.webContents.id);
-      if (context?.mode !== "multi" || context.role !== "game") {
-        return paths.buildLibrary;
-      }
-      const profile = profileFor(context.profileId);
-      return profile.builds === "shared"
-        ? paths.multiSharedBuildLibrary
-        : multiProfilePaths(paths, profile.id).buildLibrary;
-    },
-    gameStorageResetMarkerFor: (win) => {
-      const context = windowRegistry.contextForWebContents(win.webContents.id);
-      return context?.mode === "multi" && context.role === "game"
-        ? multiProfilePaths(paths, context.profileId).gameStorageClearRequest
-        : paths.gameStorageClearRequest;
-    },
+    credentialsStoreFor: (win) => accounts.credentialsStoreFor(win),
+    steamSessionStoreFor: (win) => accounts.steamSessionStoreFor(win),
+    getBuildLibrary: (win) =>
+      buildLibraries.get(win, accounts.buildLibraryPathFor(win)),
+    setBuildLibrary: (win, library) =>
+      buildLibraries.set(win, accounts.buildLibraryPathFor(win), library),
+    gameStorageResetMarkerFor: (win) => accounts.gameStorageResetMarkerFor(win),
     getProgress: () => clientRuntime.progress,
     getChunkStore: () => clientRuntime.active?.store ?? null,
     getSettings: () => loadSettings(paths.settings),
@@ -918,232 +665,18 @@ if (primaryInstance) void app.whenReady().then(async () => {
     },
     acquireSteamToken: (parent, record) =>
       acquireSteamToken(STEAM_OAUTH, { parent, record }),
-    getAccountsState: accountsState,
-    setupAccounts,
-    openAccounts: async (profileIds) => {
-      for (const profileId of profileIds) profileFor(profileId);
-      profileRuntime.queue(
-        profileIds,
-        (profileId) => windowRegistry.profileWindow(profileId) !== null,
-      );
-      let canaryChecked = false;
-      let firstFailure: unknown = null;
-      let firstSelectedWindow: BrowserWindow | null = null;
-      for (let index = 0; index < profileIds.length; index += 1) {
-        const profileId = profileIds[index]!;
-        let result: { readonly win: BrowserWindow; readonly opened: boolean };
-        try {
-          result = await accountsLock.run(() => openProfile(profileId, index));
-          firstSelectedWindow ??= result.win;
-        } catch (error) {
-          firstFailure ??= error;
-          continue;
-        }
-        if (result.opened && !canaryChecked) {
-          if (clientRuntime.healthToken) {
-            profileRuntime.set(profileId, "checking");
-            try {
-              await waitForCandidateCanary();
-            } catch (error) {
-              profileRuntime.set(
-                profileId,
-                "failed",
-                launchIssueForStage("validating"),
-              );
-              profileRuntime.releaseQueued(profileIds.slice(index + 1));
-              revealAccountsWindow();
-              throw error;
-            }
-          }
-          profileRuntime.set(profileId, "running");
-          canaryChecked = true;
-        }
-      }
-      if (firstFailure) {
-        revealAccountsWindow();
-        throw firstFailure;
-      }
-      const hub = getAccountsWindow();
-      if (hub && !hub.isDestroyed()) hub.hide();
-      if (firstSelectedWindow && !firstSelectedWindow.isDestroyed()) {
-        if (firstSelectedWindow.isMinimized()) firstSelectedWindow.restore();
-        const focused = new Promise<void>((resolve) => {
-          if (firstSelectedWindow.isFocused()) {
-            resolve();
-            return;
-          }
-          const timeout = setTimeout(resolve, 1_000);
-          firstSelectedWindow.once("focus", () => {
-            clearTimeout(timeout);
-            resolve();
-          });
-        });
-        firstSelectedWindow.show();
-        app.focus({ steal: true });
-        firstSelectedWindow.focus();
-        await focused;
-      }
-    },
-    createAccount: (request: AccountProfileCreateRequest) => accountsLock.run(async () => {
-      if (activeAccountMode !== "multi" || !multiWorkspace) {
-        throw new Error("Multiple Accounts mode is not active");
-      }
-      const firstAccount = multiWorkspace.profiles.length === 0;
-      if (!firstAccount && (request.copySingleBuilds || request.copySingleTemplates)) {
-        throw new Error("Single Account data can be copied only into the first account");
-      }
-      const next = addMultiProfile(multiWorkspace, request);
-      const profile = next.profiles.at(-1)!;
-      const profilePaths = multiProfilePaths(paths, profile.id);
-      await mkdir(profilePaths.root, { recursive: true });
-      if (firstAccount && request.copySingleBuilds) {
-        await importBuildLibraryIfPresent(
-          paths.buildLibrary,
-          profile.builds === "shared"
-            ? paths.multiSharedBuildLibrary
-            : profilePaths.buildLibrary,
-        );
-      }
-      if (firstAccount && request.copySingleTemplates) {
-        const source = await loadAccountTemplateLibrary(paths.multiSingleTemplateImport);
-        await saveAccountTemplateLibrary(
-          profile.templates === "shared"
-            ? paths.multiSharedTemplates
-            : profilePaths.templates,
-          { revision: 1, entries: source.entries },
-        );
-      }
-      await saveMultiWorkspace(paths.multiWorkspace, next);
-      multiWorkspace = next;
-      if (firstAccount) {
-        await rm(paths.multiSingleTemplateImport, { force: true }).catch(() => undefined);
-      }
-      return accountsState();
-    }),
-    updateAccount: (request: AccountProfileUpdateRequest) => accountsLock.run(async () => {
-      if (activeAccountMode !== "multi" || !multiWorkspace) {
-        throw new Error("Multiple Accounts mode is not active");
-      }
-      const current = profileFor(request.id);
-      if (
-        windowRegistry.profileWindow(request.id)
-        && (current.builds !== request.builds || current.templates !== request.templates)
-      ) {
-        throw new Error("Close this account before changing sharing");
-      }
-      const next = updateMultiProfile(multiWorkspace, request.id, request);
-      await saveMultiWorkspace(paths.multiWorkspace, next);
-      multiWorkspace = next;
-      const profileWindow = windowRegistry.profileWindow(request.id);
-      if (profileWindow) {
-        setOwnedWindowTitle(
-          profileWindow,
-          `Guild Wars Reforged — ${request.name}`,
-        );
-      }
-      return accountsState();
-    }),
-    archiveAccount: (profileId: ProfileId) => accountsLock.run(async () => {
-      if (activeAccountMode !== "multi" || !multiWorkspace) {
-        throw new Error("Multiple Accounts mode is not active");
-      }
-      if (windowRegistry.profileWindow(profileId)) {
-        throw new Error("Close this account before archiving it");
-      }
-      const next = archiveMultiProfile(multiWorkspace, profileId);
-      await saveMultiWorkspace(paths.multiWorkspace, next);
-      multiWorkspace = next;
-      return accountsState();
-    }),
-    restoreAccount: (profileId: ProfileId) => accountsLock.run(async () => {
-      if (activeAccountMode !== "multi" || !multiWorkspace) {
-        throw new Error("Multiple Accounts mode is not active");
-      }
-      const next = restoreMultiProfile(multiWorkspace, profileId);
-      await saveMultiWorkspace(paths.multiWorkspace, next);
-      multiWorkspace = next;
-      return accountsState();
-    }),
-    deleteAccount: (parent, profileId: ProfileId) => accountsLock.run(async () => {
-      if (activeAccountMode !== "multi" || !multiWorkspace) {
-        throw new Error("Multiple Accounts mode is not active");
-      }
-      const profile = multiWorkspace.profiles.find(
-        (candidate) => candidate.id === profileId && candidate.archived,
-      );
-      if (!profile) throw new Error("Only an archived profile can be deleted");
-      const { response } = await dialog.showMessageBox(parent, {
-        type: "warning",
-        buttons: ["Permanently Delete", "Cancel"],
-        defaultId: 1,
-        cancelId: 1,
-        message: `Permanently delete “${profile.name}”?`,
-        detail:
-          "Its saved login, Guild Wars files, private templates, builds, and window state cannot be recovered. Shared libraries and Single Account data stay untouched.",
-      });
-      if (response !== 0) return accountsState();
-      const next = removeArchivedMultiProfile(multiWorkspace, profileId);
-      const owner = session.fromPartition(`persist:gw-multi-${profileId}`, {
-        cache: false,
-      });
-      await Promise.all([
-        credentialStoreForProfile(profileId).clear(),
-        steamStoreForProfile(profileId).clear(),
-        owner.clearStorageData(),
-        owner.clearCache(),
-      ]);
-      await rm(multiProfilePaths(paths, profileId).root, {
-        recursive: true,
-        force: true,
-      });
-      await saveMultiWorkspace(paths.multiWorkspace, next);
-      credentialsStores.delete(profileId);
-      steamSessionStores.delete(profileId);
-      multiWorkspace = next;
-      return accountsState();
-    }),
-    loadAccountTemplates: async (win) => {
-      const context = windowRegistry.contextForWebContents(win.webContents.id);
-      if (context?.mode !== "multi" || context.role !== "game") return null;
-      const profile = profileFor(context.profileId);
-      const profilePaths = multiProfilePaths(paths, profile.id);
-      const libraryPath = profile.templates === "shared"
-        ? paths.multiSharedTemplates
-        : profilePaths.templates;
-      const library = await loadAccountTemplateLibrary(libraryPath);
-      await saveAccountTemplateLibrary(profilePaths.templateSync, library);
-      return library;
-    },
-    saveAccountTemplates: (win, entries) => templatesLock.run(async () => {
-      const context = windowRegistry.contextForWebContents(win.webContents.id);
-      if (context?.mode !== "multi" || context.role !== "game") return;
-      const profile = profileFor(context.profileId);
-      const profilePaths = multiProfilePaths(paths, profile.id);
-      if (profile.templates === "private") {
-        const current = await loadAccountTemplateLibrary(profilePaths.templates);
-        await saveAccountTemplateLibrary(profilePaths.templates, {
-          revision: current.revision + 1,
-          entries,
-        });
-        return;
-      }
-      const [base, latest] = await Promise.all([
-        loadAccountTemplateLibrary(profilePaths.templateSync),
-        loadAccountTemplateLibrary(paths.multiSharedTemplates),
-      ]);
-      const merged = {
-        revision: latest.revision + 1,
-        entries: reconcileAccountTemplates(base.entries, latest.entries, entries),
-      };
-      await saveAccountTemplateLibrary(paths.multiSharedTemplates, merged);
-      await saveAccountTemplateLibrary(profilePaths.templateSync, merged);
-    }),
-    requestQuit: (win) => {
-      const context = windowRegistry.contextForWebContents(win.webContents.id);
-      if (context?.mode === "multi") void closeProfileWindow(win);
-      else app.quit();
-    },
-    useSingleAccountMode,
+    getAccountsState: () => accounts.state(),
+    setupAccounts: (request) => accounts.setup(request),
+    openAccounts: (profileIds) => accounts.open(profileIds),
+    createAccount: (request) => accounts.create(request),
+    updateAccount: (request) => accounts.update(request),
+    archiveAccount: (profileId) => accounts.archive(profileId),
+    restoreAccount: (profileId) => accounts.restore(profileId),
+    deleteAccount: (parent, profileId) => accounts.delete(parent, profileId),
+    loadAccountTemplates: (win) => accounts.loadTemplates(win),
+    saveAccountTemplates: (win, entries) => accounts.saveTemplates(win, entries),
+    requestQuit: (win) => accounts.requestQuit(win),
+    useSingleAccountMode: () => accounts.useSingleMode(),
   });
 
   onAppQuit(async () => {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1055,9 +1055,9 @@ if (primaryInstance) void app.whenReady().then(async () => {
   });
 
   onAppQuit(async () => {
-    const gameWindows = windowRegistry.gameWindows();
-    await Promise.all(gameWindows.map(async (win) => {
-      if (!win.isDestroyed()) {
+    if (activeAccountMode === "single") {
+      const win = getMainWindow();
+      if (win && !win.isDestroyed()) {
         const outcome = await sendRendererCommand(win, {
           type: "filesystem.sync",
         });
@@ -1065,9 +1065,22 @@ if (primaryInstance) void app.whenReady().then(async () => {
           logEvent({ k: "quit.rendererSyncIncomplete", outcome });
         }
       }
-    }));
-    await ipcCleanup.drainSecrets();
-    await Promise.all(gameWindows.map((win) => flushWindowState(win)));
+      await ipcCleanup.drainSecrets();
+      await flushWindowState();
+    } else {
+      const gameWindows = windowRegistry.gameWindows();
+      await Promise.all(gameWindows.map(async (win) => {
+        if (win.isDestroyed()) return;
+        const outcome = await sendRendererCommand(win, {
+          type: "filesystem.sync",
+        });
+        if (outcome !== "completed") {
+          logEvent({ k: "quit.rendererSyncIncomplete", outcome });
+        }
+      }));
+      await ipcCleanup.drainSecrets();
+      await Promise.all(gameWindows.map((win) => flushWindowState(win)));
+    }
     sockets.closeAll();
     updateLongRunningTaskFeedback(INITIAL_PROGRESS);
     await clientRuntime.shutdown();

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -16,7 +16,7 @@ import {
   session,
 } from "electron";
 import { readFileSync } from "node:fs";
-import { mkdir, rm } from "node:fs/promises";
+import { copyFile, mkdir, rm } from "node:fs/promises";
 import path from "node:path";
 import {
   EXTERNAL_URLS,
@@ -24,6 +24,8 @@ import {
   IPC,
   type AppSettings,
   type AppSettingsPatch,
+  type AccountsSetupRequest,
+  type AccountsState,
   type DownloadProgress,
   type PrefetchProgress,
   type UpdateTrack,
@@ -69,13 +71,18 @@ import {
 } from "./lifecycle.js";
 import { sweepOrphanDirectories } from "./core/atomic-file.js";
 import { documentDirectories } from "./core/paths.js";
+import { multiProfilePaths } from "./core/paths.js";
 import { gamePaths } from "./paths.js";
 import {
   DEVELOPER_ENHANCEMENT_PROGRAM,
   ENHANCEMENT_AUTOMATION_ENABLED,
   enhancementSelectionFor,
 } from "./certification/enhancement-policy.js";
-import { installGwProtocolHandler, registerGwScheme } from "./protocol.js";
+import {
+  installGwProtocolHandler,
+  installGwProtocolHandlerForSession,
+  registerGwScheme,
+} from "./protocol.js";
 import {
   createMainWindow,
   flushWindowState,
@@ -108,6 +115,22 @@ import {
   applyPendingGameStorageReset,
 } from "./settings-actions.js";
 import { windowRegistry } from "./window-registry.js";
+import {
+  createMultiWorkspace,
+  loadAccountMode,
+  loadMultiWorkspace,
+  saveAccountMode,
+  saveMultiWorkspace,
+} from "./core/multiple-accounts.js";
+import {
+  type AccountMode,
+  type ProfileId,
+} from "../shared/multiple-accounts.js";
+import { multiSecretSlot } from "./core/native-keychain.js";
+import {
+  createAccountsWindow,
+  revealAccountsWindow,
+} from "./accounts-window.js";
 
 // The public app name changed after alpha profiles already existed. Keep that
 // one profile as the canonical home so the rename cannot strand saved login,
@@ -151,10 +174,12 @@ const settingsLock = new Mutex();
 let appUpdaterController: AppUpdater | null = null;
 let updateRestartInFlight: Promise<void> | null = null;
 let secondInstanceRequested = false;
+let activeAccountMode: AccountMode = "single";
 const INJECT_STARTUP_FAILURE =
   !app.isPackaged && process.env.GW_TEST_STARTUP_FAILURE === "1";
 
 function revealMainWindow(): void {
+  if (activeAccountMode === "multi" && revealAccountsWindow()) return;
   const win = getMainWindow();
   if (!win || win.isDestroyed()) {
     secondInstanceRequested = true;
@@ -234,12 +259,13 @@ function setPrefetch(next: PrefetchProgress): void {
 }
 
 function sendToRenderer(channel: string, value: unknown): void {
-  const win = getMainWindow();
-  if (!win || win.isDestroyed() || win.webContents.isDestroyed()) return;
-  try {
-    win.webContents.send(channel, value);
-  } catch {
-    // Renderer teardown can race a native progress callback.
+  for (const win of windowRegistry.gameWindows()) {
+    if (win.isDestroyed() || win.webContents.isDestroyed()) continue;
+    try {
+      win.webContents.send(channel, value);
+    } catch {
+      // Renderer teardown can race a native progress callback.
+    }
   }
 }
 
@@ -262,7 +288,7 @@ function packagedDistributionChannel(): DistributionChannel | null {
   }
 }
 
-async function ensureDirs(): Promise<void> {
+async function ensureDirs(mode: AccountMode): Promise<void> {
   const paths = gamePaths();
   await mkdir(paths.game, { recursive: true });
   await mkdir(paths.chunks, { recursive: true });
@@ -271,7 +297,9 @@ async function ensureDirs(): Promise<void> {
   // writes. A process killed between
   // write and rename leaves `<name>.<pid>.<hex>.tmp` behind, and boot is the
   // only moment at which every one of those directories is known to be idle.
-  const removed = await sweepOrphanDirectories(documentDirectories(paths));
+  const roots = documentDirectories(paths);
+  if (mode === "multi") roots.push(paths.multiRoot, paths.multiProfiles);
+  const removed = await sweepOrphanDirectories(roots);
   if (removed > 0) logEvent({ k: "orphanTemps.swept", removed });
 }
 
@@ -301,6 +329,15 @@ async function clearBrowserNetworkCache(): Promise<void> {
       phase: "startup",
       code: errorCode(error),
     });
+  }
+}
+
+async function copyIfPresent(source: string, destination: string): Promise<void> {
+  try {
+    await mkdir(path.dirname(destination), { recursive: true });
+    await copyFile(source, destination);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
   }
 }
 
@@ -351,9 +388,18 @@ if (primaryInstance) void app.whenReady().then(async () => {
     website: EXTERNAL_URLS.github,
   });
   const paths = gamePaths();
+  activeAccountMode = await loadAccountMode(paths.launcherMode);
+  let multiWorkspace = activeAccountMode === "multi"
+    ? await loadMultiWorkspace(paths.multiWorkspace)
+    : null;
+  if (activeAccountMode === "multi" && !multiWorkspace) {
+    throw new Error("Multiple Accounts mode has no workspace");
+  }
   await applyPendingCacheClear(paths);
-  await applyPendingGameStorageReset(paths);
-  await ensureDirs();
+  if (activeAccountMode === "single") {
+    await applyPendingGameStorageReset(paths);
+  }
+  await ensureDirs(activeAccountMode);
   await startDiagnostics();
   const distributionChannel = packagedDistributionChannel();
   const distribution = distributionCapabilities(distributionChannel);
@@ -366,7 +412,11 @@ if (primaryInstance) void app.whenReady().then(async () => {
     app.isPackaged
     && distribution.persistentSecrets
     && !app.commandLine.hasSwitch("gw-volatile-secrets");
-  if (persistentSecrets && distribution.cleanupLegacySecrets) {
+  if (
+    activeAccountMode === "single"
+    && persistentSecrets
+    && distribution.cleanupLegacySecrets
+  ) {
     const legacySecretFailures = await cleanupLegacySecretFiles(
       app.getPath("userData"),
       rm,
@@ -375,8 +425,10 @@ if (primaryInstance) void app.whenReady().then(async () => {
       logEvent({ k: "legacySecrets.cleanupFailed", code: errorCode(failure) });
     }
   }
-  await clearBrowserCookies("startup");
-  await clearBrowserNetworkCache();
+  if (activeAccountMode === "single") {
+    await clearBrowserCookies("startup");
+    await clearBrowserNetworkCache();
+  }
   logEvent({ k: "electron.ready" });
   const settings = await loadSettings(paths.settings, async () => {
     logEvent({ k: "settings.corruptRecovered" });
@@ -394,7 +446,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
     enhancementSelection,
     enhancementProgram,
   );
-  await prepareWindowState();
+  if (activeAccountMode === "single") await prepareWindowState();
   const keychain: NativeKeychain = persistentSecrets
     ? loadNativeKeychain({
         packaged: true,
@@ -402,8 +454,36 @@ if (primaryInstance) void app.whenReady().then(async () => {
         resourcesPath: process.resourcesPath,
       })
     : new VolatileNativeKeychain();
-  const credentialsStore = new CredentialsStore(keychain);
-  const steamSessionStore = new SteamSessionStore(keychain);
+  const credentialsStores = new Map<string, CredentialsStore>();
+  const steamSessionStores = new Map<string, SteamSessionStore>();
+  const credentialStoreForProfile = (profileId?: ProfileId): CredentialsStore => {
+    const key = profileId ?? "single";
+    let store = credentialsStores.get(key);
+    if (!store) {
+      store = new CredentialsStore(
+        keychain,
+        profileId
+          ? multiSecretSlot(profileId, "arenaNetCredentials")
+          : "arenaNetCredentials",
+      );
+      credentialsStores.set(key, store);
+    }
+    return store;
+  };
+  const steamStoreForProfile = (profileId?: ProfileId): SteamSessionStore => {
+    const key = profileId ?? "single";
+    let store = steamSessionStores.get(key);
+    if (!store) {
+      store = new SteamSessionStore(
+        keychain,
+        profileId
+          ? multiSecretSlot(profileId, "steamSession")
+          : "steamSession",
+      );
+      steamSessionStores.set(key, store);
+    }
+    return store;
+  };
   const expectedUserData = process.env.GW_EXPECT_USER_DATA;
   const profileMatches =
     !expectedUserData ||
@@ -467,17 +547,142 @@ if (primaryInstance) void app.whenReady().then(async () => {
     logEvent({ k: "fullDownload.stoppedForSleep" });
     clientRuntime.stopDownload();
   });
-  installGwProtocolHandler({
+  const protocolDeps = {
     getActiveClient: () => clientRuntime.active,
+  };
+  if (activeAccountMode === "single") {
+    installGwProtocolHandler(protocolDeps);
+    logEvent({ k: "protocol.installed" });
+  }
+
+  const host = buildWindowHost(
+    clientRuntime,
+    sockets,
+    enhancementSelection,
+    enhancementProgram,
+  );
+  const profileProtocolSessions = new Set<ProfileId>();
+  const profileLaunchState = new Map<ProfileId, "opening" | "failed">();
+  const profileFor = (profileId: ProfileId) => {
+    const profile = multiWorkspace?.profiles.find(
+      (candidate) => candidate.id === profileId && !candidate.archived,
+    );
+    if (!profile) throw new Error("Unknown Multiple Accounts profile");
+    return profile;
+  };
+  const accountsState = (): AccountsState => ({
+    mode: activeAccountMode,
+    profiles: (multiWorkspace?.profiles ?? [])
+      .filter((profile) => !profile.archived)
+      .map((profile) => ({
+        id: profile.id,
+        name: profile.name,
+        templates: profile.templates,
+        builds: profile.builds,
+        state: windowRegistry.profileWindow(profile.id)
+          ? "running"
+          : (profileLaunchState.get(profile.id) ?? "ready"),
+      })),
   });
-  logEvent({ k: "protocol.installed" });
+  const openProfile = async (profileId: ProfileId): Promise<void> => {
+    const profile = profileFor(profileId);
+    const existing = windowRegistry.profileWindow(profileId);
+    if (existing) {
+      if (existing.isMinimized()) existing.restore();
+      existing.show();
+      existing.focus();
+      return;
+    }
+    if (profileLaunchState.get(profileId) === "opening") return;
+    profileLaunchState.set(profileId, "opening");
+    try {
+      const owner = session.fromPartition(`persist:gw-multi-${profileId}`, {
+        cache: false,
+      });
+      if (!profileProtocolSessions.has(profileId)) {
+        installGwProtocolHandlerForSession(owner, protocolDeps);
+        profileProtocolSessions.add(profileId);
+      }
+      await Promise.all([
+        owner.clearStorageData({ storages: ["cookies"] }),
+        owner.clearCache(),
+      ]);
+      const profilePaths = multiProfilePaths(paths, profileId);
+      await mkdir(profilePaths.root, { recursive: true });
+      await prepareWindowState(profilePaths.windowState);
+      const win = createMainWindow(host, {
+        context: { mode: "multi", role: "game", profileId },
+        session: owner,
+        title: `Guild Wars Reforged — ${profile.name}`,
+        windowStatePath: profilePaths.windowState,
+      });
+      win.on("closed", () => profileLaunchState.delete(profileId));
+      profileLaunchState.delete(profileId);
+    } catch (error) {
+      profileLaunchState.set(profileId, "failed");
+      throw error;
+    }
+  };
+
+  const setupAccounts = async (request: AccountsSetupRequest): Promise<void> => {
+    if (activeAccountMode !== "single") {
+      throw new Error("Multiple Accounts mode is already enabled");
+    }
+    multiWorkspace ??= await loadMultiWorkspace(paths.multiWorkspace);
+    if (!multiWorkspace) {
+      multiWorkspace = createMultiWorkspace(request);
+      const profile = multiWorkspace.profiles[0]!;
+      const profilePaths = multiProfilePaths(paths, profile.id);
+      await mkdir(profilePaths.root, { recursive: true });
+      if (request.importBuilds) {
+        await copyIfPresent(
+          paths.buildLibrary,
+          profile.builds === "shared"
+            ? paths.multiSharedBuildLibrary
+            : profilePaths.buildLibrary,
+        );
+      }
+      if (request.importTemplates) {
+        throw new Error("Template import is not available in this build");
+      }
+      await saveMultiWorkspace(paths.multiWorkspace, multiWorkspace);
+    }
+    await saveAccountMode(paths.launcherMode, "multi");
+    app.relaunch();
+    app.quit();
+  };
+
+  const useSingleAccountMode = async (): Promise<void> => {
+    await saveAccountMode(paths.launcherMode, "single");
+    app.relaunch();
+    app.quit();
+  };
 
   const ipcCleanup = registerIpcHandlers({
     sockets,
     windows: windowRegistry,
-    credentialsStoreFor: () => credentialsStore,
-    steamSessionStoreFor: () => steamSessionStore,
-    buildLibraryPathFor: () => paths.buildLibrary,
+    credentialsStoreFor: (win) => {
+      const context = windowRegistry.contextForWebContents(win.webContents.id);
+      return context?.mode === "multi" && context.role === "game"
+        ? credentialStoreForProfile(context.profileId)
+        : credentialStoreForProfile();
+    },
+    steamSessionStoreFor: (win) => {
+      const context = windowRegistry.contextForWebContents(win.webContents.id);
+      return context?.mode === "multi" && context.role === "game"
+        ? steamStoreForProfile(context.profileId)
+        : steamStoreForProfile();
+    },
+    buildLibraryPathFor: (win) => {
+      const context = windowRegistry.contextForWebContents(win.webContents.id);
+      if (context?.mode !== "multi" || context.role !== "game") {
+        return paths.buildLibrary;
+      }
+      const profile = profileFor(context.profileId);
+      return profile.builds === "shared"
+        ? paths.multiSharedBuildLibrary
+        : multiProfilePaths(paths, profile.id).buildLibrary;
+    },
     getProgress: () => clientRuntime.progress,
     getChunkStore: () => clientRuntime.active?.store ?? null,
     getSettings: () => loadSettings(paths.settings),
@@ -535,33 +740,38 @@ if (primaryInstance) void app.whenReady().then(async () => {
     }),
     acquireSteamToken: (parent, record) =>
       acquireSteamToken(STEAM_OAUTH, { parent, record }),
+    getAccountsState: accountsState,
+    setupAccounts,
+    openAccounts: async (profileIds) => {
+      for (const profileId of profileIds) await openProfile(profileId);
+    },
+    useSingleAccountMode,
   });
 
   onAppQuit(async () => {
-    const win = getMainWindow();
-    if (win && !win.isDestroyed()) {
-      const outcome = await sendRendererCommand(win, {
-        type: "filesystem.sync",
-      });
-      if (outcome !== "completed") {
-        logEvent({ k: "quit.rendererSyncIncomplete", outcome });
+    const gameWindows = windowRegistry.gameWindows();
+    for (const win of gameWindows) {
+      if (!win.isDestroyed()) {
+        const outcome = await sendRendererCommand(win, {
+          type: "filesystem.sync",
+        });
+        if (outcome !== "completed") {
+          logEvent({ k: "quit.rendererSyncIncomplete", outcome });
+        }
       }
     }
     await ipcCleanup.drainSecrets();
-    await flushWindowState();
+    await Promise.all(gameWindows.map((win) => flushWindowState(win)));
     sockets.closeAll();
     updateLongRunningTaskFeedback(INITIAL_PROGRESS);
     await clientRuntime.shutdown();
-    await clearBrowserCookies("quit");
+    if (activeAccountMode === "single") await clearBrowserCookies("quit");
     await stopDiagnostics();
   });
 
-  const win = createMainWindow(buildWindowHost(
-    clientRuntime,
-    sockets,
-    enhancementSelection,
-    enhancementProgram,
-  ));
+  const win = activeAccountMode === "multi"
+    ? createAccountsWindow(protocolDeps)
+    : createMainWindow(host);
   if (settings.autoCheckUpdates) {
     void checkForAppUpdates(settings.updateTrack);
   }
@@ -627,13 +837,10 @@ if (primaryInstance) void app.whenReady().then(async () => {
   }
 
   app.on("activate", () => {
-    if (!getMainWindow()) {
-      createMainWindow(buildWindowHost(
-        clientRuntime,
-        sockets,
-        enhancementSelection,
-        enhancementProgram,
-      ));
+    if (activeAccountMode === "multi") {
+      if (!revealAccountsWindow()) createAccountsWindow(protocolDeps);
+    } else if (!getMainWindow()) {
+      createMainWindow(host);
     }
   });
   app.on("child-process-gone", (_event, details) => {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -107,6 +107,7 @@ import {
   applyPendingCacheClear,
   applyPendingGameStorageReset,
 } from "./settings-actions.js";
+import { windowRegistry } from "./window-registry.js";
 
 // The public app name changed after alpha profiles already existed. Keep that
 // one profile as the canonical home so the rename cannot strand saved login,
@@ -473,8 +474,10 @@ if (primaryInstance) void app.whenReady().then(async () => {
 
   const ipcCleanup = registerIpcHandlers({
     sockets,
-    credentialsStore,
-    steamSessionStore,
+    windows: windowRegistry,
+    credentialsStoreFor: () => credentialsStore,
+    steamSessionStoreFor: () => steamSessionStore,
+    buildLibraryPathFor: () => paths.buildLibrary,
     getProgress: () => clientRuntime.progress,
     getChunkStore: () => clientRuntime.active?.store ?? null,
     getSettings: () => loadSettings(paths.settings),

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -94,6 +94,7 @@ import {
   flushWindowState,
   getMainWindow,
   prepareWindowState,
+  resetRendererRecovery,
   RENDERER_URL,
   setOwnedWindowTitle,
   type WindowHost,
@@ -142,6 +143,10 @@ import {
   type ProfileId,
 } from "../shared/multiple-accounts.js";
 import { multiSecretSlot } from "./core/native-keychain.js";
+import {
+  launchIssueForStage,
+  ProfileRuntimeStore,
+} from "./core/profile-runtime.js";
 import {
   loadAccountTemplateLibrary,
   reconcileAccountTemplates,
@@ -661,7 +666,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
     enhancementProgram,
   );
   const profileProtocolSessions = new Set<ProfileId>();
-  const profileLaunchState = new Map<ProfileId, "opening" | "failed">();
+  const profileRuntime = new ProfileRuntimeStore();
   const profileFor = (profileId: ProfileId) => {
     const profile = multiWorkspace?.profiles.find(
       (candidate) => candidate.id === profileId && !candidate.archived,
@@ -677,9 +682,10 @@ if (primaryInstance) void app.whenReady().then(async () => {
         templates: profile.templates,
         builds: profile.builds,
         archived: profile.archived,
-        state: !profile.archived && windowRegistry.profileWindow(profile.id)
-          ? "running"
-          : (profileLaunchState.get(profile.id) ?? "ready"),
+        state: profileRuntime.get(profile.id).state,
+        ...(profileRuntime.get(profile.id).launchIssue
+          ? { launchIssue: profileRuntime.get(profile.id).launchIssue }
+          : {}),
       })),
   });
   const openProfile = async (
@@ -687,15 +693,23 @@ if (primaryInstance) void app.whenReady().then(async () => {
     newWindowOrdinal: number,
   ): Promise<{ readonly win: BrowserWindow; readonly opened: boolean }> => {
     const profile = profileFor(profileId);
-    const existing = windowRegistry.profileWindow(profileId);
+    let existing = windowRegistry.profileWindow(profileId);
+    const previous = profileRuntime.get(profileId);
+    const profilePaths = multiProfilePaths(paths, profileId);
+    if (previous?.state === "failed") {
+      resetRendererRecovery(profilePaths.windowState);
+      if (existing && !existing.isDestroyed()) existing.destroy();
+      existing = null;
+    }
     if (existing) {
       if (existing.isMinimized()) existing.restore();
       return { win: existing, opened: false };
     }
-    if (profileLaunchState.get(profileId) === "opening") {
+    if (previous?.state === "opening" || previous?.state === "checking") {
       throw new Error("Account is already opening");
     }
-    profileLaunchState.set(profileId, "opening");
+    profileRuntime.set(profileId, "opening");
+    let failureStage: Parameters<typeof launchIssueForStage>[0] = "preparing";
     try {
       const owner = session.fromPartition(`persist:gw-multi-${profileId}`, {
         cache: false,
@@ -708,7 +722,6 @@ if (primaryInstance) void app.whenReady().then(async () => {
         owner.clearStorageData({ storages: ["cookies"] }),
         owner.clearCache(),
       ]);
-      const profilePaths = multiProfilePaths(paths, profileId);
       const reset = await applyPendingSessionStorageReset(
         owner,
         profilePaths.gameStorageClearRequest,
@@ -719,17 +732,19 @@ if (primaryInstance) void app.whenReady().then(async () => {
       }
       await mkdir(profilePaths.root, { recursive: true });
       await prepareWindowState(profilePaths.windowState, newWindowOrdinal);
+      failureStage = "starting";
       const win = createMainWindow(host, {
         context: { mode: "multi", role: "game", profileId },
         session: owner,
         title: `Guild Wars Reforged — ${profile.name}`,
         windowStatePath: profilePaths.windowState,
         showInactive: true,
-        onRendererFailure: () => profileLaunchState.set(profileId, "failed"),
+        onRendererFailure: () =>
+          profileRuntime.set(profileId, "failed", launchIssueForStage("crashed")),
       });
       win.on("closed", () => {
-        if (profileLaunchState.get(profileId) !== "failed") {
-          profileLaunchState.delete(profileId);
+        if (profileRuntime.get(profileId).state !== "failed") {
+          profileRuntime.set(profileId, "ready");
         }
       });
       await new Promise<void>((resolve, reject) => {
@@ -753,10 +768,10 @@ if (primaryInstance) void app.whenReady().then(async () => {
         win.webContents.once("did-finish-load", loaded);
         win.once("closed", closed);
       });
-      profileLaunchState.delete(profileId);
+      profileRuntime.set(profileId, "running");
       return { win, opened: true };
     } catch (error) {
-      profileLaunchState.set(profileId, "failed");
+      profileRuntime.set(profileId, "failed", launchIssueForStage(failureStage));
       const failedWindow = windowRegistry.profileWindow(profileId);
       if (failedWindow && !failedWindow.isDestroyed()) failedWindow.destroy();
       throw error;
@@ -906,6 +921,11 @@ if (primaryInstance) void app.whenReady().then(async () => {
     getAccountsState: accountsState,
     setupAccounts,
     openAccounts: async (profileIds) => {
+      for (const profileId of profileIds) profileFor(profileId);
+      profileRuntime.queue(
+        profileIds,
+        (profileId) => windowRegistry.profileWindow(profileId) !== null,
+      );
       let canaryChecked = false;
       let firstFailure: unknown = null;
       let firstSelectedWindow: BrowserWindow | null = null;
@@ -920,7 +940,22 @@ if (primaryInstance) void app.whenReady().then(async () => {
           continue;
         }
         if (result.opened && !canaryChecked) {
-          await waitForCandidateCanary();
+          if (clientRuntime.healthToken) {
+            profileRuntime.set(profileId, "checking");
+            try {
+              await waitForCandidateCanary();
+            } catch (error) {
+              profileRuntime.set(
+                profileId,
+                "failed",
+                launchIssueForStage("validating"),
+              );
+              profileRuntime.releaseQueued(profileIds.slice(index + 1));
+              revealAccountsWindow();
+              throw error;
+            }
+          }
+          profileRuntime.set(profileId, "running");
           canaryChecked = true;
         }
       }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -733,16 +733,27 @@ if (primaryInstance) void app.whenReady().then(async () => {
       await mkdir(profilePaths.root, { recursive: true });
       await prepareWindowState(profilePaths.windowState, newWindowOrdinal);
       failureStage = "starting";
+      let hubWasVisibleBeforeRecovery = false;
       const win = createMainWindow(host, {
         context: { mode: "multi", role: "game", profileId },
         session: owner,
         title: `Guild Wars Reforged — ${profile.name}`,
         windowStatePath: profilePaths.windowState,
         showInactive: true,
-        onRendererFailure: () =>
-          profileRuntime.set(profileId, "failed", launchIssueForStage("crashed")),
+        onRendererRecoveryStart: () => {
+          hubWasVisibleBeforeRecovery = getAccountsWindow()?.isVisible() ?? false;
+        },
+        onRendererRecovered: () => {
+          if (!hubWasVisibleBeforeRecovery) getAccountsWindow()?.hide();
+        },
+        onRendererFailure: () => {
+          profileRuntime.set(profileId, "failed", launchIssueForStage("crashed"));
+          revealAccountsWindow();
+        },
       });
       win.on("closed", () => {
+        const replacement = windowRegistry.profileWindow(profileId);
+        if (replacement && replacement !== win) return;
         if (profileRuntime.get(profileId).state !== "failed") {
           profileRuntime.set(profileId, "ready");
         }
@@ -967,9 +978,21 @@ if (primaryInstance) void app.whenReady().then(async () => {
       if (hub && !hub.isDestroyed()) hub.hide();
       if (firstSelectedWindow && !firstSelectedWindow.isDestroyed()) {
         if (firstSelectedWindow.isMinimized()) firstSelectedWindow.restore();
+        const focused = new Promise<void>((resolve) => {
+          if (firstSelectedWindow.isFocused()) {
+            resolve();
+            return;
+          }
+          const timeout = setTimeout(resolve, 1_000);
+          firstSelectedWindow.once("focus", () => {
+            clearTimeout(timeout);
+            resolve();
+          });
+        });
         firstSelectedWindow.show();
         app.focus({ steal: true });
         firstSelectedWindow.focus();
+        await focused;
       }
     },
     createAccount: (request: AccountProfileRequest) => accountsLock.run(async () => {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -15,6 +15,7 @@ import {
   powerMonitor,
   session,
 } from "electron";
+import type { BrowserWindow } from "electron";
 import { readFileSync } from "node:fs";
 import { mkdir, readFile, rm } from "node:fs/promises";
 import path from "node:path";
@@ -148,6 +149,7 @@ import {
 } from "./core/account-template-library.js";
 import {
   createAccountsWindow,
+  getAccountsWindow,
   revealAccountsWindow,
 } from "./accounts-window.js";
 
@@ -680,16 +682,19 @@ if (primaryInstance) void app.whenReady().then(async () => {
           : (profileLaunchState.get(profile.id) ?? "ready"),
       })),
   });
-  const openProfile = async (profileId: ProfileId): Promise<boolean> => {
+  const openProfile = async (
+    profileId: ProfileId,
+    newWindowOrdinal: number,
+  ): Promise<{ readonly win: BrowserWindow; readonly opened: boolean }> => {
     const profile = profileFor(profileId);
     const existing = windowRegistry.profileWindow(profileId);
     if (existing) {
       if (existing.isMinimized()) existing.restore();
-      existing.show();
-      existing.focus();
-      return false;
+      return { win: existing, opened: false };
     }
-    if (profileLaunchState.get(profileId) === "opening") return false;
+    if (profileLaunchState.get(profileId) === "opening") {
+      throw new Error("Account is already opening");
+    }
     profileLaunchState.set(profileId, "opening");
     try {
       const owner = session.fromPartition(`persist:gw-multi-${profileId}`, {
@@ -713,12 +718,14 @@ if (primaryInstance) void app.whenReady().then(async () => {
         await rm(profilePaths.templateSync, { force: true });
       }
       await mkdir(profilePaths.root, { recursive: true });
-      await prepareWindowState(profilePaths.windowState);
+      await prepareWindowState(profilePaths.windowState, newWindowOrdinal);
       const win = createMainWindow(host, {
         context: { mode: "multi", role: "game", profileId },
         session: owner,
         title: `Guild Wars Reforged — ${profile.name}`,
         windowStatePath: profilePaths.windowState,
+        showInactive: true,
+        onRendererFailure: () => profileLaunchState.set(profileId, "failed"),
       });
       win.on("closed", () => {
         if (profileLaunchState.get(profileId) !== "failed") {
@@ -747,7 +754,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
         win.once("closed", closed);
       });
       profileLaunchState.delete(profileId);
-      return true;
+      return { win, opened: true };
     } catch (error) {
       profileLaunchState.set(profileId, "failed");
       const failedWindow = windowRegistry.profileWindow(profileId);
@@ -901,21 +908,34 @@ if (primaryInstance) void app.whenReady().then(async () => {
     openAccounts: async (profileIds) => {
       let canaryChecked = false;
       let firstFailure: unknown = null;
+      let firstSelectedWindow: BrowserWindow | null = null;
       for (let index = 0; index < profileIds.length; index += 1) {
         const profileId = profileIds[index]!;
-        let opened: boolean;
+        let result: { readonly win: BrowserWindow; readonly opened: boolean };
         try {
-          opened = await accountsLock.run(() => openProfile(profileId));
+          result = await accountsLock.run(() => openProfile(profileId, index));
+          firstSelectedWindow ??= result.win;
         } catch (error) {
           firstFailure ??= error;
           continue;
         }
-        if (opened && !canaryChecked) {
+        if (result.opened && !canaryChecked) {
           await waitForCandidateCanary();
           canaryChecked = true;
         }
       }
-      if (firstFailure) throw firstFailure;
+      if (firstFailure) {
+        revealAccountsWindow();
+        throw firstFailure;
+      }
+      const hub = getAccountsWindow();
+      if (hub && !hub.isDestroyed()) hub.hide();
+      if (firstSelectedWindow && !firstSelectedWindow.isDestroyed()) {
+        if (firstSelectedWindow.isMinimized()) firstSelectedWindow.restore();
+        firstSelectedWindow.show();
+        app.focus({ steal: true });
+        firstSelectedWindow.focus();
+      }
     },
     createAccount: (request: AccountProfileRequest) => accountsLock.run(async () => {
       if (activeAccountMode !== "multi" || !multiWorkspace) {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -16,7 +16,7 @@ import {
   session,
 } from "electron";
 import { readFileSync } from "node:fs";
-import { copyFile, mkdir, rm } from "node:fs/promises";
+import { mkdir, readFile, rm } from "node:fs/promises";
 import path from "node:path";
 import {
   EXTERNAL_URLS,
@@ -42,6 +42,8 @@ import { INITIAL_PROGRESS } from "../shared/progress.js";
 import { AUTOMATION_COMMAND } from "../shared/automation.js";
 import { ClientRuntime } from "./client-runtime.js";
 import { Mutex } from "./core/mutex.js";
+import { saveBuildLibrary } from "./core/build-library.js";
+import { parseBuildLibrary } from "../shared/builds/parse-library.js";
 import { loadSettings, saveSettings } from "./core/settings.js";
 import { SocketManager } from "./core/sockets.js";
 import {
@@ -87,10 +89,12 @@ import {
 } from "./protocol.js";
 import {
   createMainWindow,
+  closeProfileWindow,
   flushWindowState,
   getMainWindow,
   prepareWindowState,
   RENDERER_URL,
+  setOwnedWindowTitle,
   type WindowHost,
   updateLongRunningTaskFeedback,
 } from "./window.js";
@@ -126,12 +130,14 @@ import {
   loadMultiWorkspace,
   saveAccountMode,
   saveMultiWorkspace,
+  quarantineAccountDocument,
   removeArchivedMultiProfile,
   restoreMultiProfile,
   updateMultiProfile,
 } from "./core/multiple-accounts.js";
 import {
   type AccountMode,
+  type MultiWorkspace,
   type ProfileId,
 } from "../shared/multiple-accounts.js";
 import { multiSecretSlot } from "./core/native-keychain.js";
@@ -265,7 +271,11 @@ function buildSocketManager(): SocketManager {
 }
 
 function setProgress(next: DownloadProgress): void {
-  updateLongRunningTaskFeedback(next);
+  const gameWindows = windowRegistry.gameWindows();
+  if (gameWindows.length === 0) updateLongRunningTaskFeedback(next, null);
+  else {
+    for (const win of gameWindows) updateLongRunningTaskFeedback(next, win);
+  }
   sendToRenderer(IPC.progressEvent, next);
 }
 
@@ -347,13 +357,19 @@ async function clearBrowserNetworkCache(): Promise<void> {
   }
 }
 
-async function copyIfPresent(source: string, destination: string): Promise<void> {
+async function importBuildLibraryIfPresent(
+  source: string,
+  destination: string,
+): Promise<void> {
+  let bytes: string;
   try {
-    await mkdir(path.dirname(destination), { recursive: true });
-    await copyFile(source, destination);
+    bytes = await readFile(source, "utf8");
   } catch (error) {
-    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
   }
+  const library = parseBuildLibrary(JSON.parse(bytes) as unknown);
+  await saveBuildLibrary(destination, library);
 }
 
 function buildWindowHost(
@@ -369,10 +385,7 @@ function buildWindowHost(
     getProgress: () => clientRuntime.progress,
     getSettings: () => loadSettings(gamePaths().settings),
     updateSettings: updateAppSettings,
-    exportDiagnostics: async () => {
-      const win = getMainWindow();
-      return win ? exportDiagnosticsForWindow(win) : "";
-    },
+    exportDiagnostics: (win) => exportDiagnosticsForWindow(win),
     markPerformanceProblem,
     startCapture: startDiagnosticCapture,
     stopCapture: stopDiagnosticCapture,
@@ -409,12 +422,75 @@ if (primaryInstance) void app.whenReady().then(async () => {
     website: EXTERNAL_URLS.github,
   });
   const paths = gamePaths();
-  activeAccountMode = await loadAccountMode(paths.launcherMode);
+  try {
+    activeAccountMode = await loadAccountMode(paths.launcherMode);
+  } catch {
+    const { response } = await dialog.showMessageBox({
+      type: "warning",
+      buttons: ["Open Single Account Mode", "Quit"],
+      defaultId: 0,
+      cancelId: 1,
+      message: "Account mode settings are damaged",
+      detail:
+        "GWonMac can preserve the damaged file and restart in Single Account mode. Your saved login, templates, builds, and downloaded game data will not be changed.",
+    });
+    if (response !== 0) {
+      app.quit();
+      return;
+    }
+    await quarantineAccountDocument(paths.launcherMode);
+    await saveAccountMode(paths.launcherMode, "single");
+    app.relaunch();
+    app.quit();
+    return;
+  }
   // The registry is safe to inspect from Single mode for the explicit Accounts
   // settings pane. Its sessions, libraries, and Keychain items remain closed.
-  let multiWorkspace = await loadMultiWorkspace(paths.multiWorkspace);
+  let multiWorkspace: MultiWorkspace | null;
+  try {
+    multiWorkspace = await loadMultiWorkspace(paths.multiWorkspace);
+  } catch {
+    if (activeAccountMode === "multi") {
+      const { response } = await dialog.showMessageBox({
+        type: "warning",
+        buttons: ["Open Single Account Mode", "Quit"],
+        defaultId: 0,
+        cancelId: 1,
+        message: "Multiple Accounts profiles are damaged",
+        detail:
+          "GWonMac can preserve the damaged workspace and restart in Single Account mode. Single Account data and profile Keychain items will not be changed.",
+      });
+      if (response !== 0) {
+        app.quit();
+        return;
+      }
+      await quarantineAccountDocument(paths.multiWorkspace);
+      await saveAccountMode(paths.launcherMode, "single");
+      app.relaunch();
+      app.quit();
+      return;
+    }
+    await quarantineAccountDocument(paths.multiWorkspace);
+    multiWorkspace = null;
+  }
   if (activeAccountMode === "multi" && !multiWorkspace) {
-    throw new Error("Multiple Accounts mode has no workspace");
+    const { response } = await dialog.showMessageBox({
+      type: "warning",
+      buttons: ["Open Single Account Mode", "Quit"],
+      defaultId: 0,
+      cancelId: 1,
+      message: "Multiple Accounts profiles are missing",
+      detail:
+        "Restart in Single Account mode without changing its saved login, templates, builds, or Guild Wars files.",
+    });
+    if (response !== 0) {
+      app.quit();
+      return;
+    }
+    await saveAccountMode(paths.launcherMode, "single");
+    app.relaunch();
+    app.quit();
+    return;
   }
   await applyPendingCacheClear(paths);
   if (activeAccountMode === "single") {
@@ -604,16 +680,16 @@ if (primaryInstance) void app.whenReady().then(async () => {
           : (profileLaunchState.get(profile.id) ?? "ready"),
       })),
   });
-  const openProfile = async (profileId: ProfileId): Promise<void> => {
+  const openProfile = async (profileId: ProfileId): Promise<boolean> => {
     const profile = profileFor(profileId);
     const existing = windowRegistry.profileWindow(profileId);
     if (existing) {
       if (existing.isMinimized()) existing.restore();
       existing.show();
       existing.focus();
-      return;
+      return false;
     }
-    if (profileLaunchState.get(profileId) === "opening") return;
+    if (profileLaunchState.get(profileId) === "opening") return false;
     profileLaunchState.set(profileId, "opening");
     try {
       const owner = session.fromPartition(`persist:gw-multi-${profileId}`, {
@@ -644,11 +720,50 @@ if (primaryInstance) void app.whenReady().then(async () => {
         title: `Guild Wars Reforged — ${profile.name}`,
         windowStatePath: profilePaths.windowState,
       });
-      win.on("closed", () => profileLaunchState.delete(profileId));
+      win.on("closed", () => {
+        if (profileLaunchState.get(profileId) !== "failed") {
+          profileLaunchState.delete(profileId);
+        }
+      });
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          cleanup();
+          reject(new Error("profile window did not finish loading"));
+        }, 30_000);
+        const cleanup = () => {
+          clearTimeout(timeout);
+          win.webContents.removeListener("did-finish-load", loaded);
+          win.removeListener("closed", closed);
+        };
+        const loaded = () => {
+          cleanup();
+          resolve();
+        };
+        const closed = () => {
+          cleanup();
+          reject(new Error("profile window closed while loading"));
+        };
+        win.webContents.once("did-finish-load", loaded);
+        win.once("closed", closed);
+      });
       profileLaunchState.delete(profileId);
+      return true;
     } catch (error) {
       profileLaunchState.set(profileId, "failed");
+      const failedWindow = windowRegistry.profileWindow(profileId);
+      if (failedWindow && !failedWindow.isDestroyed()) failedWindow.destroy();
       throw error;
+    }
+  };
+  const waitForCandidateCanary = async (): Promise<void> => {
+    const candidate = clientRuntime.healthToken;
+    if (!candidate) return;
+    const deadline = Date.now() + 60_000;
+    while (clientRuntime.healthToken === candidate && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    if (clientRuntime.healthToken === candidate) {
+      throw new Error("first profile did not confirm the new client generation");
     }
   };
 
@@ -658,12 +773,12 @@ if (primaryInstance) void app.whenReady().then(async () => {
     }
     multiWorkspace ??= await loadMultiWorkspace(paths.multiWorkspace);
     if (!multiWorkspace) {
-      multiWorkspace = createMultiWorkspace(request);
-      const profile = multiWorkspace.profiles[0]!;
+      const candidate = createMultiWorkspace(request);
+      const profile = candidate.profiles[0]!;
       const profilePaths = multiProfilePaths(paths, profile.id);
       await mkdir(profilePaths.root, { recursive: true });
       if (request.importBuilds) {
-        await copyIfPresent(
+        await importBuildLibraryIfPresent(
           paths.buildLibrary,
           profile.builds === "shared"
             ? paths.multiSharedBuildLibrary
@@ -679,7 +794,8 @@ if (primaryInstance) void app.whenReady().then(async () => {
           entries: request.templateEntries,
         });
       }
-      await saveMultiWorkspace(paths.multiWorkspace, multiWorkspace);
+      await saveMultiWorkspace(paths.multiWorkspace, candidate);
+      multiWorkspace = candidate;
     }
     await saveAccountMode(paths.launcherMode, "multi");
     app.relaunch();
@@ -783,7 +899,23 @@ if (primaryInstance) void app.whenReady().then(async () => {
     getAccountsState: accountsState,
     setupAccounts,
     openAccounts: async (profileIds) => {
-      for (const profileId of profileIds) await openProfile(profileId);
+      let canaryChecked = false;
+      let firstFailure: unknown = null;
+      for (let index = 0; index < profileIds.length; index += 1) {
+        const profileId = profileIds[index]!;
+        let opened: boolean;
+        try {
+          opened = await accountsLock.run(() => openProfile(profileId));
+        } catch (error) {
+          firstFailure ??= error;
+          continue;
+        }
+        if (opened && !canaryChecked) {
+          await waitForCandidateCanary();
+          canaryChecked = true;
+        }
+      }
+      if (firstFailure) throw firstFailure;
     },
     createAccount: (request: AccountProfileRequest) => accountsLock.run(async () => {
       if (activeAccountMode !== "multi" || !multiWorkspace) {
@@ -810,9 +942,13 @@ if (primaryInstance) void app.whenReady().then(async () => {
       const next = updateMultiProfile(multiWorkspace, request.id, request);
       await saveMultiWorkspace(paths.multiWorkspace, next);
       multiWorkspace = next;
-      windowRegistry.profileWindow(request.id)?.setTitle(
-        `Guild Wars Reforged — ${request.name}`,
-      );
+      const profileWindow = windowRegistry.profileWindow(request.id);
+      if (profileWindow) {
+        setOwnedWindowTitle(
+          profileWindow,
+          `Guild Wars Reforged — ${request.name}`,
+        );
+      }
       return accountsState();
     }),
     archiveAccount: (profileId: ProfileId) => accountsLock.run(async () => {
@@ -836,10 +972,24 @@ if (primaryInstance) void app.whenReady().then(async () => {
       multiWorkspace = next;
       return accountsState();
     }),
-    deleteAccount: (profileId: ProfileId) => accountsLock.run(async () => {
+    deleteAccount: (parent, profileId: ProfileId) => accountsLock.run(async () => {
       if (activeAccountMode !== "multi" || !multiWorkspace) {
         throw new Error("Multiple Accounts mode is not active");
       }
+      const profile = multiWorkspace.profiles.find(
+        (candidate) => candidate.id === profileId && candidate.archived,
+      );
+      if (!profile) throw new Error("Only an archived profile can be deleted");
+      const { response } = await dialog.showMessageBox(parent, {
+        type: "warning",
+        buttons: ["Permanently Delete", "Cancel"],
+        defaultId: 1,
+        cancelId: 1,
+        message: `Permanently delete “${profile.name}”?`,
+        detail:
+          "Its saved login, Guild Wars files, private templates, builds, and window state cannot be recovered. Shared libraries and Single Account data stay untouched.",
+      });
+      if (response !== 0) return accountsState();
       const next = removeArchivedMultiProfile(multiWorkspace, profileId);
       const owner = session.fromPartition(`persist:gw-multi-${profileId}`, {
         cache: false,
@@ -896,12 +1046,17 @@ if (primaryInstance) void app.whenReady().then(async () => {
       await saveAccountTemplateLibrary(paths.multiSharedTemplates, merged);
       await saveAccountTemplateLibrary(profilePaths.templateSync, merged);
     }),
+    requestQuit: (win) => {
+      const context = windowRegistry.contextForWebContents(win.webContents.id);
+      if (context?.mode === "multi") void closeProfileWindow(win);
+      else app.quit();
+    },
     useSingleAccountMode,
   });
 
   onAppQuit(async () => {
     const gameWindows = windowRegistry.gameWindows();
-    for (const win of gameWindows) {
+    await Promise.all(gameWindows.map(async (win) => {
       if (!win.isDestroyed()) {
         const outcome = await sendRendererCommand(win, {
           type: "filesystem.sync",
@@ -910,7 +1065,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
           logEvent({ k: "quit.rendererSyncIncomplete", outcome });
         }
       }
-    }
+    }));
     await ipcCleanup.drainSecrets();
     await Promise.all(gameWindows.map((win) => flushWindowState(win)));
     sockets.closeAll();
@@ -963,7 +1118,9 @@ if (primaryInstance) void app.whenReady().then(async () => {
     });
   } else {
     setDiagnosticCaptureStoppedHandler(async () => {
-      const win = getMainWindow();
+      const gameWindows = windowRegistry.gameWindows();
+      const win = gameWindows.find((candidate) => candidate.isFocused())
+        ?? gameWindows[0];
       if (!win || win.isDestroyed()) return;
       await resetGameInput(win);
       const { response } = await dialog.showMessageBox(win, {

--- a/src/main/multiple-accounts-controller.ts
+++ b/src/main/multiple-accounts-controller.ts
@@ -19,7 +19,6 @@ import type {
   ProfileId,
 } from "../shared/multiple-accounts.js";
 import {
-  createAccountsWindow,
   getAccountsWindow,
   revealAccountsWindow,
 } from "./accounts-window.js";

--- a/src/main/multiple-accounts-controller.ts
+++ b/src/main/multiple-accounts-controller.ts
@@ -1,0 +1,602 @@
+/**
+ * The Electron owner for Multiple Accounts after startup has loaded its mode
+ * and workspace. It keeps profile resources, launch sequencing, persistence,
+ * and destructive cleanup out of the application composition root.
+ */
+import { app, dialog, session, type BrowserWindow } from "electron";
+import { mkdir, readFile, rm } from "node:fs/promises";
+import type {
+  AccountProfileCreateRequest,
+  AccountProfileUpdateRequest,
+  AccountTemplateLibrary,
+  AccountsSetupRequest,
+  AccountsState,
+  TemplateExportEntry,
+} from "../shared/contracts.js";
+import type {
+  AccountMode,
+  MultiWorkspace,
+  ProfileId,
+} from "../shared/multiple-accounts.js";
+import {
+  createAccountsWindow,
+  getAccountsWindow,
+  revealAccountsWindow,
+} from "./accounts-window.js";
+import type { ClientRuntime } from "./client-runtime.js";
+import {
+  loadAccountTemplateLibrary,
+  reconcileAccountTemplates,
+  saveAccountTemplateLibrary,
+} from "./core/account-template-library.js";
+import { saveBuildLibrary } from "./core/build-library.js";
+import { CredentialsStore } from "./core/credentials.js";
+import {
+  addMultiProfile,
+  archiveMultiProfile,
+  beginArchivedProfileDeletion,
+  createMultiWorkspace,
+  loadMultiWorkspace,
+  removeArchivedMultiProfile,
+  restoreMultiProfile,
+  saveAccountMode,
+  saveMultiWorkspace,
+  updateMultiProfile,
+} from "./core/multiple-accounts.js";
+import { Mutex } from "./core/mutex.js";
+import { multiSecretSlot, type NativeKeychain } from "./core/native-keychain.js";
+import { multiProfilePaths } from "./core/paths.js";
+import {
+  launchIssueForStage,
+  ProfileRuntimeStore,
+} from "./core/profile-runtime.js";
+import { SteamSessionStore } from "./core/steam-session.js";
+import type { GamePaths } from "./paths.js";
+import {
+  installGwProtocolHandlerForSession,
+  type ProtocolDeps,
+} from "./protocol.js";
+import { parseBuildLibrary } from "../shared/builds/parse-library.js";
+import { applyPendingSessionStorageReset } from "./settings-actions.js";
+import {
+  closeProfileWindow,
+  createMainWindow,
+  prepareWindowState,
+  resetRendererRecovery,
+  setOwnedWindowTitle,
+  type WindowHost,
+} from "./window.js";
+import { windowRegistry } from "./window-registry.js";
+
+export interface MultipleAccountsControllerOptions {
+  readonly mode: AccountMode;
+  readonly workspace: MultiWorkspace | null;
+  readonly paths: GamePaths;
+  readonly keychain: NativeKeychain;
+  readonly clientRuntime: ClientRuntime;
+  readonly protocol: ProtocolDeps;
+  readonly windowHost: WindowHost;
+}
+
+export class MultipleAccountsController {
+  private readonly accountsLock = new Mutex();
+  private readonly templatesLock = new Mutex();
+  private readonly credentialsStores = new Map<string, CredentialsStore>();
+  private readonly steamSessionStores = new Map<string, SteamSessionStore>();
+  private readonly profileProtocolSessions = new Set<ProfileId>();
+  private readonly profileRuntime = new ProfileRuntimeStore();
+  private workspace: MultiWorkspace | null;
+
+  constructor(private readonly options: MultipleAccountsControllerOptions) {
+    this.workspace = options.workspace;
+  }
+
+  credentialsStoreFor(win: BrowserWindow): CredentialsStore {
+    const context = windowRegistry.contextForWebContents(win.webContents.id);
+    return context?.mode === "multi" && context.role === "game"
+      ? this.credentialsForProfile(context.profileId)
+      : this.credentialsForProfile();
+  }
+
+  steamSessionStoreFor(win: BrowserWindow): SteamSessionStore {
+    const context = windowRegistry.contextForWebContents(win.webContents.id);
+    return context?.mode === "multi" && context.role === "game"
+      ? this.steamForProfile(context.profileId)
+      : this.steamForProfile();
+  }
+
+  buildLibraryPathFor(win: BrowserWindow): string {
+    const { paths } = this.options;
+    const context = windowRegistry.contextForWebContents(win.webContents.id);
+    if (context?.mode !== "multi" || context.role !== "game") {
+      return paths.buildLibrary;
+    }
+    const profile = this.profileFor(context.profileId);
+    return profile.builds === "shared"
+      ? paths.multiSharedBuildLibrary
+      : multiProfilePaths(paths, profile.id).buildLibrary;
+  }
+
+  gameStorageResetMarkerFor(win: BrowserWindow): string {
+    const { paths } = this.options;
+    const context = windowRegistry.contextForWebContents(win.webContents.id);
+    return context?.mode === "multi" && context.role === "game"
+      ? multiProfilePaths(paths, context.profileId).gameStorageClearRequest
+      : paths.gameStorageClearRequest;
+  }
+
+  state(): AccountsState {
+    return {
+      mode: this.options.mode,
+      profiles: (this.workspace?.profiles ?? [])
+        .filter((profile) => !this.workspace?.deletingProfileIds.includes(profile.id))
+        .map((profile) => {
+        const runtime = this.profileRuntime.get(profile.id);
+        return {
+          id: profile.id,
+          name: profile.name,
+          templates: profile.templates,
+          builds: profile.builds,
+          archived: profile.archived,
+          state: runtime.state,
+          ...(runtime.launchIssue ? { launchIssue: runtime.launchIssue } : {}),
+        };
+      }),
+    };
+  }
+
+  async setup(request: AccountsSetupRequest): Promise<void> {
+    const { mode, paths } = this.options;
+    if (mode !== "single") {
+      throw new Error("Multiple Accounts mode is already enabled");
+    }
+    this.workspace ??= await loadMultiWorkspace(paths.multiWorkspace);
+    if (!this.workspace) {
+      const candidate = createMultiWorkspace();
+      await saveMultiWorkspace(paths.multiWorkspace, candidate);
+      this.workspace = candidate;
+    }
+    if (this.workspace.profiles.length === 0) {
+      await saveAccountTemplateLibrary(paths.multiSingleTemplateImport, {
+        revision: 1,
+        entries: request.templateEntries,
+      });
+    }
+    await this.switchMode("multi");
+  }
+
+  async useSingleMode(): Promise<void> {
+    await this.switchMode("single");
+  }
+
+  /** Finish deletion journals left by a quit, crash, or temporary I/O failure. */
+  async resumePendingDeletions(): Promise<void> {
+    for (const profileId of this.workspace?.deletingProfileIds ?? []) {
+      await this.cleanupProfile(profileId);
+      const next = removeArchivedMultiProfile(this.workspace!, profileId);
+      await saveMultiWorkspace(this.options.paths.multiWorkspace, next);
+      this.workspace = next;
+    }
+  }
+
+  async open(profileIds: readonly ProfileId[]): Promise<void> {
+    for (const profileId of profileIds) this.profileFor(profileId);
+    this.profileRuntime.queue(
+      profileIds,
+      (profileId) => windowRegistry.profileWindow(profileId) !== null,
+    );
+    let canaryChecked = false;
+    let firstFailure: unknown = null;
+    let firstSelectedWindow: BrowserWindow | null = null;
+    for (let index = 0; index < profileIds.length; index += 1) {
+      const profileId = profileIds[index]!;
+      let result: { readonly win: BrowserWindow; readonly opened: boolean };
+      try {
+        result = await this.accountsLock.run(() => this.openProfile(profileId, index));
+        firstSelectedWindow ??= result.win;
+      } catch (error) {
+        firstFailure ??= error;
+        continue;
+      }
+      if (result.opened && !canaryChecked) {
+        if (this.options.clientRuntime.healthToken) {
+          this.profileRuntime.set(profileId, "checking");
+          try {
+            await this.waitForCandidateCanary();
+          } catch (error) {
+            this.profileRuntime.set(
+              profileId,
+              "failed",
+              launchIssueForStage("validating"),
+            );
+            this.profileRuntime.releaseQueued(profileIds.slice(index + 1));
+            revealAccountsWindow();
+            throw error;
+          }
+        }
+        this.profileRuntime.set(profileId, "running");
+        canaryChecked = true;
+      }
+    }
+    if (firstFailure) {
+      revealAccountsWindow();
+      throw firstFailure;
+    }
+    const hub = getAccountsWindow();
+    if (hub && !hub.isDestroyed()) hub.hide();
+    if (firstSelectedWindow && !firstSelectedWindow.isDestroyed()) {
+      if (firstSelectedWindow.isMinimized()) firstSelectedWindow.restore();
+      const focused = new Promise<void>((resolve) => {
+        if (firstSelectedWindow.isFocused()) {
+          resolve();
+          return;
+        }
+        const timeout = setTimeout(resolve, 1_000);
+        firstSelectedWindow.once("focus", () => {
+          clearTimeout(timeout);
+          resolve();
+        });
+      });
+      firstSelectedWindow.show();
+      app.focus({ steal: true });
+      firstSelectedWindow.focus();
+      await focused;
+    }
+  }
+
+  create(request: AccountProfileCreateRequest): Promise<AccountsState> {
+    return this.accountsLock.run(async () => {
+      const workspace = this.activeWorkspace();
+      const { paths } = this.options;
+      const firstAccount = workspace.profiles.length === 0;
+      if (!firstAccount && (request.copySingleBuilds || request.copySingleTemplates)) {
+        throw new Error("Single Account data can be copied only into the first account");
+      }
+      const next = addMultiProfile(workspace, request);
+      const profile = next.profiles.at(-1)!;
+      const profilePaths = multiProfilePaths(paths, profile.id);
+      await mkdir(profilePaths.root, { recursive: true });
+      if (firstAccount && request.copySingleBuilds) {
+        await this.importBuildLibraryIfPresent(
+          paths.buildLibrary,
+          profile.builds === "shared"
+            ? paths.multiSharedBuildLibrary
+            : profilePaths.buildLibrary,
+        );
+      }
+      if (firstAccount && request.copySingleTemplates) {
+        const source = await loadAccountTemplateLibrary(paths.multiSingleTemplateImport);
+        await saveAccountTemplateLibrary(
+          profile.templates === "shared"
+            ? paths.multiSharedTemplates
+            : profilePaths.templates,
+          { revision: 1, entries: source.entries },
+        );
+      }
+      await saveMultiWorkspace(paths.multiWorkspace, next);
+      this.workspace = next;
+      if (firstAccount) {
+        await rm(paths.multiSingleTemplateImport, { force: true }).catch(() => undefined);
+      }
+      return this.state();
+    });
+  }
+
+  update(request: AccountProfileUpdateRequest): Promise<AccountsState> {
+    return this.accountsLock.run(async () => {
+      const workspace = this.activeWorkspace();
+      const current = this.profileFor(request.id);
+      if (
+        windowRegistry.profileWindow(request.id)
+        && (current.builds !== request.builds || current.templates !== request.templates)
+      ) {
+        throw new Error("Close this account before changing sharing");
+      }
+      const next = updateMultiProfile(workspace, request.id, request);
+      await saveMultiWorkspace(this.options.paths.multiWorkspace, next);
+      this.workspace = next;
+      const profileWindow = windowRegistry.profileWindow(request.id);
+      if (profileWindow) {
+        setOwnedWindowTitle(profileWindow, `Guild Wars Reforged — ${request.name}`);
+      }
+      return this.state();
+    });
+  }
+
+  archive(profileId: ProfileId): Promise<AccountsState> {
+    return this.accountsLock.run(async () => {
+      const workspace = this.activeWorkspace();
+      if (windowRegistry.profileWindow(profileId)) {
+        throw new Error("Close this account before archiving it");
+      }
+      const next = archiveMultiProfile(workspace, profileId);
+      await saveMultiWorkspace(this.options.paths.multiWorkspace, next);
+      this.workspace = next;
+      return this.state();
+    });
+  }
+
+  restore(profileId: ProfileId): Promise<AccountsState> {
+    return this.accountsLock.run(async () => {
+      const next = restoreMultiProfile(this.activeWorkspace(), profileId);
+      await saveMultiWorkspace(this.options.paths.multiWorkspace, next);
+      this.workspace = next;
+      return this.state();
+    });
+  }
+
+  delete(parent: BrowserWindow, profileId: ProfileId): Promise<AccountsState> {
+    return this.accountsLock.run(async () => {
+      const workspace = this.activeWorkspace();
+      const profile = workspace.profiles.find(
+        (candidate) => candidate.id === profileId && candidate.archived,
+      );
+      if (!profile) throw new Error("Only an archived profile can be deleted");
+      const { response } = await dialog.showMessageBox(parent, {
+        type: "warning",
+        buttons: ["Permanently Delete", "Cancel"],
+        defaultId: 1,
+        cancelId: 1,
+        message: `Permanently delete “${profile.name}”?`,
+        detail:
+          "Its saved login, Guild Wars files, private templates, builds, and window state cannot be recovered. Shared libraries and Single Account data stay untouched.",
+      });
+      if (response !== 0) return this.state();
+
+      const pending = beginArchivedProfileDeletion(workspace, profileId);
+      await saveMultiWorkspace(this.options.paths.multiWorkspace, pending);
+      this.workspace = pending;
+      await this.cleanupProfile(profileId);
+      const next = removeArchivedMultiProfile(pending, profileId);
+      await saveMultiWorkspace(this.options.paths.multiWorkspace, next);
+      this.workspace = next;
+      return this.state();
+    });
+  }
+
+  async loadTemplates(win: BrowserWindow): Promise<AccountTemplateLibrary | null> {
+    const context = windowRegistry.contextForWebContents(win.webContents.id);
+    if (context?.mode !== "multi" || context.role !== "game") return null;
+    const profile = this.profileFor(context.profileId);
+    const profilePaths = multiProfilePaths(this.options.paths, profile.id);
+    const libraryPath = profile.templates === "shared"
+      ? this.options.paths.multiSharedTemplates
+      : profilePaths.templates;
+    const library = await loadAccountTemplateLibrary(libraryPath);
+    await saveAccountTemplateLibrary(profilePaths.templateSync, library);
+    return library;
+  }
+
+  saveTemplates(win: BrowserWindow, entries: readonly TemplateExportEntry[]): Promise<void> {
+    return this.templatesLock.run(async () => {
+      const context = windowRegistry.contextForWebContents(win.webContents.id);
+      if (context?.mode !== "multi" || context.role !== "game") return;
+      const profile = this.profileFor(context.profileId);
+      const profilePaths = multiProfilePaths(this.options.paths, profile.id);
+      if (profile.templates === "private") {
+        const current = await loadAccountTemplateLibrary(profilePaths.templates);
+        await saveAccountTemplateLibrary(profilePaths.templates, {
+          revision: current.revision + 1,
+          entries,
+        });
+        return;
+      }
+      const [base, latest] = await Promise.all([
+        loadAccountTemplateLibrary(profilePaths.templateSync),
+        loadAccountTemplateLibrary(this.options.paths.multiSharedTemplates),
+      ]);
+      const merged = {
+        revision: latest.revision + 1,
+        entries: reconcileAccountTemplates(base.entries, latest.entries, entries),
+      };
+      await saveAccountTemplateLibrary(this.options.paths.multiSharedTemplates, merged);
+      await saveAccountTemplateLibrary(profilePaths.templateSync, merged);
+    });
+  }
+
+  requestQuit(win: BrowserWindow): void {
+    const context = windowRegistry.contextForWebContents(win.webContents.id);
+    if (context?.mode === "multi") void closeProfileWindow(win);
+    else app.quit();
+  }
+
+  private activeWorkspace(): MultiWorkspace {
+    if (this.options.mode !== "multi" || !this.workspace) {
+      throw new Error("Multiple Accounts mode is not active");
+    }
+    return this.workspace;
+  }
+
+  private profileFor(profileId: ProfileId) {
+    const profile = this.workspace?.profiles.find(
+      (candidate) => candidate.id === profileId && !candidate.archived,
+    );
+    if (!profile) throw new Error("Unknown Multiple Accounts profile");
+    return profile;
+  }
+
+  private credentialsForProfile(profileId?: ProfileId): CredentialsStore {
+    const key = profileId ?? "single";
+    let store = this.credentialsStores.get(key);
+    if (!store) {
+      store = new CredentialsStore(
+        this.options.keychain,
+        profileId ? multiSecretSlot(profileId, "arenaNetCredentials") : "arenaNetCredentials",
+      );
+      this.credentialsStores.set(key, store);
+    }
+    return store;
+  }
+
+  private steamForProfile(profileId?: ProfileId): SteamSessionStore {
+    const key = profileId ?? "single";
+    let store = this.steamSessionStores.get(key);
+    if (!store) {
+      store = new SteamSessionStore(
+        this.options.keychain,
+        profileId ? multiSecretSlot(profileId, "steamSession") : "steamSession",
+      );
+      this.steamSessionStores.set(key, store);
+    }
+    return store;
+  }
+
+  private async openProfile(
+    profileId: ProfileId,
+    newWindowOrdinal: number,
+  ): Promise<{ readonly win: BrowserWindow; readonly opened: boolean }> {
+    const profile = this.profileFor(profileId);
+    let existing = windowRegistry.profileWindow(profileId);
+    const previous = this.profileRuntime.get(profileId);
+    const profilePaths = multiProfilePaths(this.options.paths, profileId);
+    if (previous.state === "failed") {
+      resetRendererRecovery(profilePaths.windowState);
+      if (existing && !existing.isDestroyed()) existing.destroy();
+      existing = null;
+    }
+    if (existing) {
+      if (existing.isMinimized()) existing.restore();
+      return { win: existing, opened: false };
+    }
+    if (previous.state === "opening" || previous.state === "checking") {
+      throw new Error("Account is already opening");
+    }
+    this.profileRuntime.set(profileId, "opening");
+    let failureStage: Parameters<typeof launchIssueForStage>[0] = "preparing";
+    try {
+      const owner = session.fromPartition(`persist:gw-multi-${profileId}`, {
+        cache: false,
+      });
+      if (!this.profileProtocolSessions.has(profileId)) {
+        installGwProtocolHandlerForSession(owner, this.options.protocol);
+        this.profileProtocolSessions.add(profileId);
+      }
+      await Promise.all([
+        owner.clearStorageData({ storages: ["cookies"] }),
+        owner.clearCache(),
+      ]);
+      const reset = await applyPendingSessionStorageReset(
+        owner,
+        profilePaths.gameStorageClearRequest,
+      );
+      if (reset && profile.templates === "private") {
+        await rm(profilePaths.templates, { force: true });
+        await rm(profilePaths.templateSync, { force: true });
+      }
+      await mkdir(profilePaths.root, { recursive: true });
+      await prepareWindowState(profilePaths.windowState, newWindowOrdinal);
+      failureStage = "starting";
+      let hubWasVisibleBeforeRecovery = false;
+      const win = createMainWindow(this.options.windowHost, {
+        context: { mode: "multi", role: "game", profileId },
+        session: owner,
+        title: `Guild Wars Reforged — ${profile.name}`,
+        windowStatePath: profilePaths.windowState,
+        showInactive: true,
+        onRendererRecoveryStart: () => {
+          hubWasVisibleBeforeRecovery = getAccountsWindow()?.isVisible() ?? false;
+        },
+        onRendererRecovered: () => {
+          if (!hubWasVisibleBeforeRecovery) getAccountsWindow()?.hide();
+        },
+        onRendererFailure: () => {
+          this.profileRuntime.set(profileId, "failed", launchIssueForStage("crashed"));
+          revealAccountsWindow();
+        },
+      });
+      win.on("closed", () => {
+        const replacement = windowRegistry.profileWindow(profileId);
+        if (replacement && replacement !== win) return;
+        if (this.profileRuntime.get(profileId).state !== "failed") {
+          this.profileRuntime.set(profileId, "ready");
+        }
+      });
+      await this.waitForWindow(win);
+      this.profileRuntime.set(profileId, "running");
+      return { win, opened: true };
+    } catch (error) {
+      this.profileRuntime.set(profileId, "failed", launchIssueForStage(failureStage));
+      const failedWindow = windowRegistry.profileWindow(profileId);
+      if (failedWindow && !failedWindow.isDestroyed()) failedWindow.destroy();
+      throw error;
+    }
+  }
+
+  private async waitForCandidateCanary(): Promise<void> {
+    const candidate = this.options.clientRuntime.healthToken;
+    if (!candidate) return;
+    const deadline = Date.now() + 60_000;
+    while (
+      this.options.clientRuntime.healthToken === candidate
+      && Date.now() < deadline
+    ) {
+      await new Promise((resolve) => setTimeout(resolve, 100));
+    }
+    if (this.options.clientRuntime.healthToken === candidate) {
+      throw new Error("first profile did not confirm the new client generation");
+    }
+  }
+
+  private async switchMode(mode: AccountMode): Promise<void> {
+    await saveAccountMode(this.options.paths.launcherMode, mode);
+    app.relaunch();
+    app.quit();
+  }
+
+  private async importBuildLibraryIfPresent(
+    source: string,
+    destination: string,
+  ): Promise<void> {
+    let bytes: string;
+    try {
+      bytes = await readFile(source, "utf8");
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+      throw error;
+    }
+    const library = parseBuildLibrary(JSON.parse(bytes) as unknown);
+    await saveBuildLibrary(destination, library);
+  }
+
+  private async cleanupProfile(profileId: ProfileId): Promise<void> {
+    const owner = session.fromPartition(`persist:gw-multi-${profileId}`, {
+      cache: false,
+    });
+    await Promise.all([
+      this.credentialsForProfile(profileId).clear(),
+      this.steamForProfile(profileId).clear(),
+      owner.clearStorageData(),
+      owner.clearCache(),
+    ]);
+    await rm(multiProfilePaths(this.options.paths, profileId).root, {
+      recursive: true,
+      force: true,
+    });
+    this.credentialsStores.delete(profileId);
+    this.steamSessionStores.delete(profileId);
+  }
+
+  private waitForWindow(win: BrowserWindow): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        cleanup();
+        reject(new Error("profile window did not finish loading"));
+      }, 30_000);
+      const cleanup = () => {
+        clearTimeout(timeout);
+        win.webContents.removeListener("did-finish-load", loaded);
+        win.removeListener("closed", closed);
+      };
+      const loaded = () => {
+        cleanup();
+        resolve();
+      };
+      const closed = () => {
+        cleanup();
+        reject(new Error("profile window closed while loading"));
+      };
+      win.webContents.once("did-finish-load", loaded);
+      win.once("closed", closed);
+    });
+  }
+}

--- a/src/main/protocol.ts
+++ b/src/main/protocol.ts
@@ -13,7 +13,7 @@
  * this scheme serves, so no individual handler can serve a document without
  * them.
  */
-import { app, protocol, net } from "electron";
+import { app, protocol, net, type Session } from "electron";
 import { createReadStream } from "node:fs";
 import { stat } from "node:fs/promises";
 import path from "node:path";
@@ -153,6 +153,14 @@ export function registerGwScheme(): void {
 
 export function installGwProtocolHandler(deps: ProtocolDeps): void {
   protocol.handle("gw", (request) => handleGwRequest(request, deps));
+}
+
+/** A custom partition owns its own protocol registry. */
+export function installGwProtocolHandlerForSession(
+  owner: Session,
+  deps: ProtocolDeps,
+): void {
+  owner.protocol.handle("gw", (request) => handleGwRequest(request, deps));
 }
 
 function headers(extra: Record<string, string> = {}): Headers {

--- a/src/main/settings-actions.ts
+++ b/src/main/settings-actions.ts
@@ -7,7 +7,7 @@
  * a settings value or reset marker is durable, a failed relaunch cannot turn
  * that completed write into a false failure response.
  */
-import { app, dialog, session } from "electron";
+import { app, dialog, session, type Session } from "electron";
 import type { BrowserWindow } from "electron";
 import { rm, stat, writeFile } from "node:fs/promises";
 import type {
@@ -208,13 +208,24 @@ export async function applyPendingCacheClear(paths: GamePaths): Promise<void> {
 export async function applyPendingGameStorageReset(
   paths: GamePaths,
 ): Promise<void> {
-  if (!(await pendingMarkerExists(paths.gameStorageClearRequest))) return;
+  await applyPendingSessionStorageReset(
+    session.defaultSession,
+    paths.gameStorageClearRequest,
+  );
+}
+
+export async function applyPendingSessionStorageReset(
+  owner: Session,
+  markerPath: string,
+): Promise<boolean> {
+  if (!(await pendingMarkerExists(markerPath))) return false;
   // This runs before a renderer can mount IDBFS. Clearing it later would race
   // the game's auto-persist and could recreate files before quit.
-  await session.defaultSession.clearStorageData({
+  await owner.clearStorageData({
     origin: "gw://app",
     storages: ["indexdb"],
   });
-  await rm(paths.gameStorageClearRequest, { force: true });
+  await rm(markerPath, { force: true });
   logEvent({ k: "filesystem.resetCompleted" });
+  return true;
 }

--- a/src/main/template-export.ts
+++ b/src/main/template-export.ts
@@ -16,11 +16,11 @@ import { dialog, type BrowserWindow } from "electron";
 import path from "node:path";
 import { mkdir, writeFile } from "node:fs/promises";
 import {
-  TEMPLATE_CEILINGS,
   type TemplateExportEntry,
   type TemplateExportResult,
 } from "../shared/contracts.js";
-import { AppError, ValidationError, type ErrorCode } from "../shared/errors.js";
+import { AppError, type ErrorCode } from "../shared/errors.js";
+import { parseTemplateEntries } from "../shared/template-entries.js";
 
 /** The folder an export creates. Numbered rather than merged, so nothing is replaced. */
 const DESTINATION_NAME = "Guild Wars Build Templates";
@@ -30,9 +30,6 @@ const MAX_DESTINATIONS = 99;
  * `Skills/<name>.txt` or `Skills/<folder>/<name>.txt` — two or three segments,
  * which is the deepest the client can key a template.
  */
-const MIN_SEGMENTS = 2;
-const MAX_SEGMENTS = 3;
-
 /**
  * The rule the writer relies on, applied at the boundary rather than trusted.
  *
@@ -42,52 +39,7 @@ const MAX_SEGMENTS = 3;
  * write the player never asked for.
  */
 export function parseExportEntries(value: unknown): TemplateExportEntry[] {
-  if (!Array.isArray(value) || value.length > TEMPLATE_CEILINGS.entries) {
-    throw new ValidationError("invalid template export");
-  }
-  return value.map((entry) => {
-    if (
-      typeof entry !== "object"
-      || entry === null
-      || Object.keys(entry).length !== 2
-    ) {
-      throw new ValidationError("invalid template export entry");
-    }
-    const { path: relative, contents } = entry as Record<string, unknown>;
-    if (
-      typeof relative !== "string"
-      || typeof contents !== "string"
-      || contents.length === 0
-      || contents.length > TEMPLATE_CEILINGS.codeLength
-    ) {
-      throw new ValidationError("invalid template export entry");
-    }
-    assertRelativePath(relative);
-    return { path: relative, contents };
-  });
-}
-
-function assertRelativePath(relative: string): void {
-  const segments = relative.split("/");
-  if (segments.length < MIN_SEGMENTS || segments.length > MAX_SEGMENTS) {
-    throw new ValidationError("invalid template export path");
-  }
-  if (!relative.toLowerCase().endsWith(".txt")) {
-    throw new ValidationError("invalid template export path");
-  }
-  for (const segment of segments) {
-    if (
-      segment.length === 0
-      || segment.length > TEMPLATE_CEILINGS.nameLength + ".txt".length
-      || segment === "."
-      || segment === ".."
-      || segment.includes("\\")
-      || segment.includes(":")
-      || /\p{Cc}/u.test(segment)
-    ) {
-      throw new ValidationError("invalid template export path");
-    }
-  }
+  return parseTemplateEntries(value);
 }
 
 /**

--- a/src/main/window-menu.ts
+++ b/src/main/window-menu.ts
@@ -195,7 +195,7 @@ export function installApplicationMenu({
               label: "Export Recent Diagnostics…",
               click: async () => {
                 await resetGameInput(win);
-                await exportDiagnosticsReport(host.exportDiagnostics);
+                await exportDiagnosticsReport(() => host.exportDiagnostics(win));
               },
             },
             { type: "separator" },

--- a/src/main/window-registry.ts
+++ b/src/main/window-registry.ts
@@ -78,3 +78,6 @@ export class WindowRegistry {
     return this.windows((context) => context.role === "game");
   }
 }
+
+/** The process has one native-window authority. */
+export const windowRegistry = new WindowRegistry();

--- a/src/main/window-registry.ts
+++ b/src/main/window-registry.ts
@@ -1,0 +1,80 @@
+/**
+ * The authority that binds every native window to one immutable app context.
+ *
+ * IPC and lifecycle code resolve context from `webContents.id`; renderers do
+ * not submit profile identifiers. The registry also enforces the one-window
+ * per Multi profile invariant and keeps transient launch state out of disk.
+ */
+import type { BrowserWindow } from "electron";
+import type { ProfileId } from "../shared/multiple-accounts.js";
+import { AppError } from "../shared/errors.js";
+
+export type WindowContext =
+  | Readonly<{ mode: "single"; role: "game" }>
+  | Readonly<{ mode: "multi"; role: "hub" }>
+  | Readonly<{ mode: "multi"; role: "game"; profileId: ProfileId }>;
+
+interface RegisteredWindow {
+  readonly webContents: { readonly id: number };
+  isDestroyed(): boolean;
+}
+
+interface Entry {
+  readonly win: RegisteredWindow;
+  readonly context: WindowContext;
+}
+
+export class WindowRegistry {
+  readonly #byWebContents = new Map<number, Entry>();
+  readonly #profileWindows = new Map<ProfileId, RegisteredWindow>();
+
+  register(win: RegisteredWindow, context: WindowContext): void {
+    const id = win.webContents.id;
+    if (this.#byWebContents.has(id)) {
+      throw new AppError("validation", "window is already registered");
+    }
+    if (context.mode === "multi" && context.role === "game") {
+      const existing = this.#profileWindows.get(context.profileId);
+      if (existing && !existing.isDestroyed()) {
+        throw new AppError("validation", "profile already has a game window");
+      }
+      this.#profileWindows.set(context.profileId, win);
+    }
+    this.#byWebContents.set(id, { win, context });
+  }
+
+  unregister(win: RegisteredWindow): void {
+    const entry = this.#byWebContents.get(win.webContents.id);
+    if (!entry || entry.win !== win) return;
+    this.#byWebContents.delete(win.webContents.id);
+    if (entry.context.mode === "multi" && entry.context.role === "game") {
+      if (this.#profileWindows.get(entry.context.profileId) === win) {
+        this.#profileWindows.delete(entry.context.profileId);
+      }
+    }
+  }
+
+  contextForWebContents(id: number): WindowContext | null {
+    const entry = this.#byWebContents.get(id);
+    return entry && !entry.win.isDestroyed() ? entry.context : null;
+  }
+
+  profileWindow(profileId: ProfileId): BrowserWindow | null {
+    const win = this.#profileWindows.get(profileId);
+    return win && !win.isDestroyed() ? win as BrowserWindow : null;
+  }
+
+  windows(
+    predicate: (context: WindowContext) => boolean = () => true,
+  ): BrowserWindow[] {
+    const result: BrowserWindow[] = [];
+    for (const { win, context } of this.#byWebContents.values()) {
+      if (!win.isDestroyed() && predicate(context)) result.push(win as BrowserWindow);
+    }
+    return result;
+  }
+
+  gameWindows(): BrowserWindow[] {
+    return this.windows((context) => context.role === "game");
+  }
+}

--- a/src/main/window-registry.ts
+++ b/src/main/window-registry.ts
@@ -27,6 +27,7 @@ interface Entry {
 export class WindowRegistry {
   readonly #byWebContents = new Map<number, Entry>();
   readonly #profileWindows = new Map<ProfileId, RegisteredWindow>();
+  readonly #webContentsIds = new WeakMap<RegisteredWindow, number>();
 
   register(win: RegisteredWindow, context: WindowContext): void {
     const id = win.webContents.id;
@@ -40,13 +41,17 @@ export class WindowRegistry {
       }
       this.#profileWindows.set(context.profileId, win);
     }
+    this.#webContentsIds.set(win, id);
     this.#byWebContents.set(id, { win, context });
   }
 
   unregister(win: RegisteredWindow): void {
-    const entry = this.#byWebContents.get(win.webContents.id);
+    const id = this.#webContentsIds.get(win);
+    if (id === undefined) return;
+    const entry = this.#byWebContents.get(id);
     if (!entry || entry.win !== win) return;
-    this.#byWebContents.delete(win.webContents.id);
+    this.#byWebContents.delete(id);
+    this.#webContentsIds.delete(win);
     if (entry.context.mode === "multi" && entry.context.role === "game") {
       if (this.#profileWindows.get(entry.context.profileId) === win) {
         this.#profileWindows.delete(entry.context.profileId);

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -66,13 +66,18 @@ export interface WindowHost {
 }
 
 let mainWindow: BrowserWindow | null = null;
-let rendererRecoveryUsed = false;
-let restoredWindowState: WindowState | null = null;
-let lastNormalBounds: WindowBounds | null = null;
-let windowStateTimer: ReturnType<typeof setTimeout> | null = null;
-let windowStateWrite: Promise<void> = Promise.resolve();
-let windowStateReset: Promise<void> = Promise.resolve();
-let windowStateResetDepth = 0;
+const rendererRecoveryUsed = new Set<string>();
+interface WindowStateOwner {
+  readonly path: string;
+  restored: WindowState | null;
+  lastNormalBounds: WindowBounds | null;
+  timer: ReturnType<typeof setTimeout> | null;
+  write: Promise<void>;
+  reset: Promise<void>;
+  resetDepth: number;
+}
+const preparedWindowStates = new Map<string, WindowState | null>();
+const windowStateOwners = new Map<BrowserWindow, WindowStateOwner>();
 let downloadPowerBlockerId: number | null = null;
 
 export function updateLongRunningTaskFeedback(
@@ -105,35 +110,37 @@ function primaryWorkArea(): WindowBounds {
   return { ...screen.getPrimaryDisplay().workArea };
 }
 
-export async function prepareWindowState(): Promise<void> {
-  const loaded = await loadWindowState(gamePaths().windowState, () => {
+export async function prepareWindowState(
+  statePath = gamePaths().windowState,
+): Promise<void> {
+  const loaded = await loadWindowState(statePath, () => {
     logEvent({ k: "window.stateCorruptCleared" });
   });
-  restoredWindowState = loaded
+  const restored = loaded
     ? fitWindowStateToDisplays(loaded, workAreas(), primaryWorkArea())
     : null;
-  lastNormalBounds = restoredWindowState?.bounds ?? null;
-  if (restoredWindowState) {
+  preparedWindowStates.set(statePath, restored);
+  if (restored) {
     logEvent({ k: "window.stateRestored",
-      mode: restoredWindowState.mode,
-      width: restoredWindowState.bounds.width,
-      height: restoredWindowState.bounds.height,
+      mode: restored.mode,
+      width: restored.bounds.width,
+      height: restored.bounds.height,
     });
   }
 }
 
-function currentWindowState(win: BrowserWindow): WindowState {
+function currentWindowState(win: BrowserWindow, owner: WindowStateOwner): WindowState {
   const mode = win.isFullScreen()
     ? "fullscreen"
     : win.isMaximized()
       ? "maximized"
       : "normal";
   if (mode === "normal") {
-    lastNormalBounds = { ...win.getBounds() };
+    owner.lastNormalBounds = { ...win.getBounds() };
   }
   return {
     bounds:
-      lastNormalBounds ??
+      owner.lastNormalBounds ??
       fitWindowStateToDisplays(
         defaultWindowState(primaryWorkArea()),
         workAreas(),
@@ -144,49 +151,56 @@ function currentWindowState(win: BrowserWindow): WindowState {
 }
 
 async function persistWindowState(win: BrowserWindow): Promise<void> {
-  if (win.isDestroyed() || mainWindow !== win) return;
-  const state = currentWindowState(win);
-  restoredWindowState = state;
-  const write = windowStateWrite.then(() =>
-    saveWindowState(gamePaths().windowState, state),
+  const owner = windowStateOwners.get(win);
+  if (win.isDestroyed() || !owner) return;
+  const state = currentWindowState(win, owner);
+  owner.restored = state;
+  const write = owner.write.then(() =>
+    saveWindowState(owner.path, state),
   );
-  windowStateWrite = write.catch(() => undefined);
+  owner.write = write.catch(() => undefined);
   await write;
 }
 
 function scheduleWindowStateSave(win: BrowserWindow): void {
+  const owner = windowStateOwners.get(win);
+  if (!owner) return;
   // Leaving fullscreen/maximized and applying the default bounds emits several
   // intermediate events. Persisting one of those after the explicit reset
   // write can resurrect the old placement.
-  if (windowStateResetDepth > 0) return;
-  if (windowStateTimer) clearTimeout(windowStateTimer);
-  windowStateTimer = setTimeout(() => {
-    windowStateTimer = null;
+  if (owner.resetDepth > 0) return;
+  if (owner.timer) clearTimeout(owner.timer);
+  owner.timer = setTimeout(() => {
+    owner.timer = null;
     void persistWindowState(win).catch(() => {
       logEvent({ k: "window.stateSaveFailed" });
     });
   }, 300);
 }
 
-export async function flushWindowState(): Promise<void> {
-  await windowStateReset;
-  if (windowStateTimer) {
-    clearTimeout(windowStateTimer);
-    windowStateTimer = null;
-  }
-  const win = mainWindow;
+export async function flushWindowState(win = mainWindow): Promise<void> {
   if (!win || win.isDestroyed()) return;
+  const owner = windowStateOwners.get(win);
+  if (!owner) return;
+  await owner.reset;
+  if (owner.timer) {
+    clearTimeout(owner.timer);
+    owner.timer = null;
+  }
   await persistWindowState(win);
-  await windowStateWrite;
+  await owner.write;
 }
 
 export function resetWindowState(win = mainWindow): Promise<void> {
-  const reset = windowStateReset.then(async () => {
-    windowStateResetDepth += 1;
+  if (!win || win.isDestroyed()) return Promise.resolve();
+  const owner = windowStateOwners.get(win);
+  if (!owner) return Promise.resolve();
+  const reset = owner.reset.then(async () => {
+    owner.resetDepth += 1;
     try {
-      if (windowStateTimer) {
-        clearTimeout(windowStateTimer);
-        windowStateTimer = null;
+      if (owner.timer) {
+        clearTimeout(owner.timer);
+        owner.timer = null;
       }
       const requested = defaultWindowState(primaryWorkArea());
       let settled = requested;
@@ -222,22 +236,22 @@ export function resetWindowState(win = mainWindow): Promise<void> {
         win.setBounds(requested.bounds);
         settled = { bounds: { ...win.getBounds() }, mode: "normal" };
       }
-      restoredWindowState = settled;
-      lastNormalBounds = settled.bounds;
-      const write = windowStateWrite.then(() =>
-        saveWindowState(gamePaths().windowState, settled),
+      owner.restored = settled;
+      owner.lastNormalBounds = settled.bounds;
+      const write = owner.write.then(() =>
+        saveWindowState(owner.path, settled),
       );
-      windowStateWrite = write.catch(() => undefined);
+      owner.write = write.catch(() => undefined);
       await write;
       logEvent({ k: "window.stateReset",
         width: settled.bounds.width,
         height: settled.bounds.height,
       });
     } finally {
-      windowStateResetDepth -= 1;
+      owner.resetDepth -= 1;
     }
   });
-  windowStateReset = reset.catch(() => undefined);
+  owner.reset = reset.catch(() => undefined);
   return reset;
 }
 
@@ -274,9 +288,12 @@ export function createMainWindow(
     readonly context?: WindowContext;
     readonly session?: Electron.Session;
     readonly title?: string;
+    readonly windowStatePath?: string;
   } = {},
 ): BrowserWindow {
   const context = options.context ?? { mode: "single", role: "game" };
+  const statePath = options.windowStatePath ?? gamePaths().windowState;
+  const restoredWindowState = preparedWindowStates.get(statePath) ?? null;
   const initialState = restoredWindowState
     ? fitWindowStateToDisplays(
         restoredWindowState,
@@ -307,6 +324,16 @@ export function createMainWindow(
   });
 
   mainWindow = win;
+  const stateOwner: WindowStateOwner = {
+    path: statePath,
+    restored: initialState,
+    lastNormalBounds: initialState?.bounds ?? null,
+    timer: null,
+    write: Promise.resolve(),
+    reset: Promise.resolve(),
+    resetDepth: 0,
+  };
+  windowStateOwners.set(win, stateOwner);
   windowRegistry.register(win, context);
   updateLongRunningTaskFeedback(host.getProgress(), win);
   const rendererId = win.webContents.id;
@@ -320,17 +347,17 @@ export function createMainWindow(
 
   const rememberNormalBounds = (): void => {
     if (
-      windowStateResetDepth > 0 ||
+      stateOwner.resetDepth > 0 ||
       win.isFullScreen() ||
       win.isMaximized()
     ) return;
-    lastNormalBounds = { ...win.getBounds() };
+    stateOwner.lastNormalBounds = { ...win.getBounds() };
     scheduleWindowStateSave(win);
   };
   win.on("move", rememberNormalBounds);
   win.on("resize", rememberNormalBounds);
   const persistMode = (): void => {
-    if (windowStateResetDepth > 0) return;
+    if (stateOwner.resetDepth > 0) return;
     void persistWindowState(win).catch(() => {
       logEvent({ k: "window.stateSaveFailed" });
     });
@@ -439,11 +466,11 @@ export function createMainWindow(
     host.sockets.closeAll(rendererId);
     if (isQuitting()) return;
     if (
-      !rendererRecoveryUsed &&
+      !rendererRecoveryUsed.has(statePath) &&
       details.reason !== "clean-exit" &&
       !win.isDestroyed()
     ) {
-      rendererRecoveryUsed = true;
+      rendererRecoveryUsed.add(statePath);
       logEvent({ k: "renderer.recoveryScheduled" });
       setTimeout(() => {
         if (isQuitting() || win.isDestroyed()) return;
@@ -480,6 +507,7 @@ export function createMainWindow(
 
   win.on("closed", () => {
     windowRegistry.unregister(win);
+    windowStateOwners.delete(win);
     if (mainWindow === win) mainWindow = null;
   });
 

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -338,6 +338,8 @@ export function createMainWindow(
     readonly title?: string;
     readonly windowStatePath?: string;
     readonly showInactive?: boolean;
+    readonly onRendererRecoveryStart?: () => void;
+    readonly onRendererRecovered?: () => void;
     readonly onRendererFailure?: () => void;
   } = {},
 ): BrowserWindow {
@@ -528,6 +530,7 @@ export function createMainWindow(
       !win.isDestroyed()
     ) {
       rendererRecoveryUsed.add(statePath);
+      options.onRendererRecoveryStart?.();
       logEvent({ k: "renderer.recoveryScheduled" });
       setTimeout(() => {
         if (isQuitting() || win.isDestroyed()) return;
@@ -547,6 +550,7 @@ export function createMainWindow(
             windowRegistry.unregister(win);
             createMainWindow(host, options);
             win.destroy();
+            options.onRendererRecovered?.();
             logEvent({ k: "renderer.recovered" });
           });
       }, 500);
@@ -575,7 +579,11 @@ export function createMainWindow(
     windowRegistry.unregister(win);
     windowStateOwners.delete(win);
     if (mainWindow === win) mainWindow = null;
-    if (context.mode === "multi") host.gameWindowClosed?.();
+    if (
+      context.mode === "multi"
+      && context.role === "game"
+      && !windowRegistry.profileWindow(context.profileId)
+    ) host.gameWindowClosed?.();
   });
 
   const installMenu = () => installApplicationMenu({

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -57,7 +57,7 @@ export interface WindowHost {
   getProgress: () => DownloadProgress;
   getSettings: () => Promise<AppSettings>;
   updateSettings: (value: AppSettingsPatch) => Promise<AppSettings>;
-  exportDiagnostics: () => Promise<string>;
+  exportDiagnostics: (win: BrowserWindow) => Promise<string>;
   markPerformanceProblem: () => void;
   startCapture: (level: 1 | 2) => Promise<void>;
   stopCapture: () => Promise<void>;
@@ -79,6 +79,9 @@ interface WindowStateOwner {
 }
 const preparedWindowStates = new Map<string, WindowState | null>();
 const windowStateOwners = new Map<BrowserWindow, WindowStateOwner>();
+const ownedWindowTitles = new WeakMap<BrowserWindow, string>();
+const profileCloses = new WeakSet<BrowserWindow>();
+const PROFILE_CLOSE_DEADLINE_MS = 6_000;
 let downloadPowerBlockerId: number | null = null;
 
 export function updateLongRunningTaskFeedback(
@@ -260,6 +263,33 @@ export function getMainWindow(): BrowserWindow | null {
   return mainWindow;
 }
 
+export function setOwnedWindowTitle(win: BrowserWindow, title: string): void {
+  ownedWindowTitles.set(win, title);
+  win.setTitle(title);
+}
+
+/** Flush and destroy exactly one Multi game window without quitting the app. */
+export async function closeProfileWindow(win: BrowserWindow): Promise<void> {
+  if (win.isDestroyed() || profileCloses.has(win)) return;
+  profileCloses.add(win);
+  try {
+    await Promise.race([
+      (async () => {
+        await sendRendererCommand(win, { type: "filesystem.sync" });
+        await flushWindowState(win);
+      })(),
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, PROFILE_CLOSE_DEADLINE_MS);
+      }),
+    ]);
+  } catch (error) {
+    logEvent({ k: "window.stateSaveFailed" });
+    console.error("profile close persistence failed", error);
+  } finally {
+    if (!win.isDestroyed()) win.destroy();
+  }
+}
+
 /** The only renderer URL, and it carries no configuration. */
 export const RENDERER_URL = "gw://app/";
 
@@ -293,7 +323,6 @@ export function createMainWindow(
   } = {},
 ): BrowserWindow {
   const context = options.context ?? { mode: "single", role: "game" };
-  let profileCloseStarted = false;
   const statePath = options.windowStatePath ?? gamePaths().windowState;
   const restoredWindowState = preparedWindowStates.get(statePath) ?? null;
   const initialState = restoredWindowState
@@ -338,9 +367,10 @@ export function createMainWindow(
   windowStateOwners.set(win, stateOwner);
   windowRegistry.register(win, context);
   if (options.title) {
+    ownedWindowTitles.set(win, options.title);
     win.webContents.on("page-title-updated", (event) => {
       event.preventDefault();
-      win.setTitle(options.title!);
+      win.setTitle(ownedWindowTitles.get(win) ?? "Guild Wars Reforged");
     });
   }
   updateLongRunningTaskFeedback(host.getProgress(), win);
@@ -508,14 +538,8 @@ export function createMainWindow(
   win.on("close", (event) => {
     if (isQuitting()) return;
     if (context.mode === "multi") {
-      if (profileCloseStarted) return;
       event.preventDefault();
-      profileCloseStarted = true;
-      void (async () => {
-        await sendRendererCommand(win, { type: "filesystem.sync" });
-        await flushWindowState(win);
-        if (!win.isDestroyed()) win.destroy();
-      })();
+      void closeProfileWindow(win);
       return;
     }
     event.preventDefault();
@@ -530,11 +554,13 @@ export function createMainWindow(
     if (context.mode === "multi") host.gameWindowClosed?.();
   });
 
-  installApplicationMenu({
+  const installMenu = () => installApplicationMenu({
     host,
     win,
     resetWindowState: () => resetWindowState(win),
   });
+  win.on("focus", installMenu);
+  installMenu();
   void win.loadURL(RENDERER_URL);
   return win;
 }

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -69,6 +69,11 @@ export interface WindowHost {
 
 let mainWindow: BrowserWindow | null = null;
 const rendererRecoveryUsed = new Set<string>();
+
+/** A deliberate player retry gets one fresh automatic renderer recovery. */
+export function resetRendererRecovery(statePath: string): void {
+  rendererRecoveryUsed.delete(statePath);
+}
 interface WindowStateOwner {
   readonly path: string;
   restored: WindowState | null;

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -39,7 +39,7 @@ import { logEvent } from "./diagnostics.js";
 import { isCanonicalRendererUrl } from "./core/renderer-trust.js";
 import { isQuitting } from "./lifecycle.js";
 import { gamePaths, preloadPath } from "./paths.js";
-import { toggleTools } from "./renderer-commands.js";
+import { sendRendererCommand, toggleTools } from "./renderer-commands.js";
 import { installApplicationMenu } from "./window-menu.js";
 import { windowRegistry, type WindowContext } from "./window-registry.js";
 
@@ -63,6 +63,7 @@ export interface WindowHost {
   stopCapture: () => Promise<void>;
   reloadGame: (win: BrowserWindow) => void;
   prepareRendererRecovery: () => Promise<void>;
+  gameWindowClosed?: () => void;
 }
 
 let mainWindow: BrowserWindow | null = null;
@@ -292,6 +293,7 @@ export function createMainWindow(
   } = {},
 ): BrowserWindow {
   const context = options.context ?? { mode: "single", role: "game" };
+  let profileCloseStarted = false;
   const statePath = options.windowStatePath ?? gamePaths().windowState;
   const restoredWindowState = preparedWindowStates.get(statePath) ?? null;
   const initialState = restoredWindowState
@@ -499,7 +501,17 @@ export function createMainWindow(
 
   win.on("close", (event) => {
     if (isQuitting()) return;
-    if (context.mode === "multi") return;
+    if (context.mode === "multi") {
+      if (profileCloseStarted) return;
+      event.preventDefault();
+      profileCloseStarted = true;
+      void (async () => {
+        await sendRendererCommand(win, { type: "filesystem.sync" });
+        await flushWindowState(win);
+        if (!win.isDestroyed()) win.destroy();
+      })();
+      return;
+    }
     event.preventDefault();
     logEvent({ k: "window.closeRequested" });
     app.quit();
@@ -509,6 +521,7 @@ export function createMainWindow(
     windowRegistry.unregister(win);
     windowStateOwners.delete(win);
     if (mainWindow === win) mainWindow = null;
+    if (context.mode === "multi") host.gameWindowClosed?.();
   });
 
   installApplicationMenu({

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -29,6 +29,7 @@ import { longRunningTaskFeedback } from "../shared/progress.js";
 import type { SocketManager } from "./core/sockets.js";
 import {
   defaultWindowState,
+  cascadeWindowState,
   fitWindowStateToDisplays,
   loadWindowState,
   saveWindowState,
@@ -116,14 +117,24 @@ function primaryWorkArea(): WindowBounds {
 
 export async function prepareWindowState(
   statePath = gamePaths().windowState,
-): Promise<void> {
+  newWindowOrdinal?: number,
+): Promise<boolean> {
   const loaded = await loadWindowState(statePath, () => {
     logEvent({ k: "window.stateCorruptCleared" });
   });
   const restored = loaded
     ? fitWindowStateToDisplays(loaded, workAreas(), primaryWorkArea())
     : null;
-  preparedWindowStates.set(statePath, restored);
+  const prepared = restored ?? (
+    newWindowOrdinal === undefined
+      ? null
+      : cascadeWindowState(
+          defaultWindowState(primaryWorkArea()),
+          newWindowOrdinal,
+          primaryWorkArea(),
+        )
+  );
+  preparedWindowStates.set(statePath, prepared);
   if (restored) {
     logEvent({ k: "window.stateRestored",
       mode: restored.mode,
@@ -131,6 +142,7 @@ export async function prepareWindowState(
       height: restored.bounds.height,
     });
   }
+  return restored !== null;
 }
 
 function currentWindowState(win: BrowserWindow, owner: WindowStateOwner): WindowState {
@@ -320,6 +332,8 @@ export function createMainWindow(
     readonly session?: Electron.Session;
     readonly title?: string;
     readonly windowStatePath?: string;
+    readonly showInactive?: boolean;
+    readonly onRendererFailure?: () => void;
   } = {},
 ): BrowserWindow {
   const context = options.context ?? { mode: "single", role: "game" };
@@ -378,7 +392,7 @@ export function createMainWindow(
 
   win.once("ready-to-show", () => {
     if (initialState?.mode === "maximized") win.maximize();
-    if (BACKGROUND_LAUNCH) win.showInactive();
+    if (BACKGROUND_LAUNCH || options.showInactive) win.showInactive();
     else win.show();
     if (initialState?.mode === "fullscreen") win.setFullScreen(true);
   });
@@ -522,12 +536,17 @@ export function createMainWindow(
           })
           .finally(() => {
             if (isQuitting() || win.isDestroyed()) return;
+            // Release the immutable profile ownership before registering its
+            // replacement. Destroying afterward keeps the transition local to
+            // this profile and lets the old closed handler remain idempotent.
+            windowRegistry.unregister(win);
             createMainWindow(host, options);
             win.destroy();
             logEvent({ k: "renderer.recovered" });
           });
       }, 500);
     } else if (details.reason !== "clean-exit") {
+      options.onRendererFailure?.();
       dialog.showErrorBox(
         "Guild Wars stopped unexpectedly",
         "Use View → Reload Game to try again. If it repeats, choose Help → Report a Bug.",

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -337,6 +337,12 @@ export function createMainWindow(
   };
   windowStateOwners.set(win, stateOwner);
   windowRegistry.register(win, context);
+  if (options.title) {
+    win.webContents.on("page-title-updated", (event) => {
+      event.preventDefault();
+      win.setTitle(options.title!);
+    });
+  }
   updateLongRunningTaskFeedback(host.getProgress(), win);
   const rendererId = win.webContents.id;
 

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -41,6 +41,7 @@ import { isQuitting } from "./lifecycle.js";
 import { gamePaths, preloadPath } from "./paths.js";
 import { toggleTools } from "./renderer-commands.js";
 import { installApplicationMenu } from "./window-menu.js";
+import { windowRegistry, type WindowContext } from "./window-registry.js";
 
 // Tests launch the app dozens of times; without this they steal keyboard focus
 // on every launch. Focus-dependent specs leave the flag unset.
@@ -267,7 +268,15 @@ export function rendererInitArgument(options: {
   return `${RENDERER_INIT_ARGUMENT}${JSON.stringify(init)}`;
 }
 
-export function createMainWindow(host: WindowHost): BrowserWindow {
+export function createMainWindow(
+  host: WindowHost,
+  options: {
+    readonly context?: WindowContext;
+    readonly session?: Electron.Session;
+    readonly title?: string;
+  } = {},
+): BrowserWindow {
+  const context = options.context ?? { mode: "single", role: "game" };
   const initialState = restoredWindowState
     ? fitWindowStateToDisplays(
         restoredWindowState,
@@ -280,7 +289,7 @@ export function createMainWindow(host: WindowHost): BrowserWindow {
     ...(initialState?.bounds ?? { width: 1280, height: 800 }),
     minWidth: 800,
     minHeight: 600,
-    title: "Guild Wars Reforged",
+    title: options.title ?? "Guild Wars Reforged",
     show: false,
     webPreferences: {
       preload: preloadPath(),
@@ -293,10 +302,12 @@ export function createMainWindow(host: WindowHost): BrowserWindow {
       spellcheck: false,
       allowRunningInsecureContent: false,
       experimentalFeatures: false,
+      ...(options.session ? { session: options.session } : {}),
     },
   });
 
   mainWindow = win;
+  windowRegistry.register(win, context);
   updateLongRunningTaskFeedback(host.getProgress(), win);
   const rendererId = win.webContents.id;
 
@@ -446,7 +457,7 @@ export function createMainWindow(host: WindowHost): BrowserWindow {
           })
           .finally(() => {
             if (isQuitting() || win.isDestroyed()) return;
-            createMainWindow(host);
+            createMainWindow(host, options);
             win.destroy();
             logEvent({ k: "renderer.recovered" });
           });
@@ -461,12 +472,14 @@ export function createMainWindow(host: WindowHost): BrowserWindow {
 
   win.on("close", (event) => {
     if (isQuitting()) return;
+    if (context.mode === "multi") return;
     event.preventDefault();
     logEvent({ k: "window.closeRequested" });
     app.quit();
   });
 
   win.on("closed", () => {
+    windowRegistry.unregister(win);
     if (mainWindow === win) mainWindow = null;
   });
 

--- a/src/native/keychain/keychain.mm
+++ b/src/native/keychain/keychain.mm
@@ -16,13 +16,13 @@ namespace {
 
 constexpr char kCredentialsSlot[] = "arenaNetCredentials";
 constexpr char kSteamSlot[] = "steamSession";
+constexpr char kMultiPrefix[] = "multi.";
 NSString *const kCredentialsAccount = @"arena-net-credentials";
 NSString *const kSteamAccount = @"steam-session";
 NSString *const kReleaseBundle = @"io.github.mat4m0.gwonmac";
 NSString *const kPreviewBundle = @"io.github.mat4m0.gwonmac.preview";
 NSString *const kDevelopmentBundle = @"io.github.mat4m0.gwonmac.dev";
 
-enum class Slot { kCredentials, kSteam };
 enum class Operation { kLoad, kSave, kClear };
 enum class Result {
   kSuccess,
@@ -37,7 +37,7 @@ struct Work {
   napi_async_work async_work = nullptr;
   napi_deferred deferred = nullptr;
   Operation operation = Operation::kLoad;
-  Slot slot = Slot::kCredentials;
+  std::string slot;
   Result result = Result::kUnavailable;
   std::vector<uint8_t> input;
   std::vector<uint8_t> output;
@@ -50,8 +50,43 @@ void Zero(std::vector<uint8_t> &bytes) {
   bytes.clear();
 }
 
-NSString *AccountForSlot(Slot slot) {
-  return slot == Slot::kCredentials ? kCredentialsAccount : kSteamAccount;
+bool IsLowerHex(char value) {
+  return (value >= '0' && value <= '9') || (value >= 'a' && value <= 'f');
+}
+
+bool IsUuidV4(const std::string &value) {
+  if (value.size() != 36 || value[8] != '-' || value[13] != '-' ||
+      value[18] != '-' || value[23] != '-' || value[14] != '4' ||
+      (value[19] != '8' && value[19] != '9' && value[19] != 'a' &&
+       value[19] != 'b'))
+    return false;
+  for (size_t i = 0; i < value.size(); ++i) {
+    if (i == 8 || i == 13 || i == 18 || i == 23)
+      continue;
+    if (!IsLowerHex(value[i]))
+      return false;
+  }
+  return true;
+}
+
+NSString *AccountForSlot(const std::string &slot) {
+  if (slot == kCredentialsSlot)
+    return kCredentialsAccount;
+  if (slot == kSteamSlot)
+    return kSteamAccount;
+  const std::string prefix = kMultiPrefix;
+  if (slot.rfind(prefix, 0) != 0)
+    return nil;
+  const size_t separator = slot.find('.', prefix.size());
+  if (separator == std::string::npos)
+    return nil;
+  const std::string profile = slot.substr(prefix.size(), separator - prefix.size());
+  const std::string kind = slot.substr(separator + 1);
+  if (!IsUuidV4(profile) ||
+      (kind != kCredentialsSlot && kind != kSteamSlot))
+    return nil;
+  NSString *base = kind == kCredentialsSlot ? kCredentialsAccount : kSteamAccount;
+  return [NSString stringWithFormat:@"%@.multi.%s", base, profile.c_str()];
 }
 
 NSString *ServiceForHostBundle() {
@@ -72,16 +107,17 @@ NSString *LabelForService(NSString *service) {
   return @"Guild Wars Reforged Dev saved login";
 }
 
-NSMutableDictionary *QueryForSlot(Slot slot) {
+NSMutableDictionary *QueryForSlot(const std::string &slot) {
   NSString *service = ServiceForHostBundle();
-  if (service == nil)
+  NSString *account = AccountForSlot(slot);
+  if (service == nil || account == nil)
     return nil;
   LAContext *context = [[LAContext alloc] init];
   context.interactionNotAllowed = YES;
   return [@{
     (__bridge id)kSecClass : (__bridge id)kSecClassGenericPassword,
     (__bridge id)kSecAttrService : service,
-    (__bridge id)kSecAttrAccount : AccountForSlot(slot),
+    (__bridge id)kSecAttrAccount : account,
     (__bridge id)kSecUseDataProtectionKeychain : @YES,
     (__bridge id)kSecUseAuthenticationContext : context,
   } mutableCopy];
@@ -251,27 +287,23 @@ void Complete(napi_env env, napi_status status, void *data) {
   delete work;
 }
 
-bool ReadSlot(napi_env env, napi_value value, Slot *slot) {
+bool ReadSlot(napi_env env, napi_value value, std::string *slot) {
   size_t length = 0;
   if (napi_get_value_string_utf8(env, value, nullptr, 0, &length) != napi_ok ||
-      length > sizeof(kCredentialsSlot)) {
+      length == 0 || length > 96) {
     return false;
   }
 
-  char text[sizeof(kCredentialsSlot)] = {};
-  if (napi_get_value_string_utf8(env, value, text, sizeof(text), &length) !=
+  std::vector<char> text(length + 1, '\0');
+  if (napi_get_value_string_utf8(env, value, text.data(), text.size(), &length) !=
       napi_ok) {
     return false;
   }
-  if (strcmp(text, kCredentialsSlot) == 0) {
-    *slot = Slot::kCredentials;
-    return true;
-  }
-  if (strcmp(text, kSteamSlot) == 0) {
-    *slot = Slot::kSteam;
-    return true;
-  }
-  return false;
+  const std::string candidate(text.data(), length);
+  if (AccountForSlot(candidate) == nil)
+    return false;
+  *slot = candidate;
+  return true;
 }
 
 napi_value Queue(napi_env env, napi_callback_info info, Operation operation) {

--- a/src/preload/preload.body.cjs
+++ b/src/preload/preload.body.cjs
@@ -235,6 +235,12 @@ const api = {
       ipcRenderer.invoke(IPC.appUpdatesRestartAndInstall),
     onState: (callback) => listen(IPC.appUpdatesState, callback),
   },
+  accounts: {
+    get: () => ipcRenderer.invoke(IPC.accountsGet),
+    setup: (value) => ipcRenderer.invoke(IPC.accountsSetup, value),
+    open: (profileIds) => ipcRenderer.invoke(IPC.accountsOpen, profileIds),
+    useSingle: () => ipcRenderer.invoke(IPC.accountsUseSingle),
+  },
 };
 for (const namespace of Object.values(api)) Object.freeze(namespace);
 Object.freeze(api);

--- a/src/preload/preload.body.cjs
+++ b/src/preload/preload.body.cjs
@@ -239,6 +239,9 @@ const api = {
     get: () => ipcRenderer.invoke(IPC.accountsGet),
     setup: (value) => ipcRenderer.invoke(IPC.accountsSetup, value),
     open: (profileIds) => ipcRenderer.invoke(IPC.accountsOpen, profileIds),
+    create: (value) => ipcRenderer.invoke(IPC.accountsCreate, value),
+    update: (value) => ipcRenderer.invoke(IPC.accountsUpdate, value),
+    archive: (profileId) => ipcRenderer.invoke(IPC.accountsArchive, profileId),
     useSingle: () => ipcRenderer.invoke(IPC.accountsUseSingle),
   },
 };

--- a/src/preload/preload.body.cjs
+++ b/src/preload/preload.body.cjs
@@ -242,6 +242,10 @@ const api = {
     create: (value) => ipcRenderer.invoke(IPC.accountsCreate, value),
     update: (value) => ipcRenderer.invoke(IPC.accountsUpdate, value),
     archive: (profileId) => ipcRenderer.invoke(IPC.accountsArchive, profileId),
+    restore: (profileId) => ipcRenderer.invoke(IPC.accountsRestore, profileId),
+    delete: (profileId) => ipcRenderer.invoke(IPC.accountsDelete, profileId),
+    loadTemplates: () => ipcRenderer.invoke(IPC.accountsTemplatesLoad),
+    saveTemplates: (entries) => ipcRenderer.invoke(IPC.accountsTemplatesSave, entries),
     useSingle: () => ipcRenderer.invoke(IPC.accountsUseSingle),
   },
 };

--- a/src/renderer/accounts.css
+++ b/src/renderer/accounts.css
@@ -23,6 +23,7 @@ button:focus-visible, input:focus-visible { outline: 3px solid color-mix(in srgb
 .chooser-header h1 { margin: 0; font-size: 25px; font-weight: 700; line-height: 1.12; letter-spacing: -.026em; }
 .chooser-header p { margin: 6px 0 0; color: #ffffffa3; font-size: 13px; }
 #accounts-form { display: flex; min-height: 0; flex: 1; flex-direction: column; }
+#accounts-form[data-empty] .chooser-actions, #accounts-form[data-empty] .privacy-note { display: none; }
 .accounts-list { display: grid; gap: 7px; min-height: 0; margin: 14px -4px 0; padding: 4px; overflow: auto; border: 0; scrollbar-width: thin; scrollbar-color: #ffffff33 transparent; }
 .account-row { display: grid; grid-template-columns: 22px minmax(0,1fr) auto auto; align-items: center; gap: 10px; min-height: 58px; padding: 8px 9px 8px 12px; border-radius: 11px; background: #ffffff11; transition: transform 80ms ease-out, background 150ms ease-out; }
 .account-row:hover { background: #ffffff1c; }
@@ -83,17 +84,25 @@ button:focus-visible, input:focus-visible { outline: 3px solid color-mix(in srgb
 .field { display: block; margin: 14px 0 17px; }
 .field > span { display: block; margin: 0 0 6px 2px; color: #515157; font-size: 12px; font-weight: 600; }
 .field input { width: 100%; height: 36px; padding: 6px 10px; border: 1px solid #3c3c4347; border-radius: 8px; background: #ffffffc7; color: #171719; }
-.sharing-row { display: grid; grid-template-columns: minmax(0, 1fr) minmax(210px, 1.25fr); align-items: center; gap: 16px; margin: 0; padding: 12px 2px; border: 0; border-top: 1px solid #3c3c4324; }
+.sharing-row { display: block; margin: 0; padding: 14px 2px; border: 0; border-top: 1px solid #3c3c4324; }
 .sharing-row legend { min-width: 0; margin: 0; padding: 0; }
 .sharing-row strong, .sharing-row small { display: block; }
 .sharing-row strong { font-size: 13px; }
 .sharing-row small { color: #737379; font-size: 11px; font-weight: 400; }
-.segmented { display: grid; grid-template-columns: 1fr; gap: 2px; padding: 2px; border-radius: 8px; background: #7676801f; }
+.segmented { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 2px; margin-top: 8px; padding: 2px; border-radius: 8px; background: #7676801f; }
 .segmented label { position: relative; }
 .segmented input { position: absolute; opacity: 0; }
 .segmented span { display: block; min-height: 27px; padding: 5px 8px; border-radius: 6px; color: #49494f; font-size: 11px; text-align: center; }
 .segmented input:checked + span { background: white; box-shadow: 0 1px 4px #0003; color: #111; }
 .segmented input:focus-visible + span { outline: 3px solid color-mix(in srgb, var(--focus) 50%, transparent); }
+.import-row { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 8px; margin: 0; padding: 14px 2px; border: 0; border-top: 1px solid #3c3c4324; }
+.import-row[hidden] { display: none; }
+.import-row legend { grid-column: 1 / -1; margin-bottom: 2px; padding: 0; }
+.import-row legend strong, .import-row legend small { display: block; }
+.import-row legend strong { font-size: 13px; }
+.import-row legend small { color: #737379; font-size: 11px; font-weight: 400; }
+.import-row label { display: flex; min-height: 32px; align-items: center; gap: 7px; padding: 5px 8px; border-radius: 8px; background: #76768012; color: #49494f; font-size: 12px; }
+.import-row input { width: 16px; height: 16px; margin: 0; accent-color: var(--ember); }
 .sheet .separation-note { margin: 12px 2px 0; font-size: 11px; }
 .sheet-status { min-height: 18px; color: #c52b23 !important; }
 .sheet-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 14px; padding-top: 14px; border-top: 1px solid #3c3c4324; }
@@ -119,12 +128,15 @@ button:focus-visible, input:focus-visible { outline: 3px solid color-mix(in srgb
   .brand { top: 10%; left: 50%; width: min(58%, 360px); }
   .chooser { right: 16px; bottom: 16px; left: 16px; width: auto; max-height: 72%; }
 }
+@media (max-width: 680px) {
+  .chooser { right: 0; bottom: 0; left: 0; border-right: 0; border-bottom: 0; border-left: 0; border-radius: 16px 16px 0 0; }
+}
 @media (max-width: 560px) {
-  .chooser { right: 0; bottom: 0; left: 0; max-height: 76%; border-right: 0; border-bottom: 0; border-left: 0; border-radius: 16px 16px 0 0; }
+  .chooser { max-height: 76%; }
   .chooser-actions { align-items: stretch; flex-direction: column-reverse; }
   .action-group, .action-group button { width: 100%; }
   .action-group .secondary { flex: 1; }
-  .sharing-row { grid-template-columns: 1fr; gap: 8px; }
+  .import-row { grid-template-columns: 1fr; }
   .mode-section { align-items: flex-start; flex-direction: column; }
 }
 @media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: .01ms !important; transition-duration: .01ms !important; } }

--- a/src/renderer/accounts.css
+++ b/src/renderer/accounts.css
@@ -113,6 +113,11 @@ h1 {
 .accounts-help { margin: var(--ui-space-3) 0; }
 .accounts-actions { display: flex; flex-wrap: wrap; gap: var(--ui-space-2); }
 .accounts-actions + .ui-status-line { min-height: 24px; margin: var(--ui-space-3) 0 0; }
+.accounts-archived { margin-top: var(--ui-space-4); border-top: 1px solid var(--ui-line-soft); padding-top: var(--ui-space-3); }
+.accounts-archived summary { color: var(--ui-text-muted); cursor: pointer; }
+.accounts-archived-list { display: grid; gap: var(--ui-space-2); margin-top: var(--ui-space-3); }
+.archived-profile { display: flex; align-items: center; gap: var(--ui-space-2); padding: var(--ui-space-2) 0; }
+.archived-profile strong { flex: 1; color: var(--ui-text-bright); }
 
 .accounts-foot {
   display: flex;

--- a/src/renderer/accounts.css
+++ b/src/renderer/accounts.css
@@ -1,0 +1,134 @@
+/* The Multiple Accounts Hub uses the existing GWonMac material system while
+ * giving profile choice a quiet, full-window home instead of impersonating an
+ * in-game overlay. All colour and control decisions resolve through ui tokens. */
+
+* { box-sizing: border-box; }
+
+html, body { min-height: 100%; }
+
+body {
+  margin: 0;
+  background:
+    radial-gradient(circle at 78% 8%, color-mix(in srgb, var(--ui-accent) 9%, transparent), transparent 34%),
+    var(--ui-well);
+  color: var(--ui-text);
+  font: var(--ui-font-size) / var(--ui-line-height) var(--ui-font);
+}
+
+button, input { font: inherit; }
+
+.accounts-shell {
+  width: min(760px, 100%);
+  min-height: 100vh;
+  margin: 0 auto;
+  padding: clamp(32px, 7vw, 68px) clamp(24px, 6vw, 54px) 28px;
+}
+
+.accounts-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: var(--ui-space-5);
+  padding-bottom: var(--ui-space-5);
+  border-bottom: 1px solid var(--ui-line-soft);
+}
+
+.accounts-head img {
+  flex: 0 0 auto;
+  object-fit: contain;
+  opacity: .9;
+}
+
+.accounts-kicker {
+  margin: 0 0 var(--ui-space-2);
+  color: var(--ui-accent);
+  font-size: var(--ui-font-size-sm);
+  font-weight: 700;
+  letter-spacing: .16em;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0;
+  color: var(--ui-text-bright);
+  font: 700 clamp(30px, 6vw, 46px) / 1.05 var(--ui-font-display);
+  letter-spacing: -.025em;
+}
+
+.accounts-intro {
+  max-width: 590px;
+  margin: var(--ui-space-3) 0 0;
+  color: var(--ui-text-muted);
+  font-size: var(--ui-font-size-lg);
+}
+
+#accounts-form { padding-top: var(--ui-space-5); }
+
+.accounts-list {
+  display: grid;
+  gap: var(--ui-space-2);
+  min-width: 0;
+  margin: 0;
+  padding: 0;
+  border: 0;
+}
+
+.account-choice {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--ui-space-3);
+  min-height: 66px;
+  padding: var(--ui-space-3) var(--ui-space-4);
+  border: 1px solid var(--ui-line-soft);
+  border-radius: var(--ui-radius);
+  background: var(--ui-row-fill);
+  cursor: pointer;
+  transition: border-color var(--ui-duration) var(--ui-ease-out), background var(--ui-duration) var(--ui-ease-out);
+}
+
+.account-choice:hover,
+.account-choice:has(input:focus-visible) {
+  border-color: var(--ui-line);
+  background: var(--ui-hover);
+}
+
+.account-choice:has(input:checked) {
+  border-color: var(--ui-accent-strong);
+  background: var(--ui-selected);
+}
+
+.account-choice input { width: 18px; height: 18px; accent-color: var(--ui-accent); }
+.account-name { display: block; overflow: hidden; color: var(--ui-text-bright); font-size: var(--ui-font-size-lg); font-weight: 700; text-overflow: ellipsis; white-space: nowrap; }
+.account-meta { display: block; margin-top: 2px; color: var(--ui-text-faint); font-size: var(--ui-font-size-sm); }
+.account-state { color: var(--ui-text-muted); font-size: var(--ui-font-size-sm); text-transform: capitalize; }
+.account-state[data-state="running"] { color: var(--ui-success); }
+.account-state[data-state="failed"] { color: var(--ui-danger); }
+
+.accounts-help,
+.accounts-foot p,
+.accounts-loading { color: var(--ui-text-muted); }
+
+.accounts-help { margin: var(--ui-space-3) 0; }
+.accounts-actions { display: flex; flex-wrap: wrap; gap: var(--ui-space-2); }
+.accounts-actions + .ui-status-line { min-height: 24px; margin: var(--ui-space-3) 0 0; }
+
+.accounts-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ui-space-4);
+  margin-top: clamp(36px, 8vw, 70px);
+  padding-top: var(--ui-space-4);
+  border-top: 1px solid var(--ui-line-soft);
+}
+
+.accounts-foot p { max-width: 420px; margin: 0; font-size: var(--ui-font-size-sm); }
+.sr-only { position: absolute; width: 1px; height: 1px; margin: -1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; }
+
+@media (max-width: 520px) {
+  .accounts-head img { display: none; }
+  .accounts-foot { align-items: flex-start; flex-direction: column; }
+  .account-choice { grid-template-columns: auto minmax(0, 1fr); }
+  .account-state { grid-column: 2; }
+}

--- a/src/renderer/accounts.css
+++ b/src/renderer/accounts.css
@@ -76,7 +76,7 @@ button:focus-visible, input:focus-visible { outline: 3px solid color-mix(in srgb
 .account-menu button:disabled { color: #8e8e93; }
 .account-menu hr { height: 1px; margin: 4px 7px; border: 0; background: #3c3c432e; }
 
-.sheet { width: min(560px, calc(100vw - 32px)); max-height: calc(100vh - 48px); padding: 0; overflow: auto; border: 1px solid #ffffffa6; border-radius: 16px; background: #f6f6f8f7; box-shadow: 0 28px 88px #0007; color: #1b1b1d; }
+.sheet { width: min(560px, calc(100vw - 32px)); max-height: calc(100vh - 48px); padding: 0; overflow: auto; border: 1px solid #ffffffa6; border-radius: 16px; background: #f6f6f8f7; box-shadow: 0 28px 88px #0007; color: #1b1b1d; -webkit-app-region: no-drag; }
 .sheet::backdrop { background: #0006; backdrop-filter: blur(5px); }
 .sheet form { padding: 22px; }
 .sheet h2 { margin: 0; font-size: 20px; line-height: 1.15; letter-spacing: -.022em; }

--- a/src/renderer/accounts.css
+++ b/src/renderer/accounts.css
@@ -75,7 +75,7 @@ h1 {
 
 .account-choice {
   display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
   align-items: center;
   gap: var(--ui-space-3);
   min-height: 66px;
@@ -104,6 +104,7 @@ h1 {
 .account-state { color: var(--ui-text-muted); font-size: var(--ui-font-size-sm); text-transform: capitalize; }
 .account-state[data-state="running"] { color: var(--ui-success); }
 .account-state[data-state="failed"] { color: var(--ui-danger); }
+.account-edit { white-space: nowrap; }
 
 .accounts-help,
 .accounts-foot p,
@@ -126,9 +127,24 @@ h1 {
 .accounts-foot p { max-width: 420px; margin: 0; font-size: var(--ui-font-size-sm); }
 .sr-only { position: absolute; width: 1px; height: 1px; margin: -1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; }
 
+.profile-dialog {
+  width: min(520px, calc(100vw - 32px));
+  padding: 0;
+  border: 0;
+  color: var(--ui-text);
+}
+.profile-dialog::backdrop { background: rgb(0 0 0 / 68%); }
+.profile-dialog .ui-panel { padding: 9px 10px 11px; }
+.profile-fields { display: grid; gap: var(--ui-space-3); }
+.profile-fields fieldset { min-width: 0; margin: 0; padding: 0; border: 0; }
+.profile-fields legend { margin-bottom: var(--ui-space-2); color: var(--ui-text-muted); }
+.profile-fields > label { color: var(--ui-text-muted); }
+.profile-actions { flex-wrap: wrap; }
+.profile-action-spacer { flex: 1; }
+
 @media (max-width: 520px) {
   .accounts-head img { display: none; }
   .accounts-foot { align-items: flex-start; flex-direction: column; }
-  .account-choice { grid-template-columns: auto minmax(0, 1fr); }
+  .account-choice { grid-template-columns: auto minmax(0, 1fr) auto; }
   .account-state { grid-column: 2; }
 }

--- a/src/renderer/accounts.css
+++ b/src/renderer/accounts.css
@@ -1,155 +1,132 @@
-/* The Multiple Accounts Hub uses the existing GWonMac material system while
- * giving profile choice a quiet, full-window home instead of impersonating an
- * in-game overlay. All colour and control decisions resolve through ui tokens. */
+:root {
+  color-scheme: dark;
+  --ember: #b84618;
+  --ember-hover: #cc5522;
+  --focus: #0a84ff;
+  --danger: #ff6961;
+  --success: #83d39a;
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+}
 
 * { box-sizing: border-box; }
-
-html, body { min-height: 100%; }
-
-body {
-  margin: 0;
-  background:
-    radial-gradient(circle at 78% 8%, color-mix(in srgb, var(--ui-accent) 9%, transparent), transparent 34%),
-    var(--ui-well);
-  color: var(--ui-text);
-  font: var(--ui-font-size) / var(--ui-line-height) var(--ui-font);
-}
-
+html, body { width: 100%; height: 100%; }
+body { margin: 0; overflow: hidden; background: #0a0806; color: #fff; font-size: 14px; -webkit-font-smoothing: antialiased; user-select: none; }
 button, input { font: inherit; }
+button { cursor: default; }
+button:focus-visible, input:focus-visible { outline: 3px solid color-mix(in srgb, var(--focus) 55%, transparent); outline-offset: 2px; }
 
-.accounts-shell {
-  width: min(760px, 100%);
-  min-height: 100vh;
-  margin: 0 auto;
-  padding: clamp(32px, 7vw, 68px) clamp(24px, 6vw, 54px) 28px;
-}
+.hub { position: relative; width: 100%; height: 100%; overflow: hidden; -webkit-app-region: drag; }
+.scene { position: absolute; inset: 0; background: radial-gradient(ellipse at 34% 40%, transparent 6%, #0706051f 46%, #070605b8 100%), linear-gradient(180deg, #08070612, #08070666), url("images/bg-reforged.jpg") center / cover no-repeat; }
+.brand { position: absolute; top: 17%; left: 27%; width: min(43%, 450px); transform: translateX(-50%); filter: drop-shadow(0 5px 20px #000c); }
 
-.accounts-head {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: var(--ui-space-5);
-  padding-bottom: var(--ui-space-5);
-  border-bottom: 1px solid var(--ui-line-soft);
-}
+.chooser { position: absolute; right: 34px; bottom: 30px; display: flex; flex-direction: column; width: min(430px, 48%); max-height: calc(100% - 96px); padding: 22px; overflow: hidden; border: 1px solid #ffffff26; border-radius: 16px; background: #1c1a18c9; box-shadow: 0 24px 64px #0007, inset 0 1px #ffffff14; backdrop-filter: blur(30px) saturate(145%); -webkit-app-region: no-drag; }
+.chooser-header h1 { margin: 0; font-size: 25px; font-weight: 700; line-height: 1.12; letter-spacing: -.026em; }
+.chooser-header p { margin: 6px 0 0; color: #ffffffa3; font-size: 13px; }
+#accounts-form { display: flex; min-height: 0; flex: 1; flex-direction: column; }
+.accounts-list { display: grid; gap: 7px; min-height: 0; margin: 14px -4px 0; padding: 4px; overflow: auto; border: 0; scrollbar-width: thin; scrollbar-color: #ffffff33 transparent; }
+.account-row { display: grid; grid-template-columns: 22px minmax(0,1fr) auto auto; align-items: center; gap: 10px; min-height: 58px; padding: 8px 9px 8px 12px; border-radius: 11px; background: #ffffff11; transition: transform 80ms ease-out, background 150ms ease-out; }
+.account-row:hover { background: #ffffff1c; }
+.account-row:active { transform: scale(.985); }
+.account-row:has(input:checked) { background: var(--ember); }
+.account-row:has(input:checked):hover { background: var(--ember-hover); }
+.account-row:has(input:focus-visible) { outline: 3px solid color-mix(in srgb, var(--focus) 60%, transparent); outline-offset: 1px; }
+.account-row > input { width: 18px; height: 18px; margin: 0; accent-color: white; }
+.account-copy { min-width: 0; }
+.account-copy strong { display: block; overflow: hidden; font-size: 14px; font-weight: 600; text-overflow: ellipsis; white-space: nowrap; }
+.account-copy small { display: block; margin-top: 1px; color: #ffffff8f; font-size: 11px; }
+.account-row:has(input:checked) .account-copy small { color: #ffffffc7; }
+.open-indicator { display: flex; align-items: center; gap: 5px; color: var(--success); font-size: 11px; }
+.open-indicator::before { width: 6px; height: 6px; border-radius: 50%; background: currentColor; content: ""; }
+.retry { min-height: 28px; padding: 3px 8px; border: 0; border-radius: 7px; background: #ffffff14; color: #ffd1cd; }
+.retry:hover { background: #ffffff24; }
+.more { display: grid; width: 30px; height: 30px; padding: 0; place-items: center; border: 0; border-radius: 7px; background: transparent; color: #ffffffa3; font-size: 18px; letter-spacing: 1px; }
+.more:hover { background: #ffffff1f; color: white; }
 
-.accounts-head img {
-  flex: 0 0 auto;
-  object-fit: contain;
-  opacity: .9;
-}
+.loading-row { pointer-events: none; }
+.loading-row i { width: 18px; height: 18px; border-radius: 50%; background: #ffffff12; }
+.loading-row span b, .loading-row span small { display: block; width: 58%; height: 10px; border-radius: 5px; background: linear-gradient(90deg, #ffffff12, #ffffff2b, #ffffff12); background-size: 220% 100%; animation: shimmer 1.4s ease-in-out infinite; }
+.loading-row span small { width: 38%; height: 8px; margin-top: 7px; }
+@keyframes shimmer { to { background-position: -220% 0; } }
 
-.accounts-kicker {
-  margin: 0 0 var(--ui-space-2);
-  color: var(--ui-accent);
-  font-size: var(--ui-font-size-sm);
-  font-weight: 700;
-  letter-spacing: .16em;
-  text-transform: uppercase;
-}
+.empty-state { min-height: 230px; padding: 28px 12px; text-align: center; }
+.empty-state svg { width: 36px; height: 36px; color: #ffffff9e; }
+.empty-state h2 { margin: 9px 0 0; font-size: 15px; }
+.empty-state p { max-width: 31ch; margin: 5px auto 15px; color: #ffffff94; font-size: 12px; }
+.status-banner { margin: 11px 0 0; padding: 9px 11px; border-radius: 9px; background: #ff453a24; color: #ffbab5; font-size: 12px; }
+.status-banner:empty { display: none; }
+.status-banner[data-tone="progress"] { background: #ffffff12; color: #ffffffad; }
+.status-banner[data-tone="success"] { background: #31c55a1f; color: #b6edc5; }
+.chooser-actions { display: flex; flex: none; align-items: center; justify-content: space-between; gap: 12px; margin-top: 13px; }
+.action-group { display: flex; gap: 8px; }
+.quiet, .secondary, .primary { min-height: 34px; padding: 6px 14px; border-radius: 8px; color: white; transition: transform 80ms ease-out, background 150ms ease-out; }
+.quiet:active, .secondary:active, .primary:active { transform: scale(.96); }
+.quiet { padding-inline: 5px; border: 0; background: transparent; color: #ffffffad; }
+.quiet:hover { color: white; }
+.secondary { border: 1px solid #ffffff26; background: #ffffff17; }
+.secondary:hover { background: #ffffff24; }
+.primary { border: 1px solid #ffffff1c; background: var(--ember); font-weight: 600; }
+.primary:hover:not(:disabled) { background: var(--ember-hover); }
+.primary:disabled { opacity: .42; }
+.privacy-note { flex: none; margin: 11px 0 0; color: #ffffff7a; font-size: 11px; }
 
-h1 {
-  margin: 0;
-  color: var(--ui-text-bright);
-  font: 700 clamp(30px, 6vw, 46px) / 1.05 var(--ui-font-display);
-  letter-spacing: -.025em;
-}
+.account-menu { position: fixed; z-index: 20; width: 190px; padding: 5px; border: 1px solid #ffffffa6; border-radius: 11px; background: #f2f2f7f2; box-shadow: 0 14px 42px #0007; backdrop-filter: blur(26px) saturate(180%); color: #1c1c1e; -webkit-app-region: no-drag; }
+.account-menu button { display: block; width: 100%; min-height: 29px; padding: 4px 9px; border: 0; border-radius: 6px; background: transparent; color: inherit; text-align: left; }
+.account-menu button:hover:not(:disabled), .account-menu button:focus-visible { background: var(--focus); color: white; outline: 0; }
+.account-menu button:disabled { color: #8e8e93; }
+.account-menu hr { height: 1px; margin: 4px 7px; border: 0; background: #3c3c432e; }
 
-.accounts-intro {
-  max-width: 590px;
-  margin: var(--ui-space-3) 0 0;
-  color: var(--ui-text-muted);
-  font-size: var(--ui-font-size-lg);
-}
-
-#accounts-form { padding-top: var(--ui-space-5); }
-
-.accounts-list {
-  display: grid;
-  gap: var(--ui-space-2);
-  min-width: 0;
-  margin: 0;
-  padding: 0;
-  border: 0;
-}
-
-.account-choice {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr) auto auto;
-  align-items: center;
-  gap: var(--ui-space-3);
-  min-height: 66px;
-  padding: var(--ui-space-3) var(--ui-space-4);
-  border: 1px solid var(--ui-line-soft);
-  border-radius: var(--ui-radius);
-  background: var(--ui-row-fill);
-  cursor: pointer;
-  transition: border-color var(--ui-duration) var(--ui-ease-out), background var(--ui-duration) var(--ui-ease-out);
-}
-
-.account-choice:hover,
-.account-choice:has(input:focus-visible) {
-  border-color: var(--ui-line);
-  background: var(--ui-hover);
-}
-
-.account-choice:has(input:checked) {
-  border-color: var(--ui-accent-strong);
-  background: var(--ui-selected);
-}
-
-.account-choice input { width: 18px; height: 18px; accent-color: var(--ui-accent); }
-.account-name { display: block; overflow: hidden; color: var(--ui-text-bright); font-size: var(--ui-font-size-lg); font-weight: 700; text-overflow: ellipsis; white-space: nowrap; }
-.account-meta { display: block; margin-top: 2px; color: var(--ui-text-faint); font-size: var(--ui-font-size-sm); }
-.account-state { color: var(--ui-text-muted); font-size: var(--ui-font-size-sm); text-transform: capitalize; }
-.account-state[data-state="running"] { color: var(--ui-success); }
-.account-state[data-state="failed"] { color: var(--ui-danger); }
-.account-edit { white-space: nowrap; }
-
-.accounts-help,
-.accounts-foot p,
-.accounts-loading { color: var(--ui-text-muted); }
-
-.accounts-help { margin: var(--ui-space-3) 0; }
-.accounts-actions { display: flex; flex-wrap: wrap; gap: var(--ui-space-2); }
-.accounts-actions + .ui-status-line { min-height: 24px; margin: var(--ui-space-3) 0 0; }
-.accounts-archived { margin-top: var(--ui-space-4); border-top: 1px solid var(--ui-line-soft); padding-top: var(--ui-space-3); }
-.accounts-archived summary { color: var(--ui-text-muted); cursor: pointer; }
-.accounts-archived-list { display: grid; gap: var(--ui-space-2); margin-top: var(--ui-space-3); }
-.archived-profile { display: flex; align-items: center; gap: var(--ui-space-2); padding: var(--ui-space-2) 0; }
-.archived-profile strong { flex: 1; color: var(--ui-text-bright); }
-
-.accounts-foot {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: var(--ui-space-4);
-  margin-top: clamp(36px, 8vw, 70px);
-  padding-top: var(--ui-space-4);
-  border-top: 1px solid var(--ui-line-soft);
-}
-
-.accounts-foot p { max-width: 420px; margin: 0; font-size: var(--ui-font-size-sm); }
+.sheet { width: min(560px, calc(100vw - 32px)); max-height: calc(100vh - 48px); padding: 0; overflow: auto; border: 1px solid #ffffffa6; border-radius: 16px; background: #f6f6f8f7; box-shadow: 0 28px 88px #0007; color: #1b1b1d; }
+.sheet::backdrop { background: #0006; backdrop-filter: blur(5px); }
+.sheet form { padding: 22px; }
+.sheet h2 { margin: 0; font-size: 20px; line-height: 1.15; letter-spacing: -.022em; }
+.sheet form > p { margin: 6px 0 17px; color: #6c6c72; font-size: 13px; }
+.field { display: block; margin: 14px 0 17px; }
+.field > span { display: block; margin: 0 0 6px 2px; color: #515157; font-size: 12px; font-weight: 600; }
+.field input { width: 100%; height: 36px; padding: 6px 10px; border: 1px solid #3c3c4347; border-radius: 8px; background: #ffffffc7; color: #171719; }
+.sharing-row { display: grid; grid-template-columns: minmax(0, 1fr) minmax(210px, 1.25fr); align-items: center; gap: 16px; margin: 0; padding: 12px 2px; border: 0; border-top: 1px solid #3c3c4324; }
+.sharing-row legend { min-width: 0; margin: 0; padding: 0; }
+.sharing-row strong, .sharing-row small { display: block; }
+.sharing-row strong { font-size: 13px; }
+.sharing-row small { color: #737379; font-size: 11px; font-weight: 400; }
+.segmented { display: grid; grid-template-columns: 1fr; gap: 2px; padding: 2px; border-radius: 8px; background: #7676801f; }
+.segmented label { position: relative; }
+.segmented input { position: absolute; opacity: 0; }
+.segmented span { display: block; min-height: 27px; padding: 5px 8px; border-radius: 6px; color: #49494f; font-size: 11px; text-align: center; }
+.segmented input:checked + span { background: white; box-shadow: 0 1px 4px #0003; color: #111; }
+.segmented input:focus-visible + span { outline: 3px solid color-mix(in srgb, var(--focus) 50%, transparent); }
+.sheet .separation-note { margin: 12px 2px 0; font-size: 11px; }
+.sheet-status { min-height: 18px; color: #c52b23 !important; }
+.sheet-actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 14px; padding-top: 14px; border-top: 1px solid #3c3c4324; }
+.sheet-secondary, .sheet-primary { min-height: 32px; padding: 5px 13px; border-radius: 8px; }
+.sheet-secondary { border: 1px solid #3c3c4324; background: #76768017; color: #29292d; }
+.sheet-primary { border: 0; background: var(--ember); color: white; font-weight: 600; }
+.settings-sheet { width: min(620px, calc(100vw - 32px)); }
+.settings-section { margin-top: 18px; padding-top: 14px; border-top: 1px solid #3c3c4324; }
+.settings-section h3 { margin: 0 0 8px; font-size: 13px; }
+.archived-list { display: grid; gap: 6px; }
+.archived-account { display: grid; grid-template-columns: minmax(0,1fr) auto auto; align-items: center; gap: 8px; min-height: 38px; padding: 5px 8px; border-radius: 8px; background: #76768012; }
+.archived-account strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.archived-account button { min-height: 28px; padding: 3px 8px; border: 0; border-radius: 6px; background: #7676801c; color: #29292d; }
+.archived-account .delete { color: #d52d25; }
+.settings-empty { margin: 0; color: #737379; font-size: 12px; }
+.mode-section { display: flex; align-items: center; justify-content: space-between; gap: 20px; }
+.mode-section h3 { margin-bottom: 3px; }
+.mode-section p { margin: 0; color: #737379; font-size: 12px; }
+.mode-section button { flex: none; }
 .sr-only { position: absolute; width: 1px; height: 1px; margin: -1px; overflow: hidden; clip: rect(0 0 0 0); white-space: nowrap; }
 
-.profile-dialog {
-  width: min(520px, calc(100vw - 32px));
-  padding: 0;
-  border: 0;
-  color: var(--ui-text);
+@media (max-width: 720px) {
+  .brand { top: 10%; left: 50%; width: min(58%, 360px); }
+  .chooser { right: 16px; bottom: 16px; left: 16px; width: auto; max-height: 72%; }
 }
-.profile-dialog::backdrop { background: rgb(0 0 0 / 68%); }
-.profile-dialog .ui-panel { padding: 9px 10px 11px; }
-.profile-fields { display: grid; gap: var(--ui-space-3); }
-.profile-fields fieldset { min-width: 0; margin: 0; padding: 0; border: 0; }
-.profile-fields legend { margin-bottom: var(--ui-space-2); color: var(--ui-text-muted); }
-.profile-fields > label { color: var(--ui-text-muted); }
-.profile-actions { flex-wrap: wrap; }
-.profile-action-spacer { flex: 1; }
-
-@media (max-width: 520px) {
-  .accounts-head img { display: none; }
-  .accounts-foot { align-items: flex-start; flex-direction: column; }
-  .account-choice { grid-template-columns: auto minmax(0, 1fr) auto; }
-  .account-state { grid-column: 2; }
+@media (max-width: 560px) {
+  .chooser { right: 0; bottom: 0; left: 0; max-height: 76%; border-right: 0; border-bottom: 0; border-left: 0; border-radius: 16px 16px 0 0; }
+  .chooser-actions { align-items: stretch; flex-direction: column-reverse; }
+  .action-group, .action-group button { width: 100%; }
+  .action-group .secondary { flex: 1; }
+  .sharing-row { grid-template-columns: 1fr; gap: 8px; }
+  .mode-section { align-items: flex-start; flex-direction: column; }
 }
+@media (prefers-reduced-motion: reduce) { *, *::before, *::after { animation-duration: .01ms !important; transition-duration: .01ms !important; } }
+@media (prefers-reduced-transparency: reduce) { .chooser, .account-menu, .sheet, .sheet::backdrop { backdrop-filter: none; } .chooser { background: #211e1c; } }
+@media (prefers-contrast: more) { .chooser { border-color: #ffffff8c; background: #141211f2; } .account-row { background: #ffffff21; } .privacy-note, .account-copy small { color: #ffffffc4; } }

--- a/src/renderer/accounts.css
+++ b/src/renderer/accounts.css
@@ -15,7 +15,9 @@ button, input { font: inherit; }
 button { cursor: default; }
 button:focus-visible, input:focus-visible { outline: 3px solid color-mix(in srgb, var(--focus) 55%, transparent); outline-offset: 2px; }
 
-.hub { position: relative; width: 100%; height: 100%; overflow: hidden; -webkit-app-region: drag; }
+.hub { position: relative; width: 100%; height: 100%; overflow: hidden; -webkit-app-region: no-drag; }
+.titlebar-drag { position: absolute; z-index: 2; top: 0; right: 0; left: 72px; height: 38px; -webkit-app-region: drag; }
+body:has(dialog[open]) .titlebar-drag { display: none; }
 .scene { position: absolute; inset: 0; background: radial-gradient(ellipse at 34% 40%, transparent 6%, #0706051f 46%, #070605b8 100%), linear-gradient(180deg, #08070612, #08070666), url("images/bg-reforged.jpg") center / cover no-repeat; }
 .brand { position: absolute; top: 17%; left: 27%; width: min(43%, 450px); transform: translateX(-50%); filter: drop-shadow(0 5px 20px #000c); }
 

--- a/src/renderer/accounts.html
+++ b/src/renderer/accounts.html
@@ -1,0 +1,43 @@
+<!doctype html>
+<html lang="en" data-ui-style="obsidian">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Guild Wars Reforged — Accounts</title>
+  <link rel="icon" href="favicon.png" type="image/png" sizes="48x48">
+  <link rel="stylesheet" href="ui/tokens.css">
+  <link rel="stylesheet" href="ui/components.css">
+  <link rel="stylesheet" href="accounts.css">
+</head>
+<body>
+  <main class="accounts-shell" aria-labelledby="accounts-title">
+    <header class="accounts-head">
+      <div>
+        <p class="accounts-kicker">Multiple Accounts</p>
+        <h1 id="accounts-title">Who are you playing?</h1>
+        <p class="accounts-intro">Choose one or more profiles. Each opens in its own window with its own saved login and Guild Wars files.</p>
+      </div>
+      <img src="images/logo.webp" alt="" width="76" height="76">
+    </header>
+
+    <form id="accounts-form">
+      <fieldset id="accounts-list" class="accounts-list" aria-describedby="accounts-help">
+        <legend class="sr-only">Account profiles</legend>
+        <div class="accounts-loading">Loading profiles…</div>
+      </fieldset>
+      <p id="accounts-help" class="accounts-help">Already-open profiles are brought to the front. Other selected profiles open independently.</p>
+      <div class="accounts-actions">
+        <button id="accounts-open" class="ui-button" data-variant="primary" type="submit" disabled>Open selected</button>
+        <button id="accounts-select-all" class="ui-button" type="button">Select all</button>
+      </div>
+      <p id="accounts-status" class="ui-status-line" data-tone="neutral" role="status" aria-live="polite"></p>
+    </form>
+
+    <footer class="accounts-foot">
+      <p>Profiles share the downloaded client, never credentials or browser storage.</p>
+      <button id="accounts-single" class="ui-link" type="button">Return to Single Account mode…</button>
+    </footer>
+  </main>
+  <script type="module" src="accounts.js"></script>
+</body>
+</html>

--- a/src/renderer/accounts.html
+++ b/src/renderer/accounts.html
@@ -32,6 +32,10 @@
         <button id="accounts-new" class="ui-button" type="button">New profile…</button>
       </div>
       <p id="accounts-status" class="ui-status-line" data-tone="neutral" role="status" aria-live="polite"></p>
+      <details id="accounts-archived" class="accounts-archived" hidden>
+        <summary>Archived profiles</summary>
+        <div id="accounts-archived-list" class="accounts-archived-list"></div>
+      </details>
     </form>
 
     <footer class="accounts-foot">

--- a/src/renderer/accounts.html
+++ b/src/renderer/accounts.html
@@ -30,7 +30,7 @@
           <svg viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true"><circle cx="16" cy="11" r="5"/><path d="M7 27c.8-5.1 4-8 9-8s8.2 2.9 9 8"/><path d="M24 7v6M21 10h6"/></svg>
           <h2>No accounts yet</h2>
           <p>Create your first account. Your Single Account data stays untouched.</p>
-          <button id="accounts-empty-new" class="primary" type="button">Create Account</button>
+          <button id="accounts-empty-new" class="primary" type="button">Create First Account</button>
         </section>
 
         <p id="accounts-status" class="status-banner" role="status" aria-live="polite" aria-atomic="true"></p>
@@ -73,6 +73,11 @@
           <label><input type="radio" name="profileTemplates" value="shared" checked><span>Shared between Multiple Accounts</span></label>
           <label><input type="radio" name="profileTemplates" value="private"><span>Separate for this account</span></label>
         </span>
+      </fieldset>
+      <fieldset id="profile-import" class="import-row" hidden>
+        <legend><strong>Start with Single Account data</strong><small>This is a one-time copy. The originals stay untouched and never synchronize.</small></legend>
+        <label><input id="profile-import-builds" type="checkbox"><span>Copy builds and teams</span></label>
+        <label><input id="profile-import-templates" type="checkbox"><span>Copy in-game templates</span></label>
       </fieldset>
       <p class="separation-note">Login, game settings, screenshots, chat logs, and Single Account data are never shared.</p>
       <p id="profile-status" class="sheet-status" role="status" aria-live="polite"></p>

--- a/src/renderer/accounts.html
+++ b/src/renderer/accounts.html
@@ -1,81 +1,106 @@
 <!doctype html>
-<html lang="en" data-ui-style="obsidian">
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Guild Wars Reforged — Accounts</title>
   <link rel="icon" href="favicon.png" type="image/png" sizes="48x48">
-  <link rel="stylesheet" href="ui/tokens.css">
-  <link rel="stylesheet" href="ui/components.css">
   <link rel="stylesheet" href="accounts.css">
 </head>
 <body>
-  <main class="accounts-shell" aria-labelledby="accounts-title">
-    <header class="accounts-head">
-      <div>
-        <p class="accounts-kicker">Multiple Accounts</p>
-        <h1 id="accounts-title">Who are you playing?</h1>
-        <p class="accounts-intro">Choose one or more profiles. Each opens in its own window with its own saved login and Guild Wars files.</p>
-      </div>
-      <img src="images/logo.webp" alt="" width="76" height="76">
-    </header>
+  <main class="hub">
+    <div class="scene" aria-hidden="true"></div>
+    <img class="brand" src="images/logo.webp" alt="">
 
-    <form id="accounts-form">
-      <fieldset id="accounts-list" class="accounts-list" aria-describedby="accounts-help">
-        <legend class="sr-only">Account profiles</legend>
-        <div class="accounts-loading">Loading profiles…</div>
-      </fieldset>
-      <p id="accounts-help" class="accounts-help">Already-open profiles are brought to the front. Other selected profiles open independently.</p>
-      <div class="accounts-actions">
-        <button id="accounts-open" class="ui-button" data-variant="primary" type="submit" disabled>Open selected</button>
-        <button id="accounts-select-all" class="ui-button" type="button">Select all</button>
-        <button id="accounts-new" class="ui-button" type="button">New profile…</button>
-      </div>
-      <p id="accounts-status" class="ui-status-line" data-tone="neutral" role="status" aria-live="polite"></p>
-      <details id="accounts-archived" class="accounts-archived" hidden>
-        <summary>Archived profiles</summary>
-        <div id="accounts-archived-list" class="accounts-archived-list"></div>
-      </details>
-    </form>
-
-    <footer class="accounts-foot">
-      <p>Profiles share the downloaded client, never credentials or browser storage.</p>
-      <button id="accounts-single" class="ui-link" type="button">Return to Single Account mode…</button>
-    </footer>
-  </main>
-  <dialog id="profile-dialog" class="profile-dialog ui-frame" aria-labelledby="profile-dialog-title">
-    <form id="profile-form" class="ui-panel">
-      <header class="ui-panel-head">
-        <h2 id="profile-dialog-title" class="ui-panel-title">New profile</h2>
-        <button id="profile-cancel-x" class="ui-button" data-icon type="button" aria-label="Close">&#10005;</button>
+    <section class="chooser" aria-labelledby="accounts-title">
+      <header class="chooser-header">
+        <h1 id="accounts-title">Choose Accounts</h1>
+        <p>Select one or more accounts to open.</p>
       </header>
-      <div class="ui-panel-body profile-fields">
-        <label for="profile-name">Profile name</label>
-        <input id="profile-name" class="ui-input" type="text" maxlength="48" autocomplete="off" required>
-        <fieldset>
-          <legend>Build library</legend>
-          <div class="ui-segment" data-fill>
-            <label><input type="radio" name="profileBuilds" value="shared" checked><span>Shared</span></label>
-            <label><input type="radio" name="profileBuilds" value="private"><span>Private</span></label>
-          </div>
+
+      <form id="accounts-form">
+        <fieldset id="accounts-list" class="accounts-list" aria-describedby="accounts-privacy" aria-busy="true">
+          <legend class="sr-only">Accounts</legend>
+          <div class="account-row loading-row" aria-hidden="true"><i></i><span><b></b><small></small></span></div>
+          <div class="account-row loading-row" aria-hidden="true"><i></i><span><b></b><small></small></span></div>
+          <div class="account-row loading-row" aria-hidden="true"><i></i><span><b></b><small></small></span></div>
         </fieldset>
-        <fieldset>
-          <legend>Build templates</legend>
-          <div class="ui-segment" data-fill>
-            <label><input type="radio" name="profileTemplates" value="shared" checked><span>Shared</span></label>
-            <label><input type="radio" name="profileTemplates" value="private"><span>Private</span></label>
-          </div>
-        </fieldset>
-        <p class="accounts-help">Sharing is only with other Multiple Accounts profiles. Saved login and Guild Wars files always stay private.</p>
-      </div>
-      <footer class="ui-panel-foot profile-actions">
-        <button id="profile-archive" class="ui-button" data-variant="danger" type="button" hidden>Archive profile…</button>
-        <span class="profile-action-spacer"></span>
-        <button id="profile-cancel" class="ui-button" type="button">Cancel</button>
-        <button id="profile-save" class="ui-button" data-variant="primary" type="submit">Create profile</button>
+
+        <section id="accounts-empty" class="empty-state" hidden>
+          <svg viewBox="0 0 32 32" fill="none" stroke="currentColor" stroke-width="1.7" aria-hidden="true"><circle cx="16" cy="11" r="5"/><path d="M7 27c.8-5.1 4-8 9-8s8.2 2.9 9 8"/><path d="M24 7v6M21 10h6"/></svg>
+          <h2>No accounts yet</h2>
+          <p>Create your first account. Your Single Account data stays untouched.</p>
+          <button id="accounts-empty-new" class="primary" type="button">Create Account</button>
+        </section>
+
+        <p id="accounts-status" class="status-banner" role="status" aria-live="polite" aria-atomic="true"></p>
+        <div class="chooser-actions">
+          <button id="accounts-new" class="quiet" type="button">New Account…</button>
+          <span class="action-group">
+            <button id="accounts-select-all" class="secondary" type="button">Select All</button>
+            <button id="accounts-open" class="primary" type="submit" disabled>Open</button>
+          </span>
+        </div>
+        <p id="accounts-privacy" class="privacy-note">Each account keeps its own saved login and game files.</p>
+      </form>
+    </section>
+  </main>
+
+  <div id="account-menu" class="account-menu" role="menu" hidden>
+    <button id="account-edit" type="button" role="menuitem">Edit Account…</button>
+    <hr>
+    <button id="account-archive" type="button" role="menuitem">Archive Account</button>
+  </div>
+
+  <dialog id="profile-dialog" class="sheet" aria-labelledby="profile-dialog-title">
+    <form id="profile-form" method="dialog">
+      <h2 id="profile-dialog-title">New Account</h2>
+      <p id="profile-dialog-description">Create an independent Guild Wars account.</p>
+      <label class="field" for="profile-name">
+        <span>Account name</span>
+        <input id="profile-name" type="text" maxlength="48" autocomplete="off" placeholder="For example, Pre-Searing" required>
+      </label>
+      <fieldset class="sharing-row">
+        <legend><strong>Builds and teams</strong><small>Choose where this account stores its library.</small></legend>
+        <span class="segmented">
+          <label><input type="radio" name="profileBuilds" value="shared" checked><span>Shared between Multiple Accounts</span></label>
+          <label><input type="radio" name="profileBuilds" value="private"><span>Separate for this account</span></label>
+        </span>
+      </fieldset>
+      <fieldset class="sharing-row">
+        <legend><strong>In-game templates</strong><small>Choose where this account stores its templates.</small></legend>
+        <span class="segmented">
+          <label><input type="radio" name="profileTemplates" value="shared" checked><span>Shared between Multiple Accounts</span></label>
+          <label><input type="radio" name="profileTemplates" value="private"><span>Separate for this account</span></label>
+        </span>
+      </fieldset>
+      <p class="separation-note">Login, game settings, screenshots, chat logs, and Single Account data are never shared.</p>
+      <p id="profile-status" class="sheet-status" role="status" aria-live="polite"></p>
+      <footer class="sheet-actions">
+        <button id="profile-cancel" class="sheet-secondary" type="button">Cancel</button>
+        <button id="profile-save" class="sheet-primary" type="submit">Create Account</button>
       </footer>
     </form>
   </dialog>
+
+  <dialog id="accounts-settings" class="sheet settings-sheet" aria-labelledby="accounts-settings-title">
+    <form method="dialog">
+      <h2 id="accounts-settings-title">Multiple Accounts Settings</h2>
+      <p>Each account has its own login, game settings, screenshots, and chat logs. Shared libraries never connect to Single Account data.</p>
+      <section class="settings-section" aria-labelledby="archived-title">
+        <h3 id="archived-title">Archived Accounts</h3>
+        <div id="accounts-archived-list" class="archived-list"></div>
+        <p id="accounts-no-archived" class="settings-empty">No archived accounts.</p>
+      </section>
+      <section class="settings-section mode-section">
+        <div><h3>Account Mode</h3><p>Returning to Single Account restarts GWonMac. Both workspaces are preserved.</p></div>
+        <button id="accounts-single" class="sheet-secondary" type="button">Return to Single Account…</button>
+      </section>
+      <p id="settings-status" class="sheet-status" role="status" aria-live="polite"></p>
+      <footer class="sheet-actions"><button id="settings-done" class="sheet-primary" type="button">Done</button></footer>
+    </form>
+  </dialog>
+
   <script type="module" src="accounts.js"></script>
 </body>
 </html>

--- a/src/renderer/accounts.html
+++ b/src/renderer/accounts.html
@@ -9,6 +9,7 @@
 </head>
 <body>
   <main class="hub">
+    <div class="titlebar-drag" aria-hidden="true"></div>
     <div class="scene" aria-hidden="true"></div>
     <img class="brand" src="images/logo.webp" alt="">
 

--- a/src/renderer/accounts.html
+++ b/src/renderer/accounts.html
@@ -29,6 +29,7 @@
       <div class="accounts-actions">
         <button id="accounts-open" class="ui-button" data-variant="primary" type="submit" disabled>Open selected</button>
         <button id="accounts-select-all" class="ui-button" type="button">Select all</button>
+        <button id="accounts-new" class="ui-button" type="button">New profile…</button>
       </div>
       <p id="accounts-status" class="ui-status-line" data-tone="neutral" role="status" aria-live="polite"></p>
     </form>
@@ -38,6 +39,39 @@
       <button id="accounts-single" class="ui-link" type="button">Return to Single Account mode…</button>
     </footer>
   </main>
+  <dialog id="profile-dialog" class="profile-dialog ui-frame" aria-labelledby="profile-dialog-title">
+    <form id="profile-form" class="ui-panel">
+      <header class="ui-panel-head">
+        <h2 id="profile-dialog-title" class="ui-panel-title">New profile</h2>
+        <button id="profile-cancel-x" class="ui-button" data-icon type="button" aria-label="Close">&#10005;</button>
+      </header>
+      <div class="ui-panel-body profile-fields">
+        <label for="profile-name">Profile name</label>
+        <input id="profile-name" class="ui-input" type="text" maxlength="48" autocomplete="off" required>
+        <fieldset>
+          <legend>Build library</legend>
+          <div class="ui-segment" data-fill>
+            <label><input type="radio" name="profileBuilds" value="shared" checked><span>Shared</span></label>
+            <label><input type="radio" name="profileBuilds" value="private"><span>Private</span></label>
+          </div>
+        </fieldset>
+        <fieldset>
+          <legend>Build templates</legend>
+          <div class="ui-segment" data-fill>
+            <label><input type="radio" name="profileTemplates" value="shared" checked><span>Shared</span></label>
+            <label><input type="radio" name="profileTemplates" value="private"><span>Private</span></label>
+          </div>
+        </fieldset>
+        <p class="accounts-help">Sharing is only with other Multiple Accounts profiles. Saved login and Guild Wars files always stay private.</p>
+      </div>
+      <footer class="ui-panel-foot profile-actions">
+        <button id="profile-archive" class="ui-button" data-variant="danger" type="button" hidden>Archive profile…</button>
+        <span class="profile-action-spacer"></span>
+        <button id="profile-cancel" class="ui-button" type="button">Cancel</button>
+        <button id="profile-save" class="ui-button" data-variant="primary" type="submit">Create profile</button>
+      </footer>
+    </form>
+  </dialog>
   <script type="module" src="accounts.js"></script>
 </body>
 </html>

--- a/src/renderer/accounts.ts
+++ b/src/renderer/accounts.ts
@@ -27,6 +27,9 @@ import type { AccountProfileSummary } from '../shared/contracts.js';
   const profileName = required<HTMLInputElement>('profile-name');
   const profileSave = required<HTMLButtonElement>('profile-save');
   const profileStatus = required<HTMLElement>('profile-status');
+  const profileImport = required<HTMLFieldSetElement>('profile-import');
+  const profileImportBuilds = required<HTMLInputElement>('profile-import-builds');
+  const profileImportTemplates = required<HTMLInputElement>('profile-import-templates');
   const settingsDialog = required<HTMLDialogElement>('accounts-settings');
   const archivedList = required<HTMLElement>('accounts-archived-list');
   const noArchived = required<HTMLElement>('accounts-no-archived');
@@ -36,6 +39,7 @@ import type { AccountProfileSummary } from '../shared/contracts.js';
   let selected = new Set<AccountProfileSummary['id']>();
   let editing: AccountProfileSummary | null = null;
   let menuProfile: AccountProfileSummary | null = null;
+  let menuTrigger: HTMLElement | null = null;
   let refreshInFlight: Promise<void> | null = null;
 
   const activeProfiles = () => profiles.filter((profile) => !profile.archived);
@@ -98,18 +102,22 @@ import type { AccountProfileSummary } from '../shared/contracts.js';
     }
   }
 
-  function closeMenu() {
+  function closeMenu(restoreFocus = false) {
     menu.hidden = true;
     menuProfile = null;
+    const trigger = menuTrigger;
+    menuTrigger = null;
+    if (restoreFocus) trigger?.focus();
   }
 
   function showMenu(profile: AccountProfileSummary, trigger: HTMLElement) {
     menuProfile = profile;
+    menuTrigger = trigger;
     const bounds = trigger.getBoundingClientRect();
     menu.style.top = `${Math.min(bounds.bottom + 4, innerHeight - 90)}px`;
     menu.style.left = `${Math.max(8, Math.min(bounds.right - 190, innerWidth - 198))}px`;
-    menuEdit.disabled = profile.state === 'running';
-    menuEdit.title = profile.state === 'running' ? 'Close this account before editing it.' : '';
+    menuEdit.disabled = false;
+    menuEdit.title = '';
     menuArchive.disabled = profile.state === 'running' || activeProfiles().length < 2;
     menuArchive.title = profile.state === 'running'
       ? 'Close this account before archiving it.'
@@ -219,6 +227,7 @@ import type { AccountProfileSummary } from '../shared/contracts.js';
     list.setAttribute('aria-busy', 'false');
     list.hidden = active.length === 0;
     empty.hidden = active.length > 0;
+    form.toggleAttribute('data-empty', active.length === 0);
     renderArchived();
     syncActions();
   }
@@ -242,14 +251,28 @@ import type { AccountProfileSummary } from '../shared/contracts.js';
 
   function showProfileDialog(profile: AccountProfileSummary | null) {
     editing = profile;
+    const sharingInputs = profileForm.querySelectorAll<HTMLInputElement>(
+      'input[name="profileBuilds"], input[name="profileTemplates"]',
+    );
+    const accountIsOpen = profile?.state === 'running';
+    const firstAccount = profile === null && profiles.length === 0;
     profileTitle.textContent = profile ? 'Edit Account' : 'New Account';
     profileDescription.textContent = profile
-      ? `Change how ${profile.name} stores builds and templates.`
-      : 'Create an independent Guild Wars account.';
-    profileSave.textContent = profile ? 'Save Changes' : 'Create Account';
+      ? accountIsOpen
+        ? `Rename ${profile.name}. Close it before changing how its libraries are shared.`
+        : `Change how ${profile.name} stores builds and templates.`
+      : firstAccount
+        ? 'Create the first account in your separate Multiple Accounts workspace.'
+        : 'Create an independent Guild Wars account.';
+    profileTitle.textContent = firstAccount ? 'Create First Account' : profileTitle.textContent;
+    profileSave.textContent = profile ? 'Save Changes' : firstAccount ? 'Create First Account' : 'Create Account';
     profileName.value = profile?.name ?? '';
     choice('profileBuilds').value = profile?.builds ?? 'shared';
     choice('profileTemplates').value = profile?.templates ?? 'shared';
+    for (const input of sharingInputs) input.disabled = accountIsOpen;
+    profileImport.hidden = !firstAccount;
+    profileImportBuilds.checked = false;
+    profileImportTemplates.checked = false;
     profileStatus.textContent = '';
     profileDialog.showModal();
     profileName.focus();
@@ -285,10 +308,19 @@ import type { AccountProfileSummary } from '../shared/contracts.js';
       name: profileName.value.trim(),
       builds: choice('profileBuilds').value as 'shared' | 'private',
       templates: choice('profileTemplates').value as 'shared' | 'private',
+      copySingleBuilds: editing === null && profiles.length === 0 && profileImportBuilds.checked,
+      copySingleTemplates: editing === null && profiles.length === 0 && profileImportTemplates.checked,
     };
     const wasEditing = editing !== null;
     try {
-      if (editing) await window.gwNative.accounts.update({ id: editing.id, ...request });
+      if (editing) {
+        await window.gwNative.accounts.update({
+          id: editing.id,
+          name: request.name,
+          builds: request.builds,
+          templates: request.templates,
+        });
+      }
       else await window.gwNative.accounts.create(request);
       profileDialog.close();
       setStatus(wasEditing ? 'Account updated.' : 'Account created.', 'success');
@@ -321,8 +353,23 @@ import type { AccountProfileSummary } from '../shared/contracts.js';
   document.addEventListener('pointerdown', (event) => {
     if (!menu.hidden && !menu.contains(event.target as Node)) closeMenu();
   });
-  document.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape' && !menu.hidden) closeMenu();
+  menu.addEventListener('keydown', (event) => {
+    const items = [...menu.querySelectorAll<HTMLButtonElement>('[role="menuitem"]:not(:disabled)')];
+    const current = items.indexOf(document.activeElement as HTMLButtonElement);
+    if (event.key === 'Escape' || event.key === 'Tab') {
+      event.preventDefault();
+      closeMenu(true);
+      return;
+    }
+    if (event.key === 'Home' || event.key === 'End') {
+      event.preventDefault();
+      items[event.key === 'Home' ? 0 : items.length - 1]?.focus();
+      return;
+    }
+    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return;
+    event.preventDefault();
+    const offset = event.key === 'ArrowDown' ? 1 : -1;
+    items[(current + offset + items.length) % items.length]?.focus();
   });
 
   const showSettings = () => {

--- a/src/renderer/accounts.ts
+++ b/src/renderer/accounts.ts
@@ -1,8 +1,3 @@
-/**
- * The Multiple Accounts Hub: a small projection of main-owned profile state.
- * Profile IDs originate in main and return only through checked controls; the
- * renderer never constructs paths, partitions, or credential names.
- */
 import type { AccountProfileSummary } from '../shared/contracts.js';
 
 (function () {
@@ -11,163 +6,273 @@ import type { AccountProfileSummary } from '../shared/contracts.js';
     if (!value) throw new Error(`missing accounts element: ${id}`);
     return value as T;
   };
+
   const form = required<HTMLFormElement>('accounts-form');
   const list = required<HTMLFieldSetElement>('accounts-list');
+  const empty = required<HTMLElement>('accounts-empty');
   const open = required<HTMLButtonElement>('accounts-open');
   const selectAll = required<HTMLButtonElement>('accounts-select-all');
-  const newProfile = required<HTMLButtonElement>('accounts-new');
   const status = required<HTMLElement>('accounts-status');
-  const single = required<HTMLButtonElement>('accounts-single');
-  const archived = required<HTMLDetailsElement>('accounts-archived');
-  const archivedList = required<HTMLElement>('accounts-archived-list');
+  const menu = required<HTMLElement>('account-menu');
+  const menuEdit = required<HTMLButtonElement>('account-edit');
+  const menuArchive = required<HTMLButtonElement>('account-archive');
   const profileDialog = required<HTMLDialogElement>('profile-dialog');
   const profileForm = required<HTMLFormElement>('profile-form');
   const profileTitle = required<HTMLElement>('profile-dialog-title');
+  const profileDescription = required<HTMLElement>('profile-dialog-description');
   const profileName = required<HTMLInputElement>('profile-name');
   const profileSave = required<HTMLButtonElement>('profile-save');
-  const profileArchive = required<HTMLButtonElement>('profile-archive');
-  let profiles: readonly AccountProfileSummary[] = [];
-  let editing: AccountProfileSummary | null = null;
+  const profileStatus = required<HTMLElement>('profile-status');
+  const settingsDialog = required<HTMLDialogElement>('accounts-settings');
+  const archivedList = required<HTMLElement>('accounts-archived-list');
+  const noArchived = required<HTMLElement>('accounts-no-archived');
+  const settingsStatus = required<HTMLElement>('settings-status');
 
-  function setStatus(message: string, tone: 'neutral' | 'progress' | 'success' | 'error') {
+  let profiles: readonly AccountProfileSummary[] = [];
+  let selected = new Set<AccountProfileSummary['id']>();
+  let editing: AccountProfileSummary | null = null;
+  let menuProfile: AccountProfileSummary | null = null;
+  let refreshInFlight: Promise<void> | null = null;
+
+  const activeProfiles = () => profiles.filter((profile) => !profile.archived);
+  const selectedProfiles = () => activeProfiles().filter((profile) => selected.has(profile.id));
+  const choice = (name: string) => profileForm.elements.namedItem(name) as RadioNodeList;
+
+  function stateLabel(profile: AccountProfileSummary): string {
+    switch (profile.state) {
+      case 'ready': return 'Ready';
+      case 'queued': return 'Waiting';
+      case 'opening': return 'Starting';
+      case 'checking': return 'Checking updated client';
+      case 'running': return 'Open';
+      case 'failed': return 'Needs Attention';
+    }
+  }
+
+  function recoveryText(profile: AccountProfileSummary): string {
+    switch (profile.launchIssue) {
+      case 'profile-preparation': return 'Couldn’t prepare this account.';
+      case 'window-startup': return 'Its game window couldn’t start.';
+      case 'client-validation': return 'The updated client couldn’t be verified.';
+      case 'renderer-crash': return 'The game stopped unexpectedly twice.';
+      default: return 'This account couldn’t be opened.';
+    }
+  }
+
+  function setStatus(message = '', tone: 'neutral' | 'progress' | 'success' | 'error' = 'neutral') {
     status.textContent = message;
     status.dataset.tone = tone;
   }
 
-  function selectedIds() {
-    return [...list.querySelectorAll<HTMLInputElement>('input:checked')]
-      .map((input) => input.value as AccountProfileSummary['id']);
-  }
-
   function syncActions() {
-    const inputs = list.querySelectorAll<HTMLInputElement>('input');
-    open.disabled = selectedIds().length === 0;
-    const allSelected = inputs.length > 0 && selectedIds().length === inputs.length;
-    selectAll.textContent = allSelected ? 'Clear selection' : 'Select all';
+    const active = activeProfiles();
+    const chosen = selectedProfiles();
+    open.disabled = chosen.length === 0 || chosen.some((profile) =>
+      profile.state === 'queued' || profile.state === 'opening' || profile.state === 'checking');
+    if (chosen.length === 0) open.textContent = 'Open';
+    else if (chosen.length > 1) open.textContent = `Open ${chosen.length} Accounts`;
+    else if (chosen[0]!.state === 'running') open.textContent = `Show ${chosen[0]!.name}`;
+    else if (chosen[0]!.state === 'failed') open.textContent = `Retry ${chosen[0]!.name}`;
+    else open.textContent = `Open ${chosen[0]!.name}`;
+    selectAll.textContent = active.length > 0 && chosen.length === active.length ? 'Clear' : 'Select All';
+    selectAll.disabled = active.length === 0;
   }
 
-  function renderProfile(profile: AccountProfileSummary) {
+  async function launch(ids: readonly AccountProfileSummary['id'][]) {
+    if (ids.length === 0) return;
+    open.disabled = true;
+    setStatus('Opening selected accounts…', 'progress');
+    const poll = window.setInterval(() => { void refresh(); }, 180);
+    try {
+      await window.gwNative.accounts.open(ids);
+      setStatus('Selected accounts are open.', 'success');
+    } catch {
+      setStatus('Some accounts need attention. Open accounts were left running.', 'error');
+    } finally {
+      window.clearInterval(poll);
+      await refresh();
+    }
+  }
+
+  function closeMenu() {
+    menu.hidden = true;
+    menuProfile = null;
+  }
+
+  function showMenu(profile: AccountProfileSummary, trigger: HTMLElement) {
+    menuProfile = profile;
+    const bounds = trigger.getBoundingClientRect();
+    menu.style.top = `${Math.min(bounds.bottom + 4, innerHeight - 90)}px`;
+    menu.style.left = `${Math.max(8, Math.min(bounds.right - 190, innerWidth - 198))}px`;
+    menuEdit.disabled = profile.state === 'running';
+    menuEdit.title = profile.state === 'running' ? 'Close this account before editing it.' : '';
+    menuArchive.disabled = profile.state === 'running' || activeProfiles().length < 2;
+    menuArchive.title = profile.state === 'running'
+      ? 'Close this account before archiving it.'
+      : activeProfiles().length < 2 ? 'At least one active account is required.' : '';
+    menu.hidden = false;
+    menuEdit.focus();
+  }
+
+  function renderProfile(profile: AccountProfileSummary): HTMLElement {
     const row = document.createElement('div');
-    row.className = 'account-choice';
+    row.className = 'account-row';
+    row.dataset.profileId = profile.id;
     const checkbox = document.createElement('input');
     checkbox.type = 'checkbox';
-    checkbox.name = 'profile';
+    checkbox.name = 'account';
     checkbox.value = profile.id;
-    checkbox.checked = false;
-    checkbox.id = `profile-${profile.id}`;
-    const details = document.createElement('label');
-    details.htmlFor = checkbox.id;
-    const name = document.createElement('span');
-    name.className = 'account-name';
-    name.textContent = profile.name;
-    const meta = document.createElement('span');
-    meta.className = 'account-meta';
-    meta.textContent = `${profile.templates} templates · ${profile.builds} builds`;
-    details.append(name, meta);
-    const state = document.createElement('span');
-    state.className = 'account-state';
-    state.dataset.state = profile.state;
-    state.textContent = profile.state;
-    const edit = document.createElement('button');
-    edit.type = 'button';
-    edit.className = 'account-edit ui-button';
-    edit.dataset.variant = 'quiet';
-    edit.textContent = 'Edit…';
-    edit.addEventListener('click', () => showProfileDialog(profile));
-    row.append(checkbox, details, state, edit);
-    return row;
-  }
-
-  function renderArchivedProfile(profile: AccountProfileSummary) {
-    const row = document.createElement('div');
-    row.className = 'archived-profile';
+    checkbox.id = `account-${profile.id}`;
+    checkbox.checked = selected.has(profile.id);
+    checkbox.setAttribute('aria-label', `Select ${profile.name}`);
+    const copy = document.createElement('label');
+    copy.className = 'account-copy';
+    copy.htmlFor = checkbox.id;
     const name = document.createElement('strong');
     name.textContent = profile.name;
-    const restore = document.createElement('button');
-    restore.type = 'button';
-    restore.className = 'ui-button';
-    restore.textContent = 'Restore';
-    restore.addEventListener('click', async () => {
-      restore.disabled = true;
-      try {
-        await window.gwNative.accounts.restore(profile.id);
-        setStatus('Profile restored.', 'success');
-        await refresh();
-      } catch {
-        restore.disabled = false;
-        setStatus('The profile could not be restored.', 'error');
-      }
+    name.title = profile.name;
+    const state = document.createElement('small');
+    state.textContent = profile.state === 'failed'
+      ? `${stateLabel(profile)} — ${recoveryText(profile)}`
+      : stateLabel(profile);
+    copy.append(name, state);
+    const indicator = document.createElement('span');
+    if (profile.state === 'running') {
+      indicator.className = 'open-indicator';
+      indicator.textContent = 'Open';
+    } else if (profile.state === 'failed') {
+      const retry = document.createElement('button');
+      retry.type = 'button';
+      retry.className = 'retry';
+      retry.textContent = 'Retry';
+      retry.setAttribute('aria-label', `Retry ${profile.name}`);
+      retry.addEventListener('click', () => { void launch([profile.id]); });
+      indicator.append(retry);
+    }
+    const trailing = document.createElement('button');
+    trailing.type = 'button';
+    trailing.className = 'more';
+    trailing.textContent = '•••';
+    trailing.setAttribute('aria-label', `More options for ${profile.name}`);
+    trailing.addEventListener('click', () => showMenu(profile, trailing));
+    row.append(checkbox, copy, indicator, trailing);
+    row.addEventListener('click', (event) => {
+      const target = event.target as Element;
+      if (target.closest('button, input, label')) return;
+      checkbox.checked = !checkbox.checked;
+      checkbox.dispatchEvent(new Event('change', { bubbles: true }));
     });
-    const remove = document.createElement('button');
-    remove.type = 'button';
-    remove.className = 'ui-button';
-    remove.dataset.variant = 'danger';
-    remove.textContent = 'Delete…';
-    remove.addEventListener('click', async () => {
-      remove.disabled = true;
-      try {
-        const state = await window.gwNative.accounts.delete(profile.id);
-        const deleted = !state.profiles.some((item) => item.id === profile.id);
-        setStatus(deleted ? 'Profile permanently deleted.' : 'Deletion cancelled.', deleted ? 'success' : 'neutral');
-        await refresh();
-      } catch {
-        remove.disabled = false;
-        setStatus('The profile could not be fully deleted. Try again.', 'error');
-      }
-    });
-    row.append(name, restore, remove);
     return row;
   }
 
-  const choice = (name: string) =>
-    profileForm.elements.namedItem(name) as RadioNodeList;
+  function renderArchived() {
+    const archived = profiles.filter((profile) => profile.archived);
+    noArchived.hidden = archived.length > 0;
+    archivedList.replaceChildren(...archived.map((profile) => {
+      const row = document.createElement('div');
+      row.className = 'archived-account';
+      const name = document.createElement('strong');
+      name.textContent = profile.name;
+      const restore = document.createElement('button');
+      restore.type = 'button';
+      restore.textContent = 'Restore';
+      restore.addEventListener('click', async () => {
+        restore.disabled = true;
+        try {
+          await window.gwNative.accounts.restore(profile.id);
+          settingsStatus.textContent = `${profile.name} was restored.`;
+          await refresh();
+        } catch {
+          restore.disabled = false;
+          settingsStatus.textContent = 'The account could not be restored.';
+        }
+      });
+      const remove = document.createElement('button');
+      remove.type = 'button';
+      remove.className = 'delete';
+      remove.textContent = 'Delete…';
+      remove.addEventListener('click', async () => {
+        remove.disabled = true;
+        try {
+          const next = await window.gwNative.accounts.delete(profile.id);
+          const deleted = !next.profiles.some((candidate) => candidate.id === profile.id);
+          settingsStatus.textContent = deleted ? `${profile.name} was permanently deleted.` : 'Deletion was cancelled.';
+          await refresh();
+        } catch {
+          remove.disabled = false;
+          settingsStatus.textContent = 'The account could not be deleted.';
+        }
+      });
+      row.append(name, restore, remove);
+      return row;
+    }));
+  }
 
-  function closeProfileDialog() {
-    profileDialog.close();
-    editing = null;
+  function render() {
+    const active = activeProfiles();
+    selected = new Set([...selected].filter((id) => active.some((profile) => profile.id === id)));
+    list.replaceChildren(...active.map(renderProfile));
+    list.setAttribute('aria-busy', 'false');
+    list.hidden = active.length === 0;
+    empty.hidden = active.length > 0;
+    renderArchived();
+    syncActions();
+  }
+
+  function refresh(): Promise<void> {
+    if (refreshInFlight) return refreshInFlight;
+    refreshInFlight = window.gwNative.accounts.get()
+      .then((state) => {
+        if (state.mode !== 'multi') throw new Error('Multiple Accounts is not active');
+        profiles = state.profiles;
+        render();
+      })
+      .catch(() => {
+        list.replaceChildren();
+        list.setAttribute('aria-busy', 'false');
+        setStatus('Accounts couldn’t be loaded. Restart GWonMac and try again.', 'error');
+      })
+      .finally(() => { refreshInFlight = null; });
+    return refreshInFlight;
   }
 
   function showProfileDialog(profile: AccountProfileSummary | null) {
     editing = profile;
-    profileTitle.textContent = profile ? `Edit ${profile.name}` : 'New profile';
-    profileSave.textContent = profile ? 'Save changes' : 'Create profile';
+    profileTitle.textContent = profile ? 'Edit Account' : 'New Account';
+    profileDescription.textContent = profile
+      ? `Change how ${profile.name} stores builds and templates.`
+      : 'Create an independent Guild Wars account.';
+    profileSave.textContent = profile ? 'Save Changes' : 'Create Account';
     profileName.value = profile?.name ?? '';
     choice('profileBuilds').value = profile?.builds ?? 'shared';
     choice('profileTemplates').value = profile?.templates ?? 'shared';
-    profileArchive.hidden =
-      !profile || profiles.filter((item) => !item.archived).length < 2;
-    profileArchive.disabled = profile?.state === 'running';
+    profileStatus.textContent = '';
     profileDialog.showModal();
     profileName.focus();
   }
 
-  async function refresh() {
-    try {
-      const state = await window.gwNative.accounts.get();
-      if (state.mode !== 'multi') throw new Error('Multiple Accounts is not active');
-      profiles = state.profiles;
-      const active = profiles.filter((profile) => !profile.archived);
-      const inactive = profiles.filter((profile) => profile.archived);
-      list.replaceChildren(...active.map(renderProfile));
-      archivedList.replaceChildren(...inactive.map(renderArchivedProfile));
-      archived.hidden = inactive.length === 0;
-      syncActions();
-    } catch {
-      list.replaceChildren();
-      setStatus('Profiles could not be loaded. Restart GWonMac and try again.', 'error');
-    }
-  }
-
-  list.addEventListener('change', syncActions);
-  selectAll.addEventListener('click', () => {
-    const inputs = [...list.querySelectorAll<HTMLInputElement>('input')];
-    const next = !inputs.every((input) => input.checked);
-    for (const input of inputs) input.checked = next;
+  list.addEventListener('change', (event) => {
+    const input = event.target;
+    if (!(input instanceof HTMLInputElement)) return;
+    if (input.checked) selected.add(input.value as AccountProfileSummary['id']);
+    else selected.delete(input.value as AccountProfileSummary['id']);
     syncActions();
   });
-  newProfile.addEventListener('click', () => showProfileDialog(null));
-  required<HTMLButtonElement>('profile-cancel').addEventListener('click', closeProfileDialog);
-  required<HTMLButtonElement>('profile-cancel-x').addEventListener('click', closeProfileDialog);
+  selectAll.addEventListener('click', () => {
+    const active = activeProfiles();
+    selected = selected.size === active.length
+      ? new Set()
+      : new Set(active.map((profile) => profile.id));
+    render();
+  });
+  form.addEventListener('submit', (event) => {
+    event.preventDefault();
+    void launch(selectedProfiles().map((profile) => profile.id));
+  });
+  required<HTMLButtonElement>('accounts-new').addEventListener('click', () => showProfileDialog(null));
+  required<HTMLButtonElement>('accounts-empty-new').addEventListener('click', () => showProfileDialog(null));
+  required<HTMLButtonElement>('profile-cancel').addEventListener('click', () => profileDialog.close());
+  profileDialog.addEventListener('close', () => { editing = null; profileStatus.textContent = ''; });
   profileForm.addEventListener('submit', async (event) => {
     event.preventDefault();
     if (!profileForm.reportValidity()) return;
@@ -177,59 +282,63 @@ import type { AccountProfileSummary } from '../shared/contracts.js';
       builds: choice('profileBuilds').value as 'shared' | 'private',
       templates: choice('profileTemplates').value as 'shared' | 'private',
     };
-    const updating = editing !== null;
+    const wasEditing = editing !== null;
     try {
       if (editing) await window.gwNative.accounts.update({ id: editing.id, ...request });
       else await window.gwNative.accounts.create(request);
-      closeProfileDialog();
-      setStatus(updating ? 'Profile updated.' : 'Profile created.', 'success');
+      profileDialog.close();
+      setStatus(wasEditing ? 'Account updated.' : 'Account created.', 'success');
       await refresh();
     } catch {
-      setStatus('The profile could not be saved. Check that its name is unique.', 'error');
+      profileStatus.textContent = 'The account could not be saved. Use a unique name and close it before changing sharing.';
     } finally {
       profileSave.disabled = false;
     }
   });
-  profileArchive.addEventListener('click', async () => {
-    const profile = editing;
-    if (!profile || !window.confirm(`Archive “${profile.name}”? Its saved login and files will be kept.`)) return;
-    profileArchive.disabled = true;
+
+  menuEdit.addEventListener('click', () => {
+    const profile = menuProfile;
+    closeMenu();
+    if (profile) showProfileDialog(profile);
+  });
+  menuArchive.addEventListener('click', async () => {
+    const profile = menuProfile;
+    closeMenu();
+    if (!profile || !window.confirm(`Archive “${profile.name}”? Its login and files will be kept.`)) return;
     try {
       await window.gwNative.accounts.archive(profile.id);
-      closeProfileDialog();
-      setStatus('Profile archived. Its data was kept.', 'success');
+      setStatus(`${profile.name} was archived.`, 'success');
+      selected.delete(profile.id);
       await refresh();
     } catch {
-      setStatus('Close the profile before archiving it, then try again.', 'error');
-    } finally {
-      profileArchive.disabled = false;
+      setStatus('Close the account before archiving it, then try again.', 'error');
     }
   });
-  form.addEventListener('submit', async (event) => {
-    event.preventDefault();
-    const ids = selectedIds();
-    if (ids.length === 0) return;
-    open.disabled = true;
-    setStatus(`Opening ${ids.length === 1 ? 'account' : `${ids.length} accounts`}…`, 'progress');
-    try {
-      await window.gwNative.accounts.open(ids);
-      setStatus('Selected accounts are open.', 'success');
-      await refresh();
-    } catch {
-      setStatus('One or more accounts could not be opened. You can retry them.', 'error');
-      await refresh();
-    }
+  document.addEventListener('pointerdown', (event) => {
+    if (!menu.hidden && !menu.contains(event.target as Node)) closeMenu();
   });
-  single.addEventListener('click', async () => {
-    if (!window.confirm('Return to Single Account mode? All open game windows will close. Your Multi profiles and saved logins are kept.')) return;
-    single.disabled = true;
-    setStatus('Restarting in Single Account mode…', 'progress');
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && !menu.hidden) closeMenu();
+  });
+
+  const showSettings = () => {
+    closeMenu();
+    settingsStatus.textContent = '';
+    renderArchived();
+    if (!settingsDialog.open) settingsDialog.showModal();
+  };
+  required<HTMLButtonElement>('settings-done').addEventListener('click', () => settingsDialog.close());
+  required<HTMLButtonElement>('accounts-single').addEventListener('click', async () => {
+    if (!window.confirm('Return to Single Account mode? GWonMac will restart. Multiple Accounts and Single Account data will both be preserved.')) return;
+    settingsStatus.textContent = 'Restarting in Single Account mode…';
     try {
       await window.gwNative.accounts.useSingle();
     } catch {
-      single.disabled = false;
-      setStatus('The mode change could not be saved. Nothing changed.', 'error');
+      settingsStatus.textContent = 'The mode change could not be saved. Nothing changed.';
     }
+  });
+  window.gwNative.commands.handle(async (command) => {
+    if (command.type === 'accounts.settings.open') showSettings();
   });
 
   window.addEventListener('focus', () => { void refresh(); });

--- a/src/renderer/accounts.ts
+++ b/src/renderer/accounts.ts
@@ -1,0 +1,110 @@
+import type { AccountProfileSummary } from '../shared/contracts.js';
+
+/**
+ * The Multiple Accounts Hub: a small projection of main-owned profile state.
+ * Profile IDs originate in main and return only through checked controls; the
+ * renderer never constructs paths, partitions, or credential names.
+ */
+(function () {
+  const required = <T extends HTMLElement>(id: string): T => {
+    const value = document.getElementById(id);
+    if (!value) throw new Error(`missing accounts element: ${id}`);
+    return value as T;
+  };
+  const form = required<HTMLFormElement>('accounts-form');
+  const list = required<HTMLFieldSetElement>('accounts-list');
+  const open = required<HTMLButtonElement>('accounts-open');
+  const selectAll = required<HTMLButtonElement>('accounts-select-all');
+  const status = required<HTMLElement>('accounts-status');
+  const single = required<HTMLButtonElement>('accounts-single');
+  let profiles: readonly AccountProfileSummary[] = [];
+
+  function setStatus(message: string, tone: 'neutral' | 'progress' | 'success' | 'error') {
+    status.textContent = message;
+    status.dataset.tone = tone;
+  }
+
+  function selectedIds() {
+    return [...list.querySelectorAll<HTMLInputElement>('input:checked')]
+      .map((input) => input.value as AccountProfileSummary['id']);
+  }
+
+  function syncActions() {
+    open.disabled = selectedIds().length === 0;
+    const allSelected = profiles.length > 0 && selectedIds().length === profiles.length;
+    selectAll.textContent = allSelected ? 'Clear selection' : 'Select all';
+  }
+
+  function renderProfile(profile: AccountProfileSummary) {
+    const label = document.createElement('label');
+    label.className = 'account-choice';
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.name = 'profile';
+    checkbox.value = profile.id;
+    checkbox.checked = profile.state !== 'failed';
+    const details = document.createElement('span');
+    const name = document.createElement('span');
+    name.className = 'account-name';
+    name.textContent = profile.name;
+    const meta = document.createElement('span');
+    meta.className = 'account-meta';
+    meta.textContent = `${profile.templates} templates · ${profile.builds} builds`;
+    details.append(name, meta);
+    const state = document.createElement('span');
+    state.className = 'account-state';
+    state.dataset.state = profile.state;
+    state.textContent = profile.state;
+    label.append(checkbox, details, state);
+    return label;
+  }
+
+  async function refresh() {
+    try {
+      const state = await window.gwNative.accounts.get();
+      if (state.mode !== 'multi') throw new Error('Multiple Accounts is not active');
+      profiles = state.profiles;
+      list.replaceChildren(...profiles.map(renderProfile));
+      syncActions();
+    } catch {
+      list.replaceChildren();
+      setStatus('Profiles could not be loaded. Restart GWonMac and try again.', 'error');
+    }
+  }
+
+  list.addEventListener('change', syncActions);
+  selectAll.addEventListener('click', () => {
+    const inputs = [...list.querySelectorAll<HTMLInputElement>('input')];
+    const next = !inputs.every((input) => input.checked);
+    for (const input of inputs) input.checked = next;
+    syncActions();
+  });
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    const ids = selectedIds();
+    if (ids.length === 0) return;
+    open.disabled = true;
+    setStatus(`Opening ${ids.length === 1 ? 'account' : `${ids.length} accounts`}…`, 'progress');
+    try {
+      await window.gwNative.accounts.open(ids);
+      setStatus('Selected accounts are open.', 'success');
+      await refresh();
+    } catch {
+      setStatus('One or more accounts could not be opened. You can retry them.', 'error');
+      await refresh();
+    }
+  });
+  single.addEventListener('click', async () => {
+    if (!window.confirm('Return to Single Account mode? All open game windows will close. Your Multi profiles and saved logins are kept.')) return;
+    single.disabled = true;
+    setStatus('Restarting in Single Account mode…', 'progress');
+    try {
+      await window.gwNative.accounts.useSingle();
+    } catch {
+      single.disabled = false;
+      setStatus('The mode change could not be saved. Nothing changed.', 'error');
+    }
+  });
+
+  void refresh();
+})();

--- a/src/renderer/accounts.ts
+++ b/src/renderer/accounts.ts
@@ -1,10 +1,10 @@
-import type { AccountProfileSummary } from '../shared/contracts.js';
-
 /**
  * The Multiple Accounts Hub: a small projection of main-owned profile state.
  * Profile IDs originate in main and return only through checked controls; the
  * renderer never constructs paths, partitions, or credential names.
  */
+import type { AccountProfileSummary } from '../shared/contracts.js';
+
 (function () {
   const required = <T extends HTMLElement>(id: string): T => {
     const value = document.getElementById(id);

--- a/src/renderer/accounts.ts
+++ b/src/renderer/accounts.ts
@@ -1,3 +1,7 @@
+/**
+ * The Multiple Accounts Hub interaction layer: it projects main-owned account
+ * state, manages selection and sheets, and never invents launch status.
+ */
 import type { AccountProfileSummary } from '../shared/contracts.js';
 
 (function () {

--- a/src/renderer/accounts.ts
+++ b/src/renderer/accounts.ts
@@ -104,11 +104,11 @@ import type { AccountProfileSummary } from '../shared/contracts.js';
     remove.dataset.variant = 'danger';
     remove.textContent = 'Delete…';
     remove.addEventListener('click', async () => {
-      if (!window.confirm(`Permanently delete “${profile.name}”? Its saved login, Guild Wars files, private templates, builds, and window state cannot be recovered.`)) return;
       remove.disabled = true;
       try {
-        await window.gwNative.accounts.delete(profile.id);
-        setStatus('Profile permanently deleted.', 'success');
+        const state = await window.gwNative.accounts.delete(profile.id);
+        const deleted = !state.profiles.some((item) => item.id === profile.id);
+        setStatus(deleted ? 'Profile permanently deleted.' : 'Deletion cancelled.', deleted ? 'success' : 'neutral');
         await refresh();
       } catch {
         remove.disabled = false;
@@ -232,5 +232,6 @@ import type { AccountProfileSummary } from '../shared/contracts.js';
     }
   });
 
+  window.addEventListener('focus', () => { void refresh(); });
   void refresh();
 })();

--- a/src/renderer/accounts.ts
+++ b/src/renderer/accounts.ts
@@ -15,9 +15,17 @@ import type { AccountProfileSummary } from '../shared/contracts.js';
   const list = required<HTMLFieldSetElement>('accounts-list');
   const open = required<HTMLButtonElement>('accounts-open');
   const selectAll = required<HTMLButtonElement>('accounts-select-all');
+  const newProfile = required<HTMLButtonElement>('accounts-new');
   const status = required<HTMLElement>('accounts-status');
   const single = required<HTMLButtonElement>('accounts-single');
+  const profileDialog = required<HTMLDialogElement>('profile-dialog');
+  const profileForm = required<HTMLFormElement>('profile-form');
+  const profileTitle = required<HTMLElement>('profile-dialog-title');
+  const profileName = required<HTMLInputElement>('profile-name');
+  const profileSave = required<HTMLButtonElement>('profile-save');
+  const profileArchive = required<HTMLButtonElement>('profile-archive');
   let profiles: readonly AccountProfileSummary[] = [];
+  let editing: AccountProfileSummary | null = null;
 
   function setStatus(message: string, tone: 'neutral' | 'progress' | 'success' | 'error') {
     status.textContent = message;
@@ -36,14 +44,16 @@ import type { AccountProfileSummary } from '../shared/contracts.js';
   }
 
   function renderProfile(profile: AccountProfileSummary) {
-    const label = document.createElement('label');
-    label.className = 'account-choice';
+    const row = document.createElement('div');
+    row.className = 'account-choice';
     const checkbox = document.createElement('input');
     checkbox.type = 'checkbox';
     checkbox.name = 'profile';
     checkbox.value = profile.id;
     checkbox.checked = profile.state !== 'failed';
-    const details = document.createElement('span');
+    checkbox.id = `profile-${profile.id}`;
+    const details = document.createElement('label');
+    details.htmlFor = checkbox.id;
     const name = document.createElement('span');
     name.className = 'account-name';
     name.textContent = profile.name;
@@ -55,8 +65,35 @@ import type { AccountProfileSummary } from '../shared/contracts.js';
     state.className = 'account-state';
     state.dataset.state = profile.state;
     state.textContent = profile.state;
-    label.append(checkbox, details, state);
-    return label;
+    const edit = document.createElement('button');
+    edit.type = 'button';
+    edit.className = 'account-edit ui-button';
+    edit.dataset.variant = 'quiet';
+    edit.textContent = 'Edit…';
+    edit.addEventListener('click', () => showProfileDialog(profile));
+    row.append(checkbox, details, state, edit);
+    return row;
+  }
+
+  const choice = (name: string) =>
+    profileForm.elements.namedItem(name) as RadioNodeList;
+
+  function closeProfileDialog() {
+    profileDialog.close();
+    editing = null;
+  }
+
+  function showProfileDialog(profile: AccountProfileSummary | null) {
+    editing = profile;
+    profileTitle.textContent = profile ? `Edit ${profile.name}` : 'New profile';
+    profileSave.textContent = profile ? 'Save changes' : 'Create profile';
+    profileName.value = profile?.name ?? '';
+    choice('profileBuilds').value = profile?.builds ?? 'shared';
+    choice('profileTemplates').value = profile?.templates ?? 'shared';
+    profileArchive.hidden = !profile || profiles.length < 2;
+    profileArchive.disabled = profile?.state === 'running';
+    profileDialog.showModal();
+    profileName.focus();
   }
 
   async function refresh() {
@@ -78,6 +115,46 @@ import type { AccountProfileSummary } from '../shared/contracts.js';
     const next = !inputs.every((input) => input.checked);
     for (const input of inputs) input.checked = next;
     syncActions();
+  });
+  newProfile.addEventListener('click', () => showProfileDialog(null));
+  required<HTMLButtonElement>('profile-cancel').addEventListener('click', closeProfileDialog);
+  required<HTMLButtonElement>('profile-cancel-x').addEventListener('click', closeProfileDialog);
+  profileForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!profileForm.reportValidity()) return;
+    profileSave.disabled = true;
+    const request = {
+      name: profileName.value.trim(),
+      builds: choice('profileBuilds').value as 'shared' | 'private',
+      templates: choice('profileTemplates').value as 'shared' | 'private',
+    };
+    const updating = editing !== null;
+    try {
+      if (editing) await window.gwNative.accounts.update({ id: editing.id, ...request });
+      else await window.gwNative.accounts.create(request);
+      closeProfileDialog();
+      setStatus(updating ? 'Profile updated.' : 'Profile created.', 'success');
+      await refresh();
+    } catch {
+      setStatus('The profile could not be saved. Check that its name is unique.', 'error');
+    } finally {
+      profileSave.disabled = false;
+    }
+  });
+  profileArchive.addEventListener('click', async () => {
+    const profile = editing;
+    if (!profile || !window.confirm(`Archive “${profile.name}”? Its saved login and files will be kept.`)) return;
+    profileArchive.disabled = true;
+    try {
+      await window.gwNative.accounts.archive(profile.id);
+      closeProfileDialog();
+      setStatus('Profile archived. Its data was kept.', 'success');
+      await refresh();
+    } catch {
+      setStatus('Close the profile before archiving it, then try again.', 'error');
+    } finally {
+      profileArchive.disabled = false;
+    }
   });
   form.addEventListener('submit', async (event) => {
     event.preventDefault();

--- a/src/renderer/accounts.ts
+++ b/src/renderer/accounts.ts
@@ -18,6 +18,8 @@ import type { AccountProfileSummary } from '../shared/contracts.js';
   const newProfile = required<HTMLButtonElement>('accounts-new');
   const status = required<HTMLElement>('accounts-status');
   const single = required<HTMLButtonElement>('accounts-single');
+  const archived = required<HTMLDetailsElement>('accounts-archived');
+  const archivedList = required<HTMLElement>('accounts-archived-list');
   const profileDialog = required<HTMLDialogElement>('profile-dialog');
   const profileForm = required<HTMLFormElement>('profile-form');
   const profileTitle = required<HTMLElement>('profile-dialog-title');
@@ -38,8 +40,9 @@ import type { AccountProfileSummary } from '../shared/contracts.js';
   }
 
   function syncActions() {
+    const inputs = list.querySelectorAll<HTMLInputElement>('input');
     open.disabled = selectedIds().length === 0;
-    const allSelected = profiles.length > 0 && selectedIds().length === profiles.length;
+    const allSelected = inputs.length > 0 && selectedIds().length === inputs.length;
     selectAll.textContent = allSelected ? 'Clear selection' : 'Select all';
   }
 
@@ -50,7 +53,7 @@ import type { AccountProfileSummary } from '../shared/contracts.js';
     checkbox.type = 'checkbox';
     checkbox.name = 'profile';
     checkbox.value = profile.id;
-    checkbox.checked = profile.state !== 'failed';
+    checkbox.checked = false;
     checkbox.id = `profile-${profile.id}`;
     const details = document.createElement('label');
     details.htmlFor = checkbox.id;
@@ -75,6 +78,47 @@ import type { AccountProfileSummary } from '../shared/contracts.js';
     return row;
   }
 
+  function renderArchivedProfile(profile: AccountProfileSummary) {
+    const row = document.createElement('div');
+    row.className = 'archived-profile';
+    const name = document.createElement('strong');
+    name.textContent = profile.name;
+    const restore = document.createElement('button');
+    restore.type = 'button';
+    restore.className = 'ui-button';
+    restore.textContent = 'Restore';
+    restore.addEventListener('click', async () => {
+      restore.disabled = true;
+      try {
+        await window.gwNative.accounts.restore(profile.id);
+        setStatus('Profile restored.', 'success');
+        await refresh();
+      } catch {
+        restore.disabled = false;
+        setStatus('The profile could not be restored.', 'error');
+      }
+    });
+    const remove = document.createElement('button');
+    remove.type = 'button';
+    remove.className = 'ui-button';
+    remove.dataset.variant = 'danger';
+    remove.textContent = 'Delete…';
+    remove.addEventListener('click', async () => {
+      if (!window.confirm(`Permanently delete “${profile.name}”? Its saved login, Guild Wars files, private templates, builds, and window state cannot be recovered.`)) return;
+      remove.disabled = true;
+      try {
+        await window.gwNative.accounts.delete(profile.id);
+        setStatus('Profile permanently deleted.', 'success');
+        await refresh();
+      } catch {
+        remove.disabled = false;
+        setStatus('The profile could not be fully deleted. Try again.', 'error');
+      }
+    });
+    row.append(name, restore, remove);
+    return row;
+  }
+
   const choice = (name: string) =>
     profileForm.elements.namedItem(name) as RadioNodeList;
 
@@ -90,7 +134,8 @@ import type { AccountProfileSummary } from '../shared/contracts.js';
     profileName.value = profile?.name ?? '';
     choice('profileBuilds').value = profile?.builds ?? 'shared';
     choice('profileTemplates').value = profile?.templates ?? 'shared';
-    profileArchive.hidden = !profile || profiles.length < 2;
+    profileArchive.hidden =
+      !profile || profiles.filter((item) => !item.archived).length < 2;
     profileArchive.disabled = profile?.state === 'running';
     profileDialog.showModal();
     profileName.focus();
@@ -101,7 +146,11 @@ import type { AccountProfileSummary } from '../shared/contracts.js';
       const state = await window.gwNative.accounts.get();
       if (state.mode !== 'multi') throw new Error('Multiple Accounts is not active');
       profiles = state.profiles;
-      list.replaceChildren(...profiles.map(renderProfile));
+      const active = profiles.filter((profile) => !profile.archived);
+      const inactive = profiles.filter((profile) => profile.archived);
+      list.replaceChildren(...active.map(renderProfile));
+      archivedList.replaceChildren(...inactive.map(renderArchivedProfile));
+      archived.hidden = inactive.length === 0;
       syncActions();
     } catch {
       list.replaceChildren();

--- a/src/renderer/commands.ts
+++ b/src/renderer/commands.ts
@@ -83,7 +83,15 @@
           }
           fs.syncfs(false, (error?: unknown) => {
             if (error) reject(error);
-            else resolve();
+            else {
+              void import('./template-store.js').then(async ({ exportEntries, templateFilesystem }) => {
+                const templates = templateFilesystem();
+                if (templates) {
+                  await window.gwNative.accounts.saveTemplates(exportEntries(templates));
+                }
+                resolve();
+              }).catch(reject);
+            }
           });
         });
         break;

--- a/src/renderer/filesystem.ts
+++ b/src/renderer/filesystem.ts
@@ -20,7 +20,13 @@ const REQUIRED_DIRECTORIES = [
 ];
 
 type EmscriptenFileSystem = {
-  analyzePath(path: string): { error: number };
+  analyzePath(path: string): { error: number; exists: boolean };
+  readdir(path: string): string[];
+  stat(path: string): { mode: number };
+  isDir(mode: number): boolean;
+  isFile(mode: number): boolean;
+  readFile(path: string, options: { encoding: 'utf8' }): string;
+  writeFile(path: string, data: string): void;
   chdir(path: string): void;
   lookupPath(path: string, options?: unknown): unknown;
   open(path: unknown, ...args: unknown[]): unknown;
@@ -54,10 +60,12 @@ export const installGameFilesystem = ({
   module,
   failed,
   log,
+  restoreTemplates,
 }: {
   module: EmscriptenModule;
   failed(error: unknown): void;
   log(...values: unknown[]): void;
+  restoreTemplates?(fs: EmscriptenFileSystem): Promise<void>;
 }) => {
   module.preRun = () => {
     module.addRunDependency(DEPENDENCY);
@@ -103,6 +111,7 @@ export const installGameFilesystem = ({
             fs.mkdirTree(directory);
           }
           fs.chdir(MOUNT);
+          const persist = () => {
           // Persist the directory invariant before the game can create a
           // template, screenshot, chat log, or diagnostic file beneath it.
           sync(false, (persistError) => {
@@ -144,6 +153,9 @@ export const installGameFilesystem = ({
               ready();
             }
           });
+          };
+          if (restoreTemplates) void restoreTemplates(fs).then(persist).catch(stop);
+          else persist();
         } catch (error) {
           stop(error);
         }

--- a/src/renderer/harness.css
+++ b/src/renderer/harness.css
@@ -294,6 +294,7 @@ html,body { width:100%; height:100%; margin:0; overflow:hidden;
 .settings-panes[data-active="display"] #settings-pane-display,
 .settings-panes[data-active="controls"] #settings-pane-controls,
 .settings-panes[data-active="updates"] #settings-pane-updates,
+.settings-panes[data-active="accounts"] #settings-pane-accounts,
 .settings-panes[data-active="advanced"] #settings-pane-advanced { display: block; }
 
 .sr-only { position:absolute; width:1px; height:1px; margin:-1px; padding:0;

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -927,6 +927,12 @@ function mountGameFilesystem() {
   host.installGameFilesystem({
     module: clientRuntime(),
     log,
+    async restoreTemplates(fs) {
+      const library = await native().accounts.loadTemplates();
+      if (!library) return;
+      const { replaceTemplateProjection } = await import('./template-store.js');
+      await replaceTemplateProjection(fs, library.entries);
+    },
     failed(error) {
       window.gwDiagnostics?.event('filesystem.persistenceFailed', error);
       log(

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -572,8 +572,9 @@
                  aria-labelledby="settings-tab-accounts">
           <h3 class="settings-pane-title">Multiple Accounts</h3>
           <p class="settings-pane-intro">Opt in to an account picker that can open several independent Guild Wars windows.</p>
-          <p class="settings-status">Single Account mode is active.</p>
+          <p id="accounts-mode-status" class="settings-status">Checking account mode…</p>
           <p class="settings-note">Your current window, saved login, settings, templates, and builds stay in Single Account mode. Multiple Accounts creates a separate workspace and asks you to sign in once for each profile.</p>
+          <div id="accounts-single-setup">
           <div class="settings-divider" aria-hidden="true"></div>
           <label class="settings-field" for="accounts-first-name">
             <span>First profile name</span>
@@ -603,6 +604,7 @@
             <button type="button" id="accounts-enable" class="ui-button" data-variant="primary">Enable and Restart…</button>
           </div>
           <p id="accounts-setup-status" class="settings-status" role="status" aria-live="polite"></p>
+          </div>
         </section>
       </div>
     </div>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -269,6 +269,9 @@
         <button type="button" class="settings-rtab" id="settings-tab-updates"
                 role="tab" aria-selected="false" aria-controls="settings-pane-updates"
                 data-pane="updates">Updates</button>
+        <button type="button" class="settings-rtab" id="settings-tab-accounts"
+                role="tab" aria-selected="false" aria-controls="settings-pane-accounts"
+                data-pane="accounts">Accounts</button>
         <button type="button" class="settings-rtab" id="settings-tab-advanced"
                 role="tab" aria-selected="false" aria-controls="settings-pane-advanced"
                 data-pane="advanced">Advanced</button>
@@ -563,6 +566,43 @@
             Reset GWonMac settings…
           </button>
           <p class="settings-danger-sub">Restores display, tools, window position, and launcher choices. Downloaded game data and your login are kept.</p>
+        </section>
+
+        <section class="settings-pane" id="settings-pane-accounts" role="tabpanel"
+                 aria-labelledby="settings-tab-accounts">
+          <h3 class="settings-pane-title">Multiple Accounts</h3>
+          <p class="settings-pane-intro">Opt in to an account picker that can open several independent Guild Wars windows.</p>
+          <p class="settings-status">Single Account mode is active.</p>
+          <p class="settings-note">Your current window, saved login, settings, templates, and builds stay in Single Account mode. Multiple Accounts creates a separate workspace and asks you to sign in once for each profile.</p>
+          <div class="settings-divider" aria-hidden="true"></div>
+          <label class="settings-field" for="accounts-first-name">
+            <span>First profile name</span>
+            <input type="text" id="accounts-first-name" class="ui-input"
+                   maxlength="48" autocomplete="off" placeholder="Main account">
+          </label>
+          <fieldset>
+            <legend>Build library</legend>
+            <div class="settings-seg ui-segment" role="presentation">
+              <label class="settings-radio"><input type="radio" name="accountsBuilds" value="shared" checked><span>Shared</span></label>
+              <label class="settings-radio"><input type="radio" name="accountsBuilds" value="private"><span>Private</span></label>
+            </div>
+          </fieldset>
+          <fieldset>
+            <legend>Build templates</legend>
+            <div class="settings-seg ui-segment" role="presentation">
+              <label class="settings-radio"><input type="radio" name="accountsTemplates" value="shared" checked><span>Shared</span></label>
+              <label class="settings-radio"><input type="radio" name="accountsTemplates" value="private"><span>Private</span></label>
+            </div>
+          </fieldset>
+          <label class="settings-check ui-check">
+            <input type="checkbox" id="accounts-import-builds">
+            <span>Copy my current build library into the new workspace</span>
+          </label>
+          <p class="settings-note">This is a one-time copy. Single Account data is never moved, linked, or written back.</p>
+          <div class="settings-actions-row">
+            <button type="button" id="accounts-enable" class="ui-button" data-variant="primary">Enable and Restart…</button>
+          </div>
+          <p id="accounts-setup-status" class="settings-status" role="status" aria-live="polite"></p>
         </section>
       </div>
     </div>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -576,6 +576,7 @@
           <p class="settings-note">Your current window, saved login, settings, templates, and builds stay in Single Account mode. Multiple Accounts creates a separate workspace and asks you to sign in once for each profile.</p>
           <div id="accounts-single-setup">
           <div class="settings-divider" aria-hidden="true"></div>
+          <div id="accounts-new-workspace-fields">
           <label class="settings-field" for="accounts-first-name">
             <span>First profile name</span>
             <input type="text" id="accounts-first-name" class="ui-input"
@@ -599,7 +600,12 @@
             <input type="checkbox" id="accounts-import-builds">
             <span>Copy my current build library into the new workspace</span>
           </label>
+          <label class="settings-check ui-check">
+            <input type="checkbox" id="accounts-import-templates">
+            <span>Copy my current Guild Wars build templates into the new workspace</span>
+          </label>
           <p class="settings-note">This is a one-time copy. Single Account data is never moved, linked, or written back.</p>
+          </div>
           <div class="settings-actions-row">
             <button type="button" id="accounts-enable" class="ui-button" data-variant="primary">Enable and Restart…</button>
           </div>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -571,16 +571,23 @@
         <section class="settings-pane" id="settings-pane-accounts" role="tabpanel"
                  aria-labelledby="settings-tab-accounts">
           <h3 class="settings-pane-title">Multiple Accounts</h3>
-          <p class="settings-pane-intro">Opt in to an account picker that can open several independent Guild Wars windows.</p>
+          <p class="settings-pane-intro">Open several independent Guild Wars accounts, each in its own window.</p>
           <p id="accounts-mode-status" class="settings-status">Checking account mode…</p>
-          <p class="settings-note">Your current window, saved login, settings, templates, and builds stay in Single Account mode. Multiple Accounts creates a separate workspace and asks you to sign in once for each profile.</p>
+          <p class="settings-note">Your current window, saved login, settings, templates, and builds stay in Single Account mode. Multiple Accounts creates a separate workspace and asks you to sign in once for each account.</p>
+          <div id="accounts-multi-active" hidden>
+            <div class="settings-divider" aria-hidden="true"></div>
+            <p class="settings-note">Login, game settings, screenshots, chat logs, and Single Account data are never shared. Returning to Single Account restarts GWonMac and preserves both workspaces.</p>
+            <div class="settings-actions-row">
+              <button type="button" id="accounts-return-single" class="ui-button">Return to Single Account…</button>
+            </div>
+          </div>
           <div id="accounts-single-setup">
           <div class="settings-divider" aria-hidden="true"></div>
           <div id="accounts-new-workspace-fields">
           <label class="settings-field" for="accounts-first-name">
-            <span>First profile name</span>
+            <span>First account name</span>
             <input type="text" id="accounts-first-name" class="ui-input"
-                   maxlength="48" autocomplete="off" placeholder="Main account">
+                   maxlength="48" autocomplete="off" placeholder="Main">
           </label>
           <fieldset>
             <legend>Build library</legend>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -589,41 +589,12 @@
             </div>
           </div>
           <div id="accounts-single-setup">
-          <div class="settings-divider" aria-hidden="true"></div>
-          <div id="accounts-new-workspace-fields">
-          <label class="settings-field" for="accounts-first-name">
-            <span>First account name</span>
-            <input type="text" id="accounts-first-name" class="ui-input"
-                   maxlength="48" autocomplete="off" placeholder="Main">
-          </label>
-          <fieldset>
-            <legend>Build library</legend>
-            <div class="settings-seg ui-segment" role="presentation">
-              <label class="settings-radio"><input type="radio" name="accountsBuilds" value="shared" checked><span>Shared</span></label>
-              <label class="settings-radio"><input type="radio" name="accountsBuilds" value="private"><span>Private</span></label>
+            <div class="settings-divider" aria-hidden="true"></div>
+            <p class="settings-note">GWonMac restarts into the Account Picker. Create and manage every account there, including any one-time copy into your first account.</p>
+            <div class="settings-actions-row">
+              <button type="button" id="accounts-enable" class="ui-button" data-variant="primary">Enable and Restart…</button>
             </div>
-          </fieldset>
-          <fieldset>
-            <legend>Build templates</legend>
-            <div class="settings-seg ui-segment" role="presentation">
-              <label class="settings-radio"><input type="radio" name="accountsTemplates" value="shared" checked><span>Shared</span></label>
-              <label class="settings-radio"><input type="radio" name="accountsTemplates" value="private"><span>Private</span></label>
-            </div>
-          </fieldset>
-          <label class="settings-check ui-check">
-            <input type="checkbox" id="accounts-import-builds">
-            <span>Copy my current build library into the new workspace</span>
-          </label>
-          <label class="settings-check ui-check">
-            <input type="checkbox" id="accounts-import-templates">
-            <span>Copy my current Guild Wars build templates into the new workspace</span>
-          </label>
-          <p class="settings-note">This is a one-time copy. Single Account data is never moved, linked, or written back.</p>
-          </div>
-          <div class="settings-actions-row">
-            <button type="button" id="accounts-enable" class="ui-button" data-variant="primary">Enable and Restart…</button>
-          </div>
-          <p id="accounts-setup-status" class="settings-status" role="status" aria-live="polite"></p>
+            <p id="accounts-setup-status" class="settings-status" role="status" aria-live="polite"></p>
           </div>
         </section>
       </div>

--- a/src/renderer/settings.ts
+++ b/src/renderer/settings.ts
@@ -52,6 +52,8 @@
   const accountsStatus = byId('accounts-setup-status');
   const accountsModeStatus = byId('accounts-mode-status');
   const accountsSingleSetup = byId('accounts-single-setup');
+  const accountsMultiActive = byId('accounts-multi-active');
+  const accountsReturnSingle = byId('accounts-return-single') as HTMLButtonElement;
   const accountsNewWorkspaceFields = byId('accounts-new-workspace-fields');
   /**
    * The appearance slider beside the `output` that reads it back.
@@ -606,16 +608,29 @@
     }
   });
 
+  accountsReturnSingle.addEventListener('click', async () => {
+    if (!window.confirm('Return to Single Account mode? GWonMac will restart. Multiple Accounts and Single Account data will both be preserved.')) return;
+    accountsReturnSingle.disabled = true;
+    accountsModeStatus.textContent = 'Restarting in Single Account mode…';
+    try {
+      await window.gwNative.accounts.useSingle();
+    } catch {
+      accountsReturnSingle.disabled = false;
+      accountsModeStatus.textContent = 'The mode change could not be saved. Nothing changed.';
+    }
+  });
+
   void window.gwNative.accounts.get().then((state) => {
     const singleMode = state.mode === 'single';
     const activeProfiles = state.profiles.filter((profile) => !profile.archived);
     const existingWorkspace = singleMode && activeProfiles.length > 0;
     accountsModeStatus.textContent = existingWorkspace
-      ? `Single Account mode is active. Your ${activeProfiles.length} Multiple Accounts ${activeProfiles.length === 1 ? 'profile is' : 'profiles are'} ready to restore.`
+      ? `Single Account mode is active. Your ${activeProfiles.length} Multiple Accounts ${activeProfiles.length === 1 ? 'account is' : 'accounts are'} ready to restore.`
       : singleMode
         ? 'Single Account mode is active.'
-      : 'Multiple Accounts mode is active. Use the Account Picker to manage profiles or return to Single Account mode.';
+      : 'Multiple Accounts mode is active. Use the Account Picker to open and manage accounts.';
     accountsSingleSetup.hidden = !singleMode;
+    accountsMultiActive.hidden = singleMode;
     if (existingWorkspace) {
       accountsName.value = activeProfiles[0]?.name ?? 'Account';
       accountsNewWorkspaceFields.hidden = true;
@@ -624,6 +639,7 @@
   }).catch(() => {
     accountsModeStatus.textContent = 'Account mode could not be read.';
     accountsSingleSetup.hidden = true;
+    accountsMultiActive.hidden = true;
   });
 
   window.addEventListener('resize', updateRenderScaleDimensions);

--- a/src/renderer/settings.ts
+++ b/src/renderer/settings.ts
@@ -43,6 +43,12 @@
   const gwonmacTools = form.elements.namedItem('gwonmacTools') as HTMLInputElement;
   const teamManagement = form.elements.namedItem('teamManagement') as HTMLInputElement;
   const targetReadout = form.elements.namedItem('targetReadout') as HTMLInputElement;
+  const accountsName = byId('accounts-first-name') as HTMLInputElement;
+  const accountsBuilds = form.elements.namedItem('accountsBuilds') as RadioNodeList;
+  const accountsTemplates = form.elements.namedItem('accountsTemplates') as RadioNodeList;
+  const accountsImportBuilds = byId('accounts-import-builds') as HTMLInputElement;
+  const accountsEnable = byId('accounts-enable') as HTMLButtonElement;
+  const accountsStatus = byId('accounts-setup-status');
   /**
    * The appearance slider beside the `output` that reads it back.
    *
@@ -561,6 +567,30 @@
       );
     } catch {
       setFeedback('GWonMac settings could not be reset. Nothing changed; try again.', 'error');
+    }
+  });
+
+  accountsEnable.addEventListener('click', async () => {
+    const name = accountsName.value.trim();
+    if (!name) {
+      accountsName.focus();
+      accountsStatus.textContent = 'Give the first profile a name.';
+      return;
+    }
+    if (!window.confirm('Enable Multiple Accounts and restart GWonMac? Your current Single Account data will stay untouched.')) return;
+    accountsEnable.disabled = true;
+    accountsStatus.textContent = 'Creating the separate workspace…';
+    try {
+      await window.gwNative.accounts.setup({
+        name,
+        templates: accountsTemplates.value as 'shared' | 'private',
+        builds: accountsBuilds.value as 'shared' | 'private',
+        importTemplates: false,
+        importBuilds: accountsImportBuilds.checked,
+      });
+    } catch {
+      accountsEnable.disabled = false;
+      accountsStatus.textContent = 'Multiple Accounts could not be enabled. Nothing changed.';
     }
   });
 

--- a/src/renderer/settings.ts
+++ b/src/renderer/settings.ts
@@ -43,18 +43,12 @@
   const gwonmacTools = form.elements.namedItem('gwonmacTools') as HTMLInputElement;
   const teamManagement = form.elements.namedItem('teamManagement') as HTMLInputElement;
   const targetReadout = form.elements.namedItem('targetReadout') as HTMLInputElement;
-  const accountsName = byId('accounts-first-name') as HTMLInputElement;
-  const accountsBuilds = form.elements.namedItem('accountsBuilds') as RadioNodeList;
-  const accountsTemplates = form.elements.namedItem('accountsTemplates') as RadioNodeList;
-  const accountsImportBuilds = byId('accounts-import-builds') as HTMLInputElement;
-  const accountsImportTemplates = byId('accounts-import-templates') as HTMLInputElement;
   const accountsEnable = byId('accounts-enable') as HTMLButtonElement;
   const accountsStatus = byId('accounts-setup-status');
   const accountsModeStatus = byId('accounts-mode-status');
   const accountsSingleSetup = byId('accounts-single-setup');
   const accountsMultiActive = byId('accounts-multi-active');
   const accountsReturnSingle = byId('accounts-return-single') as HTMLButtonElement;
-  const accountsNewWorkspaceFields = byId('accounts-new-workspace-fields');
   /**
    * The appearance slider beside the `output` that reads it back.
    *
@@ -592,30 +586,14 @@
   });
 
   accountsEnable.addEventListener('click', async () => {
-    const name = accountsName.value.trim();
-    if (!name) {
-      accountsName.focus();
-      accountsStatus.textContent = 'Give the first profile a name.';
-      return;
-    }
     if (!window.confirm('Enable Multiple Accounts and restart GWonMac? Your current Single Account data will stay untouched.')) return;
     accountsEnable.disabled = true;
     accountsStatus.textContent = 'Creating the separate workspace…';
     try {
-      let templateEntries: import('../shared/contracts.js').TemplateExportEntry[] = [];
-      if (accountsImportTemplates.checked) {
-        const { exportEntries, templateFilesystem } = await import('./template-store.js');
-        const filesystem = templateFilesystem();
-        if (!filesystem) throw new Error('template filesystem is unavailable');
-        templateEntries = exportEntries(filesystem);
-      }
+      const { exportEntries, templateFilesystem } = await import('./template-store.js');
+      const filesystem = templateFilesystem();
       await window.gwNative.accounts.setup({
-        name,
-        templates: accountsTemplates.value as 'shared' | 'private',
-        builds: accountsBuilds.value as 'shared' | 'private',
-        importTemplates: accountsImportTemplates.checked,
-        templateEntries,
-        importBuilds: accountsImportBuilds.checked,
+        templateEntries: filesystem ? exportEntries(filesystem) : [],
       });
     } catch {
       accountsEnable.disabled = false;
@@ -647,8 +625,6 @@
     accountsSingleSetup.hidden = !singleMode;
     accountsMultiActive.hidden = singleMode;
     if (existingWorkspace) {
-      accountsName.value = activeProfiles[0]?.name ?? 'Account';
-      accountsNewWorkspaceFields.hidden = true;
       accountsEnable.textContent = 'Restore Multiple Accounts and Restart…';
     }
   }).catch(() => {

--- a/src/renderer/settings.ts
+++ b/src/renderer/settings.ts
@@ -49,6 +49,8 @@
   const accountsImportBuilds = byId('accounts-import-builds') as HTMLInputElement;
   const accountsEnable = byId('accounts-enable') as HTMLButtonElement;
   const accountsStatus = byId('accounts-setup-status');
+  const accountsModeStatus = byId('accounts-mode-status');
+  const accountsSingleSetup = byId('accounts-single-setup');
   /**
    * The appearance slider beside the `output` that reads it back.
    *
@@ -592,6 +594,17 @@
       accountsEnable.disabled = false;
       accountsStatus.textContent = 'Multiple Accounts could not be enabled. Nothing changed.';
     }
+  });
+
+  void window.gwNative.accounts.get().then((state) => {
+    const singleMode = state.mode === 'single';
+    accountsModeStatus.textContent = singleMode
+      ? 'Single Account mode is active.'
+      : 'Multiple Accounts mode is active. Use the Account Picker to manage profiles or return to Single Account mode.';
+    accountsSingleSetup.hidden = !singleMode;
+  }).catch(() => {
+    accountsModeStatus.textContent = 'Account mode could not be read.';
+    accountsSingleSetup.hidden = true;
   });
 
   window.addEventListener('resize', updateRenderScaleDimensions);

--- a/src/renderer/settings.ts
+++ b/src/renderer/settings.ts
@@ -47,10 +47,12 @@
   const accountsBuilds = form.elements.namedItem('accountsBuilds') as RadioNodeList;
   const accountsTemplates = form.elements.namedItem('accountsTemplates') as RadioNodeList;
   const accountsImportBuilds = byId('accounts-import-builds') as HTMLInputElement;
+  const accountsImportTemplates = byId('accounts-import-templates') as HTMLInputElement;
   const accountsEnable = byId('accounts-enable') as HTMLButtonElement;
   const accountsStatus = byId('accounts-setup-status');
   const accountsModeStatus = byId('accounts-mode-status');
   const accountsSingleSetup = byId('accounts-single-setup');
+  const accountsNewWorkspaceFields = byId('accounts-new-workspace-fields');
   /**
    * The appearance slider beside the `output` that reads it back.
    *
@@ -583,11 +585,19 @@
     accountsEnable.disabled = true;
     accountsStatus.textContent = 'Creating the separate workspace…';
     try {
+      let templateEntries: import('../shared/contracts.js').TemplateExportEntry[] = [];
+      if (accountsImportTemplates.checked) {
+        const { exportEntries, templateFilesystem } = await import('./template-store.js');
+        const filesystem = templateFilesystem();
+        if (!filesystem) throw new Error('template filesystem is unavailable');
+        templateEntries = exportEntries(filesystem);
+      }
       await window.gwNative.accounts.setup({
         name,
         templates: accountsTemplates.value as 'shared' | 'private',
         builds: accountsBuilds.value as 'shared' | 'private',
-        importTemplates: false,
+        importTemplates: accountsImportTemplates.checked,
+        templateEntries,
         importBuilds: accountsImportBuilds.checked,
       });
     } catch {
@@ -598,10 +608,19 @@
 
   void window.gwNative.accounts.get().then((state) => {
     const singleMode = state.mode === 'single';
-    accountsModeStatus.textContent = singleMode
-      ? 'Single Account mode is active.'
+    const activeProfiles = state.profiles.filter((profile) => !profile.archived);
+    const existingWorkspace = singleMode && activeProfiles.length > 0;
+    accountsModeStatus.textContent = existingWorkspace
+      ? `Single Account mode is active. Your ${activeProfiles.length} Multiple Accounts ${activeProfiles.length === 1 ? 'profile is' : 'profiles are'} ready to restore.`
+      : singleMode
+        ? 'Single Account mode is active.'
       : 'Multiple Accounts mode is active. Use the Account Picker to manage profiles or return to Single Account mode.';
     accountsSingleSetup.hidden = !singleMode;
+    if (existingWorkspace) {
+      accountsName.value = activeProfiles[0]?.name ?? 'Account';
+      accountsNewWorkspaceFields.hidden = true;
+      accountsEnable.textContent = 'Restore Multiple Accounts and Restart…';
+    }
   }).catch(() => {
     accountsModeStatus.textContent = 'Account mode could not be read.';
     accountsSingleSetup.hidden = true;

--- a/src/renderer/template-store.ts
+++ b/src/renderer/template-store.ts
@@ -324,6 +324,46 @@ export async function applyImport(
   });
 }
 
+/** Replace the isolated profile's working templates with a canonical snapshot. */
+export async function replaceTemplateProjection(
+  fs: TemplateFileSystem,
+  entries: readonly TemplateExportEntry[],
+): Promise<void> {
+  const incoming: TemplateCandidate[] = entries.map((entry) => {
+    const segments = entry.path.split('/');
+    const kind: TemplateKind = segments[0] === 'Equipment' ? 'equipment' : 'skills';
+    const file = segments.at(-1) ?? '';
+    const name = file.replace(/\.txt$/i, '');
+    const folder = segments.length === 3 ? (segments[1] ?? null) : null;
+    const candidate = { kind, folder, name, code: entry.contents };
+    if (templatePath(candidate) === null || !isTemplateCode(candidate.code)) {
+      throw new Error('invalid account template projection');
+    }
+    return candidate;
+  });
+  await mutate(fs, () => {
+    for (const directory of Object.values(TEMPLATE_DIRECTORIES)) {
+      for (const item of listing(fs, directory)) {
+        const itemPath = `${directory}/${item}`;
+        if (isDirectory(fs, itemPath)) {
+          for (const child of listing(fs, itemPath)) {
+            const childPath = `${itemPath}/${child}`;
+            if (fs.isFile(fs.stat(childPath).mode)) fs.unlink(childPath);
+          }
+          try { fs.rmdir(itemPath); } catch { /* Keep unmanaged contents. */ }
+        } else if (fs.isFile(fs.stat(itemPath).mode)) {
+          fs.unlink(itemPath);
+        }
+      }
+    }
+    for (const candidate of incoming) {
+      const filePath = templatePath(candidate)!;
+      fs.mkdirTree(filePath.slice(0, filePath.lastIndexOf('/')));
+      fs.writeFile(filePath, candidate.code);
+    }
+  });
+}
+
 /**
  * Templates the game has no way to reach.
  *

--- a/src/shared/accounts-contracts.ts
+++ b/src/shared/accounts-contracts.ts
@@ -1,4 +1,7 @@
-/** Renderer/main value contracts owned by the Multiple Accounts feature. */
+/**
+ * Renderer/main value contracts owned by the Multiple Accounts feature.
+ * Durable workspace documents remain in `multiple-accounts.ts`.
+ */
 import type {
   AccountMode,
   LibraryScope,

--- a/src/shared/accounts-contracts.ts
+++ b/src/shared/accounts-contracts.ts
@@ -1,0 +1,61 @@
+/** Renderer/main value contracts owned by the Multiple Accounts feature. */
+import type {
+  AccountMode,
+  LibraryScope,
+  ProfileId,
+} from "./multiple-accounts.js";
+import type { TemplateExportEntry } from "./template-contracts.js";
+
+export type MultiProfileRuntimeState =
+  | "ready"
+  | "queued"
+  | "opening"
+  | "checking"
+  | "running"
+  | "failed";
+
+export type AccountLaunchIssue =
+  | "profile-preparation"
+  | "window-startup"
+  | "client-validation"
+  | "renderer-crash"
+  | "unknown";
+
+export interface AccountProfileSummary {
+  readonly id: ProfileId;
+  readonly name: string;
+  readonly templates: LibraryScope;
+  readonly builds: LibraryScope;
+  readonly archived: boolean;
+  readonly state: MultiProfileRuntimeState;
+  readonly launchIssue?: AccountLaunchIssue;
+}
+
+export interface AccountsState {
+  readonly mode: AccountMode;
+  readonly profiles: readonly AccountProfileSummary[];
+}
+
+export interface AccountsSetupRequest {
+  readonly templateEntries: readonly TemplateExportEntry[];
+}
+
+export interface AccountTemplateLibrary {
+  readonly revision: number;
+  readonly entries: readonly TemplateExportEntry[];
+}
+
+export interface AccountProfileRequest {
+  readonly name: string;
+  readonly templates: LibraryScope;
+  readonly builds: LibraryScope;
+}
+
+export interface AccountProfileCreateRequest extends AccountProfileRequest {
+  readonly copySingleBuilds: boolean;
+  readonly copySingleTemplates: boolean;
+}
+
+export interface AccountProfileUpdateRequest extends AccountProfileRequest {
+  readonly id: ProfileId;
+}

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -25,6 +25,11 @@ import type {
 import type { ErrorCode } from "./errors.js";
 import type { BuildLibrary } from "./builds/library.js";
 import type {
+  AccountMode,
+  LibraryScope,
+  ProfileId,
+} from "./multiple-accounts.js";
+import type {
   EnhancementProgram,
   EnhancementSelection,
 } from "./enhancement-contracts.js";
@@ -597,6 +602,34 @@ export interface RendererInit {
   templateFsTrace: boolean;
 }
 
+export type MultiProfileRuntimeState =
+  | "ready"
+  | "queued"
+  | "opening"
+  | "running"
+  | "failed";
+
+export interface AccountProfileSummary {
+  readonly id: ProfileId;
+  readonly name: string;
+  readonly templates: LibraryScope;
+  readonly builds: LibraryScope;
+  readonly state: MultiProfileRuntimeState;
+}
+
+export interface AccountsState {
+  readonly mode: AccountMode;
+  readonly profiles: readonly AccountProfileSummary[];
+}
+
+export interface AccountsSetupRequest {
+  readonly name: string;
+  readonly templates: LibraryScope;
+  readonly builds: LibraryScope;
+  readonly importTemplates: boolean;
+  readonly importBuilds: boolean;
+}
+
 /**
  * Prefix of the single `webPreferences.additionalArguments` entry that carries
  * a JSON `RendererInit`. The preload is the only reader.
@@ -722,6 +755,10 @@ export const IPC = {
   appUpdatesCheck: "gw:appUpdates:check",
   appUpdatesRestartAndInstall: "gw:appUpdates:restartAndInstall",
   appUpdatesState: "gw:appUpdates:state",
+  accountsGet: "gw:accounts:get",
+  accountsSetup: "gw:accounts:setup",
+  accountsOpen: "gw:accounts:open",
+  accountsUseSingle: "gw:accounts:useSingle",
 } as const;
 
 export type IpcChannel = (typeof IPC)[keyof typeof IPC];
@@ -897,5 +934,11 @@ export interface GwNativeApi {
     check(): Promise<void>;
     restartAndInstall(): Promise<void>;
     onState(callback: (state: AppUpdateState) => void): () => void;
+  };
+  accounts: {
+    get(): Promise<AccountsState>;
+    setup(value: AccountsSetupRequest): Promise<void>;
+    open(profileIds: readonly ProfileId[]): Promise<void>;
+    useSingle(): Promise<void>;
   };
 }

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -639,12 +639,7 @@ export interface AccountsState {
 }
 
 export interface AccountsSetupRequest {
-  readonly name: string;
-  readonly templates: LibraryScope;
-  readonly builds: LibraryScope;
-  readonly importTemplates: boolean;
   readonly templateEntries: readonly TemplateExportEntry[];
-  readonly importBuilds: boolean;
 }
 
 export interface AccountTemplateLibrary {
@@ -656,6 +651,11 @@ export interface AccountProfileRequest {
   readonly name: string;
   readonly templates: LibraryScope;
   readonly builds: LibraryScope;
+}
+
+export interface AccountProfileCreateRequest extends AccountProfileRequest {
+  readonly copySingleBuilds: boolean;
+  readonly copySingleTemplates: boolean;
 }
 
 export interface AccountProfileUpdateRequest extends AccountProfileRequest {
@@ -981,7 +981,7 @@ export interface GwNativeApi {
     get(): Promise<AccountsState>;
     setup(value: AccountsSetupRequest): Promise<void>;
     open(profileIds: readonly ProfileId[]): Promise<void>;
-    create(value: AccountProfileRequest): Promise<AccountsState>;
+    create(value: AccountProfileCreateRequest): Promise<AccountsState>;
     update(value: AccountProfileUpdateRequest): Promise<AccountsState>;
     archive(profileId: ProfileId): Promise<AccountsState>;
     restore(profileId: ProfileId): Promise<AccountsState>;

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -614,6 +614,7 @@ export interface AccountProfileSummary {
   readonly name: string;
   readonly templates: LibraryScope;
   readonly builds: LibraryScope;
+  readonly archived: boolean;
   readonly state: MultiProfileRuntimeState;
 }
 
@@ -627,7 +628,13 @@ export interface AccountsSetupRequest {
   readonly templates: LibraryScope;
   readonly builds: LibraryScope;
   readonly importTemplates: boolean;
+  readonly templateEntries: readonly TemplateExportEntry[];
   readonly importBuilds: boolean;
+}
+
+export interface AccountTemplateLibrary {
+  readonly revision: number;
+  readonly entries: readonly TemplateExportEntry[];
 }
 
 export interface AccountProfileRequest {
@@ -771,6 +778,10 @@ export const IPC = {
   accountsCreate: "gw:accounts:create",
   accountsUpdate: "gw:accounts:update",
   accountsArchive: "gw:accounts:archive",
+  accountsRestore: "gw:accounts:restore",
+  accountsDelete: "gw:accounts:delete",
+  accountsTemplatesLoad: "gw:accounts:templatesLoad",
+  accountsTemplatesSave: "gw:accounts:templatesSave",
   accountsUseSingle: "gw:accounts:useSingle",
 } as const;
 
@@ -955,6 +966,10 @@ export interface GwNativeApi {
     create(value: AccountProfileRequest): Promise<AccountsState>;
     update(value: AccountProfileUpdateRequest): Promise<AccountsState>;
     archive(profileId: ProfileId): Promise<AccountsState>;
+    restore(profileId: ProfileId): Promise<AccountsState>;
+    delete(profileId: ProfileId): Promise<AccountsState>;
+    loadTemplates(): Promise<AccountTemplateLibrary | null>;
+    saveTemplates(entries: readonly TemplateExportEntry[]): Promise<void>;
     useSingle(): Promise<void>;
   };
 }

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -606,8 +606,16 @@ export type MultiProfileRuntimeState =
   | "ready"
   | "queued"
   | "opening"
+  | "checking"
   | "running"
   | "failed";
+
+export type AccountLaunchIssue =
+  | "profile-preparation"
+  | "window-startup"
+  | "client-validation"
+  | "renderer-crash"
+  | "unknown";
 
 export interface AccountProfileSummary {
   readonly id: ProfileId;
@@ -616,6 +624,7 @@ export interface AccountProfileSummary {
   readonly builds: LibraryScope;
   readonly archived: boolean;
   readonly state: MultiProfileRuntimeState;
+  readonly launchIssue?: AccountLaunchIssue;
 }
 
 export interface AccountsState {

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -630,6 +630,16 @@ export interface AccountsSetupRequest {
   readonly importBuilds: boolean;
 }
 
+export interface AccountProfileRequest {
+  readonly name: string;
+  readonly templates: LibraryScope;
+  readonly builds: LibraryScope;
+}
+
+export interface AccountProfileUpdateRequest extends AccountProfileRequest {
+  readonly id: ProfileId;
+}
+
 /**
  * Prefix of the single `webPreferences.additionalArguments` entry that carries
  * a JSON `RendererInit`. The preload is the only reader.
@@ -758,6 +768,9 @@ export const IPC = {
   accountsGet: "gw:accounts:get",
   accountsSetup: "gw:accounts:setup",
   accountsOpen: "gw:accounts:open",
+  accountsCreate: "gw:accounts:create",
+  accountsUpdate: "gw:accounts:update",
+  accountsArchive: "gw:accounts:archive",
   accountsUseSingle: "gw:accounts:useSingle",
 } as const;
 
@@ -939,6 +952,9 @@ export interface GwNativeApi {
     get(): Promise<AccountsState>;
     setup(value: AccountsSetupRequest): Promise<void>;
     open(profileIds: readonly ProfileId[]): Promise<void>;
+    create(value: AccountProfileRequest): Promise<AccountsState>;
+    update(value: AccountProfileUpdateRequest): Promise<AccountsState>;
+    archive(profileId: ProfileId): Promise<AccountsState>;
     useSingle(): Promise<void>;
   };
 }

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -24,11 +24,15 @@ import type {
 } from "./diagnostics.js";
 import type { ErrorCode } from "./errors.js";
 import type { BuildLibrary } from "./builds/library.js";
+import type { ProfileId } from "./multiple-accounts.js";
+import type { TemplateExportEntry } from "./template-contracts.js";
 import type {
-  AccountMode,
-  LibraryScope,
-  ProfileId,
-} from "./multiple-accounts.js";
+  AccountProfileCreateRequest,
+  AccountProfileUpdateRequest,
+  AccountsSetupRequest,
+  AccountsState,
+  AccountTemplateLibrary,
+} from "./accounts-contracts.js";
 import type {
   EnhancementProgram,
   EnhancementSelection,
@@ -43,6 +47,18 @@ import {
 export { RELEASE_REPO } from "./project-identity.js";
 export { DEFAULT_UPDATE_TRACK, UPDATE_TRACKS };
 export type { UpdateTrack };
+export type { TemplateExportEntry } from "./template-contracts.js";
+export type {
+  AccountLaunchIssue,
+  AccountProfileCreateRequest,
+  AccountProfileRequest,
+  AccountProfileSummary,
+  AccountProfileUpdateRequest,
+  AccountsSetupRequest,
+  AccountsState,
+  AccountTemplateLibrary,
+  MultiProfileRuntimeState,
+} from "./accounts-contracts.js";
 
 export type BuildKind = "jspi";
 
@@ -102,11 +118,6 @@ export const TEMPLATE_CEILINGS = {
  * lands. `contents` is the code alone — the game writes no trailing newline and
  * a file that gains one stops being the same file.
  */
-export interface TemplateExportEntry {
-  path: string;
-  contents: string;
-}
-
 /**
  * How an export ended. A value rather than a rejection for the same reason
  * `FullDownloadOutcome` is one: Electron flattens a rejection to its message,
@@ -606,60 +617,6 @@ export interface RendererInit {
   enhancementSelection: EnhancementSelection;
   /** Template filesystem syscall trace. Unpackaged builds only. */
   templateFsTrace: boolean;
-}
-
-export type MultiProfileRuntimeState =
-  | "ready"
-  | "queued"
-  | "opening"
-  | "checking"
-  | "running"
-  | "failed";
-
-export type AccountLaunchIssue =
-  | "profile-preparation"
-  | "window-startup"
-  | "client-validation"
-  | "renderer-crash"
-  | "unknown";
-
-export interface AccountProfileSummary {
-  readonly id: ProfileId;
-  readonly name: string;
-  readonly templates: LibraryScope;
-  readonly builds: LibraryScope;
-  readonly archived: boolean;
-  readonly state: MultiProfileRuntimeState;
-  readonly launchIssue?: AccountLaunchIssue;
-}
-
-export interface AccountsState {
-  readonly mode: AccountMode;
-  readonly profiles: readonly AccountProfileSummary[];
-}
-
-export interface AccountsSetupRequest {
-  readonly templateEntries: readonly TemplateExportEntry[];
-}
-
-export interface AccountTemplateLibrary {
-  readonly revision: number;
-  readonly entries: readonly TemplateExportEntry[];
-}
-
-export interface AccountProfileRequest {
-  readonly name: string;
-  readonly templates: LibraryScope;
-  readonly builds: LibraryScope;
-}
-
-export interface AccountProfileCreateRequest extends AccountProfileRequest {
-  readonly copySingleBuilds: boolean;
-  readonly copySingleTemplates: boolean;
-}
-
-export interface AccountProfileUpdateRequest extends AccountProfileRequest {
-  readonly id: ProfileId;
 }
 
 /**

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -693,6 +693,7 @@ export type WasmBridgeMarkers = typeof WASM_BRIDGE_MARKERS;
  */
 export type RendererCommand =
   | { type: "input.reset" }
+  | { type: "accounts.settings.open" }
   | { type: "tools.toggle" }
   | {
       type: "settings.open";

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -19,6 +19,8 @@ export const ERROR_CODES = [
   "bad_compression",
   "bad_digest",
   "bad_manifest",
+  "bad_launcher_mode",
+  "bad_multi_workspace",
   "bad_range",
   "bad_settings",
   "bad_window_state",

--- a/src/shared/multiple-accounts.ts
+++ b/src/shared/multiple-accounts.ts
@@ -39,6 +39,7 @@ const PROFILE_ID_PATTERN =
   /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
 const CONTROL_CHARACTER = /[\p{Cc}\p{Cf}]/u;
 export const PROFILE_NAME_MAX_LENGTH = 48;
+export const MULTI_PROFILE_MAX_COUNT = 16;
 
 function record(value: unknown, owner: string): Record<string, unknown> {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
@@ -94,7 +95,11 @@ export function parseLauncherMode(value: unknown): LauncherModeDocument {
 
 export function parseMultiWorkspace(value: unknown): MultiWorkspace {
   const source = record(value, "Multiple Accounts workspace");
-  if (source.formatVersion !== 1 || !Array.isArray(source.profiles)) {
+  if (
+    source.formatVersion !== 1
+    || !Array.isArray(source.profiles)
+    || source.profiles.length > MULTI_PROFILE_MAX_COUNT
+  ) {
     throw new AppError("bad_multi_workspace", "workspace format or profiles are invalid");
   }
   const ids = new Set<string>();

--- a/src/shared/multiple-accounts.ts
+++ b/src/shared/multiple-accounts.ts
@@ -1,0 +1,126 @@
+/**
+ * The durable vocabulary for the opt-in Multiple Accounts workspace.
+ *
+ * Stable profile IDs authorize native resources, so this module validates
+ * them before main derives a path, partition, or Keychain item. Display names
+ * never carry authority. Runtime launch state is deliberately absent because
+ * the live window registry is its only owner.
+ */
+import { AppError } from "./errors.js";
+
+export const ACCOUNT_MODES = ["single", "multi"] as const;
+export type AccountMode = (typeof ACCOUNT_MODES)[number];
+
+export const LIBRARY_SCOPES = ["shared", "private"] as const;
+export type LibraryScope = (typeof LIBRARY_SCOPES)[number];
+
+declare const PROFILE_ID: unique symbol;
+export type ProfileId = string & { readonly [PROFILE_ID]: true };
+
+export interface LauncherModeDocument {
+  readonly formatVersion: 1;
+  readonly mode: AccountMode;
+}
+
+export interface MultiProfile {
+  readonly id: ProfileId;
+  readonly name: string;
+  readonly archived: boolean;
+  readonly templates: LibraryScope;
+  readonly builds: LibraryScope;
+}
+
+export interface MultiWorkspace {
+  readonly formatVersion: 1;
+  readonly profiles: readonly MultiProfile[];
+}
+
+const PROFILE_ID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/u;
+const CONTROL_CHARACTER = /[\p{Cc}\p{Cf}]/u;
+export const PROFILE_NAME_MAX_LENGTH = 48;
+
+function record(value: unknown, owner: string): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new AppError(owner === "launcher mode" ? "bad_launcher_mode" : "bad_multi_workspace", `${owner} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+export function parseProfileId(value: unknown): ProfileId {
+  if (typeof value !== "string" || !PROFILE_ID_PATTERN.test(value)) {
+    throw new AppError("bad_multi_workspace", "profile id must be a lowercase UUID v4");
+  }
+  return value as ProfileId;
+}
+
+export function parseProfileName(value: unknown): string {
+  if (typeof value !== "string") {
+    throw new AppError("bad_multi_workspace", "profile name must be text");
+  }
+  const name = value.normalize("NFC").trim();
+  if (
+    name.length === 0
+    || name.length > PROFILE_NAME_MAX_LENGTH
+    || CONTROL_CHARACTER.test(name)
+  ) {
+    throw new AppError("bad_multi_workspace", "profile name is empty, too long, or contains a control character");
+  }
+  return name;
+}
+
+/** Duplicate labels would make windows and destructive confirmations unsafe. */
+export function profileNameKey(name: string): string {
+  return name.normalize("NFKC").trim().toLowerCase();
+}
+
+function parseLibraryScope(value: unknown, field: string): LibraryScope {
+  if (value !== "shared" && value !== "private") {
+    throw new AppError("bad_multi_workspace", `profile ${field} must be shared or private`);
+  }
+  return value;
+}
+
+export function parseLauncherMode(value: unknown): LauncherModeDocument {
+  const source = record(value, "launcher mode");
+  if (source.formatVersion !== 1) {
+    throw new AppError("bad_launcher_mode", "launcher mode format is not supported");
+  }
+  if (source.mode !== "single" && source.mode !== "multi") {
+    throw new AppError("bad_launcher_mode", "launcher mode must be single or multi");
+  }
+  return { formatVersion: 1, mode: source.mode };
+}
+
+export function parseMultiWorkspace(value: unknown): MultiWorkspace {
+  const source = record(value, "Multiple Accounts workspace");
+  if (source.formatVersion !== 1 || !Array.isArray(source.profiles)) {
+    throw new AppError("bad_multi_workspace", "workspace format or profiles are invalid");
+  }
+  const ids = new Set<string>();
+  const names = new Set<string>();
+  const profiles = source.profiles.map((raw): MultiProfile => {
+    const profile = record(raw, "Multiple Accounts profile");
+    const id = parseProfileId(profile.id);
+    const name = parseProfileName(profile.name);
+    if (typeof profile.archived !== "boolean") {
+      throw new AppError("bad_multi_workspace", "profile archived must be a boolean");
+    }
+    if (ids.has(id) || names.has(profileNameKey(name))) {
+      throw new AppError("bad_multi_workspace", "profile ids and names must be unique");
+    }
+    ids.add(id);
+    names.add(profileNameKey(name));
+    return {
+      id,
+      name,
+      archived: profile.archived,
+      templates: parseLibraryScope(profile.templates, "templates"),
+      builds: parseLibraryScope(profile.builds, "builds"),
+    };
+  });
+  if (!profiles.some((profile) => !profile.archived)) {
+    throw new AppError("bad_multi_workspace", "workspace needs an active profile");
+  }
+  return { formatVersion: 1, profiles };
+}

--- a/src/shared/multiple-accounts.ts
+++ b/src/shared/multiple-accounts.ts
@@ -124,7 +124,7 @@ export function parseMultiWorkspace(value: unknown): MultiWorkspace {
       builds: parseLibraryScope(profile.builds, "builds"),
     };
   });
-  if (!profiles.some((profile) => !profile.archived)) {
+  if (profiles.length > 0 && !profiles.some((profile) => !profile.archived)) {
     throw new AppError("bad_multi_workspace", "workspace needs an active profile");
   }
   return { formatVersion: 1, profiles };

--- a/src/shared/multiple-accounts.ts
+++ b/src/shared/multiple-accounts.ts
@@ -33,6 +33,8 @@ export interface MultiProfile {
 export interface MultiWorkspace {
   readonly formatVersion: 1;
   readonly profiles: readonly MultiProfile[];
+  /** Archived profiles whose idempotent native cleanup must finish on startup. */
+  readonly deletingProfileIds: readonly ProfileId[];
 }
 
 const PROFILE_ID_PATTERN =
@@ -127,5 +129,21 @@ export function parseMultiWorkspace(value: unknown): MultiWorkspace {
   if (profiles.length > 0 && !profiles.some((profile) => !profile.archived)) {
     throw new AppError("bad_multi_workspace", "workspace needs an active profile");
   }
-  return { formatVersion: 1, profiles };
+  if (!Array.isArray(source.deletingProfileIds)) {
+    throw new AppError("bad_multi_workspace", "workspace deletions are invalid");
+  }
+  const deletingProfileIds = source.deletingProfileIds.map(parseProfileId);
+  if (new Set(deletingProfileIds).size !== deletingProfileIds.length) {
+    throw new AppError("bad_multi_workspace", "workspace deletions must be unique");
+  }
+  for (const profileId of deletingProfileIds) {
+    const profile = profiles.find((candidate) => candidate.id === profileId);
+    if (!profile?.archived) {
+      throw new AppError(
+        "bad_multi_workspace",
+        "only archived profiles can be pending deletion",
+      );
+    }
+  }
+  return { formatVersion: 1, profiles, deletingProfileIds };
 }

--- a/src/shared/template-contracts.ts
+++ b/src/shared/template-contracts.ts
@@ -1,4 +1,7 @@
-/** The one renderer/main value contract for a game template file. */
+/**
+ * The one renderer/main value contract for a game template file.
+ * Filesystem policy and export behavior stay in their process owners.
+ */
 export interface TemplateExportEntry {
   readonly path: string;
   readonly contents: string;

--- a/src/shared/template-contracts.ts
+++ b/src/shared/template-contracts.ts
@@ -1,0 +1,5 @@
+/** The one renderer/main value contract for a game template file. */
+export interface TemplateExportEntry {
+  readonly path: string;
+  readonly contents: string;
+}

--- a/src/shared/template-entries.ts
+++ b/src/shared/template-entries.ts
@@ -1,4 +1,7 @@
-/** The one trust-boundary parser for portable Guild Wars template entries. */
+/**
+ * The one trust-boundary parser for portable Guild Wars template entries.
+ * It validates bounded paths and contents before either process may store them.
+ */
 import {
   TEMPLATE_CEILINGS,
   type TemplateExportEntry,

--- a/src/shared/template-entries.ts
+++ b/src/shared/template-entries.ts
@@ -1,0 +1,59 @@
+/** The one trust-boundary parser for portable Guild Wars template entries. */
+import {
+  TEMPLATE_CEILINGS,
+  type TemplateExportEntry,
+} from "./contracts.js";
+import { ValidationError } from "./errors.js";
+
+const MIN_SEGMENTS = 2;
+const MAX_SEGMENTS = 3;
+
+export function parseTemplateEntries(value: unknown): TemplateExportEntry[] {
+  if (!Array.isArray(value) || value.length > TEMPLATE_CEILINGS.entries) {
+    throw new ValidationError("invalid template export");
+  }
+  return value.map((entry) => {
+    if (
+      typeof entry !== "object"
+      || entry === null
+      || Object.keys(entry).length !== 2
+    ) {
+      throw new ValidationError("invalid template export entry");
+    }
+    const { path: relative, contents } = entry as Record<string, unknown>;
+    if (
+      typeof relative !== "string"
+      || typeof contents !== "string"
+      || contents.length === 0
+      || contents.length > TEMPLATE_CEILINGS.codeLength
+    ) {
+      throw new ValidationError("invalid template export entry");
+    }
+    assertRelativePath(relative);
+    return { path: relative, contents };
+  });
+}
+
+function assertRelativePath(relative: string): void {
+  const segments = relative.split("/");
+  if (
+    segments.length < MIN_SEGMENTS
+    || segments.length > MAX_SEGMENTS
+    || !relative.toLowerCase().endsWith(".txt")
+  ) {
+    throw new ValidationError("invalid template export path");
+  }
+  for (const segment of segments) {
+    if (
+      segment.length === 0
+      || segment.length > TEMPLATE_CEILINGS.nameLength + ".txt".length
+      || segment === "."
+      || segment === ".."
+      || segment.includes("\\")
+      || segment.includes(":")
+      || /\p{Cc}/u.test(segment)
+    ) {
+      throw new ValidationError("invalid template export path");
+    }
+  }
+}

--- a/tests/electron/fixtures.mts
+++ b/tests/electron/fixtures.mts
@@ -148,7 +148,13 @@ async function waitForExit(
 }
 
 async function stopElectron(app: ElectronApplication): Promise<void> {
-  const child = app.process();
+  let child: ReturnType<ElectronApplication["process"]>;
+  try {
+    child = app.process();
+  } catch {
+    // Playwright drops its process handle after an app has already exited.
+    return;
+  }
   const closed = await new Promise<boolean>((resolve) => {
     const finish = (value: boolean) => {
       clearTimeout(timeout);

--- a/tests/electron/multiple-accounts.spec.ts
+++ b/tests/electron/multiple-accounts.spec.ts
@@ -286,7 +286,7 @@ test("Multi starts at the Hub and isolates two profile windows from Single", asy
       "Guild Wars Reforged — Alt",
       "Guild Wars Reforged — Primary",
     ]);
-    const presentation = await fixture.app.evaluate(({ BrowserWindow }) => {
+    const readPresentation = () => fixture.app.evaluate(({ BrowserWindow }) => {
       const windows = BrowserWindow.getAllWindows();
       return {
         focused: BrowserWindow.getFocusedWindow()?.getTitle(),
@@ -296,6 +296,17 @@ test("Multi starts at the Hub and isolates two profile windows from Single", asy
           .map((win) => [win.getTitle(), win.getBounds()])),
       };
     });
+    await expect.poll(async () => {
+      const presentation = await readPresentation();
+      return {
+        focused: presentation.focused,
+        hubVisible: presentation.hubVisible,
+      };
+    }).toEqual({
+      focused: "Guild Wars Reforged — Primary",
+      hubVisible: false,
+    });
+    const presentation = await readPresentation();
     expect(presentation.focused).toBe("Guild Wars Reforged — Primary");
     expect(presentation.hubVisible).toBe(false);
     const primaryBounds = presentation.bounds["Guild Wars Reforged — Primary"]!;

--- a/tests/electron/multiple-accounts.spec.ts
+++ b/tests/electron/multiple-accounts.spec.ts
@@ -145,6 +145,25 @@ test("Multi starts at the Hub and isolates two profile windows from Single", asy
       "clear-game-storage-on-start",
     ))).rejects.toMatchObject({ code: "ENOENT" });
 
+    const identifiedGames = await Promise.all(games.map(async (game) => ({
+      game,
+      credentials: await game.evaluate(() => window.gwNative.credentials.load()),
+    })));
+    const primaryPage = identifiedGames.find(({ credentials }) =>
+      credentials?.username === "first@example.test")?.game;
+    const altPage = identifiedGames.find(({ credentials }) =>
+      credentials?.username === "second@example.test")?.game;
+    if (!primaryPage || !altPage) throw new Error("profile pages not found");
+    const primaryClosed = primaryPage.waitForEvent("close", { timeout: 12_000 });
+    await primaryPage.evaluate(() => {
+      void window.gwNative.app.requestQuit();
+    });
+    await primaryClosed;
+    expect(await altPage.evaluate(() => window.gwNative.credentials.load())).toEqual({
+      username: "second@example.test",
+      password: "two",
+    });
+    expect(await fixture.page.evaluate(() => document.visibilityState)).toBe("visible");
   } finally {
     await closeOffline(fixture);
   }

--- a/tests/electron/multiple-accounts.spec.ts
+++ b/tests/electron/multiple-accounts.spec.ts
@@ -29,13 +29,24 @@ test("Multi starts at the Hub and isolates two profile windows from Single", asy
       JSON.stringify({
         formatVersion: 1,
         profiles: [
-          { id: FIRST, name: "Primary", archived: false, templates: "private", builds: "private" },
-          { id: SECOND, name: "Alt", archived: false, templates: "private", builds: "private" },
+          { id: FIRST, name: "Primary", archived: false, templates: "shared", builds: "shared" },
+          { id: SECOND, name: "Alt", archived: false, templates: "shared", builds: "shared" },
         ],
       }),
     );
     await writeFile(path.join(userData, "build-library.json"), "single-sentinel");
     await writeFile(path.join(userData, "clear-game-storage-on-start"), "pending");
+    await mkdir(path.join(userData, "multi", "profiles", FIRST), { recursive: true });
+    await writeFile(
+      path.join(
+        userData,
+        "multi",
+        "profiles",
+        FIRST,
+        "clear-game-storage-on-start",
+      ),
+      "pending",
+    );
   });
   try {
     await expect(fixture.page.locator("h1")).toHaveText("Who are you playing?");
@@ -51,6 +62,7 @@ test("Multi starts at the Hub and isolates two profile windows from Single", asy
     await expect.poll(() => fixture.app.windows().length).toBe(3);
     const games = fixture.app.windows().filter((page) => page !== fixture.page);
     await Promise.all(games.map((page) => page.waitForLoadState("domcontentloaded")));
+    expect(games.map((page) => page.url())).toEqual(["gw://app/", "gw://app/"]);
 
     const titles = await fixture.app.evaluate(({ BrowserWindow }) =>
       BrowserWindow.getAllWindows().map((win) => win.getTitle()).sort(),
@@ -87,25 +99,61 @@ test("Multi starts at the Hub and isolates two profile windows from Single", asy
       fixture.page.evaluate(() => window.gwNative.credentials.load()),
     ).rejects.toThrow();
 
-    for (const game of games) {
-      await game.evaluate(async () => {
-        const { library } = await window.gwNative.buildLibrary.get();
-        await window.gwNative.buildLibrary.set(library);
-      });
-    }
+    await Promise.all(games.map((game) =>
+      game.evaluate(() => window.gwNative.accounts.loadTemplates()),
+    ));
+    await games[0]!.evaluate(() => window.gwNative.accounts.saveTemplates([{
+      path: "Skills/Primary.txt",
+      contents: "OQCiUyo8AkVwR4KMMGAAAEAA",
+    }]));
+    await games[1]!.evaluate(() => window.gwNative.accounts.saveTemplates([{
+      path: "Skills/Alt.txt",
+      contents: "OQCiUyo8AkVwR4KMMGAAAEAB",
+    }]));
+    const sharedTemplates = JSON.parse(await readFile(
+      path.join(fixture.userData, "multi", "shared", "templates.json"),
+      "utf8",
+    )) as { entries: Array<{ path: string }> };
+    expect(sharedTemplates.entries.map((entry) => entry.path)).toEqual([
+      "Skills/Alt.txt",
+      "Skills/Primary.txt",
+    ]);
+
+    const libraries = await Promise.all(games.map((game) =>
+      game.evaluate(() => window.gwNative.buildLibrary.get()),
+    ));
+    await games[0]!.evaluate(
+      (library) => window.gwNative.buildLibrary.set({ ...library, tags: ["primary"] }),
+      libraries[0]!.library,
+    );
+    await expect(games[1]!.evaluate(
+      (library) => window.gwNative.buildLibrary.set({ ...library, tags: ["alt"] }),
+      libraries[1]!.library,
+    )).rejects.toThrow();
     expect(await readFile(path.join(fixture.userData, "build-library.json"), "utf8"))
       .toBe("single-sentinel");
-    await stat(path.join(fixture.userData, "multi", "profiles", FIRST, "build-library.json"));
-    await stat(path.join(fixture.userData, "multi", "profiles", SECOND, "build-library.json"));
+    expect(JSON.parse(await readFile(
+      path.join(fixture.userData, "multi", "shared", "build-library.json"),
+      "utf8",
+    ))).toMatchObject({ tags: ["primary"] });
     await stat(path.join(fixture.userData, "clear-game-storage-on-start"));
+    await expect(stat(path.join(
+      fixture.userData,
+      "multi",
+      "profiles",
+      FIRST,
+      "clear-game-storage-on-start",
+    ))).rejects.toMatchObject({ code: "ENOENT" });
+
   } finally {
     await closeOffline(fixture);
   }
 });
 
 test("opt-in publishes a separate workspace before requesting restart", async () => {
+  const singleLibrary = JSON.stringify({ version: 3, builds: [], teams: [], tags: [] });
   const fixture = await launchOffline("gw-multi-setup-e2e-", {}, async (userData) => {
-    await writeFile(path.join(userData, "build-library.json"), "single-stays-here");
+    await writeFile(path.join(userData, "build-library.json"), singleLibrary);
   });
   try {
     await fixture.app.evaluate(({ app }) => {
@@ -122,9 +170,12 @@ test("opt-in publishes a separate workspace before requesting restart", async ()
       name: "Primary",
       templates: "shared",
       builds: "private",
-      importTemplates: false,
-      templateEntries: [],
-      importBuilds: false,
+      importTemplates: true,
+      templateEntries: [{
+        path: "Skills/Imported.txt",
+        contents: "OQCiUyo8AkVwR4KMMGAAAEAA",
+      }],
+      importBuilds: true,
     }));
     expect(JSON.parse(await readFile(
       path.join(fixture.userData, "launcher-mode.json"),
@@ -133,10 +184,31 @@ test("opt-in publishes a separate workspace before requesting restart", async ()
     const workspace = JSON.parse(await readFile(
       path.join(fixture.userData, "multi", "workspace.json"),
       "utf8",
-    )) as { profiles: Array<{ name: string }> };
+    )) as { profiles: Array<{ id: string; name: string }> };
     expect(workspace.profiles.map((profile) => profile.name)).toEqual(["Primary"]);
     expect(await readFile(path.join(fixture.userData, "build-library.json"), "utf8"))
-      .toBe("single-stays-here");
+      .toBe(singleLibrary);
+    expect(JSON.parse(await readFile(
+      path.join(
+        fixture.userData,
+        "multi",
+        "profiles",
+        workspace.profiles[0]!.id,
+        "build-library.json",
+      ),
+      "utf8",
+    ))).toEqual(JSON.parse(singleLibrary));
+    expect(JSON.parse(await readFile(
+      path.join(fixture.userData, "multi", "shared", "templates.json"),
+      "utf8",
+    ))).toEqual({
+      formatVersion: 1,
+      revision: 1,
+      entries: [{
+        path: "Skills/Imported.txt",
+        contents: "OQCiUyo8AkVwR4KMMGAAAEAA",
+      }],
+    });
     expect(await fixture.app.evaluate(() => ({
       quit: globalThis.__multiModeRestart.quit,
       relaunch: globalThis.__multiModeRestart.relaunch,

--- a/tests/electron/multiple-accounts.spec.ts
+++ b/tests/electron/multiple-accounts.spec.ts
@@ -1,0 +1,152 @@
+/** Real Electron coverage for the opt-in Hub and profile isolation boundary. */
+import { expect, test } from "@playwright/test";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { ProfileId } from "../../src/shared/multiple-accounts.js";
+import { closeOffline, launchOffline } from "./fixtures.mjs";
+
+declare global {
+  var __multiModeRestart: {
+    quit: boolean;
+    relaunch: boolean;
+    originalQuit: Electron.App["quit"];
+    originalRelaunch: Electron.App["relaunch"];
+  };
+}
+
+const FIRST = "00000000-0000-4000-8000-000000000001";
+const SECOND = "00000000-0000-4000-8000-000000000002";
+
+test("Multi starts at the Hub and isolates two profile windows from Single", async () => {
+  const fixture = await launchOffline("gw-multi-e2e-", {}, async (userData) => {
+    await mkdir(path.join(userData, "multi"), { recursive: true });
+    await writeFile(
+      path.join(userData, "launcher-mode.json"),
+      JSON.stringify({ formatVersion: 1, mode: "multi" }),
+    );
+    await writeFile(
+      path.join(userData, "multi", "workspace.json"),
+      JSON.stringify({
+        formatVersion: 1,
+        profiles: [
+          { id: FIRST, name: "Primary", archived: false, templates: "private", builds: "private" },
+          { id: SECOND, name: "Alt", archived: false, templates: "private", builds: "private" },
+        ],
+      }),
+    );
+    await writeFile(path.join(userData, "build-library.json"), "single-sentinel");
+    await writeFile(path.join(userData, "clear-game-storage-on-start"), "pending");
+  });
+  try {
+    await expect(fixture.page.locator("h1")).toHaveText("Who are you playing?");
+    const state = await fixture.page.evaluate(() => window.gwNative.accounts.get());
+    expect(state.mode).toBe("multi");
+    expect(state.profiles.map((profile) => profile.name)).toEqual(["Primary", "Alt"]);
+
+    await fixture.page.evaluate(
+      ([first, second]) =>
+        window.gwNative.accounts.open([first, second] as ProfileId[]),
+      [FIRST, SECOND] as const,
+    );
+    await expect.poll(() => fixture.app.windows().length).toBe(3);
+    const games = fixture.app.windows().filter((page) => page !== fixture.page);
+    await Promise.all(games.map((page) => page.waitForLoadState("domcontentloaded")));
+
+    const titles = await fixture.app.evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getAllWindows().map((win) => win.getTitle()).sort(),
+    );
+    expect(titles).toEqual([
+      "Guild Wars Reforged — Accounts",
+      "Guild Wars Reforged — Alt",
+      "Guild Wars Reforged — Primary",
+    ]);
+    const storagePaths = await fixture.app.evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getAllWindows()
+        .filter((win) => win.getTitle() !== "Guild Wars Reforged — Accounts")
+        .map((win) => win.webContents.session.storagePath),
+    );
+    expect(new Set(storagePaths).size).toBe(2);
+    expect(storagePaths.every((value) => value?.includes("Partitions/gw-multi-"))).toBe(true);
+
+    await games[0]!.evaluate(() => localStorage.setItem("profile-proof", "first"));
+    await games[1]!.evaluate(() => localStorage.setItem("profile-proof", "second"));
+    expect(await games[0]!.evaluate(() => localStorage.getItem("profile-proof"))).toBe("first");
+    expect(await games[1]!.evaluate(() => localStorage.getItem("profile-proof"))).toBe("second");
+
+    await games[0]!.evaluate(() =>
+      window.gwNative.credentials.save({ username: "first@example.test", password: "one" }),
+    );
+    await games[1]!.evaluate(() =>
+      window.gwNative.credentials.save({ username: "second@example.test", password: "two" }),
+    );
+    expect(await games[0]!.evaluate(() => window.gwNative.credentials.load()))
+      .toEqual({ username: "first@example.test", password: "one" });
+    expect(await games[1]!.evaluate(() => window.gwNative.credentials.load()))
+      .toEqual({ username: "second@example.test", password: "two" });
+    await expect(
+      fixture.page.evaluate(() => window.gwNative.credentials.load()),
+    ).rejects.toThrow();
+
+    for (const game of games) {
+      await game.evaluate(async () => {
+        const { library } = await window.gwNative.buildLibrary.get();
+        await window.gwNative.buildLibrary.set(library);
+      });
+    }
+    expect(await readFile(path.join(fixture.userData, "build-library.json"), "utf8"))
+      .toBe("single-sentinel");
+    await stat(path.join(fixture.userData, "multi", "profiles", FIRST, "build-library.json"));
+    await stat(path.join(fixture.userData, "multi", "profiles", SECOND, "build-library.json"));
+    await stat(path.join(fixture.userData, "clear-game-storage-on-start"));
+  } finally {
+    await closeOffline(fixture);
+  }
+});
+
+test("opt-in publishes a separate workspace before requesting restart", async () => {
+  const fixture = await launchOffline("gw-multi-setup-e2e-", {}, async (userData) => {
+    await writeFile(path.join(userData, "build-library.json"), "single-stays-here");
+  });
+  try {
+    await fixture.app.evaluate(({ app }) => {
+      globalThis.__multiModeRestart = {
+        quit: false,
+        relaunch: false,
+        originalQuit: app.quit.bind(app),
+        originalRelaunch: app.relaunch.bind(app),
+      };
+      app.quit = () => { globalThis.__multiModeRestart.quit = true; };
+      app.relaunch = () => { globalThis.__multiModeRestart.relaunch = true; };
+    });
+    await fixture.page.evaluate(() => window.gwNative.accounts.setup({
+      name: "Primary",
+      templates: "shared",
+      builds: "private",
+      importTemplates: false,
+      templateEntries: [],
+      importBuilds: false,
+    }));
+    expect(JSON.parse(await readFile(
+      path.join(fixture.userData, "launcher-mode.json"),
+      "utf8",
+    ))).toEqual({ formatVersion: 1, mode: "multi" });
+    const workspace = JSON.parse(await readFile(
+      path.join(fixture.userData, "multi", "workspace.json"),
+      "utf8",
+    )) as { profiles: Array<{ name: string }> };
+    expect(workspace.profiles.map((profile) => profile.name)).toEqual(["Primary"]);
+    expect(await readFile(path.join(fixture.userData, "build-library.json"), "utf8"))
+      .toBe("single-stays-here");
+    expect(await fixture.app.evaluate(() => ({
+      quit: globalThis.__multiModeRestart.quit,
+      relaunch: globalThis.__multiModeRestart.relaunch,
+    }))).toEqual({ quit: true, relaunch: true });
+  } finally {
+    await fixture.app.evaluate(({ app }) => {
+      if (!globalThis.__multiModeRestart) return;
+      app.quit = globalThis.__multiModeRestart.originalQuit;
+      app.relaunch = globalThis.__multiModeRestart.originalRelaunch;
+    }).catch(() => undefined);
+    await closeOffline(fixture);
+  }
+});

--- a/tests/electron/multiple-accounts.spec.ts
+++ b/tests/electron/multiple-accounts.spec.ts
@@ -17,6 +17,22 @@ declare global {
 const FIRST = "00000000-0000-4000-8000-000000000001";
 const SECOND = "00000000-0000-4000-8000-000000000002";
 
+test("Single Account remains the invisible default", async () => {
+  const fixture = await launchOffline("gw-single-default-e2e-");
+  try {
+    await expect(fixture.page).toHaveURL("gw://app/");
+    expect((await fixture.app.evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getAllWindows().map((win) => win.getTitle()),
+    )).some((title) => title.endsWith("Accounts"))).toBe(false);
+    expect(await fixture.page.evaluate(() => window.gwNative.accounts.get()))
+      .toMatchObject({ mode: "single", profiles: [] });
+    await expect(stat(path.join(fixture.userData, "multi")))
+      .rejects.toMatchObject({ code: "ENOENT" });
+  } finally {
+    await closeOffline(fixture);
+  }
+});
+
 test("Hub exposes the focused chooser, account sheets, and Settings management", async () => {
   const fixture = await launchOffline("gw-multi-hub-ui-e2e-", {}, async (userData) => {
     await mkdir(path.join(userData, "multi"), { recursive: true });
@@ -57,8 +73,9 @@ test("Hub exposes the focused chooser, account sheets, and Settings management",
 
     await fixture.page.getByRole("button", { name: "New Account…" }).click();
     await expect(fixture.page.getByRole("dialog", { name: "New Account" })).toBeVisible();
-    await expect(fixture.page.getByText("Builds and teams")).toBeVisible();
-    await expect(fixture.page.getByText("In-game templates")).toBeVisible();
+    await expect(fixture.page.getByText("Builds and teams", { exact: true })).toBeVisible();
+    await expect(fixture.page.getByText("In-game templates", { exact: true })).toBeVisible();
+    await expect(fixture.page.getByText("Start with Single Account data")).toBeHidden();
     await expect(fixture.page.getByText(/Single Account data are never shared/)).toBeVisible();
     await fixture.page.getByRole("button", { name: "Cancel" }).click();
 
@@ -77,6 +94,54 @@ test("Hub exposes the focused chooser, account sheets, and Settings management",
     await expect(fixture.page.getByRole("button", { name: "Restore" })).toBeVisible();
     await expect(fixture.page.getByRole("button", { name: "Delete…" })).toBeVisible();
     await expect(fixture.page.getByRole("button", { name: "Return to Single Account…" })).toBeVisible();
+  } finally {
+    await closeOffline(fixture);
+  }
+});
+
+test("a bank account opens alone and Show never creates a duplicate window", async () => {
+  const fixture = await launchOffline("gw-multi-bank-e2e-", {}, async (userData) => {
+    await mkdir(path.join(userData, "multi"), { recursive: true });
+    await writeFile(
+      path.join(userData, "launcher-mode.json"),
+      JSON.stringify({ formatVersion: 1, mode: "multi" }),
+    );
+    await writeFile(
+      path.join(userData, "multi", "workspace.json"),
+      JSON.stringify({
+        formatVersion: 1,
+        profiles: [
+          { id: FIRST, name: "Main", archived: false, templates: "shared", builds: "shared" },
+          { id: SECOND, name: "Storage and Materials", archived: false, templates: "shared", builds: "shared" },
+        ],
+      }),
+    );
+  });
+  try {
+    const bank = fixture.page.getByRole("checkbox", { name: "Select Storage and Materials" });
+    await bank.check();
+    await fixture.page.getByRole("button", { name: "Open Storage and Materials" }).click();
+    await expect.poll(() => fixture.app.evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getAllWindows().filter((win) => !win.getTitle().endsWith("Accounts")).length,
+    )).toBe(1);
+    await expect.poll(() => fixture.page.evaluate(() => window.gwNative.accounts.get()))
+      .toMatchObject({
+        profiles: [
+          { name: "Main", state: "ready" },
+          { name: "Storage and Materials", state: "running" },
+        ],
+      });
+
+    await fixture.app.evaluate(({ app }) => app.emit("activate"));
+    await expect(fixture.page.getByRole("heading", { name: "Choose Accounts" })).toBeVisible();
+    await expect(fixture.page.getByRole("button", { name: "Show Storage and Materials" })).toBeVisible();
+    await fixture.page.getByRole("button", { name: "Show Storage and Materials" }).click();
+    await expect.poll(() => fixture.app.evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getAllWindows().filter((win) => !win.getTitle().endsWith("Accounts")).length,
+    )).toBe(1);
+    expect(await fixture.app.evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getFocusedWindow()?.getTitle(),
+    )).toBe("Guild Wars Reforged — Storage and Materials");
   } finally {
     await closeOffline(fixture);
   }
@@ -324,15 +389,10 @@ test("opt-in publishes a separate workspace before requesting restart", async ()
       app.relaunch = () => { globalThis.__multiModeRestart.relaunch = true; };
     });
     await fixture.page.evaluate(() => window.gwNative.accounts.setup({
-      name: "Primary",
-      templates: "shared",
-      builds: "private",
-      importTemplates: true,
       templateEntries: [{
         path: "Skills/Imported.txt",
         contents: "OQCiUyo8AkVwR4KMMGAAAEAA",
       }],
-      importBuilds: true,
     }));
     expect(JSON.parse(await readFile(
       path.join(fixture.userData, "launcher-mode.json"),
@@ -342,21 +402,11 @@ test("opt-in publishes a separate workspace before requesting restart", async ()
       path.join(fixture.userData, "multi", "workspace.json"),
       "utf8",
     )) as { profiles: Array<{ id: string; name: string }> };
-    expect(workspace.profiles.map((profile) => profile.name)).toEqual(["Primary"]);
+    expect(workspace.profiles).toEqual([]);
     expect(await readFile(path.join(fixture.userData, "build-library.json"), "utf8"))
       .toBe(singleLibrary);
     expect(JSON.parse(await readFile(
-      path.join(
-        fixture.userData,
-        "multi",
-        "profiles",
-        workspace.profiles[0]!.id,
-        "build-library.json",
-      ),
-      "utf8",
-    ))).toEqual(JSON.parse(singleLibrary));
-    expect(JSON.parse(await readFile(
-      path.join(fixture.userData, "multi", "shared", "templates.json"),
+      path.join(fixture.userData, "multi", "single-template-import.json"),
       "utf8",
     ))).toEqual({
       formatVersion: 1,
@@ -376,6 +426,71 @@ test("opt-in publishes a separate workspace before requesting restart", async ()
       app.quit = globalThis.__multiModeRestart.originalQuit;
       app.relaunch = globalThis.__multiModeRestart.originalRelaunch;
     }).catch(() => undefined);
+    await closeOffline(fixture);
+  }
+});
+
+test("the empty Hub owns first-account creation and optional Single Account copies", async () => {
+  const singleLibrary = { version: 3, builds: [], teams: [], tags: ["single"] };
+  const fixture = await launchOffline("gw-multi-first-account-e2e-", {}, async (userData) => {
+    await mkdir(path.join(userData, "multi"), { recursive: true });
+    await writeFile(
+      path.join(userData, "launcher-mode.json"),
+      JSON.stringify({ formatVersion: 1, mode: "multi" }),
+    );
+    await writeFile(
+      path.join(userData, "multi", "workspace.json"),
+      JSON.stringify({ formatVersion: 1, profiles: [] }),
+    );
+    await writeFile(
+      path.join(userData, "multi", "single-template-import.json"),
+      JSON.stringify({
+        formatVersion: 1,
+        revision: 1,
+        entries: [{
+          path: "Skills/Imported.txt",
+          contents: "OQCiUyo8AkVwR4KMMGAAAEAA",
+        }],
+      }),
+    );
+    await writeFile(path.join(userData, "build-library.json"), JSON.stringify(singleLibrary));
+  });
+  try {
+    await expect(fixture.page.getByRole("heading", { name: "No accounts yet" })).toBeVisible();
+    await expect(fixture.page.getByRole("button", { name: "Create First Account" })).toBeVisible();
+    await expect(fixture.page.getByRole("button", { name: "New Account…" })).toBeHidden();
+
+    await fixture.page.getByRole("button", { name: "Create First Account" }).click();
+    const dialog = fixture.page.getByRole("dialog", { name: "Create First Account" });
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText("Start with Single Account data")).toBeVisible();
+    await dialog.getByLabel("Account name").fill("Main");
+    await dialog.getByLabel("Copy builds and teams").check();
+    await dialog.getByLabel("Copy in-game templates").check();
+    await dialog.getByRole("button", { name: "Create First Account" }).click();
+
+    await expect(fixture.page.getByRole("checkbox", { name: "Select Main" })).toBeVisible();
+    const workspace = JSON.parse(await readFile(
+      path.join(fixture.userData, "multi", "workspace.json"),
+      "utf8",
+    )) as { profiles: Array<{ id: string; name: string }> };
+    expect(workspace.profiles.map((profile) => profile.name)).toEqual(["Main"]);
+    expect(JSON.parse(await readFile(
+      path.join(fixture.userData, "multi", "shared", "build-library.json"),
+      "utf8",
+    ))).toEqual(singleLibrary);
+    expect(JSON.parse(await readFile(
+      path.join(fixture.userData, "multi", "shared", "templates.json"),
+      "utf8",
+    ))).toMatchObject({ entries: [{ path: "Skills/Imported.txt" }] });
+    await expect(stat(path.join(
+      fixture.userData,
+      "multi",
+      "single-template-import.json",
+    ))).rejects.toMatchObject({ code: "ENOENT" });
+    expect(await readFile(path.join(fixture.userData, "build-library.json"), "utf8"))
+      .toBe(JSON.stringify(singleLibrary));
+  } finally {
     await closeOffline(fixture);
   }
 });

--- a/tests/electron/multiple-accounts.spec.ts
+++ b/tests/electron/multiple-accounts.spec.ts
@@ -58,6 +58,12 @@ test("Hub exposes the focused chooser, account sheets, and Settings management",
   });
   try {
     await expect(fixture.page.getByRole("heading", { name: "Choose Accounts" })).toBeVisible();
+    expect(await fixture.page.locator(".hub").evaluate((element) =>
+      getComputedStyle(element).getPropertyValue("-webkit-app-region"),
+    )).toBe("no-drag");
+    expect(await fixture.page.locator(".titlebar-drag").evaluate((element) =>
+      getComputedStyle(element).getPropertyValue("-webkit-app-region"),
+    )).toBe("drag");
     await expect(fixture.page.getByText("Each account keeps its own saved login and game files.")).toBeVisible();
     await expect(fixture.page.getByRole("checkbox")).toHaveCount(5);
     await expect(fixture.page.getByRole("button", { name: "Open", exact: true })).toBeDisabled();
@@ -94,6 +100,7 @@ test("Hub exposes the focused chooser, account sheets, and Settings management",
     expect(await fixture.page.locator("#accounts-settings").evaluate((element) =>
       getComputedStyle(element).getPropertyValue("-webkit-app-region"),
     )).toBe("no-drag");
+    await expect(fixture.page.locator(".titlebar-drag")).toBeHidden();
     await expect(fixture.page.getByText("Archived", { exact: true })).toBeVisible();
     await expect(fixture.page.getByRole("button", { name: "Restore" })).toHaveCount(2);
     await expect(fixture.page.getByRole("button", { name: "Delete…" })).toHaveCount(2);

--- a/tests/electron/multiple-accounts.spec.ts
+++ b/tests/electron/multiple-accounts.spec.ts
@@ -17,8 +17,130 @@ declare global {
 const FIRST = "00000000-0000-4000-8000-000000000001";
 const SECOND = "00000000-0000-4000-8000-000000000002";
 
+test("Hub exposes the focused chooser, account sheets, and Settings management", async () => {
+  const fixture = await launchOffline("gw-multi-hub-ui-e2e-", {}, async (userData) => {
+    await mkdir(path.join(userData, "multi"), { recursive: true });
+    await writeFile(
+      path.join(userData, "launcher-mode.json"),
+      JSON.stringify({ formatVersion: 1, mode: "multi" }),
+    );
+    await writeFile(
+      path.join(userData, "multi", "workspace.json"),
+      JSON.stringify({
+        formatVersion: 1,
+        profiles: [
+          { id: FIRST, name: "Primary Account With A Deliberately Long Name", archived: false, templates: "shared", builds: "shared" },
+          { id: SECOND, name: "Alt", archived: false, templates: "private", builds: "private" },
+          { id: "00000000-0000-4000-8000-000000000003", name: "Pre-Searing", archived: false, templates: "shared", builds: "shared" },
+          { id: "00000000-0000-4000-8000-000000000004", name: "Storage", archived: false, templates: "shared", builds: "shared" },
+          { id: "00000000-0000-4000-8000-000000000005", name: "PvP", archived: false, templates: "shared", builds: "shared" },
+          { id: "00000000-0000-4000-8000-000000000006", name: "Archived", archived: true, templates: "shared", builds: "shared" },
+        ],
+      }),
+    );
+  });
+  try {
+    await expect(fixture.page.getByRole("heading", { name: "Choose Accounts" })).toBeVisible();
+    await expect(fixture.page.getByText("Each account keeps its own saved login and game files.")).toBeVisible();
+    await expect(fixture.page.getByRole("checkbox")).toHaveCount(5);
+    await expect(fixture.page.getByRole("button", { name: "Open", exact: true })).toBeDisabled();
+
+    const primary = fixture.page.getByRole("checkbox", { name: /Select Primary Account/ });
+    await primary.check();
+    await expect(fixture.page.getByRole("button", { name: /Open Primary Account/ })).toBeEnabled();
+    expect(await fixture.page.locator("#accounts-list").evaluate((element) =>
+      element.scrollHeight >= element.clientHeight)).toBe(true);
+    await expect(fixture.page.locator(".account-copy strong").first()).toHaveAttribute(
+      "title",
+      "Primary Account With A Deliberately Long Name",
+    );
+
+    await fixture.page.getByRole("button", { name: "New Account…" }).click();
+    await expect(fixture.page.getByRole("dialog", { name: "New Account" })).toBeVisible();
+    await expect(fixture.page.getByText("Builds and teams")).toBeVisible();
+    await expect(fixture.page.getByText("In-game templates")).toBeVisible();
+    await expect(fixture.page.getByText(/Single Account data are never shared/)).toBeVisible();
+    await fixture.page.getByRole("button", { name: "Cancel" }).click();
+
+    await fixture.page.getByRole("button", { name: /More options for Primary/ }).click();
+    await expect(fixture.page.getByRole("menuitem", { name: "Edit Account…" })).toBeVisible();
+    await expect(fixture.page.getByRole("menuitem", { name: "Archive Account" })).toBeVisible();
+    await fixture.page.keyboard.press("Escape");
+
+    await fixture.app.evaluate(({ Menu }) => {
+      const item = Menu.getApplicationMenu()?.getMenuItemById("accounts-settings-menu");
+      if (!item?.click) throw new Error("Accounts Settings menu item is unavailable");
+      item.click(item, undefined, {} as Electron.KeyboardEvent);
+    });
+    await expect(fixture.page.getByRole("dialog", { name: "Multiple Accounts Settings" })).toBeVisible();
+    await expect(fixture.page.getByText("Archived", { exact: true })).toBeVisible();
+    await expect(fixture.page.getByRole("button", { name: "Restore" })).toBeVisible();
+    await expect(fixture.page.getByRole("button", { name: "Delete…" })).toBeVisible();
+    await expect(fixture.page.getByRole("button", { name: "Return to Single Account…" })).toBeVisible();
+  } finally {
+    await closeOffline(fixture);
+  }
+});
+
+test("renderer recovery stays with its account and a second crash needs attention", async () => {
+  const fixture = await launchOffline("gw-multi-recovery-e2e-", {}, async (userData) => {
+    await mkdir(path.join(userData, "multi"), { recursive: true });
+    await writeFile(path.join(userData, "launcher-mode.json"), JSON.stringify({ formatVersion: 1, mode: "multi" }));
+    await writeFile(path.join(userData, "multi", "workspace.json"), JSON.stringify({
+      formatVersion: 1,
+      profiles: [
+        { id: FIRST, name: "Primary", archived: false, templates: "shared", builds: "shared" },
+        { id: SECOND, name: "Alt", archived: false, templates: "shared", builds: "shared" },
+      ],
+    }));
+  });
+  try {
+    await fixture.page.evaluate(
+      ([first, second]) => window.gwNative.accounts.open([first, second] as ProfileId[]),
+      [FIRST, SECOND] as const,
+    );
+    const firstRenderer = await fixture.app.evaluate(({ BrowserWindow, dialog }) => {
+      dialog.showErrorBox = () => undefined;
+      const win = BrowserWindow.getAllWindows().find((candidate) => candidate.getTitle().endsWith("Primary"));
+      if (!win) throw new Error("Primary window not found");
+      const id = win.webContents.id;
+      win.webContents.forcefullyCrashRenderer();
+      return id;
+    });
+    await expect.poll(() => fixture.app.evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getAllWindows().find((win) => win.getTitle().endsWith("Primary"))?.webContents.id,
+    )).not.toBe(firstRenderer);
+    await expect.poll(() => fixture.page.evaluate(() =>
+      window.gwNative.accounts.get().then((state) => state.profiles.find((profile) => profile.name === "Primary")?.state),
+    )).toBe("running");
+    expect(await fixture.app.evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getAllWindows().find((win) => win.getTitle().endsWith("Accounts"))?.isVisible(),
+    )).toBe(false);
+
+    await fixture.app.evaluate(({ BrowserWindow }) => {
+      const win = BrowserWindow.getAllWindows().find((candidate) => candidate.getTitle().endsWith("Primary"));
+      if (!win) throw new Error("Recovered Primary window not found");
+      win.webContents.forcefullyCrashRenderer();
+    });
+    await expect.poll(() => fixture.page.evaluate(() =>
+      window.gwNative.accounts.get().then((state) => state.profiles.find((profile) => profile.name === "Primary")),
+    )).toMatchObject({ state: "failed", launchIssue: "renderer-crash" });
+    expect(await fixture.app.evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getAllWindows().find((win) => win.getTitle().endsWith("Accounts"))?.isVisible(),
+    )).toBe(true);
+    expect(await fixture.app.evaluate(({ BrowserWindow }) => {
+      const alt = BrowserWindow.getAllWindows().find((win) => win.getTitle().endsWith("Alt"));
+      return !!alt && !alt.webContents.isCrashed();
+    })).toBe(true);
+  } finally {
+    await closeOffline(fixture);
+  }
+});
+
 test("Multi starts at the Hub and isolates two profile windows from Single", async () => {
-  const fixture = await launchOffline("gw-multi-e2e-", {}, async (userData) => {
+  const fixture = await launchOffline("gw-multi-e2e-", {
+    GW_BACKGROUND_LAUNCH: "0",
+  }, async (userData) => {
     await mkdir(path.join(userData, "multi"), { recursive: true });
     await writeFile(
       path.join(userData, "launcher-mode.json"),
@@ -49,16 +171,16 @@ test("Multi starts at the Hub and isolates two profile windows from Single", asy
     );
   });
   try {
-    await expect(fixture.page.locator("h1")).toHaveText("Who are you playing?");
+    await expect(fixture.page.locator("h1")).toHaveText("Choose Accounts");
     const state = await fixture.page.evaluate(() => window.gwNative.accounts.get());
     expect(state.mode).toBe("multi");
     expect(state.profiles.map((profile) => profile.name)).toEqual(["Primary", "Alt"]);
 
-    await fixture.page.evaluate(
-      ([first, second]) =>
-        window.gwNative.accounts.open([first, second] as ProfileId[]),
-      [FIRST, SECOND] as const,
-    );
+    await fixture.page.getByRole("checkbox", { name: "Select Primary" }).check();
+    await expect(fixture.page.getByRole("button", { name: "Open Primary" })).toBeVisible();
+    await fixture.page.getByRole("checkbox", { name: "Select Alt" }).check();
+    await expect(fixture.page.getByRole("button", { name: "Open 2 Accounts" })).toBeVisible();
+    await fixture.page.getByRole("button", { name: "Open 2 Accounts" }).click();
     await expect.poll(() => fixture.app.windows().length).toBe(3);
     const games = fixture.app.windows().filter((page) => page !== fixture.page);
     await Promise.all(games.map((page) => page.waitForLoadState("domcontentloaded")));
@@ -72,6 +194,22 @@ test("Multi starts at the Hub and isolates two profile windows from Single", asy
       "Guild Wars Reforged — Alt",
       "Guild Wars Reforged — Primary",
     ]);
+    const presentation = await fixture.app.evaluate(({ BrowserWindow }) => {
+      const windows = BrowserWindow.getAllWindows();
+      return {
+        focused: BrowserWindow.getFocusedWindow()?.getTitle(),
+        hubVisible: windows.find((win) => win.getTitle() === "Guild Wars Reforged — Accounts")?.isVisible(),
+        bounds: Object.fromEntries(windows
+          .filter((win) => win.getTitle() !== "Guild Wars Reforged — Accounts")
+          .map((win) => [win.getTitle(), win.getBounds()])),
+      };
+    });
+    expect(presentation.focused).toBe("Guild Wars Reforged — Primary");
+    expect(presentation.hubVisible).toBe(false);
+    const primaryBounds = presentation.bounds["Guild Wars Reforged — Primary"]!;
+    const altBounds = presentation.bounds["Guild Wars Reforged — Alt"]!;
+    expect(altBounds.x - primaryBounds.x).toBe(32);
+    expect(altBounds.y - primaryBounds.y).toBe(32);
     const storagePaths = await fixture.app.evaluate(({ BrowserWindow }) =>
       BrowserWindow.getAllWindows()
         .filter((win) => win.getTitle() !== "Guild Wars Reforged — Accounts")

--- a/tests/electron/multiple-accounts.spec.ts
+++ b/tests/electron/multiple-accounts.spec.ts
@@ -44,6 +44,7 @@ test("Hub exposes the focused chooser, account sheets, and Settings management",
       path.join(userData, "multi", "workspace.json"),
       JSON.stringify({
         formatVersion: 1,
+        deletingProfileIds: [],
         profiles: [
           { id: FIRST, name: "Primary Account With A Deliberately Long Name", archived: false, templates: "shared", builds: "shared" },
           { id: SECOND, name: "Alt", archived: false, templates: "private", builds: "private" },
@@ -133,6 +134,7 @@ test("a bank account opens alone and Show never creates a duplicate window", asy
       path.join(userData, "multi", "workspace.json"),
       JSON.stringify({
         formatVersion: 1,
+        deletingProfileIds: [],
         profiles: [
           { id: FIRST, name: "Main", archived: false, templates: "shared", builds: "shared" },
           { id: SECOND, name: "Storage and Materials", archived: false, templates: "shared", builds: "shared" },
@@ -176,6 +178,7 @@ test("renderer recovery stays with its account and a second crash needs attentio
     await writeFile(path.join(userData, "launcher-mode.json"), JSON.stringify({ formatVersion: 1, mode: "multi" }));
     await writeFile(path.join(userData, "multi", "workspace.json"), JSON.stringify({
       formatVersion: 1,
+      deletingProfileIds: [],
       profiles: [
         { id: FIRST, name: "Primary", archived: false, templates: "shared", builds: "shared" },
         { id: SECOND, name: "Alt", archived: false, templates: "shared", builds: "shared" },
@@ -238,6 +241,7 @@ test("Multi starts at the Hub and isolates two profile windows from Single", asy
       path.join(userData, "multi", "workspace.json"),
       JSON.stringify({
         formatVersion: 1,
+        deletingProfileIds: [],
         profiles: [
           { id: FIRST, name: "Primary", archived: false, templates: "shared", builds: "shared" },
           { id: SECOND, name: "Alt", archived: false, templates: "shared", builds: "shared" },
@@ -463,7 +467,7 @@ test("the empty Hub owns first-account creation and optional Single Account copi
     );
     await writeFile(
       path.join(userData, "multi", "workspace.json"),
-      JSON.stringify({ formatVersion: 1, profiles: [] }),
+      JSON.stringify({ formatVersion: 1, profiles: [], deletingProfileIds: [] }),
     );
     await writeFile(
       path.join(userData, "multi", "single-template-import.json"),

--- a/tests/electron/multiple-accounts.spec.ts
+++ b/tests/electron/multiple-accounts.spec.ts
@@ -51,6 +51,7 @@ test("Hub exposes the focused chooser, account sheets, and Settings management",
           { id: "00000000-0000-4000-8000-000000000004", name: "Storage", archived: false, templates: "shared", builds: "shared" },
           { id: "00000000-0000-4000-8000-000000000005", name: "PvP", archived: false, templates: "shared", builds: "shared" },
           { id: "00000000-0000-4000-8000-000000000006", name: "Archived", archived: true, templates: "shared", builds: "shared" },
+          { id: "00000000-0000-4000-8000-000000000007", name: "Delete Me", archived: true, templates: "shared", builds: "shared" },
         ],
       }),
     );
@@ -90,10 +91,25 @@ test("Hub exposes the focused chooser, account sheets, and Settings management",
       item.click(item, undefined, {} as Electron.KeyboardEvent);
     });
     await expect(fixture.page.getByRole("dialog", { name: "Multiple Accounts Settings" })).toBeVisible();
+    expect(await fixture.page.locator("#accounts-settings").evaluate((element) =>
+      getComputedStyle(element).getPropertyValue("-webkit-app-region"),
+    )).toBe("no-drag");
     await expect(fixture.page.getByText("Archived", { exact: true })).toBeVisible();
-    await expect(fixture.page.getByRole("button", { name: "Restore" })).toBeVisible();
-    await expect(fixture.page.getByRole("button", { name: "Delete…" })).toBeVisible();
+    await expect(fixture.page.getByRole("button", { name: "Restore" })).toHaveCount(2);
+    await expect(fixture.page.getByRole("button", { name: "Delete…" })).toHaveCount(2);
     await expect(fixture.page.getByRole("button", { name: "Return to Single Account…" })).toBeVisible();
+
+    await fixture.page.getByRole("button", { name: "Restore" }).first().click();
+    await expect(fixture.page.getByText("Archived was restored.")).toBeVisible();
+    await expect(fixture.page.getByRole("checkbox", { name: "Select Archived" })).toBeVisible();
+    await expect(fixture.page.getByRole("button", { name: "Restore" })).toHaveCount(1);
+
+    await fixture.app.evaluate(({ dialog }) => {
+      dialog.showMessageBox = async () => ({ response: 0, checkboxChecked: false });
+    });
+    await fixture.page.getByRole("button", { name: "Delete…" }).click();
+    await expect(fixture.page.getByText("Delete Me was permanently deleted.")).toBeVisible();
+    await expect(fixture.page.getByText("No archived accounts.")).toBeVisible();
   } finally {
     await closeOffline(fixture);
   }

--- a/tests/electron/sandbox.spec.ts
+++ b/tests/electron/sandbox.spec.ts
@@ -44,6 +44,7 @@ test.describe("sandbox boundary", () => {
         // if a member is added there without a call — the two files change
         // together.
         keys: [
+          "accounts",
           "app",
           "appUpdates",
           "buildLibrary",

--- a/tests/electron/settings-data-display.spec.ts
+++ b/tests/electron/settings-data-display.spec.ts
@@ -5,6 +5,30 @@ import { closeOffline, launchOffline } from "./fixtures.mjs";
 import "./settings-test-fixture.mjs";
 
 test.describe("data and display settings", () => {
+  test("shows the Multiple Accounts setup when its tab is selected", async () => {
+    const fixture = await launchOffline("gw-settings-accounts-e2e-");
+    try {
+      const { page } = fixture;
+      await page.evaluate(() =>
+        globalThis.dispatchEvent(new globalThis.Event("gw:settings")),
+      );
+      await page.locator("#settings-tab-accounts").click();
+
+      const pane = page.locator("#settings-pane-accounts");
+      await expect(pane).toBeVisible();
+      await expect(pane.getByRole("heading", { name: "Multiple Accounts" }))
+        .toBeVisible();
+      await expect(page.locator("#accounts-first-name")).toBeVisible();
+      await expect(page.getByRole("group", { name: "Build library" }))
+        .toBeVisible();
+      await expect(page.getByRole("group", { name: "Build templates" }))
+        .toBeVisible();
+      await expect(page.locator("#accounts-enable")).toBeVisible();
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
   test("interface style and panel opacity apply live and survive", async () => {
     const fixture = await launchOffline("gw-settings-appearance-e2e-");
     try {

--- a/tests/electron/settings-data-display.spec.ts
+++ b/tests/electron/settings-data-display.spec.ts
@@ -18,11 +18,12 @@ test.describe("data and display settings", () => {
       await expect(pane).toBeVisible();
       await expect(pane.getByRole("heading", { name: "Multiple Accounts" }))
         .toBeVisible();
-      await expect(page.locator("#accounts-first-name")).toBeVisible();
+      await expect(page.locator("#accounts-first-name")).toHaveCount(0);
       await expect(page.getByRole("group", { name: "Build library" }))
-        .toBeVisible();
+        .toHaveCount(0);
       await expect(page.getByRole("group", { name: "Build templates" }))
-        .toBeVisible();
+        .toHaveCount(0);
+      await expect(pane).toContainText("Create and manage every account there");
       await expect(page.locator("#accounts-enable")).toBeVisible();
     } finally {
       await closeOffline(fixture);

--- a/tests/policy/forbidden-artifacts.test.ts
+++ b/tests/policy/forbidden-artifacts.test.ts
@@ -108,6 +108,7 @@ test("only public identifiers and explicit profile-id fixtures are UUID-shaped",
   const allowed = new Set(["2043FE79-F32D-4FD7-8C27-0D47231C4F03"]);
   const profileIdFixtures = new Set([
     "tests/electron/multiple-accounts.spec.ts",
+    "tests/release/preload-behaviour.test.ts",
     "tests/unit/credentials.test.ts",
     "tests/unit/multiple-accounts.test.ts",
     "tests/unit/native-keychain.test.ts",

--- a/tests/policy/forbidden-artifacts.test.ts
+++ b/tests/policy/forbidden-artifacts.test.ts
@@ -100,12 +100,20 @@ test("no private key material is tracked", () => {
   assert.deepEqual(hits, []);
 });
 
-test("only the public client access key is UUID-shaped", () => {
+test("only public identifiers and explicit profile-id fixtures are UUID-shaped", () => {
   const uuid = /\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b/gi;
   // One entry, the public client access key. The RFC 6455 WebSocket GUID used
   // to sit beside it; it belonged to the retired Python runtime's relay and
   // matches nothing in the tree, so it is gone.
   const allowed = new Set(["2043FE79-F32D-4FD7-8C27-0D47231C4F03"]);
+  const profileIdFixtures = new Set([
+    "tests/electron/multiple-accounts.spec.ts",
+    "tests/unit/credentials.test.ts",
+    "tests/unit/multiple-accounts.test.ts",
+    "tests/unit/native-keychain.test.ts",
+    "tests/unit/paths.test.ts",
+    "tests/unit/window-registry.test.ts",
+  ]);
   const hits = [];
   for (const file of tracked) {
     if (file === "tests/policy/forbidden-artifacts.test.ts") continue;
@@ -116,7 +124,10 @@ test("only the public client access key is UUID-shaped", () => {
       continue;
     }
     for (const match of text.matchAll(uuid)) {
-      if (!allowed.has(match[0].toUpperCase())) hits.push(`${file}:${match[0]}`);
+      if (
+        !allowed.has(match[0].toUpperCase())
+        && !profileIdFixtures.has(file)
+      ) hits.push(`${file}:${match[0]}`);
     }
   }
   assert.deepEqual(hits, []);

--- a/tests/policy/source-saved-login-surface.test.ts
+++ b/tests/policy/source-saved-login-surface.test.ts
@@ -63,7 +63,7 @@ test("only provisioned distribution channels enable persistent secrets", () => {
   );
   assert.match(
     main,
-    /if \(persistentSecrets && distribution\.cleanupLegacySecrets\) \{[\s\S]{0,200}cleanupLegacySecretFiles/,
+    /if \(\s*activeAccountMode === "single"\s*&& persistentSecrets\s*&& distribution\.cleanupLegacySecrets\s*\) \{[\s\S]{0,200}cleanupLegacySecretFiles/,
   );
   assert.match(main, /capable: distribution\.automaticUpdates/);
   assert.match(main, /persistentSecrets\s*\? loadNativeKeychain/);

--- a/tests/release/preload-behaviour.test.ts
+++ b/tests/release/preload-behaviour.test.ts
@@ -158,6 +158,7 @@ function call(api: GwNativeApi, dotted: string): Capability {
 }
 
 const PACKET = new Uint8Array([1, 2, 3, 4]);
+const PROFILE_ID = "00000000-0000-4000-8000-000000000001";
 
 /** A request/response capability, with the arguments a caller really passes. */
 interface Invocation {
@@ -179,6 +180,49 @@ const INVOCATIONS: Invocation[] = [
   { path: "settings.get", args: [], channel: IPC.settingsGet },
   { path: "settings.set", args: [{ renderScale: 2 }], channel: IPC.settingsSet },
   { path: "settings.reset", args: [], channel: IPC.settingsReset },
+  { path: "accounts.get", args: [], channel: IPC.accountsGet },
+  {
+    path: "accounts.setup",
+    args: [{
+      name: "Primary",
+      templates: "shared",
+      builds: "private",
+      importTemplates: false,
+      templateEntries: [],
+      importBuilds: false,
+    }],
+    channel: IPC.accountsSetup,
+  },
+  {
+    path: "accounts.create",
+    args: [{ name: "Alt", templates: "private", builds: "private" }],
+    channel: IPC.accountsCreate,
+  },
+  {
+    path: "accounts.update",
+    args: [{
+      id: PROFILE_ID,
+      name: "Alt",
+      templates: "shared",
+      builds: "private",
+    }],
+    channel: IPC.accountsUpdate,
+  },
+  { path: "accounts.archive", args: [PROFILE_ID], channel: IPC.accountsArchive },
+  { path: "accounts.restore", args: [PROFILE_ID], channel: IPC.accountsRestore },
+  { path: "accounts.delete", args: [PROFILE_ID], channel: IPC.accountsDelete },
+  { path: "accounts.open", args: [[PROFILE_ID]], channel: IPC.accountsOpen },
+  { path: "accounts.useSingle", args: [], channel: IPC.accountsUseSingle },
+  {
+    path: "accounts.loadTemplates",
+    args: [],
+    channel: IPC.accountsTemplatesLoad,
+  },
+  {
+    path: "accounts.saveTemplates",
+    args: [[{ path: "Skills/Alt.txt", contents: "OQCiUyo8AkVwR4KMMGAAAEAA" }]],
+    channel: IPC.accountsTemplatesSave,
+  },
   { path: "buildLibrary.get", args: [], channel: IPC.buildLibraryGet },
   {
     path: "buildLibrary.set",

--- a/tests/release/preload-behaviour.test.ts
+++ b/tests/release/preload-behaviour.test.ts
@@ -183,19 +183,18 @@ const INVOCATIONS: Invocation[] = [
   { path: "accounts.get", args: [], channel: IPC.accountsGet },
   {
     path: "accounts.setup",
-    args: [{
-      name: "Primary",
-      templates: "shared",
-      builds: "private",
-      importTemplates: false,
-      templateEntries: [],
-      importBuilds: false,
-    }],
+    args: [{ templateEntries: [] }],
     channel: IPC.accountsSetup,
   },
   {
     path: "accounts.create",
-    args: [{ name: "Alt", templates: "private", builds: "private" }],
+    args: [{
+      name: "Alt",
+      templates: "private",
+      builds: "private",
+      copySingleBuilds: false,
+      copySingleTemplates: false,
+    }],
     channel: IPC.accountsCreate,
   },
   {

--- a/tests/unit/account-template-library.test.ts
+++ b/tests/unit/account-template-library.test.ts
@@ -1,0 +1,42 @@
+/** Shared template reconciliation preserves concurrent work and applies edits. */
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { reconcileAccountTemplates } from "../../src/main/core/account-template-library.js";
+
+const A = "OQCiUyo8AkVwR4KMMGAAAEAA";
+const B = "OQCiUyo8AkVwR4KMMGAAAEAB";
+const C = "OQCiUyo8AkVwR4KMMGAAAEAC";
+const entry = (path: string, contents: string) => ({ path, contents });
+
+test("merges unrelated shared-template edits", () => {
+  assert.deepEqual(
+    reconcileAccountTemplates(
+      [entry("Skills/A.txt", A)],
+      [entry("Skills/A.txt", A), entry("Skills/B.txt", B)],
+      [entry("Skills/A.txt", A), entry("Skills/C.txt", C)],
+    ),
+    [entry("Skills/A.txt", A), entry("Skills/B.txt", B), entry("Skills/C.txt", C)],
+  );
+});
+
+test("a stale deletion cannot discard a concurrent edit", () => {
+  assert.deepEqual(
+    reconcileAccountTemplates(
+      [entry("Skills/A.txt", A)],
+      [entry("Skills/A.txt", B)],
+      [],
+    ),
+    [entry("Skills/A.txt", B)],
+  );
+});
+
+test("two concurrent edits to one path preserve both contents", () => {
+  assert.deepEqual(
+    reconcileAccountTemplates(
+      [entry("Skills/A.txt", A)],
+      [entry("Skills/A.txt", B)],
+      [entry("Skills/A.txt", C)],
+    ),
+    [entry("Skills/A (conflict).txt", C), entry("Skills/A.txt", B)],
+  );
+});

--- a/tests/unit/build-library-coordinator.test.ts
+++ b/tests/unit/build-library-coordinator.test.ts
@@ -1,0 +1,36 @@
+/** Build-library concurrency belongs to its durable owner, not IPC. */
+import assert from "node:assert/strict";
+import { mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { BuildLibraryCoordinator } from "../../src/main/core/build-library-coordinator.js";
+import { EMPTY_LIBRARY } from "../../src/shared/builds/parse-library.js";
+
+test("rejects a stale write from another window", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "gwonmac-build-coordinator-"));
+  const path = join(directory, "build-library.json");
+  const coordinator = new BuildLibraryCoordinator();
+  const firstWindow = {};
+  const secondWindow = {};
+
+  await coordinator.get(firstWindow, path);
+  await coordinator.get(secondWindow, path);
+  await coordinator.set(firstWindow, path, { ...EMPTY_LIBRARY, tags: ["current"] });
+
+  await assert.rejects(
+    coordinator.set(secondWindow, path, { ...EMPTY_LIBRARY, tags: ["stale"] }),
+    /changed in another account/u,
+  );
+  assert.deepEqual((await coordinator.get(secondWindow, path)).library.tags, ["current"]);
+});
+
+test("requires a baseline read before the first write", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "gwonmac-build-coordinator-"));
+  const coordinator = new BuildLibraryCoordinator();
+
+  await assert.rejects(
+    coordinator.set({}, join(directory, "build-library.json"), EMPTY_LIBRARY),
+    /reload before saving/u,
+  );
+});

--- a/tests/unit/credentials.test.ts
+++ b/tests/unit/credentials.test.ts
@@ -6,6 +6,8 @@ import type {
   SecretSlot,
 } from "../../src/main/core/native-keychain.js";
 import { AppError } from "../../src/shared/errors.js";
+import { parseProfileId } from "../../src/shared/multiple-accounts.js";
+import { multiSecretSlot } from "../../src/main/core/native-keychain.js";
 
 class FakeKeychain implements NativeKeychain {
   readonly values = new Map<SecretSlot, Buffer>();
@@ -41,6 +43,21 @@ describe("credentials", () => {
 
     await store.clear();
     assert.equal(await store.load(), null);
+  });
+
+  it("keeps a Multi profile out of the fixed Single slot", async () => {
+    const keychain = new FakeKeychain();
+    const slot = multiSecretSlot(
+      parseProfileId("2d31e565-9fc8-4dde-9fd4-9d644f8283ae"),
+      "arenaNetCredentials",
+    );
+    const store = new CredentialsStore(keychain, slot);
+    await store.save({ username: "multi@example.test", password: "secret" });
+    assert.equal(keychain.values.has("arenaNetCredentials"), false);
+    assert.deepEqual(
+      JSON.parse(keychain.values.get(slot)!.toString("utf8")),
+      { username: "multi@example.test", password: "secret" },
+    );
   });
 
   it("maps native failure to the credential vocabulary", async () => {

--- a/tests/unit/multiple-accounts.test.ts
+++ b/tests/unit/multiple-accounts.test.ts
@@ -10,6 +10,7 @@ import {
   createMultiWorkspace,
   loadAccountMode,
   loadMultiWorkspace,
+  quarantineAccountDocument,
   removeArchivedMultiProfile,
   restoreMultiProfile,
   saveAccountMode,
@@ -63,6 +64,16 @@ describe("Multiple Accounts documents", () => {
     await assert.rejects(loadAccountMode(modePath), AppError);
     await writeFile(workspacePath, JSON.stringify({ formatVersion: 2, profiles: [] }));
     await assert.rejects(loadMultiWorkspace(workspacePath), AppError);
+  });
+
+  it("quarantines a damaged document without rewriting its bytes", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "gw-accounts-"));
+    const workspacePath = join(dir, "workspace.json");
+    await writeFile(workspacePath, "{damaged");
+    const backup = await quarantineAccountDocument(workspacePath);
+    assert.ok(backup);
+    assert.equal(await readFile(backup, "utf8"), "{damaged");
+    assert.equal(await loadMultiWorkspace(workspacePath), null);
   });
 
   it("accepts only lowercase UUID v4 identifiers", () => {

--- a/tests/unit/multiple-accounts.test.ts
+++ b/tests/unit/multiple-accounts.test.ts
@@ -37,7 +37,7 @@ describe("Multiple Accounts documents", () => {
     const dir = await mkdtemp(join(tmpdir(), "gw-accounts-"));
     const workspacePath = join(dir, "multi", "workspace.json");
     const modePath = join(dir, "launcher-mode.json");
-    const workspace = createMultiWorkspace({
+    const workspace = addMultiProfile(createMultiWorkspace(), {
       id: ID,
       name: "Main",
       templates: "shared",
@@ -106,7 +106,8 @@ describe("Multiple Accounts documents", () => {
     );
   });
 
-  it("requires one active profile and valid binary sharing choices", () => {
+  it("accepts an empty onboarding workspace but rejects an all-archived workspace", () => {
+    assert.deepEqual(createMultiWorkspace(), { formatVersion: 1, profiles: [] });
     assert.throws(
       () => parseMultiWorkspace({
         formatVersion: 1,
@@ -120,8 +121,11 @@ describe("Multiple Accounts documents", () => {
       }),
       AppError,
     );
+  });
+
+  it("requires valid binary sharing choices", () => {
     assert.throws(
-      () => createMultiWorkspace({
+      () => addMultiProfile(createMultiWorkspace(), {
         id: ID,
         name: "Main",
         templates: "linked" as never,
@@ -132,7 +136,7 @@ describe("Multiple Accounts documents", () => {
   });
 
   it("adds, updates, and archives profiles without changing stable IDs", () => {
-    const first = createMultiWorkspace({
+    const first = addMultiProfile(createMultiWorkspace(), {
       id: "00000000-0000-4000-8000-000000000001",
       name: "Primary",
       templates: "private",

--- a/tests/unit/multiple-accounts.test.ts
+++ b/tests/unit/multiple-accounts.test.ts
@@ -7,6 +7,7 @@ import { describe, it } from "node:test";
 import {
   addMultiProfile,
   archiveMultiProfile,
+  beginArchivedProfileDeletion,
   createMultiWorkspace,
   loadAccountMode,
   loadMultiWorkspace,
@@ -91,6 +92,7 @@ describe("Multiple Accounts documents", () => {
     assert.throws(
       () => parseMultiWorkspace({
         formatVersion: 1,
+        deletingProfileIds: [],
         profiles: [
           { id: ID, name: "Main", archived: false, templates: "shared", builds: "shared" },
           {
@@ -107,10 +109,15 @@ describe("Multiple Accounts documents", () => {
   });
 
   it("accepts an empty onboarding workspace but rejects an all-archived workspace", () => {
-    assert.deepEqual(createMultiWorkspace(), { formatVersion: 1, profiles: [] });
+    assert.deepEqual(createMultiWorkspace(), {
+      formatVersion: 1,
+      profiles: [],
+      deletingProfileIds: [],
+    });
     assert.throws(
       () => parseMultiWorkspace({
         formatVersion: 1,
+        deletingProfileIds: [],
         profiles: [{
           id: ID,
           name: "Main",
@@ -161,10 +168,16 @@ describe("Multiple Accounts documents", () => {
     const restored = restoreMultiProfile(archived, archived.profiles[1]!.id);
     assert.equal(restored.profiles[1]!.archived, false);
     const archivedAgain = archiveMultiProfile(restored, restored.profiles[1]!.id);
-    const removed = removeArchivedMultiProfile(
+    const pending = beginArchivedProfileDeletion(
       archivedAgain,
       archivedAgain.profiles[1]!.id,
     );
+    assert.deepEqual(pending.deletingProfileIds, [archivedAgain.profiles[1]!.id]);
+    const removed = removeArchivedMultiProfile(
+      pending,
+      pending.profiles[1]!.id,
+    );
     assert.deepEqual(removed.profiles.map((profile) => profile.name), ["Primary"]);
+    assert.deepEqual(removed.deletingProfileIds, []);
   });
 });

--- a/tests/unit/multiple-accounts.test.ts
+++ b/tests/unit/multiple-accounts.test.ts
@@ -10,6 +10,8 @@ import {
   createMultiWorkspace,
   loadAccountMode,
   loadMultiWorkspace,
+  removeArchivedMultiProfile,
+  restoreMultiProfile,
   saveAccountMode,
   saveMultiWorkspace,
   updateMultiProfile,
@@ -141,5 +143,13 @@ describe("Multiple Accounts documents", () => {
     assert.equal(archived.profiles[1]!.id, added.profiles[1]!.id);
     assert.equal(archived.profiles[1]!.name, "Storage Alt");
     assert.equal(archived.profiles[1]!.archived, true);
+    const restored = restoreMultiProfile(archived, archived.profiles[1]!.id);
+    assert.equal(restored.profiles[1]!.archived, false);
+    const archivedAgain = archiveMultiProfile(restored, restored.profiles[1]!.id);
+    const removed = removeArchivedMultiProfile(
+      archivedAgain,
+      archivedAgain.profiles[1]!.id,
+    );
+    assert.deepEqual(removed.profiles.map((profile) => profile.name), ["Primary"]);
   });
 });

--- a/tests/unit/multiple-accounts.test.ts
+++ b/tests/unit/multiple-accounts.test.ts
@@ -1,0 +1,117 @@
+/** The account-mode documents preserve Single and reject ambiguous profiles. */
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import {
+  createMultiWorkspace,
+  loadAccountMode,
+  loadMultiWorkspace,
+  saveAccountMode,
+  saveMultiWorkspace,
+} from "../../src/main/core/multiple-accounts.js";
+import {
+  parseMultiWorkspace,
+  parseProfileId,
+  profileNameKey,
+} from "../../src/shared/multiple-accounts.js";
+import { AppError } from "../../src/shared/errors.js";
+
+const ID = "2d31e565-9fc8-4dde-9fd4-9d644f8283ae";
+
+describe("Multiple Accounts documents", () => {
+  it("keeps a missing mode and workspace on the legacy Single path", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "gw-accounts-"));
+    assert.equal(await loadAccountMode(join(dir, "launcher-mode.json")), "single");
+    assert.equal(await loadMultiWorkspace(join(dir, "workspace.json")), null);
+  });
+
+  it("publishes a workspace before an explicit Multi selection", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "gw-accounts-"));
+    const workspacePath = join(dir, "multi", "workspace.json");
+    const modePath = join(dir, "launcher-mode.json");
+    const workspace = createMultiWorkspace({
+      id: ID,
+      name: "Main",
+      templates: "shared",
+      builds: "private",
+    });
+    await saveMultiWorkspace(workspacePath, workspace);
+    assert.equal(await loadAccountMode(modePath), "single");
+    await saveAccountMode(modePath, "multi");
+    assert.equal(await loadAccountMode(modePath), "multi");
+    assert.deepEqual(await loadMultiWorkspace(workspacePath), workspace);
+    assert.deepEqual(JSON.parse(await readFile(modePath, "utf8")), {
+      formatVersion: 1,
+      mode: "multi",
+    });
+  });
+
+  it("fails closed for corrupt or future documents", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "gw-accounts-"));
+    const modePath = join(dir, "launcher-mode.json");
+    const workspacePath = join(dir, "workspace.json");
+    await writeFile(modePath, "{broken");
+    await assert.rejects(loadAccountMode(modePath), AppError);
+    await writeFile(modePath, JSON.stringify({ formatVersion: 2, mode: "single" }));
+    await assert.rejects(loadAccountMode(modePath), AppError);
+    await writeFile(workspacePath, JSON.stringify({ formatVersion: 2, profiles: [] }));
+    await assert.rejects(loadMultiWorkspace(workspacePath), AppError);
+  });
+
+  it("accepts only lowercase UUID v4 identifiers", () => {
+    assert.equal(parseProfileId(ID), ID);
+    assert.throws(() => parseProfileId("../single"), AppError);
+    assert.throws(() => parseProfileId(ID.toUpperCase()), AppError);
+    assert.throws(
+      () => parseProfileId("2d31e565-9fc8-3dde-9fd4-9d644f8283ae"),
+      AppError,
+    );
+  });
+
+  it("rejects duplicate labels after normalization and case folding", () => {
+    assert.equal(profileNameKey("  MAIN  "), "main");
+    assert.throws(
+      () => parseMultiWorkspace({
+        formatVersion: 1,
+        profiles: [
+          { id: ID, name: "Main", archived: false, templates: "shared", builds: "shared" },
+          {
+            id: "6038c349-435a-4483-933f-0a792563a370",
+            name: "  main ",
+            archived: false,
+            templates: "private",
+            builds: "private",
+          },
+        ],
+      }),
+      AppError,
+    );
+  });
+
+  it("requires one active profile and valid binary sharing choices", () => {
+    assert.throws(
+      () => parseMultiWorkspace({
+        formatVersion: 1,
+        profiles: [{
+          id: ID,
+          name: "Main",
+          archived: true,
+          templates: "shared",
+          builds: "private",
+        }],
+      }),
+      AppError,
+    );
+    assert.throws(
+      () => createMultiWorkspace({
+        id: ID,
+        name: "Main",
+        templates: "linked" as never,
+        builds: "private",
+      }),
+      AppError,
+    );
+  });
+});

--- a/tests/unit/multiple-accounts.test.ts
+++ b/tests/unit/multiple-accounts.test.ts
@@ -5,11 +5,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
 import {
+  addMultiProfile,
+  archiveMultiProfile,
   createMultiWorkspace,
   loadAccountMode,
   loadMultiWorkspace,
   saveAccountMode,
   saveMultiWorkspace,
+  updateMultiProfile,
 } from "../../src/main/core/multiple-accounts.js";
 import {
   parseMultiWorkspace,
@@ -113,5 +116,30 @@ describe("Multiple Accounts documents", () => {
       }),
       AppError,
     );
+  });
+
+  it("adds, updates, and archives profiles without changing stable IDs", () => {
+    const first = createMultiWorkspace({
+      id: "00000000-0000-4000-8000-000000000001",
+      name: "Primary",
+      templates: "private",
+      builds: "private",
+    });
+    const added = addMultiProfile(first, {
+      id: "00000000-0000-4000-8000-000000000002",
+      name: "Storage",
+      templates: "shared",
+      builds: "shared",
+    });
+    const updated = updateMultiProfile(added, added.profiles[1]!.id, {
+      name: "Storage Alt",
+      templates: "private",
+      builds: "shared",
+    });
+    const archived = archiveMultiProfile(updated, updated.profiles[1]!.id);
+    assert.equal(archived.profiles[0]!.name, "Primary");
+    assert.equal(archived.profiles[1]!.id, added.profiles[1]!.id);
+    assert.equal(archived.profiles[1]!.name, "Storage Alt");
+    assert.equal(archived.profiles[1]!.archived, true);
   });
 });

--- a/tests/unit/native-keychain.test.ts
+++ b/tests/unit/native-keychain.test.ts
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
-  SECRET_SLOTS,
+  SINGLE_SECRET_SLOTS,
+  multiSecretSlot,
   type NativeKeychain,
   type SecretSlot,
 } from "../../src/main/core/native-keychain.js";
@@ -26,7 +27,14 @@ class FakeNativeKeychain implements NativeKeychain {
 
 describe("native Keychain boundary", () => {
   it("has exactly the two product-owned slots", () => {
-    assert.deepEqual(SECRET_SLOTS, ["arenaNetCredentials", "steamSession"]);
+    assert.deepEqual(SINGLE_SECRET_SLOTS, ["arenaNetCredentials", "steamSession"]);
+    assert.equal(
+      multiSecretSlot(
+        "2d31e565-9fc8-4dde-9fd4-9d644f8283ae" as never,
+        "arenaNetCredentials",
+      ),
+      "multi.2d31e565-9fc8-4dde-9fd4-9d644f8283ae.arenaNetCredentials",
+    );
   });
 
   it("resolves the one development and one packaged binary path", () => {

--- a/tests/unit/paths.test.ts
+++ b/tests/unit/paths.test.ts
@@ -58,7 +58,6 @@ describe("resolved profile paths", () => {
     // — nothing else collects them.
     assert.deepEqual(documentDirectories(gamePaths(root)), [
       root,
-      `${root}/multi`,
       `${root}/game`,
       `${root}/diagnostics`,
       `${root}/game/chunks`,
@@ -81,6 +80,7 @@ describe("resolved profile paths", () => {
       templates: `${root}/multi/profiles/${id}/templates.json`,
       templateSync: `${root}/multi/profiles/${id}/template-sync.json`,
       windowState: `${root}/multi/profiles/${id}/window-state.json`,
+      gameStorageClearRequest: `${root}/multi/profiles/${id}/clear-game-storage-on-start`,
     });
   });
 

--- a/tests/unit/paths.test.ts
+++ b/tests/unit/paths.test.ts
@@ -29,6 +29,7 @@ describe("resolved profile paths", () => {
       launcherMode: `${root}/launcher-mode.json`,
       multiRoot: `${root}/multi`,
       multiWorkspace: `${root}/multi/workspace.json`,
+      multiSingleTemplateImport: `${root}/multi/single-template-import.json`,
       multiSharedBuildLibrary: `${root}/multi/shared/build-library.json`,
       multiSharedTemplates: `${root}/multi/shared/templates.json`,
       multiProfiles: `${root}/multi/profiles`,

--- a/tests/unit/paths.test.ts
+++ b/tests/unit/paths.test.ts
@@ -6,8 +6,10 @@ import {
   diagnosticFramesPath,
   documentDirectories,
   gamePaths,
+  multiProfilePaths,
   unpackedPath,
 } from "../../src/main/core/paths.ts";
+import { parseProfileId } from "../../src/shared/multiple-accounts.ts";
 
 // Every value below is a literal on purpose. A refactor may move where a path
 // is *constructed*; it may not change what the path *is*. `game/chunks` holds
@@ -24,6 +26,13 @@ describe("resolved profile paths", () => {
       settings: `${root}/settings.json`,
       buildLibrary: `${root}/build-library.json`,
       windowState: `${root}/window-state.json`,
+      launcherMode: `${root}/launcher-mode.json`,
+      multiRoot: `${root}/multi`,
+      multiWorkspace: `${root}/multi/workspace.json`,
+      multiHubWindowState: `${root}/multi/hub-window-state.json`,
+      multiSharedBuildLibrary: `${root}/multi/shared/build-library.json`,
+      multiSharedTemplates: `${root}/multi/shared/templates.json`,
+      multiProfiles: `${root}/multi/profiles`,
       diagnostics: `${root}/diagnostics`,
       game: `${root}/game`,
       artifacts: `${root}/game/artifacts`,
@@ -49,6 +58,7 @@ describe("resolved profile paths", () => {
     // — nothing else collects them.
     assert.deepEqual(documentDirectories(gamePaths(root)), [
       root,
+      `${root}/multi`,
       `${root}/game`,
       `${root}/diagnostics`,
       `${root}/game/chunks`,
@@ -61,6 +71,17 @@ describe("resolved profile paths", () => {
       // so `SkillAssets.prepare` collects its own orphans instead — the same
       // owner-recovery exemption the hashed derived-WASM entries take.
     ]);
+  });
+
+  it("derives profile paths only beneath the Multi namespace", () => {
+    const id = parseProfileId("2d31e565-9fc8-4dde-9fd4-9d644f8283ae");
+    assert.deepEqual(multiProfilePaths(gamePaths(root), id), {
+      root: `${root}/multi/profiles/${id}`,
+      buildLibrary: `${root}/multi/profiles/${id}/build-library.json`,
+      templates: `${root}/multi/profiles/${id}/templates.json`,
+      templateSync: `${root}/multi/profiles/${id}/template-sync.json`,
+      windowState: `${root}/multi/profiles/${id}/window-state.json`,
+    });
   });
 
   it("keeps the downloaded chunk cache exactly where the alpha put it", () => {

--- a/tests/unit/paths.test.ts
+++ b/tests/unit/paths.test.ts
@@ -29,7 +29,6 @@ describe("resolved profile paths", () => {
       launcherMode: `${root}/launcher-mode.json`,
       multiRoot: `${root}/multi`,
       multiWorkspace: `${root}/multi/workspace.json`,
-      multiHubWindowState: `${root}/multi/hub-window-state.json`,
       multiSharedBuildLibrary: `${root}/multi/shared/build-library.json`,
       multiSharedTemplates: `${root}/multi/shared/templates.json`,
       multiProfiles: `${root}/multi/profiles`,

--- a/tests/unit/profile-runtime.test.ts
+++ b/tests/unit/profile-runtime.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  launchIssueForStage,
+  ProfileRuntimeStore,
+} from "../../src/main/core/profile-runtime.js";
+import type { ProfileId } from "../../src/shared/multiple-accounts.js";
+
+const id = (value: string) => value as ProfileId;
+
+describe("Multiple Accounts runtime state", () => {
+  it("tracks honest batch transitions without changing already-open accounts", () => {
+    const runtime = new ProfileRuntimeStore();
+    const open = id("open");
+    const first = id("first");
+    const second = id("second");
+    runtime.set(open, "running");
+
+    runtime.queue([open, first, second], (profileId) => profileId === open);
+    assert.equal(runtime.get(open).state, "running");
+    assert.equal(runtime.get(first).state, "queued");
+    assert.equal(runtime.get(second).state, "queued");
+
+    runtime.set(first, "opening");
+    runtime.set(first, "checking");
+    runtime.set(first, "running");
+    assert.equal(runtime.get(first).state, "running");
+  });
+
+  it("releases the untouched queue after canary failure", () => {
+    const runtime = new ProfileRuntimeStore();
+    const canary = id("canary");
+    const waiting = id("waiting");
+    runtime.queue([canary, waiting], () => false);
+    runtime.set(canary, "failed", launchIssueForStage("validating"));
+    runtime.releaseQueued([waiting]);
+
+    assert.deepEqual(runtime.get(canary), {
+      state: "failed",
+      launchIssue: "client-validation",
+    });
+    assert.deepEqual(runtime.get(waiting), { state: "ready" });
+  });
+
+  it("maps every failure stage to bounded player-safe vocabulary", () => {
+    assert.deepEqual(
+      ["preparing", "starting", "validating", "crashed", "unknown"].map(
+        (stage) => launchIssueForStage(stage as Parameters<typeof launchIssueForStage>[0]),
+      ),
+      [
+        "profile-preparation",
+        "window-startup",
+        "client-validation",
+        "renderer-crash",
+        "unknown",
+      ],
+    );
+  });
+});

--- a/tests/unit/renderer-trust.test.ts
+++ b/tests/unit/renderer-trust.test.ts
@@ -1,6 +1,9 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import { isCanonicalRendererUrl } from "../../src/main/core/renderer-trust.js";
+import {
+  isAccountsRendererUrl,
+  isCanonicalRendererUrl,
+} from "../../src/main/core/renderer-trust.js";
 
 describe("canonical renderer URL", () => {
   it("allows the launcher document and nothing else", () => {
@@ -30,6 +33,7 @@ describe("canonical renderer URL", () => {
     for (const url of [
       "gw://app/account/login",
       "gw://app/Gw.jspi.js",
+      "gw://app/accounts.html",
       "gw://app/#fragment",
       "gw://user@app/",
       "gw://app:443/",
@@ -37,6 +41,18 @@ describe("canonical renderer URL", () => {
       "not a URL",
     ]) {
       assert.equal(isCanonicalRendererUrl(url), false, url);
+    }
+  });
+
+  it("gives the accounts Hub its own document boundary", () => {
+    assert.equal(isAccountsRendererUrl("gw://app/accounts.html"), true);
+    for (const url of [
+      "gw://app/",
+      "gw://app/index.html",
+      "gw://app/accounts.html?profile=one",
+      "gw://app/accounts.html#profile",
+    ]) {
+      assert.equal(isAccountsRendererUrl(url), false, url);
     }
   });
 });

--- a/tests/unit/template-store.test.ts
+++ b/tests/unit/template-store.test.ts
@@ -14,6 +14,7 @@ import {
   mutationInFlight,
   planImport,
   readTemplates,
+  replaceTemplateProjection,
   rescueStranded,
   strandedTemplates,
   templatePath,
@@ -147,6 +148,22 @@ test("addresses an export the way an export folder is addressed", () => {
     { path: "Equipment/PvP Set.txt", contents: EQUIPMENT },
     { path: "Skills/Warrior/Shockaxe.txt", contents: SKILLS },
   ]);
+});
+
+test("replaces a profile projection with the canonical snapshot", async () => {
+  const fs = fakeFilesystem({
+    [`${SKILLS_DIR}/Old.txt`]: SKILLS,
+    [`${SKILLS_DIR}/Folder/Old child.txt`]: OTHER_SKILLS,
+  });
+  await replaceTemplateProjection(fs, [
+    { path: "Equipment/PvP Set.txt", contents: EQUIPMENT },
+    { path: "Skills/New.txt", contents: OTHER_SKILLS },
+  ]);
+  assert.deepEqual(exportEntries(fs), [
+    { path: "Equipment/PvP Set.txt", contents: EQUIPMENT },
+    { path: "Skills/New.txt", contents: OTHER_SKILLS },
+  ]);
+  assert.equal(fs.syncs, 1);
 });
 
 test("re-importing the same folder does nothing at all", () => {

--- a/tests/unit/the-companion-kernel-is-compiled-once-per-build.test.ts
+++ b/tests/unit/the-companion-kernel-is-compiled-once-per-build.test.ts
@@ -54,6 +54,7 @@ function rendererCheckout(): string {
   write("src/renderer/images/logo.webp", "webp");
   write("src/renderer/images/hero-poster.jpg", "jpeg");
   write("src/renderer/images/hero-video.webm", "webm");
+  write("apps/website/public/bg-reforged.jpg", "landscape");
   write("src/renderer/.DS_Store", "local metadata");
   write("src/renderer/images/local-note.txt", "untracked");
   // The design system is a package input that does not live under src/renderer:
@@ -100,6 +101,10 @@ describe("scripts/copy-renderer.mjs only copies assets", () => {
       readFileSync(path.join(root, "build/renderer/images/hero-video.webm"), "utf8"),
       "webm",
     );
+    assert.equal(
+      readFileSync(path.join(root, "build/renderer/images/bg-reforged.jpg"), "utf8"),
+      "landscape",
+    );
     // Not the preload: scripts/generate-preload.ts owns that output, splices
     // the canonical channel constants in and is the only producer of
     // build/preload/preload.cjs.
@@ -125,6 +130,7 @@ describe("scripts/copy-renderer.mjs only copies assets", () => {
       "fonts/COPYING-QUALITYPE",
       "fonts/QTFrizQuad.otf",
       "harness.css",
+      "images/bg-reforged.jpg",
       "images/hero-poster.jpg",
       "images/hero-video.webm",
       "images/logo.webp",

--- a/tests/unit/the-companion-kernel-is-compiled-once-per-build.test.ts
+++ b/tests/unit/the-companion-kernel-is-compiled-once-per-build.test.ts
@@ -41,6 +41,8 @@ function rendererCheckout(): string {
     writeFileSync(file, contents);
   };
   write("src/renderer/index.html", "<!doctype html>\n");
+  write("src/renderer/accounts.html", "<!doctype html>\n");
+  write("src/renderer/accounts.css", "css");
   write("src/renderer/loading.js", "export {};\n");
   write("src/renderer/gw-native.d.ts", "export {};\n");
   write("src/renderer/favicon.ico", "ico");
@@ -116,6 +118,8 @@ describe("scripts/copy-renderer.mjs only copies assets", () => {
       .map((file) => path.relative(path.join(root, "build/renderer"), file))
       .sort();
     assert.deepEqual(relative, [
+      "accounts.css",
+      "accounts.html",
       "favicon.ico",
       "favicon.png",
       "fonts/COPYING-QUALITYPE",

--- a/tests/unit/window-registry.test.ts
+++ b/tests/unit/window-registry.test.ts
@@ -1,0 +1,69 @@
+/** The window registry is the only authority from IPC senders to profiles. */
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { WindowRegistry } from "../../src/main/window-registry.js";
+import { parseProfileId } from "../../src/shared/multiple-accounts.js";
+import { AppError } from "../../src/shared/errors.js";
+
+function fake(id: number) {
+  let destroyed = false;
+  return {
+    webContents: { id },
+    isDestroyed: () => destroyed,
+    destroy: () => { destroyed = true; },
+  };
+}
+
+describe("window registry", () => {
+  it("resolves immutable context from the native sender id", () => {
+    const registry = new WindowRegistry();
+    const win = fake(7);
+    const profileId = parseProfileId("2d31e565-9fc8-4dde-9fd4-9d644f8283ae");
+    registry.register(win, { mode: "multi", role: "game", profileId });
+    assert.deepEqual(registry.contextForWebContents(7), {
+      mode: "multi",
+      role: "game",
+      profileId,
+    });
+    assert.equal(registry.contextForWebContents(8), null);
+  });
+
+  it("enforces one live game window for a profile", () => {
+    const registry = new WindowRegistry();
+    const profileId = parseProfileId("2d31e565-9fc8-4dde-9fd4-9d644f8283ae");
+    const first = fake(1);
+    registry.register(first, { mode: "multi", role: "game", profileId });
+    assert.throws(
+      () => registry.register(fake(2), { mode: "multi", role: "game", profileId }),
+      AppError,
+    );
+    first.destroy();
+    registry.register(fake(2), { mode: "multi", role: "game", profileId });
+  });
+
+  it("unregisters only the exact native window", () => {
+    const registry = new WindowRegistry();
+    const win = fake(1);
+    registry.register(win, { mode: "single", role: "game" });
+    registry.unregister(fake(1));
+    assert.notEqual(registry.contextForWebContents(1), null);
+    registry.unregister(win);
+    assert.equal(registry.contextForWebContents(1), null);
+  });
+
+  it("does not return destroyed windows", () => {
+    const registry = new WindowRegistry();
+    const hub = fake(1);
+    const game = fake(2);
+    registry.register(hub, { mode: "multi", role: "hub" });
+    registry.register(game, {
+      mode: "multi",
+      role: "game",
+      profileId: parseProfileId("2d31e565-9fc8-4dde-9fd4-9d644f8283ae"),
+    });
+    assert.equal(registry.gameWindows().length, 1);
+    game.destroy();
+    assert.equal(registry.gameWindows().length, 0);
+    assert.equal(registry.windows().length, 1);
+  });
+});

--- a/tests/unit/window-registry.test.ts
+++ b/tests/unit/window-registry.test.ts
@@ -51,6 +51,22 @@ describe("window registry", () => {
     assert.equal(registry.contextForWebContents(1), null);
   });
 
+  it("unregisters after Electron has made webContents unreadable", () => {
+    const registry = new WindowRegistry();
+    let readable = true;
+    const win = {
+      get webContents() {
+        if (!readable) throw new Error("destroyed webContents was read");
+        return { id: 1 };
+      },
+      isDestroyed: () => !readable,
+    };
+    registry.register(win, { mode: "single", role: "game" });
+    readable = false;
+    assert.doesNotThrow(() => registry.unregister(win));
+    assert.equal(registry.contextForWebContents(1), null);
+  });
+
   it("does not return destroyed windows", () => {
     const registry = new WindowRegistry();
     const hub = fake(1);

--- a/tests/unit/window-state.test.ts
+++ b/tests/unit/window-state.test.ts
@@ -6,6 +6,7 @@ import { join } from "node:path";
 import { AppError } from "../../src/shared/errors.js";
 import {
   defaultWindowState,
+  cascadeWindowState,
   fitWindowStateToDisplays,
   loadWindowState,
   parseWindowState,
@@ -122,6 +123,23 @@ describe("window state", () => {
     assert.deepEqual(defaultWindowState(primary), {
       bounds: { x: 32, y: 57, width: 960, height: 620 },
       mode: "normal",
+    });
+  });
+
+  it("cascades new account windows by 32px and clamps them", () => {
+    const workArea = { x: 0, y: 24, width: 1600, height: 1000 };
+    const base = defaultWindowState(workArea);
+
+    assert.deepEqual(cascadeWindowState(base, 1, workArea).bounds, {
+      ...base.bounds,
+      x: base.bounds.x + 32,
+      y: base.bounds.y + 32,
+    });
+    assert.deepEqual(cascadeWindowState(base, 20, workArea).bounds, {
+      x: workArea.x + workArea.width - base.bounds.width,
+      y: workArea.y + workArea.height - base.bounds.height,
+      width: base.bounds.width,
+      height: base.bounds.height,
     });
   });
 });


### PR DESCRIPTION
Multiple Accounts lets players run isolated Guild Wars sessions without cloning the app or risking their existing single-account setup.

## What changed

- Add an explicit Single Account / Multiple Accounts mode with isolated sessions, profile-scoped credentials, storage, window state, templates, and build libraries.
- Add a focused Hub for account creation, editing, archive recovery, launch progress, and mode management.
- Launch accounts independently with deterministic placement, final focus, and honest partial-failure recovery.
- Keep Single Account as the untouched default and support explicit one-way imports without linking the two modes.
- Make permanent deletion durable and resumable: a deletion marker is saved before cleanup, cleanup is idempotent, and interrupted work resumes on startup.

## Why

The old single-window lifecycle could not give two clients clear ownership of credentials, files, focus, and recovery. Each game window now has one immutable account context, while the verified client and updater remain shared.

## Architecture and failure safety

The account coordinator owns workspace state, profile resources, windows, and deletion recovery. Main remains composition-focused. Build-library concurrency stays behind its own coordinator instead of IPC. A failed disk or cleanup step cannot leave a registered account with silently erased data.

## Stack

1. **This PR — Multiple Accounts**
2. #145 — Xunlai Storage and shared Tools preparation
3. #147 — Quick Travel
4. #148 — Local Guild Wars font

Review and merge bottom-to-top, then release once from `main`.

## Verification

- Full `pnpm verify` on the complete four-PR stack
- 1,070 unit tests; 165 policy tests; 78 Tools tests
- 41 integration tests; 21 release tests; 33 Tools UI journeys
- 120 Electron tests passed; one intentional live-client test skipped
- Packaged application and Enhancement runtime lifecycle checks
- Failure-injection coverage for durable profile deletion and stale build-library writes

- [x] I kept this pull request focused.
- [x] I ran the relevant checks.
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [x] I updated documentation when behavior or an invariant changed.
