### PR TITLE
fix(input): enable native text key repeat

### DIFF
--- a/docs/process-model.md
+++ b/docs/process-model.md
@@ -168,6 +168,12 @@ but does not register their AppKit accelerators. The focused proxy routes truste
 select, cut, and paste commands through its own renderer window; password text
 never crosses that bridge.
 
+The native input host registers `ApplePressAndHoldEnabled = false` as a
+process-only default before the first game window exists. This makes macOS send
+its physical repeat keydowns to hidden text proxies for printable characters,
+Backspace, and Delete. It does not write the player's preferences, create a
+timer, or synthesize repeat cadence; macOS remains the sole repeat clock.
+
 Certified Core supplies native double-click and the Guild Wars cursor. Core is
 required behavior. It is not a saved player preference. If an ArenaNet build
 is not certified, the official client remains playable with the normal macOS

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -315,6 +315,8 @@ opens its GitHub issue form immediately. GitHub issues are public.
   problems. Reproduce the problem, pause the bounded timeline, then copy it
   into the issue. It omits text, secrets, field lengths, coordinates, account
   identifiers, and controller identifiers. Closing it discards the trace.
+- Holding a character, Backspace, or Delete in Guild Wars text fields follows
+  the repeat delay and speed configured in macOS Keyboard settings.
 
 The diagnostics ZIP excludes saved login, account request bodies, game traffic,
 chat, and crash dumps. Other text is scanned for known secret and path patterns.

--- a/src/native/host/host.mm
+++ b/src/native/host/host.mm
@@ -115,6 +115,14 @@ napi_value MonitorCommandKeyUpsCallback(napi_env env, napi_callback_info info) {
     return nullptr;
   }
 
