### PR TITLE
fix(input): translate macOS text editing chords

### DIFF
--- a/docs/process-model.md
+++ b/docs/process-model.md
@@ -161,12 +161,12 @@ physical keyboard positions before the official client receives them. Text
 fields still use the active macOS input source.
 
 The game's hidden text proxies own macOS editing while they are active.
-Command-A/C/X/V are claimed before game input, update the proxy through its
-normal `input` event, and never arrive as bare A/C/X/V game keys. Control stays
-available to Guild Wars. The application menu keeps its Edit commands clickable
-but does not register their AppKit accelerators. The focused proxy routes trusted
-select, cut, and paste commands through its own renderer window; password text
-never crosses that bridge.
+Command-A/C/X/V are claimed before game input and never arrive as bare
+A/C/X/V game keys. Copy and paste use the proxy; select-all and cut become the
+Control chords already owned by Guild Wars' visible editor. Physical Control
+stays available to Guild Wars unchanged. The application menu keeps its Edit
+commands clickable but does not register their AppKit accelerators. Password
+text never crosses the renderer bridge.
 
 The native input host registers `ApplePressAndHoldEnabled = false` as a
 process-only default before the first game window exists. This makes macOS send

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -706,9 +706,31 @@ export function registerIpcHandlers(ctx: IpcContext): {
     }),
 
     clipboardEdit: channel(asTextEditCommand, (win, command) => {
-      if (command === "selectAll") win.webContents.selectAll();
-      else if (command === "cut") win.webContents.cut();
-      else {
+      if (command === "selectAll" || command === "cut") {
+        // The visible editor belongs to Guild Wars; Chromium owns only its
+        // hidden OSK proxy. Deliver the Windows editing chord that the client
+        // already handles instead of editing only Chromium's proxy.
+        const keyCode = command === "selectAll" ? "A" : "X";
+        win.webContents.sendInputEvent({
+          type: "keyDown",
+          keyCode: "Control",
+          modifiers: ["control"],
+        });
+        win.webContents.sendInputEvent({
+          type: "keyDown",
+          keyCode,
+          modifiers: ["control"],
+        });
+        win.webContents.sendInputEvent({
+          type: "keyUp",
+          keyCode,
+          modifiers: ["control"],
+        });
+        win.webContents.sendInputEvent({
+          type: "keyUp",
+          keyCode: "Control",
+        });
+      } else {
         // ArenaNet's OSK listener forwards InputEvent.data, which Chromium's
         // native paste does not populate. Keep the secret in main and replay
         // the trusted typing contract without sending it over IPC.

--- a/src/renderer/text-editing.ts
+++ b/src/renderer/text-editing.ts
@@ -3,9 +3,10 @@
  *
  * The official client understands Windows-style Control chords and also sees
  * Command combinations as their unmodified base keys. Claiming Command editing
- * here gives players one predictable macOS contract and keeps A/C/V/X out of
- * the game input stream. The proxy's input event remains the single route by
- * which an edit reaches the client.
+ * here gives players one predictable macOS contract and keeps the Command
+ * chord itself out of the game input stream. Copy and paste use the proxy;
+ * select-all and cut translate to the Control chords the visible game editor
+ * already owns.
  */
 import type { TextEditCommand } from '../shared/contracts.js';
 import type {
@@ -179,6 +180,7 @@ export const installTextEditing = ({
   }, true);
 
   window.addEventListener('keyup', (event) => {
+    if (!event.isTrusted || !event.metaKey || event.ctrlKey || event.altKey) return;
     const code = event.code as EditingKey;
     if (!claimedKeys.delete(code)) return;
     const active = document.activeElement;

--- a/tests/electron/input-clipboard.spec.ts
+++ b/tests/electron/input-clipboard.spec.ts
@@ -5,7 +5,14 @@ import { startGameInput } from "./input-helpers.js";
 /** The page-side handle the OSK focus guard honours. */
 type OskWindow = typeof window & {
   Module: { oskActiveInput?: Element | null };
-  __clipboardGameKeys?: string[];
+  __clipboardGameKeys?: Array<{
+    type: string;
+    key: string;
+    code: string;
+    control: boolean;
+    meta: boolean;
+    trusted: boolean;
+  }>;
   __clipboardInputTypes?: Array<{
     inputType: string;
     trusted: boolean;
@@ -48,10 +55,24 @@ test.describe("renderer text editing", () => {
           (window as OskWindow).__clipboardTypedKeys = [];
           for (const type of ["keydown", "keyup"] as const) {
             window.addEventListener(type, (event) => {
-              if (event.metaKey && ["KeyA", "KeyC", "KeyV", "KeyX"].includes(event.code)) {
-                (window as OskWindow).__clipboardGameKeys?.push(`${type}:${event.code}`);
+              if (
+                (event.metaKey || event.ctrlKey || event.code.startsWith("Control"))
+                && event.target instanceof HTMLInputElement
+              ) {
+                (window as OskWindow).__clipboardGameKeys?.push({
+                  type,
+                  key: event.key,
+                  code: event.code,
+                  control: event.ctrlKey,
+                  meta: event.metaKey,
+                  trusted: event.isTrusted,
+                });
               }
-              if (!event.metaKey && event.target instanceof HTMLInputElement) {
+              if (
+                !event.metaKey && !event.ctrlKey && !event.altKey
+                && !event.code.startsWith("Control")
+                && event.target instanceof HTMLInputElement
+              ) {
                 (window as OskWindow).__clipboardTypedKeys?.push({
                   type,
                   trusted: event.isTrusted,
@@ -98,19 +119,18 @@ test.describe("renderer text editing", () => {
           field.setSelectionRange(6, 10);
         });
         await page.keyboard.press("Meta+x");
-        await expect.poll(() => page.locator("#osk-input-text").inputValue())
-          .toBe("alpha ");
-        await expect.poll(() => app.evaluate(({ clipboard }) => clipboard.readText()))
-          .toBe("beta");
-
+        // The real client owns selection and cut. Set up the independent paste
+        // case explicitly instead of pretending the hidden proxy is the game.
+        await app.evaluate(({ clipboard }) => clipboard.writeText("beta"));
+        await page.evaluate(() => {
+          const field = document.getElementById("osk-input-text") as HTMLInputElement;
+          field.value = "alpha ";
+          field.setSelectionRange(6, 6);
+        });
         await page.keyboard.press("Meta+v");
         await expect.poll(() => page.locator("#osk-input-text").inputValue())
           .toBe("alpha beta");
         await page.keyboard.press("Meta+a");
-        expect(await page.evaluate(() => {
-          const field = document.getElementById("osk-input-text") as HTMLInputElement;
-          return [field.selectionStart, field.selectionEnd];
-        })).toEqual([0, 10]);
 
         // Secrets do not leave through this path.
         await app.evaluate(({ clipboard }) => clipboard.writeText("sentinel"));
@@ -137,11 +157,43 @@ test.describe("renderer text editing", () => {
         await expect(page.locator("#osk-input-password")).toHaveValue("sentinel");
         expect(await page.evaluate(() => (
           window as OskWindow
-        ).__clipboardGameKeys)).toEqual([]);
+        ).__clipboardGameKeys)).toEqual([
+          {
+            type: "keydown", key: "Control", code: "ControlLeft", control: true,
+            meta: false, trusted: true,
+          },
+          {
+            type: "keydown", key: "x", code: "KeyX", control: true,
+            meta: false, trusted: true,
+          },
+          {
+            type: "keyup", key: "x", code: "KeyX", control: true,
+            meta: false, trusted: true,
+          },
+          {
+            type: "keyup", key: "Control", code: "ControlLeft", control: false,
+            meta: false, trusted: true,
+          },
+          {
+            type: "keydown", key: "Control", code: "ControlLeft", control: true,
+            meta: false, trusted: true,
+          },
+          {
+            type: "keydown", key: "a", code: "KeyA", control: true,
+            meta: false, trusted: true,
+          },
+          {
+            type: "keyup", key: "a", code: "KeyA", control: true,
+            meta: false, trusted: true,
+          },
+          {
+            type: "keyup", key: "Control", code: "ControlLeft", control: false,
+            meta: false, trusted: true,
+          },
+        ]);
         expect(await page.evaluate(() => (
           window as OskWindow
         ).__clipboardInputTypes)).toEqual([
-          { inputType: "deleteByCut", trusted: true, dataLength: 0 },
           ...Array.from({ length: 4 }, () => (
             { inputType: "insertText", trusted: true, dataLength: 1 }
           )),


### PR DESCRIPTION
## What changed

Command-A and Command-X now work in Guild Wars chat. Each macOS gesture is claimed before its bare letter reaches the game, then replayed as the complete Windows-style chord Guild Wars already owns: Control down, A/X down, A/X up, Control up.

Command-C keeps the safe clipboard-copy path, Command-V keeps trusted character replay, physical Control shortcuts remain untouched, and password cut remains blocked.

## Why

Chromium's hidden text proxy is not the visible Guild Wars editor. Calling Electron's native select/cut methods changed only the proxy. Input traces and live tests showed that Guild Wars also tracks the physical Control transition; setting only the letter event's Ctrl flag was insufficient.

## Invariant

The Electron clipboard regression now asserts the exact trusted four-event Control chord for Command-A and Command-X, no original Command letter reaches Guild Wars, copy/paste behavior remains intact, and secrets cannot leave through copy or cut.

## Verification

- live Guild Wars chat: Command-A and Command-X confirmed working
- focused keyboard, clipboard, and text-repeat suite: 10 passed
- `pnpm check`
- `pnpm verify`: 133 Electron tests passed, 1 existing live-download test skipped; packaging and packaged-runtime smoke checks passed

- [x] I kept this pull request focused.
- [x] I ran the relevant checks.
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [x] I updated documentation when behavior or an invariant changed.
