### PR TITLE
ci(website): cut unrelated Vercel build usage

### DIFF
--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": true
+  },
+  "ignoreCommand": "if [ -z \"$VERCEL_GIT_PREVIOUS_SHA\" ]; then exit 1; fi; git diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" HEAD -- . ../../src/shared ../../package.json ../../pnpm-lock.yaml ../../pnpm-workspace.yaml"
+}

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -35,6 +35,10 @@ type Manifest = {
   dependencies?: Record<string, string>;
   scripts?: Record<string, string>;
 };
+type VercelConfig = {
+  git?: { deploymentEnabled?: boolean };
+  ignoreCommand?: string;
+};
 const json = (file: string): Manifest => JSON.parse(read(file));
 
 // A script the manifest must actually define: a missing one would otherwise
@@ -722,6 +726,7 @@ test("the maintainer tests a temporary exact draft without replacing Application
 test("the website suite runs on its own path-filtered workflow", () => {
   const workflow = read(".github/workflows/website.yml");
   const website = json("apps/website/package.json");
+  const vercel: VercelConfig = JSON.parse(read("apps/website/vercel.json"));
   assert.match(workflow, /runs-on: ubuntu-latest/);
   assert.match(workflow, /run: pnpm test:website/);
   assert.match(workflow, /paths:[\s\S]*apps\/website\/\*\*/);
@@ -739,6 +744,11 @@ test("the website suite runs on its own path-filtered workflow", () => {
     existsSync(path.join(root, "apps/website/pnpm-lock.yaml")),
     false,
     "the workspace root lockfile is the website's dependency truth",
+  );
+  assert.equal(vercel.git?.deploymentEnabled, true);
+  assert.equal(
+    vercel.ignoreCommand,
+    'if [ -z "$VERCEL_GIT_PREVIOUS_SHA" ]; then exit 1; fi; git diff --quiet "$VERCEL_GIT_PREVIOUS_SHA" HEAD -- . ../../src/shared ../../package.json ../../pnpm-lock.yaml ../../pnpm-workspace.yaml',
   );
 });
 


### PR DESCRIPTION
The website currently rebuilds for every gwonmac commit, including desktop-only work. That made the website responsible for 41.6% of the reviewed Vercel Build CPU usage.

This keeps Vercel connected for required pull-request statuses, but skips a build when the changes since the branch's last successful deployment do not affect the website. The affected paths reuse the repository's existing website workflow boundary: the website app, shared source, and workspace dependency manifests.

The rule fails open. A first deployment, missing previous SHA, or unavailable comparison commit continues with a normal build.

## Verification

- `pnpm check`
- Focused `source-release-pipeline` policy test
- Historical desktop-only range returns `0` and skips
- Historical shared-source range returns `1` and builds
- Missing previous SHA returns `1` and builds

Implemented and verified with OpenAI Codex.
