### PR TITLE
fix(ci): restore exact-head PR verification

### DIFF
--- a/.github/workflows/macos-verify.yml
+++ b/.github/workflows/macos-verify.yml
@@ -48,6 +48,10 @@ jobs:
         uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: high
+          # A reusable workflow called by workflow_dispatch has no pull_request
+          # event, so the action cannot infer the comparison on its own.
+          base-ref: ${{ github.event.pull_request.base.sha || github.event.repository.default_branch }}
+          head-ref: ${{ github.event.pull_request.head.sha || inputs.checkout-ref || github.sha }}
       - uses: pnpm/action-setup@d15e628ca66d93ee5f352c71671a7bc6a97af5c9 # v6.0.8
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -491,6 +491,14 @@ test("tester snapshots are verified, immutable, bounded, and isolated from relea
   assert.match(verification, /run: pnpm verify:runtime/);
   assert.match(
     verification,
+    /base-ref: \$\{\{ github\.event\.pull_request\.base\.sha \|\| github\.event\.repository\.default_branch \}\}/,
+  );
+  assert.match(
+    verification,
+    /head-ref: \$\{\{ github\.event\.pull_request\.head\.sha \|\| inputs\.checkout-ref \|\| github\.sha \}\}/,
+  );
+  assert.match(
+    verification,
     /if: inputs\.artifact-name != ''\n {8}run: pnpm package:built && pnpm test:packaged/,
   );
   assert.match(verification, /codesign --verify --deep --strict/);


### PR DESCRIPTION
## Problem

The automated ArenaNet recertification PRs started their exact-head `workflow_dispatch` verification, but dependency review stopped before macOS verification because that event has no pull-request base and head refs.

## Fix

Pass the pull request base and head refs explicitly when the workflow has them, with safe fallbacks for manual exact-head runs. Add policy assertions so the dispatch path cannot regress.

## Verification

- 1,084 unit tests passed
- 167 policy tests passed
- 83 Tools tests passed
- Main, renderer, test, and Tools TypeScript checks passed
- ESLint and Markdown link checks passed
- Workflow YAML parsed successfully

The `pnpm check` wrapper could not complete because the local dependency relink exhausted available disk space; its individual checks passed directly after the locked dependency install completed as far as space allowed.
