### PR TITLE
fix(input): make shortcut release ownership deterministic

### DIFF
--- a/docs/process-model.md
+++ b/docs/process-model.md
@@ -179,15 +179,17 @@ required behavior. It is not a saved player preference. If an ArenaNet build
 is not certified, the official client remains playable with the normal macOS
 pointer and without the certified repair.
 
-The input harness is a player-visible troubleshooting view with one ordered,
-bounded renderer-memory timeline. AppKit and main-process decisions cross one
-redacted main-to-renderer event; renderer keyboard, hidden text proxy, pointer,
-wheel, pointer-lock, cleanup, and thresholded gamepad transitions join the same
-timeline. It records no text, clipboard contents, secret-field lengths, exact
-printable keys while a text proxy is active, coordinates, account identifiers,
-or controller identifiers. Pausing changes only recording. Closing clears the
-memory. The trace is not persisted, exported with diagnostics, or sent over the
-network.
+The input harness is a player-visible troubleshooting view with one bounded,
+receipt-ordered renderer-memory timeline. AppKit and main-process decisions
+cross one redacted main-to-renderer event; renderer keyboard, hidden text proxy,
+pointer, wheel, pointer-lock, cleanup, and thresholded gamepad transitions join
+the same timeline. It records no text, clipboard contents, secret-field lengths,
+exact printable keys while a text proxy is active, coordinates, account
+identifiers, or controller identifiers. Pausing changes only recording. Closing
+clears the memory. The trace is not persisted, exported with diagnostics, or
+sent over the network. Copy keeps the newest complete rows that fit the same
+bounded clipboard contract used elsewhere and states how many older rows were
+omitted.
 
 ## Native network boundary
 

--- a/src/main/game-text-editing.ts
+++ b/src/main/game-text-editing.ts
@@ -1,0 +1,46 @@
+/**
+ * Trusted input sequences for the game's hidden OSK text proxies.
+ *
+ * Chromium owns the proxy, but Guild Wars owns the visible editor. Keep the
+ * two protocols together so the IPC boundary only validates and delegates.
+ */
+import { clipboard, type WebContents } from 'electron';
+import {
+  CLIPBOARD_TEXT_CEILING,
+  type TextEditCommand,
+} from '../shared/contracts.js';
+
+const sendControlChord = (contents: WebContents, keyCode: 'A' | 'X'): void => {
+  contents.sendInputEvent({
+    type: 'keyDown', keyCode: 'Control', modifiers: ['control'],
+  });
+  contents.sendInputEvent({
+    type: 'keyDown', keyCode, modifiers: ['control'],
+  });
+  contents.sendInputEvent({
+    type: 'keyUp', keyCode, modifiers: ['control'],
+  });
+  contents.sendInputEvent({ type: 'keyUp', keyCode: 'Control' });
+};
+
+export function editGameText(
+  contents: WebContents,
+  command: TextEditCommand,
+): void {
+  if (command === 'selectAll' || command === 'cut') {
+    // The visible editor understands Windows-style Control chords. Editing
+    // Chromium's hidden proxy alone would leave the game field unchanged.
+    sendControlChord(contents, command === 'selectAll' ? 'A' : 'X');
+    return;
+  }
+
+  // ArenaNet's OSK listener forwards InputEvent.data, which Chromium's native
+  // paste does not populate. Keep the secret in main and replay the trusted
+  // keyboard/input contract without sending clipboard contents over IPC.
+  const text = clipboard.readText().slice(0, CLIPBOARD_TEXT_CEILING);
+  for (const character of text) {
+    contents.sendInputEvent({ type: 'keyDown', keyCode: character });
+    contents.sendInputEvent({ type: 'char', keyCode: character });
+    contents.sendInputEvent({ type: 'keyUp', keyCode: character });
+  }
+}

--- a/src/main/input-trace.ts
+++ b/src/main/input-trace.ts
@@ -3,10 +3,31 @@
  * Renderer memory remains the only trace store.
  */
 import type { BrowserWindow } from 'electron';
-import { IPC } from '../shared/contracts.js';
-import type { InputTraceEntry } from '../shared/input-trace.js';
+import {
+  IPC,
+  type RendererCommandOutcome,
+} from '../shared/contracts.js';
+import type { MainInputTraceEntry } from '../shared/input-trace.js';
+
+type InputTraceCommandSender = (
+  win: BrowserWindow,
+  command: { type: 'input.trace'; enabled: boolean },
+) => Promise<RendererCommandOutcome>;
 
 const enabledWindows = new WeakSet<BrowserWindow>();
