### PR TITLE
feat(release): simplify exact-draft testing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
       actions: read
       contents: read
     outputs:
+      bundle-version: ${{ steps.version.outputs.bundle-version }}
       prerelease: ${{ steps.version.outputs.prerelease }}
       tag: ${{ steps.version.outputs.tag }}
       version: ${{ steps.version.outputs.version }}
@@ -82,10 +83,10 @@ jobs:
         id: version
         run: |
           version="$(node -p "require('./package.json').version")"
-          node --import ./scripts/ts-hook.mjs --experimental-strip-types -e '
+          bundle_version="$(node --import ./scripts/ts-hook.mjs --experimental-strip-types -e '
             const { macOSBundleVersions } = await import("./scripts/macos-version.js");
-            macOSBundleVersions(process.argv[1]);
-          ' "$version"
+            console.log(macOSBundleVersions(process.argv[1]).buildVersion);
+          ' "$version")"
           prerelease=false
           if [[ "$version" == *-* ]]; then prerelease=true; fi
           if [[ "$version" == *-alpha.* ]]; then
@@ -93,6 +94,7 @@ jobs:
             exit 1
           fi
           echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "bundle-version=$bundle_version" >> "$GITHUB_OUTPUT"
           echo "tag=v$version" >> "$GITHUB_OUTPUT"
           echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
 
@@ -245,6 +247,15 @@ jobs:
             "$app" "$dmg"
           pnpm verify:signed-app \
             "$unzip_dir/Guild Wars Reforged.app"
+          mount="$RUNNER_TEMP/verified-release-dmg"
+          mkdir -p "$mount"
+          hdiutil attach "$dmg" -readonly -nobrowse -mountpoint "$mount"
+          trap 'hdiutil detach "$mount"' EXIT
+          diff -qr \
+            "$unzip_dir/Guild Wars Reforged.app" \
+            "$mount/Guild Wars Reforged.app"
+          hdiutil detach "$mount"
+          trap - EXIT
 
       - name: Prepare signed Keychain replacement fixture
         id: runtime-fixture
@@ -465,12 +476,19 @@ jobs:
     timeout-minutes: 15
     outputs:
       checksums-sha256: ${{ steps.draft.outputs.checksums-sha256 }}
