### PR TITLE
fix(input): make login and game overlays keyboard reliable

### DIFF
--- a/apps/tools/DESIGN.md
+++ b/apps/tools/DESIGN.md
@@ -52,6 +52,10 @@ density, or behavior.
 - Arrow keys resize the window. Shift increases the step.
 - Start a Tools drag only from title-bar furniture.
 - Do not start a drag from an interactive child.
+- Keep a non-modal surface open when the player clicks Guild Wars behind it.
+- Escape closes the topmost GWonMac surface before Guild Wars receives it.
+- Tab enters the topmost open GWonMac surface and wraps inside its controls.
+- Keep native confirmation dialogs above non-modal Tools and Travel surfaces.
 - Keep a dragged window inside the viewport.
 - Keep scrolling flex and grid children shrinkable.
 - Use container width to change panel layout.

--- a/apps/tools/DESIGN.md
+++ b/apps/tools/DESIGN.md
@@ -56,6 +56,10 @@ density, or behavior.
 - Escape closes the topmost GWonMac surface before Guild Wars receives it.
 - Tab enters the topmost open GWonMac surface and wraps inside its controls.
 - Keep native confirmation dialogs above non-modal Tools and Travel surfaces.
+- Open Travel with Quick Travel destinations only; reveal the full catalogue as
+  the player searches.
+- Keep version availability collapsed in Settings unless something is
+  unavailable.
 - Keep a dragged window inside the viewport.
 - Keep scrolling flex and grid children shrinkable.
 - Use container width to change panel layout.

--- a/apps/tools/src/ToolsApp.shell.test.ts
+++ b/apps/tools/src/ToolsApp.shell.test.ts
@@ -146,6 +146,26 @@ describe("ToolsApp shell and library", () => {
     wrapper.unmount();
   });
 
