### PR TITLE
fix(appearance): replicate original Guild Wars typography

### DIFF
--- a/apps/tools/src/components/LiveParty.vue
+++ b/apps/tools/src/components/LiveParty.vue
@@ -139,7 +139,7 @@ const canCapture = computed(() =>
   min-width: 0;
   flex: 1;
   font-size: var(--ui-font-size);
-  font-weight: 600;
+  font-weight: var(--ui-font-weight-semibold);
 }
 
 .live-party-body {

--- a/apps/tools/src/styles.css
+++ b/apps/tools/src/styles.css
@@ -99,7 +99,7 @@
   color: var(--ui-text-muted);
   font-size: var(--ui-font-size-sm);
 }
-.travel-shortcuts header strong { color: var(--ui-text); font-weight: 600; }
+.travel-shortcuts header strong { color: var(--ui-text); font-weight: var(--ui-font-weight-semibold); }
 .travel-shortcuts button {
   display: flex;
   align-items: center;
@@ -136,7 +136,7 @@
 .travel-results button:disabled,
 .travel-shortcuts button:disabled { cursor: default; }
 .travel-results button > span:first-child { display: grid; gap: 1px; }
-.travel-results strong { font-weight: 600; }
+.travel-results strong { font-weight: var(--ui-font-weight-semibold); }
 .travel-results small { color: var(--ui-text-muted); }
 .travel-progress { color: var(--ui-accent); }
 .travel-empty { padding: 20px 12px; color: var(--ui-text-muted); text-align: center; }

--- a/apps/tools/src/styles/base-shell.css
+++ b/apps/tools/src/styles/base-shell.css
@@ -136,7 +136,7 @@ body:has(.tools-stage[data-mode="standalone"]) {
   color: var(--ui-accent);
   font-family: var(--ui-font-display);
   font-size: var(--ui-font-size-sm);
-  font-weight: 600;
+  font-weight: var(--ui-font-weight-semibold);
 }
 
 .window-close { font-size: var(--ui-font-size-lg); }

--- a/apps/tools/src/styles/build.css
+++ b/apps/tools/src/styles/build.css
@@ -263,7 +263,7 @@
   margin: 0;
   color: var(--ui-text-bright);
   font-size: var(--ui-font-size);
-  font-weight: 600;
+  font-weight: var(--ui-font-weight-semibold);
 }
 
 .section-heading p { margin-left: 0; }
@@ -529,7 +529,7 @@
 
 .usage-row strong,
 .usage-row small { display: block; }
-.usage-row strong { font-weight: 500; }
+.usage-row strong { font-weight: var(--ui-font-weight-medium); }
 
 .usage-row small {
   margin-top: 2px;
@@ -540,7 +540,7 @@
   display: block;
   margin-bottom: var(--ui-space-2);
   color: var(--ui-text-bright);
-  font-weight: 600;
+  font-weight: var(--ui-font-weight-semibold);
 }
 
 /* An action that needs explaining before it happens, shown where it will take
@@ -636,7 +636,7 @@
 
 .team-action-buttons .ui-link[data-variant="danger"] { margin: 0 auto 0 0; }
 .apply-details { margin-top: var(--ui-space-1); color: var(--ui-text); }
-.apply-details summary { cursor: pointer; font-weight: 600; }
+.apply-details summary { cursor: pointer; font-weight: var(--ui-font-weight-semibold); }
 .apply-details ul { margin: var(--ui-space-1) 0 0; padding-left: var(--ui-space-4); }
 
 @container detail-pane (max-width: 860px) {

--- a/apps/tools/src/styles/catalogue.css
+++ b/apps/tools/src/styles/catalogue.css
@@ -192,7 +192,7 @@
   color: var(--ui-text-muted);
   font: inherit;
   font-size: var(--ui-font-size-sm);
-  font-weight: 600;
+  font-weight: var(--ui-font-weight-semibold);
   text-align: left;
 }
 
@@ -216,7 +216,7 @@
 .skill-group-count {
   color: var(--ui-text-faint);
   font-variant-numeric: tabular-nums;
-  font-weight: 500;
+  font-weight: var(--ui-font-weight-medium);
 }
 
 .skill-group-results:empty { display: none; }

--- a/apps/tools/src/styles/team.css
+++ b/apps/tools/src/styles/team.css
@@ -129,7 +129,7 @@
 
 .hero-cell strong {
   font-size: var(--ui-font-size-sm);
-  font-weight: 600;
+  font-weight: var(--ui-font-weight-semibold);
 }
 
 .hero-cell small {
@@ -276,7 +276,7 @@
 .apply-issue-list strong {
   color: var(--ui-text-bright);
   font-size: var(--ui-font-size-sm);
-  font-weight: 600;
+  font-weight: var(--ui-font-weight-semibold);
 }
 .apply-issue-list small {
   margin-top: 2px;

--- a/apps/website/app/pages/index.vue
+++ b/apps/website/app/pages/index.vue
@@ -26,7 +26,6 @@ const localize = (value: Localized) => getLocalizedSiteText(value, locale.value)
 // the DMG in the browser instead raced hydration: a third of clicks landed on
 // the releases page because the fetch had not answered yet.
 const DOWNLOAD_PATH = "/download";
-const BETA_DOWNLOAD_PATH = "/download?channel=beta";
 // /api/latest resolves the newest downloadable release from GitHub (cached
 // server-side, Stable by default). Fetched in the browser so
 // the prerendered page never bakes in a stale version; it only names the
@@ -77,7 +76,6 @@ const HERO = {
   },
   download: { en: "Download for Mac", de: "Für Mac herunterladen" },
   docs: { en: "Installation guide", de: "Installationsanleitung" },
-  betaDownload: { en: "Download the Beta", de: "Beta herunterladen" },
   finePrint: {
     en: "Free · For Apple Silicon · Signed & notarized",
     de: "Kostenlos · Für Apple Silicon · Signiert & notarisiert",

--- a/docs/content-pipeline.md
+++ b/docs/content-pipeline.md
@@ -119,11 +119,12 @@ network cache does not become a second copy of the game-data store.
 ## Original interface font
 
 Guild Wars stores its interface lettering as bitmap strikes, not as a standard
-font file. GWonMac reads the hand-tuned 24-pixel basic-Latin body strike
-(archive file 123027) from the active local game, validates and decompresses
-that one bounded stream, and converts its 94 printable ASCII glyphs to TrueType
-in memory. The shared Guild Wars interface theme loads it from
-`gw://app/game-font.ttf`.
+font file. GWonMac reads two hand-tuned basic-Latin strikes from the active
+local game: the 24-pixel body face (archive file 123027) and the finer 52-pixel
+display face (archive file 123028). It validates and decompresses only those
+bounded streams, then converts their 94 printable ASCII glyphs to separate
+TrueType families in memory. The shared Guild Wars interface theme loads them
+from `gw://app/game-font.ttf` and `gw://app/game-font-display.ttf`.
 
 The local archive remains the source of truth. GWonMac does not commit, cache,
 package, or redistribute the game glyphs or the converted font. If the file is
@@ -133,10 +134,11 @@ ASCII also use that fallback.
 
 ### Font calibration
 
-Run `pnpm font:calibrate` after changing the converter. The command reads the
-same bounded strike from the local installed game, renders threshold candidates
-through Chromium at 24 physical pixels, and writes reference, rendered,
-difference, and numeric-error results to `/tmp/gwonmac-font-calibration`.
+Run `pnpm font:calibrate` after changing the body converter. Add
+`-- --role display --text "Primary Quests"` to calibrate the display face. The
+command reads the selected bounded strike from the local installed game,
+renders threshold candidates through Chromium at its native physical size, and
+writes reference, rendered, difference, and numeric-error results under `/tmp`.
 
 The original grayscale strike is the reference; a screenshot is not. Generated
 reports are disposable local evidence and must not be committed because they

--- a/docs/content-pipeline.md
+++ b/docs/content-pipeline.md
@@ -131,6 +131,19 @@ missing or ArenaNet changes its format, the request fails closed and the theme
 uses its existing Palatino-compatible serif fallback. Characters outside basic
 ASCII also use that fallback.
 
+### Font calibration
+
+Run `pnpm font:calibrate` after changing the converter. The command reads the
+same bounded strike from the local installed game, renders threshold candidates
+through Chromium at 24 physical pixels, and writes reference, rendered,
+difference, and numeric-error results to `/tmp/gwonmac-font-calibration`.
+
+The original grayscale strike is the reference; a screenshot is not. Generated
+reports are disposable local evidence and must not be committed because they
+contain ArenaNet glyph pixels. The converter's default contour threshold is the
+best measured candidate from this loop, while a final visual check still guards
+against a metric rewarding an obviously poor shape.
+
 At startup, the native store scans chunk residency once. It updates the
 in-memory residency set after publication. A range request does not rescan the
 chunk directory.

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "certification": "pnpm build && node build/tools/certification.js",
     "client:official": "node --import ./scripts/ts-hook.mjs --experimental-strip-types scripts/official-client.ts",
     "enhancements:visual": "pnpm build && node --import ./scripts/ts-hook.mjs --experimental-strip-types scripts/enhancements-visual.ts",
+    "font:calibrate": "pnpm build && node --import ./scripts/ts-hook.mjs --experimental-strip-types scripts/calibrate-game-font.ts",
     "enhancements:kernel:verify": "pnpm build && node scripts/verify-companion-kernel.mjs",
     "snapshot:prune": "node --import ./scripts/ts-hook.mjs --experimental-strip-types scripts/snapshot-retention.ts",
     "test:website": "pnpm --filter gw-website certify && node --import ./scripts/ts-hook.mjs --experimental-strip-types tests/website-smoke.ts",

--- a/scripts/calibrate-game-font.ts
+++ b/scripts/calibrate-game-font.ts
@@ -3,12 +3,12 @@
  *
  * The player's own archive is the reference. Nothing from it is committed:
  * this command writes a disposable report under `/tmp` unless `--out` says
- * otherwise. Each candidate outline is rasterised by Chromium at 24 physical
- * pixels (the 12 CSS px / Retina case), aligned against the original grayscale
+ * otherwise. Each candidate outline is rasterised by Chromium at the strike's
+ * native physical size, aligned against the original grayscale
  * strike, scored by alpha error, and shown beside a heat-map difference.
  *
  *   pnpm font:calibrate
- *   pnpm font:calibrate -- --out /tmp/my-font-report --text "Seek Party"
+ *   pnpm font:calibrate -- --role display --text "Primary Quests"
  */
 
 import { homedir } from "node:os";
@@ -20,7 +20,8 @@ import { readGameFontStrike } from "../src/main/core/game-font-assets.js";
 import {
   buildGuildWarsTrueType,
   decodeGameFontRange,
-  GUILD_WARS_FONT_METRICS,
+  GUILD_WARS_BODY_FONT,
+  GUILD_WARS_DISPLAY_FONT,
 } from "../src/main/core/gw-font.js";
 import { parsePublishedClientManifest } from "../src/main/core/published-client.js";
 
@@ -34,8 +35,18 @@ const gameDir = path.resolve(flag(
   "game",
   path.join(homedir(), "Library", "Application Support", "Guild Wars", "game"),
 ));
-const outDir = path.resolve(flag("out", "/tmp/gwonmac-font-calibration"));
-const sample = flag("text", "Seek Party");
+const role = flag("role", "body");
+if (role !== "body" && role !== "display") {
+  throw new Error("--role must be body or display");
+}
+const metrics = role === "display" ? GUILD_WARS_DISPLAY_FONT : GUILD_WARS_BODY_FONT;
+const outDir = path.resolve(flag(
+  "out",
+  role === "body"
+    ? "/tmp/gwonmac-font-calibration"
+    : "/tmp/gwonmac-font-calibration-display",
+));
+const sample = flag("text", role === "display" ? "Primary Quests" : "Seek Party");
 const manifestPath = path.join(gameDir, "artifacts", "manifest.json");
 const decoderPath = path.resolve("build/native/gw-dat-decode");
 const thresholds = [0x60, 0x70, 0x80, 0x90, 0xa0, 0xb0, 0xc0, 0xd0, 0xe0];