+  // NSTextInputClient asks this process default before it schedules a held
+  // key. Electron otherwise inherits macOS press-and-hold, which waits for an
+  // accent choice and emits no repeat keydowns to the game's hidden proxy.
+  // Registration is process-local and non-persistent: it changes neither the
+  // player's global keyboard preference nor another application.
+  [NSUserDefaults.standardUserDefaults
+      registerDefaults:@{ @"ApplePressAndHoldEnabled" : @NO }];
+
   auto *monitor = new (std::nothrow) CommandKeyUpMonitor();
   if (monitor == nullptr) {
     napi_throw_error(env, nullptr, "input monitor is unavailable");

--- a/tests/electron/input-text-repeat.spec.ts
+++ b/tests/electron/input-text-repeat.spec.ts
@@ -1,0 +1,233 @@
+/**
+ * ArenaNet OSK contract probe for physical repeats.
+ *
+ * It models the shipped glue's keyboard copy and input callback independently,
+ * then asserts every trusted browser edit instead of only the final value.
+ */
+import { expect, test } from '@playwright/test';
+import { closeOffline, launchCachedClient } from './fixtures.mjs';
+import { startGameInput } from './input-helpers.js';
+
+type KeyboardObservation = {
+  target: 'proxy' | 'canvas';
+  phase: 'keydown' | 'keyup';
+  code: string;
+  repeat: boolean;
+  trusted: boolean;
+};
+
+type EditObservation = {
+  phase: 'beforeinput' | 'input';
+  inputType: string;
+  data: 'text' | 'none';
+  trusted: boolean;
+  value: string;
+};
+
+type RepeatProbe = {
+  keyboard: KeyboardObservation[];
+  edits: EditObservation[];
+};
+
+test('physical repeats preserve the complete hidden-proxy OSK contract', async () => {
+  const fixture = await launchCachedClient('gw-text-repeat-contract-');
+  try {
+    const { app, page } = fixture;
+    await startGameInput(page);
+    await page.evaluate(() => {
+      const field = document.getElementById('osk-input-text');
+      const canvas = document.getElementById('canvas');
+      if (!(field instanceof HTMLInputElement) || !(canvas instanceof HTMLCanvasElement)) {
+        throw new Error('OSK contract fixture is incomplete');
+      }
+      const host = window as typeof window & { __repeatProbe?: RepeatProbe };
+      host.__repeatProbe = { keyboard: [], edits: [] };
+      const observeKeyboard = (target: 'proxy' | 'canvas') =>
+        (event: KeyboardEvent) => {
+          host.__repeatProbe?.keyboard.push({
+            target,
+            phase: event.type as 'keydown' | 'keyup',
+            code: event.code,
+            repeat: event.repeat,
+            trusted: event.isTrusted,
+          });
+        };
+      field.addEventListener('keydown', (event) => {
+        observeKeyboard('proxy')(event);
+        // Exact behavior of the official glue's handleKeyEvent: preserve the
+        // repeat and modifiers in a keyboard copy delivered to the canvas.
+        canvas.dispatchEvent(new KeyboardEvent(event.type, {
+          bubbles: true,
+          cancelable: true,
+          key: event.key,
+          code: event.code,
+          location: event.location,
+          repeat: event.repeat,
+          isComposing: event.isComposing,
+          ctrlKey: event.ctrlKey,
+          shiftKey: event.shiftKey,
+          altKey: event.altKey,
+          metaKey: event.metaKey,
+        }));
+      });
+      field.addEventListener('keyup', (event) => {
+        observeKeyboard('proxy')(event);
+        canvas.dispatchEvent(new KeyboardEvent(event.type, {
+          bubbles: true,
+          cancelable: true,
+          key: event.key,
+          code: event.code,
+          location: event.location,
+          repeat: event.repeat,
+          isComposing: event.isComposing,
+          ctrlKey: event.ctrlKey,
+          shiftKey: event.shiftKey,
+          altKey: event.altKey,
+          metaKey: event.metaKey,
+        }));
+      });
+      canvas.addEventListener('keydown', observeKeyboard('canvas'));
+      canvas.addEventListener('keyup', observeKeyboard('canvas'));
+      for (const phase of ['beforeinput', 'input'] as const) {
+        field.addEventListener(phase, (event) => {
+          if (!(event instanceof InputEvent)) return;
+          host.__repeatProbe?.edits.push({
+            phase,
+            inputType: event.inputType,
+            data: event.data === null ? 'none' : 'text',
+            trusted: event.isTrusted,
+            value: field.value,
+          });
+        });
+      }
+      field.value = 'seed';
+      field.focus();
+      field.setSelectionRange(4, 4);
+      (window.Module as { oskActiveInput?: Element | null }).oskActiveInput = field;
+    });
+
+    const cdp = await app.context().newCDPSession(page);
+    const key = async (
+      type: 'keyDown' | 'keyUp',
+      code: string,
+      keyValue: string,
+      windowsVirtualKeyCode: number,
+      repeat = false,
+      text?: string,
+    ) => cdp.send('Input.dispatchKeyEvent', {
+      type,
+      code,
+      key: keyValue,
+      windowsVirtualKeyCode,
+      nativeVirtualKeyCode: windowsVirtualKeyCode,
+      autoRepeat: repeat,
+      ...(text === undefined ? {} : { text }),
+    });
+    const held = async (
+      code: string,
+      keyValue: string,
+      windowsVirtualKeyCode: number,
+      text?: string,
+    ) => {
+      await key('keyDown', code, keyValue, windowsVirtualKeyCode, false, text);
+      await key('keyDown', code, keyValue, windowsVirtualKeyCode, true, text);
+      await key('keyDown', code, keyValue, windowsVirtualKeyCode, true, text);
+      await key('keyUp', code, keyValue, windowsVirtualKeyCode);
+    };
+
+    await held('KeyL', 'l', 76, 'l');
+    await held('Backspace', 'Backspace', 8);
+    await page.evaluate(() => {
+      const field = document.getElementById('osk-input-text') as HTMLInputElement;
+      field.value = 'abcdef';
+      field.setSelectionRange(2, 2);
+    });
+    await held('Delete', 'Delete', 46);
+    await page.evaluate(() => {
+      const field = document.getElementById('osk-input-text') as HTMLInputElement;
+      field.value = 'abcdef';
+      field.setSelectionRange(2, 5);
+    });
+    await key('keyDown', 'Backspace', 'Backspace', 8);
+    await key('keyDown', 'Backspace', 'Backspace', 8, true);
+    await key('keyUp', 'Backspace', 'Backspace', 8);
+    await page.evaluate(() => {
+      const field = document.getElementById('osk-input-text') as HTMLInputElement;
+      field.value = 'abcdef';
+      field.setSelectionRange(1, 4);
+    });
+    await key('keyDown', 'Delete', 'Delete', 46);
+    await key('keyDown', 'Delete', 'Delete', 46, true);
+    await key('keyUp', 'Delete', 'Delete', 46);
+
+    const editsBeforeBoundaries = await page.evaluate(() =>
+      (window as typeof window & { __repeatProbe?: RepeatProbe })
+        .__repeatProbe?.edits.length);
+    await page.evaluate(() => {
+      const field = document.getElementById('osk-input-text') as HTMLInputElement;
+      field.value = 'abc';
+      field.setSelectionRange(0, 0);
+    });
+    await held('Backspace', 'Backspace', 8);
+    await page.evaluate(() => {
+      const field = document.getElementById('osk-input-text') as HTMLInputElement;
+      field.setSelectionRange(field.value.length, field.value.length);
+    });
+    await held('Delete', 'Delete', 46);
+
+    const probe = await page.evaluate(() =>
+      (window as typeof window & { __repeatProbe?: RepeatProbe }).__repeatProbe);
+    expect(probe).toBeDefined();
+    const proxyKeys = probe!.keyboard.filter(({ target }) => target === 'proxy');
+    const canvasKeys = probe!.keyboard.filter(({ target }) => target === 'canvas');
+    expect(proxyKeys.every(({ trusted }) => trusted)).toBe(true);
+    expect(canvasKeys.every(({ trusted }) => !trusted)).toBe(true);
+    expect(canvasKeys.map(({ phase, code, repeat }) => ({ phase, code, repeat })))
+      .toEqual(proxyKeys.map(({ phase, code, repeat }) => ({ phase, code, repeat })));
+    expect(proxyKeys.filter(({ phase, repeat }) => phase === 'keydown' && repeat))
+      .toHaveLength(12);
+
+    expect(probe!.edits.every(({ trusted }) => trusted)).toBe(true);
+    expect(probe!.edits.map(({ phase, inputType, data }) => ({
+      phase, inputType, data,
+    }))).toEqual([
+      ...Array.from({ length: 3 }, () => [
+        { phase: 'beforeinput', inputType: 'insertText', data: 'text' },
+        { phase: 'input', inputType: 'insertText', data: 'text' },
+      ]).flat(),
+      ...Array.from({ length: 3 }, () => [
+        { phase: 'beforeinput', inputType: 'deleteContentBackward', data: 'none' },
+        { phase: 'input', inputType: 'deleteContentBackward', data: 'none' },
+      ]).flat(),
+      ...Array.from({ length: 3 }, () => [
+        { phase: 'beforeinput', inputType: 'deleteContentForward', data: 'none' },
+        { phase: 'input', inputType: 'deleteContentForward', data: 'none' },
+      ]).flat(),
+      ...Array.from({ length: 2 }, () => [
+        { phase: 'beforeinput', inputType: 'deleteContentBackward', data: 'none' },
+        { phase: 'input', inputType: 'deleteContentBackward', data: 'none' },
+      ]).flat(),
+      ...Array.from({ length: 2 }, () => [
+        { phase: 'beforeinput', inputType: 'deleteContentForward', data: 'none' },
+        { phase: 'input', inputType: 'deleteContentForward', data: 'none' },
+      ]).flat(),
+      ...Array.from({ length: 3 }, () => ({
+        phase: 'beforeinput', inputType: 'deleteContentBackward', data: 'none',
+      })),
+      ...Array.from({ length: 3 }, () => ({
+        phase: 'beforeinput', inputType: 'deleteContentForward', data: 'none',
+      })),
+    ]);
+    expect(probe!.edits.filter(({ phase }) => phase === 'input').map(({ value }) => value))
+      .toEqual([
+        'seedl', 'seedll', 'seedlll',
+        'seedll', 'seedl', 'seed',
+        'abdef', 'abef', 'abf',
+        'abf', 'af',
+        'aef', 'af',
+      ]);
+    expect(probe!.edits).toHaveLength((editsBeforeBoundaries ?? 0) + 6);
+  } finally {
+    await closeOffline(fixture);
+  }
+});

--- a/tests/policy/source-native-keychain.test.ts
+++ b/tests/policy/source-native-keychain.test.ts
@@ -37,6 +37,17 @@ test("Command-held releases use one app-local macOS monitor", () => {
   assert.doesNotMatch(source, /CGEventTap|IOHID|AXIsProcessTrusted/u);
 });
 
+test("the app enables physical key repeat without changing user defaults", () => {
+  assert.match(
+    source,
+    /registerDefaults:@\{ @"ApplePressAndHoldEnabled" : @NO \}/u,
+  );
+  assert.doesNotMatch(
+    source,
+    /set(?:Bool|Object):[\s\S]{0,80}ApplePressAndHoldEnabled/u,
+  );
+});
+
 test("the native boundary owns two fixed Data Protection Keychain items", () => {
   const nativeBundleIds = [
     ...source.matchAll(/NSString \*const k\w+Bundle = @"([^"]+)";/gu),


### PR DESCRIPTION
## What changed

Holding a printable character, Backspace, or Delete now repeats inside Guild Wars text fields at the cadence configured by macOS.

The native host registers the process-only `ApplePressAndHoldEnabled = false` default before Electron creates the game window. This lets AppKit deliver real repeat keydowns to the existing hidden text proxy instead of replacing them with the accent press-and-hold behavior. The app does not write global preferences, add a timer, infer repeats, or create another held-key registry.

## Why

ArenaNet's shipped OSK glue already preserves repeat keydowns and Chromium already performs the correct edits when those events arrive. The missing boundary was macOS: printable holds were diverted into press-and-hold before Electron received a repeat event.

## Invariant

The new Electron contract probe observes the proxy and ArenaNet canvas paths independently. It asserts every trusted keyboard event, `inputType`, redacted data shape, and intermediate proxy value for character, Backspace, and Delete repeats at the start, middle, end, and across selections.

## Verification

- `pnpm check`
- focused Electron keyboard, clipboard, and text-repeat tests: 10 passed
- `pnpm verify`: 133 Electron tests passed, 1 live-download test skipped by its existing gate; packaging and packaged-runtime checks passed
- the unrelated Multiple Accounts focus assertion that flaked once passed both in isolation and in the clean full rerun

- [x] I kept this pull request focused.
- [x] I ran the relevant checks.
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [x] I updated documentation when behavior or an invariant changed.
