### PR TITLE
feat(appearance): use the original Guild Wars font locally

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -8,7 +8,11 @@ macOS supplies interaction.
 - Use the reviewed static Reforged landscape as environmental key art. Do not
   load the launcher video in utility windows.
 - Use the existing Reforged logo as the only ornamental brand element.
-- Use the macOS system font for application controls, labels, forms, and status.
+- Keep visual style and typeface independent in in-game GWonMac panels. The
+  locally converted Guild Wars body font is the default; Inter/system type is
+  the modern option, and Palatino is the fail-safe when the game asset is not
+  available. Utility windows such as the Multiple Accounts Hub keep macOS
+  system type.
 - Use one ember tint (`#b84618`) for selection and primary action. Reserve red
   for destructive actions and green for an already-open account.
 - Prefer native hierarchy: system-sized controls, semantic checkboxes, sheets,

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -59,8 +59,10 @@ application's Resources directory.
 This is decoding machinery, not game content. Every fact the build editor shows
 — each skill's name, description, icon, profession, attribute and costs — is
 read at runtime out of the Guild Wars installation on the player's own machine
-and cached there. As with the game cursor described above, none of it is copied
-into this repository, the packaged application, or any release artifact.
+and cached there. The original Latin UI font is also read from that local game
+archive and converted to a browser font in memory. As with the game cursor
+described above, none of this game content is copied into this repository, the
+packaged application, or any release artifact.
 
 ## QT Friz Quad
 