+      workflow-url: ${{ steps.verification.outputs.workflow-url }}
     permissions:
       attestations: write
       artifact-metadata: write
       contents: write
       id-token: write
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-assets-${{ github.run_id }}-${{ github.run_attempt }}
@@ -531,6 +549,33 @@ jobs:
         with:
           subject-path: release-assets/*.dmg
 
+      - name: Prepare machine-owned Verification record
+        id: verification
+        env:
+          BUNDLE_VERSION: ${{ needs.release-build.outputs.bundle-version }}
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.release-build.outputs.tag }}
+          VERSION: ${{ needs.release-build.outputs.version }}
+        run: |
+          body="$RUNNER_TEMP/release-body.md"
+          if [ "${{ steps.release-state.outputs.create }}" = "true" ]; then
+            : > "$body"
+          else
+            gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
+              --json body --jq .body > "$body"
+          fi
+          output="$RUNNER_TEMP/release-body-with-verification.md"
+          workflow_url="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          node --import ./scripts/ts-hook.mjs --experimental-strip-types \
+            scripts/release-verification-record.ts stage \
+            "$body" release-assets/SHA256SUMS.txt "$workflow_url" \
+            "$GITHUB_SHA" "$VERSION" "$BUNDLE_VERSION" "$output"
+          echo "body=$output" >> "$GITHUB_OUTPUT"
+          record_workflow_url="$(node --import ./scripts/ts-hook.mjs \
+            --experimental-strip-types scripts/release-verification-record.ts \
+            workflow-url "$output")"
+          echo "workflow-url=$record_workflow_url" >> "$GITHUB_OUTPUT"
+
       - name: Create complete draft release
         if: steps.release-state.outputs.create == 'true'
         env:
@@ -539,11 +584,21 @@ jobs:
           TAG: ${{ needs.release-build.outputs.tag }}
         run: |
           args=(--repo "$GITHUB_REPOSITORY" --target "$GITHUB_SHA" \
-            --title "$TAG" --draft --generate-notes)
+            --title "$TAG" --draft --generate-notes \
+            --notes-file "${{ steps.verification.outputs.body }}")
           if [ "$PRERELEASE" = "true" ]; then
             args+=(--prerelease --latest=false)
           fi
           gh release create "$TAG" "${args[@]}" release-assets/*
+
+      - name: Refresh Verification record on resumed draft
+        if: steps.release-state.outputs.create == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.release-build.outputs.tag }}
+        run: |
+          gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" \
+            --notes-file "${{ steps.verification.outputs.body }}"
 
       - name: Verify exact remote draft
         id: draft
@@ -587,12 +642,21 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
       - name: Verify staged candidate and publish
         env:
+          BUNDLE_VERSION: ${{ needs.release-build.outputs.bundle-version }}
           EXPECTED_CHECKSUMS_SHA256: ${{ needs.stage-release.outputs.checksums-sha256 }}
+          EXPECTED_WORKFLOW_URL: ${{ needs.stage-release.outputs.workflow-url }}
           GH_TOKEN: ${{ github.token }}
           PRERELEASE: ${{ needs.release-build.outputs.prerelease }}
           TAG: ${{ needs.release-build.outputs.tag }}
+          VERSION: ${{ needs.release-build.outputs.version }}
         run: |
           release_json="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
             --json body,isDraft,isPrerelease,targetCommitish)"
@@ -621,23 +685,8 @@ jobs:
           body_file="$RUNNER_TEMP/release-body.md"
           node -e 'process.stdout.write(JSON.parse(process.argv[1]).body)' \
             "$release_json" > "$body_file"
-          node - "$body_file" "$remote/SHA256SUMS.txt" <<'NODE'
-          const { readFileSync } = require("node:fs");
-          const [bodyPath, checksumsPath] = process.argv.slice(2);
-          const lines = readFileSync(bodyPath, "utf8").split(/\r?\n/u);
-          if (!lines.some((line) => line.trim() === "## Verification")) {
-            console.error("::error::Draft release notes need an exact ## Verification heading.");
-            process.exit(1);
-          }
-          const normalize = (line) => line.trim().replace(/[\t ]+/gu, " ");
-          const releaseRows = new Set(lines.map(normalize));
-          const requiredRows = readFileSync(checksumsPath, "utf8")
-            .split(/\r?\n/u)
-            .filter(Boolean);
-          for (const row of requiredRows) {
-            if (releaseRows.has(normalize(row))) continue;
-            console.error(`::error::Draft release notes are missing checksum row: ${row}`);
-            process.exitCode = 1;
-          }
-          NODE
+          node --import ./scripts/ts-hook.mjs --experimental-strip-types \
+            scripts/release-verification-record.ts publish \
+            "$body_file" "$remote/SHA256SUMS.txt" "$EXPECTED_WORKFLOW_URL" \
+            "$GITHUB_SHA" "$VERSION" "$BUNDLE_VERSION"
           gh release edit "$TAG" --repo "$GITHUB_REPOSITORY" --draft=false

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -83,7 +83,8 @@ The workflow has two decisions:
 approval 1
   -> build, sign, notarize, staple, and verify
   -> create or resume one checksum-pinned draft
-  -> maintainer tests the exact draft assets
+  -> workflow writes the machine-owned Verification record
+  -> maintainer tests the exact draft ZIP
 approval 2
   -> re-download and verify the same draft
   -> publish by removing the draft flag
@@ -105,20 +106,32 @@ replace a published asset in place.
 
 ## Test the exact draft
 
-Download the DMG, ZIP, `RELEASES.json`, `SHA256SUMS.txt`, and SBOM from the draft.
-Do not test a local development build as release evidence.
+Close the installed application, then run:
+
+```bash
+pnpm release:test <tag>
+```
+
+The command downloads every exact draft asset, verifies its checksums, GitHub
+attestations, versions, Release identity, signature, entitlements,
+notarization, and Gatekeeper assessment. It extracts the updater ZIP into a
+temporary directory and launches that signed candidate directly.
+
+The command never changes `/Applications`. If the candidate fails, close it and
+reopen the installed version. There is no backup or rollback state to manage.
+Failed checks before launch remove their downloads automatically. A failure
+after launch retains the temporary candidate and prints its path for diagnosis.
+The command accepts Stable, Beta, and RC drafts; Alpha remains internal.
 
 On the maintainer Mac:
 
-1. Verify checksums and run the signed-app verifier on the app and DMG.
-2. Install from the DMG and start through Gatekeeper.
-3. Confirm the exact version.
-4. Start the current official client and reach a playable character.
-5. Enter an outpost and an explorable area.
-6. Play for ten minutes and check rendering, input, audio, templates, and saved
+1. Confirm the exact version.
+2. Start the current official client and reach a playable character.
+3. Enter an outpost and an explorable area.
+4. Play for ten minutes and check rendering, input, audio, templates, and saved
    login.
-7. Confirm current Core certification.
-8. If the release claims Tools support, test the claimed Target Distance and
+5. Confirm current Core certification.
+6. If the release claims Tools support, test the claimed Target Distance and
    Team Management behavior.
 
 A 16 GB Apple Silicon MacBook Pro is sufficient for this owned check. Record the
@@ -129,23 +142,20 @@ The run fails if it has an authentication loop, black game surface, GPU-process
 crash, context loss, persistent-file loss, or incorrect client-certification
 status.
 
-## Add the Verification record
+## Complete the Verification record
 
-Edit the draft release notes. Add a heading with this exact text:
-
-```text
-## Verification
-```
-
-Record the workflow URL, application and bundle versions, every complete staged
-checksum row, test result, Mac model, memory, macOS version, and current ArenaNet
-module SHA-256. Add a diagnostics fingerprint only when it informed the result.
+The workflow writes the technical fields and checksum rows. After testing,
+close the candidate and type `pass` or `fail`. A pass records the time, Mac
+model, memory, macOS version, and SHA-256 calculated directly from the active
+official ArenaNet module. It changes only the marked Verification block.
 
 Never record a credential, account identifier, token, or game traffic.
 
-The final workflow checks the heading and checksum rows. The protected reviewer
-must assess the human observations. Automation cannot decide whether the game
-looked and behaved correctly.
+The final workflow parses the record and requires an exact-draft result of
+`Passed`. The protected reviewer must still assess the human observation.
+Automation cannot decide whether the game looked and behaved correctly.
+The record is also tied to the original staging workflow URL. Re-run failed
+jobs on that workflow instead of starting another release run.
 
 Approve publication only when every applicable result passes and belongs to the
 exact draft assets.
@@ -245,6 +255,13 @@ The command must identify `Mat4m0/gwonmac` and verify the artifact digest.
 
 ## Install with Gatekeeper
 
-Open the verified DMG. Drag the application to Applications. Start it normally.
+CI builds, signs, notarizes, staples, mounts, and assesses every DMG. It also
+proves that the DMG and updater ZIP contain the same signed application.
+
+Manually install the exact DMG when Electron, Forge, signing, notarization,
+entitlements, bundle identity, DMG layout, or installation behavior changed.
+Open the verified DMG, drag the application to Applications, and start it
+normally. When the change is application-only, the temporary ZIP test is the
+owned human check.
 
 Do not disable Gatekeeper. Do not use a blanket quarantine-removal command.

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "test:packaged": "node --import ./scripts/ts-hook.mjs --experimental-strip-types tests/packaged-smoke.ts && node --import ./scripts/ts-hook.mjs --experimental-strip-types tests/packaged-enhancement-runtime.ts",
     "test:signed-keychain": "node --import ./scripts/ts-hook.mjs --experimental-strip-types tests/signed-keychain-runtime.ts",
     "test:stable-beta-roundtrip": "node --import ./scripts/ts-hook.mjs --experimental-strip-types scripts/verify-stable-beta-roundtrip.ts",
+    "release:test": "node --import ./scripts/ts-hook.mjs --experimental-strip-types scripts/test-draft-release.ts",
     "verify:signed-app": "node --import ./scripts/ts-hook.mjs --experimental-strip-types scripts/verify-signed-app.ts",
     "test:policy": "node --import ./scripts/ts-hook.mjs --experimental-strip-types --test --test-timeout=60000 tests/policy/*.ts",
     "test:release": "node --import ./scripts/ts-hook.mjs --experimental-strip-types --test --test-timeout=60000 tests/release/*.ts",

--- a/scripts/release-verification-record.ts
+++ b/scripts/release-verification-record.ts
@@ -1,0 +1,237 @@
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+
+const START = "<!-- gwonmac-verification:start -->";
+const END = "<!-- gwonmac-verification:end -->";
+const PENDING = "Pending";
+
+export interface MachineVerification {
+  workflowUrl: string;
+  targetCommit: string;
+  applicationVersion: string;
+  bundleVersion: string;
+  checksums: readonly string[];
+}
+
+export interface ManualVerification {
+  status: "Pending" | "Passed";
+  testedAt: string;
+  macModel: string;
+  memory: string;
+  macOSVersion: string;
+  arenaNetSha256: string;
+  dmgResult: "Pending" | "Passed" | "Not required — no packaging-sensitive change";
+}
+
+export interface VerificationRecord {
+  machine: MachineVerification;
+  manual: ManualVerification;
+}
+
+const pendingManual = (): ManualVerification => ({
+  status: "Pending",
+  testedAt: PENDING,
+  macModel: PENDING,
+  memory: PENDING,
+  macOSVersion: PENDING,
+  arenaNetSha256: PENDING,
+  dmgResult: "Pending",
+});
+
+function oneLine(label: string, value: string): string {
+  if (!value || /[\r\n`]/u.test(value)) {
+    throw new Error(`${label} must be one non-empty Markdown-safe line`);
+  }
+  return value;
+}
+
+export function checksumDigest(rows: readonly string[]): string {
+  return createHash("sha256").update(`${rows.join("\n")}\n`).digest("hex");
+}
+
+export function renderVerificationRecord(record: VerificationRecord): string {
+  const { machine, manual } = record;
+  const rows = machine.checksums.map((row) => oneLine("checksum row", row));
+  if (rows.length === 0) throw new Error("verification needs checksum rows");
+  return [
+    START,
+    "## Verification",
+    "",
+    `- Status: \`${oneLine("status", manual.status)}\``,
+    `- Workflow: ${oneLine("workflow URL", machine.workflowUrl)}`,
+    `- Target commit: \`${oneLine("target commit", machine.targetCommit)}\``,
+    `- Application version: \`${oneLine("application version", machine.applicationVersion)}\``,
+    `- macOS bundle version: \`${oneLine("bundle version", machine.bundleVersion)}\``,
+    `- Checksum file SHA-256: \`${checksumDigest(rows)}\``,
+    `- Tested at: \`${oneLine("test timestamp", manual.testedAt)}\``,
+    `- Mac model: \`${oneLine("Mac model", manual.macModel)}\``,
+    `- Memory: \`${oneLine("memory", manual.memory)}\``,
+    `- macOS: \`${oneLine("macOS version", manual.macOSVersion)}\``,
+    `- ArenaNet client SHA-256: \`${oneLine("ArenaNet SHA-256", manual.arenaNetSha256)}\``,
+    `- DMG: \`${oneLine("DMG result", manual.dmgResult)}\``,
+    "",
+    "### Checksums",
+    "",
+    "```text",
+    ...rows,
+    "```",
+    END,
+  ].join("\n");
+}
+
+function markers(body: string): { start: number; end: number } | null {
+  const starts = [...body.matchAll(new RegExp(START, "gu"))];
+  const ends = [...body.matchAll(new RegExp(END, "gu"))];
+  if (starts.length === 0 && ends.length === 0) return null;
+  if (starts.length !== 1 || ends.length !== 1) {
+    throw new Error("release notes must contain at most one complete Verification block");
+  }
+  const start = starts[0]!.index;
+  const end = ends[0]!.index + END.length;
+  if (end <= start) throw new Error("Verification block markers are out of order");
+  return { start, end };
+}
+
+function field(block: string, label: string): string {
+  const match = block.match(new RegExp(`^- ${label}: (?:\\x60([^\\x60]+)\\x60|(https://\\S+))$`, "mu"));
+  const value = match?.[1] ?? match?.[2];
+  if (!value) throw new Error(`Verification block is missing ${label}`);
+  return value;
+}
+
+export function parseVerificationRecord(body: string): VerificationRecord | null {
+  const location = markers(body);
+  if (!location) return null;
+  const block = body.slice(location.start, location.end);
+  const checksumMatch = block.match(/### Checksums\n\n```text\n([\s\S]*?)\n```/u);
+  if (!checksumMatch) throw new Error("Verification block has no checksum section");
+  const checksums = checksumMatch[1]!.split("\n").filter(Boolean);
+  const status = field(block, "Status");
+  const dmgResult = field(block, "DMG");
+  if (status !== "Pending" && status !== "Passed") {
+    throw new Error(`unknown verification status ${status}`);
+  }
+  if (
+    dmgResult !== "Pending"
+    && dmgResult !== "Passed"
+    && dmgResult !== "Not required — no packaging-sensitive change"
+  ) {
+    throw new Error(`unknown DMG result ${dmgResult}`);
+  }
+  const record: VerificationRecord = {
+    machine: {
+      workflowUrl: field(block, "Workflow"),
+      targetCommit: field(block, "Target commit"),
+      applicationVersion: field(block, "Application version"),
+      bundleVersion: field(block, "macOS bundle version"),
+      checksums,
+    },
+    manual: {
+      status,
+      testedAt: field(block, "Tested at"),
+      macModel: field(block, "Mac model"),
+      memory: field(block, "Memory"),
+      macOSVersion: field(block, "macOS"),
+      arenaNetSha256: field(block, "ArenaNet client SHA-256"),
+      dmgResult,
+    },
+  };
+  if (field(block, "Checksum file SHA-256") !== checksumDigest(checksums)) {
+    throw new Error("Verification checksum digest does not match its rows");
+  }
+  return record;
+}
+
+function sameAssets(a: MachineVerification, b: MachineVerification): boolean {
+  return a.targetCommit === b.targetCommit
+    && a.applicationVersion === b.applicationVersion
+    && a.bundleVersion === b.bundleVersion
+    && checksumDigest(a.checksums) === checksumDigest(b.checksums);
+}
+
+function sameMachine(a: MachineVerification, b: MachineVerification): boolean {
+  return sameAssets(a, b) && a.workflowUrl === b.workflowUrl;
+}
+
+export function replaceVerificationRecord(
+  body: string,
+  record: VerificationRecord,
+): string {
+  const location = markers(body);
+  const rendered = renderVerificationRecord(record);
+  if (!location) return `${body.trimEnd()}\n\n${rendered}\n`;
+  return `${body.slice(0, location.start)}${rendered}${body.slice(location.end)}`;
+}
+
+export function stageVerificationRecord(
+  body: string,
+  machine: MachineVerification,
+): string {
+  const existing = parseVerificationRecord(body);
+  if (existing?.manual.status === "Passed") {
+    if (!sameMachine(existing.machine, machine)) {
+      throw new Error("refusing to overwrite passed verification for different assets");
+    }
+    return body;
+  }
+  return replaceVerificationRecord(body, { machine, manual: pendingManual() });
+}
+
+export function assertPublishableVerification(
+  body: string,
+  machine: MachineVerification,
+): void {
+  const record = parseVerificationRecord(body);
+  if (!record || !sameMachine(record.machine, machine)) {
+    throw new Error("Verification record does not belong to these exact release assets");
+  }
+  if (record.manual.status !== "Passed") {
+    throw new Error("exact-draft gameplay verification is still Pending");
+  }
+  for (const [name, value] of Object.entries(record.manual)) {
+    if (value === PENDING) throw new Error(`manual verification field ${name} is Pending`);
+  }
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/u.test(record.manual.testedAt)) {
+    throw new Error("manual verification timestamp is not canonical UTC");
+  }
+  if (!/^[0-9a-f]{64}$/u.test(record.manual.arenaNetSha256)) {
+    throw new Error("ArenaNet client SHA-256 is not a digest");
+  }
+}
+
+function machineFromArgs(args: readonly string[]): MachineVerification {
+  const [checksumsPath, workflowUrl, targetCommit, applicationVersion, bundleVersion] = args;
+  if (!checksumsPath || !workflowUrl || !targetCommit || !applicationVersion || !bundleVersion) {
+    throw new Error("missing Verification machine-evidence argument");
+  }
+  return {
+    workflowUrl,
+    targetCommit,
+    applicationVersion,
+    bundleVersion,
+    checksums: readFileSync(checksumsPath, "utf8").trimEnd().split(/\r?\n/u),
+  };
+}
+
+function main(): void {
+  const [operation, bodyPath, ...args] = process.argv.slice(2);
+  if (!operation || !bodyPath) {
+    throw new Error("usage: release-verification-record <stage|publish|workflow-url> ...");
+  }
+  const body = readFileSync(bodyPath, "utf8");
+  if (operation === "stage") {
+    const outputPath = args.at(-1);
+    if (!outputPath) throw new Error("stage needs an output path");
+    writeFileSync(outputPath, stageVerificationRecord(body, machineFromArgs(args.slice(0, -1))));
+  } else if (operation === "publish") {
+    assertPublishableVerification(body, machineFromArgs(args));
+  } else if (operation === "workflow-url") {
+    const record = parseVerificationRecord(body);
+    if (!record) throw new Error("release notes have no Verification record");
+    process.stdout.write(record.machine.workflowUrl);
+  } else {
+    throw new Error(`unknown operation ${operation}`);
+  }
+}
+
+if (process.argv[1]?.endsWith("release-verification-record.ts")) main();

--- a/scripts/test-draft-release.ts
+++ b/scripts/test-draft-release.ts
@@ -1,0 +1,364 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createInterface } from "node:readline/promises";
+import { pathToFileURL } from "node:url";
+import { macOSBundleVersions } from "./macos-version.ts";
+import {
+  checksumDigest,
+  parseVerificationRecord,
+  replaceVerificationRecord,
+  type ManualVerification,
+} from "./release-verification-record.ts";
+import { verifySignedApplication } from "./verify-signed-app.ts";
+
+const REPOSITORY = "Mat4m0/gwonmac";
+const PRODUCT = "Guild Wars Reforged";
+const DEFAULT_INSTALLED_APP = `/Applications/${PRODUCT}.app`;
+const DEFAULT_OFFICIAL_WASM = path.join(
+  os.homedir(),
+  "Library/Application Support/Guild Wars/game/artifacts/Gw.jspi.wasm",
+);
+
+export interface DraftRelease {
+  body: string;
+  isDraft: boolean;
+  isPrerelease: boolean;
+  targetCommitish: string;
+  assets: { name: string }[];
+}
+
+export interface ReleaseTag {
+  version: string;
+  prerelease: boolean;
+}
+
+export interface TestResult {
+  passed: boolean;
+  dmgResult: ManualVerification["dmgResult"];
+}
+
+export interface ReleaseTestDependencies {
+  platform: NodeJS.Platform;
+  arch: string;
+  installedApp: string;
+  officialWasm: string;
+  temporaryParent: string;
+  run(command: string, args: readonly string[], cwd?: string): string;
+  status(command: string, args: readonly string[]): number | null;
+  verifyCandidate(application: string): void;
+  prompt(): Promise<TestResult>;
+  now(): Date;
+  log(message: string): void;
+}
+
+function command(command: string, args: readonly string[], cwd?: string): string {
+  return execFileSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+async function promptForResult(): Promise<TestResult> {
+  const input = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const result = (await input.question(
+      "Close the candidate after testing, then type 'pass' or 'fail': ",
+    )).trim();
+    if (result !== "pass" && result !== "fail") {
+      throw new Error("result must be exactly 'pass' or 'fail'");
+    }
+    if (result === "fail") return { passed: false, dmgResult: "Pending" };
+    const dmg = (await input.question(
+      "Type 'dmg' if the packaging checklist was required and passed; otherwise press Return: ",
+    )).trim();
+    if (dmg !== "" && dmg !== "dmg") {
+      throw new Error("DMG result must be 'dmg' or empty");
+    }
+    return {
+      passed: true,
+      dmgResult: dmg === "dmg"
+        ? "Passed"
+        : "Not required — no packaging-sensitive change",
+    };
+  } finally {
+    input.close();
+  }
+}
+
+function productionDependencies(): ReleaseTestDependencies {
+  return {
+    platform: process.platform,
+    arch: process.arch,
+    installedApp: DEFAULT_INSTALLED_APP,
+    officialWasm: DEFAULT_OFFICIAL_WASM,
+    temporaryParent: os.tmpdir(),
+    run: command,
+    status: (executable, args) => spawnSync(executable, args).status,
+    verifyCandidate: (application) => verifySignedApplication("release", application),
+    prompt: promptForResult,
+    now: () => new Date(),
+    log: console.log,
+  };
+}
+
+function gh(dependencies: ReleaseTestDependencies, args: readonly string[]): string {
+  return dependencies.run("gh", [...args, "--repo", REPOSITORY]);
+}
+
+function plist(
+  dependencies: ReleaseTestDependencies,
+  application: string,
+  key: string,
+): string {
+  return dependencies.run("/usr/libexec/PlistBuddy", [
+    "-c",
+    `Print :${key}`,
+    path.join(application, "Contents/Info.plist"),
+  ]);
+}
+
+export function compareBundleVersions(left: string, right: string): number {
+  const a = left.split(".").map(Number);
+  const b = right.split(".").map(Number);
+  if ([...a, ...b].some(Number.isNaN)) {
+    throw new Error("invalid macOS bundle version");
+  }
+  for (let index = 0; index < Math.max(a.length, b.length); index += 1) {
+    const difference = (a[index] ?? 0) - (b[index] ?? 0);
+    if (difference !== 0) return Math.sign(difference);
+  }
+  return 0;
+}
+
+export function expectedAssets(version: string): string[] {
+  const base = `Guild-Wars-Reforged-${version}-macOS-arm64`;
+  return [
+    `${base}.dmg`,
+    `${base}.spdx.json`,
+    `${base}.zip`,
+    "RELEASES.json",
+    "SHA256SUMS.txt",
+  ].sort();
+}
+
+export function parseReleaseTestTag(tag: string): ReleaseTag {
+  const match = /^v(\d{4}\.\d{1,2}\.\d{1,2}(?:-(beta|rc)\.\d+)?)$/u.exec(tag);
+  if (!match) {
+    throw new Error("tag must be a Stable, Beta, or RC release such as v2026.8.8");
+  }
+  return { version: match[1]!, prerelease: match[2] !== undefined };
+}
+
+function sha256(file: string): string {
+  return createHash("sha256").update(readFileSync(file)).digest("hex");
+}
+
+function appIsRunning(dependencies: ReleaseTestDependencies): boolean {
+  return dependencies.status(
+    "pgrep",
+    ["-f", `/${PRODUCT}\\.app/Contents/MacOS/${PRODUCT}`],
+  ) === 0;
+}
+
+function systemDetails(
+  dependencies: ReleaseTestDependencies,
+): Pick<ManualVerification, "macModel" | "memory" | "macOSVersion"> {
+  const bytes = Number(dependencies.run("sysctl", ["-n", "hw.memsize"]));
+  return {
+    macModel: dependencies.run("sysctl", ["-n", "hw.model"]),
+    memory: `${Math.round(bytes / 1024 ** 3)} GB`,
+    macOSVersion: dependencies.run("sw_vers", ["-productVersion"]),
+  };
+}
+
+function readDraft(
+  dependencies: ReleaseTestDependencies,
+  tag: string,
+): DraftRelease {
+  return JSON.parse(gh(dependencies, [
+    "release",
+    "view",
+    tag,
+    "--json",
+    "body,isDraft,isPrerelease,targetCommitish,assets",
+  ])) as DraftRelease;
+}
+
+export function assertDraftMetadata(
+  tag: string,
+  draft: DraftRelease,
+  mainCommit: string,
+  releaseTag: ReleaseTag,
+): void {
+  if (!draft.isDraft) throw new Error(`${tag} is not a draft release`);
+  if (draft.isPrerelease !== releaseTag.prerelease) {
+    throw new Error(`${tag} has inconsistent GitHub prerelease metadata`);
+  }
+  if (draft.targetCommitish !== mainCommit) {
+    throw new Error(
+      `${tag} targets ${draft.targetCommitish}, not current main ${mainCommit}`,
+    );
+  }
+  const actual = draft.assets.map(({ name }) => name).sort();
+  const expected = expectedAssets(releaseTag.version);
+  if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(
+      `unexpected release assets\nexpected: ${expected.join(", ")}\nactual: ${actual.join(", ")}`,
+    );
+  }
+}
+
+export async function runDraftReleaseTest(
+  tag: string,
+  dependencies: ReleaseTestDependencies,
+): Promise<void> {
+  const releaseTag = parseReleaseTestTag(tag);
+  if (dependencies.platform !== "darwin" || dependencies.arch !== "arm64") {
+    throw new Error("release:test requires an Apple Silicon Mac");
+  }
+  if (!existsSync(dependencies.installedApp)) {
+    throw new Error(`${dependencies.installedApp} is not installed`);
+  }
+  dependencies.run("gh", ["auth", "status"]);
+  if (dependencies.run("git", ["branch", "--show-current"]) !== "main") {
+    throw new Error("release:test must run from the main branch");
+  }
+
+  const mainCommit = dependencies.run("git", ["rev-parse", "HEAD"]);
+  const draft = readDraft(dependencies, tag);
+  assertDraftMetadata(tag, draft, mainCommit, releaseTag);
+  const expectedBundle = macOSBundleVersions(releaseTag.version);
+  const installedBundle = plist(
+    dependencies,
+    dependencies.installedApp,
+    "CFBundleVersion",
+  );
+  if (compareBundleVersions(expectedBundle.buildVersion, installedBundle) <= 0) {
+    throw new Error(`${tag} is not newer than the installed bundle ${installedBundle}`);
+  }
+  if (appIsRunning(dependencies)) {
+    throw new Error(`Close ${PRODUCT} normally, then run this command again`);
+  }
+
+  let temporary: string | undefined;
+  let launched = false;
+  let retainTemporary = false;
+  try {
+    temporary = mkdtempSync(path.join(dependencies.temporaryParent, "gwonmac-draft-"));
+    dependencies.log(`Downloading and verifying ${tag} in ${temporary}`);
+    gh(dependencies, ["release", "download", tag, "--dir", temporary]);
+    const downloaded = readdirSync(temporary).sort();
+    if (JSON.stringify(downloaded) !== JSON.stringify(expectedAssets(releaseTag.version))) {
+      throw new Error("downloaded asset inventory changed after draft inspection");
+    }
+    dependencies.run("shasum", ["-a", "256", "-c", "SHA256SUMS.txt"], temporary);
+
+    const base = `Guild-Wars-Reforged-${releaseTag.version}-macOS-arm64`;
+    const zip = path.join(temporary, `${base}.zip`);
+    const dmg = path.join(temporary, `${base}.dmg`);
+    gh(dependencies, ["attestation", "verify", zip]);
+    gh(dependencies, ["attestation", "verify", dmg]);
+
+    const extracted = path.join(temporary, "candidate");
+    mkdirSync(extracted);
+    dependencies.run("ditto", ["-x", "-k", zip, extracted]);
+    const candidate = path.join(extracted, `${PRODUCT}.app`);
+    if (!existsSync(candidate)) {
+      throw new Error("updater ZIP has no canonical application bundle");
+    }
+    dependencies.verifyCandidate(candidate);
+    if (
+      plist(dependencies, candidate, "CFBundleShortVersionString")
+      !== expectedBundle.appVersion
+    ) {
+      throw new Error("candidate application version does not match the release tag");
+    }
+    if (plist(dependencies, candidate, "CFBundleVersion") !== expectedBundle.buildVersion) {
+      throw new Error("candidate bundle version does not match the release tag");
+    }
+
+    dependencies.log(
+      "Verified the exact signed draft. Launching it from the temporary folder.",
+    );
+    dependencies.run("open", ["-n", candidate]);
+    launched = true;
+    const result = await dependencies.prompt();
+    if (appIsRunning(dependencies)) {
+      throw new Error(`Close ${PRODUCT} normally before completing the test`);
+    }
+    if (!result.passed) {
+      dependencies.log(
+        "Test failed. Verification remains Pending; the installed app was not changed.",
+      );
+      return;
+    }
+    if (!existsSync(dependencies.officialWasm)) {
+      throw new Error(`active official client is missing at ${dependencies.officialWasm}`);
+    }
+
+    const latest = readDraft(dependencies, tag);
+    assertDraftMetadata(tag, latest, mainCommit, releaseTag);
+    const record = parseVerificationRecord(latest.body);
+    const downloadedChecksums = readFileSync(
+      path.join(temporary, "SHA256SUMS.txt"),
+      "utf8",
+    ).trimEnd().split(/\r?\n/u);
+    if (
+      !record
+      || record.machine.targetCommit !== draft.targetCommitish
+      || record.machine.applicationVersion !== releaseTag.version
+      || record.machine.bundleVersion !== expectedBundle.buildVersion
+      || checksumDigest(record.machine.checksums) !== checksumDigest(downloadedChecksums)
+    ) {
+      throw new Error("draft Verification record changed or is missing");
+    }
+    const updatedBody = replaceVerificationRecord(latest.body, {
+      machine: record.machine,
+      manual: {
+        status: "Passed",
+        testedAt: dependencies.now().toISOString(),
+        ...systemDetails(dependencies),
+        arenaNetSha256: sha256(dependencies.officialWasm),
+        dmgResult: result.dmgResult,
+      },
+    });
+    const notes = path.join(temporary, "release-notes.md");
+    writeFileSync(notes, updatedBody);
+    gh(dependencies, ["release", "edit", tag, "--notes-file", notes]);
+    dependencies.log(
+      `Recorded Passed verification for ${tag}. ${dependencies.installedApp} was never changed.`,
+    );
+  } catch (error) {
+    retainTemporary = launched;
+    if (temporary && retainTemporary) {
+      dependencies.log(`Candidate retained for diagnosis at ${temporary}`);
+    }
+    throw error;
+  } finally {
+    if (temporary && !retainTemporary && existsSync(temporary)) {
+      rmSync(temporary, { recursive: true });
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const [tag, ...extra] = process.argv.slice(2);
+  if (!tag || extra.length > 0) throw new Error("usage: pnpm release:test <tag>");
+  await runDraftReleaseTest(tag, productionDependencies());
+}
+
+if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
+  await main();
+}

--- a/scripts/verify-signed-app.ts
+++ b/scripts/verify-signed-app.ts
@@ -20,6 +20,7 @@
 import { spawnSync } from "node:child_process";
 import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import {
   approvedDistributionEntitlements,
   distributionAuthorityName,
@@ -110,10 +111,10 @@ function verifyHelpers(channel: DistributionChannel, application: string): void 
   }
 }
 
-function verifyApplication(
+export function verifySignedApplication(
   channel: DistributionChannel,
   application: string,
-  profile: string,
+  profile?: string,
 ): void {
   capture("codesign", [
     "--verify",
@@ -139,7 +140,7 @@ function verifyApplication(
   const embedded = readFileSync(
     path.join(application, "Contents/embedded.provisionprofile"),
   );
-  if (!embedded.equals(readFileSync(profile))) {
+  if (profile && !embedded.equals(readFileSync(profile))) {
     fail(`${application} embeds a provisioning profile other than ${profile}`);
   }
   if (
@@ -155,7 +156,10 @@ function verifyApplication(
   capture("spctl", ["--assess", "--type", "execute", "--verbose=4", application]);
 }
 
-function verifyDiskImage(channel: DistributionChannel, diskImage: string): void {
+export function verifySignedDiskImage(
+  channel: DistributionChannel,
+  diskImage: string,
+): void {
   capture("codesign", ["--verify", "--verbose=2", diskImage]);
   expectSignature(diskImage, [
     `Authority=${distributionAuthorityName(channel)}`,
@@ -176,25 +180,27 @@ function verifyDiskImage(channel: DistributionChannel, diskImage: string): void 
   ]);
 }
 
-const args = process.argv.slice(2);
-const [application, diskImage] = args;
-const channel = process.env.GW_SIGNED_CHANNEL;
-const profile = process.env.APPLE_PROVISIONING_PROFILE;
-// Only an absent second argument means a package with no disk image. An empty
-// one is a caller whose lookup found nothing, and skipping the image
-// assertions for it would let a release pass by verifying less than it asked
-// to.
-if (
-  !application
-  || !isDistributionChannel(channel)
-  || !profile
-  || (args.length > 1 && !diskImage)
-) {
-  throw new Error(
-    "usage: GW_SIGNED_CHANNEL=<channel> APPLE_PROVISIONING_PROFILE=<profile> "
-      + "verify-signed-app <application> [<disk image>]",
-  );
+function main(): void {
+  const args = process.argv.slice(2);
+  const [application, diskImage] = args;
+  const channel = process.env.GW_SIGNED_CHANNEL;
+  const profile = process.env.APPLE_PROVISIONING_PROFILE;
+  // CI keeps the protected profile comparison. Local exact-draft testing can
+  // reuse every public verification check without possessing that secret.
+  if (
+    !application
+    || !isDistributionChannel(channel)
+    || !profile
+    || (args.length > 1 && !diskImage)
+  ) {
+    throw new Error(
+      "usage: GW_SIGNED_CHANNEL=<channel> APPLE_PROVISIONING_PROFILE=<profile> "
+        + "verify-signed-app <application> [<disk image>]",
+    );
+  }
+  verifySignedApplication(channel, application, profile);
+  if (diskImage) verifySignedDiskImage(channel, diskImage);
+  console.log(`Verified the signed ${channel} package at ${application}.`);
 }
-verifyApplication(channel, application, profile);
-if (diskImage) verifyDiskImage(channel, diskImage);
-console.log(`Verified the signed ${channel} package at ${application}.`);
+
+if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) main();

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -319,8 +319,9 @@ test("release workflow stages and publishes one tested, attested package version
   assert.match(releasePublish, /gh release download/);
   assert.doesNotMatch(
     releasePublish,
-    /actions\/checkout|actions\/download-artifact|actions\/attest|pnpm install|pnpm make|pnpm test|gh release create/,
+    /actions\/download-artifact|actions\/attest|pnpm install|pnpm make|pnpm test|gh release create/,
   );
+  assert.match(releasePublish, /actions\/checkout@[0-9a-f]{40}/);
   const signingMaterialRemovedAt = releaseBuild.indexOf(
     "security delete-keychain \"$APPLE_KEYCHAIN\"\n          rm -f",
   );
@@ -396,6 +397,10 @@ test("release workflow stages and publishes one tested, attested package version
     /verify-stable-beta-roundtrip\.ts/,
   );
   assert.match(workflow, /--draft --generate-notes/);
+  assert.match(
+    releaseStage,
+    /name: Prepare machine-owned Verification record[\s\S]*scripts\/release-verification-record\.ts stage/,
+  );
   assert.match(workflow, /--json isDraft --jq '\.isDraft'\)" != "true"/);
   assert.match(
     workflow,
@@ -428,6 +433,10 @@ test("release workflow stages and publishes one tested, attested package version
   );
   assert.match(
     releasePublish,
+    /EXPECTED_WORKFLOW_URL: \$\{\{ needs\.stage-release\.outputs\.workflow-url \}\}/,
+  );
+  assert.match(
+    releasePublish,
     /--json body,isDraft,isPrerelease,targetCommitish[\s\S]*isDraft'[\s\S]*isPrerelease'[\s\S]*targetCommitish'/,
   );
   assert.match(
@@ -436,7 +445,11 @@ test("release workflow stages and publishes one tested, attested package version
   );
   assert.match(
     releasePublish,
-    /actual_checksums_sha256[\s\S]*EXPECTED_CHECKSUMS_SHA256[\s\S]*body_file="\$RUNNER_TEMP\/release-body\.md"[\s\S]*line\.trim\(\) === "## Verification"[\s\S]*replace\(\/\[\\t \]\+\/gu, " "\)[\s\S]*Draft release notes are missing checksum row/,
+    /actual_checksums_sha256[\s\S]*EXPECTED_CHECKSUMS_SHA256[\s\S]*body_file="\$RUNNER_TEMP\/release-body\.md"[\s\S]*scripts\/release-verification-record\.ts publish/,
+  );
+  assert.match(
+    releaseBuild,
+    /hdiutil attach[\s\S]*diff -qr[\s\S]*Guild Wars Reforged\.app[\s\S]*hdiutil detach/,
   );
   assert.match(releasePublish, /gh release edit "\$TAG"[\s\S]*--draft=false/);
   assert.match(workflow, /RELEASES\.json/);
@@ -683,7 +696,23 @@ test("release verification tells the player to check, never to disable a check",
   const verification = read("docs/release-verification.md");
   assert.match(verification, /shasum -a 256 -c SHA256SUMS\.txt/);
   assert.match(verification, /gh attestation verify/);
+  assert.match(verification, /pnpm release:test <tag>/);
   assert.doesNotMatch(verification, /xattr|spctl --master-disable/);
+});
+
+test("the maintainer tests a temporary exact draft without replacing Applications", () => {
+  const command = read("scripts/test-draft-release.ts");
+  assert.match(script("release:test"), /scripts\/test-draft-release\.ts/);
+  assert.match(command, /mkdtempSync/);
+  assert.match(command, /verifyCandidate: \(application\) => verifySignedApplication\("release", application\)/);
+  assert.match(command, /dependencies\.run\("open", \["-n", candidate\]\)/);
+  assert.match(command, /gh\(dependencies, \["attestation", "verify", zip\]\)/);
+  assert.match(command, /replaceVerificationRecord/);
+  assert.match(command, /finally \{[\s\S]*rmSync\(temporary, \{ recursive: true \}\)/);
+  assert.match(command, /isPrerelease !== releaseTag\.prerelease/);
+  assert.match(command, /\(beta\|rc\)/);
+  assert.doesNotMatch(command, /alpha\|beta\|rc/);
+  assert.doesNotMatch(command, /renameSync|\/\.release-test-backup|--rollback|sudo|xattr/);
 });
 
 test("the website suite runs on its own path-filtered workflow", () => {

--- a/tests/unit/release-verification-record.test.ts
+++ b/tests/unit/release-verification-record.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  assertPublishableVerification,
+  parseVerificationRecord,
+  replaceVerificationRecord,
+  stageVerificationRecord,
+  type MachineVerification,
+} from "../../scripts/release-verification-record.ts";
+
+const machine: MachineVerification = {
+  workflowUrl: "https://github.com/Mat4m0/gwonmac/actions/runs/123",
+  targetCommit: "a".repeat(40),
+  applicationVersion: "2026.8.8",
+  bundleVersion: "2608.8.99",
+  checksums: [
+    `${"1".repeat(64)}  Guild-Wars-Reforged-2026.8.8-macOS-arm64.zip`,
+    `${"2".repeat(64)}  RELEASES.json`,
+  ],
+};
+
+describe("the one marked release Verification record", () => {
+  it("stages Pending evidence without changing generated notes", () => {
+    const body = "Intro\n\n## What's Changed\n\n- Fixed things\n";
+    const staged = stageVerificationRecord(body, machine);
+    assert.match(staged, /^Intro[\s\S]*## What's Changed/u);
+    assert.match(staged, /Status: `Pending`/u);
+    assert.deepEqual(parseVerificationRecord(staged)?.machine, machine);
+  });
+
+  it("replaces only the marked block", () => {
+    const body = stageVerificationRecord("Before\n\nAfter", machine);
+    const parsed = parseVerificationRecord(body);
+    assert.ok(parsed);
+    const passed = replaceVerificationRecord(body, {
+      machine: parsed.machine,
+      manual: {
+        status: "Passed",
+        testedAt: "2026-08-14T12:00:00.000Z",
+        macModel: "Mac16,1",
+        memory: "16 GB",
+        macOSVersion: "15.6",
+        arenaNetSha256: "f".repeat(64),
+        dmgResult: "Not required — no packaging-sensitive change",
+      },
+    });
+    assert.match(passed, /^Before\n\nAfter\n\n<!-- gwonmac-verification:start -->/u);
+    assert.doesNotThrow(() => assertPublishableVerification(passed, machine));
+  });
+
+  it("preserves a passed result only for the same immutable evidence", () => {
+    const pending = stageVerificationRecord("Notes", machine);
+    const parsed = parseVerificationRecord(pending);
+    assert.ok(parsed);
+    const passed = replaceVerificationRecord(pending, {
+      machine: parsed.machine,
+      manual: {
+        status: "Passed",
+        testedAt: "2026-08-14T12:00:00.000Z",
+        macModel: "Mac16,1",
+        memory: "16 GB",
+        macOSVersion: "15.6",
+        arenaNetSha256: "f".repeat(64),
+        dmgResult: "Passed",
+      },
+    });
+    assert.equal(stageVerificationRecord(passed, machine), passed);
+    assert.throws(
+      () => stageVerificationRecord(passed, {
+        ...machine,
+        workflowUrl: "https://github.com/Mat4m0/gwonmac/actions/runs/456",
+      }),
+      /refusing to overwrite passed verification/u,
+    );
+    assert.throws(
+      () => assertPublishableVerification(passed, {
+        ...machine,
+        workflowUrl: "https://github.com/Mat4m0/gwonmac/actions/runs/456",
+      }),
+      /exact release assets/u,
+    );
+    assert.throws(
+      () => stageVerificationRecord(passed, { ...machine, targetCommit: "b".repeat(40) }),
+      /refusing to overwrite passed verification/u,
+    );
+  });
+
+  it("refuses duplicate markers, changed checksum rows, and Pending results", () => {
+    const staged = stageVerificationRecord("Notes", machine);
+    assert.throws(() => parseVerificationRecord(`${staged}\n${staged}`), /at most one/u);
+    assert.throws(() => assertPublishableVerification(staged, machine), /Pending/u);
+    assert.throws(
+      () => assertPublishableVerification(staged, { ...machine, checksums: ["different"] }),
+      /exact release assets/u,
+    );
+  });
+});

--- a/tests/unit/test-draft-release.test.ts
+++ b/tests/unit/test-draft-release.test.ts
@@ -1,0 +1,279 @@
+import assert from "node:assert/strict";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+import { stageVerificationRecord } from "../../scripts/release-verification-record.ts";
+import {
+  assertDraftMetadata,
+  compareBundleVersions,
+  expectedAssets,
+  parseReleaseTestTag,
+  runDraftReleaseTest,
+  type DraftRelease,
+  type ReleaseTestDependencies,
+} from "../../scripts/test-draft-release.ts";
+
+const TAG = "v2026.8.8";
+const VERSION = "2026.8.8";
+const COMMIT = "a".repeat(40);
+const CHECKSUM_ROWS = [
+  `${"1".repeat(64)}  Guild-Wars-Reforged-${VERSION}-macOS-arm64.zip`,
+  `${"2".repeat(64)}  Guild-Wars-Reforged-${VERSION}-macOS-arm64.dmg`,
+  `${"3".repeat(64)}  Guild-Wars-Reforged-${VERSION}-macOS-arm64.spdx.json`,
+  `${"4".repeat(64)}  RELEASES.json`,
+];
+
+interface Fixture {
+  dependencies: ReleaseTestDependencies;
+  root: string;
+  temporaryParent: string;
+  calls: string[];
+  logs: string[];
+  editedBody(): string | undefined;
+  setFailure(value: string | undefined): void;
+  setRunningAfterLaunch(value: boolean): void;
+  close(): void;
+}
+
+function fixture(): Fixture {
+  const root = mkdtempSync(path.join(os.tmpdir(), "release-test-unit-"));
+  const temporaryParent = path.join(root, "temporary");
+  const installedApp = path.join(root, "Applications", "Guild Wars Reforged.app");
+  const officialWasm = path.join(root, "profile", "Gw.jspi.wasm");
+  mkdirSync(temporaryParent, { recursive: true });
+  mkdirSync(installedApp, { recursive: true });
+  mkdirSync(path.dirname(officialWasm), { recursive: true });
+  writeFileSync(officialWasm, "official ArenaNet module");
+
+  const body = stageVerificationRecord("Generated notes", {
+    workflowUrl: "https://github.com/Mat4m0/gwonmac/actions/runs/123",
+    targetCommit: COMMIT,
+    applicationVersion: VERSION,
+    bundleVersion: "2608.8.99",
+    checksums: CHECKSUM_ROWS,
+  });
+  const draft: DraftRelease = {
+    body,
+    isDraft: true,
+    isPrerelease: false,
+    targetCommitish: COMMIT,
+    assets: expectedAssets(VERSION).map((name) => ({ name })),
+  };
+  const calls: string[] = [];
+  const logs: string[] = [];
+  let failure: string | undefined;
+  let runningAfterLaunch = false;
+  let statusCalls = 0;
+  let releaseBody: string | undefined;
+
+  const run = (command: string, args: readonly string[]): string => {
+    const call = `${command} ${args.join(" ")}`;
+    calls.push(call);
+    if (failure === "auth" && call.startsWith("gh auth status")) {
+      throw new Error("expired GitHub login");
+    }
+    if (command === "git") return args[0] === "branch" ? "main" : COMMIT;
+    if (command === "/usr/libexec/PlistBuddy") {
+      const key = args[1];
+      const application = args[2] ?? "";
+      if (key === "Print :CFBundleShortVersionString") return VERSION;
+      return application === path.join(installedApp, "Contents/Info.plist")
+        ? "2608.7.99"
+        : "2608.8.99";
+    }
+    if (command === "gh" && args[0] === "release" && args[1] === "view") {
+      return JSON.stringify(draft);
+    }
+    if (command === "gh" && args[0] === "release" && args[1] === "download") {
+      const directory = args[args.indexOf("--dir") + 1]!;
+      for (const asset of expectedAssets(VERSION)) writeFileSync(path.join(directory, asset), asset);
+      writeFileSync(path.join(directory, "SHA256SUMS.txt"), `${CHECKSUM_ROWS.join("\n")}\n`);
+      return "";
+    }
+    if (command === "shasum" && failure === "checksum") {
+      throw new Error("checksum mismatch");
+    }
+    if (
+      command === "gh"
+      && args[0] === "attestation"
+      && failure === "attestation"
+    ) {
+      throw new Error("attestation failed");
+    }
+    if (command === "ditto") {
+      mkdirSync(path.join(args[3]!, "Guild Wars Reforged.app"), { recursive: true });
+      return "";
+    }
+    if (command === "open" && failure === "launch") {
+      throw new Error("candidate launch refused");
+    }
+    if (command === "gh" && args[0] === "release" && args[1] === "edit") {
+      if (failure === "notes") throw new Error("release-note update failed");
+      releaseBody = readFileSync(args[args.indexOf("--notes-file") + 1]!, "utf8");
+      return "";
+    }
+    if (command === "sysctl") {
+      return args[1] === "hw.memsize" ? String(16 * 1024 ** 3) : "Mac16,1";
+    }
+    if (command === "sw_vers") return "15.6";
+    return "";
+  };
+
+  const dependencies: ReleaseTestDependencies = {
+    platform: "darwin",
+    arch: "arm64",
+    installedApp,
+    officialWasm,
+    temporaryParent,
+    run,
+    status: () => {
+      statusCalls += 1;
+      return statusCalls > 1 && runningAfterLaunch ? 0 : 1;
+    },
+    verifyCandidate: () => {
+      if (failure === "signature") throw new Error("invalid signature");
+    },
+    prompt: async () => ({
+      passed: true,
+      dmgResult: "Not required — no packaging-sensitive change",
+    }),
+    now: () => new Date("2026-08-14T12:00:00.000Z"),
+    log: (message) => logs.push(message),
+  };
+
+  return {
+    dependencies,
+    root,
+    temporaryParent,
+    calls,
+    logs,
+    editedBody: () => releaseBody,
+    setFailure: (value) => { failure = value; },
+    setRunningAfterLaunch: (value) => { runningAfterLaunch = value; },
+    close: () => rmSync(root, { recursive: true }),
+  };
+}
+
+describe("temporary exact-draft testing", () => {
+  it("compares macOS bundle versions numerically", () => {
+    assert.equal(compareBundleVersions("2608.8.99", "2608.7.99"), 1);
+    assert.equal(compareBundleVersions("2608.8.31", "2608.8.31"), 0);
+    assert.equal(compareBundleVersions("2608.8.1", "2608.8.31"), -1);
+    assert.throws(() => compareBundleVersions("bad", "2608.8.31"));
+  });
+
+  it("accepts Stable, Beta, and RC but refuses Alpha", () => {
+    assert.deepEqual(parseReleaseTestTag("v2026.8.8"), {
+      version: "2026.8.8",
+      prerelease: false,
+    });
+    assert.equal(parseReleaseTestTag("v2026.8.8-beta.1").prerelease, true);
+    assert.equal(parseReleaseTestTag("v2026.8.8-rc.1").prerelease, true);
+    assert.throws(() => parseReleaseTestTag("v2026.8.8-alpha.1"), /Stable, Beta, or RC/u);
+  });
+
+  it("requires GitHub prerelease metadata to match the tag", () => {
+    const releaseTag = parseReleaseTestTag("v2026.8.8-beta.1");
+    assert.throws(
+      () => assertDraftMetadata(
+        "v2026.8.8-beta.1",
+        {
+          body: "",
+          isDraft: true,
+          isPrerelease: false,
+          targetCommitish: COMMIT,
+          assets: expectedAssets("2026.8.8-beta.1").map((name) => ({ name })),
+        },
+        COMMIT,
+        releaseTag,
+      ),
+      /inconsistent GitHub prerelease metadata/u,
+    );
+  });
+
+  it("refuses non-drafts and changed asset inventories", () => {
+    const releaseTag = parseReleaseTestTag(TAG);
+    const valid: DraftRelease = {
+      body: "",
+      isDraft: true,
+      isPrerelease: false,
+      targetCommitish: COMMIT,
+      assets: expectedAssets(VERSION).map((name) => ({ name })),
+    };
+    assert.throws(
+      () => assertDraftMetadata(TAG, { ...valid, isDraft: false }, COMMIT, releaseTag),
+      /not a draft/u,
+    );
+    assert.throws(
+      () => assertDraftMetadata(TAG, { ...valid, assets: [] }, COMMIT, releaseTag),
+      /unexpected release assets/u,
+    );
+  });
+
+  it("launches, records Passed, and removes the temporary candidate", async () => {
+    const test = fixture();
+    try {
+      await runDraftReleaseTest(TAG, test.dependencies);
+      assert.deepEqual(readdirSync(test.temporaryParent), []);
+      assert.match(test.editedBody() ?? "", /Status: `Passed`/u);
+      assert.ok(test.calls.some((call) => call.startsWith("open -n ")));
+    } finally {
+      test.close();
+    }
+  });
+
+  for (const failure of ["checksum", "attestation", "signature", "launch"] as const) {
+    it(`removes complete downloads after a pre-launch ${failure} failure`, async () => {
+      const test = fixture();
+      test.setFailure(failure);
+      try {
+        await assert.rejects(runDraftReleaseTest(TAG, test.dependencies));
+        assert.deepEqual(readdirSync(test.temporaryParent), []);
+      } finally {
+        test.close();
+      }
+    });
+  }
+
+  it("creates no temporary download when GitHub authentication fails", async () => {
+    const test = fixture();
+    test.setFailure("auth");
+    try {
+      await assert.rejects(runDraftReleaseTest(TAG, test.dependencies), /expired GitHub login/u);
+      assert.deepEqual(readdirSync(test.temporaryParent), []);
+    } finally {
+      test.close();
+    }
+  });
+
+  it("retains a launched candidate when it is still running", async () => {
+    const test = fixture();
+    test.setRunningAfterLaunch(true);
+    try {
+      await assert.rejects(runDraftReleaseTest(TAG, test.dependencies), /Close Guild Wars Reforged/u);
+      assert.equal(readdirSync(test.temporaryParent).length, 1);
+      assert.ok(test.logs.some((line) => line.includes("retained for diagnosis")));
+    } finally {
+      test.close();
+    }
+  });
+
+  it("retains a launched candidate when release-note recording fails", async () => {
+    const test = fixture();
+    test.setFailure("notes");
+    try {
+      await assert.rejects(runDraftReleaseTest(TAG, test.dependencies), /release-note update failed/u);
+      assert.equal(readdirSync(test.temporaryParent).length, 1);
+    } finally {
+      test.close();
+    }
+  });
+});


### PR DESCRIPTION
## Why

Testing an exact draft release required reinstalling the DMG and manually copying machine-generated verification data into the release notes. That made routine releases slow and allowed harmless formatting differences to block publication.

This keeps the process simple: the installed application stays untouched, while the exact signed draft is verified and launched from a temporary location for the one check automation cannot perform—real gameplay.

## What changed

- Add `pnpm release:test <tag>` to download, verify, and temporarily launch the exact draft updater ZIP without modifying `/Applications`.
- Verify draft metadata, canonical assets, checksums, GitHub attestations, application identity and version, entitlements, code signature, notarization, and Gatekeeper status.
- Generate and parse one structured `## Verification` block shared by staging, local testing, and publication.
- Populate machine-owned evidence automatically and require a structured `Passed` gameplay result before publication.
- Compare the signed application payloads from the updater ZIP and DMG in CI.
- Keep manual DMG installation testing only for packaging-sensitive changes.
- Document the new maintainer flow and its safety boundary.

## Safety boundary

The command never replaces the installed application, creates rollback state, uses `sudo`, disables Gatekeeper, or touches player data. A failed candidate is closed and the existing application can be reopened normally.

## Verification

- [x] `pnpm check`
- [x] `pnpm verify`
- [x] 1,014 unit tests
- [x] 164 release-policy tests
- [x] 41 integration tests
- [x] 21 release tests
- [x] 31 Tools browser tests
- [x] 110 Electron scenarios passed; 1 intentional live-only scenario skipped
- [x] Packaged application and Enhancement runtime checks
- [x] `git diff --check`
- [x] I kept this pull request focused.
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [x] I updated documentation where behavior and invariants changed.

The first release containing this command still uses the existing manual DMG verification flow.