### PR TITLE
fix(input): keep game audio playing across app controls

### DIFF
--- a/docs/process-model.md
+++ b/docs/process-model.md
@@ -141,6 +141,11 @@ trackpad actions go to Guild Wars without a selectable input mode. The host
 releases held keys and buttons when focus changes or native UI consumes a
 release.
 
+Moving focus from the game canvas into a control in the same renderer does not
+blur Guild Wars. Settings, Tools, Travel, warnings, and game text fields remain
+part of the active game window, so they do not mute game audio. A real window
+blur still reaches Guild Wars and releases held input.
+
 Right-drag uses pointer lock and a virtual cursor. The host bounds drag
 recycling so camera movement can continue. The host normalizes supported
 physical keyboard positions before the official client receives them. Text

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -1112,17 +1112,13 @@ function loadGlue(isProxyRouteLabel: (route: string) => boolean) {
     log,
   });
 
-  // The desktop text proxy and the same-window Toolbox overlay are part of the
-  // game experience, not a loss of application focus. Keep the client's
-  // canvas-blur callback from muting audio for those internal transfers. Real
-  // window blur still reaches the canvas and releases input.
+  // Every same-document control is part of the game experience, not a loss of
+  // application focus. Keep the client's canvas-blur callback from muting
+  // audio when focus moves into Settings, Tools, Travel, a warning, or a game
+  // text proxy. A real window blur has no related element, so it still reaches
+  // the client and releases input.
   c.addEventListener('blur', (event) => {
-    const target = event.relatedTarget;
-    if (
-      oskInputs.has(target) ||
-      (target instanceof Element
-        && target.closest('#toolbox-foundation, #memory-notice'))
-    ) {
+    if (event.relatedTarget instanceof Element) {
       event.stopImmediatePropagation();
     }
   }, true);

--- a/tests/electron/input-keyboard.spec.ts
+++ b/tests/electron/input-keyboard.spec.ts
@@ -65,6 +65,45 @@ test.describe("renderer keyboard input", () => {
       await closeOffline(fixture);
     }
   });
+
+  test("keeps same-window controls inside the game focus lifecycle", async () => {
+    const fixture = await launchCachedClient("gw-internal-focus-e2e-");
+    try {
+      const { page } = fixture;
+      await startGameInput(page);
+      const result = await page.evaluate(() => {
+        const canvas = document.getElementById("canvas");
+        if (!(canvas instanceof HTMLCanvasElement)) {
+          throw new Error("#canvas is missing");
+        }
+        const control = document.createElement("input");
+        control.setAttribute("aria-label", "Renderer control");
+        document.body.append(control);
+        let clientCanvasBlurs = 0;
+        canvas.addEventListener("blur", () => {
+          clientCanvasBlurs += 1;
+        });
+
+        canvas.focus();
+        control.focus();
+        const afterInternalTransfer = clientCanvasBlurs;
+
+        canvas.focus();
+        canvas.dispatchEvent(new FocusEvent("blur", { relatedTarget: null }));
+        const afterWindowBlur = clientCanvasBlurs;
+        control.remove();
+        return { afterInternalTransfer, afterWindowBlur };
+      });
+
+      expect(result).toEqual({
+        afterInternalTransfer: 0,
+        afterWindowBlur: 1,
+      });
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
   test("lets the client own Tab focus between login fields", async () => {
     const fixture = await launchCachedClient("gw-tab-focus-e2e-");
     try {

--- a/tests/electron/input-travel.spec.ts
+++ b/tests/electron/input-travel.spec.ts
@@ -65,6 +65,17 @@ test.describe("renderer Travel input", () => {
       const canvas = page.locator("#canvas");
       const palette = page.getByRole("dialog", { name: "Travel" });
       const search = page.getByRole("combobox", { name: "Search destinations" });
+      await page.evaluate(() => {
+        const gameCanvas = document.getElementById("canvas");
+        if (!(gameCanvas instanceof HTMLCanvasElement)) {
+          throw new Error("#canvas is missing");
+        }
+        document.body.dataset.travelCanvasBlurs = "0";
+        gameCanvas.addEventListener("blur", () => {
+          const count = Number(document.body.dataset.travelCanvasBlurs ?? "0");
+          document.body.dataset.travelCanvasBlurs = String(count + 1);
+        });
+      });
 
       await page.evaluate(() => {
         window.dispatchEvent(new CustomEvent("gw:travel-toggle", {
@@ -74,6 +85,10 @@ test.describe("renderer Travel input", () => {
       });
       await expect(palette).toBeVisible();
       await expect.poll(() => isDomActiveElement(search)).toBe(true);
+      await expect(page.locator("body")).toHaveAttribute(
+        "data-travel-canvas-blurs",
+        "0",
+      );
       await expect(search).toHaveAccessibleName("Search destinations");
       await expect(palette.getByRole("listbox")).toHaveCount(0);
       await expect(page.getByText("Start typing to search all outposts."))


### PR DESCRIPTION
## Problem

Focusing Travel, Settings, Tools, or another in-game app control moved DOM focus away from the Guild Wars canvas. Guild Wars interpreted that same-window focus transfer as an application blur, which could mute the game music even though the user was still interacting with the game window.

## Solution

Treat every focus transfer to another control in the same renderer as part of the active game experience. The canvas blur callback is suppressed only when the next focus target is a same-document element. A real window blur still reaches Guild Wars, so held input is released as before.

This replaces the incomplete per-window selector list with one shared rule covering:

- Travel
- Settings and its panes
- Tools, Build and Hero management, and nested dialogs
- warnings and game text fields

The process model now owns this behavior, and Electron regression tests cover both the general focus lifecycle and the real Travel search flow.

## User impact

Keyboard focus can move naturally into every in-game app window without stopping Guild Wars audio. Leaving the actual application still behaves normally.

## Verification

- `pnpm verify`
- focused Electron keyboard, Travel, Tools, and Settings scenarios
- packaged Enhancement runtime verification