--- a/apps/tools/tests/workbench.spec.ts
+++ b/apps/tools/tests/workbench.spec.ts
@@ -532,6 +532,7 @@ test("reorders team members with keyboard and pointer drag, then removes and und
 test("projects Obsidian through the shared system without layout drift", async ({ page }) => {
   await page.evaluate(() => {
     document.documentElement.dataset.uiStyle = "obsidian";
+    document.documentElement.dataset.uiFont = "inter";
     document.documentElement.style.setProperty("--ui-panel-opacity", "0.65");
   });
   await page.setViewportSize({ width: 360, height: 800 });

--- a/docs/content-pipeline.md
+++ b/docs/content-pipeline.md
@@ -116,6 +116,21 @@ The main-process chunk store is canonical. The renderer has a bounded,
 disposable byte cache for active play. Chromium responses use `no-store` so its
 network cache does not become a second copy of the game-data store.
 
+## Original interface font
+
+Guild Wars stores its interface lettering as bitmap strikes, not as a standard
+font file. GWonMac reads the hand-tuned 24-pixel basic-Latin body strike
+(archive file 123027) from the active local game, validates and decompresses
+that one bounded stream, and converts its 94 printable ASCII glyphs to TrueType
+in memory. The shared Guild Wars interface theme loads it from
+`gw://app/game-font.ttf`.
+
+The local archive remains the source of truth. GWonMac does not commit, cache,
+package, or redistribute the game glyphs or the converted font. If the file is
+missing or ArenaNet changes its format, the request fails closed and the theme
+uses its existing Palatino-compatible serif fallback. Characters outside basic
+ASCII also use that fallback.
+
 At startup, the native store scans chunk residency once. It updates the
 in-memory residency set after publication. A range request does not rescan the
 chunk directory.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -83,8 +83,10 @@ the action and restarts. It keeps the small official client files.
 
 ## Display and input
 
-Open **Settings → Display** to select render scale, interface style, and
-panel opacity.
+Open **Settings → Display** to select render scale, interface style, interface
+font, and panel opacity. **Guild Wars Original** is converted locally from your
+installed game. **Inter** uses the modern font when it is installed and the
+closest system sans-serif otherwise.
 
 **Retina — 2×** is the image-quality default. Use 1.5× or 1× to reduce GPU work
 and memory. Settings shows the current backing resolution. The official web

--- a/scripts/verify-stable-beta-roundtrip.ts
+++ b/scripts/verify-stable-beta-roundtrip.ts
@@ -33,6 +33,7 @@ import {
   RENDER_SCALES,
   UI_PANEL_OPACITY_MAX,
   UI_PANEL_OPACITY_MIN,
+  UI_FONTS,
   UI_STYLES,
   UPDATE_TRACKS,
   type AppSettings,
@@ -143,6 +144,7 @@ const compatibilityValues = [null, "a".repeat(64)] as const;
 const domainCaseCount = Math.max(
   RENDER_SCALES.length,
   UI_STYLES.length,
+  UI_FONTS.length,
   opacityValues.length,
   booleanValues.length,
   DATA_STRATEGIES.length,
@@ -156,6 +158,7 @@ const candidateSettingsDomains = Array.from(
     const settings: AppSettings = {
       renderScale: cycle(RENDER_SCALES, index),
       uiStyle: cycle(UI_STYLES, index),
+      uiFont: cycle(UI_FONTS, index),
       uiPanelOpacity: cycle(opacityValues, index),
       gwonmacTools: cycle(booleanValues, index),
       teamManagement: cycle(booleanValues, index + 1),

--- a/src/main/core/game-font-assets.ts
+++ b/src/main/core/game-font-assets.ts
@@ -28,23 +28,30 @@ const MAX_COMPRESSED_FONT_BYTES = 64 * 1024;
 const MAX_DECODED_FONT_BYTES = 64 * 1024;
 
 export interface GameFontSource {
-  readonly store: ChunkStore;
+  readonly store: Pick<ChunkStore, "readRange">;
   readonly decoderPath: string;
 }
+
+export type GameFontRefusal = "unsupported" | "read-or-format";
 
 export class GameFontAssets {
   private readonly source: GameFontSource;
   private result: Promise<Buffer | null> | null = null;
+  private refusalCode: GameFontRefusal | null = null;
 
   constructor(source: GameFontSource) {
     this.source = source;
   }
 
   async font(): Promise<Buffer | null> {
-    const pending = this.result ??= this.convert().catch(() => null);
-    const value = await pending;
-    if (value === null && this.result === pending) this.result = null;
-    return value;
+    return this.result ??= this.convert().catch(() => {
+      this.refusalCode = "read-or-format";
+      return null;
+    });
+  }
+
+  refusal(): GameFontRefusal | null {
+    return this.refusalCode;
   }
 
   private async convert(): Promise<Buffer | null> {
@@ -69,10 +76,10 @@ export class GameFontAssets {
       files,
     );
     const stream = findStream(files, index, GUILD_WARS_LATIN_FONT_FILE_ID);
-    if (
-      !stream?.compressed
-      || stream.size > MAX_COMPRESSED_FONT_BYTES
-    ) return null;
+    if (!stream?.compressed || stream.size > MAX_COMPRESSED_FONT_BYTES) {
+      this.refusalCode = "unsupported";
+      return null;
+    }
     const compressed = await store.readRange(stream.offset, stream.size);
     const raw = await runGwDatDecoder(this.source.decoderPath, compressed, {
       args: ["--raw"],

--- a/src/main/core/game-font-assets.ts
+++ b/src/main/core/game-font-assets.ts
@@ -1,0 +1,84 @@
+/**
+ * The original Guild Wars Latin UI font, derived from the active local game.
+ *
+ * The archive contains a high-resolution bitmap strike rather than an ordinary
+ * font file. This class reads only that bounded stream, asks the existing local
+ * helper to decompress it, and converts it to TrueType in memory. A missing or
+ * changed asset returns `null`, so the renderer keeps its normal serif fallback.
+ */
+
+import type { ChunkStore } from "./chunk-store.js";
+import {
+  fileIdIndex,
+  findStream,
+  parseArchiveHeader,
+  parseSlot,
+  readFileTable,
+} from "./gw-archive.js";
+import {
+  decodedArchiveBytes,
+  runGwDatDecoder,
+} from "./gw-dat-decoder.js";
+import {
+  buildGuildWarsTrueType,
+  GUILD_WARS_LATIN_FONT_FILE_ID,
+} from "./gw-font.js";
+
+const MAX_COMPRESSED_FONT_BYTES = 64 * 1024;
+const MAX_DECODED_FONT_BYTES = 64 * 1024;
+
+export interface GameFontSource {
+  readonly store: ChunkStore;
+  readonly decoderPath: string;
+}
+
+export class GameFontAssets {
+  private readonly source: GameFontSource;
+  private result: Promise<Buffer | null> | null = null;
+
+  constructor(source: GameFontSource) {
+    this.source = source;
+  }
+
+  async font(): Promise<Buffer | null> {
+    const pending = this.result ??= this.convert().catch(() => null);
+    const value = await pending;
+    if (value === null && this.result === pending) this.result = null;
+    return value;
+  }
+
+  private async convert(): Promise<Buffer | null> {
+    const { store } = this.source;
+    const headerBytes = await store.readRange(0, 32);
+    const header = parseArchiveHeader(() => headerBytes);
+    const tableBytes = await store.readRange(header.tableOffset, header.tableSize);
+    const files = readFileTable(
+      (offset, length) => tableBytes.subarray(
+        offset - header.tableOffset,
+        offset - header.tableOffset + length,
+      ),
+      header,
+    );
+    const indexSlot = parseSlot(files.bytes, 2);
+    const indexBytes = await store.readRange(indexSlot.offset, indexSlot.size);
+    const index = fileIdIndex(
+      (offset, length) => indexBytes.subarray(
+        offset - indexSlot.offset,
+        offset - indexSlot.offset + length,
+      ),
+      files,
+    );
+    const stream = findStream(files, index, GUILD_WARS_LATIN_FONT_FILE_ID);
+    if (
+      !stream?.compressed
+      || stream.size > MAX_COMPRESSED_FONT_BYTES
+    ) return null;
+    const compressed = await store.readRange(stream.offset, stream.size);
+    const raw = await runGwDatDecoder(this.source.decoderPath, compressed, {
+      args: ["--raw"],
+      maxOutput: MAX_DECODED_FONT_BYTES + 8,
+      parse: (bytes) => decodedArchiveBytes(bytes, MAX_DECODED_FONT_BYTES),
+    });
+    return buildGuildWarsTrueType(raw);
+  }
+}

--- a/src/main/core/gw-dat-decoder.ts
+++ b/src/main/core/gw-dat-decoder.ts
@@ -1,0 +1,88 @@
+/**
+ * The bounded process boundary around the vendored Guild Wars archive decoder.
+ *
+ * The helper accepts one compressed archive stream on stdin. Callers choose
+ * the decoder mode and validate the returned format, while this module owns
+ * the shared timeout and output-size enforcement.
+ */
+
+import { spawn } from "node:child_process";
+
+const HELPER_TIMEOUT_MS = 5_000;
+
+export function runGwDatDecoder(
+  executable: string,
+  input: Uint8Array,
+  options: {
+    readonly args: readonly string[];
+    readonly maxOutput: number;
+    parse(output: Uint8Array): Buffer;
+  },
+): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(executable, options.args, {
+      stdio: ["pipe", "pipe", "ignore"],
+      windowsHide: true,
+    });
+    const chunks: Buffer[] = [];
+    let length = 0;
+    let settled = false;
+    const fail = (error: Error) => {
+      if (settled) return;
+      settled = true;
+      child.kill();
+      reject(error);
+    };
+    const timer = setTimeout(
+      () => fail(new Error("the archive decoder timed out")),
+      HELPER_TIMEOUT_MS,
+    );
+    child.stdout.on("data", (chunk: Buffer) => {
+      length += chunk.length;
+      if (length > options.maxOutput) {
+        fail(new Error("the archive decoder exceeded its output bound"));
+      } else {
+        chunks.push(chunk);
+      }
+    });
+    child.on("error", fail);
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (settled) return;
+      settled = true;
+      if (code !== 0) {
+        reject(new Error("the archive decoder refused the local asset"));
+        return;
+      }
+      try {
+        resolve(options.parse(Buffer.concat(chunks, length)));
+      } catch (error) {
+        reject(error);
+      }
+    });
+    child.stdin.end(input);
+  });
+}
+
+/** Read the decoder's `GWDB`, little-endian length, payload envelope. */
+export function decodedArchiveBytes(
+  decoded: Uint8Array,
+  maximumPayloadBytes: number,
+  content = "data",
+): Buffer {
+  if (
+    decoded.length < 8
+    || String.fromCharCode(...decoded.subarray(0, 4)) !== "GWDB"
+  ) {
+    throw new Error(`the archive decoder returned an invalid ${content} header`);
+  }
+  const length = new DataView(
+    decoded.buffer,
+    decoded.byteOffset + 4,
+    4,
+  ).getUint32(0, true);
+  if (length > maximumPayloadBytes || decoded.byteLength !== length + 8) {
+    throw new Error(`the archive decoder returned an invalid ${content} length`);
+  }
+  return Buffer.from(decoded.subarray(8));
+}

--- a/src/main/core/gw-font.ts
+++ b/src/main/core/gw-font.ts
@@ -1,0 +1,488 @@
+/**
+ * The original Guild Wars Latin UI face, converted from the player's archive.
+ *
+ * Guild Wars stores one bitmap strike per character range. File 123027 is its
+ * hand-tuned 24-pixel Latin body strike: 94 glyphs in ASCII order (`!` through
+ * `~`). It matches the physical size of GWonMac's interface on a Retina
+ * display; scaling the 52-pixel title strike down lost the weight and spacing
+ * visible in the real game, while doubling the 14-pixel strike looked blocky.
+ * Every boundary below validates the local data before it becomes a browser
+ * font. No game bytes or generated font ship with GWonMac.
+ *
+ * The range is a low-nibble-first stream. Each glyph starts with top inset,
+ * width, height and alpha mode, followed by palette or alternating runs. The
+ * converter traces the high-resolution bitmap into a small TrueType `glyf`
+ * font. Chromium can then use it through an ordinary `FontFace`, while glyphs
+ * outside basic ASCII fall through to the existing serif stack.
+ */
+
+export const GUILD_WARS_LATIN_FONT_FILE_ID = 123027;
+
+const ALPHA = Uint8Array.of(
+  0x00, 0x66, 0x79, 0x8d, 0x97, 0xa5, 0xaf, 0xbd,
+  0xc6, 0xce, 0xd6, 0xde, 0xe7, 0xef, 0xf7, 0xff,
+);
+const FIRST_CHARACTER = 0x21;
+const LAST_CHARACTER = 0x7e;
+const SOURCE_EM = 24;
+const SOURCE_BASELINE = 18;
+const SOURCE_LINE_HEIGHT = 25;
+const SOURCE_SPACE_WIDTH = 6;
+const UNITS_PER_EM = 1024;
+const OUTLINE_THRESHOLD = 0x80;
+const OUTLINE_SAMPLE_SCALE = 4;
+
+export interface GameGlyph {
+  readonly top: number;
+  readonly width: number;
+  readonly height: number;
+  readonly pixels: Uint8Array;
+}
+
+class Nibbles {
+  private at = 0;
+  private readonly bytes: Uint8Array;
+
+  constructor(bytes: Uint8Array) {
+    this.bytes = bytes;
+  }
+
+  read(): number {
+    const byte = this.bytes[this.at >> 1];
+    if (byte === undefined) throw new Error("font glyph ended inside a nibble");
+    const value = (this.at & 1) === 0 ? byte & 0x0f : byte >>> 4;
+    this.at += 1;
+    return value;
+  }
+
+  /** Three data bits, then one or three extension nibbles. */
+  value(): number {
+    const first = this.read();
+    if (first < 8) return first;
+    const low = first & 7;
+    const middle = this.read();
+    if (middle < 15) return low | (middle << 3);
+    return low | (this.read() << 3) | (this.read() << 7);
+  }
+
+  run(): number {
+    let part = this.read();
+    if (part < 15) return part + 1;
+    let length = 16;
+    do {
+      part = this.read();
+      length += part;
+    } while (part === 15);
+    return length;
+  }
+
+  get bytesRead(): number {
+    return (this.at + 1) >> 1;
+  }
+}
+
+function decodeGlyph(source: Uint8Array): { glyph: GameGlyph; bytes: number } {
+  const input = new Nibbles(source);
+  const top = input.value();
+  const width = input.value() + 1;
+  const height = input.value() + 1;
+  const mode = input.read();
+  const pixelCount = width * height;
+  if (width > 256 || height > 256 || pixelCount > 65_536) {
+    throw new Error("font glyph dimensions exceed their bound");
+  }
+
+  const pixels = new Uint8Array(pixelCount);
+  let written = 0;
+  let alpha = ALPHA[mode]!;
+  while (written < pixelCount) {
+    let length: number;
+    if (mode === 0 || mode === 15) {
+      alpha ^= 0xff;
+      length = input.run();
+    } else {
+      const value = input.read();
+      alpha = ALPHA[value]!;
+      length = value === 0 || value === 15 ? input.run() : 1;
+    }
+    if (length > pixelCount - written) {
+      throw new Error("font glyph run exceeds its bitmap");
+    }
+    pixels.fill(alpha, written, written + length);
+    written += length;
+  }
+  return { glyph: { top, width, height, pixels }, bytes: input.bytesRead };
+}
+
+export function decodeGameFontRange(bytes: Uint8Array): readonly GameGlyph[] {
+  const glyphs: GameGlyph[] = [];
+  let at = 0;
+  while (at < bytes.byteLength) {
+    const decoded = decodeGlyph(bytes.subarray(at));
+    if (decoded.bytes <= 0 || at + decoded.bytes > bytes.byteLength) {
+      throw new Error("font glyph length is invalid");
+    }
+    glyphs.push(decoded.glyph);
+    at += decoded.bytes;
+  }
+  const expected = LAST_CHARACTER - FIRST_CHARACTER + 1;
+  if (glyphs.length !== expected) {
+    throw new Error(`font range has ${glyphs.length} glyphs instead of ${expected}`);
+  }
+  return glyphs;
+}
+
+const align4 = (value: number): number => (value + 3) & ~3;
+
+function u16(value: number): Buffer {
+  const out = Buffer.allocUnsafe(2);
+  out.writeUInt16BE(value & 0xffff);
+  return out;
+}
+
+function i16(value: number): Buffer {
+  const out = Buffer.allocUnsafe(2);
+  out.writeInt16BE(value);
+  return out;
+}
+
+function u32(value: number): Buffer {
+  const out = Buffer.allocUnsafe(4);
+  out.writeUInt32BE(value >>> 0);
+  return out;
+}
+
+function checksum(bytes: Uint8Array): number {
+  let sum = 0;
+  for (let at = 0; at < align4(bytes.byteLength); at += 4) {
+    sum = (
+      sum
+      + (((bytes[at] ?? 0) << 24) >>> 0)
+      + ((bytes[at + 1] ?? 0) << 16)
+      + ((bytes[at + 2] ?? 0) << 8)
+      + (bytes[at + 3] ?? 0)
+    ) >>> 0;
+  }
+  return sum;
+}
+
+interface Rectangle {
+  readonly left: number;
+  readonly right: number;
+  readonly top: number;
+  bottom: number;
+}
+
+interface HorizontalMetrics {
+  readonly advance: number;
+  readonly shift: number;
+}
+
+function interpolatedAlpha(glyph: GameGlyph, x: number, y: number): number {
+  const sourceX = (x + 0.5) / OUTLINE_SAMPLE_SCALE - 0.5;
+  const sourceY = (y + 0.5) / OUTLINE_SAMPLE_SCALE - 0.5;
+  const left = Math.floor(sourceX);
+  const top = Math.floor(sourceY);
+  const xBlend = sourceX - left;
+  const yBlend = sourceY - top;
+  const pixel = (pixelX: number, pixelY: number): number =>
+    pixelX < 0
+      || pixelY < 0
+      || pixelX >= glyph.width
+      || pixelY >= glyph.height
+      ? 0
+      : glyph.pixels[pixelY * glyph.width + pixelX]!;
+  const upper = pixel(left, top) * (1 - xBlend)
+    + pixel(left + 1, top) * xBlend;
+  const lower = pixel(left, top + 1) * (1 - xBlend)
+    + pixel(left + 1, top + 1) * xBlend;
+  return upper * (1 - yBlend) + lower * yBlend;
+}
+
+/**
+ * Trace the game's grayscale mask on a quarter-pixel grid, then merge equal
+ * horizontal runs into outline rectangles. The interpolation retains where a
+ * soft edge crosses half opacity; tracing the source pixels directly produced
+ * the visibly stepped curves the bitmap's alpha levels were meant to hide.
+ */
+function bitmapRectangles(glyph: GameGlyph): readonly Rectangle[] {
+  const complete: Rectangle[] = [];
+  let active = new Map<string, Rectangle>();
+  const width = glyph.width * OUTLINE_SAMPLE_SCALE;
+  const height = glyph.height * OUTLINE_SAMPLE_SCALE;
+  for (let y = 0; y < height; y++) {
+    const next = new Map<string, Rectangle>();
+    for (let x = 0; x < width;) {
+      if (interpolatedAlpha(glyph, x, y) < OUTLINE_THRESHOLD) {
+        x += 1;
+        continue;
+      }
+      const left = x;
+      while (
+        x < width
+        && interpolatedAlpha(glyph, x, y) >= OUTLINE_THRESHOLD
+      ) x += 1;
+      const key = `${left}:${x}`;
+      const rectangle = active.get(key) ?? {
+        left: left / OUTLINE_SAMPLE_SCALE,
+        right: x / OUTLINE_SAMPLE_SCALE,
+        top: y / OUTLINE_SAMPLE_SCALE,
+        bottom: y / OUTLINE_SAMPLE_SCALE,
+      };
+      rectangle.bottom = (y + 1) / OUTLINE_SAMPLE_SCALE;
+      next.set(key, rectangle);
+      active.delete(key);
+    }
+    complete.push(...active.values());
+    active = next;
+  }
+  complete.push(...active.values());
+  return complete;
+}
+
+/**
+ * The source gives every digit the same cell so game counters line up. Its
+ * narrow `1` consequently carries very wide blank sides and reads like a word
+ * space in ordinary interface copy. Preserve every ink pixel, but give the ten
+ * digits balanced two-pixel side bearings for proportional UI text. Wide
+ * digits keep the original cell rather than growing past it.
+ */
+function horizontalMetrics(glyph: GameGlyph, character: number): HorizontalMetrics {
+  if (character < 0x30 || character > 0x39) {
+    return { advance: glyph.width, shift: 0 };
+  }
+  const rectangles = bitmapRectangles(glyph);
+  if (rectangles.length === 0) return { advance: glyph.width, shift: 0 };
+  const inkLeft = Math.min(...rectangles.map(({ left }) => left));
+  const inkRight = Math.max(...rectangles.map(({ right }) => right));
+  const inkWidth = inkRight - inkLeft;
+  const advance = Math.min(glyph.width, inkWidth + 4);
+  const shift = (advance - inkWidth) / 2 - inkLeft;
+  return { advance, shift };
+}
+
+function trueTypeGlyph(glyph: GameGlyph, horizontalShift: number): Buffer {
+  const scale = UNITS_PER_EM / SOURCE_EM;
+  const rectangles = bitmapRectangles(glyph);
+  if (rectangles.length === 0) return Buffer.alloc(10);
+  const points = rectangles.flatMap((rectangle) => {
+    const left = Math.round((rectangle.left + horizontalShift) * scale);
+    const right = Math.round((rectangle.right + horizontalShift) * scale);
+    const top = Math.round((SOURCE_BASELINE - glyph.top - rectangle.top) * scale);
+    const bottom = Math.round(
+      (SOURCE_BASELINE - glyph.top - rectangle.bottom) * scale,
+    );
+    return [[left, top], [right, top], [right, bottom], [left, bottom]] as const;
+  });
+  const xs = points.map(([x]) => x);
+  const ys = points.map(([, y]) => y);
+  const header = Buffer.concat([
+    i16(rectangles.length),
+    i16(Math.min(...xs)),
+    i16(Math.min(...ys)),
+    i16(Math.max(...xs)),
+    i16(Math.max(...ys)),
+  ]);
+  const ends = Buffer.concat(rectangles.map((_, index) => u16(index * 4 + 3)));
+  const flags = Buffer.alloc(points.length, 1);
+  let previousX = 0;
+  let previousY = 0;
+  const xCoordinates: Buffer[] = [];
+  const yCoordinates: Buffer[] = [];
+  for (const [x, y] of points) {
+    xCoordinates.push(i16(x - previousX));
+    yCoordinates.push(i16(y - previousY));
+    previousX = x;
+    previousY = y;
+  }
+  const out = Buffer.concat([
+    header,
+    ends,
+    u16(0),
+    flags,
+    ...xCoordinates,
+    ...yCoordinates,
+  ]);
+  return out.byteLength % 2 === 0 ? out : Buffer.concat([out, Buffer.alloc(1)]);
+}
+
+function cmapTable(): Buffer {
+  const segmentCount = 2;
+  const format4 = Buffer.concat([
+    u16(4), u16(32), u16(0),
+    u16(segmentCount * 2), u16(4), u16(1), u16(0),
+    u16(LAST_CHARACTER), u16(0xffff),
+    u16(0),
+    u16(0x20), u16(0xffff),
+    i16(1 - 0x20), i16(1),
+    u16(0), u16(0),
+  ]);
+  return Buffer.concat([u16(0), u16(1), u16(3), u16(1), u32(12), format4]);
+}
+
+function nameTable(): Buffer {
+  const names = new Map<number, string>([
+    [1, "Guild Wars Original"],
+    [2, "Regular"],
+    [3, "Guild Wars Original; locally converted by GWonMac"],
+    [4, "Guild Wars Original Regular"],
+    [5, "Version 1.0"],
+    [6, "GuildWarsOriginal-Regular"],
+    [8, "Converted locally by GWonMac"],
+    [9, "ArenaNet"],
+  ]);
+  const records: Buffer[] = [];
+  const strings: Buffer[] = [];
+  let offset = 0;
+  for (const [nameId, text] of names) {
+    const encoded = Buffer.from(text, "utf16le");
+    encoded.swap16();
+    records.push(Buffer.concat([
+      u16(3), u16(1), u16(0x0409), u16(nameId),
+      u16(encoded.byteLength), u16(offset),
+    ]));
+    strings.push(encoded);
+    offset += encoded.byteLength;
+  }
+  return Buffer.concat([
+    u16(0), u16(records.length), u16(6 + records.length * 12),
+    ...records,
+    ...strings,
+  ]);
+}
+
+function os2Table(advances: readonly number[]): Buffer {
+  const scale = UNITS_PER_EM / SOURCE_EM;
+  const out = Buffer.alloc(78);
+  out.writeUInt16BE(0, 0);
+  out.writeInt16BE(Math.round(advances.reduce((a, b) => a + b, 0) / advances.length), 2);
+  out.writeUInt16BE(500, 4);
+  out.writeUInt16BE(5, 6);
+  // Restricted embedding: this derivative is for the player's local UI only.
+  out.writeUInt16BE(2, 8);
+  out.writeInt16BE(650, 10);
+  out.writeInt16BE(600, 12);
+  out.writeInt16BE(0, 14);
+  out.writeInt16BE(75, 16);
+  out.writeInt16BE(650, 18);
+  out.writeInt16BE(600, 20);
+  out.writeInt16BE(0, 22);
+  out.writeInt16BE(350, 24);
+  out.writeInt16BE(50, 26);
+  out.writeInt16BE(300, 28);
+  out[32] = 2;
+  out[33] = 2;
+  out.writeUInt32BE(1, 42);
+  out.write("GWoM", 58, "ascii");
+  out.writeUInt16BE(0x40, 62);
+  out.writeUInt16BE(0x20, 64);
+  out.writeUInt16BE(LAST_CHARACTER, 66);
+  out.writeInt16BE(Math.round(SOURCE_BASELINE * scale), 68);
+  out.writeInt16BE(Math.round((SOURCE_BASELINE - SOURCE_EM) * scale), 70);
+  out.writeInt16BE(Math.round((SOURCE_LINE_HEIGHT - SOURCE_EM) * scale), 72);
+  out.writeUInt16BE(Math.round(SOURCE_BASELINE * scale), 74);
+  out.writeUInt16BE(Math.round((SOURCE_EM - SOURCE_BASELINE) * scale), 76);
+  return out;
+}
+
+/** Build a standards-compliant TrueType font from the 24px body strike. */
+export function buildGuildWarsTrueType(source: Uint8Array): Buffer {
+  const glyphs = decodeGameFontRange(source);
+  const sourceGlyphs: readonly (GameGlyph | null)[] = [null, null, ...glyphs];
+  const metrics = sourceGlyphs.map((glyph, glyphId) =>
+    glyph
+      ? horizontalMetrics(glyph, glyphId + FIRST_CHARACTER - 2)
+      : { advance: SOURCE_SPACE_WIDTH, shift: 0 });
+  const glyfParts = sourceGlyphs.map((glyph, glyphId) =>
+    glyph ? trueTypeGlyph(glyph, metrics[glyphId]!.shift) : Buffer.alloc(10));
+  const loca: number[] = [0];
+  let glyfLength = 0;
+  for (const glyph of glyfParts) {
+    glyfLength += glyph.byteLength;
+    loca.push(glyfLength);
+  }
+  const advances = metrics.map(({ advance }) =>
+    Math.max(1, Math.round(advance * UNITS_PER_EM / SOURCE_EM)));
+  const maxRectangles = Math.max(0, ...glyphs.map((glyph) => bitmapRectangles(glyph).length));
+  const ascent = Math.round(SOURCE_BASELINE * UNITS_PER_EM / SOURCE_EM);
+  const descent = Math.round((SOURCE_BASELINE - SOURCE_EM) * UNITS_PER_EM / SOURCE_EM);
+  const lineGap = Math.round((SOURCE_LINE_HEIGHT - SOURCE_EM) * UNITS_PER_EM / SOURCE_EM);
+
+  const head = Buffer.alloc(54);
+  head.writeUInt32BE(0x00010000, 0);
+  head.writeUInt32BE(0x00010000, 4);
+  head.writeUInt32BE(0x5f0f3cf5, 12);
+  head.writeUInt16BE(3, 16);
+  head.writeUInt16BE(UNITS_PER_EM, 18);
+  head.writeInt16BE(descent, 38);
+  head.writeInt16BE(UNITS_PER_EM, 40);
+  head.writeInt16BE(ascent, 42);
+  head.writeUInt16BE(0, 44);
+  head.writeUInt16BE(8, 46);
+  head.writeInt16BE(2, 48);
+  head.writeInt16BE(1, 50);
+
+  const hhea = Buffer.alloc(36);
+  hhea.writeUInt32BE(0x00010000, 0);
+  hhea.writeInt16BE(ascent, 4);
+  hhea.writeInt16BE(descent, 6);
+  hhea.writeInt16BE(lineGap, 8);
+  hhea.writeUInt16BE(Math.max(...advances), 10);
+  hhea.writeInt16BE(0, 12);
+  hhea.writeInt16BE(0, 14);
+  hhea.writeInt16BE(Math.max(...advances), 16);
+  hhea.writeInt16BE(1, 18);
+  hhea.writeInt16BE(0, 20);
+  hhea.writeUInt16BE(sourceGlyphs.length, 34);
+
+  const maxp = Buffer.alloc(32);
+  maxp.writeUInt32BE(0x00010000, 0);
+  maxp.writeUInt16BE(sourceGlyphs.length, 4);
+  maxp.writeUInt16BE(maxRectangles * 4, 6);
+  maxp.writeUInt16BE(maxRectangles, 8);
+  maxp.writeUInt16BE(2, 14);
+
+  const post = Buffer.alloc(32);
+  post.writeUInt32BE(0x00030000, 0);
+  post.writeInt16BE(-100, 8);
+  post.writeInt16BE(50, 10);
+
+  const tables = new Map<string, Buffer>([
+    ["OS/2", os2Table(advances)],
+    ["cmap", cmapTable()],
+    ["glyf", Buffer.concat(glyfParts)],
+    ["head", head],
+    ["hhea", hhea],
+    ["hmtx", Buffer.concat(advances.map((advance) => Buffer.concat([u16(advance), i16(0)])))],
+    ["loca", Buffer.concat(loca.map(u32))],
+    ["maxp", maxp],
+    ["name", nameTable()],
+    ["post", post],
+  ]);
+  const entries = [...tables].sort(([a], [b]) => a.localeCompare(b));
+  const tableCount = entries.length;
+  const power = 2 ** Math.floor(Math.log2(tableCount));
+  const header = Buffer.concat([
+    u32(0x00010000), u16(tableCount), u16(power * 16),
+    u16(Math.log2(power)), u16(tableCount * 16 - power * 16),
+  ]);
+  const directory = Buffer.alloc(tableCount * 16);
+  const bodies: Buffer[] = [];
+  let offset = header.byteLength + directory.byteLength;
+  let headOffset = 0;
+  entries.forEach(([tag, table], index) => {
+    const at = index * 16;
+    directory.write(tag, at, 4, "ascii");
+    directory.writeUInt32BE(checksum(table), at + 4);
+    directory.writeUInt32BE(offset, at + 8);
+    directory.writeUInt32BE(table.byteLength, at + 12);
+    if (tag === "head") headOffset = offset;
+    const padded = Buffer.alloc(align4(table.byteLength));
+    table.copy(padded);
+    bodies.push(padded);
+    offset += padded.byteLength;
+  });
+  const font = Buffer.concat([header, directory, ...bodies]);
+  font.writeUInt32BE((0xb1b0afba - checksum(font)) >>> 0, headOffset + 8);
+  return font;
+}

--- a/src/main/core/gw-font.ts
+++ b/src/main/core/gw-font.ts
@@ -28,6 +28,10 @@ const SOURCE_EM = 24;
 const SOURCE_BASELINE = 18;
 const SOURCE_LINE_HEIGHT = 25;
 const SOURCE_SPACE_WIDTH = 6;
+const MAX_SOURCE_DIMENSION = 24;
+const MAX_SOURCE_PIXELS = 24 * 24 * 94;
+const MAX_RECTANGLES_PER_GLYPH = 512;
+const MAX_TOTAL_RECTANGLES = 16_384;
 const UNITS_PER_EM = 1024;
 const OUTLINE_THRESHOLD = 0x80;
 const OUTLINE_SAMPLE_SCALE = 4;
@@ -88,8 +92,13 @@ function decodeGlyph(source: Uint8Array): { glyph: GameGlyph; bytes: number } {
   const height = input.value() + 1;
   const mode = input.read();
   const pixelCount = width * height;
-  if (width > 256 || height > 256 || pixelCount > 65_536) {
-    throw new Error("font glyph dimensions exceed their bound");
+  if (
+    width > MAX_SOURCE_DIMENSION
+    || height > MAX_SOURCE_DIMENSION
+    || top >= SOURCE_LINE_HEIGHT
+    || top + height > SOURCE_LINE_HEIGHT
+  ) {
+    throw new Error("font glyph does not match the 24px strike");
   }
 
   const pixels = new Uint8Array(pixelCount);
@@ -128,6 +137,9 @@ export function decodeGameFontRange(bytes: Uint8Array): readonly GameGlyph[] {
   const expected = LAST_CHARACTER - FIRST_CHARACTER + 1;
   if (glyphs.length !== expected) {
     throw new Error(`font range has ${glyphs.length} glyphs instead of ${expected}`);
+  }
+  if (glyphs.reduce((total, glyph) => total + glyph.pixels.length, 0) > MAX_SOURCE_PIXELS) {
+    throw new Error("font strike exceeds its pixel budget");
   }
   return glyphs;
 }
@@ -237,6 +249,9 @@ function bitmapRectangles(glyph: GameGlyph): readonly Rectangle[] {
     active = next;
   }
   complete.push(...active.values());
+  if (complete.length > MAX_RECTANGLES_PER_GLYPH) {
+    throw new Error("font glyph exceeds its contour budget");
+  }
   return complete;
 }
 
@@ -247,11 +262,14 @@ function bitmapRectangles(glyph: GameGlyph): readonly Rectangle[] {
  * digits balanced two-pixel side bearings for proportional UI text. Wide
  * digits keep the original cell rather than growing past it.
  */
-function horizontalMetrics(glyph: GameGlyph, character: number): HorizontalMetrics {
+function horizontalMetrics(
+  glyph: GameGlyph,
+  character: number,
+  rectangles: readonly Rectangle[],
+): HorizontalMetrics {
   if (character < 0x30 || character > 0x39) {
     return { advance: glyph.width, shift: 0 };
   }
-  const rectangles = bitmapRectangles(glyph);
   if (rectangles.length === 0) return { advance: glyph.width, shift: 0 };
   const inkLeft = Math.min(...rectangles.map(({ left }) => left));
   const inkRight = Math.max(...rectangles.map(({ right }) => right));
@@ -261,9 +279,12 @@ function horizontalMetrics(glyph: GameGlyph, character: number): HorizontalMetri
   return { advance, shift };
 }
 
-function trueTypeGlyph(glyph: GameGlyph, horizontalShift: number): Buffer {
+function trueTypeGlyph(
+  glyph: GameGlyph,
+  horizontalShift: number,
+  rectangles: readonly Rectangle[],
+): Buffer {
   const scale = UNITS_PER_EM / SOURCE_EM;
-  const rectangles = bitmapRectangles(glyph);
   if (rectangles.length === 0) return Buffer.alloc(10);
   const points = rectangles.flatMap((rectangle) => {
     const left = Math.round((rectangle.left + horizontalShift) * scale);
@@ -389,12 +410,26 @@ function os2Table(advances: readonly number[]): Buffer {
 export function buildGuildWarsTrueType(source: Uint8Array): Buffer {
   const glyphs = decodeGameFontRange(source);
   const sourceGlyphs: readonly (GameGlyph | null)[] = [null, null, ...glyphs];
+  const rectangles = sourceGlyphs.map((glyph) =>
+    glyph === null ? [] : bitmapRectangles(glyph));
+  if (
+    rectangles.reduce((total, value) => total + value.length, 0)
+    > MAX_TOTAL_RECTANGLES
+  ) {
+    throw new Error("font strike exceeds its contour budget");
+  }
   const metrics = sourceGlyphs.map((glyph, glyphId) =>
     glyph
-      ? horizontalMetrics(glyph, glyphId + FIRST_CHARACTER - 2)
+      ? horizontalMetrics(
+          glyph,
+          glyphId + FIRST_CHARACTER - 2,
+          rectangles[glyphId]!,
+        )
       : { advance: SOURCE_SPACE_WIDTH, shift: 0 });
   const glyfParts = sourceGlyphs.map((glyph, glyphId) =>
-    glyph ? trueTypeGlyph(glyph, metrics[glyphId]!.shift) : Buffer.alloc(10));
+    glyph
+      ? trueTypeGlyph(glyph, metrics[glyphId]!.shift, rectangles[glyphId]!)
+      : Buffer.alloc(10));
   const loca: number[] = [0];
   let glyfLength = 0;
   for (const glyph of glyfParts) {
@@ -403,7 +438,7 @@ export function buildGuildWarsTrueType(source: Uint8Array): Buffer {
   }
   const advances = metrics.map(({ advance }) =>
     Math.max(1, Math.round(advance * UNITS_PER_EM / SOURCE_EM)));
-  const maxRectangles = Math.max(0, ...glyphs.map((glyph) => bitmapRectangles(glyph).length));
+  const maxRectangles = Math.max(0, ...rectangles.map((value) => value.length));
   const ascent = Math.round(SOURCE_BASELINE * UNITS_PER_EM / SOURCE_EM);
   const descent = Math.round((SOURCE_BASELINE - SOURCE_EM) * UNITS_PER_EM / SOURCE_EM);
   const lineGap = Math.round((SOURCE_LINE_HEIGHT - SOURCE_EM) * UNITS_PER_EM / SOURCE_EM);

--- a/src/main/core/settings.ts
+++ b/src/main/core/settings.ts
@@ -24,6 +24,7 @@ import {
   UPDATE_TRACKS,
   UI_PANEL_OPACITY_MAX,
   UI_PANEL_OPACITY_MIN,
+  UI_FONTS,
   UI_STYLES,
   type AppSettings,
   type AppSettingsPatch,
@@ -37,6 +38,7 @@ import { writeAtomicJson } from "./atomic-file.js";
 const RENDER_SCALE_VALUES = new Set<AppSettings["renderScale"]>(RENDER_SCALES);
 const DATA_STRATEGY_VALUES = new Set<AppSettings["dataStrategy"]>(DATA_STRATEGIES);
 const UI_STYLE_VALUES = new Set<AppSettings["uiStyle"]>(UI_STYLES);
+const UI_FONT_VALUES = new Set<AppSettings["uiFont"]>(UI_FONTS);
 const UPDATE_TRACK_VALUES = new Set<AppSettings["updateTrack"]>(UPDATE_TRACKS);
 
 /**
@@ -110,6 +112,12 @@ export function parseSettings(raw: unknown): AppSettings {
       throw new AppError("bad_settings", "settings.uiStyle has unknown value");
     }
     out.uiStyle = src.uiStyle as AppSettings["uiStyle"];
+  }
+  if ("uiFont" in src) {
+    if (!UI_FONT_VALUES.has(src.uiFont as AppSettings["uiFont"])) {
+      throw new AppError("bad_settings", "settings.uiFont has unknown value");
+    }
+    out.uiFont = src.uiFont as AppSettings["uiFont"];
   }
   if ("uiPanelOpacity" in src) {
     out.uiPanelOpacity = asBoundedInteger(

--- a/src/main/core/skill-catalogue.ts
+++ b/src/main/core/skill-catalogue.ts
@@ -31,7 +31,6 @@
 import { mkdir, readFile } from "node:fs/promises";
 import { createHash } from "node:crypto";
 import path from "node:path";
-import { spawn } from "node:child_process";
 import { mapPool } from "./async-pool.js";
 import { sweepOrphans, writeAtomic } from "./atomic-file.js";
 import type { ChunkStore } from "./chunk-store.js";
@@ -43,6 +42,10 @@ import {
   readFileTable,
   type FileTable,
 } from "./gw-archive.js";
+import {
+  decodedArchiveBytes,
+  runGwDatDecoder,
+} from "./gw-dat-decoder.js";
 import {
   ATTRIBUTE_BY_ID,
   PROFESSION_BY_ID,
@@ -77,7 +80,6 @@ const EQUIPPABLE = 1;
 const MAX_ICON_BYTES = 256 * 256 * 4 + 8;
 const MAX_SHARD_BYTES = 1024 * 1024 + 8;
 const MAX_STREAM_BYTES = 1024 * 1024;
-const HELPER_TIMEOUT_MS = 5_000;
 /**
  * How many shard decoders run at once. This bounds local processes against
  * local cores; it is deliberately not named for a "job" or a "concurrency"
@@ -194,75 +196,7 @@ export function decodedIconToBmp(decoded: Uint8Array): Buffer {
 
 /** The helper's decompress-only output — `GWDB`, length, then the payload. */
 export function decodedShard(decoded: Uint8Array): Buffer {
-  if (
-    decoded.length < 8
-    || String.fromCharCode(...decoded.subarray(0, 4)) !== "GWDB"
-  ) {
-    throw new Error("the archive decoder returned an invalid shard header");
-  }
-  const length = new DataView(
-    decoded.buffer,
-    decoded.byteOffset + 4,
-    4,
-  ).getUint32(0, true);
-  if (length > MAX_STREAM_BYTES || decoded.byteLength !== length + 8) {
-    throw new Error("the archive decoder returned an invalid shard length");
-  }
-  return Buffer.from(decoded.subarray(8));
-}
-
-function runDecoder(
-  executable: string,
-  input: Uint8Array,
-  options: {
-    readonly args: readonly string[];
-    readonly maxOutput: number;
-    parse(output: Uint8Array): Buffer;
-  },
-): Promise<Buffer> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(executable, options.args, {
-      stdio: ["pipe", "pipe", "ignore"],
-      windowsHide: true,
-    });
-    const chunks: Buffer[] = [];
-    let length = 0;
-    let settled = false;
-    const fail = (error: Error) => {
-      if (settled) return;
-      settled = true;
-      child.kill();
-      reject(error);
-    };
-    const timer = setTimeout(
-      () => fail(new Error("the archive decoder timed out")),
-      HELPER_TIMEOUT_MS,
-    );
-    child.stdout.on("data", (chunk: Buffer) => {
-      length += chunk.length;
-      if (length > options.maxOutput) {
-        fail(new Error("the archive decoder exceeded its output bound"));
-      } else {
-        chunks.push(chunk);
-      }
-    });
-    child.on("error", fail);
-    child.on("close", (code) => {
-      clearTimeout(timer);
-      if (settled) return;
-      settled = true;
-      if (code !== 0) {
-        reject(new Error("the archive decoder refused the local asset"));
-        return;
-      }
-      try {
-        resolve(options.parse(Buffer.concat(chunks, length)));
-      } catch (error) {
-        reject(error);
-      }
-    });
-    child.stdin.end(input);
-  });
+  return decodedArchiveBytes(decoded, MAX_STREAM_BYTES, "shard");
 }
 
 export interface SkillAssetSource {
@@ -443,7 +377,7 @@ export class SkillAssets {
           stream.size,
         );
         const records = parseStringShard(
-          await runDecoder(this.source.decoderPath, compressed, {
+          await runGwDatDecoder(this.source.decoderPath, compressed, {
             args: ["--raw"],
             maxOutput: MAX_SHARD_BYTES,
             parse: decodedShard,
@@ -596,7 +530,7 @@ export class SkillAssets {
       stream.offset,
       stream.size,
     );
-    const bmp = await runDecoder(this.source.decoderPath, compressed, {
+    const bmp = await runGwDatDecoder(this.source.decoderPath, compressed, {
       args: [],
       maxOutput: MAX_ICON_BYTES,
       parse: decodedIconToBmp,

--- a/src/main/diagnostics/schema-protocol-renderer.ts
+++ b/src/main/diagnostics/schema-protocol-renderer.ts
@@ -113,6 +113,11 @@ export const PROTOCOL_AND_RENDERER_EVENT_SCHEMA = {
     level: "warn",
     fields: { reason: catalogueRefusal },
   },
+  "protocol.gameFontRefused": {
+    subsystem: "protocol",
+    level: "warn",
+    fields: { reason: literal(["unsupported", "read-or-format"] as const) },
+  },
 
   // Managed sockets and IPC rejection.
   "socket.open": {

--- a/src/main/protocol.ts
+++ b/src/main/protocol.ts
@@ -33,6 +33,7 @@ import {
   resolveProxyHost,
 } from "./core/proxy-routes.js";
 import { clientArtifactPath } from "./core/paths.js";
+import { GameFontAssets } from "./core/game-font-assets.js";
 import { SkillAssets } from "./core/skill-catalogue.js";
 import { parseRangeHeader } from "./core/ranges.js";
 import { errorCode } from "../shared/errors.js";
@@ -53,6 +54,7 @@ const MIME: Record<string, string> = {
   ".ico": "image/x-icon",
   ".webp": "image/webp",
   ".png": "image/png",
+  ".ttf": "font/ttf",
   ".woff": "font/woff",
   ".woff2": "font/woff2",
 };
@@ -116,6 +118,11 @@ let skillAssets: {
   readonly value: SkillAssets;
 } | null = null;
 
+let gameFontAssets: {
+  readonly store: ChunkStore;
+  readonly value: GameFontAssets;
+} | null = null;
+
 function assetsFor(
   active: NonNullable<ReturnType<ProtocolDeps["getActiveClient"]>>,
 ): SkillAssets {
@@ -132,6 +139,18 @@ function assetsFor(
     cacheRoot: gamePaths().skillAssets,
   });
   skillAssets = { store: active.store, wasmPath: active.wasmPath, value };
+  return value;
+}
+
+function fontFor(
+  active: NonNullable<ReturnType<ProtocolDeps["getActiveClient"]>>,
+): GameFontAssets {
+  if (gameFontAssets?.store === active.store) return gameFontAssets.value;
+  const value = new GameFontAssets({
+    store: active.store,
+    decoderPath: gwDatDecoderPath(),
+  });
+  gameFontAssets = { store: active.store, value };
   return value;
 }
 
@@ -460,6 +479,27 @@ async function handleGwRequest(
   const first = (base.split("/")[0] ?? "").toLowerCase();
 
   if (base === "Gw.snapshot") return handleSnapshot(request, deps);
+
+  if (base === "game-font.ttf") {
+    const missing = () =>
+      new Response("not found", {
+        status: 404,
+        headers: headers({ "Cache-Control": "no-store" }),
+      });
+    const active = deps.getActiveClient();
+    if (!active || request.method !== "GET") return missing();
+    const font = await fontFor(active).font();
+    return font
+      ? new Response(compactResponseBody(font), {
+          status: 200,
+          headers: headers({
+            "Content-Type": "font/ttf",
+            "Content-Length": String(font.byteLength),
+            "Cache-Control": "no-store",
+          }),
+        })
+      : missing();
+  }
 
   if (base === SKILL_CATALOGUE_ROUTE) {
     const empty = () =>

--- a/src/main/protocol.ts
+++ b/src/main/protocol.ts
@@ -122,6 +122,7 @@ let gameFontAssets: {
   readonly store: ChunkStore;
   readonly value: GameFontAssets;
 } | null = null;
+const reportedGameFontRefusals = new WeakSet<GameFontAssets>();
 
 function assetsFor(
   active: NonNullable<ReturnType<ProtocolDeps["getActiveClient"]>>,
@@ -488,7 +489,15 @@ async function handleGwRequest(
       });
     const active = deps.getActiveClient();
     if (!active || request.method !== "GET") return missing();
-    const font = await fontFor(active).font();
+    const assets = fontFor(active);
+    const font = await assets.font();
+    if (!font && !reportedGameFontRefusals.has(assets)) {
+      reportedGameFontRefusals.add(assets);
+      logEvent({
+        k: "protocol.gameFontRefused",
+        reason: assets.refusal() ?? "unsupported",
+      });
+    }
     return font
       ? new Response(compactResponseBody(font), {
           status: 200,

--- a/src/renderer/appearance.ts
+++ b/src/renderer/appearance.ts
@@ -28,4 +28,9 @@ export function applyAppearance(
   } else {
     delete root.dataset.uiStyle;
   }
+  if (settings.uiFont === "inter") {
+    root.dataset.uiFont = "inter";
+  } else {
+    delete root.dataset.uiFont;
+  }
 }

--- a/src/renderer/appearance.ts
+++ b/src/renderer/appearance.ts
@@ -10,6 +10,28 @@
  */
 import type { AppSettings } from "../shared/contracts.js";
 
+const fontChoices = new WeakMap<HTMLElement, AppSettings["uiFont"]>();
+const fontLoads = new Map<string, Promise<boolean>>();
+let activeGeneration = "active";
+
+function loadGuildWarsFont(generation: string): Promise<boolean> {
+  const existing = fontLoads.get(generation);
+  if (existing) return existing;
+  if (typeof FontFace === "undefined" || typeof document === "undefined") {
+    return Promise.resolve(false);
+  }
+  const source = `url("gw://app/game-font.ttf?generation=${encodeURIComponent(generation)}")`;
+  const pending = new FontFace("Guild Wars Original", source, {
+    style: "normal",
+    weight: "400",
+  }).load().then((font) => {
+    document.fonts.add(font);
+    return true;
+  }).catch(() => false);
+  fontLoads.set(generation, pending);
+  return pending;
+}
+
 export const appearanceVariables = (
   settings: AppSettings,
 ): Readonly<Record<string, string>> => ({
@@ -19,7 +41,9 @@ export const appearanceVariables = (
 export function applyAppearance(
   settings: AppSettings,
   root: HTMLElement = document.documentElement,
+  generation = activeGeneration,
 ): void {
+  activeGeneration = generation;
   for (const [name, value] of Object.entries(appearanceVariables(settings))) {
     root.style.setProperty(name, value);
   }
@@ -32,5 +56,11 @@ export function applyAppearance(
     root.dataset.uiFont = "inter";
   } else {
     delete root.dataset.uiFont;
+    void loadGuildWarsFont(generation).then((loaded) => {
+      if (loaded && fontChoices.get(root) === "guild-wars") {
+        root.dataset.uiFont = "guild-wars";
+      }
+    });
   }
+  fontChoices.set(root, settings.uiFont);
 }

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -1224,7 +1224,12 @@ function loadGlue(isProxyRouteLabel: (route: string) => boolean) {
     appSettings = settings;
     templatePublishingAvailable =
       session.compatibility?.features.gameFileSaving.status === 'available';
-    applyAppearance(settings);
+    applyAppearance(
+      settings,
+      document.documentElement,
+      session.compatibility?.clientSha256
+        ?? String(session.healthToken?.generation ?? "active"),
+    );
     clientHealthConfirmation = createClientHealthConfirmation({
       token: session.healthToken,
       confirm: (token) => native().client.healthy(token),

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -441,7 +441,7 @@
                 <input type="radio" name="uiStyle" value="guild-wars">
                 <span class="settings-style-option">
                   <span>Guild Wars <small>Default</small></span>
-                  <small>Ornamental metal and engraved type</small>
+                  <small>Ornamental metal and classic game surfaces</small>
                 </span>
               </label>
               <label class="settings-radio">
@@ -449,6 +449,26 @@
                 <span class="settings-style-option">
                   <span>Obsidian</span>
                   <small>Borderless charcoal and muted gilt</small>
+                </span>
+              </label>
+            </div>
+          </fieldset>
+
+          <fieldset>
+            <legend>Interface font</legend>
+            <div class="settings-seg settings-style-seg ui-segment" data-fill role="presentation">
+              <label class="settings-radio">
+                <input type="radio" name="uiFont" value="guild-wars">
+                <span class="settings-style-option">
+                  <span>Guild Wars Original <small>Default</small></span>
+                  <small>Lettering converted locally from your game</small>
+                </span>
+              </label>
+              <label class="settings-radio">
+                <input type="radio" name="uiFont" value="inter">
+                <span class="settings-style-option">
+                  <span>Inter</span>
+                  <small>Clean modern lettering with a system fallback</small>
                 </span>
               </label>
             </div>

--- a/src/renderer/settings.ts
+++ b/src/renderer/settings.ts
@@ -32,6 +32,7 @@
     'renderScale',
   ) as RadioNodeList;
   const uiStyle = form.elements.namedItem('uiStyle') as RadioNodeList;
+  const uiFont = form.elements.namedItem('uiFont') as RadioNodeList;
   const showDiagnostics = form.elements.namedItem(
     'showDiagnostics',
   ) as HTMLInputElement;
@@ -568,6 +569,10 @@
         return control.value === 'guild-wars' || control.value === 'obsidian'
           ? { uiStyle: control.value }
           : null;
+      case 'uiFont':
+        return control.value === 'guild-wars' || control.value === 'inter'
+          ? { uiFont: control.value }
+          : null;
       case 'uiPanelOpacity':
       {
         // The slider's own min/max/step are the bounds; a value outside them
@@ -615,6 +620,7 @@
   function fillForm(settings: AppSettings) {
     renderScale.value = String(settings.renderScale);
     uiStyle.value = settings.uiStyle;
+    uiFont.value = settings.uiFont;
     for (const { name } of appearanceRanges) {
       const range = appearanceRange(name);
       if (range) range.value = String(settings[name]);

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -309,6 +309,8 @@ export interface ClockSyncResponse {
 
 export const UI_STYLES = ["guild-wars", "obsidian"] as const;
 export type UiStyle = (typeof UI_STYLES)[number];
+export const UI_FONTS = ["guild-wars", "inter"] as const;
+export type UiFont = (typeof UI_FONTS)[number];
 export const RENDER_SCALES = [1, 1.5, 2] as const;
 export type RenderScale = (typeof RENDER_SCALES)[number];
 export const UI_PANEL_OPACITY_MIN = 65;
@@ -321,6 +323,8 @@ export interface AppSettings {
   renderScale: RenderScale;
   /** The visual treatment applied to every GWonMac panel. */
   uiStyle: UiStyle;
+  /** The typeface applied to every GWonMac panel. */
+  uiFont: UiFont;
   /**
    * The application's Guild Wars panels stay translucent enough to see the
    * game behind them. This is presentation only and never reaches the game.
@@ -383,6 +387,7 @@ export type AppSettingsPatch = Partial<AppSettings>;
 export const DEFAULT_SETTINGS: AppSettings = {
   renderScale: 2,
   uiStyle: "guild-wars",
+  uiFont: "guild-wars",
   uiPanelOpacity: 94,
   gwonmacTools: false,
   teamManagement: true,

--- a/src/shared/ui/tokens.css
+++ b/src/shared/ui/tokens.css
@@ -1,14 +1,24 @@
 /* GWonMac's single visual source of truth.
  *
  * The vocabulary is taken from the original Guild Wars client: an ivory metal
- * ring, engraved parchment text, blue-black selected faces, graphite controls,
+ * ring, parchment text, blue-black selected faces, graphite controls,
  * and recessed black wells. Obsidian is the one optional projection of this
  * vocabulary: it changes tokens, never markup or component behaviour.
  *
- * `--ui-panel-opacity` controls visibility of the game behind either style.
+ * Font and style are independent settings. `--ui-panel-opacity` controls
+ * visibility of the game behind either style.
  * The `--ui-*` names remain the public component vocabulary; consumers do not
  * branch on the selected style.
  */
+
+@font-face {
+  font-family: "Guild Wars Original";
+  src: url("gw://app/game-font.ttf") format("truetype");
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+  unicode-range: U+0020-007E;
+}
 
 :root {
   color-scheme: dark;
@@ -89,7 +99,7 @@
   --ui-font-size-sm: 12px;
   --ui-font-size-lg: 17px;
   --ui-line-height: 1.4;
-  --ui-font: "Palatino Linotype", "Book Antiqua", Palatino,
+  --ui-font: "Guild Wars Original", "Palatino Linotype", "Book Antiqua", Palatino,
     "URW Palladio L", Georgia, serif;
   --ui-font-display: var(--ui-font);
   --ui-font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
@@ -180,13 +190,17 @@
   --ui-z-toast: 40;
 }
 
+/* A player can keep either visual style while selecting modern system type. */
+:root[data-ui-font="inter"] {
+  --ui-font: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --ui-font-display: var(--ui-font);
+}
+
 /* Obsidian keeps the same hierarchy and components, then removes ornamental
- * chrome in favour of warm-black tonal depth, quiet gilt, and system type.
+ * chrome in favour of warm-black tonal depth and quiet gilt.
  * The selector lives here—and only here—so every surface changes together. */
 :root[data-ui-style="obsidian"] {
   --ui-border-width: 0px;
-  --ui-font: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  --ui-font-display: var(--ui-font);
 
   --ui-text: oklch(0.93 0.012 84);
   --ui-text-bright: oklch(0.97 0.01 84);

--- a/src/shared/ui/tokens.css
+++ b/src/shared/ui/tokens.css
@@ -11,15 +11,6 @@
  * branch on the selected style.
  */
 
-@font-face {
-  font-family: "Guild Wars Original";
-  src: url("gw://app/game-font.ttf") format("truetype");
-  font-style: normal;
-  font-weight: 400;
-  font-display: swap;
-  unicode-range: U+0020-007E;
-}
-
 :root {
   color-scheme: dark;
 
@@ -99,7 +90,7 @@
   --ui-font-size-sm: 12px;
   --ui-font-size-lg: 17px;
   --ui-line-height: 1.4;
-  --ui-font: "Guild Wars Original", "Palatino Linotype", "Book Antiqua", Palatino,
+  --ui-font: "Palatino Linotype", "Book Antiqua", Palatino,
     "URW Palladio L", Georgia, serif;
   --ui-font-display: var(--ui-font);
   --ui-font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
@@ -188,6 +179,13 @@
   --ui-z-status: 9;
   --ui-z-tools: 30;
   --ui-z-toast: 40;
+}
+
+/* The local face becomes active only after the client generation supplied it. */
+:root[data-ui-font="guild-wars"] {
+  --ui-font: "Guild Wars Original", "Palatino Linotype", "Book Antiqua", Palatino,
+    "URW Palladio L", Georgia, serif;
+  --ui-font-display: var(--ui-font);
 }
 
 /* A player can keep either visual style while selecting modern system type. */

--- a/tests/electron/live.spec.ts
+++ b/tests/electron/live.spec.ts
@@ -127,6 +127,25 @@ test.describe("live client", () => {
         )
         .toBeGreaterThan(0);
 
+      await test.step("the locally converted Guild Wars font becomes active", async () => {
+        await expect
+          .poll(
+            () => page.evaluate(() => ({
+              selected: document.documentElement.dataset.uiFont,
+              loaded: document.fonts.check('16px "Guild Wars Original"'),
+              applied: getComputedStyle(document.documentElement)
+                .getPropertyValue("--ui-font-family")
+                .includes("Guild Wars Original"),
+            })),
+            { timeout: 30_000, intervals: [100, 250, 500] },
+          )
+          .toMatchObject({
+            selected: "guild-wars",
+            loaded: true,
+            applied: true,
+          });
+      });
+
       const platform = await page.evaluate(async () => {
         const game = globalThis as GameGlobals;
         const diagnostics = await window.gwNative.diagnostics.current();

--- a/tests/electron/settings-data-display.spec.ts
+++ b/tests/electron/settings-data-display.spec.ts
@@ -30,7 +30,7 @@ test.describe("data and display settings", () => {
     }
   });
 
-  test("interface style and panel opacity apply live and survive", async () => {
+  test("interface style, font, and panel opacity apply live and survive", async () => {
     const fixture = await launchOffline("gw-settings-appearance-e2e-");
     try {
       const { page } = fixture;
@@ -45,7 +45,11 @@ test.describe("data and display settings", () => {
       await expect(
         page.locator('input[name="uiStyle"][value="guild-wars"]'),
       ).toBeChecked();
+      await expect(
+        page.locator('input[name="uiFont"][value="guild-wars"]'),
+      ).toBeChecked();
       await expect(root).not.toHaveAttribute("data-ui-style");
+      await expect(root).not.toHaveAttribute("data-ui-font");
       await expect(page.locator('select[name="uiTheme"]')).toHaveCount(0);
       await expect(page.locator('select[name="uiDensity"]')).toHaveCount(0);
       // Polled, not read once: the save is a round trip through main and the
@@ -75,6 +79,9 @@ test.describe("data and display settings", () => {
 
       await page.locator('input[name="uiStyle"][value="obsidian"]').click();
       await expect(root).toHaveAttribute("data-ui-style", "obsidian");
+      await expect(root).not.toHaveAttribute("data-ui-font");
+      await page.locator('label:has(input[name="uiFont"][value="inter"])').click();
+      await expect(root).toHaveAttribute("data-ui-font", "inter");
       await expect(page.locator("#settings-feedback")).toHaveText("Saved.");
       expect(
         await page.locator("#settings-dialog").evaluate((element) =>
@@ -100,6 +107,10 @@ test.describe("data and display settings", () => {
         page.locator('input[name="uiStyle"][value="obsidian"]'),
       ).toBeChecked();
       await expect(root).toHaveAttribute("data-ui-style", "obsidian");
+      await expect(
+        page.locator('input[name="uiFont"][value="inter"]'),
+      ).toBeChecked();
+      await expect(root).toHaveAttribute("data-ui-font", "inter");
       await expect(page.locator('input[name="uiPanelOpacity"]')).toHaveValue("65");
       await expect(page.locator('output[name="uiPanelOpacityValue"]')).toHaveText("65%");
     } finally {

--- a/tests/policy/source-settings-appearance.test.ts
+++ b/tests/policy/source-settings-appearance.test.ts
@@ -22,6 +22,13 @@ test("Settings exposes the two interface styles and no retired variants", async 
   assert.deepEqual(values, ["guild-wars", "obsidian"]);
 });
 
+test("Settings exposes the two independent interface fonts", async () => {
+  const html = await readFile(path.join(root, "src/renderer/index.html"), "utf8");
+  const values = [...html.matchAll(/<input\b[^>]*\bname=["']uiFont["'][^>]*\bvalue=["']([^"']+)["'][^>]*>/giu)]
+    .map((match) => match[1]);
+  assert.deepEqual(values, ["guild-wars", "inter"]);
+});
+
 test("panel opacity uses the canonical bounds", async () => {
   const html = await readFile(path.join(root, "src/renderer/index.html"), "utf8");
   const input = /<input\b[^>]*\bname\s*=\s*["']uiPanelOpacity["'][^>]*>/iu.exec(html);

--- a/tests/unit/appearance.test.ts
+++ b/tests/unit/appearance.test.ts
@@ -44,4 +44,46 @@ describe("appearance settings", () => {
     assert.equal(root.dataset.uiStyle, undefined);
     assert.equal(root.dataset.uiFont, undefined);
   });
+
+  it("activates a generation-keyed game font only after it loads", async () => {
+    const sources: string[] = [];
+    const added: unknown[] = [];
+    const originalFontFace = globalThis.FontFace;
+    const originalDocument = globalThis.document;
+    class TestFontFace {
+      constructor(_family: string, source: string) {
+        sources.push(source);
+      }
+      async load() { return this; }
+    }
+    Object.defineProperty(globalThis, "FontFace", { configurable: true, value: TestFontFace });
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: { fonts: { add: (font: unknown) => added.push(font) } },
+    });
+    try {
+      const root = {
+        dataset: {} as DOMStringMap,
+        style: {
+          setProperty(name: string, value: string) {
+            void name;
+            void value;
+          },
+        },
+      } as HTMLElement;
+      applyAppearance(DEFAULT_SETTINGS, root, "generation-a");
+      assert.equal(root.dataset.uiFont, undefined);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      assert.equal(root.dataset.uiFont, "guild-wars");
+      assert.equal(added.length, 1);
+      assert.match(sources[0]!, /generation=generation-a/u);
+
+      applyAppearance({ ...DEFAULT_SETTINGS, uiFont: "inter" }, root, "generation-b");
+      await Promise.resolve();
+      assert.equal(root.dataset.uiFont, "inter");
+    } finally {
+      Object.defineProperty(globalThis, "FontFace", { configurable: true, value: originalFontFace });
+      Object.defineProperty(globalThis, "document", { configurable: true, value: originalDocument });
+    }
+  });
 });

--- a/tests/unit/appearance.test.ts
+++ b/tests/unit/appearance.test.ts
@@ -20,7 +20,7 @@ describe("appearance settings", () => {
     });
   });
 
-  it("sets only the optional style marker and removes it for the default", () => {
+  it("sets independent style and font markers and removes their defaults", () => {
     const properties = new Map<string, string>();
     const root = {
       dataset: {} as DOMStringMap,
@@ -31,11 +31,17 @@ describe("appearance settings", () => {
       },
     } as HTMLElement;
 
-    applyAppearance({ ...DEFAULT_SETTINGS, uiStyle: "obsidian" }, root);
+    applyAppearance({
+      ...DEFAULT_SETTINGS,
+      uiStyle: "obsidian",
+      uiFont: "inter",
+    }, root);
     assert.equal(root.dataset.uiStyle, "obsidian");
+    assert.equal(root.dataset.uiFont, "inter");
     assert.equal(properties.get("--ui-panel-opacity"), "0.94");
 
     applyAppearance(DEFAULT_SETTINGS, root);
     assert.equal(root.dataset.uiStyle, undefined);
+    assert.equal(root.dataset.uiFont, undefined);
   });
 });

--- a/tests/unit/guild-wars-font.test.ts
+++ b/tests/unit/guild-wars-font.test.ts
@@ -5,7 +5,6 @@
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import test from "node:test";
-import type { ChunkStore } from "../../src/main/core/chunk-store.js";
 import { GameFontAssets } from "../../src/main/core/game-font-assets.js";
 import {
   buildGuildWarsTrueType,
@@ -99,7 +98,7 @@ test("a narrow numeral gets balanced proportional spacing", () => {
   assert.ok(advance("1") < advance("2"));
 });
 
-test("a temporary local font refusal can recover without an app restart", async () => {
+test("an unsupported font is refused once for its immutable client generation", async () => {
   let reads = 0;
   const assets = new GameFontAssets({
     store: {
@@ -107,19 +106,31 @@ test("a temporary local font refusal can recover without an app restart", async 
         reads += 1;
         throw new Error("temporarily unavailable");
       },
-    } as unknown as ChunkStore,
+    },
     decoderPath: "/not-reached",
   });
 
   assert.equal(await assets.font(), null);
   assert.equal(await assets.font(), null);
-  assert.equal(reads, 2);
+  assert.equal(reads, 1);
+  assert.equal(assets.refusal(), "read-or-format");
+});
+
+test("a compact oversized strike is refused before outline tracing", () => {
+  // top=0, width value=24 (therefore 25 pixels), height=1, palette mode=1.
+  const oversized = repeatedGlyph([0x80, 0x03, 0x01]);
+  assert.throws(
+    () => buildGuildWarsTrueType(oversized),
+    /does not match the 24px strike/,
+  );
 });
 
 test("the shared UI offers the local Guild Wars font independently of Inter", () => {
   const css = readFileSync(new URL("src/shared/ui/tokens.css", root), "utf8");
-  assert.match(css, /url\("gw:\/\/app\/game-font\.ttf"\)/);
+  assert.match(css, /data-ui-font="guild-wars"/);
   assert.match(css, /--ui-font: "Guild Wars Original"/);
   assert.match(css, /:root\[data-ui-font="inter"\]/);
-  assert.match(css, /unicode-range: U\+0020-007E/);
+  const appearance = readFileSync(new URL("src/renderer/appearance.ts", root), "utf8");
+  assert.match(appearance, /new FontFace\("Guild Wars Original"/);
+  assert.match(appearance, /generation=/);
 });

--- a/tests/unit/guild-wars-font.test.ts
+++ b/tests/unit/guild-wars-font.test.ts
@@ -1,0 +1,125 @@
+// The game ships bitmap strikes, not an installable font. These fixtures prove
+// their nibble/RLE boundary and the generated TrueType container without
+// committing or reading any ArenaNet data.
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import type { ChunkStore } from "../../src/main/core/chunk-store.js";
+import { GameFontAssets } from "../../src/main/core/game-font-assets.js";
+import {
+  buildGuildWarsTrueType,
+  decodeGameFontRange,
+} from "../../src/main/core/gw-font.ts";
+
+const root = new URL("../../", import.meta.url);
+const GLYPH_COUNT = 94;
+
+function repeatedGlyph(bytes: readonly number[]): Uint8Array {
+  return Uint8Array.from(
+    Array.from({ length: GLYPH_COUNT }, () => bytes).flat(),
+  );
+}
+
+function packedNibbles(values: readonly number[]): number[] {
+  const bytes: number[] = [];
+  for (let at = 0; at < values.length; at += 2) {
+    bytes.push(values[at]! | ((values[at + 1] ?? 0) << 4));
+  }
+  return bytes;
+}
+
+function tableOffset(font: Buffer, wanted: string): number {
+  const count = font.readUInt16BE(4);
+  for (let index = 0; index < count; index++) {
+    const at = 12 + index * 16;
+    if (font.toString("ascii", at, at + 4) === wanted) {
+      return font.readUInt32BE(at + 8);
+    }
+  }
+  throw new Error(`font has no ${wanted} table`);
+}
+
+function fontChecksum(bytes: Uint8Array): number {
+  const padded = Math.ceil(bytes.byteLength / 4) * 4;
+  let sum = 0;
+  for (let at = 0; at < padded; at += 4) {
+    sum = (
+      sum
+      + (((bytes[at] ?? 0) << 24) >>> 0)
+      + ((bytes[at + 1] ?? 0) << 16)
+      + ((bytes[at + 2] ?? 0) << 8)
+      + (bytes[at + 3] ?? 0)
+    ) >>> 0;
+  }
+  return sum;
+}
+
+test("the Guild Wars nibble stream decodes every printable ASCII glyph", () => {
+  // top=0, width=1, height=1, palette mode=1, one palette-1 pixel.
+  const glyphs = decodeGameFontRange(repeatedGlyph([0x00, 0x10, 0x01]));
+  assert.equal(glyphs.length, GLYPH_COUNT);
+  assert.deepEqual(
+    { top: glyphs[0]?.top, width: glyphs[0]?.width, height: glyphs[0]?.height },
+    { top: 0, width: 1, height: 1 },
+  );
+  assert.deepEqual([...glyphs[0]!.pixels], [0x66]);
+});
+
+test("alternating runs cannot overrun a glyph", () => {
+  // top=0, width=2, height=2, mode=0, then runs of two lit and two clear.
+  const glyphs = decodeGameFontRange(repeatedGlyph([0x10, 0x01, 0x11]));
+  assert.deepEqual([...glyphs[0]!.pixels], [0xff, 0xff, 0x00, 0x00]);
+  assert.throws(
+    () => decodeGameFontRange(repeatedGlyph([0x00, 0x00, 0x1f])),
+    /run exceeds its bitmap/,
+  );
+});
+
+test("the converted result is a complete checksummed TrueType font", () => {
+  const font = buildGuildWarsTrueType(repeatedGlyph([0x00, 0x10, 0x01]));
+  assert.equal(font.readUInt32BE(0), 0x00010000);
+  assert.equal(font.readUInt16BE(4), 10);
+  assert.equal(fontChecksum(font), 0xb1b0afba);
+  assert.ok(font.includes(Buffer.from("Guild Wars Original", "utf16le").swap16()));
+});
+
+test("a narrow numeral gets balanced proportional spacing", () => {
+  // Most fixture glyphs fill a nine-pixel cell. `1` occupies only its centre
+  // pixel, matching the large empty sides found in the game's real digit cell.
+  const full = packedNibbles([0, 8, 1, 0, 1, 8, 8, 8, 8, 8, 8, 8, 8, 8]);
+  const narrow = packedNibbles([0, 8, 1, 0, 1, 0, 3, 8, 0, 3]);
+  const glyphs = Array.from({ length: GLYPH_COUNT }, () => full);
+  glyphs[0x31 - 0x21] = narrow;
+  const font = buildGuildWarsTrueType(Uint8Array.from(glyphs.flat()));
+  const hmtx = tableOffset(font, "hmtx");
+  const glyphId = (character: string) => character.charCodeAt(0) - 0x20 + 1;
+  const advance = (character: string) =>
+    font.readUInt16BE(hmtx + glyphId(character) * 4);
+  assert.ok(advance("1") < advance("2"));
+});
+
+test("a temporary local font refusal can recover without an app restart", async () => {
+  let reads = 0;
+  const assets = new GameFontAssets({
+    store: {
+      readRange: async () => {
+        reads += 1;
+        throw new Error("temporarily unavailable");
+      },
+    } as unknown as ChunkStore,
+    decoderPath: "/not-reached",
+  });
+
+  assert.equal(await assets.font(), null);
+  assert.equal(await assets.font(), null);
+  assert.equal(reads, 2);
+});
+
+test("the shared UI offers the local Guild Wars font independently of Inter", () => {
+  const css = readFileSync(new URL("src/shared/ui/tokens.css", root), "utf8");
+  assert.match(css, /url\("gw:\/\/app\/game-font\.ttf"\)/);
+  assert.match(css, /--ui-font: "Guild Wars Original"/);
+  assert.match(css, /:root\[data-ui-font="inter"\]/);
+  assert.match(css, /unicode-range: U\+0020-007E/);
+});

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -20,6 +20,7 @@ describe("settings", () => {
     assert.deepEqual(DEFAULT_SETTINGS, {
       renderScale: 2,
       uiStyle: "guild-wars",
+      uiFont: "guild-wars",
       uiPanelOpacity: 94,
       gwonmacTools: false,
       teamManagement: true,
@@ -64,6 +65,7 @@ describe("settings", () => {
       uiPanelOpacity: 94,
       renderScale: 1,
       uiStyle: "guild-wars",
+      uiFont: "guild-wars",
       gwonmacTools: false,
       teamManagement: true,
       xunlaiStorage: false,
@@ -104,6 +106,13 @@ describe("settings", () => {
     assert.equal(parseSettings({ uiStyle: "obsidian" }).uiStyle, "obsidian");
     assert.throws(() => parseSettings({ uiStyle: "jade" }), AppError);
     assert.throws(() => parseSettings({ uiStyle: true }), AppError);
+  });
+
+  it("accepts only the two supported interface fonts", () => {
+    assert.equal(parseSettings({ uiFont: "guild-wars" }).uiFont, "guild-wars");
+    assert.equal(parseSettings({ uiFont: "inter" }).uiFont, "inter");
+    assert.throws(() => parseSettings({ uiFont: "papyrus" }), AppError);
+    assert.throws(() => parseSettings({ uiFont: false }), AppError);
   });
 
   it("rejects unknown types", () => {
@@ -214,6 +223,9 @@ describe("settings", () => {
     assert.deepEqual(parseSettingsPatch({ uiStyle: "obsidian" }), {
       uiStyle: "obsidian",
     });
+    assert.deepEqual(parseSettingsPatch({ uiFont: "inter" }), {
+      uiFont: "inter",
+    });
   });
 
   it("loads defaults for missing or corrupt files", async () => {
@@ -265,6 +277,7 @@ describe("settings", () => {
       "teamManagement",
       "travelPalette",
       "travelShortcuts",
+      "uiFont",
       "uiPanelOpacity",
       "uiStyle",
       "updateTrack",
@@ -301,6 +314,7 @@ describe("settings", () => {
       uiPanelOpacity: 94,
       renderScale: 1.5,
       uiStyle: "guild-wars",
+      uiFont: "guild-wars",
       gwonmacTools: false,
       teamManagement: true,
       xunlaiStorage: false,


### PR DESCRIPTION
The app can now use the original Guild Wars body font without bundling or redistributing ArenaNet font data. GWonMac converts the installed game's bitmap strike locally, loads it only after the verified client is ready, and falls back safely when the resource is unavailable or changes.

## What changed

- Add **Guild Wars Original** and **Inter** as independent font choices for Settings and Tools surfaces.
- Decode the known 24 px Guild Wars body strike from the player's installed client and convert it to an in-memory TrueType font.
- Preserve the game's soft grayscale edges and proportional numeral spacing.
- Wait for an active client generation before loading the font, then use a generation-keyed URL so a cold-start refusal can retry correctly.
- Bound glyph geometry, contour work, and output size so malformed or changed ArenaNet data fails quickly instead of blocking Electron's main process.
- Cache an unsupported result for the immutable client generation and keep the normal fallback active.
- Store and redistribute no Guild Wars font data or generated font file.

## Why

The bundled Friz-style fallback gives the app a similar mood, but the locally converted game strike matches the actual in-game interface. Keeping conversion local gives players that visual continuity without adding a proprietary asset or a fragile extraction cache.

## ArenaNet update behavior

The parser accepts only the measured body-strike contract. If ArenaNet moves or changes the resource, GWonMac logs one bounded refusal and uses the fallback font for that client generation. A later verified client generation gets a fresh attempt. The app remains usable throughout.

## Stack

1. #136 — Multiple Accounts
2. #145 — Xunlai Storage and shared Tools preparation
3. #147 — Quick Travel
4. **This PR — Local Guild Wars font**

Review and merge bottom-to-top, then release once from `main`.

## Verification

- Full `pnpm verify` on the complete four-PR stack
- 1,070 unit tests
- 165 policy tests
- 78 Tools tests
- 41 integration tests
- 21 release tests
- 33 Tools UI journeys
- 120 Electron tests passed; one intentional live-client test skipped
- Packaged application and Enhancement runtime lifecycle checks
- Cold-start, deferred font activation, unsupported-format fallback, and adversarial glyph bounds

- [x] I kept this pull request focused.
- [x] I ran the relevant checks.
- [x] I did not add game binaries, font binaries, credentials, diagnostics, or private traffic.
- [x] I updated documentation when behavior or an invariant changed.
