### PR TITLE
feat(input): add privacy-safe input harness

### DIFF
--- a/docs/process-model.md
+++ b/docs/process-model.md
@@ -173,9 +173,15 @@ required behavior. It is not a saved player preference. If an ArenaNet build
 is not certified, the official client remains playable with the normal macOS
 pointer and without the certified repair.
 
-The input trace is a renderer-only troubleshooting view. It records bounded
-counts and distances. It does not record coordinates. It does not cross IPC or
-write to disk.
+The input harness is a player-visible troubleshooting view with one ordered,
+bounded renderer-memory timeline. AppKit and main-process decisions cross one
+redacted main-to-renderer event; renderer keyboard, hidden text proxy, pointer,
+wheel, pointer-lock, cleanup, and thresholded gamepad transitions join the same
+timeline. It records no text, clipboard contents, secret-field lengths, exact
+printable keys while a text proxy is active, coordinates, account identifiers,
+or controller identifiers. Pausing changes only recording. Closing clears the
+memory. The trace is not persisted, exported with diagnostics, or sent over the
+network.
 
 ## Native network boundary
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -311,8 +311,10 @@ opens its GitHub issue form immediately. GitHub issues are public.
   **Help → Diagnostics → Export Recent Diagnostics…** and attach the ZIP.
 - Use **Record Performance Problem** for stutter. Reproduce it, press
   **Command-Shift-M**, stop the capture, and export it when prompted.
-- Use **Show Input Trace** for click problems. It records bounded counts and
-  distances, not coordinates. Closing it discards the trace.
+- Use **Show Input Trace** for keyboard, text, pointer, shortcut, or gamepad
+  problems. Reproduce the problem, pause the bounded timeline, then copy it
+  into the issue. It omits text, secrets, field lengths, coordinates, account
+  identifiers, and controller identifiers. Closing it discards the trace.
 
 The diagnostics ZIP excludes saved login, account request bodies, game traffic,
 chat, and crash dumps. Other text is scanned for known secret and path patterns.

--- a/src/main/input-trace.ts
+++ b/src/main/input-trace.ts
@@ -1,0 +1,29 @@
+/**
+ * Main-process producer and enable gate for the player-visible input harness.
+ * Renderer memory remains the only trace store.
+ */
+import type { BrowserWindow } from 'electron';
+import { IPC } from '../shared/contracts.js';
+import type { InputTraceEntry } from '../shared/input-trace.js';
+
+const enabledWindows = new WeakSet<BrowserWindow>();
+
+export function inputTraceEnabled(win: BrowserWindow): boolean {
+  return enabledWindows.has(win);
+}
+
+export function setInputTraceEnabled(
+  win: BrowserWindow,
+  enabled: boolean,
+): void {
+  if (enabled) enabledWindows.add(win);
+  else enabledWindows.delete(win);
+}
+
+export function recordMainInput(
+  win: BrowserWindow,
+  entry: InputTraceEntry,
+): void {
+  if (!enabledWindows.has(win) || win.isDestroyed()) return;
+  win.webContents.send(IPC.inputTraceEvent, entry);
+}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -99,6 +99,7 @@ import {
 } from "./core/native-keychain.js";
 import { loadNativeHost } from "./native-host.js";
 import { installMacosCommandKeyUps } from "./macos-command-key-ups.js";
+import { recordMainInput } from './input-trace.js';
 import { cleanupLegacySecretFiles } from "./core/legacy-secret-cleanup.js";
 import {
   distributionCapabilities,
@@ -391,6 +392,16 @@ if (primaryInstance) void app.whenReady().then(async () => {
         : null;
     },
     release(win, code) {
+      recordMainInput(win, {
+        source: 'appkit',
+        kind: 'native-key',
+        phase: 'up',
+        key: code.startsWith('Key') || code.startsWith('Digit')
+          ? 'printable'
+          : 'other',
+        repeat: false,
+        decision: 'normalized-release',
+      });
       void sendRendererCommand(win, { type: "input.release", code });
     },
   });

--- a/src/main/window-menu.ts
+++ b/src/main/window-menu.ts
@@ -26,6 +26,10 @@ import {
   toggleTools,
 } from "./renderer-commands.js";
 import { isDevBuild } from "./protocol.js";