+const observedWindows = new WeakSet<BrowserWindow>();
+
+const observeRendererLifetime = (win: BrowserWindow): void => {
+  if (observedWindows.has(win)) return;
+  observedWindows.add(win);
+  const disable = () => enabledWindows.delete(win);
+  win.webContents.on('render-process-gone', disable);
+  win.webContents.on('did-start-navigation', (details) => {
+    if (details.isMainFrame && !details.isSameDocument) disable();
+  });
+  win.webContents.once('destroyed', disable);
+  win.once('closed', disable);
+};
 
 export function inputTraceEnabled(win: BrowserWindow): boolean {
   return enabledWindows.has(win);
@@ -20,10 +41,32 @@ export function setInputTraceEnabled(
   else enabledWindows.delete(win);
 }
 
+/** Commit main's gate only after the renderer confirms the same state. */
+export async function setInputTraceVisibility(
+  win: BrowserWindow,
+  enabled: boolean,
+  send: InputTraceCommandSender,
+): Promise<boolean> {
+  const outcome = await send(win, { type: 'input.trace', enabled });
+  if (outcome !== 'completed') return false;
+  setInputTraceEnabled(win, enabled);
+  if (enabled) observeRendererLifetime(win);
+  return true;
+}
+
 export function recordMainInput(
   win: BrowserWindow,
-  entry: InputTraceEntry,
+  entry: MainInputTraceEntry,
 ): void {
-  if (!enabledWindows.has(win) || win.isDestroyed()) return;
-  win.webContents.send(IPC.inputTraceEvent, entry);
+  if (
+    !enabledWindows.has(win)
+    || win.isDestroyed()
+    || win.webContents.isDestroyed()
+  ) return;
+  try {
+    win.webContents.send(IPC.inputTraceEvent, entry);
+  } catch {
+    // A renderer may disappear between the checks and send. Tracing is an
+    // observer and must never interrupt the input path it is observing.
+  }
 }

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -50,7 +50,11 @@ import {
   isRendererFrameBatch,
   isRendererMetrics,
 } from "../shared/diagnostics.js";
-import { EXTERNAL_URLS, IPC } from "../shared/contracts.js";
+import {
+  CLIPBOARD_TEXT_CEILING,
+  EXTERNAL_URLS,
+  IPC,
+} from "../shared/contracts.js";
 import { ENHANCEMENT_RUNTIME_FEATURES } from "../shared/contracts.js";
 import { isDigest } from "../shared/digest.js";
 import {
@@ -119,6 +123,7 @@ import {
   requestCacheClear,
   requestGameStorageReset,
 } from "./settings-actions.js";
+import { editGameText } from './game-text-editing.js';
 
 export interface IpcContext {
   sockets: SocketManager;
@@ -407,10 +412,6 @@ const asRevealKind = one((value: unknown): RevealKind => {
   }
   return value;
 });
-
-// Far above any text a game field holds, low enough that a renderer gone
-// wrong cannot stuff megabytes into the OS pasteboard.
-const CLIPBOARD_TEXT_CEILING = 64 * 1024;
 
 const asClipboardText = one((value: unknown): string => {
   if (
@@ -706,43 +707,7 @@ export function registerIpcHandlers(ctx: IpcContext): {
     }),
 
     clipboardEdit: channel(asTextEditCommand, (win, command) => {
-      if (command === "selectAll" || command === "cut") {
-        // The visible editor belongs to Guild Wars; Chromium owns only its
-        // hidden OSK proxy. Deliver the Windows editing chord that the client
-        // already handles instead of editing only Chromium's proxy.
-        const keyCode = command === "selectAll" ? "A" : "X";
-        win.webContents.sendInputEvent({
-          type: "keyDown",
-          keyCode: "Control",
-          modifiers: ["control"],
-        });
-        win.webContents.sendInputEvent({
-          type: "keyDown",
-          keyCode,
-          modifiers: ["control"],
-        });
-        win.webContents.sendInputEvent({
-          type: "keyUp",
-          keyCode,
-          modifiers: ["control"],
-        });
-        win.webContents.sendInputEvent({
-          type: "keyUp",
-          keyCode: "Control",
-        });
-      } else {
-        // ArenaNet's OSK listener forwards InputEvent.data, which Chromium's
-        // native paste does not populate. Keep the secret in main and replay
-        // the trusted typing contract without sending it over IPC.
-        const text = clipboard.readText().slice(0, CLIPBOARD_TEXT_CEILING);
-        // Guild Wars expects the keyboard events around each OSK input event.
-        // `insertText` alone updates Chromium's proxy but not the game field.
-        for (const character of text) {
-          win.webContents.sendInputEvent({ type: "keyDown", keyCode: character });
-          win.webContents.sendInputEvent({ type: "char", keyCode: character });
-          win.webContents.sendInputEvent({ type: "keyUp", keyCode: character });
-        }
-      }
+      editGameText(win.webContents, command);
     }),
 
     // Truncated rather than refused: a player who copied something large before

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -89,6 +89,7 @@ import {
   type WindowHost,
   updateLongRunningTaskFeedback,
 } from "./window.js";
+import { releaseWindowShortcutKey } from './window-shortcuts.js';
 import { exportDiagnosticsReport } from "./diagnostics-export.js";
 import { resetGameInput, sendRendererCommand } from "./renderer-commands.js";
 import { STEAM_OAUTH } from "./core/steam-oauth.js";
@@ -392,6 +393,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
         : null;
     },
     release(win, code) {
+      releaseWindowShortcutKey(win, code);
       recordMainInput(win, {
         source: 'appkit',
         kind: 'native-key',

--- a/src/main/window-menu.ts
+++ b/src/main/window-menu.ts
@@ -28,7 +28,7 @@ import {
 import { isDevBuild } from "./protocol.js";
 import {
   inputTraceEnabled,
-  setInputTraceEnabled,
+  setInputTraceVisibility,
 } from './input-trace.js';
 import type { WindowHost } from "./window.js";
 import {
@@ -273,10 +273,9 @@ export function installApplicationMenu({
             {
               id: "toggle-input-trace",
               label: "Show Input Trace",
-              click: () => {
+              click: async () => {
                 const enabled = !inputTraceEnabled(win);
-                setInputTraceEnabled(win, enabled);
-                void sendRendererCommand(win, { type: "input.trace", enabled });
+                await setInputTraceVisibility(win, enabled, sendRendererCommand);
               },
             },
             {

--- a/src/main/window-shortcuts.ts
+++ b/src/main/window-shortcuts.ts
@@ -33,26 +33,30 @@ class WindowShortcuts {
   readonly #actions: ShortcutActions;
   #shortcuts = resolveShortcuts({});
   #capture: ((result: ShortcutCaptureResult) => void) | null = null;
-  #capturedCode: string | null = null;
+  #claimedCodes = new Map<string, 'capture' | 'shortcut'>();
 
   constructor(win: BrowserWindow, actions: ShortcutActions) {
     this.#actions = actions;
     win.webContents.on("before-input-event", (event, input) => {
       if (input.type === "keyUp") {
+        const decision = this.#claimedCodes.get(input.code);
         recordMainInput(win, {
           source: 'main', kind: 'native-key', phase: 'up',
-          key: tracedKey(input.key), repeat: false, decision: 'forwarded',
+          key: tracedKey(input.key), repeat: false,
+          decision: decision ?? 'forwarded',
         });
-        if (input.key === "Meta" || input.code === this.#capturedCode) {
-          this.#capturedCode = null;
+        if (decision) {
+          this.#claimedCodes.delete(input.code);
+          event.preventDefault();
         }
         return;
       }
       if (input.type !== "keyDown") return;
-      if (input.code === this.#capturedCode) {
+      const claimed = this.#claimedCodes.get(input.code);
+      if (claimed) {
         recordMainInput(win, {
           source: 'main', kind: 'native-key', phase: 'down',
-          key: tracedKey(input.key), repeat: input.isAutoRepeat, decision: 'capture',
+          key: tracedKey(input.key), repeat: input.isAutoRepeat, decision: claimed,
         });
         event.preventDefault();
         return;
@@ -65,7 +69,7 @@ class WindowShortcuts {
           source: 'main', kind: 'native-key', phase: 'down',
           key: tracedKey(input.key), repeat: input.isAutoRepeat, decision: 'capture',
         });
-        this.#capturedCode = input.code;
+        this.#claimedCodes.set(input.code, 'capture');
         if (input.key === "Escape") {
           this.#finish({ status: "cancelled" });
           return;
@@ -87,6 +91,7 @@ class WindowShortcuts {
             key: tracedKey(input.key), repeat: input.isAutoRepeat, decision: 'shortcut',
           });
           event.preventDefault();
+          this.#claimedCodes.set(input.code, 'shortcut');
           if (!input.isAutoRepeat) {
             this.#actions.run(action as ShortcutAction);
           }
@@ -109,15 +114,18 @@ class WindowShortcuts {
 
   capture(): Promise<ShortcutCaptureResult> {
     this.cancelCapture();
-    this.#capturedCode = null;
     return new Promise((resolve) => {
       this.#capture = resolve;
     });
   }
 
   cancelCapture(): void {
-    this.#capturedCode = null;
+    this.#claimedCodes.clear();
     this.#finish({ status: "cancelled" });
+  }
+
+  release(code: string): void {
+    this.#claimedCodes.delete(code);
   }
 
   #finish(result: ShortcutCaptureResult): void {
@@ -155,4 +163,12 @@ export function captureWindowShortcut(
 
 export function cancelWindowShortcutCapture(win: BrowserWindow): void {
   controllers.get(win)?.cancelCapture();
+}
+
+/** Forget a release that AppKit consumed before `before-input-event`. */
+export function releaseWindowShortcutKey(
+  win: BrowserWindow,
+  code: string,
+): void {
+  controllers.get(win)?.release(code);
 }

--- a/src/native/host/host.mm
+++ b/src/native/host/host.mm
@@ -115,14 +115,6 @@ napi_value MonitorCommandKeyUpsCallback(napi_env env, napi_callback_info info) {
     return nullptr;
   }
 
-  // NSTextInputClient asks this process default before it schedules a held
-  // key. Electron otherwise inherits macOS press-and-hold, which waits for an
-  // accent choice and emits no repeat keydowns to the game's hidden proxy.
-  // Registration is process-local and non-persistent: it changes neither the
-  // player's global keyboard preference nor another application.
-  [NSUserDefaults.standardUserDefaults
-      registerDefaults:@{ @"ApplePressAndHoldEnabled" : @NO }];
-
   auto *monitor = new (std::nothrow) CommandKeyUpMonitor();
   if (monitor == nullptr) {
     napi_throw_error(env, nullptr, "input monitor is unavailable");
@@ -543,6 +535,15 @@ napi_value ClearCallback(napi_env env, napi_callback_info info) {
 }
 
 napi_value Init(napi_env env, napi_value exports) {
+  // NSTextInputClient asks this process default before it schedules a held
+  // key. Electron otherwise inherits macOS press-and-hold, which waits for an
+  // accent choice and emits no repeat keydowns to the game's hidden proxy.
+  // Registration is process-local and non-persistent: it changes neither the
+  // player's global keyboard preference nor another application. This policy
+  // belongs to native input initialization, not the Command-release monitor.
+  [NSUserDefaults.standardUserDefaults
+      registerDefaults:@{ @"ApplePressAndHoldEnabled" : @NO }];
+
   napi_property_descriptor properties[] = {
       {"load", nullptr, LoadCallback, nullptr, nullptr, nullptr, napi_default,
        nullptr},

--- a/src/renderer/input-trace.ts
+++ b/src/renderer/input-trace.ts
@@ -7,6 +7,7 @@ import type {
   InputTraceEntry,
   InputTraceRecord,
 } from '../shared/input-trace.js';
+import { CLIPBOARD_TEXT_CEILING } from '../shared/contracts.js';
 
 const TRACE_CAPACITY = 1_000;
 const VISIBLE_ROWS = 18;
@@ -63,12 +64,15 @@ const label = (record: InputTraceRecord): { text: string; tone: string } => {
       return {
         tone: 'event',
         text: `${prefix} text ${record.owner} ${record.phase}`
-          + ` trusted=${record.trusted} repeat=${record.repeat}`
-          + ` type=${record.inputType} selection=${record.selectionChanged}`
-          + ` delta=${record.delta}`,
+          + ` trusted=${record.trusted} type=${record.inputType}`,
       };
     case 'press':
-      return { tone: 'event', text: `${prefix} press ${BUTTON_NAMES[record.button] ?? 'other'} run=${record.detail}${record.modifiers}` };
+      return {
+        tone: 'event',
+        text: `${prefix} press ${BUTTON_NAMES[record.button] ?? 'other'}`
+          + ` run=${record.detail}`
+          + record.modifiers.map((modifier) => ` +${modifier}`).join(''),
+      };
     case 'release':
       return { tone: 'event', text: `${prefix} release ${BUTTON_NAMES[record.button] ?? 'other'} travel=${record.travel} remaining=${record.buttonsRemaining}` };
     case 'modifier':
@@ -156,7 +160,7 @@ export function createInputTrace(
   });
   clearButton.addEventListener('click', clear);
   copyButton.addEventListener('click', () => {
-    void writeText(transcript(entries)).then(
+    void writeText(inputTraceTranscript(entries)).then(
       () => { copyButton.textContent = 'Copied'; },
       () => { copyButton.textContent = 'Copy failed'; },
     ).then(() => {
@@ -194,12 +198,30 @@ export function createInputTrace(
   });
 }
 
-function transcript(entries: readonly InputTraceRecord[]): string {
-  return [
+function inputTraceTranscript(
+  entries: readonly InputTraceRecord[],
+): string {
+  const heading = [
     `gwonmac input harness — ${entries.length} events`,
     'privacy: text, clipboard data, field lengths, coordinates, account and device identifiers omitted',
     'columns: sequence  gap  source  event  decision',
+  ];
+  // Reserve enough room for the omission line before collecting the newest
+  // complete rows. The main process enforces the same clipboard ceiling.
+  const omissionReserve = 64;
+  let used = heading.join('\n').length + 2 + omissionReserve;
+  const rows: string[] = [];
+  for (let index = entries.length - 1; index >= 0; index -= 1) {
+    const row = label(entries[index]!).text;
+    if (used + row.length + 1 > CLIPBOARD_TEXT_CEILING) break;
+    rows.unshift(row);
+    used += row.length + 1;
+  }
+  const omitted = entries.length - rows.length;
+  return [
+    ...heading,
+    ...(omitted > 0 ? [`${omitted} older events omitted`] : []),
     '',
-    ...entries.map((record) => label(record).text),
+    ...rows,
   ].join('\n');
 }

--- a/src/renderer/input.ts
+++ b/src/renderer/input.ts
@@ -57,11 +57,12 @@ const isCommandKey = (code: string): boolean =>
  * that shows `left +ctrl` on the press and no Control key down before it is
  * therefore a report about the keyboard path, not the mouse one.
  */
-const modifierText = (event: MouseEvent): string =>
-  (event.ctrlKey ? ' +ctrl' : '') +
-  (event.shiftKey ? ' +shift' : '') +
-  (event.altKey ? ' +alt' : '') +
-  (event.metaKey ? ' +cmd' : '');
+const tracedModifiers = (event: MouseEvent) => [
+  ...(event.ctrlKey ? ['ctrl' as const] : []),
+  ...(event.shiftKey ? ['shift' as const] : []),
+  ...(event.altKey ? ['alt' as const] : []),
+  ...(event.metaKey ? ['cmd' as const] : []),
+];
 
 const physicalKey = (code: string, fallback: string): string => {
   if (/^Key[A-Z]$/.test(code)) return code.slice(3).toLowerCase();
@@ -452,16 +453,13 @@ export const installGameInput = ({
     decision: 'observed' | 'held' | 'released' | 'suppressed' | 'command',
   ) => {
     const owner = traceOwner(event.target);
-    trace?.record({
-      source: 'renderer',
-      kind: 'key',
-      phase,
-      owner,
-      ...(owner === 'canvas' ? { code: event.code } : {}),
-      repeat: event.repeat,
-      trusted: event.isTrusted,
-      decision,
-    });
+    const common = {
+      source: 'renderer' as const, kind: 'key' as const, phase,
+      repeat: event.repeat, trusted: event.isTrusted, decision,
+    };
+    trace?.record(owner === 'canvas'
+      ? { ...common, owner, code: event.code }
+      : { ...common, owner });
   };
 
   window.addEventListener('keydown', (event) => {
@@ -559,7 +557,7 @@ export const installGameInput = ({
       kind: 'press',
       button: event.button,
       detail: event.detail,
-      modifiers: modifierText(event),
+      modifiers: tracedModifiers(event),
     });
     heldButtons.set(event.button, {
       target: event.target,

--- a/src/renderer/text-editing.ts
+++ b/src/renderer/text-editing.ts
@@ -12,7 +12,6 @@ import type { TextEditCommand } from '../shared/contracts.js';
 import type {
   InputTrace,
   InputTraceInputType,
-  InputTraceLengthDelta,
   InputTraceTextPhase,
 } from '../shared/input-trace.js';
 
@@ -28,9 +27,14 @@ type TextEditingOptions = {
   log(...values: unknown[]): void;
 };
 
-type EditingKey = 'KeyA' | 'KeyC' | 'KeyV' | 'KeyX';
+type EditingCommand = TextEditCommand | 'copy';
 
-const EDITING_KEYS = new Set<EditingKey>(['KeyA', 'KeyC', 'KeyV', 'KeyX']);
+const EDITING_COMMANDS = new Map<string, EditingCommand>([
+  ['a', 'selectAll'],
+  ['c', 'copy'],
+  ['v', 'paste'],
+  ['x', 'cut'],
+]);
 
 const isGameTextField = (value: unknown): value is GameTextField =>
   value instanceof HTMLTextAreaElement || value instanceof HTMLInputElement;
@@ -54,13 +58,6 @@ const inputType = (value: string): InputTraceInputType => {
   return value ? 'other' : 'none';
 };
 
-const lengthDelta = (type: InputTraceInputType): InputTraceLengthDelta => {
-  if (type.startsWith('insert-')) return 'grow';
-  if (type.startsWith('delete-')) return 'shrink';
-  if (type === 'history') return 'unknown';
-  return 'same';
-};
-
 export const installTextEditing = ({
   fields,
   writeText,
@@ -70,7 +67,9 @@ export const installTextEditing = ({
   log,
 }: TextEditingOptions): void => {
   const sources = new Set<GameTextField>();
-  const claimedKeys = new Set<EditingKey>();
+  // Semantic commands follow the active keyboard layout (`event.key`), while
+  // release ownership follows the exact physical key (`event.code`).
+  const claimedKeys = new Set<string>();
   for (const field of fields) {
     if (isGameTextField(field)) sources.add(field);
   }
@@ -90,14 +89,7 @@ export const installTextEditing = ({
         : 'text',
       phase,
       trusted: event.isTrusted,
-      repeat: false,
       inputType: type,
-      // The event itself says a selection changed without exposing either
-      // endpoint (which would reveal a secret field's minimum length).
-      selectionChanged: phase === 'selectionchange',
-      delta: phase === 'input' || phase === 'beforeinput'
-        ? lengthDelta(type)
-        : 'same',
     });
   };
 
@@ -131,14 +123,15 @@ export const installTextEditing = ({
   };
 
   window.addEventListener('keydown', (event) => {
-    if (!event.isTrusted || !EDITING_KEYS.has(event.code as EditingKey)) return;
+    const command = EDITING_COMMANDS.get(event.key.toLowerCase());
+    if (!event.isTrusted || !command) return;
     if (!event.metaKey || event.ctrlKey || event.altKey || event.shiftKey) return;
     const active = document.activeElement;
     if (!isGameTextField(active) || !sources.has(active)) return;
 
     event.preventDefault();
     event.stopImmediatePropagation();
-    const code = event.code as EditingKey;
+    const code = event.code;
     trace?.record({
       source: 'renderer', kind: 'key', phase: 'down',
       owner: active.type === 'password' || active.type === 'email'
@@ -151,18 +144,17 @@ export const installTextEditing = ({
     }
     claimedKeys.add(code);
 
-    if (code === 'KeyA') {
+    if (command === 'selectAll') {
       void edit('selectAll');
       return;
     }
 
-    if (code === 'KeyV') {
+    if (command === 'paste') {
       void edit('paste');
       return;
     }
 
-    if (code === 'KeyC') {
-      event.preventDefault();
+    if (command === 'copy') {
       if (!canExportText(active)) return;
       const { start, end } = selection(active);
       const text = start !== null && end !== null && start !== end
@@ -180,9 +172,8 @@ export const installTextEditing = ({
   }, true);
 
   window.addEventListener('keyup', (event) => {
-    if (!event.isTrusted || !event.metaKey || event.ctrlKey || event.altKey) return;
-    const code = event.code as EditingKey;
-    if (!claimedKeys.delete(code)) return;
+    if (!event.isTrusted || event.ctrlKey || event.altKey) return;
+    if (!claimedKeys.delete(event.code)) return;
     const active = document.activeElement;
     trace?.record({
       source: 'renderer', kind: 'key', phase: 'up',
@@ -201,7 +192,9 @@ export const installTextEditing = ({
   window.addEventListener('pagehide', clearClaimedKeys);
   window.addEventListener('gw:input-reset', clearClaimedKeys);
   window.addEventListener('gw:input-release', (event) => {
-    if (event instanceof CustomEvent) claimedKeys.delete(event.detail as EditingKey);
+    if (event instanceof CustomEvent && typeof event.detail === 'string') {
+      claimedKeys.delete(event.detail);
+    }
   });
   document.addEventListener('visibilitychange', () => {
     if (document.visibilityState === 'hidden') clearClaimedKeys();

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -26,7 +26,7 @@ import type { ErrorCode } from "./errors.js";
 import type { BuildLibrary } from "./builds/library.js";
 import type { ProfileId } from "./multiple-accounts.js";
 import type { TemplateExportEntry } from "./template-contracts.js";
-import type { InputTraceEntry } from "./input-trace.js";
+import type { MainInputTraceEntry } from "./input-trace.js";
 import type {
   AccountProfileCreateRequest,
   AccountProfileUpdateRequest,
@@ -823,6 +823,10 @@ export type InvokeChannel = Exclude<keyof typeof IPC, EventChannel>;
 
 export type TextEditCommand = "selectAll" | "cut" | "paste";
 
+// Far above any text a game field holds, low enough that a renderer gone
+// wrong cannot stuff megabytes into the OS pasteboard.
+export const CLIPBOARD_TEXT_CEILING = 64 * 1024;
+
 export interface GwNativeApi {
   /** Launch-time configuration, available before the first renderer script. */
   init: RendererInit;
@@ -841,7 +845,7 @@ export interface GwNativeApi {
     handle(handler: (command: RendererCommand) => void | Promise<void>): void;
   };
   inputTrace: {
-    onEntry(callback: (entry: InputTraceEntry) => void): () => void;
+    onEntry(callback: (entry: MainInputTraceEntry) => void): () => void;
   };
   progress: {
     current(): Promise<DownloadProgress>;
@@ -943,7 +947,7 @@ export interface GwNativeApi {
      * never arrives here.
      */
     writeText(text: string): Promise<void>;
-    /** Apply Chromium's trusted edit command to the currently focused field. */
+    /** Apply a trusted edit command to the game's active text field. */
     edit(command: TextEditCommand): Promise<void>;
     /**
      * Read the OS pasteboard so a player can import build codes they copied

--- a/src/shared/input-trace.ts
+++ b/src/shared/input-trace.ts
@@ -27,8 +27,7 @@ export type InputTraceInputType =
   | 'history'
   | 'other'
   | 'none';
-export type InputTraceLengthDelta = 'grow' | 'shrink' | 'same' | 'unknown';
-
+export type InputTraceModifier = 'ctrl' | 'shift' | 'alt' | 'cmd';
 export type InputTraceEntry =
   | {
       source: 'appkit' | 'main';
@@ -42,9 +41,18 @@ export type InputTraceEntry =
       source: 'renderer';
       kind: 'key';
       phase: 'down' | 'up';
-      owner: InputTraceOwner;
-      /** Exact codes are present only while the game canvas owns input. */
-      code?: string;
+      owner: 'canvas';
+      code: string;
+      repeat: boolean;
+      trusted: boolean;
+      decision: 'observed' | 'held' | 'released' | 'suppressed' | 'command';
+    }
+  | {
+      source: 'renderer';
+      kind: 'key';
+      phase: 'down' | 'up';
+      owner: Exclude<InputTraceOwner, 'canvas'>;
+      code?: never;
       repeat: boolean;
       trusted: boolean;
       decision: 'observed' | 'held' | 'released' | 'suppressed' | 'command';
@@ -55,17 +63,14 @@ export type InputTraceEntry =
       owner: 'text' | 'secret';
       phase: InputTraceTextPhase;
       trusted: boolean;
-      repeat: boolean;
       inputType: InputTraceInputType;
-      selectionChanged: boolean;
-      delta: InputTraceLengthDelta;
     }
   | {
       source: 'renderer';
       kind: 'press';
       button: number;
       detail: number;
-      modifiers: string;
+      modifiers: readonly InputTraceModifier[];
     }
   | {
       source: 'renderer';
@@ -100,6 +105,11 @@ export type InputTraceEntry =
       control?: number;
       direction?: -1 | 0 | 1;
     };
+
+export type MainInputTraceEntry = Extract<
+  InputTraceEntry,
+  { source: 'appkit' | 'main' }
+>;
 
 export type InputTraceRecord = InputTraceEntry & {
   sequence: number;

--- a/tests/electron/input-clipboard.spec.ts
+++ b/tests/electron/input-clipboard.spec.ts
@@ -22,6 +22,62 @@ type OskWindow = typeof window & {
 };
 
 test.describe("renderer text editing", () => {
+  test("survives releasing Command before the editing key", async () => {
+    const fixture = await launchCachedClient("gw-editing-release-order-");
+    try {
+      const { app, page } = fixture;
+      await startGameInput(page);
+      await page.evaluate(() => {
+        const field = document.getElementById("osk-input-text");
+        if (!(field instanceof HTMLInputElement)) throw new Error("text proxy missing");
+        (window as OskWindow).Module.oskActiveInput = field;
+        (window as OskWindow).__clipboardGameKeys = [];
+        window.addEventListener("keydown", (event) => {
+          if (event.ctrlKey && event.key === "a") {
+            (window as OskWindow).__clipboardGameKeys?.push({
+              type: event.type,
+              key: event.key,
+              code: event.code,
+              control: event.ctrlKey,
+              meta: event.metaKey,
+              trusted: event.isTrusted,
+            });
+          }
+        }, true);
+        field.value = "alpha";
+        field.focus();
+      });
+      const cdp = await app.context().newCDPSession(page);
+      const chord = async () => {
+        await cdp.send("Input.dispatchKeyEvent", {
+          type: "keyDown", key: "Meta", code: "MetaLeft",
+          windowsVirtualKeyCode: 91, nativeVirtualKeyCode: 91,
+          modifiers: 4,
+        });
+        await cdp.send("Input.dispatchKeyEvent", {
+          type: "keyDown", key: "a", code: "KeyA",
+          windowsVirtualKeyCode: 65, nativeVirtualKeyCode: 65,
+          modifiers: 4,
+        });
+        await cdp.send("Input.dispatchKeyEvent", {
+          type: "keyUp", key: "Meta", code: "MetaLeft",
+          windowsVirtualKeyCode: 91, nativeVirtualKeyCode: 91,
+        });
+        await cdp.send("Input.dispatchKeyEvent", {
+          type: "keyUp", key: "a", code: "KeyA",
+          windowsVirtualKeyCode: 65, nativeVirtualKeyCode: 65,
+        });
+      };
+      await chord();
+      await chord();
+      await expect.poll(() => page.evaluate(() => (
+        window as OskWindow
+      ).__clipboardGameKeys?.length)).toBe(2);
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
   test("uses macOS copy, cut, paste, and select-all without leaking game keys", async () => {
     const fixture = await launchCachedClient("gw-clipboard-e2e-");
     try {

--- a/tests/electron/input-text-repeat.spec.ts
+++ b/tests/electron/input-text-repeat.spec.ts
@@ -1,15 +1,15 @@
 /**
- * ArenaNet OSK contract probe for physical repeats.
+ * Chromium hidden-proxy contract probe for physical repeats.
  *
- * It models the shipped glue's keyboard copy and input callback independently,
- * then asserts every trusted browser edit instead of only the final value.
+ * It asserts every trusted browser edit instead of only the final value. The
+ * native process policy and a live client check cover the AppKit boundary;
+ * this test does not imitate the closed-source client's forwarding glue.
  */
 import { expect, test } from '@playwright/test';
 import { closeOffline, launchCachedClient } from './fixtures.mjs';
 import { startGameInput } from './input-helpers.js';
 
 type KeyboardObservation = {
-  target: 'proxy' | 'canvas';
   phase: 'keydown' | 'keyup';
   code: string;
   repeat: boolean;
@@ -29,65 +29,28 @@ type RepeatProbe = {
   edits: EditObservation[];
 };
 
-test('physical repeats preserve the complete hidden-proxy OSK contract', async () => {
+test('physical repeats preserve Chromium hidden-proxy editing', async () => {
   const fixture = await launchCachedClient('gw-text-repeat-contract-');
   try {
     const { app, page } = fixture;
     await startGameInput(page);
     await page.evaluate(() => {
       const field = document.getElementById('osk-input-text');
-      const canvas = document.getElementById('canvas');
-      if (!(field instanceof HTMLInputElement) || !(canvas instanceof HTMLCanvasElement)) {
+      if (!(field instanceof HTMLInputElement)) {
         throw new Error('OSK contract fixture is incomplete');
       }
       const host = window as typeof window & { __repeatProbe?: RepeatProbe };
       host.__repeatProbe = { keyboard: [], edits: [] };
-      const observeKeyboard = (target: 'proxy' | 'canvas') =>
-        (event: KeyboardEvent) => {
-          host.__repeatProbe?.keyboard.push({
-            target,
-            phase: event.type as 'keydown' | 'keyup',
-            code: event.code,
-            repeat: event.repeat,
-            trusted: event.isTrusted,
-          });
-        };
-      field.addEventListener('keydown', (event) => {
-        observeKeyboard('proxy')(event);
-        // Exact behavior of the official glue's handleKeyEvent: preserve the
-        // repeat and modifiers in a keyboard copy delivered to the canvas.
-        canvas.dispatchEvent(new KeyboardEvent(event.type, {
-          bubbles: true,
-          cancelable: true,
-          key: event.key,
+      const observeKeyboard = (event: KeyboardEvent) => {
+        host.__repeatProbe?.keyboard.push({
+          phase: event.type as 'keydown' | 'keyup',
           code: event.code,
-          location: event.location,
           repeat: event.repeat,
-          isComposing: event.isComposing,
-          ctrlKey: event.ctrlKey,
-          shiftKey: event.shiftKey,
-          altKey: event.altKey,
-          metaKey: event.metaKey,
-        }));
-      });
-      field.addEventListener('keyup', (event) => {
-        observeKeyboard('proxy')(event);
-        canvas.dispatchEvent(new KeyboardEvent(event.type, {
-          bubbles: true,
-          cancelable: true,
-          key: event.key,
-          code: event.code,
-          location: event.location,
-          repeat: event.repeat,
-          isComposing: event.isComposing,
-          ctrlKey: event.ctrlKey,
-          shiftKey: event.shiftKey,
-          altKey: event.altKey,
-          metaKey: event.metaKey,
-        }));
-      });
-      canvas.addEventListener('keydown', observeKeyboard('canvas'));
-      canvas.addEventListener('keyup', observeKeyboard('canvas'));
+          trusted: event.isTrusted,
+        });
+      };
+      field.addEventListener('keydown', observeKeyboard);
+      field.addEventListener('keyup', observeKeyboard);
       for (const phase of ['beforeinput', 'input'] as const) {
         field.addEventListener(phase, (event) => {
           if (!(event instanceof InputEvent)) return;
@@ -178,13 +141,8 @@ test('physical repeats preserve the complete hidden-proxy OSK contract', async (
     const probe = await page.evaluate(() =>
       (window as typeof window & { __repeatProbe?: RepeatProbe }).__repeatProbe);
     expect(probe).toBeDefined();
-    const proxyKeys = probe!.keyboard.filter(({ target }) => target === 'proxy');
-    const canvasKeys = probe!.keyboard.filter(({ target }) => target === 'canvas');
-    expect(proxyKeys.every(({ trusted }) => trusted)).toBe(true);
-    expect(canvasKeys.every(({ trusted }) => !trusted)).toBe(true);
-    expect(canvasKeys.map(({ phase, code, repeat }) => ({ phase, code, repeat })))
-      .toEqual(proxyKeys.map(({ phase, code, repeat }) => ({ phase, code, repeat })));
-    expect(proxyKeys.filter(({ phase, repeat }) => phase === 'keydown' && repeat))
+    expect(probe!.keyboard.every(({ trusted }) => trusted)).toBe(true);
+    expect(probe!.keyboard.filter(({ phase, repeat }) => phase === 'keydown' && repeat))
       .toHaveLength(12);
 
     expect(probe!.edits.every(({ trusted }) => trusted)).toBe(true);

--- a/tests/electron/input-trace.spec.ts
+++ b/tests/electron/input-trace.spec.ts
@@ -1,5 +1,8 @@
 import { expect, test } from "@playwright/test";
-import { IPC } from '../../src/shared/contracts.js';
+import {
+  CLIPBOARD_TEXT_CEILING,
+  IPC,
+} from '../../src/shared/contracts.js';
 import { closeOffline, launchCachedClient } from "./fixtures.mjs";
 import { boxOf, startGameInput } from "./input-helpers.js";
 
@@ -187,18 +190,24 @@ test.describe("input trace", () => {
       expect(await count.textContent()).toBe(beforePause);
       await page.locator('#input-trace [data-role="pause"]').click();
 
-      await app.evaluate(({ BrowserWindow }, value) => {
-        const target = BrowserWindow.getAllWindows()[0]?.webContents;
+      await page.evaluate(() => {
+        const field = document.getElementById('osk-input-password');
+        if (!(field instanceof HTMLInputElement)) throw new Error('password proxy missing');
         for (let index = 0; index < 1_010; index += 1) {
-          target?.send(value.channel, value.entry);
+          field.dispatchEvent(new InputEvent('beforeinput', {
+            bubbles: true,
+            inputType: 'insertCompositionText',
+          }));
         }
-      }, { channel: IPC.inputTraceEvent, entry: mainEntry });
+      });
       await expect(count).toHaveText('1000/1000');
 
       await page.locator('#input-trace [data-role="copy"]').click();
       await expect.poll(() => app.evaluate(({ clipboard }) => clipboard.readText()))
         .toContain('gwonmac input harness — 1000 events');
       const copied = await app.evaluate(({ clipboard }) => clipboard.readText());
+      expect(copied.length).toBeLessThanOrEqual(CLIPBOARD_TEXT_CEILING);
+      expect(copied).toContain('older events omitted');
       expect(copied).not.toContain(secret);
       expect(copied).not.toMatch(/password|email|coordinate=/iu);
 

--- a/tests/policy/source-native-keychain.test.ts
+++ b/tests/policy/source-native-keychain.test.ts
@@ -46,6 +46,11 @@ test("the app enables physical key repeat without changing user defaults", () =>
     source,
     /set(?:Bool|Object):[\s\S]{0,80}ApplePressAndHoldEnabled/u,
   );
+  const initialization = source.indexOf('napi_value Init');
+  const repeatPolicy = source.indexOf('registerDefaults:@{ @"ApplePressAndHoldEnabled"');
+  const monitor = source.indexOf('napi_value MonitorCommandKeyUpsCallback');
+  assert.ok(initialization >= 0 && repeatPolicy > initialization);
+  assert.ok(repeatPolicy > monitor, 'repeat policy belongs to module initialization');
 });
 
 test("the native boundary owns two fixed Data Protection Keychain items", () => {

--- a/tests/unit/input-trace.test.ts
+++ b/tests/unit/input-trace.test.ts
@@ -10,13 +10,17 @@ import {
   inputTraceEnabled,
   recordMainInput,
   setInputTraceEnabled,
+  setInputTraceVisibility,
 } from '../../src/main/input-trace.js';
 
 test('main input trace emits only while its renderer harness is enabled', () => {
   const sent: unknown[][] = [];
   const win = {
     isDestroyed: () => false,
-    webContents: { send: (...args: unknown[]) => sent.push(args) },
+    webContents: {
+      isDestroyed: () => false,
+      send: (...args: unknown[]) => sent.push(args),
+    },
   } as unknown as BrowserWindow;
   const entry = {
     source: 'main',
@@ -39,4 +43,48 @@ test('main input trace emits only while its renderer harness is enabled', () => 
   setInputTraceEnabled(win, false);
   recordMainInput(win, entry);
   assert.equal(sent.length, 1);
+
+  setInputTraceEnabled(win, true);
+  win.webContents.send = () => { throw new Error('renderer disappeared'); };
+  assert.doesNotThrow(() => recordMainInput(win, entry));
+});
+
+test('main trace state changes only after renderer acknowledgement', async () => {
+  const contentsListeners = new Map<string, (...args: never[]) => void>();
+  const winListeners = new Map<string, (...args: never[]) => void>();
+  const win = {
+    isDestroyed: () => false,
+    webContents: {
+      isDestroyed: () => false,
+      on: (name: string, listener: (...args: never[]) => void) => {
+        contentsListeners.set(name, listener);
+      },
+      once: (name: string, listener: (...args: never[]) => void) => {
+        contentsListeners.set(name, listener);
+      },
+    },
+    once: (name: string, listener: (...args: never[]) => void) => {
+      winListeners.set(name, listener);
+    },
+  } as unknown as BrowserWindow;
+
+  assert.equal(await setInputTraceVisibility(
+    win,
+    true,
+    async () => 'failed',
+  ), false);
+  assert.equal(inputTraceEnabled(win), false);
+
+  assert.equal(await setInputTraceVisibility(
+    win,
+    true,
+    async () => 'completed',
+  ), true);
+  assert.equal(inputTraceEnabled(win), true);
+  contentsListeners.get('did-start-navigation')?.({
+    isMainFrame: true,
+    isSameDocument: false,
+  } as never);
+  assert.equal(inputTraceEnabled(win), false);
+  assert.equal(winListeners.has('closed'), true);
 });

--- a/tests/unit/window-shortcuts.test.ts
+++ b/tests/unit/window-shortcuts.test.ts
@@ -4,6 +4,7 @@ import type { BrowserWindow } from "electron";
 import {
   captureWindowShortcut,
   installWindowShortcuts,
+  releaseWindowShortcutKey,
   updateWindowShortcuts,
 } from "../../src/main/window-shortcuts.js";
 
@@ -61,6 +62,16 @@ describe("window shortcut input", () => {
       assert.equal(dispatch(keyDown("KeyB", "b", { isAutoRepeat: true })), true);
     }
     assert.deepEqual(actions, ["tools.toggle"]);
+    // Releasing Command first must not leak the base key's repeats or key-up.
+    assert.equal(dispatch({
+      ...keyDown("MetaLeft", "Meta"), type: "keyUp", meta: false,
+    }), false);
+    assert.equal(dispatch(keyDown("KeyB", "b", {
+      meta: false, isAutoRepeat: true,
+    })), true);
+    assert.equal(dispatch({
+      ...keyDown("KeyB", "b"), type: "keyUp", meta: false,
+    }), true);
     assert.equal(dispatch(keyDown("KeyB", "b", {
       meta: false,
       control: true,
@@ -82,6 +93,27 @@ describe("window shortcut input", () => {
       type: "keyUp",
       meta: false,
     });
+    assert.equal(dispatch(keyDown("KeyK", "k", {
+      meta: false,
+      shift: true,
+      isAutoRepeat: true,
+    })), true);
+    assert.equal(dispatch({
+      ...keyDown("KeyK", "k", { shift: true }),
+      type: "keyUp",
+      meta: false,
+    }), true);
     assert.equal(dispatch(keyDown("KeyK", "k", { shift: true })), false);
+
+    const secondCapture = captureWindowShortcut(win);
+    assert.equal(dispatch(keyDown("KeyW", "w")), true);
+    assert.deepEqual(await secondCapture, {
+      status: "captured",
+      binding: { key: "w", shift: false, option: false },
+    });
+    // AppKit consumes this release, so the shortcut controller must receive
+    // the same exact code through the native normalization route.
+    releaseWindowShortcutKey(win, "KeyW");
+    assert.equal(dispatch(keyDown("KeyW", "w", { isAutoRepeat: true })), false);
   });
 });


### PR DESCRIPTION
The macOS input fixes now work live, but the quality review found two release-order paths that could still leave shortcut state stuck or leak unmatched key events into Guild Wars. It also found that the troubleshooting harness could drift out of sync after a renderer reload and could produce a copy larger than its clipboard boundary.

This hardening layer keeps semantic editing commands separate from physical release ownership, consumes host-shortcut key-ups in either modifier release order, and routes AppKit-consumed releases back to the shortcut owner. It makes trace enablement acknowledgement-based, bounds copied reports, enforces privacy in the shared types, and removes inferred text facts that the browser did not actually report.

The main text-input choreography now lives in a focused owner instead of the IPC registry. Native repeat policy is initialized explicitly with the native module, and the repeat regression test no longer imitates closed-source game forwarding that it cannot verify.

Verification:

- `pnpm check`
- focused Electron keyboard, clipboard, text-repeat, and input-trace tests: 15 passed
- `pnpm verify`: 134 Electron tests passed, 1 gated live-client test skipped; packaging and packaged-runtime smoke checks passed
- prior live acceptance on this stack: password paste, text repeat, Command editing, and Command-held movement

Review method: full multi-agent thermo-nuclear code-quality review, reconciled against the complete `origin/main...HEAD` input stack.