@@ -51,10 +62,10 @@ const store = new ChunkStore({
   compression: manifest.compressionMode,
   fetch: null,
 });
-const strike = await readGameFontStrike({ store, decoderPath });
+const strike = await readGameFontStrike({ store, decoderPath }, metrics);
 if (!strike) throw new Error("the installed client does not contain the expected Latin strike");
 
-const glyphs = decodeGameFontRange(strike).map((glyph) => ({
+const glyphs = decodeGameFontRange(strike, metrics).map((glyph) => ({
   top: glyph.top,
   width: glyph.width,
   height: glyph.height,
@@ -62,7 +73,7 @@ const glyphs = decodeGameFontRange(strike).map((glyph) => ({
 }));
 const candidates = thresholds.map((threshold) => ({
   threshold,
-  font: buildGuildWarsTrueType(strike, { outlineThreshold: threshold })
+  font: buildGuildWarsTrueType(strike, { outlineThreshold: threshold, strike: metrics })
     .toString("base64"),
 }));
 
@@ -211,21 +222,25 @@ const results = await page.evaluate(
     }
     return output;
   },
-  { candidates, glyphs, metrics: GUILD_WARS_FONT_METRICS, sample },
+  { candidates, glyphs, metrics, sample },
 ) as CandidateResult[];
 
 results.sort((left, right) => left.error - right.error);
 const best = results[0];
 if (!best) throw new Error("font calibration produced no candidates");
+const bestFont = candidates.find(({ threshold }) => threshold === best.threshold);
+if (!bestFont) throw new Error("font calibration lost its best candidate");
 const pngBytes = (dataUrl: string) => Buffer.from(dataUrl.split(",", 2)[1]!, "base64");
 await mkdir(outDir, { recursive: true });
 await Promise.all([
+  writeFile(path.join(outDir, "font.ttf"), Buffer.from(bestFont.font, "base64")),
   writeFile(path.join(outDir, "reference.png"), pngBytes(best.referencePng)),
   writeFile(path.join(outDir, "rendered.png"), pngBytes(best.renderedPng)),
   writeFile(path.join(outDir, "difference.png"), pngBytes(best.differencePng)),
   writeFile(path.join(outDir, "report.json"), JSON.stringify({
     sample,
-    physicalPixelSize: GUILD_WARS_FONT_METRICS.em,
+    role,
+    physicalPixelSize: metrics.em,
     bestThreshold: best.threshold,
     candidates: results.map(({ threshold, error, coverageDelta }) => ({
       threshold,
@@ -250,8 +265,8 @@ await page.setContent(`<!doctype html><meta charset="utf-8"><style>
   th:first-child, td:first-child { text-align: left; }
   tr.best { color: #f2d58e; font-weight: 700; }
 </style>
-<h1>Guild Wars font calibration</h1>
-<p class="summary">“${sample.replaceAll("&", "&amp;").replaceAll("<", "&lt;")}” at 24 physical pixels · best alpha threshold: 0x${best.threshold.toString(16)} · mean error ${(best.error * 100).toFixed(2)}%</p>
+<h1>Guild Wars ${role} font calibration</h1>
+<p class="summary">“${sample.replaceAll("&", "&amp;").replaceAll("<", "&lt;")}” at ${metrics.em} physical pixels · best alpha threshold: 0x${best.threshold.toString(16)} · mean error ${(best.error * 100).toFixed(2)}%</p>
 <div class="grid">
   <article><h2>Original archive strike</h2><img src="${best.referencePng}"></article>
   <article><h2>Chromium render</h2><img src="${best.renderedPng}"></article>
@@ -266,6 +281,8 @@ await browser.close();
 console.log(JSON.stringify({
   report: path.join(outDir, "report.png"),
   data: path.join(outDir, "report.json"),
+  font: path.join(outDir, "font.ttf"),
+  role,
   bestThreshold: `0x${best.threshold.toString(16)}`,
   meanAlphaError: best.error,
   coverageDelta: best.coverageDelta,

--- a/scripts/calibrate-game-font.ts
+++ b/scripts/calibrate-game-font.ts
@@ -1,0 +1,272 @@
+/**
+ * Visual calibration loop for the locally converted Guild Wars UI font.
+ *
+ * The player's own archive is the reference. Nothing from it is committed:
+ * this command writes a disposable report under `/tmp` unless `--out` says
+ * otherwise. Each candidate outline is rasterised by Chromium at 24 physical
+ * pixels (the 12 CSS px / Retina case), aligned against the original grayscale
+ * strike, scored by alpha error, and shown beside a heat-map difference.
+ *
+ *   pnpm font:calibrate
+ *   pnpm font:calibrate -- --out /tmp/my-font-report --text "Seek Party"
+ */
+
+import { homedir } from "node:os";
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import path from "node:path";
+import { chromium } from "playwright";
+import { ChunkStore } from "../src/main/core/chunk-store.js";
+import { readGameFontStrike } from "../src/main/core/game-font-assets.js";
+import {
+  buildGuildWarsTrueType,
+  decodeGameFontRange,
+  GUILD_WARS_FONT_METRICS,
+} from "../src/main/core/gw-font.js";
+import { parsePublishedClientManifest } from "../src/main/core/published-client.js";
+
+const args = process.argv.slice(2);
+const flag = (name: string, fallback: string): string => {
+  const at = args.indexOf(`--${name}`);
+  return at === -1 ? fallback : (args[at + 1] ?? fallback);
+};
+
+const gameDir = path.resolve(flag(
+  "game",
+  path.join(homedir(), "Library", "Application Support", "Guild Wars", "game"),
+));
+const outDir = path.resolve(flag("out", "/tmp/gwonmac-font-calibration"));
+const sample = flag("text", "Seek Party");
+const manifestPath = path.join(gameDir, "artifacts", "manifest.json");
+const decoderPath = path.resolve("build/native/gw-dat-decode");
+const thresholds = [0x60, 0x70, 0x80, 0x90, 0xa0, 0xb0, 0xc0, 0xd0, 0xe0];
+
+const manifest = parsePublishedClientManifest(
+  JSON.parse(await readFile(manifestPath, "utf8")),
+);
+const store = new ChunkStore({
+  chunksDir: path.join(gameDir, "chunks"),
+  size: manifest.size,
+  chunkSize: manifest.chunkSize,
+  chunkHashes: manifest.chunkHashes,
+  compression: manifest.compressionMode,
+  fetch: null,
+});
+const strike = await readGameFontStrike({ store, decoderPath });
+if (!strike) throw new Error("the installed client does not contain the expected Latin strike");
+
+const glyphs = decodeGameFontRange(strike).map((glyph) => ({
+  top: glyph.top,
+  width: glyph.width,
+  height: glyph.height,
+  pixels: Array.from(glyph.pixels),
+}));
+const candidates = thresholds.map((threshold) => ({
+  threshold,
+  font: buildGuildWarsTrueType(strike, { outlineThreshold: threshold })
+    .toString("base64"),
+}));
+
+interface CandidateResult {
+  threshold: number;
+  error: number;
+  coverageDelta: number;
+  referencePng: string;
+  renderedPng: string;
+  differencePng: string;
+}
+
+const browser = await chromium.launch({ headless: true });
+const page = await browser.newPage({ viewport: { width: 1180, height: 900 } });
+const results = await page.evaluate(
+  async ({ candidates, glyphs, metrics, sample }) => {
+    const margin = 3;
+    const glyphFor = (character: string) => {
+      const code = character.charCodeAt(0);
+      return code >= 0x21 && code <= 0x7e ? glyphs[code - 0x21] : null;
+    };
+    const advance = (character: string) =>
+      character === " " ? metrics.spaceWidth : (glyphFor(character)?.width ?? 0);
+    const contentWidth = [...sample].reduce(
+      (total, character) => total + advance(character),
+      0,
+    );
+    const width = contentWidth + margin * 2;
+    const height = metrics.lineHeight + margin * 2;
+
+    const makeCanvas = () => {
+      const canvas = document.createElement("canvas");
+      canvas.width = width;
+      canvas.height = height;
+      return canvas;
+    };
+    const reference = makeCanvas();
+    const referenceContext = reference.getContext("2d", { willReadFrequently: true });
+    if (!referenceContext) throw new Error("Chromium did not provide a 2D canvas");
+    const referenceImage = referenceContext.createImageData(width, height);
+    let pen = margin;
+    for (const character of sample) {
+      const glyph = glyphFor(character);
+      if (glyph) {
+        for (let y = 0; y < glyph.height; y += 1) {
+          for (let x = 0; x < glyph.width; x += 1) {
+            const alpha = glyph.pixels[y * glyph.width + x] ?? 0;
+            const at = ((margin + glyph.top + y) * width + pen + x) * 4;
+            referenceImage.data[at] = 255;
+            referenceImage.data[at + 1] = 255;
+            referenceImage.data[at + 2] = 255;
+            referenceImage.data[at + 3] = alpha;
+          }
+        }
+      }
+      pen += advance(character);
+    }
+    referenceContext.putImageData(referenceImage, 0, 0);
+    const referenceAlpha = referenceContext.getImageData(0, 0, width, height).data;
+
+    const score = (
+      rendered: Uint8ClampedArray,
+      xShift: number,
+      yShift: number,
+    ) => {
+      let error = 0;
+      let referenceCoverage = 0;
+      let renderedCoverage = 0;
+      for (let y = 0; y < height; y += 1) {
+        for (let x = 0; x < width; x += 1) {
+          const referenceValue = referenceAlpha[(y * width + x) * 4 + 3] ?? 0;
+          const shiftedX = x + xShift;
+          const shiftedY = y + yShift;
+          const renderedValue = shiftedX < 0 || shiftedY < 0
+            || shiftedX >= width || shiftedY >= height
+            ? 0
+            : (rendered[(shiftedY * width + shiftedX) * 4 + 3] ?? 0);
+          error += Math.abs(referenceValue - renderedValue);
+          referenceCoverage += referenceValue;
+          renderedCoverage += renderedValue;
+        }
+      }
+      return {
+        error: error / (width * height * 255),
+        coverageDelta: (renderedCoverage - referenceCoverage)
+          / Math.max(referenceCoverage, 1),
+      };
+    };
+
+    const output = [];
+    for (const candidate of candidates) {
+      const family = `Candidate${candidate.threshold}`;
+      const face = new FontFace(
+        family,
+        `url(data:font/ttf;base64,${candidate.font})`,
+        { weight: "400" },
+      );
+      await face.load();
+      document.fonts.add(face);
+      const rendered = makeCanvas();
+      const context = rendered.getContext("2d", { willReadFrequently: true });
+      if (!context) throw new Error("Chromium did not provide a 2D canvas");
+      context.fillStyle = "white";
+      context.font = `400 ${metrics.em}px ${family}`;
+      context.textBaseline = "alphabetic";
+      context.fillText(sample, margin, margin + metrics.baseline);
+      const renderedImage = context.getImageData(0, 0, width, height);
+
+      let best = { x: 0, y: 0, ...score(renderedImage.data, 0, 0) };
+      for (let y = -2; y <= 2; y += 1) {
+        for (let x = -2; x <= 2; x += 1) {
+          const candidateScore = score(renderedImage.data, x, y);
+          if (candidateScore.error < best.error) best = { x, y, ...candidateScore };
+        }
+      }
+
+      const difference = makeCanvas();
+      const differenceContext = difference.getContext("2d");
+      if (!differenceContext) throw new Error("Chromium did not provide a 2D canvas");
+      const differenceImage = differenceContext.createImageData(width, height);
+      for (let y = 0; y < height; y += 1) {
+        for (let x = 0; x < width; x += 1) {
+          const at = (y * width + x) * 4;
+          const referenceValue = referenceAlpha[at + 3] ?? 0;
+          const shiftedX = x + best.x;
+          const shiftedY = y + best.y;
+          const renderedValue = shiftedX < 0 || shiftedY < 0
+            || shiftedX >= width || shiftedY >= height
+            ? 0
+            : (renderedImage.data[(shiftedY * width + shiftedX) * 4 + 3] ?? 0);
+          differenceImage.data[at] = Math.max(referenceValue - renderedValue, 0);
+          differenceImage.data[at + 1] = Math.min(referenceValue, renderedValue);
+          differenceImage.data[at + 2] = Math.max(renderedValue - referenceValue, 0);
+          differenceImage.data[at + 3] = Math.max(referenceValue, renderedValue);
+        }
+      }
+      differenceContext.putImageData(differenceImage, 0, 0);
+      output.push({
+        threshold: candidate.threshold,
+        error: best.error,
+        coverageDelta: best.coverageDelta,
+        referencePng: reference.toDataURL("image/png"),
+        renderedPng: rendered.toDataURL("image/png"),
+        differencePng: difference.toDataURL("image/png"),
+      });
+    }
+    return output;
+  },
+  { candidates, glyphs, metrics: GUILD_WARS_FONT_METRICS, sample },
+) as CandidateResult[];
+
+results.sort((left, right) => left.error - right.error);
+const best = results[0];
+if (!best) throw new Error("font calibration produced no candidates");
+const pngBytes = (dataUrl: string) => Buffer.from(dataUrl.split(",", 2)[1]!, "base64");
+await mkdir(outDir, { recursive: true });
+await Promise.all([
+  writeFile(path.join(outDir, "reference.png"), pngBytes(best.referencePng)),
+  writeFile(path.join(outDir, "rendered.png"), pngBytes(best.renderedPng)),
+  writeFile(path.join(outDir, "difference.png"), pngBytes(best.differencePng)),
+  writeFile(path.join(outDir, "report.json"), JSON.stringify({
+    sample,
+    physicalPixelSize: GUILD_WARS_FONT_METRICS.em,
+    bestThreshold: best.threshold,
+    candidates: results.map(({ threshold, error, coverageDelta }) => ({
+      threshold,
+      error,
+      coverageDelta,
+    })),
+  }, null, 2)),
+]);
+
+await page.setContent(`<!doctype html><meta charset="utf-8"><style>
+  :root { color-scheme: dark; font-family: ui-sans-serif, system-ui, sans-serif; }
+  body { width: 1080px; margin: 0; padding: 40px; background: #0c0b0a; color: #eee9df; }
+  h1 { margin: 0 0 8px; font-size: 28px; }
+  p { color: #aaa397; }
+  .summary { margin-bottom: 28px; }
+  .grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+  article { padding: 18px; border: 1px solid #454038; border-radius: 10px; background: #171410; }
+  h2 { margin: 0 0 14px; color: #e7c982; font-size: 16px; }
+  img { width: auto; height: auto; min-width: 100%; image-rendering: pixelated; background: #241b14; }
+  table { width: 100%; margin-top: 28px; border-collapse: collapse; font-variant-numeric: tabular-nums; }
+  th, td { padding: 8px 10px; border-bottom: 1px solid #39352f; text-align: right; }
+  th:first-child, td:first-child { text-align: left; }
+  tr.best { color: #f2d58e; font-weight: 700; }
+</style>
+<h1>Guild Wars font calibration</h1>
+<p class="summary">“${sample.replaceAll("&", "&amp;").replaceAll("<", "&lt;")}” at 24 physical pixels · best alpha threshold: 0x${best.threshold.toString(16)} · mean error ${(best.error * 100).toFixed(2)}%</p>
+<div class="grid">
+  <article><h2>Original archive strike</h2><img src="${best.referencePng}"></article>
+  <article><h2>Chromium render</h2><img src="${best.renderedPng}"></article>
+  <article><h2>Difference heat map</h2><img src="${best.differencePng}"></article>
+</div>
+<table><thead><tr><th>Threshold</th><th>Mean alpha error</th><th>Coverage delta</th></tr></thead><tbody>
+${results.map((result) => `<tr class="${result === best ? "best" : ""}"><td>0x${result.threshold.toString(16)}</td><td>${(result.error * 100).toFixed(2)}%</td><td>${(result.coverageDelta * 100).toFixed(2)}%</td></tr>`).join("")}
+</tbody></table>`);
+await page.screenshot({ path: path.join(outDir, "report.png"), fullPage: true });
+await browser.close();
+
+console.log(JSON.stringify({
+  report: path.join(outDir, "report.png"),
+  data: path.join(outDir, "report.json"),
+  bestThreshold: `0x${best.threshold.toString(16)}`,
+  meanAlphaError: best.error,
+  coverageDelta: best.coverageDelta,
+}, null, 2));

--- a/src/main/core/game-font-assets.ts
+++ b/src/main/core/game-font-assets.ts
@@ -34,6 +34,40 @@ export interface GameFontSource {
 
 export type GameFontRefusal = "unsupported" | "read-or-format";
 
+/** Read and decompress only the bounded local strike used by the converter. */
+export async function readGameFontStrike(
+  source: GameFontSource,
+): Promise<Buffer | null> {
+  const { store } = source;
+  const headerBytes = await store.readRange(0, 32);
+  const header = parseArchiveHeader(() => headerBytes);
+  const tableBytes = await store.readRange(header.tableOffset, header.tableSize);
+  const files = readFileTable(
+    (offset, length) => tableBytes.subarray(
+      offset - header.tableOffset,
+      offset - header.tableOffset + length,
+    ),
+    header,
+  );
+  const indexSlot = parseSlot(files.bytes, 2);
+  const indexBytes = await store.readRange(indexSlot.offset, indexSlot.size);
+  const index = fileIdIndex(
+    (offset, length) => indexBytes.subarray(
+      offset - indexSlot.offset,
+      offset - indexSlot.offset + length,
+    ),
+    files,
+  );
+  const stream = findStream(files, index, GUILD_WARS_LATIN_FONT_FILE_ID);
+  if (!stream?.compressed || stream.size > MAX_COMPRESSED_FONT_BYTES) return null;
+  const compressed = await store.readRange(stream.offset, stream.size);
+  return runGwDatDecoder(source.decoderPath, compressed, {
+    args: ["--raw"],
+    maxOutput: MAX_DECODED_FONT_BYTES + 8,
+    parse: (bytes) => decodedArchiveBytes(bytes, MAX_DECODED_FONT_BYTES),
+  });
+}
+
 export class GameFontAssets {
   private readonly source: GameFontSource;
   private result: Promise<Buffer | null> | null = null;
@@ -55,37 +89,11 @@ export class GameFontAssets {
   }
 
   private async convert(): Promise<Buffer | null> {
-    const { store } = this.source;
-    const headerBytes = await store.readRange(0, 32);
-    const header = parseArchiveHeader(() => headerBytes);
-    const tableBytes = await store.readRange(header.tableOffset, header.tableSize);
-    const files = readFileTable(
-      (offset, length) => tableBytes.subarray(
-        offset - header.tableOffset,
-        offset - header.tableOffset + length,
-      ),
-      header,
-    );
-    const indexSlot = parseSlot(files.bytes, 2);
-    const indexBytes = await store.readRange(indexSlot.offset, indexSlot.size);
-    const index = fileIdIndex(
-      (offset, length) => indexBytes.subarray(
-        offset - indexSlot.offset,
-        offset - indexSlot.offset + length,
-      ),
-      files,
-    );
-    const stream = findStream(files, index, GUILD_WARS_LATIN_FONT_FILE_ID);
-    if (!stream?.compressed || stream.size > MAX_COMPRESSED_FONT_BYTES) {
+    const raw = await readGameFontStrike(this.source);
+    if (!raw) {
       this.refusalCode = "unsupported";
       return null;
     }
-    const compressed = await store.readRange(stream.offset, stream.size);
-    const raw = await runGwDatDecoder(this.source.decoderPath, compressed, {
-      args: ["--raw"],
-      maxOutput: MAX_DECODED_FONT_BYTES + 8,
-      parse: (bytes) => decodedArchiveBytes(bytes, MAX_DECODED_FONT_BYTES),
-    });
     return buildGuildWarsTrueType(raw);
   }
 }

--- a/src/main/core/game-font-assets.ts
+++ b/src/main/core/game-font-assets.ts
@@ -21,7 +21,9 @@ import {
 } from "./gw-dat-decoder.js";
 import {
   buildGuildWarsTrueType,
-  GUILD_WARS_LATIN_FONT_FILE_ID,
+  GUILD_WARS_BODY_FONT,
+  GUILD_WARS_DISPLAY_FONT,
+  type GameFontStrike,
 } from "./gw-font.js";
 
 const MAX_COMPRESSED_FONT_BYTES = 64 * 1024;
@@ -33,10 +35,17 @@ export interface GameFontSource {
 }
 
 export type GameFontRefusal = "unsupported" | "read-or-format";
+export type GameFontRole = "body" | "display";
+
+const strikes: Readonly<Record<GameFontRole, GameFontStrike>> = {
+  body: GUILD_WARS_BODY_FONT,
+  display: GUILD_WARS_DISPLAY_FONT,
+};
 
 /** Read and decompress only the bounded local strike used by the converter. */
 export async function readGameFontStrike(
   source: GameFontSource,
+  strike: GameFontStrike = GUILD_WARS_BODY_FONT,
 ): Promise<Buffer | null> {
   const { store } = source;
   const headerBytes = await store.readRange(0, 32);
@@ -58,7 +67,7 @@ export async function readGameFontStrike(
     ),
     files,
   );
-  const stream = findStream(files, index, GUILD_WARS_LATIN_FONT_FILE_ID);
+  const stream = findStream(files, index, strike.fileId);
   if (!stream?.compressed || stream.size > MAX_COMPRESSED_FONT_BYTES) return null;
   const compressed = await store.readRange(stream.offset, stream.size);
   return runGwDatDecoder(source.decoderPath, compressed, {
@@ -70,30 +79,35 @@ export async function readGameFontStrike(
 
 export class GameFontAssets {
   private readonly source: GameFontSource;
-  private result: Promise<Buffer | null> | null = null;
+  private readonly results = new Map<GameFontRole, Promise<Buffer | null>>();
   private refusalCode: GameFontRefusal | null = null;
 
   constructor(source: GameFontSource) {
     this.source = source;
   }
 
-  async font(): Promise<Buffer | null> {
-    return this.result ??= this.convert().catch(() => {
+  async font(role: GameFontRole = "body"): Promise<Buffer | null> {
+    const existing = this.results.get(role);
+    if (existing) return existing;
+    const result = this.convert(role).catch(() => {
       this.refusalCode = "read-or-format";
       return null;
     });
+    this.results.set(role, result);
+    return result;
   }
 
   refusal(): GameFontRefusal | null {
     return this.refusalCode;
   }
 
-  private async convert(): Promise<Buffer | null> {
-    const raw = await readGameFontStrike(this.source);
+  private async convert(role: GameFontRole): Promise<Buffer | null> {
+    const strike = strikes[role];
+    const raw = await readGameFontStrike(this.source, strike);
     if (!raw) {
       this.refusalCode = "unsupported";
       return null;
     }
-    return buildGuildWarsTrueType(raw);
+    return buildGuildWarsTrueType(raw, { strike });
   }
 }

--- a/src/main/core/gw-font.ts
+++ b/src/main/core/gw-font.ts
@@ -16,7 +16,40 @@
  * outside basic ASCII fall through to the existing serif stack.
  */
 
-export const GUILD_WARS_LATIN_FONT_FILE_ID = 123027;
+export interface GameFontStrike {
+  readonly fileId: number;
+  readonly family: string;
+  readonly fullName: string;
+  readonly postScriptName: string;
+  readonly em: number;
+  readonly baseline: number;
+  readonly lineHeight: number;
+  readonly spaceWidth: number;
+}
+
+export const GUILD_WARS_BODY_FONT = {
+  fileId: 123027,
+  family: "Guild Wars Original",
+  fullName: "Guild Wars Original Regular",
+  postScriptName: "GuildWarsOriginal-Regular",
+  em: 24,
+  baseline: 18,
+  lineHeight: 25,
+  spaceWidth: 6,
+} as const satisfies GameFontStrike;
+
+export const GUILD_WARS_DISPLAY_FONT = {
+  fileId: 123028,
+  family: "Guild Wars Original Display",
+  fullName: "Guild Wars Original Display Regular",
+  postScriptName: "GuildWarsOriginalDisplay-Regular",
+  em: 52,
+  baseline: 40,
+  lineHeight: 52,
+  spaceWidth: 13,
+} as const satisfies GameFontStrike;
+
+export const GUILD_WARS_LATIN_FONT_FILE_ID = GUILD_WARS_BODY_FONT.fileId;
 
 const ALPHA = Uint8Array.of(
   0x00, 0x66, 0x79, 0x8d, 0x97, 0xa5, 0xaf, 0xbd,
@@ -24,23 +57,13 @@ const ALPHA = Uint8Array.of(
 );
 const FIRST_CHARACTER = 0x21;
 const LAST_CHARACTER = 0x7e;
-export const GUILD_WARS_FONT_METRICS = {
-  em: 24,
-  baseline: 18,
-  lineHeight: 25,
-  spaceWidth: 6,
-} as const;
-const SOURCE_EM = GUILD_WARS_FONT_METRICS.em;
-const SOURCE_BASELINE = GUILD_WARS_FONT_METRICS.baseline;
-const SOURCE_LINE_HEIGHT = GUILD_WARS_FONT_METRICS.lineHeight;
-const SOURCE_SPACE_WIDTH = GUILD_WARS_FONT_METRICS.spaceWidth;
-const MAX_SOURCE_DIMENSION = 24;
-const MAX_SOURCE_PIXELS = 24 * 24 * 94;
-const MAX_RECTANGLES_PER_GLYPH = 512;
-const MAX_TOTAL_RECTANGLES = 16_384;
+export const GUILD_WARS_FONT_METRICS = GUILD_WARS_BODY_FONT;
+const MAX_RECTANGLES_PER_GLYPH = 2_048;
+const MAX_TOTAL_RECTANGLES = 65_536;
 const UNITS_PER_EM = 1024;
 // Measured by `pnpm font:calibrate` against the original grayscale strike.
-const OUTLINE_THRESHOLD = 0xa0;
+const BODY_OUTLINE_THRESHOLD = 0xa0;
+const DISPLAY_OUTLINE_THRESHOLD = 0xe0;
 const OUTLINE_SAMPLE_SCALE = 4;
 
 export interface GameFontBuildOptions {
@@ -48,6 +71,8 @@ export interface GameFontBuildOptions {
   readonly outlineThreshold?: number;
   /** Sub-pixel grid used while locating that crossing. */
   readonly outlineSampleScale?: 1 | 2 | 4;
+  /** The bounded original bitmap strike being converted. */
+  readonly strike?: GameFontStrike;
 }
 
 export interface GameGlyph {
@@ -99,7 +124,10 @@ class Nibbles {
   }
 }
 
-function decodeGlyph(source: Uint8Array): { glyph: GameGlyph; bytes: number } {
+function decodeGlyph(
+  source: Uint8Array,
+  strike: GameFontStrike,
+): { glyph: GameGlyph; bytes: number } {
   const input = new Nibbles(source);
   const top = input.value();
   const width = input.value() + 1;
@@ -107,12 +135,12 @@ function decodeGlyph(source: Uint8Array): { glyph: GameGlyph; bytes: number } {
   const mode = input.read();
   const pixelCount = width * height;
   if (
-    width > MAX_SOURCE_DIMENSION
-    || height > MAX_SOURCE_DIMENSION
-    || top >= SOURCE_LINE_HEIGHT
-    || top + height > SOURCE_LINE_HEIGHT
+    width > strike.em
+    || height > strike.em
+    || top >= strike.lineHeight
+    || top + height > strike.lineHeight
   ) {
-    throw new Error("font glyph does not match the 24px strike");
+    throw new Error(`font glyph does not match the ${strike.em}px strike`);
   }
 
   const pixels = new Uint8Array(pixelCount);
@@ -137,11 +165,14 @@ function decodeGlyph(source: Uint8Array): { glyph: GameGlyph; bytes: number } {
   return { glyph: { top, width, height, pixels }, bytes: input.bytesRead };
 }
 
-export function decodeGameFontRange(bytes: Uint8Array): readonly GameGlyph[] {
+export function decodeGameFontRange(
+  bytes: Uint8Array,
+  strike: GameFontStrike = GUILD_WARS_BODY_FONT,
+): readonly GameGlyph[] {
   const glyphs: GameGlyph[] = [];
   let at = 0;
   while (at < bytes.byteLength) {
-    const decoded = decodeGlyph(bytes.subarray(at));
+    const decoded = decodeGlyph(bytes.subarray(at), strike);
     if (decoded.bytes <= 0 || at + decoded.bytes > bytes.byteLength) {
       throw new Error("font glyph length is invalid");
     }
@@ -152,7 +183,10 @@ export function decodeGameFontRange(bytes: Uint8Array): readonly GameGlyph[] {
   if (glyphs.length !== expected) {
     throw new Error(`font range has ${glyphs.length} glyphs instead of ${expected}`);
   }
-  if (glyphs.reduce((total, glyph) => total + glyph.pixels.length, 0) > MAX_SOURCE_PIXELS) {
+  if (
+    glyphs.reduce((total, glyph) => total + glyph.pixels.length, 0)
+    > strike.em * strike.em * expected
+  ) {
     throw new Error("font strike exceeds its pixel budget");
   }
   return glyphs;
@@ -306,15 +340,16 @@ function trueTypeGlyph(
   glyph: GameGlyph,
   horizontalShift: number,
   rectangles: readonly Rectangle[],
+  strike: GameFontStrike,
 ): Buffer {
-  const scale = UNITS_PER_EM / SOURCE_EM;
+  const scale = UNITS_PER_EM / strike.em;
   if (rectangles.length === 0) return Buffer.alloc(10);
   const points = rectangles.flatMap((rectangle) => {
     const left = Math.round((rectangle.left + horizontalShift) * scale);
     const right = Math.round((rectangle.right + horizontalShift) * scale);
-    const top = Math.round((SOURCE_BASELINE - glyph.top - rectangle.top) * scale);
+    const top = Math.round((strike.baseline - glyph.top - rectangle.top) * scale);
     const bottom = Math.round(
-      (SOURCE_BASELINE - glyph.top - rectangle.bottom) * scale,
+      (strike.baseline - glyph.top - rectangle.bottom) * scale,
     );
     return [[left, top], [right, top], [right, bottom], [left, bottom]] as const;
   });
@@ -364,14 +399,14 @@ function cmapTable(): Buffer {
   return Buffer.concat([u16(0), u16(1), u16(3), u16(1), u32(12), format4]);
 }
 
-function nameTable(): Buffer {
+function nameTable(strike: GameFontStrike): Buffer {
   const names = new Map<number, string>([
-    [1, "Guild Wars Original"],
+    [1, strike.family],
     [2, "Regular"],
-    [3, "Guild Wars Original; locally converted by GWonMac"],
-    [4, "Guild Wars Original Regular"],
+    [3, `${strike.family}; locally converted by GWonMac`],
+    [4, strike.fullName],
     [5, "Version 1.0"],
-    [6, "GuildWarsOriginal-Regular"],
+    [6, strike.postScriptName],
     [8, "Converted locally by GWonMac"],
     [9, "ArenaNet"],
   ]);
@@ -395,8 +430,8 @@ function nameTable(): Buffer {
   ]);
 }
 
-function os2Table(advances: readonly number[]): Buffer {
-  const scale = UNITS_PER_EM / SOURCE_EM;
+function os2Table(advances: readonly number[], strike: GameFontStrike): Buffer {
+  const scale = UNITS_PER_EM / strike.em;
   const out = Buffer.alloc(78);
   out.writeUInt16BE(0, 0);
   out.writeInt16BE(Math.round(advances.reduce((a, b) => a + b, 0) / advances.length), 2);
@@ -421,20 +456,25 @@ function os2Table(advances: readonly number[]): Buffer {
   out.writeUInt16BE(0x40, 62);
   out.writeUInt16BE(0x20, 64);
   out.writeUInt16BE(LAST_CHARACTER, 66);
-  out.writeInt16BE(Math.round(SOURCE_BASELINE * scale), 68);
-  out.writeInt16BE(Math.round((SOURCE_BASELINE - SOURCE_EM) * scale), 70);
-  out.writeInt16BE(Math.round((SOURCE_LINE_HEIGHT - SOURCE_EM) * scale), 72);
-  out.writeUInt16BE(Math.round(SOURCE_BASELINE * scale), 74);
-  out.writeUInt16BE(Math.round((SOURCE_EM - SOURCE_BASELINE) * scale), 76);
+  out.writeInt16BE(Math.round(strike.baseline * scale), 68);
+  out.writeInt16BE(Math.round((strike.baseline - strike.em) * scale), 70);
+  out.writeInt16BE(Math.round((strike.lineHeight - strike.em) * scale), 72);
+  out.writeUInt16BE(Math.round(strike.baseline * scale), 74);
+  out.writeUInt16BE(Math.round((strike.em - strike.baseline) * scale), 76);
   return out;
 }
 
-/** Build a standards-compliant TrueType font from the 24px body strike. */
+/** Build a standards-compliant TrueType font from one original UI strike. */
 export function buildGuildWarsTrueType(
   source: Uint8Array,
   options: GameFontBuildOptions = {},
 ): Buffer {
-  const threshold = options.outlineThreshold ?? OUTLINE_THRESHOLD;
+  const strike = options.strike ?? GUILD_WARS_BODY_FONT;
+  const threshold = options.outlineThreshold ?? (
+    strike.fileId === GUILD_WARS_DISPLAY_FONT.fileId
+      ? DISPLAY_OUTLINE_THRESHOLD
+      : BODY_OUTLINE_THRESHOLD
+  );
   const sampleScale = options.outlineSampleScale ?? OUTLINE_SAMPLE_SCALE;
   if (!Number.isSafeInteger(threshold) || threshold <= 0 || threshold >= 0xff) {
     throw new Error("font outline threshold must be an integer from 1 to 254");
@@ -442,7 +482,7 @@ export function buildGuildWarsTrueType(
   if (sampleScale !== 1 && sampleScale !== 2 && sampleScale !== 4) {
     throw new Error("font outline sample scale must be 1, 2, or 4");
   }
-  const glyphs = decodeGameFontRange(source);
+  const glyphs = decodeGameFontRange(source, strike);
   const sourceGlyphs: readonly (GameGlyph | null)[] = [null, null, ...glyphs];
   const rectangles = sourceGlyphs.map((glyph) =>
     glyph === null ? [] : bitmapRectangles(glyph, threshold, sampleScale));
@@ -459,10 +499,10 @@ export function buildGuildWarsTrueType(
           glyphId + FIRST_CHARACTER - 2,
           rectangles[glyphId]!,
         )
-      : { advance: SOURCE_SPACE_WIDTH, shift: 0 });
+      : { advance: strike.spaceWidth, shift: 0 });
   const glyfParts = sourceGlyphs.map((glyph, glyphId) =>
     glyph
-      ? trueTypeGlyph(glyph, metrics[glyphId]!.shift, rectangles[glyphId]!)
+      ? trueTypeGlyph(glyph, metrics[glyphId]!.shift, rectangles[glyphId]!, strike)
       : Buffer.alloc(10));
   const loca: number[] = [0];
   let glyfLength = 0;
@@ -471,11 +511,11 @@ export function buildGuildWarsTrueType(
     loca.push(glyfLength);
   }
   const advances = metrics.map(({ advance }) =>
-    Math.max(1, Math.round(advance * UNITS_PER_EM / SOURCE_EM)));
+    Math.max(1, Math.round(advance * UNITS_PER_EM / strike.em)));
   const maxRectangles = Math.max(0, ...rectangles.map((value) => value.length));
-  const ascent = Math.round(SOURCE_BASELINE * UNITS_PER_EM / SOURCE_EM);
-  const descent = Math.round((SOURCE_BASELINE - SOURCE_EM) * UNITS_PER_EM / SOURCE_EM);
-  const lineGap = Math.round((SOURCE_LINE_HEIGHT - SOURCE_EM) * UNITS_PER_EM / SOURCE_EM);
+  const ascent = Math.round(strike.baseline * UNITS_PER_EM / strike.em);
+  const descent = Math.round((strike.baseline - strike.em) * UNITS_PER_EM / strike.em);
+  const lineGap = Math.round((strike.lineHeight - strike.em) * UNITS_PER_EM / strike.em);
 
   const head = Buffer.alloc(54);
   head.writeUInt32BE(0x00010000, 0);
@@ -517,7 +557,7 @@ export function buildGuildWarsTrueType(
   post.writeInt16BE(50, 10);
 
   const tables = new Map<string, Buffer>([
-    ["OS/2", os2Table(advances)],
+    ["OS/2", os2Table(advances, strike)],
     ["cmap", cmapTable()],
     ["glyf", Buffer.concat(glyfParts)],
     ["head", head],
@@ -525,7 +565,7 @@ export function buildGuildWarsTrueType(
     ["hmtx", Buffer.concat(advances.map((advance) => Buffer.concat([u16(advance), i16(0)])))],
     ["loca", Buffer.concat(loca.map(u32))],
     ["maxp", maxp],
-    ["name", nameTable()],
+    ["name", nameTable(strike)],
     ["post", post],
   ]);
   const entries = [...tables].sort(([a], [b]) => a.localeCompare(b));

--- a/src/main/core/gw-font.ts
+++ b/src/main/core/gw-font.ts
@@ -24,17 +24,31 @@ const ALPHA = Uint8Array.of(
 );
 const FIRST_CHARACTER = 0x21;
 const LAST_CHARACTER = 0x7e;
-const SOURCE_EM = 24;
-const SOURCE_BASELINE = 18;
-const SOURCE_LINE_HEIGHT = 25;
-const SOURCE_SPACE_WIDTH = 6;
+export const GUILD_WARS_FONT_METRICS = {
+  em: 24,
+  baseline: 18,
+  lineHeight: 25,
+  spaceWidth: 6,
+} as const;
+const SOURCE_EM = GUILD_WARS_FONT_METRICS.em;
+const SOURCE_BASELINE = GUILD_WARS_FONT_METRICS.baseline;
+const SOURCE_LINE_HEIGHT = GUILD_WARS_FONT_METRICS.lineHeight;
+const SOURCE_SPACE_WIDTH = GUILD_WARS_FONT_METRICS.spaceWidth;
 const MAX_SOURCE_DIMENSION = 24;
 const MAX_SOURCE_PIXELS = 24 * 24 * 94;
 const MAX_RECTANGLES_PER_GLYPH = 512;
 const MAX_TOTAL_RECTANGLES = 16_384;
 const UNITS_PER_EM = 1024;
-const OUTLINE_THRESHOLD = 0x80;
+// Measured by `pnpm font:calibrate` against the original grayscale strike.
+const OUTLINE_THRESHOLD = 0xa0;
 const OUTLINE_SAMPLE_SCALE = 4;
+
+export interface GameFontBuildOptions {
+  /** Alpha crossing traced into the monochrome TrueType outline. */
+  readonly outlineThreshold?: number;
+  /** Sub-pixel grid used while locating that crossing. */
+  readonly outlineSampleScale?: 1 | 2 | 4;
+}
 
 export interface GameGlyph {
   readonly top: number;
@@ -190,9 +204,14 @@ interface HorizontalMetrics {
   readonly shift: number;
 }
 
-function interpolatedAlpha(glyph: GameGlyph, x: number, y: number): number {
-  const sourceX = (x + 0.5) / OUTLINE_SAMPLE_SCALE - 0.5;
-  const sourceY = (y + 0.5) / OUTLINE_SAMPLE_SCALE - 0.5;
+function interpolatedAlpha(
+  glyph: GameGlyph,
+  x: number,
+  y: number,
+  sampleScale: number,
+): number {
+  const sourceX = (x + 0.5) / sampleScale - 0.5;
+  const sourceY = (y + 0.5) / sampleScale - 0.5;
   const left = Math.floor(sourceX);
   const top = Math.floor(sourceY);
   const xBlend = sourceX - left;
@@ -217,31 +236,35 @@ function interpolatedAlpha(glyph: GameGlyph, x: number, y: number): number {
  * soft edge crosses half opacity; tracing the source pixels directly produced
  * the visibly stepped curves the bitmap's alpha levels were meant to hide.
  */
-function bitmapRectangles(glyph: GameGlyph): readonly Rectangle[] {
+function bitmapRectangles(
+  glyph: GameGlyph,
+  threshold: number,
+  sampleScale: number,
+): readonly Rectangle[] {
   const complete: Rectangle[] = [];
   let active = new Map<string, Rectangle>();
-  const width = glyph.width * OUTLINE_SAMPLE_SCALE;
-  const height = glyph.height * OUTLINE_SAMPLE_SCALE;
+  const width = glyph.width * sampleScale;
+  const height = glyph.height * sampleScale;
   for (let y = 0; y < height; y++) {
     const next = new Map<string, Rectangle>();
     for (let x = 0; x < width;) {
-      if (interpolatedAlpha(glyph, x, y) < OUTLINE_THRESHOLD) {
+      if (interpolatedAlpha(glyph, x, y, sampleScale) < threshold) {
         x += 1;
         continue;
       }
       const left = x;
       while (
         x < width
-        && interpolatedAlpha(glyph, x, y) >= OUTLINE_THRESHOLD
+        && interpolatedAlpha(glyph, x, y, sampleScale) >= threshold
       ) x += 1;
       const key = `${left}:${x}`;
       const rectangle = active.get(key) ?? {
-        left: left / OUTLINE_SAMPLE_SCALE,
-        right: x / OUTLINE_SAMPLE_SCALE,
-        top: y / OUTLINE_SAMPLE_SCALE,
-        bottom: y / OUTLINE_SAMPLE_SCALE,
+        left: left / sampleScale,
+        right: x / sampleScale,
+        top: y / sampleScale,
+        bottom: y / sampleScale,
       };
-      rectangle.bottom = (y + 1) / OUTLINE_SAMPLE_SCALE;
+      rectangle.bottom = (y + 1) / sampleScale;
       next.set(key, rectangle);
       active.delete(key);
     }
@@ -407,11 +430,22 @@ function os2Table(advances: readonly number[]): Buffer {
 }
 
 /** Build a standards-compliant TrueType font from the 24px body strike. */
-export function buildGuildWarsTrueType(source: Uint8Array): Buffer {
+export function buildGuildWarsTrueType(
+  source: Uint8Array,
+  options: GameFontBuildOptions = {},
+): Buffer {
+  const threshold = options.outlineThreshold ?? OUTLINE_THRESHOLD;
+  const sampleScale = options.outlineSampleScale ?? OUTLINE_SAMPLE_SCALE;
+  if (!Number.isSafeInteger(threshold) || threshold <= 0 || threshold >= 0xff) {
+    throw new Error("font outline threshold must be an integer from 1 to 254");
+  }
+  if (sampleScale !== 1 && sampleScale !== 2 && sampleScale !== 4) {
+    throw new Error("font outline sample scale must be 1, 2, or 4");
+  }
   const glyphs = decodeGameFontRange(source);
   const sourceGlyphs: readonly (GameGlyph | null)[] = [null, null, ...glyphs];
   const rectangles = sourceGlyphs.map((glyph) =>
-    glyph === null ? [] : bitmapRectangles(glyph));
+    glyph === null ? [] : bitmapRectangles(glyph, threshold, sampleScale));
   if (
     rectangles.reduce((total, value) => total + value.length, 0)
     > MAX_TOTAL_RECTANGLES

--- a/src/main/protocol.ts
+++ b/src/main/protocol.ts
@@ -481,7 +481,10 @@ async function handleGwRequest(
 
   if (base === "Gw.snapshot") return handleSnapshot(request, deps);
 
-  if (base === "game-font.ttf") {
+  const gameFontRole = base === "game-font.ttf"
+    ? "body"
+    : base === "game-font-display.ttf" ? "display" : null;
+  if (gameFontRole) {
     const missing = () =>
       new Response("not found", {
         status: 404,
@@ -490,7 +493,7 @@ async function handleGwRequest(
     const active = deps.getActiveClient();
     if (!active || request.method !== "GET") return missing();
     const assets = fontFor(active);
-    const font = await assets.font();
+    const font = await assets.font(gameFontRole);
     if (!font && !reportedGameFontRefusals.has(assets)) {
       reportedGameFontRefusals.add(assets);
       logEvent({

--- a/src/renderer/appearance.ts
+++ b/src/renderer/appearance.ts
@@ -20,12 +20,19 @@ function loadGuildWarsFont(generation: string): Promise<boolean> {
   if (typeof FontFace === "undefined" || typeof document === "undefined") {
     return Promise.resolve(false);
   }
-  const source = `url("gw://app/game-font.ttf?generation=${encodeURIComponent(generation)}")`;
-  const pending = new FontFace("Guild Wars Original", source, {
-    style: "normal",
-    weight: "400",
-  }).load().then((font) => {
-    document.fonts.add(font);
+  const suffix = `?generation=${encodeURIComponent(generation)}`;
+  const pending = Promise.all([
+    new FontFace("Guild Wars Original", `url("gw://app/game-font.ttf${suffix}")`, {
+      style: "normal",
+      weight: "400",
+    }).load(),
+    new FontFace(
+      "Guild Wars Original Display",
+      `url("gw://app/game-font-display.ttf${suffix}")`,
+      { style: "normal", weight: "400" },
+    ).load(),
+  ]).then((fonts) => {
+    for (const font of fonts) document.fonts.add(font);
     return true;
   }).catch(() => false);
   fontLoads.set(generation, pending);

--- a/src/renderer/harness.css
+++ b/src/renderer/harness.css
@@ -306,7 +306,7 @@ html,body { width:100%; height:100%; margin:0; overflow:hidden;
   color: var(--ui-display-text);
   font-family: var(--ui-font-display);
   font-size: var(--ui-font-size-lg);
-  font-weight: 700;
+  font-weight: var(--ui-font-weight-bold);
   text-shadow: var(--ui-display-text-shadow);
   letter-spacing: var(--ui-display-letter-spacing);
   text-wrap: balance;
@@ -416,7 +416,7 @@ html,body { width:100%; height:100%; margin:0; overflow:hidden;
   gap: 2px;
   text-align: left;
 }
-.settings-style-option > span { color: var(--ui-text-bright); font-weight: 600; }
+.settings-style-option > span { color: var(--ui-text-bright); font-weight: var(--ui-font-weight-semibold); }
 .settings-style-option small { color: var(--ui-text-faint); font-size: var(--ui-font-size-sm); white-space: normal; }
 #settings-form label.settings-radio:has(input:checked) .settings-style-option small { color: var(--ui-text-muted); }
 
@@ -428,11 +428,11 @@ html,body { width:100%; height:100%; margin:0; overflow:hidden;
 #settings-form button.quiet-danger { min-height: 0; }
 .settings-danger-sub { margin: var(--ui-space-1) 0 0; color: var(--ui-text-faint); font-size: var(--ui-font-size-sm); }
 
-.settings-status { margin: 0; color: var(--ui-text-bright); font-size: var(--ui-font-size); font-weight: 600; }
+.settings-status { margin: 0; color: var(--ui-text-bright); font-size: var(--ui-font-size); font-weight: var(--ui-font-weight-semibold); }
 .settings-feature-status { display:grid; gap:var(--ui-space-2); margin:0; }
 .settings-feature-status > div { display:flex; justify-content:space-between; gap:var(--ui-space-4); }
 .settings-feature-status dt { color:var(--ui-text); }
-.settings-feature-status dd { margin:0; color:var(--ui-text-bright); font-weight:600; text-align:right; }
+.settings-feature-status dd { margin:0; color:var(--ui-text-bright); font-weight:var(--ui-font-weight-semibold); text-align:right; }
 #settings-progress {
   height: var(--ui-space-2);
   margin: var(--ui-space-3) 0 0;

--- a/src/renderer/harness.css
+++ b/src/renderer/harness.css
@@ -238,6 +238,12 @@ html,body { width:100%; height:100%; margin:0; overflow:hidden;
 
 #settings-dialog {
   --ui-panel-opacity: 0.97;
+  /* Settings must remain easy to read while it changes the font everywhere
+     else. The converted game face has one bitmap-derived weight, so using it
+     for dense labels and synthesised bold makes this decision surface muddy. */
+  --ui-font: var(--ui-font-readable);
+  --ui-font-display: var(--ui-font-readable);
+  --ui-text-shadow: none;
   width: min(700px, calc(100vw - 32px));
   min-width: min(480px, calc(100vw - 32px));
   height: min(520px, calc(100vh - 32px));

--- a/src/renderer/harness.css
+++ b/src/renderer/harness.css
@@ -244,6 +244,7 @@ html,body { width:100%; height:100%; margin:0; overflow:hidden;
   --ui-font: var(--ui-font-readable);
   --ui-font-display: var(--ui-font-readable);
   --ui-text-shadow: none;
+  --ui-display-text-shadow: none;
   width: min(700px, calc(100vw - 32px));
   min-width: min(480px, calc(100vw - 32px));
   height: min(520px, calc(100vh - 32px));
@@ -313,6 +314,7 @@ html,body { width:100%; height:100%; margin:0; overflow:hidden;
   font-family: var(--ui-font-display);
   font-size: var(--ui-font-size-lg);
   font-weight: 700;
+  text-shadow: var(--ui-display-text-shadow);
   letter-spacing: 0.02em;
   text-wrap: balance;
 }

--- a/src/renderer/harness.css
+++ b/src/renderer/harness.css
@@ -238,13 +238,6 @@ html,body { width:100%; height:100%; margin:0; overflow:hidden;
 
 #settings-dialog {
   --ui-panel-opacity: 0.97;
-  /* Settings must remain easy to read while it changes the font everywhere
-     else. The converted game face has one bitmap-derived weight, so using it
-     for dense labels and synthesised bold makes this decision surface muddy. */
-  --ui-font: var(--ui-font-readable);
-  --ui-font-display: var(--ui-font-readable);
-  --ui-text-shadow: none;
-  --ui-display-text-shadow: none;
   width: min(700px, calc(100vw - 32px));
   min-width: min(480px, calc(100vw - 32px));
   height: min(520px, calc(100vh - 32px));
@@ -310,12 +303,12 @@ html,body { width:100%; height:100%; margin:0; overflow:hidden;
 
 .settings-pane-title {
   margin: 0;
-  color: var(--ui-text-bright);
+  color: var(--ui-display-text);
   font-family: var(--ui-font-display);
   font-size: var(--ui-font-size-lg);
   font-weight: 700;
   text-shadow: var(--ui-display-text-shadow);
-  letter-spacing: 0.02em;
+  letter-spacing: var(--ui-display-letter-spacing);
   text-wrap: balance;
 }
 .settings-pane-intro {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -487,7 +487,7 @@
               </span>
             </label>
           </fieldset>
-          <p id="settings-opacity-help" class="settings-note">This changes GWonMac panels, not Guild Wars itself. Settings stays readable while you choose.</p>
+          <p id="settings-opacity-help" class="settings-note">This changes GWonMac panels, not Guild Wars itself. Your font choice applies here and across every GWonMac interface.</p>
         </section>
 
         <section class="settings-pane" id="settings-pane-controls" role="tabpanel"

--- a/src/renderer/loading.css
+++ b/src/renderer/loading.css
@@ -5,10 +5,10 @@
    control lives in a slim dock along the bottom edge with the progress rail on
    its top border. Only the dock's text and buttons change between states. */
 
-/* QT Friz Quad is the OFL-licensed QualiType face closest to the former
-   Fremont/Friz Quadrata styling. swap keeps startup progress immediately visible. */
+/* QT Friz Quad is the packaged fallback while the selected original face is
+   still being converted from the active local game. */
 @font-face {
-  font-family: "QT Friz Quad";
+  font-family: "QTFrizQuad";
   src: url("fonts/QTFrizQuad.otf") format("opentype");
   font-weight: 400;
   font-style: normal;
@@ -24,7 +24,7 @@
            display:flex; flex-direction:column;
            --dock-h: 104px;
            background:#0a0806; color:#e8dcc0;
-           font:16px/1.5 "QT Friz Quad","Iowan Old Style",Palatino,Georgia,serif;
+           font:16px/1.5 var(--ui-font);
            transition:opacity .6s ease; }
 #loading.gone { opacity:0; pointer-events:none; }
 
@@ -169,7 +169,8 @@
 #loading-dock:has(#loading-crash-detail:not([hidden])) #loading-boot {
   flex-basis:100%; }
 
-#loading-label { font-size:17px; letter-spacing:.02em; color:#f2e8d2;
+#loading-label { font-size:17px; letter-spacing:var(--ui-display-letter-spacing); color:#f2e8d2;
+                 font-family:var(--ui-font-display);
                  text-shadow:0 1px 6px #000c; }
 #loading-detail { min-height:1.3em; font-size:13px; color:#e8dcc099;
                   text-shadow:0 1px 6px #000c; }
@@ -187,14 +188,16 @@
    beneath it, which is a separate sentence and not a conclusion drawn from
    the heading. */
 #client-compat-title { margin:0 0 2px; font-size:17px; font-weight:400;
-                       letter-spacing:.02em; color:#f2e8d2; }
+                       font-family:var(--ui-font-display);
+                       letter-spacing:var(--ui-display-letter-spacing); color:#f2e8d2; }
 #client-compat-detail { margin:0; font-size:13px; color:#d8caaaad;
                         max-width:104ch; }
 .client-compat-version { margin:3px 0 0; font-size:12.5px; color:#e8dcc08c; }
 
 .dock-info { min-width:0; }
 #data-choice-title { margin:0 0 2px; font-size:17px; font-weight:400;
-                     letter-spacing:.02em; color:#f2e8d2; }
+                     font-family:var(--ui-font-display);
+                     letter-spacing:var(--ui-display-letter-spacing); color:#f2e8d2; }
 .dock-info > p { margin:0; font-size:13px; color:#d8caaaad; }
 /* The gate's save-failure line: never shares a slot with the size label. */
 #data-choice-error { color:#ff8f6b; }

--- a/src/shared/ui/components.css
+++ b/src/shared/ui/components.css
@@ -186,7 +186,7 @@
   color: var(--ui-display-text);
   font-family: var(--ui-font-display);
   font-size: var(--ui-font-size-lg);
-  font-weight: 700;
+  font-weight: var(--ui-font-weight-bold);
   letter-spacing: var(--ui-display-letter-spacing);
   text-shadow: var(--ui-display-text-shadow);
   text-overflow: ellipsis;
@@ -275,7 +275,7 @@
   background: var(--ui-primary-fill) padding-box, var(--ui-ring-gold) border-box;
   box-shadow: var(--ui-shadow-raised), 0 0 0 1px var(--ui-outline);
   color: var(--ui-primary-ink);
-  font-weight: 600;
+  font-weight: var(--ui-font-weight-semibold);
 }
 
 .ui-button[data-variant="primary"]:hover:not(:disabled):not([aria-disabled="true"]) {
@@ -926,7 +926,7 @@ button.ui-chip[aria-disabled="true"] {
   box-shadow: var(--ui-shadow-inset), 0 0 0 1px var(--ui-outline);
   color: var(--ui-profession-ink);
   font-size: var(--ui-font-size-sm);
-  font-weight: 700;
+  font-weight: var(--ui-font-weight-bold);
   /* The icon carries the meaning; a shadow on a two-letter stand-in blurs it. */
   text-shadow: none;
 }
@@ -1002,7 +1002,7 @@ button.ui-chip[aria-disabled="true"] {
   background: linear-gradient(var(--ui-profession, var(--ui-line)), var(--ui-profession, var(--ui-line))) padding-box,
     var(--ui-ring-mark) border-box;
   color: var(--ui-profession-ink);
-  font-weight: 700;
+  font-weight: var(--ui-font-weight-bold);
   text-shadow: none;
 }
 
@@ -1092,7 +1092,7 @@ button.ui-chip[aria-disabled="true"] {
 .ui-empty strong {
   color: var(--ui-text-bright);
   font-size: var(--ui-font-size-lg);
-  font-weight: 600;
+  font-weight: var(--ui-font-weight-semibold);
 }
 
 .ui-empty p {

--- a/src/shared/ui/components.css
+++ b/src/shared/ui/components.css
@@ -183,11 +183,12 @@
   min-width: 0;
   margin: 0;
   overflow: hidden;
-  color: var(--ui-text-bright);
+  color: var(--ui-display-text);
   font-family: var(--ui-font-display);
   font-size: var(--ui-font-size-lg);
   font-weight: 700;
-  letter-spacing: 0.045em;
+  letter-spacing: var(--ui-display-letter-spacing);
+  text-shadow: var(--ui-display-text-shadow);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -798,7 +799,7 @@
   min-width: 0;
   overflow: hidden;
   color: var(--ui-text-bright);
-  font-family: var(--ui-font-display);
+  font-family: var(--ui-font);
   font-weight: 400;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/src/shared/ui/tokens.css
+++ b/src/shared/ui/tokens.css
@@ -96,6 +96,12 @@
   --ui-font-readable: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont,
     "Segoe UI", sans-serif;
   --ui-font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+  /* The game-derived and packaged fallback faces each contain one real
+   * weight. Keep their strokes untouched; hierarchy comes from scale, colour,
+   * and spacing. Inter restores its native weight range below. */
+  --ui-font-weight-medium: 400;
+  --ui-font-weight-semibold: 400;
+  --ui-font-weight-bold: 400;
 
   /* Ink and state. */
   --ui-text: #ebe5d3;
@@ -185,6 +191,12 @@
   --ui-z-toast: 40;
 }
 
+/* Preserve semantic emphasis in the markup while letting the selected face
+ * decide whether that emphasis is expressed through stroke weight. */
+:where(strong, b, h1, h2, h3, h4, h5, h6) {
+  font-weight: var(--ui-font-weight-bold);
+}
+
 /* The local face becomes active only after the client generation supplied it. */
 :root[data-ui-font="guild-wars"] {
   --ui-font: "Guild Wars Original", "QTFrizQuad", "Palatino Linotype",
@@ -208,6 +220,9 @@
 :root[data-ui-font="inter"] {
   --ui-font: var(--ui-font-readable);
   --ui-font-display: var(--ui-font);
+  --ui-font-weight-medium: 500;
+  --ui-font-weight-semibold: 600;
+  --ui-font-weight-bold: 700;
 }
 
 /* Obsidian keeps the same hierarchy and components, then removes ornamental

--- a/src/shared/ui/tokens.css
+++ b/src/shared/ui/tokens.css
@@ -90,7 +90,7 @@
   --ui-font-size-sm: 12px;
   --ui-font-size-lg: 17px;
   --ui-line-height: 1.4;
-  --ui-font: "Palatino Linotype", "Book Antiqua", Palatino,
+  --ui-font: "QTFrizQuad", "Palatino Linotype", "Book Antiqua", Palatino,
     "URW Palladio L", Georgia, serif;
   --ui-font-display: var(--ui-font);
   --ui-font-readable: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont,
@@ -187,11 +187,11 @@
 
 /* The local face becomes active only after the client generation supplied it. */
 :root[data-ui-font="guild-wars"] {
-  --ui-font: "Guild Wars Original", "Palatino Linotype", "Book Antiqua", Palatino,
-    "URW Palladio L", Georgia, serif;
+  --ui-font: "Guild Wars Original", "QTFrizQuad", "Palatino Linotype",
+    "Book Antiqua", Palatino, "URW Palladio L", Georgia, serif;
   --ui-font-display: "Guild Wars Original Display", "Guild Wars Original",
-    "Palatino Linotype", "Book Antiqua", Palatino, "URW Palladio L", Georgia,
-    serif;
+    "QTFrizQuad", "Palatino Linotype", "Book Antiqua", Palatino,
+    "URW Palladio L", Georgia, serif;
   --ui-display-text: #f2dfad;
   --ui-display-text-shadow:
     0 -0.5px 0 rgb(255 248 220 / 72%),

--- a/src/shared/ui/tokens.css
+++ b/src/shared/ui/tokens.css
@@ -102,6 +102,7 @@
   --ui-text-bright: #f5f0e2;
   --ui-text-muted: #b2ac9d;
   --ui-text-faint: #948e7e;
+  --ui-display-text: var(--ui-text-bright);
   --ui-accent: #e6c882;
   --ui-accent-hover: var(--gw-gold-bright);
   --ui-accent-strong: #8a7433;
@@ -138,6 +139,8 @@
   --ui-shadow-selected: 0 1px 3px rgb(0 0 0 / 70%);
   --ui-shadow-row-selected: 0 1px 4px rgb(0 0 0 / 70%);
   --ui-text-shadow: 0 1px 1px #000, 0 2px 3px rgb(0 0 0 / 85%);
+  --ui-display-text-shadow: var(--ui-text-shadow);
+  --ui-display-letter-spacing: 0.045em;
   --ui-frame: var(--gw-ring-bone);
   --ui-frame-top: var(--gw-bone-hi);
   --ui-ring-gilt: var(--gw-ring-gilt);
@@ -186,7 +189,16 @@
 :root[data-ui-font="guild-wars"] {
   --ui-font: "Guild Wars Original", "Palatino Linotype", "Book Antiqua", Palatino,
     "URW Palladio L", Georgia, serif;
-  --ui-font-display: var(--ui-font);
+  --ui-font-display: "Guild Wars Original Display", "Guild Wars Original",
+    "Palatino Linotype", "Book Antiqua", Palatino, "URW Palladio L", Georgia,
+    serif;
+  --ui-display-text: #f2dfad;
+  --ui-display-text-shadow:
+    0 -0.5px 0 rgb(255 248 220 / 72%),
+    0 1px 0 rgb(115 99 67 / 90%),
+    1px 1px 1px rgb(0 0 0 / 92%),
+    0 2px 2px rgb(0 0 0 / 78%);
+  --ui-display-letter-spacing: 0;
   /* The local strike has one hand-tuned weight. Chromium's synthetic bold
    * expands its pixel-shaped outline and makes small labels look blurry. */
   font-synthesis-weight: none;
@@ -208,6 +220,7 @@
   --ui-text-bright: oklch(0.97 0.01 84);
   --ui-text-muted: oklch(0.76 0.014 82);
   --ui-text-faint: oklch(0.64 0.012 82);
+  --ui-display-text: var(--ui-text-bright);
   --ui-accent: oklch(0.79 0.105 83);
   --ui-accent-hover: oklch(0.88 0.095 86);
   --ui-accent-strong: oklch(0.7 0.105 82);
@@ -242,6 +255,7 @@
   --ui-shadow-selected: 0 1px 2px oklch(0 0 0 / 0.36);
   --ui-shadow-row-selected: 0 1px 2px oklch(0 0 0 / 0.28);
   --ui-text-shadow: none;
+  --ui-display-text-shadow: none;
   --ui-frame: transparent;
   --ui-frame-top: transparent;
   --ui-ring-gilt: transparent;

--- a/src/shared/ui/tokens.css
+++ b/src/shared/ui/tokens.css
@@ -93,6 +93,8 @@
   --ui-font: "Palatino Linotype", "Book Antiqua", Palatino,
     "URW Palladio L", Georgia, serif;
   --ui-font-display: var(--ui-font);
+  --ui-font-readable: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
   --ui-font-mono: ui-monospace, SFMono-Regular, Menlo, monospace;
 
   /* Ink and state. */
@@ -135,8 +137,7 @@
   --ui-shadow-raised-soft: 0 2px 5px rgb(0 0 0 / 60%);
   --ui-shadow-selected: 0 1px 3px rgb(0 0 0 / 70%);
   --ui-shadow-row-selected: 0 1px 4px rgb(0 0 0 / 70%);
-  --ui-text-shadow: 1px 1px 0 #000, -1px 1px 0 #000,
-    1px -1px 0 #000, -1px -1px 0 #000, 0 2px 4px rgb(0 0 0 / 90%);
+  --ui-text-shadow: 0 1px 1px #000, 0 2px 3px rgb(0 0 0 / 85%);
   --ui-frame: var(--gw-ring-bone);
   --ui-frame-top: var(--gw-bone-hi);
   --ui-ring-gilt: var(--gw-ring-gilt);
@@ -186,11 +187,14 @@
   --ui-font: "Guild Wars Original", "Palatino Linotype", "Book Antiqua", Palatino,
     "URW Palladio L", Georgia, serif;
   --ui-font-display: var(--ui-font);
+  /* The local strike has one hand-tuned weight. Chromium's synthetic bold
+   * expands its pixel-shaped outline and makes small labels look blurry. */
+  font-synthesis-weight: none;
 }
 
 /* A player can keep either visual style while selecting modern system type. */
 :root[data-ui-font="inter"] {
-  --ui-font: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --ui-font: var(--ui-font-readable);
   --ui-font-display: var(--ui-font);
 }
 

--- a/tests/electron/settings-data-display.spec.ts
+++ b/tests/electron/settings-data-display.spec.ts
@@ -52,6 +52,18 @@ test.describe("data and display settings", () => {
       await expect(root).not.toHaveAttribute("data-ui-font");
       await expect(page.locator('select[name="uiTheme"]')).toHaveCount(0);
       await expect(page.locator('select[name="uiDensity"]')).toHaveCount(0);
+      const settingsTypography = await page.locator("#settings-dialog").evaluate(
+        (dialog) => {
+          const style = globalThis.getComputedStyle(dialog);
+          return {
+            font: style.fontFamily,
+            textShadow: style.textShadow,
+          };
+        },
+      );
+      expect(settingsTypography.font).toContain("ui-sans-serif");
+      expect(settingsTypography.font).not.toContain("Guild Wars Original");
+      expect(settingsTypography.textShadow).toBe("none");
       // Polled, not read once: the save is a round trip through main and the
       // token is written when it returns. The slider's own readout updates on
       // the drag and so proves nothing about the setting having landed.

--- a/tests/electron/settings-data-display.spec.ts
+++ b/tests/electron/settings-data-display.spec.ts
@@ -58,6 +58,9 @@ test.describe("data and display settings", () => {
           return {
             font: style.fontFamily,
             textShadow: style.textShadow,
+            titleWeight: globalThis.getComputedStyle(
+              globalThis.document.querySelector("#settings-title")!,
+            ).fontWeight,
           };
         },
       );
@@ -67,6 +70,7 @@ test.describe("data and display settings", () => {
       expect(settingsTypography.font).toContain("QTFrizQuad");
       expect(settingsTypography.font).not.toContain("Guild Wars Original");
       expect(settingsTypography.textShadow).not.toBe("none");
+      expect(settingsTypography.titleWeight).toBe("400");
       // Polled, not read once: the save is a round trip through main and the
       // token is written when it returns. The slider's own readout updates on
       // the drag and so proves nothing about the setting having landed.
@@ -104,12 +108,16 @@ test.describe("data and display settings", () => {
           return {
             font: style.fontFamily,
             textShadow: style.textShadow,
+            titleWeight: globalThis.getComputedStyle(
+              globalThis.document.querySelector("#settings-title")!,
+            ).fontWeight,
           };
         },
       );
       expect(interTypography.font).toContain("ui-sans-serif");
       expect(interTypography.font).not.toContain("QTFrizQuad");
       expect(interTypography.textShadow).toBe("none");
+      expect(interTypography.titleWeight).toBe("700");
       expect(
         await page.locator("#settings-dialog").evaluate((element) =>
           globalThis.getComputedStyle(element)

--- a/tests/electron/settings-data-display.spec.ts
+++ b/tests/electron/settings-data-display.spec.ts
@@ -61,9 +61,12 @@ test.describe("data and display settings", () => {
           };
         },
       );
-      expect(settingsTypography.font).toContain("ui-sans-serif");
+      // Offline has no active game archive to convert yet, so the selected
+      // Guild Wars face resolves to the homepage's packaged QT fallback. The
+      // dialog must not replace that global choice with its own font.
+      expect(settingsTypography.font).toContain("QTFrizQuad");
       expect(settingsTypography.font).not.toContain("Guild Wars Original");
-      expect(settingsTypography.textShadow).toBe("none");
+      expect(settingsTypography.textShadow).not.toBe("none");
       // Polled, not read once: the save is a round trip through main and the
       // token is written when it returns. The slider's own readout updates on
       // the drag and so proves nothing about the setting having landed.
@@ -95,6 +98,18 @@ test.describe("data and display settings", () => {
       await page.locator('label:has(input[name="uiFont"][value="inter"])').click();
       await expect(root).toHaveAttribute("data-ui-font", "inter");
       await expect(page.locator("#settings-feedback")).toHaveText("Saved.");
+      const interTypography = await page.locator("#settings-dialog").evaluate(
+        (dialog) => {
+          const style = globalThis.getComputedStyle(dialog);
+          return {
+            font: style.fontFamily,
+            textShadow: style.textShadow,
+          };
+        },
+      );
+      expect(interTypography.font).toContain("ui-sans-serif");
+      expect(interTypography.font).not.toContain("QTFrizQuad");
+      expect(interTypography.textShadow).toBe("none");
       expect(
         await page.locator("#settings-dialog").evaluate((element) =>
           globalThis.getComputedStyle(element)

--- a/tests/policy/font-license.test.ts
+++ b/tests/policy/font-license.test.ts
@@ -27,6 +27,6 @@ test("the only bundled font is the pinned OFL-licensed QT Friz Quad", () => {
   assert.match(license, /Copyright \(c\) 1992 QualiType/);
   assert.match(license, /SIL OPEN FONT LICENSE[\s\S]*Version 1\.1/);
   const css = readFileSync(path.join(root, "src/renderer/loading.css"), "utf8");
-  assert.match(css, /font-family: "QT Friz Quad"/);
+  assert.match(css, /font-family: "QTFrizQuad"/);
   assert.match(css, /url\("fonts\/QTFrizQuad\.otf"\)/);
 });

--- a/tests/unit/appearance.test.ts
+++ b/tests/unit/appearance.test.ts
@@ -75,8 +75,9 @@ describe("appearance settings", () => {
       assert.equal(root.dataset.uiFont, undefined);
       await new Promise<void>((resolve) => setImmediate(resolve));
       assert.equal(root.dataset.uiFont, "guild-wars");
-      assert.equal(added.length, 1);
+      assert.equal(added.length, 2);
       assert.match(sources[0]!, /generation=generation-a/u);
+      assert.match(sources[1]!, /game-font-display\.ttf/u);
 
       applyAppearance({ ...DEFAULT_SETTINGS, uiFont: "inter" }, root, "generation-b");
       await Promise.resolve();

--- a/tests/unit/guild-wars-font.test.ts
+++ b/tests/unit/guild-wars-font.test.ts
@@ -173,6 +173,9 @@ test("the shared UI offers the local Guild Wars font independently of Inter", ()
   assert.match(css, /"Guild Wars Original", "QTFrizQuad"/);
   assert.match(css, /:root\[data-ui-font="inter"\]/);
   assert.match(css, /font-synthesis-weight: none/);
+  assert.match(css, /--ui-font-weight-bold: 400/);
+  assert.match(css, /--ui-font-weight-bold: 700/);
+  assert.match(css, /:where\(strong, b, h1, h2, h3, h4, h5, h6\)/);
   assert.doesNotMatch(css, /-1px 1px 0 #000/);
   assert.doesNotMatch(
     harness.match(/#settings-dialog\s*\{[\s\S]*?\}/u)?.[0] ?? "",

--- a/tests/unit/guild-wars-font.test.ts
+++ b/tests/unit/guild-wars-font.test.ts
@@ -83,6 +83,23 @@ test("the converted result is a complete checksummed TrueType font", () => {
   assert.ok(font.includes(Buffer.from("Guild Wars Original", "utf16le").swap16()));
 });
 
+test("the measured contour remains the default and calibration inputs are bounded", () => {
+  const strike = repeatedGlyph([0x00, 0x00, 0x00]);
+  const font = buildGuildWarsTrueType(strike);
+  assert.deepEqual(
+    font,
+    buildGuildWarsTrueType(strike, { outlineThreshold: 0xa0 }),
+  );
+  assert.notDeepEqual(
+    font,
+    buildGuildWarsTrueType(strike, { outlineThreshold: 0x80 }),
+  );
+  assert.throws(
+    () => buildGuildWarsTrueType(strike, { outlineThreshold: 0 }),
+    /threshold must be an integer from 1 to 254/,
+  );
+});
+
 test("a narrow numeral gets balanced proportional spacing", () => {
   // Most fixture glyphs fill a nine-pixel cell. `1` occupies only its centre
   // pixel, matching the large empty sides found in the game's real digit cell.
@@ -90,7 +107,11 @@ test("a narrow numeral gets balanced proportional spacing", () => {
   const narrow = packedNibbles([0, 8, 1, 0, 1, 0, 3, 8, 0, 3]);
   const glyphs = Array.from({ length: GLYPH_COUNT }, () => full);
   glyphs[0x31 - 0x21] = narrow;
-  const font = buildGuildWarsTrueType(Uint8Array.from(glyphs.flat()));
+  const font = buildGuildWarsTrueType(Uint8Array.from(glyphs.flat()), {
+    // This synthetic one-pixel stem exists to isolate the spacing rule. The
+    // real calibrated strike has a wider `1`; keep the fixture visible here.
+    outlineThreshold: 0x80,
+  });
   const hmtx = tableOffset(font, "hmtx");
   const glyphId = (character: string) => character.charCodeAt(0) - 0x20 + 1;
   const advance = (character: string) =>

--- a/tests/unit/guild-wars-font.test.ts
+++ b/tests/unit/guild-wars-font.test.ts
@@ -9,6 +9,7 @@ import { GameFontAssets } from "../../src/main/core/game-font-assets.js";
 import {
   buildGuildWarsTrueType,
   decodeGameFontRange,
+  GUILD_WARS_DISPLAY_FONT,
 } from "../../src/main/core/gw-font.ts";
 
 const root = new URL("../../", import.meta.url);
@@ -83,6 +84,22 @@ test("the converted result is a complete checksummed TrueType font", () => {
   assert.ok(font.includes(Buffer.from("Guild Wars Original", "utf16le").swap16()));
 });
 
+test("the original display strike builds as a separate browser family", () => {
+  const font = buildGuildWarsTrueType(repeatedGlyph([0x00, 0x10, 0x01]), {
+    strike: GUILD_WARS_DISPLAY_FONT,
+  });
+  assert.ok(font.includes(
+    Buffer.from("Guild Wars Original Display", "utf16le").swap16(),
+  ));
+  assert.deepEqual(
+    font,
+    buildGuildWarsTrueType(repeatedGlyph([0x00, 0x10, 0x01]), {
+      strike: GUILD_WARS_DISPLAY_FONT,
+      outlineThreshold: 0xe0,
+    }),
+  );
+});
+
 test("the measured contour remains the default and calibration inputs are bounded", () => {
   const strike = repeatedGlyph([0x00, 0x00, 0x00]);
   const font = buildGuildWarsTrueType(strike);
@@ -150,10 +167,12 @@ test("the shared UI offers the local Guild Wars font independently of Inter", ()
   const css = readFileSync(new URL("src/shared/ui/tokens.css", root), "utf8");
   assert.match(css, /data-ui-font="guild-wars"/);
   assert.match(css, /--ui-font: "Guild Wars Original"/);
+  assert.match(css, /--ui-font-display: "Guild Wars Original Display"/);
   assert.match(css, /:root\[data-ui-font="inter"\]/);
   assert.match(css, /font-synthesis-weight: none/);
   assert.doesNotMatch(css, /-1px 1px 0 #000/);
   const appearance = readFileSync(new URL("src/renderer/appearance.ts", root), "utf8");
   assert.match(appearance, /new FontFace\("Guild Wars Original"/);
+  assert.match(appearance, /"Guild Wars Original Display"/);
   assert.match(appearance, /generation=/);
 });

--- a/tests/unit/guild-wars-font.test.ts
+++ b/tests/unit/guild-wars-font.test.ts
@@ -130,6 +130,8 @@ test("the shared UI offers the local Guild Wars font independently of Inter", ()
   assert.match(css, /data-ui-font="guild-wars"/);
   assert.match(css, /--ui-font: "Guild Wars Original"/);
   assert.match(css, /:root\[data-ui-font="inter"\]/);
+  assert.match(css, /font-synthesis-weight: none/);
+  assert.doesNotMatch(css, /-1px 1px 0 #000/);
   const appearance = readFileSync(new URL("src/renderer/appearance.ts", root), "utf8");
   assert.match(appearance, /new FontFace\("Guild Wars Original"/);
   assert.match(appearance, /generation=/);

--- a/tests/unit/guild-wars-font.test.ts
+++ b/tests/unit/guild-wars-font.test.ts
@@ -165,12 +165,20 @@ test("a compact oversized strike is refused before outline tracing", () => {
 
 test("the shared UI offers the local Guild Wars font independently of Inter", () => {
   const css = readFileSync(new URL("src/shared/ui/tokens.css", root), "utf8");
+  const harness = readFileSync(new URL("src/renderer/harness.css", root), "utf8");
+  const loading = readFileSync(new URL("src/renderer/loading.css", root), "utf8");
   assert.match(css, /data-ui-font="guild-wars"/);
   assert.match(css, /--ui-font: "Guild Wars Original"/);
   assert.match(css, /--ui-font-display: "Guild Wars Original Display"/);
+  assert.match(css, /"Guild Wars Original", "QTFrizQuad"/);
   assert.match(css, /:root\[data-ui-font="inter"\]/);
   assert.match(css, /font-synthesis-weight: none/);
   assert.doesNotMatch(css, /-1px 1px 0 #000/);
+  assert.doesNotMatch(
+    harness.match(/#settings-dialog\s*\{[\s\S]*?\}/u)?.[0] ?? "",
+    /--ui-font(?:-display)?\s*:/u,
+  );
+  assert.match(loading, /font:16px\/1\.5 var\(--ui-font\)/u);
   const appearance = readFileSync(new URL("src/renderer/appearance.ts", root), "utf8");
   assert.match(appearance, /new FontFace\("Guild Wars Original"/);
   assert.match(appearance, /"Guild Wars Original Display"/);

--- a/tests/website-smoke.ts
+++ b/tests/website-smoke.ts
@@ -329,9 +329,6 @@ try {
   for (const href of downloadLinks(germanHtml)) {
     assert.match(href, /^\/(de\/)?download$/);
   }
-  assert.match(germanHtml, /href="\/download\?channel=beta"/);
-  assert.match(germanHtml, />Beta herunterladen</);
-
   // Public performance-sensitive prose stays qualitative. Controlled, dated
   // measurements belong in docs/performance-electron.md, not in marketing
   // pages assembled from individual tester reports.


### PR DESCRIPTION
The converted interface font looked too rough and flat compared with Guild Wars, while Settings and the launcher ignored the selected typeface. The font choice now controls the complete active-game interface and the original lettering is calibrated directly against the player’s local game assets.

## What changed

- Calibrate the original 24 px body strike against its grayscale source instead of relying on visual guesses.
- Convert the separate 52 px display strike for the finer heading letterforms used by Guild Wars.
- Give body text and display headings their correct roles, spacing, contour thresholds, and restrained depth treatment.
- Apply the Guild Wars/Inter choice consistently across Settings, loading UI, Tools, dialogs, controls, and headings.
- Use the homepage’s byte-identical QTFrizQuad face as the fallback while local game fonts are unavailable.
- Add a repeatable `pnpm font:calibrate` feedback loop for body and display strikes.
- Keep all ArenaNet font bytes local; no game glyph data or generated font is committed or packaged.

## User impact

Choosing **Guild Wars Original** now uses the locally converted body and display faces everywhere in the active-game UI. Choosing **Inter** uses the modern sans-serif stack everywhere, except technical fixed-width diagnostics. If the game-derived face cannot load, the UI falls back to the same QTFrizQuad font used by the homepage.

## Verification

- 1,072 unit tests
- 165 policy tests
- TypeScript checks
- Focused ESLint checks
- Production build
- Chromium pixel calibration against both original archive strikes

- [x] I kept this pull request focused.
- [x] I ran the relevant checks.
- [x] I did not add game binaries, generated fonts, credentials, diagnostics, or private traffic.
- [x] I updated documentation and tests for the new behavior.