+import {
+  inputTraceEnabled,
+  setInputTraceEnabled,
+} from './input-trace.js';
 import type { WindowHost } from "./window.js";
 import {
   resolveShortcuts,
@@ -270,7 +274,9 @@ export function installApplicationMenu({
               id: "toggle-input-trace",
               label: "Show Input Trace",
               click: () => {
-                void sendRendererCommand(win, { type: "input.trace" });
+                const enabled = !inputTraceEnabled(win);
+                setInputTraceEnabled(win, enabled);
+                void sendRendererCommand(win, { type: "input.trace", enabled });
               },
             },
             {

--- a/src/main/window-shortcuts.ts
+++ b/src/main/window-shortcuts.ts
@@ -11,6 +11,16 @@ import {
   type ShortcutCaptureResult,
   type ShortcutOverrides,
 } from "../shared/keyboard-shortcuts.js";
+import { recordMainInput } from './input-trace.js';
+
+const tracedKey = (key: string) => {
+  if (["Meta", "Control", "Shift", "Alt"].includes(key)) return 'modifier' as const;
+  if (["ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "Tab"].includes(key)) {
+    return 'navigation' as const;
+  }
+  if (["Backspace", "Delete", "Enter", "Escape"].includes(key)) return 'editing' as const;
+  return key.length === 1 ? 'printable' as const : 'other' as const;
+};
 
 interface ShortcutActions {
   run(action: ShortcutAction): void;
@@ -29,6 +39,10 @@ class WindowShortcuts {
     this.#actions = actions;
     win.webContents.on("before-input-event", (event, input) => {
       if (input.type === "keyUp") {
+        recordMainInput(win, {
+          source: 'main', kind: 'native-key', phase: 'up',
+          key: tracedKey(input.key), repeat: false, decision: 'forwarded',
+        });
         if (input.key === "Meta" || input.code === this.#capturedCode) {
           this.#capturedCode = null;
         }
@@ -36,6 +50,10 @@ class WindowShortcuts {
       }
       if (input.type !== "keyDown") return;
       if (input.code === this.#capturedCode) {
+        recordMainInput(win, {
+          source: 'main', kind: 'native-key', phase: 'down',
+          key: tracedKey(input.key), repeat: input.isAutoRepeat, decision: 'capture',
+        });
         event.preventDefault();
         return;
       }
@@ -43,6 +61,10 @@ class WindowShortcuts {
         if (["Meta", "Control", "Shift", "Alt"].includes(input.key)) return;
         if (input.key === "Tab") return;
         event.preventDefault();
+        recordMainInput(win, {
+          source: 'main', kind: 'native-key', phase: 'down',
+          key: tracedKey(input.key), repeat: input.isAutoRepeat, decision: 'capture',
+        });
         this.#capturedCode = input.code;
         if (input.key === "Escape") {
           this.#finish({ status: "cancelled" });
@@ -60,6 +82,10 @@ class WindowShortcuts {
       }
       for (const [action, binding] of Object.entries(this.#shortcuts)) {
         if (binding && shortcutMatches(binding, input)) {
+          recordMainInput(win, {
+            source: 'main', kind: 'native-key', phase: 'down',
+            key: tracedKey(input.key), repeat: input.isAutoRepeat, decision: 'shortcut',
+          });
           event.preventDefault();
           if (!input.isAutoRepeat) {
             this.#actions.run(action as ShortcutAction);
@@ -67,6 +93,10 @@ class WindowShortcuts {
           return;
         }
       }
+      recordMainInput(win, {
+        source: 'main', kind: 'native-key', phase: 'down',
+        key: tracedKey(input.key), repeat: input.isAutoRepeat, decision: 'forwarded',
+      });
     });
     win.on("blur", () => this.cancelCapture());
     win.on("closed", () => this.cancelCapture());

--- a/src/preload/preload.body.cjs
+++ b/src/preload/preload.body.cjs
@@ -137,6 +137,9 @@ const api = {
       rendererCommandHandler = handler;
     },
   },
+  inputTrace: {
+    onEntry: (callback) => listen(IPC.inputTraceEvent, callback),
+  },
   progress: {
     current: () => ipcRenderer.invoke(IPC.progressCurrent),
     onChange: (callback) => listen(IPC.progressEvent, callback),

--- a/src/renderer/commands.ts
+++ b/src/renderer/commands.ts
@@ -117,7 +117,7 @@
         });
         break;
       case 'input.trace':
-        dispatch('gw:input-trace');
+        dispatch('gw:input-trace', command.enabled);
         break;
       case 'diagnostics.toggle':
         dispatch('gw:diagnostics-toggle');

--- a/src/renderer/gamepad-trace.ts
+++ b/src/renderer/gamepad-trace.ts
@@ -1,0 +1,73 @@
+/**
+ * Thresholded, identifier-free gamepad transitions for the input harness.
+ * Sampling exists only while the player has the harness open.
+ */
+import type { InputTrace } from '../shared/input-trace.js';
+
+export interface GamepadTraceController {
+  setEnabled(enabled: boolean): void;
+}
+
+type Snapshot = {
+  buttons: boolean[];
+  axes: Array<-1 | 0 | 1>;
+};
+
+const axisDirection = (value: number): -1 | 0 | 1 =>
+  value < -0.55 ? -1 : value > 0.55 ? 1 : 0;
+
+export function installGamepadTrace(trace: InputTrace): GamepadTraceController {
+  const previous = new Map<number, Snapshot>();
+  let active = false;
+  let frame = 0;
+
+  const sample = () => {
+    frame = 0;
+    if (!active) return;
+    const seen = new Set<number>();
+    for (const gamepad of navigator.getGamepads?.() ?? []) {
+      if (!gamepad) continue;
+      seen.add(gamepad.index);
+      const before = previous.get(gamepad.index);
+      const next: Snapshot = {
+        buttons: gamepad.buttons.map((button) => button.pressed),
+        axes: gamepad.axes.map(axisDirection),
+      };
+      if (!before) {
+        trace.record({ source: 'renderer', kind: 'gamepad', phase: 'connected' });
+      } else {
+        next.buttons.forEach((pressed, control) => {
+          if (pressed === before.buttons[control]) return;
+          trace.record({
+            source: 'renderer', kind: 'gamepad',
+            phase: pressed ? 'button-down' : 'button-up', control,
+          });
+        });
+        next.axes.forEach((direction, control) => {
+          if (direction === before.axes[control]) return;
+          trace.record({
+            source: 'renderer', kind: 'gamepad', phase: 'axis', control, direction,
+          });
+        });
+      }
+      previous.set(gamepad.index, next);
+    }
+    for (const index of previous.keys()) {
+      if (seen.has(index)) continue;
+      previous.delete(index);
+      trace.record({ source: 'renderer', kind: 'gamepad', phase: 'disconnected' });
+    }
+    frame = requestAnimationFrame(sample);
+  };
+
+  return Object.freeze({
+    setEnabled(enabled: boolean) {
+      if (enabled === active) return;
+      active = enabled;
+      previous.clear();
+      if (enabled) frame = requestAnimationFrame(sample);
+      else if (frame) cancelAnimationFrame(frame);
+      frame = 0;
+    },
+  });
+}

--- a/src/renderer/gw-native.d.ts
+++ b/src/renderer/gw-native.d.ts
@@ -17,6 +17,11 @@ import type {
   RendererMetrics,
 } from "../shared/diagnostics.js";
 import type { ToolboxObservation } from "../shared/builds/live-party.js";
+import type {
+  InputTrace as SharedInputTrace,
+  InputTraceEntry as SharedInputTraceEntry,
+  InputTraceRecord as SharedInputTraceRecord,
+} from '../shared/input-trace.js';
 
 /**
  * Negative type test, run by every `tsc -p tsconfig.renderer.json`.
@@ -58,43 +63,9 @@ declare global {
     }>): GwonmacSurfaceHandle;
   }
 
-  /**
-   * One thing the input host saw or decided, before the trace stamps it. The
-   * union is closed because a trace whose vocabulary can grow by writing a
-   * string is a trace nobody can summarise: every member here has a fixed row
-   * in the overlay and a fixed line in the copied transcript.
-   *
-   * `travelPx` is a distance, `detail` is Chromium's click-run count, and
-   * neither is a position — no member carries a coordinate, so the transcript
-   * a player pastes into a public issue cannot describe where their window is
-   * or what they clicked.
-   */
-  type InputTraceEntry =
-    | { kind: "press"; button: number; detail: number; modifiers: string }
-    | { kind: "release"; button: number; travelPx: number }
-    | { kind: "modifier"; key: "ctrl" | "shift" | "alt"; down: boolean }
-    /**
-     * A press Chromium counted as an even click of a run. `delivered` is
-     * whether the client could be told: false means the served module carries
-     * no double-click flag, which is what an uncertified build looks like from
-     * here and the first thing to check when double-click does nothing.
-     */
-    | { kind: "double-click"; delivered: boolean }
-    | { kind: "pointer-lock"; locked: boolean }
-    | { kind: "release-all"; cause: "blur" | "hidden" | "command" };
-
-  /** An entry with the trace's own timing attached. */
-  type InputTraceRecord = InputTraceEntry & {
-    atMs: number;
-    sinceMs: number | null;
-  };
-
-  interface InputTrace {
-    enabled(): boolean;
-    /** Returns the state it switched to, so a caller can report it. */
-    toggle(): boolean;
-    record(entry: InputTraceEntry): void;
-  }
+  type InputTraceEntry = SharedInputTraceEntry;
+  type InputTraceRecord = SharedInputTraceRecord;
+  type InputTrace = SharedInputTrace;
 
   interface LoadingController {
     set(message: string, fraction: number | null, detail?: string): void;

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -483,6 +483,7 @@ let applyAppearance:
   typeof import('./appearance.js').applyAppearance = () => {};
 let inputHost: GameInputController | null = null;
 let inputTrace: InputTrace | null = null;
+let gamepadTrace: import('./gamepad-trace.js').GamepadTraceController | null = null;
 window.gwToolsSettings = () => Object.freeze({
   enabled: appSettings?.gwonmacTools ?? false,
   teamManagement: appSettings?.teamManagement ?? true,
@@ -525,6 +526,7 @@ let host: typeof import('./graphics.js') &
   typeof import('./surface-controller.js') &
   typeof import('./native-double-click.js') &
   typeof import('./text-editing.js') &
+  typeof import('./gamepad-trace.js') &
   typeof import('./template-save-compatibility.js') &
   typeof import('./template-filesystem-trace.js');
 
@@ -1052,11 +1054,16 @@ function loadGlue(isProxyRouteLabel: (route: string) => boolean) {
     document.body,
     (text) => native().clipboard.writeText(text),
   );
+  gamepadTrace = host.installGamepadTrace(inputTrace);
   // Install before game input so a key claimed by the topmost GWonMac surface
   // cannot also reach the official client's window-capture listener.
   window.gwSurfaces = host.installSurfaceController(document);
-  window.addEventListener('gw:input-trace', () => {
-    log(`input trace: ${inputTrace?.toggle() ? 'on' : 'off'}`);
+  native().inputTrace.onEntry((entry) => inputTrace?.record(entry));
+  window.addEventListener('gw:input-trace', (event) => {
+    if (!(event instanceof CustomEvent) || typeof event.detail !== 'boolean') return;
+    inputTrace?.setEnabled(event.detail);
+    gamepadTrace?.setEnabled(event.detail);
+    log(`input trace: ${event.detail ? 'on' : 'off'}`);
   });
 
   // Text entry runs through these, not through keydown on the canvas. The
@@ -1082,6 +1089,7 @@ function loadGlue(isProxyRouteLabel: (route: string) => boolean) {
     writeText: (text) => native().clipboard.writeText(text),
     edit: (command) => native().clipboard.edit(command),
     diagnostics: window.gwDiagnostics,
+    trace: inputTrace,
     log,
   });
 
@@ -1167,6 +1175,7 @@ function loadGlue(isProxyRouteLabel: (route: string) => boolean) {
       surfaceController,
       nativeDoubleClickModule,
       textEditing,
+      gamepadTraceModule,
       templateSaveCompatibility,
       templateFilesystemTrace,
       clientHealth,
@@ -1185,6 +1194,7 @@ function loadGlue(isProxyRouteLabel: (route: string) => boolean) {
       import('./surface-controller.js'),
       import('./native-double-click.js'),
       import('./text-editing.js'),
+      import('./gamepad-trace.js'),
       import('./template-save-compatibility.js'),
       import('./template-filesystem-trace.js'),
       import('./client-health.js'),
@@ -1202,6 +1212,7 @@ function loadGlue(isProxyRouteLabel: (route: string) => boolean) {
       ...surfaceController,
       ...nativeDoubleClickModule,
       ...textEditing,
+      ...gamepadTraceModule,
       ...templateSaveCompatibility,
       ...templateFilesystemTrace,
     };

--- a/src/renderer/input-trace.ts
+++ b/src/renderer/input-trace.ts
@@ -1,159 +1,98 @@
 /**
- * The input trace: a live, bounded record of what the input host saw and what
- * it decided, drawn over the game so a player can reproduce a click bug and
- * hand back the sequence that caused it.
- *
- * It owns the ring buffer, the overlay, and the text it copies out. It decides
- * nothing about input — `input.ts` remains the one input policy and calls in
- * here at the points where it makes a choice. Turning the trace off must not
- * change a single client-visible event, so this module never dispatches, never
- * cancels, and never touches the canvas.
- *
- * Deliberately not the diagnostics recorder: that is the certified,
- * closed-schema, main-process path for shipped telemetry. This is a developer
- * and bug-reporter instrument the player can read on screen and paste into an
- * issue, and it never leaves the renderer unless the player copies it.
+ * Player-visible input harness. This is the sole owner of trace memory,
+ * presentation, and copied output. It never changes input or persists data.
  */
+import type {
+  InputTrace,
+  InputTraceEntry,
+  InputTraceRecord,
+} from '../shared/input-trace.js';
 
-// A hand cannot produce more than a few events per second that matter here,
-// and a reporter needs the run-up to the mistake rather than the whole
-// session. Two hundred entries is about a minute of deliberate clicking.
-const TRACE_CAPACITY = 200;
-
-// Rows drawn in the panel. The buffer keeps more than the panel shows so the
-// copied text carries the run-up that scrolled away.
-const VISIBLE_ROWS = 14;
+const TRACE_CAPACITY = 1_000;
+const VISIBLE_ROWS = 18;
 
 const OVERLAY_CSS = `
-/*
- * Bottom left: the other fixed overlays own the rest — #capture-status the top
- * left, #diagnostics the top right, Tools the bottom right — and a capture is
- * exactly the thing most likely to be running at the same time as this. Only
- * the two buttons take the pointer; every other pixel of the panel lets a
- * click through to the game beneath it.
- */
-#input-trace {
-  position: fixed;
-  bottom: 12px;
-  left: 12px;
-  z-index: 5;
-  width: 460px;
-  max-width: calc(100vw - 24px);
-  box-sizing: border-box;
-  padding: 8px 12px;
-  border: 1px solid #4a4740;
-  border-radius: 3px;
-  /* Near-opaque on purpose. At 0.88 the game's own chat drew straight through
-     the rows and the trace was unreadable in exactly the crowded district
-     someone would be debugging in. */
-  background: rgba(8, 8, 10, 0.97);
-  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.55);
-  color: #e8e4d8;
-  font: 11px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace;
-  font-variant-numeric: tabular-nums;
-  pointer-events: none;
-  user-select: none;
-  -webkit-user-select: none;
-}
-#input-trace[hidden] { display: none; }
-#input-trace header {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-bottom: 6px;
-  color: #c8aa6e;
-  text-transform: uppercase;
-  letter-spacing: 0.06em;
-}
-#input-trace header span[data-role="count"] { color: #8d8a82; margin-left: auto; }
-#input-trace button {
-  pointer-events: auto;
-  padding: 2px 8px;
-  border: 1px solid #524e44;
-  border-radius: 2px;
-  background: #1d1c19;
-  color: #e8e4d8;
-  font: inherit;
-  text-transform: none;
-  letter-spacing: 0;
-  cursor: default;
-}
-#input-trace button:hover { background: #2a2823; border-color: #6b6557; }
-#input-trace button:focus-visible { outline: 1px solid #c8aa6e; outline-offset: 1px; }
-#input-trace ol {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-  display: grid;
-  gap: 1px;
-}
-#input-trace li { white-space: pre; overflow: hidden; text-overflow: ellipsis; }
-#input-trace li[data-tone="decision"] { color: #ffb488; }
-#input-trace li[data-tone="refused"] { color: #8d8a82; }
-#input-trace p {
-  margin: 6px 0 0;
-  color: #8d8a82;
-  white-space: normal;
-}
+#input-trace { position:fixed; bottom:12px; left:12px; z-index:5;
+  width:min(720px,calc(100vw - 24px)); box-sizing:border-box; padding:8px 12px;
+  border:1px solid #4a4740; border-radius:3px; background:rgba(8,8,10,.97);
+  box-shadow:0 6px 20px rgba(0,0,0,.55); color:#e8e4d8;
+  font:11px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;
+  font-variant-numeric:tabular-nums; pointer-events:none; user-select:none; }
+#input-trace[hidden] { display:none; }
+#input-trace header { display:flex; align-items:center; gap:8px; margin-bottom:6px;
+  color:#c8aa6e; text-transform:uppercase; letter-spacing:.06em; }
+#input-trace header span[data-role="count"] { color:#8d8a82; margin-left:auto; }
+#input-trace button { pointer-events:auto; padding:2px 8px; border:1px solid #524e44;
+  border-radius:2px; background:#1d1c19; color:#e8e4d8; font:inherit;
+  text-transform:none; letter-spacing:0; cursor:default; }
+#input-trace button:hover { background:#2a2823; border-color:#6b6557; }
+#input-trace button:focus-visible { outline:1px solid #c8aa6e; outline-offset:1px; }
+#input-trace ol { margin:0; padding:0; list-style:none; display:grid; gap:1px; }
+#input-trace li { white-space:pre; overflow:hidden; text-overflow:ellipsis; }
+#input-trace li[data-tone="decision"] { color:#ffb488; }
+#input-trace li[data-tone="refused"] { color:#8d8a82; }
+#input-trace p { margin:6px 0 0; color:#8d8a82; white-space:normal; }
 `;
 
+const BUTTON_NAMES: Readonly<Record<number, string>> = {
+  0: 'left', 1: 'middle', 2: 'right',
+};
+
 const label = (record: InputTraceRecord): { text: string; tone: string } => {
-  const at = String(Math.round(record.atMs)).padStart(6, ' ');
+  const sequence = String(record.sequence).padStart(4, '0');
   const gap = record.sinceMs === null
-    ? '     —'
-    : `${String(Math.round(record.sinceMs)).padStart(5, ' ')}ms`;
+    ? '    —'
+    : `${String(Math.round(record.sinceMs)).padStart(4, ' ')}ms`;
+  const prefix = `${sequence} ${gap} ${record.source.padEnd(8)}`;
   switch (record.kind) {
+    case 'native-key':
+      return {
+        tone: record.decision === 'forwarded' ? 'event' : 'decision',
+        text: `${prefix} key ${record.phase} ${record.key}`
+          + `${record.repeat ? ' repeat' : ''} → ${record.decision}`,
+      };
+    case 'key':
+      return {
+        tone: record.decision === 'suppressed' ? 'decision' : 'event',
+        text: `${prefix} key ${record.phase} ${record.owner}`
+          + `${record.code ? ` ${record.code}` : ''}`
+          + `${record.repeat ? ' repeat' : ''}`
+          + ` trusted=${record.trusted} → ${record.decision}`,
+      };
+    case 'text':
+      return {
+        tone: 'event',
+        text: `${prefix} text ${record.owner} ${record.phase}`
+          + ` trusted=${record.trusted} repeat=${record.repeat}`
+          + ` type=${record.inputType} selection=${record.selectionChanged}`
+          + ` delta=${record.delta}`,
+      };
     case 'press':
-      return {
-        tone: 'event',
-        text: `${at} ${gap}  press  ${BUTTON_NAMES[record.button] ?? record.button}`
-          + `  run=${record.detail}${record.modifiers}`,
-      };
+      return { tone: 'event', text: `${prefix} press ${BUTTON_NAMES[record.button] ?? 'other'} run=${record.detail}${record.modifiers}` };
     case 'release':
-      return {
-        tone: 'event',
-        text: `${at} ${gap}  release ${BUTTON_NAMES[record.button] ?? record.button}`
-          + `  moved=${record.travelPx}px`,
-      };
+      return { tone: 'event', text: `${prefix} release ${BUTTON_NAMES[record.button] ?? 'other'} travel=${record.travel} remaining=${record.buttonsRemaining}` };
     case 'modifier':
-      // Its own row rather than a column on the press, because the client
-      // builds the modifier state a click carries out of these events and not
-      // out of the click. A missing row here is the whole bug for Ctrl+click.
+      return { tone: 'event', text: `${prefix} ${record.key} ${record.down ? 'down' : 'up'}` };
+    case 'double-click':
+      return record.delivered
+        ? { tone: 'decision', text: `${prefix} DOUBLE-CLICK flagged` }
+        : { tone: 'refused', text: `${prefix} DOUBLE-CLICK unavailable` };
+    case 'pointer-lock':
+      return { tone: 'decision', text: `${prefix} pointer lock ${record.locked ? 'engaged' : 'released'}` };
+    case 'wheel':
+      return { tone: 'event', text: `${prefix} wheel ${record.direction} ${record.mode}` };
+    case 'release-all':
+      return { tone: 'refused', text: `${prefix} input released (${record.cause})` };
+    case 'gamepad':
       return {
         tone: 'event',
-        text: `${at} ${gap}  ${record.key}${record.down ? ' down' : ' up'}`,
+        text: `${prefix} gamepad ${record.phase}`
+          + `${record.control === undefined ? '' : ` control=${record.control}`}`
+          + `${record.direction === undefined ? '' : ` direction=${record.direction}`}`,
       };
-    case 'double-click':
-      // Recorded from the press that carried it, so it sits immediately under
-      // its own `press … run=2` row rather than a quarter second later.
-      return record.delivered
-        ? { tone: 'decision', text: `${at} ${gap}  DOUBLE-CLICK flagged` }
-        : {
-            tone: 'refused',
-            text: `${at} ${gap}  DOUBLE-CLICK unavailable (client not certified)`,
-          };
-    case 'pointer-lock':
-      return {
-        tone: 'decision',
-        text: `${at} ${gap}  pointer lock ${record.locked ? 'engaged' : 'released'}`,
-      };
-    case 'release-all':
-      return { tone: 'refused', text: `${at} ${gap}  input released (${record.cause})` };
   }
 };
 
-const BUTTON_NAMES: Readonly<Record<number, string>> = {
-  0: 'left ',
-  1: 'middle',
-  2: 'right',
-};
-
-/**
- * `writeText` is the native clipboard bridge, not `navigator.clipboard`: the
- * renderer is a sandboxed custom-scheme document, so the Clipboard API rejects
- * the write and the button reported a failure it could do nothing about. The
- * same bridge already serves Cmd+C from the game's text proxy.
- */
 export function createInputTrace(
   parent: HTMLElement,
   writeText: (text: string) => Promise<void>,
@@ -165,47 +104,57 @@ export function createInputTrace(
   root.hidden = true;
   root.innerHTML = `
     <header>
-      Input trace
+      Input harness
+      <button type="button" data-role="pause">Pause</button>
       <button type="button" data-role="copy">Copy</button>
       <button type="button" data-role="clear">Clear</button>
       <span data-role="count"></span>
     </header>
     <ol data-role="rows"></ol>
-    <p data-role="hint">Reproduce the problem, then Copy and paste it into the issue.</p>
+    <p>Reproduce the problem, Pause, then Copy and paste it into the issue.</p>
   `;
   parent.append(style, root);
 
   const rows = root.querySelector<HTMLOListElement>('[data-role="rows"]')!;
   const count = root.querySelector<HTMLElement>('[data-role="count"]')!;
+  const pauseButton = root.querySelector<HTMLButtonElement>('[data-role="pause"]')!;
   const copyButton = root.querySelector<HTMLButtonElement>('[data-role="copy"]')!;
   const clearButton = root.querySelector<HTMLButtonElement>('[data-role="clear"]')!;
-
   const entries: InputTraceRecord[] = [];
-  let enabled = false;
+  let active = false;
+  let isPaused = false;
   let lastAt: number | null = null;
-  // A frame's worth of records is one repaint, not one repaint each: a burst
-  // that arrives inside a single task must not lay out the panel per entry.
+  let sequence = 0;
   let painting = false;
 
   const paint = () => {
     painting = false;
-    const shown = entries.slice(-VISIBLE_ROWS);
-    rows.replaceChildren(...shown.map((record) => {
-      const { text, tone } = label(record);
+    rows.replaceChildren(...entries.slice(-VISIBLE_ROWS).map((record) => {
+      const rendered = label(record);
       const li = document.createElement('li');
-      li.dataset.tone = tone;
-      li.textContent = text;
+      li.dataset.tone = rendered.tone;
+      li.textContent = rendered.text;
       return li;
     }));
     count.textContent = `${entries.length}/${TRACE_CAPACITY}`;
   };
-
   const schedulePaint = () => {
     if (painting) return;
     painting = true;
     requestAnimationFrame(paint);
   };
+  const clear = () => {
+    entries.length = 0;
+    lastAt = null;
+    sequence = 0;
+    schedulePaint();
+  };
 
+  pauseButton.addEventListener('click', () => {
+    isPaused = !isPaused;
+    pauseButton.textContent = isPaused ? 'Resume' : 'Pause';
+  });
+  clearButton.addEventListener('click', clear);
   copyButton.addEventListener('click', () => {
     void writeText(transcript(entries)).then(
       () => { copyButton.textContent = 'Copied'; },
@@ -214,53 +163,43 @@ export function createInputTrace(
       setTimeout(() => { copyButton.textContent = 'Copy'; }, 1_500);
     });
   });
-  clearButton.addEventListener('click', () => {
-    entries.length = 0;
-    lastAt = null;
-    schedulePaint();
-  });
 
   return Object.freeze({
-    enabled: () => enabled,
-    toggle() {
-      enabled = !enabled;
+    enabled: () => active,
+    paused: () => isPaused,
+    setEnabled(enabled: boolean) {
+      active = enabled;
       root.hidden = !enabled;
-      // A trace that keeps accumulating while hidden would hand back a
-      // transcript of whatever the player did after they stopped looking.
       if (!enabled) {
-        entries.length = 0;
-        lastAt = null;
+        isPaused = false;
+        pauseButton.textContent = 'Pause';
+        clear();
+      } else {
+        schedulePaint();
       }
-      schedulePaint();
-      return enabled;
     },
     record(entry: InputTraceEntry) {
-      if (!enabled) return;
+      if (!active || isPaused) return;
       const atMs = performance.now();
-      const record = {
+      entries.push({
         ...entry,
+        sequence: ++sequence,
         atMs,
         sinceMs: lastAt === null ? null : atMs - lastAt,
-      } as InputTraceRecord;
+      } as InputTraceRecord);
       lastAt = atMs;
-      entries.push(record);
       if (entries.length > TRACE_CAPACITY) entries.shift();
       schedulePaint();
     },
   });
 }
 
-/**
- * The text the Copy button produces: the same rows the panel draws, oldest
- * first, under a header naming what produced them. Nothing here is an
- * identifier — no coordinates, no window position, no account state — so a
- * player can paste it into a public issue without reading it first.
- */
 function transcript(entries: readonly InputTraceRecord[]): string {
-  const head = [
-    `gwonmac input trace — ${entries.length} events`,
-    'columns: elapsed  gap  event  detail',
+  return [
+    `gwonmac input harness — ${entries.length} events`,
+    'privacy: text, clipboard data, field lengths, coordinates, account and device identifiers omitted',
+    'columns: sequence  gap  source  event  decision',
     '',
-  ];
-  return [...head, ...entries.map((record) => label(record).text)].join('\n');
+    ...entries.map((record) => label(record).text),
+  ].join('\n');
 }

--- a/src/renderer/input.ts
+++ b/src/renderer/input.ts
@@ -433,16 +433,51 @@ export const installGameInput = ({
     }, CHARACTER_ENTER_DELAY_MS);
   };
 
+  const traceOwner = (target: EventTarget | null) => {
+    if (target === canvas) return 'canvas' as const;
+    if (textInputs.has(target)) {
+      return target instanceof HTMLInputElement &&
+        (target.type === 'password' || target.type === 'email')
+        ? 'secret' as const
+        : 'text' as const;
+    }
+    return target instanceof Element && target.closest('[data-gwonmac-surface]')
+      ? 'surface' as const
+      : 'other' as const;
+  };
+
+  const traceKey = (
+    event: KeyboardEvent,
+    phase: 'down' | 'up',
+    decision: 'observed' | 'held' | 'released' | 'suppressed' | 'command',
+  ) => {
+    const owner = traceOwner(event.target);
+    trace?.record({
+      source: 'renderer',
+      kind: 'key',
+      phase,
+      owner,
+      ...(owner === 'canvas' ? { code: event.code } : {}),
+      repeat: event.repeat,
+      trusted: event.isTrusted,
+      decision,
+    });
+  };
+
   window.addEventListener('keydown', (event) => {
     if (!event.isTrusted) return;
     // Guild Wars has no Command modifier. Let Chromium and the main-process
     // shortcut controller keep the combination, but do not let the bare
     // modifier transition disturb game keys that are already held.
     if (isCommandKey(event.code)) {
+      traceKey(event, 'down', 'command');
       event.stopImmediatePropagation();
       return;
     }
-    if (handleProviderKey(event)) return;
+    if (handleProviderKey(event)) {
+      traceKey(event, 'down', 'suppressed');
+      return;
+    }
     if (
       event.target === canvas &&
       event.key === 'Enter' &&
@@ -452,6 +487,7 @@ export const installGameInput = ({
       event.preventDefault();
       event.stopImmediatePropagation();
       suppressedKeyUps.add(event.code);
+      traceKey(event, 'down', 'suppressed');
       sendBufferedCharacterEnter(event);
       return;
     }
@@ -464,9 +500,14 @@ export const installGameInput = ({
     }
     const held = heldKeys.get(event.code);
     const key = clientKey(event, event.repeat ? held?.key : undefined);
-    if (event.repeat && held) return;
+    if (event.repeat && held) {
+      traceKey(event, 'down', 'observed');
+      return;
+    }
     const modifier = TRACED_MODIFIERS[key];
-    if (modifier) trace?.record({ kind: 'modifier', key: modifier, down: true });
+    if (modifier) trace?.record({
+      source: 'renderer', kind: 'modifier', key: modifier, down: true,
+    });
     heldKeys.set(event.code, {
       target: event.target,
       key,
@@ -480,14 +521,17 @@ export const installGameInput = ({
       altKey: event.altKey,
       metaKey: event.metaKey,
     });
+    traceKey(event, 'down', 'held');
   }, true);
   window.addEventListener('keyup', (event) => {
     if (!event.isTrusted) return;
     if (isCommandKey(event.code)) {
+      traceKey(event, 'up', 'command');
       event.stopImmediatePropagation();
       return;
     }
     if (suppressedKeyUps.delete(event.code)) {
+      traceKey(event, 'up', 'suppressed');
       event.preventDefault();
       event.stopImmediatePropagation();
       return;
@@ -495,8 +539,11 @@ export const installGameInput = ({
     const held = heldKeys.get(event.code);
     const key = clientKey(event, held?.key);
     const modifier = TRACED_MODIFIERS[key];
-    if (modifier) trace?.record({ kind: 'modifier', key: modifier, down: false });
+    if (modifier) trace?.record({
+      source: 'renderer', kind: 'modifier', key: modifier, down: false,
+    });
     heldKeys.delete(event.code);
+    traceKey(event, 'up', 'released');
     // A release landing on renderer UI (the Tools palette) never bubbles back
     // to the client's canvas listeners, so a press the canvas received would
     // stay held forever. Replay exactly those releases at the press target;
@@ -508,6 +555,7 @@ export const installGameInput = ({
   window.addEventListener('mousedown', (event) => {
     if (!event.isTrusted) return;
     trace?.record({
+      source: 'renderer',
       kind: 'press',
       button: event.button,
       detail: event.detail,
@@ -532,14 +580,19 @@ export const installGameInput = ({
     if (!event.isTrusted) return;
     const held = heldButtons.get(event.button);
     trace?.record({
+      source: 'renderer',
       kind: 'release',
       button: event.button,
-      travelPx: held
-        ? Math.round(Math.hypot(
+      travel: held
+        ? (() => {
+            const pixels = Math.hypot(
           event.clientX - held.originX,
           event.clientY - held.originY,
-        ))
-        : 0,
+            );
+            return pixels < 3 ? 'still' : pixels < 40 ? 'short' : 'far';
+          })()
+        : 'still',
+      buttonsRemaining: heldButtons.size - (held ? 1 : 0),
     });
     heldButtons.delete(event.button);
     if (held && held.target === canvas && event.target !== canvas) {
@@ -560,18 +613,18 @@ export const installGameInput = ({
     }
   }, true);
 
-  const releaseFor = (cause: 'blur' | 'hidden' | 'command') => () => {
+  const releaseFor = (cause: 'blur' | 'hidden' | 'command' | 'pagehide') => () => {
     // Only the causes are named, not a new reason to release: every one of
     // these already released everything, and the trace exists to say which
     // native interruption ended a drag the player thought they still had.
     if (heldKeys.size || heldButtons.size) {
-      trace?.record({ kind: 'release-all', cause });
+      trace?.record({ source: 'renderer', kind: 'release-all', cause });
     }
     suppressedKeyUps.clear();
     releaseAll();
   };
   window.addEventListener('blur', releaseFor('blur'));
-  window.addEventListener('pagehide', releaseFor('blur'));
+  window.addEventListener('pagehide', releaseFor('pagehide'));
   window.addEventListener('gw:input-reset', releaseFor('command'));
   window.addEventListener('gw:input-release', (event) => {
     if (!(event instanceof CustomEvent) || typeof event.detail !== 'string') return;
@@ -588,6 +641,16 @@ export const installGameInput = ({
   canvas.addEventListener('wheel', (event) => {
     if (normalizedWheels.has(event)) return;
     if (event.deltaMode !== globalThis.WheelEvent.DOM_DELTA_PIXEL) {
+      trace?.record({
+        source: 'renderer',
+        kind: 'wheel',
+        direction: Math.abs(event.deltaX) > Math.abs(event.deltaY)
+          ? event.deltaX < 0 ? 'left' : 'right'
+          : event.deltaY < 0 ? 'up' : 'down',
+        mode: event.deltaMode === globalThis.WheelEvent.DOM_DELTA_LINE
+          ? 'line'
+          : 'page',
+      });
       resetWheel();
       return;
     }
@@ -607,6 +670,12 @@ export const installGameInput = ({
     wheelRemainder += event.deltaY;
     const steps = Math.max(-3, Math.min(3, Math.trunc(wheelRemainder / 100)));
     if (!steps) return;
+    trace?.record({
+      source: 'renderer',
+      kind: 'wheel',
+      direction: steps < 0 ? 'up' : 'down',
+      mode: 'pixel',
+    });
     wheelRemainder -= steps * 100;
     const normalized = new globalThis.WheelEvent('wheel', {
       bubbles: true,
@@ -755,7 +824,7 @@ export const installGameInput = ({
     const locked = document.pointerLockElement === canvas;
     if (locked !== lockTraced) {
       lockTraced = locked;
-      trace?.record({ kind: 'pointer-lock', locked });
+      trace?.record({ source: 'renderer', kind: 'pointer-lock', locked });
     }
     canvas.classList.toggle('cursor-hidden', locked);
     if (locked && !pointerWanted) {

--- a/src/renderer/native-double-click.ts
+++ b/src/renderer/native-double-click.ts
@@ -54,7 +54,11 @@ export const installNativeDoubleClick = ({
     // the client cannot be told about is the report worth having, and the
     // absent row would otherwise look like the press never happened.
     if (doubleClick) {
-      trace?.record({ kind: 'double-click', delivered: global !== null });
+      trace?.record({
+        source: 'renderer',
+        kind: 'double-click',
+        delivered: global !== null,
+      });
     }
   }, true);
   log('native double-click: enabled');

--- a/src/renderer/text-editing.ts
+++ b/src/renderer/text-editing.ts
@@ -8,6 +8,12 @@
  * which an edit reaches the client.
  */
 import type { TextEditCommand } from '../shared/contracts.js';
+import type {
+  InputTrace,
+  InputTraceInputType,
+  InputTraceLengthDelta,
+  InputTraceTextPhase,
+} from '../shared/input-trace.js';
 
 type GameTextField = HTMLInputElement | HTMLTextAreaElement;
 
@@ -17,6 +23,7 @@ type TextEditingOptions = {
   writeText(text: string): Promise<void>;
   edit(command: TextEditCommand): Promise<void>;
   diagnostics?: GameInputDiagnostics;
+  trace?: InputTrace;
   log(...values: unknown[]): void;
 };
 
@@ -35,11 +42,30 @@ const selection = (field: GameTextField) => ({
   end: field.selectionEnd,
 });
 
+const inputType = (value: string): InputTraceInputType => {
+  if (value === 'insertText') return 'insert-text';
+  if (value === 'insertFromPaste') return 'insert-paste';
+  if (value.includes('Composition')) return 'insert-composition';
+  if (value === 'deleteContentBackward') return 'delete-backward';
+  if (value === 'deleteContentForward') return 'delete-forward';
+  if (value === 'deleteByCut') return 'delete-cut';
+  if (value === 'historyUndo' || value === 'historyRedo') return 'history';
+  return value ? 'other' : 'none';
+};
+
+const lengthDelta = (type: InputTraceInputType): InputTraceLengthDelta => {
+  if (type.startsWith('insert-')) return 'grow';
+  if (type.startsWith('delete-')) return 'shrink';
+  if (type === 'history') return 'unknown';
+  return 'same';
+};
+
 export const installTextEditing = ({
   fields,
   writeText,
   edit,
   diagnostics,
+  trace,
   log,
 }: TextEditingOptions): void => {
   const sources = new Set<GameTextField>();
@@ -47,6 +73,53 @@ export const installTextEditing = ({
   for (const field of fields) {
     if (isGameTextField(field)) sources.add(field);
   }
+
+  const recordText = (
+    field: GameTextField,
+    phase: InputTraceTextPhase,
+    event: Event,
+  ) => {
+    if (!trace?.enabled()) return;
+    const type = inputType(event instanceof InputEvent ? event.inputType : '');
+    trace.record({
+      source: 'renderer',
+      kind: 'text',
+      owner: field.type === 'password' || field.type === 'email'
+        ? 'secret'
+        : 'text',
+      phase,
+      trusted: event.isTrusted,
+      repeat: false,
+      inputType: type,
+      // The event itself says a selection changed without exposing either
+      // endpoint (which would reveal a secret field's minimum length).
+      selectionChanged: phase === 'selectionchange',
+      delta: phase === 'input' || phase === 'beforeinput'
+        ? lengthDelta(type)
+        : 'same',
+    });
+  };
+
+  for (const field of sources) {
+    field.addEventListener('focus', (event) => recordText(field, 'focus', event));
+    field.addEventListener('blur', (event) => recordText(field, 'blur', event));
+    field.addEventListener('beforeinput', (event) =>
+      recordText(field, 'beforeinput', event));
+    field.addEventListener('input', (event) => recordText(field, 'input', event));
+    for (const phase of [
+      'compositionstart',
+      'compositionupdate',
+      'compositionend',
+    ] as const) {
+      field.addEventListener(phase, (event) => recordText(field, phase, event));
+    }
+  }
+  document.addEventListener('selectionchange', (event) => {
+    const active = document.activeElement;
+    if (isGameTextField(active) && sources.has(active)) {
+      recordText(active, 'selectionchange', event);
+    }
+  });
 
   const reportClipboardFailure = (error: unknown) => {
     diagnostics?.event('clipboard.writeFailed', error);
@@ -65,6 +138,13 @@ export const installTextEditing = ({
     event.preventDefault();
     event.stopImmediatePropagation();
     const code = event.code as EditingKey;
+    trace?.record({
+      source: 'renderer', kind: 'key', phase: 'down',
+      owner: active.type === 'password' || active.type === 'email'
+        ? 'secret'
+        : 'text',
+      repeat: event.repeat, trusted: event.isTrusted, decision: 'command',
+    });
     if (claimedKeys.has(code) || event.repeat) {
       return;
     }
@@ -101,6 +181,15 @@ export const installTextEditing = ({
   window.addEventListener('keyup', (event) => {
     const code = event.code as EditingKey;
     if (!claimedKeys.delete(code)) return;
+    const active = document.activeElement;
+    trace?.record({
+      source: 'renderer', kind: 'key', phase: 'up',
+      owner: isGameTextField(active) &&
+        (active.type === 'password' || active.type === 'email')
+        ? 'secret'
+        : 'text',
+      repeat: event.repeat, trusted: event.isTrusted, decision: 'command',
+    });
     event.preventDefault();
     event.stopImmediatePropagation();
   }, true);

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -26,6 +26,7 @@ import type { ErrorCode } from "./errors.js";
 import type { BuildLibrary } from "./builds/library.js";
 import type { ProfileId } from "./multiple-accounts.js";
 import type { TemplateExportEntry } from "./template-contracts.js";
+import type { InputTraceEntry } from "./input-trace.js";
 import type {
   AccountProfileCreateRequest,
   AccountProfileUpdateRequest,
@@ -694,7 +695,7 @@ export type RendererCommand =
       checkForUpdates?: boolean;
     }
   | { type: "filesystem.sync" }
-  | { type: "input.trace" }
+  | { type: "input.trace"; enabled: boolean }
   | { type: "diagnostics.toggle" }
   | {
       type: "diagnostics.capture";
@@ -775,6 +776,7 @@ export const IPC = {
   // window, which `executeJavaScript`'s awaited result used to guarantee.
   rendererCommand: "gw:renderer:command",
   rendererCommandDone: "gw:renderer:commandDone",
+  inputTraceEvent: "gw:inputTrace:event",
   appUpdatesGetState: "gw:appUpdates:getState",
   appUpdatesCheck: "gw:appUpdates:check",
   appUpdatesRestartAndInstall: "gw:appUpdates:restartAndInstall",
@@ -810,6 +812,7 @@ export const EVENT_CHANNELS = [
   "socketEvent",
   "rendererCommand",
   "rendererCommandDone",
+  "inputTraceEvent",
   "appUpdatesState",
 ] as const;
 
@@ -836,6 +839,9 @@ export interface GwNativeApi {
      * early or have a rejection disguised as success.
      */
     handle(handler: (command: RendererCommand) => void | Promise<void>): void;
+  };
+  inputTrace: {
+    onEntry(callback: (entry: InputTraceEntry) => void): () => void;
   };
   progress: {
     current(): Promise<DownloadProgress>;

--- a/src/shared/input-trace.ts
+++ b/src/shared/input-trace.ts
@@ -1,0 +1,116 @@
+/**
+ * Privacy-safe vocabulary for the player-visible input harness.
+ *
+ * This is deliberately a closed union. Main and renderer may both produce
+ * entries, but neither may attach arbitrary text, coordinates, identifiers,
+ * clipboard data, or field lengths to a report a player can copy publicly.
+ */
+
+export type InputTraceSource = 'appkit' | 'main' | 'renderer';
+export type InputTraceOwner = 'canvas' | 'text' | 'secret' | 'surface' | 'other';
+export type InputTraceTextPhase =
+  | 'focus'
+  | 'blur'
+  | 'beforeinput'
+  | 'input'
+  | 'compositionstart'
+  | 'compositionupdate'
+  | 'compositionend'
+  | 'selectionchange';
+export type InputTraceInputType =
+  | 'insert-text'
+  | 'insert-paste'
+  | 'insert-composition'
+  | 'delete-backward'
+  | 'delete-forward'
+  | 'delete-cut'
+  | 'history'
+  | 'other'
+  | 'none';
+export type InputTraceLengthDelta = 'grow' | 'shrink' | 'same' | 'unknown';
+
+export type InputTraceEntry =
+  | {
+      source: 'appkit' | 'main';
+      kind: 'native-key';
+      phase: 'down' | 'up';
+      key: 'printable' | 'modifier' | 'navigation' | 'editing' | 'other';
+      repeat: boolean;
+      decision: 'forwarded' | 'shortcut' | 'capture' | 'normalized-release';
+    }
+  | {
+      source: 'renderer';
+      kind: 'key';
+      phase: 'down' | 'up';
+      owner: InputTraceOwner;
+      /** Exact codes are present only while the game canvas owns input. */
+      code?: string;
+      repeat: boolean;
+      trusted: boolean;
+      decision: 'observed' | 'held' | 'released' | 'suppressed' | 'command';
+    }
+  | {
+      source: 'renderer';
+      kind: 'text';
+      owner: 'text' | 'secret';
+      phase: InputTraceTextPhase;
+      trusted: boolean;
+      repeat: boolean;
+      inputType: InputTraceInputType;
+      selectionChanged: boolean;
+      delta: InputTraceLengthDelta;
+    }
+  | {
+      source: 'renderer';
+      kind: 'press';
+      button: number;
+      detail: number;
+      modifiers: string;
+    }
+  | {
+      source: 'renderer';
+      kind: 'release';
+      button: number;
+      travel: 'still' | 'short' | 'far';
+      buttonsRemaining: number;
+    }
+  | {
+      source: 'renderer';
+      kind: 'modifier';
+      key: 'ctrl' | 'shift' | 'alt';
+      down: boolean;
+    }
+  | { source: 'renderer'; kind: 'double-click'; delivered: boolean }
+  | { source: 'renderer'; kind: 'pointer-lock'; locked: boolean }
+  | {
+      source: 'renderer';
+      kind: 'wheel';
+      direction: 'up' | 'down' | 'left' | 'right';
+      mode: 'pixel' | 'line' | 'page';
+    }
+  | {
+      source: 'renderer';
+      kind: 'release-all';
+      cause: 'blur' | 'hidden' | 'command' | 'pagehide';
+    }
+  | {
+      source: 'renderer';
+      kind: 'gamepad';
+      phase: 'connected' | 'disconnected' | 'button-down' | 'button-up' | 'axis';
+      control?: number;
+      direction?: -1 | 0 | 1;
+    };
+
+export type InputTraceRecord = InputTraceEntry & {
+  sequence: number;
+  atMs: number;
+  sinceMs: number | null;
+};
+
+export interface InputTrace {
+  enabled(): boolean;
+  paused(): boolean;
+  /** Sets visibility explicitly so main and renderer cannot toggle out of sync. */
+  setEnabled(enabled: boolean): void;
+  record(entry: InputTraceEntry): void;
+}

--- a/tests/electron/input-trace.spec.ts
+++ b/tests/electron/input-trace.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { IPC } from '../../src/shared/contracts.js';
 import { closeOffline, launchCachedClient } from "./fixtures.mjs";
 import { boxOf, startGameInput } from "./input-helpers.js";
 
@@ -23,9 +24,12 @@ const expectTrace = (page: import("@playwright/test").Page) =>
   expect.poll(() => traceText(page));
 
 const toggleTrace = (page: import("@playwright/test").Page) =>
-  page.evaluate(() =>
-    window.dispatchEvent(new globalThis.CustomEvent("gw:input-trace")),
-  );
+  page.evaluate(() => {
+    const enabled = globalThis.document.getElementById('input-trace')?.hidden ?? true;
+    window.dispatchEvent(new globalThis.CustomEvent("gw:input-trace", {
+      detail: enabled,
+    }));
+  });
 
 /**
  * Announces a lock state the way the browser does: set the element, then
@@ -135,6 +139,122 @@ test.describe("input trace", () => {
       const rows = await traceText(page);
       expect(rows.match(/pointer lock engaged/gu)?.length ?? 0).toBe(1);
       expect(rows.match(/pointer lock released/gu)?.length ?? 0).toBe(1);
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
+  test("joins redacted main and text events, pauses, bounds, copies, and clears", async () => {
+    test.setTimeout(60_000);
+    const fixture = await launchCachedClient("gw-input-trace-timeline-");
+    try {
+      const { app, page } = fixture;
+      await startGameInput(page);
+      await page.evaluate(() => {
+        globalThis.document.getElementById('loading')?.classList.add('gone');
+      });
+      await toggleTrace(page);
+
+      const mainEntry = {
+        source: 'main', kind: 'native-key', phase: 'down',
+        key: 'printable', repeat: true, decision: 'forwarded',
+      } as const;
+      await app.evaluate(({ BrowserWindow }, value) => {
+        BrowserWindow.getAllWindows()[0]?.webContents.send(value.channel, value.entry);
+      }, { channel: IPC.inputTraceEvent, entry: mainEntry });
+
+      const secret = 'must-not-appear-in-input-trace';
+      await page.locator('#osk-input-password').evaluate((field, value) => {
+        const input = field as HTMLInputElement;
+        input.focus();
+        input.value = value;
+        input.dispatchEvent(new InputEvent('beforeinput', {
+          bubbles: true, inputType: 'insertText', data: value,
+        }));
+        input.dispatchEvent(new InputEvent('input', {
+          bubbles: true, inputType: 'insertText', data: value,
+        }));
+      }, secret);
+      await expectTrace(page).toContain('main     key down printable repeat');
+      await expectTrace(page).toContain('text secret input');
+
+      const count = page.locator('#input-trace [data-role="count"]');
+      await page.locator('#input-trace [data-role="pause"]').click();
+      await page.evaluate(() => new Promise<void>((resolve) =>
+        requestAnimationFrame(() => requestAnimationFrame(() => resolve()))));
+      const beforePause = await count.textContent();
+      await page.mouse.click(100, 100);
+      expect(await count.textContent()).toBe(beforePause);
+      await page.locator('#input-trace [data-role="pause"]').click();
+
+      await app.evaluate(({ BrowserWindow }, value) => {
+        const target = BrowserWindow.getAllWindows()[0]?.webContents;
+        for (let index = 0; index < 1_010; index += 1) {
+          target?.send(value.channel, value.entry);
+        }
+      }, { channel: IPC.inputTraceEvent, entry: mainEntry });
+      await expect(count).toHaveText('1000/1000');
+
+      await page.locator('#input-trace [data-role="copy"]').click();
+      await expect.poll(() => app.evaluate(({ clipboard }) => clipboard.readText()))
+        .toContain('gwonmac input harness — 1000 events');
+      const copied = await app.evaluate(({ clipboard }) => clipboard.readText());
+      expect(copied).not.toContain(secret);
+      expect(copied).not.toMatch(/password|email|coordinate=/iu);
+
+      await toggleTrace(page);
+      await expect(page.locator('#input-trace')).toBeHidden();
+      await expectTrace(page).toBe('');
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
+  test("records thresholded gamepad transitions without a device identity", async () => {
+    const fixture = await launchCachedClient("gw-input-trace-gamepad-");
+    try {
+      const { page } = fixture;
+      await startGameInput(page);
+      await page.evaluate(() => {
+        const state = globalThis as typeof globalThis & { testPads?: Gamepad[] };
+        state.testPads = [{
+          index: 0,
+          id: 'private-controller-name',
+          connected: true,
+          mapping: 'standard',
+          timestamp: 1,
+          vibrationActuator: null,
+          buttons: [{ pressed: false, touched: false, value: 0 }],
+          axes: [0],
+        } as unknown as Gamepad];
+        Object.defineProperty(globalThis.navigator, 'getGamepads', {
+          configurable: true,
+          value: () => state.testPads ?? [],
+        });
+      });
+      await toggleTrace(page);
+      await expectTrace(page).toContain('gamepad connected');
+
+      await page.evaluate(() => {
+        const state = globalThis as typeof globalThis & { testPads?: Gamepad[] };
+        const gamepad = state.testPads?.[0];
+        if (!gamepad) return;
+        state.testPads = [{
+          ...gamepad,
+          timestamp: 2,
+          buttons: [{ pressed: true, touched: true, value: 1 }],
+          axes: [0.8],
+        } as Gamepad];
+      });
+      await expectTrace(page).toContain('gamepad button-down control=0');
+      await expectTrace(page).toContain('gamepad axis control=0 direction=1');
+
+      await page.evaluate(() => {
+        const state = globalThis as typeof globalThis & { testPads?: Gamepad[] };
+        state.testPads = [];
+      });
+      await expectTrace(page).toContain('gamepad disconnected');
+      expect(await traceText(page)).not.toContain('private-controller-name');
     } finally {
       await closeOffline(fixture);
     }

--- a/tests/electron/sandbox.spec.ts
+++ b/tests/electron/sandbox.spec.ts
@@ -57,6 +57,7 @@ test.describe("sandbox boundary", () => {
           "dns",
           "gameStorage",
           "init",
+          "inputTrace",
           "progress",
           "settings",
           "shortcuts",

--- a/tests/release/preload-behaviour.test.ts
+++ b/tests/release/preload-behaviour.test.ts
@@ -356,6 +356,11 @@ const SUBSCRIPTIONS: Subscription[] = [
     subscribe: (api, listener) => api.sockets.onEvent(listener),
   },
   {
+    path: "inputTrace.onEntry",
+    channel: IPC.inputTraceEvent,
+    subscribe: (api, listener) => api.inputTrace.onEntry(listener),
+  },
+  {
     path: "appUpdates.onState",
     channel: IPC.appUpdatesState,
     subscribe: (api, listener) => api.appUpdates.onState(listener),

--- a/tests/release/source-agrees-with-the-shared-contracts.test.ts
+++ b/tests/release/source-agrees-with-the-shared-contracts.test.ts
@@ -76,7 +76,7 @@ test("every main→renderer event channel is named somewhere in main", async () 
     .filter((file) => file && existsSync(path.join(root, file)))
     .map(read)
     .join("\n");
-  assert.equal(EVENT_CHANNELS.length, 6);
+  assert.equal(EVENT_CHANNELS.length, 7);
   for (const key of EVENT_CHANNELS) {
     assert.match(main, new RegExp(`\\bIPC\\.${key}\\b`), `${key} is missing from main`);
   }

--- a/tests/unit/input-trace.test.ts
+++ b/tests/unit/input-trace.test.ts
@@ -1,0 +1,42 @@
+/**
+ * The main trace producer is gated and transports only the shared entry.
+ * Its disabled state must be completely dormant.
+ */
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import type { BrowserWindow } from 'electron';
+import { IPC } from '../../src/shared/contracts.js';
+import {
+  inputTraceEnabled,
+  recordMainInput,
+  setInputTraceEnabled,
+} from '../../src/main/input-trace.js';
+
+test('main input trace emits only while its renderer harness is enabled', () => {
+  const sent: unknown[][] = [];
+  const win = {
+    isDestroyed: () => false,
+    webContents: { send: (...args: unknown[]) => sent.push(args) },
+  } as unknown as BrowserWindow;
+  const entry = {
+    source: 'main',
+    kind: 'native-key',
+    phase: 'down',
+    key: 'printable',
+    repeat: true,
+    decision: 'forwarded',
+  } as const;
+
+  assert.equal(inputTraceEnabled(win), false);
+  recordMainInput(win, entry);
+  assert.deepEqual(sent, []);
+
+  setInputTraceEnabled(win, true);
+  assert.equal(inputTraceEnabled(win), true);
+  recordMainInput(win, entry);
+  assert.deepEqual(sent, [[IPC.inputTraceEvent, entry]]);
+
+  setInputTraceEnabled(win, false);
+  recordMainInput(win, entry);
+  assert.equal(sent.length, 1);
+});

--- a/tests/unit/main-to-renderer-commands-carry-values-not-source.test.ts
+++ b/tests/unit/main-to-renderer-commands-carry-values-not-source.test.ts
@@ -265,6 +265,15 @@ test("one physical key release crosses preload and is acknowledged", async () =>
   assert.deepEqual(fixture.acknowledgements(), [[1, "completed"]]);
 });
 
+test("input harness state crosses as an explicit value and is acknowledged", async () => {
+  const fixture = harness(ARGV);
+  fixture.deliver(1, { type: "input.trace", enabled: true });
+  await new Promise(setImmediate);
+  assert.deepEqual(fixture.dispatched, ["gw:input-trace"]);
+  assert.deepEqual(fixture.dispatchedDetails, [true]);
+  assert.deepEqual(fixture.acknowledgements(), [[1, "completed"]]);
+});
+
 test("the Tools shortcut is refused when there is no Toolbox to toggle", async () => {
   // The capability is off on an ordinary launch, and an event nobody listens
   // for is indistinguishable from one that worked. The command has to fail so


### PR DESCRIPTION
## What changed

Input failures that depend on macOS, Electron, or particular hardware were hard to diagnose from a player report. **Show Input Trace** now provides one ordered, bounded timeline across AppKit/main decisions, renderer keyboard ownership, hidden text proxies, pointer input, wheel and pointer lock, interruption cleanup, and thresholded gamepad transitions.

The panel can pause/resume, clear, and copy its report. Closing it clears all trace memory.

## Why

The remaining text-repeat bug cannot be fixed safely from the final field value alone. This harness makes the first missing transition visible without adding another input owner or changing input behavior.

## Invariant

- The renderer owns the only 1,000-entry trace buffer.
- Main emits trace events only while the harness is enabled.
- Pausing affects recording only.
- Reports omit text, clipboard contents, secret-field lengths, printable text-proxy keys, coordinates, account identifiers, and controller identifiers.
- Trace data is not persisted, exported with diagnostics, or sent over the network.

## Verification

- `pnpm check`
- `pnpm verify`
- Focused Electron input-trace and sandbox suites
- Full Electron suite: 132 passed, 1 expected live-client skip
- Packaged smoke and packaged Enhancement runtime

- [x] I kept this pull request focused.
- [x] I ran the relevant checks.
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [x] I updated documentation when behavior or an invariant changed.