+  it("protects an unsaved build when the host requests that Tools close", async () => {
+    const wrapper = await workbench();
+    await wrapper.get("#builds-library-tab").trigger("click");
+    await wrapper.findAll(".library-row")[0]!.trigger("click");
+    await wrapper.get("#build-name").setValue("Unsaved keyboard draft");
+
+    (wrapper.vm as unknown as { requestClose(): void }).requestClose();
+    await flushPromises();
+    expect(wrapper.text()).toContain("Save this draft?");
+    expect(wrapper.emitted("close")).toBeUndefined();
+
+    await wrapper
+      .findAll(".leave-dialog .ui-button")
+      .find((button) => button.text() === "Discard changes")!
+      .trigger("click");
+    await flushPromises();
+    expect(wrapper.emitted("close")).toHaveLength(1);
+    wrapper.unmount();
+  });
+
   it("forks a selected build and keeps the operation undoable", async () => {
     const wrapper = await workbench();
     await wrapper.get('[role="tab"]:nth-child(2)').trigger("click");

--- a/apps/tools/src/ToolsApp.vue
+++ b/apps/tools/src/ToolsApp.vue
@@ -177,6 +177,7 @@ const saveAndNavigate = async () => {
 };
 
 const requestClose = () => navigate(() => emit("close"));
+defineExpose({ requestClose });
 
 const openStorage = async () => {
   storageProblem.value = "";
@@ -333,6 +334,7 @@ onBeforeUnmount(() => {
       class="ui-frame ui-panel tools-window"
       :style="panelStyle"
       aria-label="GWonMac Tools"
+      role="dialog"
     >
       <header class="ui-panel-head window-bar" @pointerdown="startDrag">
         <div class="window-brand" aria-hidden="true">GW</div>

--- a/apps/tools/src/components/TravelPalette.test.ts
+++ b/apps/tools/src/components/TravelPalette.test.ts
@@ -24,6 +24,19 @@ function fixture(initial: TravelShortcuts = DEFAULT_TRAVEL_SHORTCUTS) {
 }
 
 describe("TravelPalette", () => {
+  it("opens with Quick Travel only and keeps Close out of the search label", async () => {
+    const { wrapper } = fixture();
+    await flushPromises();
+
+    expect(wrapper.findAll('[role="option"]')).toHaveLength(0);
+    expect(wrapper.text()).toContain("Start typing to search all outposts");
+    expect(wrapper.get('label[for="travel-search-input"]').text())
+      .toBe("Search destinations");
+    expect(wrapper.get('[aria-label="Close Travel"]').element.closest("label"))
+      .toBeNull();
+    wrapper.unmount();
+  });
+
   it("autocompletes aliases and travels to the active result", async () => {
     const { wrapper, travel } = fixture();
     await flushPromises();
@@ -46,6 +59,16 @@ describe("TravelPalette", () => {
     await flushPromises();
 
     await wrapper.get('[role="combobox"]').trigger("keydown", { key: "1" });
+
+    expect(travel).toHaveBeenCalledWith(DEFAULT_TRAVEL_SHORTCUTS[0]);
+    wrapper.unmount();
+  });
+
+  it("keeps Quick Travel numbers active after using the district selector", async () => {
+    const { wrapper, travel } = fixture();
+    await flushPromises();
+
+    await wrapper.get(".travel-district-region select").trigger("keydown", { key: "1" });
 
     expect(travel).toHaveBeenCalledWith(DEFAULT_TRAVEL_SHORTCUTS[0]);
     wrapper.unmount();
@@ -79,6 +102,7 @@ describe("TravelPalette", () => {
   it("leaves arrow keys to the district controls", async () => {
     const { wrapper } = fixture();
     await flushPromises();
+    await wrapper.get('[role="combobox"]').setValue("la");
 
     const region = wrapper.get(".travel-district-region select");
     await region.trigger("keydown", { key: "ArrowDown" });
@@ -100,6 +124,39 @@ describe("TravelPalette", () => {
     expect(saved.slice(6, 8)).toEqual([null, null]);
     expect(saved[8]).toEqual({ mapId: 642, district: "international", districtNumber: 0 });
     expect(wrapper.text()).toContain("Eye of the North is now shortcut 9");
+    wrapper.unmount();
+  });
+
+  it("preserves the previous shortcut and explains a failed save", async () => {
+    const { wrapper, travel, saveShortcuts } = fixture();
+    await flushPromises();
+    saveShortcuts.mockRejectedValueOnce(new Error("private persistence detail"));
+    await wrapper.get('[role="combobox"]').setValue("eotn");
+
+    await wrapper.get(".travel-palette").trigger("keydown", { key: "1", metaKey: true });
+    await flushPromises();
+    expect(wrapper.text()).toContain(
+      "Shortcut could not be saved. Your previous shortcut is still active.",
+    );
+    expect(wrapper.text()).not.toContain("private persistence detail");
+
+    await wrapper.get('[role="combobox"]').setValue("");
+    await wrapper.get(".travel-palette").trigger("keydown", { key: "1" });
+    expect(travel).toHaveBeenCalledWith(DEFAULT_TRAVEL_SHORTCUTS[0]);
+    wrapper.unmount();
+  });
+
+  it("turns host travel failures into actionable player copy", async () => {
+    const { wrapper, travel } = fixture();
+    await flushPromises();
+    travel.mockRejectedValueOnce(new Error("private host detail"));
+    await wrapper.get('[role="combobox"]').setValue("kama");
+
+    await wrapper.get('[role="combobox"]').trigger("keydown", { key: "Enter" });
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("Travel could not start. Check Guild Wars, then try again.");
+    expect(wrapper.text()).not.toContain("private host detail");
     wrapper.unmount();
   });
 });

--- a/apps/tools/src/components/TravelPalette.vue
+++ b/apps/tools/src/components/TravelPalette.vue
@@ -27,6 +27,7 @@ const emit = defineEmits<{ close: [] }>();
 
 const palette = ref<HTMLElement | null>(null);
 const input = ref<HTMLInputElement | null>(null);
+const districtNumberInput = ref<HTMLInputElement | null>(null);
 const query = ref("");
 const active = ref(0);
 const district = ref<TravelDistrictId>("international");
@@ -37,7 +38,11 @@ const feedbackLevel = ref<"info" | "success" | "warning" | "danger">("info");
 const busyMapId = ref<number | null>(null);
 let timeout = 0;
 
-const results = computed(() => searchTravelDestinations(query.value));
+const hasQuery = computed(() => query.value.trim().length > 0);
+const results = computed(() => hasQuery.value
+  ? searchTravelDestinations(query.value)
+  : []
+);
 const shortcutRows = computed(() => shortcuts.value
   .map((request, index) => ({
     index,
@@ -51,7 +56,9 @@ const activeDestination = computed(() => results.value[active.value] ?? null);
 const statusText = computed(() =>
   feedback.value
   || props.host.unavailable
-  || "Arrow keys choose · ⌘1–9 saves the selected shortcut"
+  || (hasQuery.value
+    ? "Arrow keys choose · Return travels · ⌘1–9 saves this destination"
+    : "Press 1–9 for Quick Travel")
 );
 const statusLevel = computed(() => {
   if (feedback.value) return feedbackLevel.value;
@@ -73,8 +80,16 @@ watch(() => props.visible, async (visible) => {
 
 watch(() => props.host.state.value, (state) => {
   if (busyMapId.value === null) return;
-  if (state.status === "waiting" && state.reason === "loading") emit("close");
-  else if (state.status === "ready" && state.mapId === busyMapId.value) emit("close");
+  if (
+    (state.status === "waiting" && state.reason === "loading")
+    || (state.status === "ready" && state.mapId === busyMapId.value)
+  ) {
+    window.clearTimeout(timeout);
+    busyMapId.value = null;
+    feedback.value = "Travel started.";
+    feedbackLevel.value = "success";
+    timeout = window.setTimeout(() => emit("close"), 350);
+  }
 });
 
 function requestFor(destination: TravelDestination): TravelRequest {
@@ -99,14 +114,15 @@ async function travel(request: TravelRequest): Promise<void> {
   busyMapId.value = request.mapId;
   try {
     await props.host.travel(request);
+    if (busyMapId.value !== request.mapId) return;
     timeout = window.setTimeout(() => {
       busyMapId.value = null;
       feedback.value = "Travel did not start. Check that this outpost is unlocked, then try again.";
       feedbackLevel.value = "warning";
     }, 3_000);
-  } catch (cause) {
+  } catch {
     busyMapId.value = null;
-    feedback.value = cause instanceof Error ? cause.message : "Travel could not start. Try again.";
+    feedback.value = "Travel could not start. Check Guild Wars, then try again.";
     feedbackLevel.value = "danger";
   }
 }
@@ -114,12 +130,19 @@ async function travel(request: TravelRequest): Promise<void> {
 async function assignShortcut(slot: number): Promise<void> {
   const destination = activeDestination.value;
   if (!destination) return;
+  const previous = shortcuts.value;
   const next = Array.from(shortcuts.value);
   while (next.length <= slot) next.push(null);
   next[slot] = requestFor(destination);
-  shortcuts.value = await props.host.saveShortcuts(next.slice(0, 9));
-  feedback.value = `${destination.name} is now shortcut ${slot + 1}.`;
-  feedbackLevel.value = "success";
+  try {
+    shortcuts.value = await props.host.saveShortcuts(next.slice(0, 9));
+    feedback.value = `${destination.name} is now shortcut ${slot + 1}.`;
+    feedbackLevel.value = "success";
+  } catch {
+    shortcuts.value = previous;
+    feedback.value = "Shortcut could not be saved. Your previous shortcut is still active.";
+    feedbackLevel.value = "danger";
+  }
 }
 
 async function moveActive(direction: 1 | -1): Promise<void> {
@@ -155,16 +178,19 @@ function onKeydown(event: KeyboardEvent): void {
     return;
   }
   if (
-    isSearchInput
-    && /^[1-9]$/u.test(event.key)
-    && query.value === ""
+    /^[1-9]$/u.test(event.key)
+    && query.value.trim() === ""
     && !event.metaKey
     && !event.ctrlKey
+    && event.target !== districtNumberInput.value
   ) {
+    event.preventDefault();
     const shortcut = shortcuts.value[Number(event.key) - 1];
     if (shortcut) {
-      event.preventDefault();
       void travel(shortcut);
+    } else {
+      feedback.value = `Quick Travel ${event.key} is not set.`;
+      feedbackLevel.value = "warning";
     }
   }
 }
@@ -172,10 +198,8 @@ function onKeydown(event: KeyboardEvent): void {
 onMounted(() => {
   void props.host.loadShortcuts()
     .then((loaded) => { shortcuts.value = loaded; })
-    .catch((cause: unknown) => {
-      feedback.value = cause instanceof Error
-        ? cause.message
-        : "Shortcuts could not be loaded. Reopen Travel to try again.";
+    .catch(() => {
+      feedback.value = "Shortcuts could not be loaded. Reopen Travel to try again.";
       feedbackLevel.value = "danger";
     });
 });
@@ -193,17 +217,18 @@ onBeforeUnmount(() => {
     aria-label="Travel"
     @keydown="onKeydown"
   >
-    <label class="ui-input-group travel-search">
+    <div class="ui-input-group travel-search">
       <svg class="travel-search-icon" viewBox="0 0 20 20" aria-hidden="true">
         <circle cx="8.5" cy="8.5" r="5.25" />
         <path d="m12.4 12.4 4.1 4.1" />
       </svg>
-      <span class="ui-sr-only">Search destinations</span>
+      <label class="ui-sr-only" for="travel-search-input">Search destinations</label>
       <input
+        id="travel-search-input"
         ref="input"
         v-model="query"
         role="combobox"
-        aria-controls="travel-results"
+        :aria-controls="hasQuery ? 'travel-results' : undefined"
         aria-autocomplete="list"
         aria-haspopup="listbox"
         :aria-activedescendant="activeDestination ? `travel-${activeDestination.mapId}` : undefined"
@@ -218,8 +243,12 @@ onBeforeUnmount(() => {
         data-icon
         aria-label="Close Travel"
         @click="emit('close')"
-      >×</button>
-    </label>
+      >
+        <svg viewBox="0 0 16 16" aria-hidden="true">
+          <path d="m3 3 10 10M13 3 3 13" />
+        </svg>
+      </button>
+    </div>
 
     <div class="travel-options">
       <span class="travel-options-label">District</span>
@@ -234,6 +263,7 @@ onBeforeUnmount(() => {
       <label class="travel-district-number">
         <span class="ui-sr-only">District number</span>
         <input
+          ref="districtNumberInput"
           v-model.number="districtNumber"
           class="ui-input"
           type="number"
@@ -246,10 +276,13 @@ onBeforeUnmount(() => {
       </label>
     </div>
 
-    <div v-if="!query && shortcutRows.length" class="travel-shortcuts" aria-label="Quick Travel">
+    <section
+      v-if="!hasQuery && shortcutRows.length"
+      class="travel-shortcuts"
+      aria-labelledby="travel-shortcuts-title"
+    >
       <header>
-        <strong>Quick Travel</strong>
-        <span>Press 1–9</span>
+        <h2 id="travel-shortcuts-title">Quick Travel</h2>
       </header>
       <button
         v-for="row in shortcutRows"
@@ -263,9 +296,18 @@ onBeforeUnmount(() => {
         <kbd class="ui-kbd">{{ row.index + 1 }}</kbd>
         <span>{{ row.destination.name }}</span>
       </button>
-    </div>
+    </section>
 
-    <div id="travel-results" class="ui-scroll travel-results" role="listbox">
+    <p v-if="!hasQuery" class="travel-search-prompt">
+      Start typing to search all outposts.
+    </p>
+
+    <div
+      v-if="hasQuery"
+      id="travel-results"
+      class="ui-scroll travel-results"
+      role="listbox"
+    >
       <button
         v-for="(destination, index) in results"
         :id="`travel-${destination.mapId}`"
@@ -292,7 +334,6 @@ onBeforeUnmount(() => {
 
     <footer class="travel-footer">
       <span :data-level="statusLevel" role="status" aria-live="polite">{{ statusText }}</span>
-      <span><kbd class="ui-kbd">1–9</kbd> travels</span>
     </footer>
   </section>
 </template>

--- a/apps/tools/src/components/TravelPalette.vue
+++ b/apps/tools/src/components/TravelPalette.vue
@@ -69,7 +69,7 @@ watch(() => props.visible, async (visible) => {
   window.clearTimeout(timeout);
   await nextTick();
   input.value?.focus({ preventScroll: true });
-});
+}, { immediate: true, flush: "post" });
 
 watch(() => props.host.state.value, (state) => {
   if (busyMapId.value === null) return;
@@ -212,7 +212,13 @@ onBeforeUnmount(() => {
         spellcheck="false"
         placeholder="Travel to an outpost…"
       >
-      <kbd class="ui-kbd">esc</kbd>
+      <button
+        type="button"
+        class="ui-button travel-close"
+        data-icon
+        aria-label="Close Travel"
+        @click="emit('close')"
+      >×</button>
     </label>
 
     <div class="travel-options">
@@ -267,6 +273,7 @@ onBeforeUnmount(() => {
         type="button"
         class="ui-row"
         role="option"
+        tabindex="-1"
         :aria-selected="index === active"
         :aria-disabled="busyMapId !== null || host.unavailable !== null"
         :disabled="busyMapId !== null || host.unavailable !== null"

--- a/apps/tools/src/mount.ts
+++ b/apps/tools/src/mount.ts
@@ -12,6 +12,7 @@ export type ToolsAppHandle = Readonly<{
   show(): void;
   hide(): void;
   toggle(): void;
+  requestClose(): void;
   /**
    * The companion's latest projection of the running game, from the overlay.
    *
@@ -37,6 +38,7 @@ export function mountToolsApp(
   let lastPartyTrace = "";
   const development = options.development === true;
   const visible = ref(options.initiallyVisible ?? options.mode === "standalone");
+  const tools = ref<InstanceType<typeof ToolsApp> | null>(null);
   const setVisible = (next: boolean) => {
     if (visible.value === next) return;
     if (!next) options.host.cancelApply();
@@ -48,6 +50,7 @@ export function mountToolsApp(
     setup() {
       return () =>
         h(ToolsApp, {
+          ref: tools,
           host: options.host,
           mode: options.mode,
           visible: visible.value,
@@ -68,6 +71,7 @@ export function mountToolsApp(
     show: () => setVisible(true),
     hide: () => setVisible(false),
     toggle: () => setVisible(!visible.value),
+    requestClose: () => tools.value?.requestClose(),
     update: (observation: ToolboxObservation) => {
       options.host.party.value = liveParty(observation);
       const observed = options.host.party.value;

--- a/apps/tools/src/styles.css
+++ b/apps/tools/src/styles.css
@@ -68,6 +68,14 @@
   min-width: 32px;
   min-height: 32px;
 }
+.travel-close svg {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-width: 1.75;
+}
 
 .travel-options {
   display: flex;
@@ -89,22 +97,24 @@
 
 .travel-shortcuts {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 6px;
   padding: 10px 12px;
   flex: none;
   border-bottom: 1px solid var(--ui-line-soft);
 }
 .travel-shortcuts header {
-  display: flex;
   grid-column: 1 / -1;
-  align-items: baseline;
-  justify-content: space-between;
   padding: 0 3px 2px;
   color: var(--ui-text-muted);
   font-size: var(--ui-font-size-sm);
 }
-.travel-shortcuts header strong { color: var(--ui-text); font-weight: var(--ui-font-weight-semibold); }
+.travel-shortcuts h2 {
+  margin: 0;
+  color: var(--ui-text);
+  font: inherit;
+  font-weight: var(--ui-font-weight-semibold);
+}
 .travel-shortcuts button {
   display: flex;
   align-items: center;
@@ -116,10 +126,17 @@
   box-shadow: none;
 }
 .travel-shortcuts span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.travel-search-prompt {
+  margin: 0;
+  padding: 18px 12px 20px;
+  color: var(--ui-text-muted);
+  text-align: center;
+}
 
 .travel-results {
-  min-height: 150px;
-  flex: 1 1 360px;
+  min-height: 0;
+  max-height: 360px;
+  flex: 0 1 auto;
   overflow-y: auto;
   padding: 6px;
 }
@@ -137,6 +154,9 @@
 .travel-results button[aria-selected="true"] {
   background: var(--ui-accent-fill) padding-box, var(--ui-ring-gold) border-box;
   box-shadow: var(--ui-shadow-row-selected);
+}
+.travel-results button[aria-selected="true"] .ui-kbd {
+  color: var(--ui-text-bright);
 }
 .travel-results button:disabled,
 .travel-shortcuts button:disabled { cursor: default; }
@@ -156,7 +176,7 @@
   align-items: center;
   border-top: 1px solid var(--ui-line-soft);
   color: var(--ui-text-muted);
-  font-size: 11px;
+  font-size: var(--ui-font-size-sm);
 }
 .travel-footer > span:first-child { min-width: 0; }
 .travel-footer [data-level="info"] { color: var(--ui-info); }
@@ -180,11 +200,6 @@
     filter: blur(0);
     transform: translate(-50%, 0);
   }
-}
-
-@media (max-width: 520px) {
-  .travel-shortcuts { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  .travel-footer > span:last-child { display: none; }
 }
 
 @media (max-height: 560px) {

--- a/apps/tools/src/styles.css
+++ b/apps/tools/src/styles.css
@@ -63,6 +63,11 @@
   font-size: 17px;
   caret-color: var(--ui-accent);
 }
+.travel-close {
+  width: 32px;
+  min-width: 32px;
+  min-height: 32px;
+}
 
 .travel-options {
   display: flex;

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -126,10 +126,11 @@ After that restart, these choices update immediately:
 - **Open Xunlai storage** (Beta) allows the Storage button, Command-Shift-C
   shortcut, and the `/chest` and `/xunlai` chat commands in a supported PvE
   outpost.
-- **Quick Travel palette** (Beta) opens with Command-T. Type a destination or
-  alias such as `la`, `kama`, or `eotn`, choose a district, and press Return.
-  With an empty search, press 1–9 to travel through saved quick destinations.
-  Command-1 through Command-9 assigns the selected result to that number.
+- **Quick Travel palette** (Beta) opens with Command-T. Before you search, it
+  shows only your saved quick destinations; press 1–9 from anywhere in Travel
+  to use one. Type a destination or alias such as `la`, `kama`, or `eotn`,
+  choose a district, and press Return. Command-1 through Command-9 assigns the
+  selected result to that number.
 
 Tools and Travel stay open when you click Guild Wars behind them. Press Tab to
 move the keyboard into the topmost GWonMac window. Press Escape to close that

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -130,6 +130,11 @@ After that restart, these choices update immediately:
   alias such as `la`, `kama`, or `eotn`, choose a district, and press Return.
   With an empty search, press 1–9 to travel through saved quick destinations.
   Command-1 through Command-9 assigns the selected result to that number.
+
+Tools and Travel stay open when you click Guild Wars behind them. Press Tab to
+move the keyboard into the topmost GWonMac window. Press Escape to close that
+window and return the keyboard to Guild Wars. If a confirmation dialog is open,
+Escape closes the confirmation first.
 - **Target distance and range** (Test) shows the selected target's distance and
 range band.
 

--- a/src/renderer/client-compatibility-notice.ts
+++ b/src/renderer/client-compatibility-notice.ts
@@ -181,6 +181,10 @@ export function renderClientCompatibility(
   const settingsStatus = requiredElement(root, 'settings-compat-status');
   const settingsDetail = requiredElement(root, 'settings-compat-detail');
   const settingsVersion = requiredElement(root, 'settings-compat-version');
+  const settingsAvailability = requiredElement(
+    root,
+    'settings-availability',
+  ) as HTMLDetailsElement;
   const launcherTitle = requiredElement(root, 'client-compat-title');
   const launcherDetail = requiredElement(root, 'client-compat-detail');
   const launcherVersion = requiredElement(root, 'client-compat-version');
@@ -200,6 +204,7 @@ export function renderClientCompatibility(
   }
 
   const report = compatibilityReport(session.compatibility);
+  settingsAvailability.open = report.degraded;
   for (const feature of Object.keys(session.compatibility.features) as Feature[]) {
     requiredElement(root, `settings-feature-${feature}`).textContent =
       featureStatusLabel(session.compatibility.features[feature]);

--- a/src/renderer/gw-native.d.ts
+++ b/src/renderer/gw-native.d.ts
@@ -45,6 +45,19 @@ declare global {
     expectCharacterSelection(): void;
   }
 
+  interface GwonmacSurfaceHandle {
+    setOpen(open: boolean): void;
+    dispose(): void;
+  }
+
+  interface GwonmacSurfaceController {
+    register(surface: Readonly<{
+      root: HTMLElement;
+      priority: number;
+      dismiss(): void;
+    }>): GwonmacSurfaceHandle;
+  }
+
   /**
    * One thing the input host saw or decided, before the trace stamps it. The
    * union is closed because a trace whose vocabulary can grow by writing a
@@ -214,6 +227,7 @@ declare global {
       };
     };
     gwApplySettings?(settings: AppSettings): void;
+    gwSurfaces: GwonmacSurfaceController;
     gwToolsSettings(): Readonly<{
       enabled: boolean;
       teamManagement: boolean;

--- a/src/renderer/gw-native.d.ts
+++ b/src/renderer/gw-native.d.ts
@@ -41,6 +41,8 @@ declare global {
 
   interface GameInputController {
     releaseAll(): void;
+    setLoginProviderChooser(visible: boolean): void;
+    expectCharacterSelection(): void;
   }
 
   /**

--- a/src/renderer/harness.css
+++ b/src/renderer/harness.css
@@ -365,6 +365,12 @@ html,body { width:100%; height:100%; margin:0; overflow:hidden;
   font-size: var(--ui-font-size);
   letter-spacing: .02em;
 }
+#settings-tool-features {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--ui-space-2) var(--ui-space-4);
+}
+#settings-form #settings-tool-features label.settings-check { margin: 0; }
 .settings-shortcuts { display: grid; gap: var(--ui-space-2); }
 .settings-shortcuts > .settings-note { margin: 0; }
 .settings-shortcut-row {
@@ -394,6 +400,27 @@ html,body { width:100%; height:100%; margin:0; overflow:hidden;
 }
 .settings-shortcut-message { color: var(--ui-warning); }
 #settings-shortcuts-restore { justify-self: start; margin-top: var(--ui-space-1); }
+.settings-availability {
+  margin-top: var(--ui-space-4);
+  padding-top: var(--ui-space-3);
+  border-top: 1px solid var(--ui-line-soft);
+}
+.settings-availability summary {
+  width: fit-content;
+  color: var(--ui-text-muted);
+  cursor: pointer;
+  font-weight: 600;
+}
+.settings-availability summary:hover { color: var(--ui-text-bright); }
+.settings-availability summary:focus-visible {
+  border-radius: var(--ui-radius-sm);
+  outline: 2px solid var(--ui-focus);
+  outline-offset: 3px;
+}
+.settings-availability[open] summary {
+  margin-bottom: var(--ui-space-3);
+  color: var(--ui-text-bright);
+}
 
 .settings-seg { max-width: 100%; }
 .settings-quality-seg { width: min(100%, 560px); }
@@ -488,27 +515,37 @@ html,body { width:100%; height:100%; margin:0; overflow:hidden;
   #settings-resize { display: none; }
   .settings-body { flex-direction: column; }
   .settings-rail {
-    display: grid;
     width: auto;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    flex-direction: row;
     padding: 0;
-    overflow: visible;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scrollbar-color: var(--ui-text-faint) transparent;
+    scrollbar-width: thin;
+  }
+  .settings-rail::-webkit-scrollbar { height: 6px; }
+  .settings-rail::-webkit-scrollbar-track { background: transparent; }
+  .settings-rail::-webkit-scrollbar-thumb {
+    border-radius: var(--ui-radius-sm);
+    background: var(--ui-text-faint);
   }
   #settings-form .settings-rtab {
-    min-width: 0;
+    min-width: max-content;
+    flex: 0 0 auto;
     border-left: 0;
     border-bottom: 2px solid transparent;
     text-align: center;
-    white-space: normal;
+    white-space: nowrap;
   }
   #settings-form .settings-rtab[aria-selected="true"] { border-left: 0; border-bottom-color: var(--ui-accent); }
   .settings-panes { padding: var(--ui-space-3); }
+  #settings-tool-features { grid-template-columns: minmax(0, 1fr); }
+  .settings-quality-seg { flex-direction: column; }
+  .settings-quality-seg label { width: 100%; }
 }
 
 @media (max-width: 420px) {
-  .settings-quality-seg,
   .settings-style-seg { flex-direction: column; }
-  .settings-quality-seg label,
   .settings-style-seg label { width: 100%; }
   .settings-footerbar { padding-right: var(--ui-space-5); }
 }

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -376,7 +376,11 @@ function requestHeapCap() {
       const capBytes = Module.gwonmacHeapCapBytes ?? WASM_HEAP_CAP_BYTES;
       heapCapBytes = capBytes;
       heapWatch = createHeapPressureWatch({ capBytes });
-      heapWarning = bindMemoryWarning(document, reloadClientSafely);
+      heapWarning = bindMemoryWarning(
+        document,
+        reloadClientSafely,
+        window.gwSurfaces,
+      );
     })
     // A failed load retries on the next tick rather than silencing the
     // warning for the whole session.
@@ -518,6 +522,7 @@ let host: typeof import('./graphics.js') &
   typeof import('./filesystem.js') &
   typeof import('./input.js') &
   typeof import('./input-trace.js') &
+  typeof import('./surface-controller.js') &
   typeof import('./native-double-click.js') &
   typeof import('./clipboard-copy.js') &
   typeof import('./template-save-compatibility.js') &
@@ -1047,6 +1052,9 @@ function loadGlue(isProxyRouteLabel: (route: string) => boolean) {
     document.body,
     (text) => native().clipboard.writeText(text),
   );
+  // Install before game input so a key claimed by the topmost GWonMac surface
+  // cannot also reach the official client's window-capture listener.
+  window.gwSurfaces = host.installSurfaceController(document);
   window.addEventListener('gw:input-trace', () => {
     log(`input trace: ${inputTrace?.toggle() ? 'on' : 'off'}`);
   });
@@ -1158,6 +1166,7 @@ function loadGlue(isProxyRouteLabel: (route: string) => boolean) {
       filesystem,
       input,
       inputTraceModule,
+      surfaceController,
       nativeDoubleClickModule,
       clipboardCopy,
       templateSaveCompatibility,
@@ -1175,6 +1184,7 @@ function loadGlue(isProxyRouteLabel: (route: string) => boolean) {
       import('./filesystem.js'),
       import('./input.js'),
       import('./input-trace.js'),
+      import('./surface-controller.js'),
       import('./native-double-click.js'),
       import('./clipboard-copy.js'),
       import('./template-save-compatibility.js'),
@@ -1191,6 +1201,7 @@ function loadGlue(isProxyRouteLabel: (route: string) => boolean) {
       ...filesystem,
       ...input,
       ...inputTraceModule,
+      ...surfaceController,
       ...nativeDoubleClickModule,
       ...clipboardCopy,
       ...templateSaveCompatibility,

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -697,6 +697,7 @@ Module = {
   // call their fallback without returning. Main owns encrypted persistence.
   secureStorage: {
     async getCredentials() {
+      inputHost?.setLoginProviderChooser(false);
       const stored = await native().credentials.load();
       if (!stored) {
         log('secureStorage: no saved credentials — the module should prompt');
@@ -719,8 +720,8 @@ Module = {
   },
 
   // Steam is the one federated provider this host answers for. Saying yes is
-  // what makes the client render its "Sign in with Steam" button; the ArenaNet
-  // email/password form renders beside it, unchanged.
+  // what makes the client offer its account-provider chooser; choosing the
+  // ArenaNet path then opens the client's unchanged email/password form.
   login: {
     hasProvider(name) {
       const offered = isSteamProvider(name);
@@ -750,9 +751,11 @@ Module = {
         throw new Error('provider not offered');
       }
       const silent = isSilentRequest(options);
+      if (!silent) inputHost?.setLoginProviderChooser(false);
       const result = await native().steam.getToken(silent);
       if (!result.token) {
         log(`login.getAuthToken(silent=${silent}) -> no token`);
+        inputHost?.setLoginProviderChooser(true);
         // The refusal still ends on the client's own login screen; the line
         // below is the one explanation the host may add beside it. A plain
         // cancel stays silent — describeSteamRefusal answers null for it.
@@ -761,6 +764,7 @@ Module = {
       }
       // Never the value: the token must not reach this log, which is bounded
       // and read back into diagnostics.
+      inputHost?.setLoginProviderChooser(false);
       log(`login.getAuthToken(silent=${silent}) -> token vended`);
       return {
         userId: LOCAL_PROFILE_INDEX,
@@ -1009,6 +1013,12 @@ function loadGlue(isProxyRouteLabel: (route: string) => boolean) {
         const path = u.pathname.startsWith('/') ? u.pathname : '/' + u.pathname;
         const rewritten = `gw://app${path}${u.search}`;
         log(`api: ${method} ${path}`);
+        // This is the last account-service request before the client opens
+        // character selection. It occurs for password and federated accounts,
+        // including when the player chose not to save credentials.
+        if (path === '/webgate/my_account/token.xml') {
+          inputHost?.expectCharacterSelection();
+        }
         return origOpen.call(this, method, rewritten, ...rest);
       }
     } catch { /* not a URL we can rewrite */ }
@@ -1041,8 +1051,24 @@ function loadGlue(isProxyRouteLabel: (route: string) => boolean) {
     log(`input trace: ${inputTrace?.toggle() ? 'on' : 'off'}`);
   });
 
+  // Text entry runs through these, not through keydown on the canvas. The
+  // input host also needs their identity before the generated glue installs
+  // its own Tab listener, so Chromium cannot perform a second focus move.
+  Module.oskInput = {
+    text:      document.getElementById('osk-input-text'),
+    email:     document.getElementById('osk-input-email'),
+    password:  document.getElementById('osk-input-password'),
+    number:    document.getElementById('osk-input-number'),
+    multiline: document.getElementById('osk-input-multiline'),
+  };
+  Module.oskIsModal = Module.isMobile;
+  const oskInputs = new Set<EventTarget | null>(
+    Object.values(Module.oskInput).filter((input): input is HTMLElement => !!input),
+  );
+
   inputHost = host.installGameInput({
     canvas: c,
+    textInputs: oskInputs,
     diagnostics: window.gwDiagnostics,
     trace: inputTrace,
     // Read through the window global rather than a module handle: input
@@ -1069,19 +1095,8 @@ function loadGlue(isProxyRouteLabel: (route: string) => boolean) {
     trace: inputTrace,
     log,
   });
-  // Text entry runs through these, not through keydown on the canvas. Stray
-  // focus must bounce off, or a field silently swallows keys meant for the game.
-  Module.oskInput = {
-    text:      document.getElementById('osk-input-text'),
-    email:     document.getElementById('osk-input-email'),
-    password:  document.getElementById('osk-input-password'),
-    number:    document.getElementById('osk-input-number'),
-    multiline: document.getElementById('osk-input-multiline'),
-  };
-  Module.oskIsModal = Module.isMobile;   // on desktop the field stays behind the canvas
-  const oskInputs = new Set<EventTarget | null>(
-    Object.values(Module.oskInput).filter(Boolean),
-  );
+  // Stray focus must bounce off, or a field silently swallows keys meant for
+  // the game. On desktop the active field itself stays behind the canvas.
   host.installClipboardCopy({
     fields: oskInputs,
     writeText: (text) => native().clipboard.writeText(text),
@@ -1109,7 +1124,7 @@ function loadGlue(isProxyRouteLabel: (route: string) => boolean) {
     if (!el) { log(`[warn] missing OSK element for "${type}"`); continue; }
     el.addEventListener('focus', () => {
       globalThis.queueMicrotask(() => {
-        if (Module.oskActiveInput !== el && document.activeElement === el) el.blur();
+        if (Module.oskActiveInput !== el && document.activeElement === el) c.focus();
       });
     });
     if (Module.oskIsModal) {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -493,69 +493,75 @@
         <section class="settings-pane" id="settings-pane-controls" role="tabpanel"
                  aria-labelledby="settings-tab-controls">
           <h3 id="settings-controls-title" class="settings-pane-title">Tools</h3>
-          <p class="settings-pane-intro">Choose the GWonMac features you want. File saving stays on when this Guild Wars version supports it.</p>
+          <p class="settings-pane-intro">Choose which optional GWonMac features are available while you play.</p>
           <label class="settings-check ui-check">
             <input type="checkbox" name="gwonmacTools" aria-describedby="settings-tools-help">
             <span>Enable optional Tools Beta</span>
           </label>
-          <p id="settings-tools-help" class="settings-note">The first Tools enable needs one restart to prepare every certified capability. After that, Tools and individual features turn on or off immediately. Your saved Builds and Teams stay available at login and in PvP.</p>
-          <fieldset>
-            <legend>Optional tools</legend>
-            <label class="settings-check ui-check">
-              <input type="checkbox" name="teamManagement">
-              <span>Apply teams in Guild Wars <small>Beta</small></span>
-            </label>
-            <label class="settings-check ui-check">
-              <input type="checkbox" name="xunlaiStorage">
-              <span>Open Xunlai storage <small>Beta</small></span>
-            </label>
-            <label class="settings-check ui-check">
-              <input type="checkbox" name="travelPalette">
-              <span>Quick Travel palette <small>Beta</small></span>
-            </label>
-            <label class="settings-check ui-check">
-              <input type="checkbox" name="targetReadout">
-              <span>Target distance and range <small>Test</small></span>
-            </label>
-          </fieldset>
-          <fieldset class="settings-shortcuts" aria-describedby="settings-shortcuts-help">
-            <legend>Keyboard shortcuts</legend>
-            <p id="settings-shortcuts-help" class="settings-note">Shortcuts work while the Guild Wars window is active.</p>
-            <div class="settings-shortcut-row" data-shortcut-action="tools.toggle">
-              <span class="settings-shortcut-name">Toggle Tools</span>
-              <kbd class="settings-shortcut-value">—</kbd>
-              <button type="button" class="ui-button settings-shortcut-change">Change</button>
-              <p class="settings-shortcut-message" role="status" aria-live="polite" hidden></p>
-              <button type="button" class="ui-link settings-shortcut-replace" hidden>Replace existing shortcut</button>
-            </div>
-            <div class="settings-shortcut-row" data-shortcut-action="storage.open">
-              <span class="settings-shortcut-name">Open Xunlai storage</span>
-              <kbd class="settings-shortcut-value">—</kbd>
-              <button type="button" class="ui-button settings-shortcut-change">Change</button>
-              <p class="settings-shortcut-message" role="status" aria-live="polite" hidden></p>
-              <button type="button" class="ui-link settings-shortcut-replace" hidden>Replace existing shortcut</button>
-            </div>
-            <div class="settings-shortcut-row" data-shortcut-action="travel.open">
-              <span class="settings-shortcut-name">Open Travel</span>
-              <kbd class="settings-shortcut-value">—</kbd>
-              <button type="button" class="ui-button settings-shortcut-change">Change</button>
-              <p class="settings-shortcut-message" role="status" aria-live="polite" hidden></p>
-              <button type="button" class="ui-link settings-shortcut-replace" hidden>Replace existing shortcut</button>
-            </div>
-            <button type="button" id="settings-shortcuts-restore" class="ui-link">Restore default shortcuts</button>
-          </fieldset>
-          <dl class="settings-feature-status" aria-label="Feature availability">
-            <div><dt>Guild Wars file saving</dt><dd id="settings-feature-gameFileSaving">—</dd></div>
-            <div><dt>Guild Wars cursor</dt><dd id="settings-feature-nativeCursor">—</dd></div>
-            <div><dt>Target distance</dt><dd id="settings-feature-targetObservation">—</dd></div>
-            <div><dt>Live party details</dt><dd id="settings-feature-partyObservation">—</dd></div>
-            <div><dt>Apply team</dt><dd id="settings-feature-teamApply">—</dd></div>
-            <div><dt>Xunlai / Travel integration</dt><dd id="settings-feature-xunlaiStorage">—</dd></div>
-          </dl>
-          <p id="settings-compat-status" class="settings-status"
-             role="status" aria-live="polite"></p>
-          <p id="settings-compat-detail" class="settings-note"></p>
-          <p id="settings-compat-version" class="settings-note"></p>
+          <p id="settings-tools-help" class="settings-note">The first enable needs one restart. After that, changes apply immediately. Your saved Builds and Teams stay available at login and in PvP.</p>
+          <p id="settings-tools-off" class="settings-note">Enable Tools Beta to choose individual tools and keyboard shortcuts.</p>
+          <div id="settings-tools-config">
+            <fieldset id="settings-tool-features" hidden>
+              <legend>Optional tools</legend>
+              <label class="settings-check ui-check">
+                <input type="checkbox" name="teamManagement">
+                <span>Apply teams in Guild Wars <small>Beta</small></span>
+              </label>
+              <label class="settings-check ui-check">
+                <input type="checkbox" name="xunlaiStorage">
+                <span>Open Xunlai storage <small>Beta</small></span>
+              </label>
+              <label class="settings-check ui-check">
+                <input type="checkbox" name="travelPalette">
+                <span>Quick Travel palette <small>Beta</small></span>
+              </label>
+              <label class="settings-check ui-check">
+                <input type="checkbox" name="targetReadout">
+                <span>Target distance and range <small>Test</small></span>
+              </label>
+            </fieldset>
+            <fieldset class="settings-shortcuts" aria-describedby="settings-shortcuts-help">
+              <legend>Keyboard shortcuts</legend>
+              <p id="settings-shortcuts-help" class="settings-note">Shortcuts work while the Guild Wars window is active.</p>
+              <div class="settings-shortcut-row" data-shortcut-action="tools.toggle">
+                <span class="settings-shortcut-name">Toggle Tools</span>
+                <kbd class="settings-shortcut-value">—</kbd>
+                <button type="button" class="ui-button settings-shortcut-change">Change</button>
+                <p class="settings-shortcut-message" role="status" aria-live="polite" hidden></p>
+                <button type="button" class="ui-link settings-shortcut-replace" hidden>Replace existing shortcut</button>
+              </div>
+              <div class="settings-shortcut-row" data-shortcut-action="storage.open">
+                <span class="settings-shortcut-name">Open Xunlai storage</span>
+                <kbd class="settings-shortcut-value">—</kbd>
+                <button type="button" class="ui-button settings-shortcut-change">Change</button>
+                <p class="settings-shortcut-message" role="status" aria-live="polite" hidden></p>
+                <button type="button" class="ui-link settings-shortcut-replace" hidden>Replace existing shortcut</button>
+              </div>
+              <div class="settings-shortcut-row" data-shortcut-action="travel.open">
+                <span class="settings-shortcut-name">Open Travel</span>
+                <kbd class="settings-shortcut-value">—</kbd>
+                <button type="button" class="ui-button settings-shortcut-change">Change</button>
+                <p class="settings-shortcut-message" role="status" aria-live="polite" hidden></p>
+                <button type="button" class="ui-link settings-shortcut-replace" hidden>Replace existing shortcut</button>
+              </div>
+              <button type="button" id="settings-shortcuts-restore" class="ui-link">Restore default shortcuts</button>
+            </fieldset>
+          </div>
+          <details id="settings-availability" class="settings-availability">
+            <summary>Availability for this Guild Wars version</summary>
+            <dl class="settings-feature-status">
+              <div><dt>Guild Wars file saving</dt><dd id="settings-feature-gameFileSaving">—</dd></div>
+              <div><dt>Guild Wars cursor</dt><dd id="settings-feature-nativeCursor">—</dd></div>
+              <div><dt>Target distance</dt><dd id="settings-feature-targetObservation">—</dd></div>
+              <div><dt>Live party details</dt><dd id="settings-feature-partyObservation">—</dd></div>
+              <div><dt>Apply team</dt><dd id="settings-feature-teamApply">—</dd></div>
+              <div><dt>Xunlai / Travel integration</dt><dd id="settings-feature-xunlaiStorage">—</dd></div>
+            </dl>
+            <p id="settings-compat-status" class="settings-status"
+               role="status" aria-live="polite"></p>
+            <p id="settings-compat-detail" class="settings-note"></p>
+            <p id="settings-compat-version" class="settings-note"></p>
+          </details>
         </section>
 
         <section class="settings-pane" id="settings-pane-updates" role="tabpanel"

--- a/src/renderer/input.ts
+++ b/src/renderer/input.ts
@@ -109,6 +109,12 @@ type HeldButton = {
 
 type GameInputOptions = {
   canvas: HTMLCanvasElement;
+  /**
+   * The hidden desktop fields the client uses as native text-editing proxies.
+   * They stay out of the browser's tab order; the client owns which one is
+   * active and moves between them itself.
+   */
+  textInputs?: ReadonlySet<EventTarget | null>;
   diagnostics?: GameInputDiagnostics;
   /**
    * The developer trace, when the player has switched it on. It observes and
@@ -131,8 +137,22 @@ type GameInputOptions = {
 // mouse-look, matching the cursor observer's own sampling cadence.
 const POINTER_MODE_INTERVAL_MS = 50;
 
+// The provider chooser is laid out in the client's fixed 600-unit-tall login
+// coordinate system. These are the centres of its two buttons, measured from
+// the current official client. Expressing them through the canvas height keeps
+// the hit targets stable across window sizes and Retina scale factors.
+const PROVIDER_BUTTON_X_FROM_CENTRE = -161 / 600;
+const PROVIDER_BUTTON_Y = [219 / 600, 253 / 600] as const;
+
+// A successful login can paint character selection one or two frames before
+// that screen starts accepting keys. Delay only the first immediate Enter;
+// after this short window, the upstream client is ready and needs no help.
+const CHARACTER_SELECTION_WINDOW_MS = 8_000;
+const CHARACTER_ENTER_DELAY_MS = 180;
+
 export const installGameInput = ({
   canvas,
+  textInputs = new Set(),
   diagnostics,
   trace,
   clientCursorHidden,
@@ -140,6 +160,10 @@ export const installGameInput = ({
 }: GameInputOptions): GameInputController => {
   const heldKeys = new Map<string, HeldKey>();
   const heldButtons = new Map<number, HeldButton>();
+  const suppressedKeyUps = new Set<string>();
+  let providerChooserVisible = false;
+  let providerSelection = 0;
+  let characterSelectionUntil = 0;
   let virtualCursor: { x: number; y: number } | null = null;
   let pointerWanted = false;
   let modeWatch: ReturnType<typeof setInterval> | null = null;
@@ -325,8 +349,101 @@ export const installGameInput = ({
     }
   }
 
+  const providerPoint = (selection = providerSelection) => {
+    const rect = canvas.getBoundingClientRect();
+    return {
+      rect,
+      x: rect.left + rect.width / 2 + rect.height * PROVIDER_BUTTON_X_FROM_CENTRE,
+      y: rect.top + rect.height *
+        (PROVIDER_BUTTON_Y[selection] ?? PROVIDER_BUTTON_Y[0]),
+    };
+  };
+
+  const sendProviderMouse = (
+    type: 'mousemove' | 'mousedown' | 'mouseup' | 'click',
+    buttons: number,
+  ) => {
+    const { x, y } = providerPoint();
+    canvas.dispatchEvent(new MouseEvent(type, {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      button: type === 'mousemove' ? -1 : 0,
+      buttons,
+      clientX: x,
+      clientY: y,
+      screenX: window.screenX + x,
+      screenY: window.screenY + y,
+      detail: type === 'click' ? 1 : 0,
+    }));
+  };
+
+  const pointAtProviderSelection = () => sendProviderMouse('mousemove', 0);
+
+  const activateProviderSelection = () => {
+    sendProviderMouse('mousedown', 1);
+    sendProviderMouse('mouseup', 0);
+    sendProviderMouse('click', 0);
+    providerChooserVisible = false;
+  };
+
+  const handleProviderKey = (event: KeyboardEvent) => {
+    if (!providerChooserVisible || event.target !== canvas) return false;
+    const backwards = event.key === 'ArrowUp' || event.key === 'ArrowLeft' ||
+      (event.key === 'Tab' && event.shiftKey);
+    const forwards = event.key === 'ArrowDown' || event.key === 'ArrowRight' ||
+      (event.key === 'Tab' && !event.shiftKey);
+    if (backwards || forwards) {
+      providerSelection = (providerSelection + (backwards ? -1 : 1) + 2) % 2;
+      pointAtProviderSelection();
+    } else if (event.key === 'Enter' || event.key === ' ') {
+      activateProviderSelection();
+    } else {
+      return false;
+    }
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    suppressedKeyUps.add(event.code);
+    return true;
+  };
+
+  const sendBufferedCharacterEnter = (event: KeyboardEvent) => {
+    const init: KeyboardEventInit = {
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      key: event.key,
+      code: event.code,
+      location: event.location,
+    };
+    setTimeout(() => {
+      canvas.dispatchEvent(new globalThis.KeyboardEvent('keydown', init));
+      canvas.dispatchEvent(new globalThis.KeyboardEvent('keyup', init));
+    }, CHARACTER_ENTER_DELAY_MS);
+  };
+
   window.addEventListener('keydown', (event) => {
     if (!event.isTrusted) return;
+    if (handleProviderKey(event)) return;
+    if (
+      event.target === canvas &&
+      event.key === 'Enter' &&
+      performance.now() < characterSelectionUntil
+    ) {
+      characterSelectionUntil = 0;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      suppressedKeyUps.add(event.code);
+      sendBufferedCharacterEnter(event);
+      return;
+    }
+    if (performance.now() >= characterSelectionUntil) characterSelectionUntil = 0;
+    // The client changes its active proxy in its own keydown listener. Do not
+    // let Chromium then perform a second Tab move from the newly focused field
+    // to the canvas, which made focus appear to skip at random.
+    if (event.key === 'Tab' && textInputs.has(event.target)) {
+      event.preventDefault();
+    }
     const held = heldKeys.get(event.code);
     const key = clientKey(event, event.repeat ? held?.key : undefined);
     if (event.repeat && held) return;
@@ -348,6 +465,11 @@ export const installGameInput = ({
   }, true);
   window.addEventListener('keyup', (event) => {
     if (!event.isTrusted) return;
+    if (suppressedKeyUps.delete(event.code)) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      return;
+    }
     const held = heldKeys.get(event.code);
     const key = clientKey(event, held?.key);
     const modifier = TRACED_MODIFIERS[key];
@@ -637,5 +759,21 @@ export const installGameInput = ({
 
   return Object.freeze({
     releaseAll,
+    setLoginProviderChooser(visible: boolean) {
+      providerChooserVisible = visible;
+      if (!visible) return;
+      characterSelectionUntil = 0;
+      providerSelection = 0;
+      // The rejection resolves just before the client rebuilds this screen.
+      // Two frames let that rebuild install its canvas listeners before the
+      // synthetic move gives the first button its visible hover state.
+      requestAnimationFrame(() => requestAnimationFrame(() => {
+        if (providerChooserVisible) pointAtProviderSelection();
+      }));
+    },
+    expectCharacterSelection() {
+      providerChooserVisible = false;
+      characterSelectionUntil = performance.now() + CHARACTER_SELECTION_WINDOW_MS;
+    },
   });
 };

--- a/src/renderer/memory-warning.ts
+++ b/src/renderer/memory-warning.ts
@@ -15,6 +15,7 @@ export interface MemoryWarningPresenter {
 export function bindMemoryWarning(
   document: Document,
   reload: () => void,
+  surfaces: GwonmacSurfaceController | null = null,
 ): MemoryWarningPresenter | null {
   const root = document.getElementById("memory-notice");
   const live = document.getElementById("memory-notice-text");
@@ -34,6 +35,18 @@ export function bindMemoryWarning(
   let currentLevel: MemoryWarningLevel | null = null;
   let dismissedLevel: MemoryWarningLevel | null = null;
   const rank = (level: MemoryWarningLevel) => level === "critical" ? 2 : 1;
+  const dismiss = () => {
+    dismissedLevel = currentLevel;
+    root.hidden = true;
+    details.open = false;
+    dismissable?.setOpen(false);
+    document.getElementById("canvas")?.focus();
+  };
+  const dismissable = surfaces?.register({
+    root,
+    priority: 8,
+    dismiss,
+  }) ?? null;
 
   for (const name of [
     "keydown", "keyup", "pointerdown", "pointerup", "pointermove",
@@ -44,14 +57,10 @@ export function bindMemoryWarning(
 
   reloadButton.addEventListener("click", () => {
     root.hidden = true;
+    dismissable?.setOpen(false);
     reload();
   });
-  laterButton.addEventListener("click", () => {
-    dismissedLevel = currentLevel;
-    root.hidden = true;
-    details.open = false;
-    document.getElementById("canvas")?.focus();
-  });
+  laterButton.addEventListener("click", dismiss);
 
   return {
     present(level, capBytes) {
@@ -67,10 +76,12 @@ export function bindMemoryWarning(
       live.setAttribute("role", level === "critical" ? "alert" : "status");
       live.setAttribute("aria-live", level === "critical" ? "assertive" : "polite");
       root.hidden = false;
+      dismissable?.setOpen(true);
     },
     hide() {
       root.hidden = true;
       details.open = false;
+      dismissable?.setOpen(false);
     },
   };
 }

--- a/src/renderer/settings.ts
+++ b/src/renderer/settings.ts
@@ -48,6 +48,8 @@
   const xunlaiStorage = form.elements.namedItem('xunlaiStorage') as HTMLInputElement;
   const travelPalette = form.elements.namedItem('travelPalette') as HTMLInputElement;
   const targetReadout = form.elements.namedItem('targetReadout') as HTMLInputElement;
+  const toolFeatures = byId('settings-tool-features');
+  const toolsOff = byId('settings-tools-off');
   const accountsEnable = byId('accounts-enable') as HTMLButtonElement;
   const accountsStatus = byId('accounts-setup-status');
   const accountsModeStatus = byId('accounts-mode-status');
@@ -109,6 +111,7 @@
   function clearShortcutMessages(): void {
     for (const action of shortcutRows.keys()) {
       const { message, replace } = shortcutRowParts(action);
+      message.textContent = '';
       message.hidden = true;
       replace.hidden = true;
     }
@@ -120,7 +123,7 @@
     for (const action of shortcutRows.keys()) {
       const { value, change } = shortcutRowParts(action);
       value.textContent = recordingShortcut === action
-        ? 'Press shortcut…'
+        ? 'Listening…'
         : shortcutDisplay(resolved[action]);
       change.textContent = recordingShortcut === action ? 'Cancel' : 'Change';
     }
@@ -149,10 +152,13 @@
     pendingShortcutReplacement = null;
     clearShortcutMessages();
     await renderShortcuts(currentSettings);
+    const parts = shortcutRowParts(action);
+    parts.message.textContent =
+      'Press Command with a letter or number · Delete clears · Escape cancels.';
+    parts.message.hidden = false;
     const result = await window.gwNative.shortcuts.capture();
     if (recordingShortcut !== action) return;
     recordingShortcut = null;
-    const parts = shortcutRowParts(action);
     if (result.status === 'cancelled') {
       clearShortcutMessages();
       await renderShortcuts(currentSettings);
@@ -639,6 +645,8 @@
     travelPalette.checked = settings.travelPalette;
     targetReadout.checked = settings.targetReadout;
     void renderShortcuts(settings);
+    toolFeatures.hidden = !settings.gwonmacTools;
+    toolsOff.hidden = settings.gwonmacTools;
     teamManagement.disabled = !settings.gwonmacTools;
     xunlaiStorage.disabled = !settings.gwonmacTools;
     travelPalette.disabled = !settings.gwonmacTools;
@@ -658,11 +666,14 @@
   };
   async function openSettings() {
     const wasOpen = dialog.open;
+    const needsSettings = currentSettings === null;
+    form.setAttribute('aria-busy', String(needsSettings));
+    settingsPanes.inert = needsSettings;
     if (!wasOpen) {
       if (typeof dialog.showModal === 'function') dialog.showModal();
       else dialog.setAttribute('open', '');
     }
-    setFeedback();
+    setFeedback(needsSettings ? 'Loading settings…' : idleFeedback, needsSettings ? 'progress' : 'neutral');
     selectPane(activeSettingsPane);
     if (!wasOpen) {
       form.querySelector<HTMLElement>('.settings-rtab[aria-selected="true"]')
@@ -678,8 +689,12 @@
       // so it is in Settings whether or not the launcher notice was ever seen.
       await readSession().catch(() => undefined);
       await (await dataStrategy).refresh();
+      if (feedback.textContent === 'Loading settings…') setFeedback();
     } catch {
       setFeedback('Settings could not be loaded. Close Settings and try again.', 'error');
+    } finally {
+      form.setAttribute('aria-busy', 'false');
+      settingsPanes.inert = false;
     }
   }
 

--- a/src/renderer/settings.ts
+++ b/src/renderer/settings.ts
@@ -244,6 +244,11 @@
     pendingShortcutReplacement = null;
     clearShortcutMessages();
   });
+  // Settings is renderer UI, not game input. Keep its keys inside the modal;
+  // Escape still reaches the dialog's native cancel behavior because stopping
+  // propagation does not cancel the event.
+  dialog.addEventListener('keydown', (event) => event.stopPropagation());
+  dialog.addEventListener('keyup', (event) => event.stopPropagation());
 
   void import('../shared/ui/resize.js').then(({ installResizeGrip }) => {
     installResizeGrip(settingsResize, {
@@ -652,12 +657,17 @@
     await resolveClientCompatibility();
   };
   async function openSettings() {
-    if (!dialog.open) {
+    const wasOpen = dialog.open;
+    if (!wasOpen) {
       if (typeof dialog.showModal === 'function') dialog.showModal();
       else dialog.setAttribute('open', '');
     }
     setFeedback();
     selectPane(activeSettingsPane);
+    if (!wasOpen) {
+      form.querySelector<HTMLElement>('.settings-rtab[aria-selected="true"]')
+        ?.focus({ preventScroll: true });
+    }
     settingsCache.textContent = 'Checking downloaded game data…';
     try {
       await settingsWrite;

--- a/src/renderer/surface-controller.ts
+++ b/src/renderer/surface-controller.ts
@@ -1,0 +1,119 @@
+/**
+ * Keyboard ownership for non-modal GWonMac surfaces above the game.
+ *
+ * Tools and Travel deliberately stay open when a player clicks Guild Wars, so
+ * DOM focus alone cannot decide which surface Escape or Tab belongs to. This
+ * controller keeps one ordered list of visible host surfaces. Escape dismisses
+ * the topmost one and Tab enters or wraps within it. Native modal dialogs stay
+ * above this list and keep their browser-provided focus and Escape behavior.
+ */
+
+type Surface = Readonly<{
+  root: HTMLElement;
+  priority: number;
+  dismiss(): void;
+}>;
+
+type OpenSurface = Surface & { order: number };
+
+const FOCUSABLE = [
+  "button:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "textarea:not([disabled])",
+  "a[href]",
+  "summary",
+  '[tabindex]:not([tabindex="-1"])',
+].join(",");
+
+function focusableElements(root: HTMLElement): HTMLElement[] {
+  return [...root.querySelectorAll<HTMLElement>(FOCUSABLE)].filter((element) =>
+    !element.hidden
+    && element.getAttribute("aria-hidden") !== "true"
+    && element.closest("[hidden], [inert]") === null
+    && element.getClientRects().length > 0
+  );
+}
+
+export function installSurfaceController(
+  document: Document,
+): GwonmacSurfaceController {
+  const surfaces = new Map<symbol, OpenSurface>();
+  const suppressedKeyUps = new Set<string>();
+  let order = 0;
+
+  const topmost = () => [...surfaces.values()].sort((left, right) =>
+    right.priority - left.priority || right.order - left.order
+  )[0] ?? null;
+
+  const claim = (event: KeyboardEvent) => {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    suppressedKeyUps.add(event.code);
+  };
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (document.querySelector("dialog:modal") !== null) return;
+    const surface = topmost();
+    if (!surface) return;
+
+    if (event.key === "Escape") {
+      claim(event);
+      surface.dismiss();
+      return;
+    }
+    if (
+      event.key !== "Tab"
+      || event.altKey
+      || event.ctrlKey
+      || event.metaKey
+    ) return;
+
+    const elements = focusableElements(surface.root);
+    if (elements.length === 0) {
+      claim(event);
+      return;
+    }
+    const first = elements[0]!;
+    const last = elements.at(-1)!;
+    const active = document.activeElement;
+    if (!surface.root.contains(active)) {
+      claim(event);
+      (event.shiftKey ? last : first).focus({ preventScroll: true });
+    } else if (event.shiftKey && active === first) {
+      claim(event);
+      last.focus({ preventScroll: true });
+    } else if (!event.shiftKey && active === last) {
+      claim(event);
+      first.focus({ preventScroll: true });
+    }
+  };
+
+  const onKeyUp = (event: KeyboardEvent) => {
+    if (!suppressedKeyUps.delete(event.code)) return;
+    event.preventDefault();
+    event.stopImmediatePropagation();
+  };
+
+  window.addEventListener("keydown", onKeyDown, true);
+  window.addEventListener("keyup", onKeyUp, true);
+
+  return Object.freeze({
+    register(surface: Surface): GwonmacSurfaceHandle {
+      const id = Symbol("surface");
+      let open = false;
+      return Object.freeze({
+        setOpen(next: boolean) {
+          if (next === open) return;
+          open = next;
+          if (next) surfaces.set(id, { ...surface, order: order++ });
+          else surfaces.delete(id);
+        },
+        dispose() {
+          open = false;
+          surfaces.delete(id);
+        },
+      });
+    },
+  });
+}

--- a/src/renderer/toolbox-foundation.ts
+++ b/src/renderer/toolbox-foundation.ts
@@ -54,6 +54,8 @@ const TOGGLE_CODE = "Space";
  */
 export interface MountedTool {
   setVisible(visible: boolean): void;
+  /** Ask the tool to close so it can protect any unsaved authoring work. */
+  requestClose(): void;
   /**
    * The companion's latest projection of the running game.
    *
@@ -145,6 +147,17 @@ export function createToolboxFoundation(
   let state: ToolboxState = Object.freeze({ status: "waiting" });
   let overlayOpen = false;
 
+  const requestClose = () => {
+    if (!overlayOpen) return;
+    if (tool) tool.requestClose();
+    else setOpen(false);
+  };
+  const dismissable = window.gwSurfaces.register({
+    root,
+    priority: 4,
+    dismiss: requestClose,
+  });
+
   const releaseGameInput = () => {
     window.dispatchEvent(new CustomEvent("gw:input-reset"));
   };
@@ -155,6 +168,7 @@ export function createToolboxFoundation(
     if (next) ensureTool();
     tool?.setVisible(next);
     root.dataset.open = String(next);
+    dismissable.setOpen(next);
     // Pointer lock still has to go: the tool is unreachable by a captured
     // cursor. The keyboard, though, stays with the game — opening Tools is not
     // a statement that you have stopped playing.
@@ -164,9 +178,13 @@ export function createToolboxFoundation(
     surface.releaseKeyboard();
   };
 
-  // The global chord is the only key the overlay claims from game focus.
-  // Escape is handled inside the overlay boundary below, so with the game
-  // focused it keeps meaning what Guild Wars says it means.
+  const toggleOpen = () => {
+    if (overlayOpen) requestClose();
+    else setOpen(true);
+  };
+
+  // The global chord toggles Tools. The shared surface controller separately
+  // owns Escape and keyboard entry for whichever GWonMac surface is topmost.
   const onToggleChord = (event: KeyboardEvent) => {
     const toggles =
       event.code === TOGGLE_CODE &&
@@ -177,7 +195,7 @@ export function createToolboxFoundation(
     if (!toggles) return;
     event.preventDefault();
     event.stopImmediatePropagation();
-    setOpen(!overlayOpen);
+    toggleOpen();
   };
 
   // Events from Tools chrome stop at this renderer-owned boundary. The game's
@@ -199,17 +217,6 @@ export function createToolboxFoundation(
   ]) {
     root.addEventListener(name, stopAtOverlay);
   }
-
-  // Escape reaches this listener only while the surface holds the keyboard,
-  // which is to say only while the player is typing in the tool. There it means
-  // what it means in any field — stop typing — and hands the game back rather
-  // than closing anything. With the game focused it never fires, so Escape
-  // keeps meaning what Guild Wars says it means.
-  root.addEventListener("keydown", (event) => {
-    if (event.key !== "Escape") return;
-    event.preventDefault();
-    surface.releaseKeyboard();
-  });
 
   // The native Guild Wars cursor is published as the canvas's style cursor.
   // Mirror it so the game cursor stays the cursor over Tools chrome too;
@@ -233,7 +240,7 @@ export function createToolboxFoundation(
   // build with no menu.
   const onCommand = (event: Event) => {
     event.preventDefault();
-    setOpen(!overlayOpen);
+    toggleOpen();
   };
   window.addEventListener("gw:tools-toggle", onCommand);
   window.addEventListener("keydown", onToggleChord, true);
@@ -257,6 +264,7 @@ export function createToolboxFoundation(
       disposed = true;
       tool?.dispose();
       tool = null;
+      dismissable.dispose();
       surface.dispose();
       cursorMirror.disconnect();
       window.removeEventListener("gw:tools-toggle", onCommand);

--- a/src/renderer/tools-host.ts
+++ b/src/renderer/tools-host.ts
@@ -42,6 +42,7 @@ type ToolsAppHandle = Readonly<{
   show(): void;
   hide(): void;
   toggle(): void;
+  requestClose(): void;
   update(observation: ToolboxObservation): void;
   dispose(): void;
 }>;
@@ -179,6 +180,7 @@ export function mountToolsInto(
           if (visible) app.show();
           else app.hide();
         },
+        requestClose: app.requestClose,
         update: app.update,
         dispose: app.dispose,
       };

--- a/src/renderer/travel-palette.ts
+++ b/src/renderer/travel-palette.ts
@@ -53,12 +53,18 @@ export function createTravelPalette(
   let disposed = false;
   let state: TravelGameState = { status: "waiting", reason: "game" };
   let app: TravelPaletteHandle | null = null;
+  const dismissable = window.gwSurfaces.register({
+    root,
+    priority: 6,
+    dismiss: () => setOpen(false),
+  });
 
   const setOpen = (next: boolean) => {
     if (!enabled && next) throw new Error(command.unavailable() ?? "Travel is turned off");
     if (open === next) return;
     open = next;
     root.hidden = !next;
+    dismissable.setOpen(next);
     if (next && parent.ownerDocument.pointerLockElement !== null) {
       parent.ownerDocument.exitPointerLock();
     }
@@ -116,6 +122,7 @@ export function createTravelPalette(
       disposed = true;
       window.removeEventListener("gw:travel-toggle", onCommand);
       app?.dispose();
+      dismissable.dispose();
       style.remove();
       root.remove();
       canvas.focus({ preventScroll: true });

--- a/tests/electron/input-keyboard.spec.ts
+++ b/tests/electron/input-keyboard.spec.ts
@@ -65,6 +65,110 @@ test.describe("renderer keyboard input", () => {
       await closeOffline(fixture);
     }
   });
+  test("lets the client own Tab focus between login fields", async () => {
+    const fixture = await launchCachedClient("gw-tab-focus-e2e-");
+    try {
+      const { page } = fixture;
+      await startGameInput(page);
+      await page.evaluate(() => {
+        const email = document.getElementById("osk-input-email");
+        const password = document.getElementById("osk-input-password");
+        const gameModule = window.Module as OskModuleHost | undefined;
+        if (!(email instanceof HTMLInputElement)) throw new Error("email proxy is missing");
+        if (!(password instanceof HTMLInputElement)) throw new Error("password proxy is missing");
+        if (!gameModule) throw new Error("window.Module is not installed");
+        (window as typeof window & { __tabPrevented?: boolean }).__tabPrevented = false;
+        email.addEventListener("keydown", (event) => {
+          if (event.key !== "Tab") return;
+          (window as typeof window & { __tabPrevented?: boolean }).__tabPrevented =
+            event.defaultPrevented;
+          gameModule.oskActiveInput = password;
+          password.focus();
+        }, { once: true });
+        gameModule.oskActiveInput = email;
+        email.focus();
+      });
+
+      await page.keyboard.press("Tab");
+      expect(await page.evaluate(() => {
+        const clientChoice = (window.Module as OskModuleHost).oskActiveInput;
+        return {
+          active: document.activeElement?.id,
+          clientChoice: clientChoice instanceof Element ? clientChoice.id : null,
+          prevented: (window as typeof window & { __tabPrevented?: boolean }).__tabPrevented,
+        };
+      })).toEqual({
+        active: "osk-input-password",
+        clientChoice: "osk-input-password",
+        prevented: true,
+      });
+
+      // A proxy the client did not claim must return focus to the canvas, not
+      // leave the document body as an intermittent keyboard dead end.
+      expect(await page.evaluate(async () => {
+        const email = document.getElementById("osk-input-email");
+        const gameModule = window.Module as OskModuleHost;
+        gameModule.oskActiveInput = null;
+        email?.focus();
+        await Promise.resolve();
+        return document.activeElement?.id;
+      })).toBe("canvas");
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
+  test("buffers only the first immediate character-selection Enter", async () => {
+    const fixture = await launchCachedClient("gw-character-enter-e2e-");
+    try {
+      const { page } = fixture;
+      await startGameInput(page);
+      await page.evaluate(() => {
+        const canvas = document.getElementById("canvas");
+        if (!(canvas instanceof HTMLCanvasElement)) throw new Error("canvas is missing");
+        new XMLHttpRequest().open("POST", "/webgate/my_account/token.xml");
+        const started = performance.now();
+        (window as typeof window & { __characterEnters?: unknown[] }).__characterEnters = [];
+        for (const type of ["keydown", "keyup"] as const) {
+          canvas.addEventListener(type, (event) => {
+            if (event.key !== "Enter") return;
+            (window as typeof window & { __characterEnters?: unknown[] })
+              .__characterEnters?.push({
+                type: event.type,
+                trusted: event.isTrusted,
+                afterMs: performance.now() - started,
+              });
+          });
+        }
+        canvas.focus();
+      });
+
+      await page.keyboard.press("Enter");
+      await page.waitForTimeout(80);
+      expect(await page.evaluate(() =>
+        (window as typeof window & { __characterEnters?: unknown[] }).__characterEnters,
+      )).toEqual([]);
+      await expect.poll(() => page.evaluate(() =>
+        (window as typeof window & { __characterEnters?: unknown[] }).__characterEnters,
+      )).toHaveLength(2);
+      expect(await page.evaluate(() =>
+        (window as typeof window & {
+          __characterEnters?: Array<{ type: string; trusted: boolean; afterMs: number }>;
+        }).__characterEnters,
+      )).toEqual([
+        { type: "keydown", trusted: false, afterMs: expect.any(Number) },
+        { type: "keyup", trusted: false, afterMs: expect.any(Number) },
+      ]);
+      expect(await page.evaluate(() =>
+        (window as typeof window & {
+          __characterEnters?: Array<{ afterMs: number }>;
+        }).__characterEnters?.[0]?.afterMs,
+      )).toBeGreaterThanOrEqual(140);
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
   test("uses physical main-block keys without changing typed text", async () => {
     const fixture = await launchCachedClient("gw-physical-key-e2e-");
     try {

--- a/tests/electron/input-toolbox.spec.ts
+++ b/tests/electron/input-toolbox.spec.ts
@@ -67,6 +67,7 @@ test.describe("renderer Tools input", () => {
                 onVisibilityChange: (visible: boolean) => void,
               ): Promise<{
                 setVisible(visible: boolean): void;
+                requestClose(): void;
                 update(state: object): void;
                 dispose(): void;
               } | null>;
@@ -118,6 +119,10 @@ test.describe("renderer Tools input", () => {
             return Promise.resolve({
               setVisible: (visible: boolean) => {
                 panel.style.display = visible ? "block" : "none";
+              },
+              requestClose: () => {
+                panel.style.display = "none";
+                onVisibilityChange(false);
               },
               // A real tool draws the party from this. The stub records what
               // arrived and when, which is the part the overlay is responsible
@@ -224,6 +229,20 @@ test.describe("renderer Tools input", () => {
       await expect(body).toHaveAttribute("data-toolbox-game-key-ups", "1");
       await expect(body).toHaveAttribute("data-toolbox-last-key-up", "KeyW");
 
+      // Tab is the explicit keyboard entry into the open topmost surface. It
+      // is claimed before Guild Wars and wraps inside the surface at its ends.
+      await page.keyboard.press("Tab");
+      await expect.poll(() => isDomActiveElement(
+        page.getByRole("button", { name: "Tool action" }),
+      )).toBe(true);
+      await expect(body).toHaveAttribute("data-toolbox-game-keys", "1");
+      await page.getByRole("button", { name: "Close tool" }).focus();
+      await page.keyboard.press("Tab");
+      await expect.poll(() => isDomActiveElement(
+        page.getByRole("button", { name: "Tool action" }),
+      )).toBe(true);
+      await page.locator("#canvas").click({ position: GAME_POINT });
+
       // The tool is open and the game still has the keyboard.
       await page.keyboard.press("x");
       await expect(body).toHaveAttribute("data-toolbox-game-keys", "2");
@@ -235,7 +254,7 @@ test.describe("renderer Tools input", () => {
       // tool stays open rather than dismissing itself.
       await page.locator("#canvas").click({ position: GAME_POINT });
       await expect(tool).toBeVisible();
-      await expect(body).toHaveAttribute("data-toolbox-game-mouse-downs", "2");
+      await expect(body).toHaveAttribute("data-toolbox-game-mouse-downs", "3");
       await expect.poll(() => isDomActiveElement(page.locator("#canvas")))
         .toBe(true);
 
@@ -243,7 +262,7 @@ test.describe("renderer Tools input", () => {
       // and does not leak the click into the game. This is the whole point —
       // the player clicks the panel and can still run.
       await page.getByRole("button", { name: "Tool action" }).click();
-      await expect(body).toHaveAttribute("data-toolbox-game-mouse-downs", "2");
+      await expect(body).toHaveAttribute("data-toolbox-game-mouse-downs", "3");
       await expect.poll(() => isDomActiveElement(page.locator("#canvas")))
         .toBe(true);
       await page.keyboard.press("x");
@@ -259,23 +278,29 @@ test.describe("renderer Tools input", () => {
       await expect(page.getByLabel("Tool field")).toHaveValue("aggro");
       await expect(body).toHaveAttribute("data-toolbox-game-keys", "3");
 
-      // Escape means "stop typing" and gives the game back. It never reaches
-      // Guild Wars from here, and it does not close the tool: closing is the
-      // chord, the menu, or the tool's own close control.
+      // Escape closes the topmost host surface even when a field owns focus.
+      // It does not also spend an in-game Escape.
       await page.keyboard.press("Escape");
       await expect.poll(() => isDomActiveElement(page.locator("#canvas")))
         .toBe(true);
-      await expect(tool).toBeVisible();
+      await expect(tool).toBeHidden();
       await expect(body).toHaveAttribute("data-toolbox-game-keys", "3");
 
-      // With the game holding the keyboard again, Escape belongs to Guild Wars.
-      await page.keyboard.press("Escape");
-      await expect(body).toHaveAttribute("data-toolbox-game-keys", "4");
+      await page.keyboard.press("Control+Shift+Space");
       await expect(tool).toBeVisible();
 
-      // The chord toggles from anywhere.
-      await page.keyboard.press("Control+Shift+Space");
+      // The same Escape closes Tools after a game click left focus on canvas.
+      const gameKeysBeforeCanvasEscape = await body.getAttribute(
+        "data-toolbox-game-keys",
+      );
+      await page.keyboard.press("Escape");
       await expect(tool).toBeHidden();
+      await expect(body).toHaveAttribute(
+        "data-toolbox-game-keys",
+        gameKeysBeforeCanvasEscape ?? "",
+      );
+
+      // The chord toggles from anywhere.
       await page.keyboard.press("Control+Shift+Space");
       await expect(tool).toBeVisible();
 
@@ -407,17 +432,18 @@ test.describe("renderer Tools input", () => {
       await settleEmbeddedShow();
       await expect.poll(() => isDomActiveElement(canvas)).toBe(true);
 
-      // Establish the boundary explicitly: Escape from a Tools field returns
-      // the keyboard to Guild Wars without spending the in-game Escape or
-      // closing the window. Reopening intentionally leaves focus on the game.
+      // Escape closes Tools from either a field or the game without spending
+      // the same key in Guild Wars. Reopening leaves focus on the game.
       const search = page.getByPlaceholder("Search names, tags, heroes, skills");
       await search.focus();
       await expect.poll(() => isDomActiveElement(search)).toBe(true);
       await page.keyboard.press("Escape");
-      await expect(panel).toBeVisible();
+      await expect(panel).toBeHidden();
       await expect.poll(() => isDomActiveElement(canvas)).toBe(true);
-      await page.keyboard.press("Escape");
+      await page.keyboard.press("Control+Shift+Space");
       await expect(panel).toBeVisible();
+      await page.keyboard.press("Escape");
+      await expect(panel).toBeHidden();
       await expect.poll(() => isDomActiveElement(canvas)).toBe(true);
     } finally {
       await closeOffline(fixture);
@@ -429,18 +455,25 @@ test.describe("renderer Tools input", () => {
     try {
       const disposed = await fixture.page.evaluate(async () => {
         const specifier = "./toolbox-foundation.js";
-        const module = await import(specifier) as {
+        const surfaceSpecifier = "./surface-controller.js";
+        const [module, surfaces] = await Promise.all([
+          import(specifier),
+          import(surfaceSpecifier),
+        ]) as [{
           createToolboxFoundation(
             parent: HTMLElement,
             options: { mountTool(): Promise<{
               setVisible(visible: boolean): void;
+              requestClose(): void;
               update(state: object): void;
               dispose(): void;
             }> },
           ): { dispose(): void };
-        };
+        }, typeof import("../../src/renderer/surface-controller.js")];
+        window.gwSurfaces = surfaces.installSurfaceController(document);
         let resolveMount!: (tool: {
           setVisible(visible: boolean): void;
+          requestClose(): void;
           update(state: object): void;
           dispose(): void;
         }) => void;
@@ -452,6 +485,7 @@ test.describe("renderer Tools input", () => {
         foundation.dispose();
         resolveMount({
           setVisible: () => undefined,
+          requestClose: () => undefined,
           update: () => undefined,
           dispose: () => { count += 1; },
         });

--- a/tests/electron/input-travel.spec.ts
+++ b/tests/electron/input-travel.spec.ts
@@ -1,0 +1,77 @@
+import { expect, test } from "@playwright/test";
+import {
+  closeOffline,
+  isDomActiveElement,
+  launchCachedClient,
+} from "./fixtures.mjs";
+import { startGameInput } from "./input-helpers.js";
+
+test.describe("renderer Travel input", () => {
+  test("stays open over game interaction and closes from every focus state", async () => {
+    const fixture = await launchCachedClient("gw-travel-input-e2e-");
+    try {
+      const { page } = fixture;
+      await startGameInput(page);
+      await page.evaluate(async () => {
+        document.getElementById("loading")?.classList.add("gone");
+        const specifier = "./travel-palette.js";
+        const module = await import(specifier) as
+          typeof import("../../src/renderer/travel-palette.js");
+        const palette = module.createTravelPalette(document.body, {
+          travel: () => undefined,
+          unavailable: () => null,
+        });
+        palette.setEnabled(true);
+      });
+
+      const canvas = page.locator("#canvas");
+      const palette = page.getByRole("dialog", { name: "Travel" });
+      const search = page.getByRole("combobox", { name: "Search destinations" });
+
+      await page.evaluate(() => {
+        window.dispatchEvent(new CustomEvent("gw:travel-toggle", {
+          cancelable: true,
+          detail: {},
+        }));
+      });
+      await expect(palette).toBeVisible();
+      await expect.poll(() => isDomActiveElement(search)).toBe(true);
+
+      // Native modal work is above non-modal surfaces. The first Escape closes
+      // Settings and restores Travel; the palette remains open underneath.
+      await page.evaluate(() => {
+        window.dispatchEvent(new CustomEvent("gw:settings", {
+          detail: { pane: "controls" },
+        }));
+      });
+      await expect(page.locator("#settings-dialog")).toHaveAttribute("open", "");
+      await page.keyboard.press("Escape");
+      await expect(page.locator("#settings-dialog")).not.toHaveAttribute("open", "");
+      await expect(palette).toBeVisible();
+
+      await canvas.click({ position: { x: 20, y: 300 } });
+      await expect.poll(() => isDomActiveElement(canvas)).toBe(true);
+      await expect(palette).toBeVisible();
+      await page.keyboard.press("Escape");
+      await expect(palette).toBeHidden();
+      await expect.poll(() => isDomActiveElement(canvas)).toBe(true);
+
+      await page.evaluate(() => {
+        window.dispatchEvent(new CustomEvent("gw:travel-toggle", {
+          cancelable: true,
+          detail: {},
+        }));
+      });
+      await expect.poll(() => isDomActiveElement(search)).toBe(true);
+      await canvas.click({ position: { x: 20, y: 300 } });
+      await page.keyboard.press("Tab");
+      await expect.poll(() => isDomActiveElement(search)).toBe(true);
+
+      await page.getByRole("button", { name: "Close Travel" }).click();
+      await expect(palette).toBeHidden();
+      await expect.poll(() => isDomActiveElement(canvas)).toBe(true);
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+});

--- a/tests/electron/input-travel.spec.ts
+++ b/tests/electron/input-travel.spec.ts
@@ -36,6 +36,10 @@ test.describe("renderer Travel input", () => {
       });
       await expect(palette).toBeVisible();
       await expect.poll(() => isDomActiveElement(search)).toBe(true);
+      await expect(search).toHaveAccessibleName("Search destinations");
+      await expect(palette.getByRole("listbox")).toHaveCount(0);
+      await expect(page.getByText("Start typing to search all outposts."))
+        .toBeVisible();
 
       // Native modal work is above non-modal surfaces. The first Escape closes
       // Settings and restores Travel; the palette remains open underneath.

--- a/tests/electron/settings-data-display.spec.ts
+++ b/tests/electron/settings-data-display.spec.ts
@@ -436,7 +436,9 @@ test.describe("data and display settings", () => {
         compactGeometry.dialog.bottom,
       );
       expect(compactGeometry.paneWidth[1]).toBe(compactGeometry.paneWidth[0]);
-      expect(compactGeometry.railWidth[1]).toBe(compactGeometry.railWidth[0]);
+      expect(compactGeometry.railWidth[1]!).toBeGreaterThan(
+        compactGeometry.railWidth[0]!,
+      );
 
       const firstCompactTab = page.locator(`#settings-tab-${first}`);
       await firstCompactTab.focus();

--- a/tests/electron/settings-tools-updates.spec.ts
+++ b/tests/electron/settings-tools-updates.spec.ts
@@ -124,6 +124,18 @@ test.describe("tools and update settings", () => {
         }),
       ).toBe("CmdOrCtrl+,");
       await expect(page.locator("#settings-dialog")).toHaveAttribute("open", "");
+      await expect.poll(() => page.evaluate(() => document.activeElement?.id))
+        .toBe("settings-tab-data");
+      await page.keyboard.press("Escape");
+      await expect(page.locator("#settings-dialog")).not.toHaveAttribute("open", "");
+      await app.evaluate(({ Menu }) => {
+        Menu.getApplicationMenu()
+          ?.items[0]?.submenu?.items.find(
+            (candidate) => candidate.label === "Settings…",
+          )
+          ?.click();
+      });
+      await expect(page.locator("#settings-dialog")).toHaveAttribute("open", "");
       await page.locator("#settings-done").click();
       await app.evaluate(({ Menu }) => {
         Menu.getApplicationMenu()

--- a/tests/electron/settings-tools-updates.spec.ts
+++ b/tests/electron/settings-tools-updates.spec.ts
@@ -48,7 +48,9 @@ test.describe("tools and update settings", () => {
       });
 
       await toolsRow.locator(".settings-shortcut-change").click();
-      await expect(toolsRow.locator("kbd")).toHaveText("Press shortcut…");
+      await expect(toolsRow.locator("kbd")).toHaveText("Listening…");
+      await expect(toolsRow.locator(".settings-shortcut-message"))
+        .toContainText("Delete clears · Escape cancels");
       await sendInput("B", ["meta"]);
       await expect.poll(() => page.evaluate(() => window.gwNative.settings.get()))
         .toMatchObject({
@@ -57,7 +59,7 @@ test.describe("tools and update settings", () => {
       await expect(page.locator("body")).toHaveAttribute("data-shortcut-actions", "0");
 
       await toolsRow.locator(".settings-shortcut-change").click();
-      await expect(toolsRow.locator("kbd")).toHaveText("Press shortcut…");
+      await expect(toolsRow.locator("kbd")).toHaveText("Listening…");
       await sendInput("K", ["meta", "shift"]);
       await expect.poll(async () => ({
         key: await toolsRow.locator("kbd").textContent(),
@@ -124,6 +126,13 @@ test.describe("tools and update settings", () => {
         }),
       ).toBe("CmdOrCtrl+,");
       await expect(page.locator("#settings-dialog")).toHaveAttribute("open", "");
+      await expect(page.locator("#settings-form")).toHaveAttribute(
+        "aria-busy",
+        "false",
+      );
+      await expect(page.locator("#settings-feedback")).toHaveText(
+        "Changes save automatically.",
+      );
       await expect.poll(() => page.evaluate(() => document.activeElement?.id))
         .toBe("settings-tab-data");
       await page.keyboard.press("Escape");
@@ -345,6 +354,12 @@ test.describe("tools and update settings", () => {
       );
       await page.locator("#settings-tab-controls").click();
       const controls = page.locator("#settings-pane-controls");
+      await expect(page.locator("#settings-tool-features")).toBeHidden();
+      await expect(page.locator("#settings-tools-off")).toBeVisible();
+      await expect(page.locator("#settings-availability")).not.toHaveAttribute(
+        "open",
+        "",
+      );
       await expect(controls).toContainText(
         "Guild Wars cursor",
       );

--- a/tests/electron/steam-login.spec.ts
+++ b/tests/electron/steam-login.spec.ts
@@ -17,11 +17,13 @@ import path from "node:path";
 import { promisify } from "node:util";
 import {
   closeOffline,
+  launchCachedClient,
   launchOffline,
   launchOfflineAt,
   root,
   type OfflineFixture,
 } from "./fixtures.mts";
+import { startGameInput } from "./input-helpers.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -287,8 +289,8 @@ test.describe("the Steam credential seam", () => {
   });
 
   test("advertises Steam and nothing else", async () => {
-    // The client renders its Steam button beside the
-    // unchanged ArenaNet email/password form.
+    // The client offers Steam in its provider chooser, before the unchanged
+    // ArenaNet email/password form.
     fixture = await launchOffline("gw-steam-providers-");
     const answers = await fixture.page.evaluate(() => {
       const login = (
@@ -324,6 +326,64 @@ test.describe("the Steam credential seam", () => {
     expect(result).toEqual({ settled: "rejected" });
     expect(await windowCount(fixture.app)).toBe(before);
     expect(await readStore(fixture.app)).toBe(null);
+  });
+
+  test("makes the provider chooser operable from the keyboard", async () => {
+    fixture = await launchCachedClient("gw-steam-provider-keyboard-");
+    await startGameInput(fixture.page);
+    expect(await getAuthToken(fixture, "Steam", true)).toEqual({
+      settled: "rejected",
+    });
+    await fixture.page.evaluate(() => {
+      const canvas = document.getElementById("canvas");
+      if (!(canvas instanceof HTMLCanvasElement)) throw new Error("canvas is missing");
+      const events: Array<{ type: string; x: number; y: number; trusted: boolean }> = [];
+      for (const type of ["mousemove", "mousedown", "mouseup", "click"]) {
+        canvas.addEventListener(type, (event) => {
+          if (!(event instanceof MouseEvent)) return;
+          events.push({
+            type: event.type,
+            x: event.clientX,
+            y: event.clientY,
+            trusted: event.isTrusted,
+          });
+        });
+      }
+      (window as typeof window & { __providerMouse?: typeof events }).__providerMouse = events;
+      canvas.focus();
+    });
+
+    await fixture.page.keyboard.press("Tab");
+    await fixture.page.keyboard.press("Enter");
+    const result = await fixture.page.evaluate(() => {
+      const canvas = document.getElementById("canvas") as HTMLCanvasElement;
+      const rect = canvas.getBoundingClientRect();
+      return {
+        events: (window as typeof window & {
+          __providerMouse?: Array<{
+            type: string;
+            x: number;
+            y: number;
+            trusted: boolean;
+          }>;
+        }).__providerMouse,
+        expected: {
+          x: rect.left + rect.width / 2 - rect.height * 161 / 600,
+          y: rect.top + rect.height * 253 / 600,
+        },
+      };
+    });
+    expect(result.events?.map(({ type }) => type)).toEqual([
+      "mousemove",
+      "mousedown",
+      "mouseup",
+      "click",
+    ]);
+    expect(result.events?.every(({ trusted }) => !trusted)).toBe(true);
+    expect(Math.abs((result.events?.at(-1)?.x ?? 0) - result.expected.x))
+      .toBeLessThanOrEqual(1);
+    expect(Math.abs((result.events?.at(-1)?.y ?? 0) - result.expected.y))
+      .toBeLessThanOrEqual(1);
   });
 
   test("drives an explicit request through the real bridge and IPC seam", async () => {

--- a/tests/helpers/packaged-enhancement-scenarios.ts
+++ b/tests/helpers/packaged-enhancement-scenarios.ts
@@ -526,6 +526,11 @@ export async function assertToolboxFoundationLifecycle() {
       const { installCertifiedCompanion }:
         typeof import("../../src/renderer/certified-companion-installation.ts") =
           await import(specifier);
+      const surfaceSpecifier = "./surface-controller.js";
+      const { installSurfaceController }:
+        typeof import("../../src/renderer/surface-controller.ts") =
+          await import(surfaceSpecifier);
+      window.gwSurfaces = installSurfaceController(document);
       const snapshotSpecifier = "./companion-snapshot.js";
       const { readCompanionSnapshot }:
         typeof import("../../src/renderer/companion-snapshot.ts") =

--- a/tests/unit/client-compatibility-notice.test.ts
+++ b/tests/unit/client-compatibility-notice.test.ts
@@ -33,12 +33,14 @@ class FakeElement extends EventTarget {
   textContent = "";
   hidden = false;
   disabled = false;
+  open = false;
   dataset: Record<string, string> = {};
   click() { this.dispatchEvent(new Event("click")); }
 }
 
 const IDS = [
   "settings-compat-status", "settings-compat-detail", "settings-compat-version",
+  "settings-availability",
   "client-compat-title", "client-compat-detail", "client-compat-version",
   "client-compat", "client-compat-play",
   "client-compat-check", "client-compat-restart", "client-compat-update",
@@ -236,6 +238,7 @@ describe("client compatibility notice", () => {
     assert.equal(dom.element("settings-compat-status").textContent, report.summary);
     assert.equal(dom.element("client-compat-title").textContent, report.summary);
     assert.equal(dom.element("settings-feature-nativeCursor").textContent, "Unavailable");
+    assert.equal(dom.element("settings-availability").open, true);
   });
 
   it("dismisses the launcher even when acknowledgement cannot persist", async () => {

--- a/tests/unit/memory-warning.test.ts
+++ b/tests/unit/memory-warning.test.ts
@@ -89,4 +89,28 @@ describe("memory warning presenter", () => {
     assert.equal(reloads, 1);
     assert.equal(dom.element("memory-notice").hidden, true);
   });
+
+  it("registers as a dismissible keyboard surface while visible", () => {
+    const dom = memoryDom();
+    const open: boolean[] = [];
+    let dismiss = () => {};
+    const surfaces: GwonmacSurfaceController = {
+      register(surface) {
+        dismiss = surface.dismiss;
+        return {
+          setOpen(value) { open.push(value); },
+          dispose() {},
+        };
+      },
+    };
+    const presenter = bindMemoryWarning(dom.document, () => {}, surfaces);
+    assert.ok(presenter);
+
+    presenter.present("low", 2_147_483_648);
+    assert.deepEqual(open, [true]);
+    dismiss();
+    assert.equal(dom.element("memory-notice").hidden, true);
+    assert.equal(dom.element("canvas").focused, true);
+    assert.deepEqual(open, [true, false]);
+  });
 });


### PR DESCRIPTION
Login, character selection, Settings, and in-game Tools did not share one keyboard interaction model. Focus could fall back into the game canvas, Escape could close the wrong surface or nothing at all, and the same login flow exposed two different account-choice screens.

This change gives every app-owned surface one predictable focus and dismissal path, then polishes Settings and Travel around that foundation.

## What changed

- Make the existing-account login flow consistent after leaving character creation.
- Keep Tab within the login fields and actions instead of losing focus to the game client.
- Make the first Return activate the selected character reliably.
- Route Escape through the topmost app surface, including Settings, Build and Hero management, Travel, warnings, and dialogs.
- Keep open non-modal Tools visible while the player interacts with the game, while Escape still closes them from game focus.
- Restore focus deliberately when a surface closes.
- Open Travel in a favorites-first state, support palette-wide 1–9 shortcuts, and require typing before destination results appear.
- Improve Travel errors, status feedback, result sizing, and keyboard semantics.
- Simplify Settings hierarchy, responsive navigation, shortcut recording, disabled Tools options, and compatibility details.
- Document the keyboard and Travel behavior and add focused regression coverage.

## Root cause

Keyboard handling was split between native dialogs, custom overlays, and the Guild Wars canvas. Each surface implemented parts of focus, Escape, Tab, and Return behavior independently. That allowed the canvas or another scope to consume keys before the intended control acted.

The renderer now has one surface controller for ordering, dismissal, and focus restoration. Individual interfaces retain only their local actions.

## Player impact

The complete login-to-game path can be used without a mouse. App-owned windows behave consistently over Guild Wars, Travel starts in a safe non-destructive state, and Settings remains usable at compact window sizes.

## Verification

- Full `pnpm verify`
- 1,073 unit tests
- 165 policy tests
- 83 Tools unit tests
- 41 integration tests
- 21 release tests
- 33 Tools browser journeys
- 124 Electron scenarios passed; one intentional live-client scenario skipped
- Packaged application smoke and Enhancement lifecycle checks
- Desktop and compact Electron visual review
- `git diff --check origin/main...HEAD`

- [x] I kept this pull request focused.
- [x] I rebased onto the latest `main`.
- [x] I did not add credentials, game binaries, diagnostics, or private traffic.
- [x] I updated documentation and tests for the changed behavior.
