### PR TITLE
fix(input): preserve native double-click across rebuilds

### DIFF
--- a/docs/enhancement-development.md
+++ b/docs/enhancement-development.md
@@ -239,11 +239,9 @@ pnpm certification double-click "/absolute/path/Gw.jspi.wasm"
 pnpm check
 ```
 
-`recertify` must report `bundleVerified: true`, `double-click` must report
-`matchesShippedTable: true`, and `doctor` must name the new build before a live
-run. Native double-click and extended-memory tables are cumulative: add every
-profile emitted by the capability registry without removing the preceding
-build.
+`recertify` must report `bundleVerified: true`, and `double-click` must prove
+one unique callback, active table slot, signature, insertion point, and valid
+output. A shipped hash-table match is regression evidence, not authority.
 
 Each recovered fact needs an independent semantic anchor. A common movement is
 not enough. Automated candidates are review evidence and cannot create runtime

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -111,7 +111,8 @@ Open **Settings → Tools**.
 GWonMac checks each certified game-integration feature after a Guild Wars
 update. File saving, the Guild Wars cursor, local actions, and Apply team can
 remain available or turn off independently.
-Native double-click uses a safe tap fallback when its repair is unavailable.
+Native double-click is unavailable when its native callback proof refuses. The
+app never substitutes touch events.
 The cursor has no player switch. The app does not ship or download cursor
 artwork.
 
@@ -284,7 +285,7 @@ The official client remains playable. Saved builds and teams remain available.
 File saving, the Guild Wars cursor, storage opening, and Apply team have scoped
 support checks. One unavailable command does not turn off the other command,
 the official client, saved builds, or host-owned templates. The macOS pointer
-and tap-based double-click fallback remain available.
+remains available; the app does not synthesize a double-click.
 
 Use **Check for updates** to look for a newer GWonMac release.
 

--- a/internal/upstream/README.md
+++ b/internal/upstream/README.md
@@ -22,7 +22,7 @@ named in the file that contains them.
 | File | Purpose | Current conclusion |
 | --- | --- | --- |
 | [upstream-defects.md](upstream-defects.md) | Self-contained ArenaNet report | Eight measured template, cursor, and subdirectory defects exist in the examined builds. |
-| [mouse-double-click.md](mouse-double-click.md) | Self-contained ArenaNet report and local evidence | The client has a complete mouse double-click channel, but its Emscripten input path never feeds the flag. gwonmac uses an exact-build transform. |
+| [mouse-double-click.md](mouse-double-click.md) | Self-contained ArenaNet report and local evidence | The client has a complete mouse double-click channel, but its Emscripten input path never feeds the flag. gwonmac proves and patches the native callback structurally. |
 | [upstream-keyboard-labels.md](upstream-keyboard-labels.md) | Self-contained ArenaNet report and local investigation | Printable key labels render one character too high. Input remains correct. No local transform is justified. |
 | [client-internals.md](client-internals.md) | Exact-build reference | Template layouts, call sites, and costly Enhancement foundation measurements. |
 | [host-bridge.md](host-bridge.md) | Implemented workaround record | The template transform and renderer bridge fail closed and keep the official module canonical. |

--- a/internal/upstream/mouse-double-click.md
+++ b/internal/upstream/mouse-double-click.md
@@ -265,5 +265,6 @@ player's own macOS double-click preferences. The synthetic tap pair is deleted
 rather than kept beside it, and an Electron spec refuses any touch event so it
 cannot return as a fallback.
 
-`pnpm certification double-click` re-derives the whole table from the official
-bytes and exits non-zero when it disagrees with what is checked in.
+`pnpm certification double-click` re-runs the same structural proof from the
+official bytes. Unknown parsing stays in the bounded utility process;
+production repeats the record-driven transform and checks the exact output.

--- a/src/main/certification/client-module.ts
+++ b/src/main/certification/client-module.ts
@@ -40,13 +40,12 @@ import {
 } from "./enhancement-builds.js";
 import { transformEnhancementWasm } from "./enhancement-transform.js";
 import {
-  deriveNativeDoubleClickBuild,
   findNativeDoubleClickBuild,
   nativeDoubleClickOutputSha256,
   NATIVE_DOUBLE_CLICK_TRANSFORM_ABI,
-  rewriteNativeDoubleClickWasm,
+  rewriteWithBuild,
+  type NativeDoubleClickBuild,
 } from "./native-double-click.js";
-import { readFile } from "node:fs/promises";
 import {
   EXTENDED_MEMORY_MAX_BYTES,
   prepareExtendedMemoryArtifacts,
@@ -248,20 +247,24 @@ async function discardEnhancementCache(
  * The last stage, applied to whatever the chain above settled on.
  *
  * It is deliberately not part of the certification *state*: a module it cannot
- * derive is served exactly as the previous stage produced it, and the renderer
- * falls back to synthesising taps. So an unrecognised predecessor costs the
- * player the double-click repair's latency, never the client.
+ * derive is served exactly as the previous stage produced it. The official
+ * client remains playable, but no synthetic input path is substituted.
  */
 async function withNativeDoubleClick(
   prepared: PreparedWasmClientModule,
   cacheRoot: string,
+  verifyUnknown: (options: {
+    wasmPath: string;
+    inputSha256: string;
+  }) => Promise<NativeDoubleClickBuild | null>,
 ): Promise<PreparedWasmClientModule> {
   try {
     const inputSha256 = await sha256File(prepared.wasmPath);
     const build = findNativeDoubleClickBuild(inputSha256)
-      ?? deriveNativeDoubleClickBuild(
-        new Uint8Array(await readFile(prepared.wasmPath)),
-      );
+      ?? await verifyUnknown({
+        wasmPath: prepared.wasmPath,
+        inputSha256,
+      });
     const expectedOutputSha256 = build
       ? nativeDoubleClickOutputSha256(build, inputSha256)
       : null;
@@ -280,7 +283,7 @@ async function withNativeDoubleClick(
           buildFingerprint: buildFingerprint(build),
           expectedOutputSha256,
         },
-        (base) => rewriteNativeDoubleClickWasm(base),
+        (base) => rewriteWithBuild(base, build),
       ),
       nativeDoubleClick: true,
     };
@@ -294,10 +297,15 @@ async function withNativeDoubleClick(
 
 export async function prepareClientModule(
   options: PrepareClientModuleOptions,
+  verifyUnknownNativeDoubleClick: (options: {
+    wasmPath: string;
+    inputSha256: string;
+  }) => Promise<NativeDoubleClickBuild | null> = async () => null,
 ): Promise<PreparedClientModule> {
   const prepared = await withNativeDoubleClick(
     await prepareCertifiedChain(options),
     options.nativeDoubleClickCacheRoot,
+    verifyUnknownNativeDoubleClick,
   );
   if (!options.extendedMemoryEnabled) {
     return {

--- a/src/main/certification/local-client-verifier-host.ts
+++ b/src/main/certification/local-client-verifier-host.ts
@@ -2,7 +2,8 @@
  * Runs the local client proof and owns everything the proof itself may not:
  * the bounded child process and its timeout.
  *
- * The child gets the module path and the hash it must match, and nothing else.
+ * The child gets the proof mode, module path, and hash it must match, and
+ * nothing else.
  * A result is accepted only if it arrives from this launch's process and
  * survives `isLocalClientVerification` against that same hash. Profile state is
  * never certification authority, so every unknown exact hash runs the proof.
@@ -16,6 +17,10 @@ import {
   isLocalClientVerification,
   type LocalClientVerification,
 } from "./local-client-verifier.js";
+import {
+  isDerivedNativeDoubleClickBuild,
+  type NativeDoubleClickBuild,
+} from "./native-double-click.js";
 
 const VERIFIER_TIMEOUT_MS = 5_000;
 
@@ -29,7 +34,7 @@ function runVerifierProcess(
     );
     const child = utilityProcess.fork(
       entry,
-      [officialWasmPath, officialSha256],
+      ["client", officialWasmPath, officialSha256],
       { serviceName: "Guild Wars client compatibility verifier" },
     );
     let settled = false;
@@ -50,6 +55,35 @@ function runVerifierProcess(
   });
 }
 
+function runNativeDoubleClickVerifierProcess(
+  wasmPath: string,
+  inputSha256: string,
+): Promise<NativeDoubleClickBuild | null> {
+  return new Promise((resolve) => {
+    const entry = fileURLToPath(
+      new URL("./local-client-verifier-process.js", import.meta.url),
+    );
+    const child = utilityProcess.fork(
+      entry,
+      ["native-double-click", wasmPath, inputSha256],
+      { serviceName: "Guild Wars double-click verifier" },
+    );
+    let settled = false;
+    const finish = (value: NativeDoubleClickBuild | null): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      child.kill();
+      resolve(value);
+    };
+    const timeout = setTimeout(() => finish(null), VERIFIER_TIMEOUT_MS);
+    child.once("message", (value: unknown) => {
+      finish(isDerivedNativeDoubleClickBuild(value, inputSha256) ? value : null);
+    });
+    child.once("exit", () => finish(null));
+  });
+}
+
 /**
  * Runs the expensive parsers outside the main and renderer processes for every
  * unknown exact hash. A crash, timeout or malformed reply is simply "no proof";
@@ -62,5 +96,16 @@ export async function verifyClientLocally(options: {
   return runVerifierProcess(
     options.officialWasmPath,
     options.officialSha256,
+  ).catch(() => null);
+}
+
+/** Derives a native callback record without parsing unknown bytes in Main. */
+export async function verifyNativeDoubleClickLocally(options: {
+  wasmPath: string;
+  inputSha256: string;
+}): Promise<NativeDoubleClickBuild | null> {
+  return runNativeDoubleClickVerifierProcess(
+    options.wasmPath,
+    options.inputSha256,
   ).catch(() => null);
 }

--- a/src/main/certification/local-client-verifier-process.ts
+++ b/src/main/certification/local-client-verifier-process.ts
@@ -7,9 +7,9 @@
  * launch nothing. The host owns the timeout; this process holds no state and
  * writes no files.
  *
- * Every refusal is its own exit code, and no message is posted unless the
- * result also passes the boundary check, so the parent never has to interpret a
- * partial answer.
+ * Every refusal is its own exit code and posts `null` before returning. That
+ * closes the parent's wait immediately; the parent still validates every
+ * non-null result and owns the timeout for a crash or a hung parser.
  */
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
@@ -17,6 +17,10 @@ import {
   isLocalClientVerification,
   verifyLocalClientBytes,
 } from "./local-client-verifier.js";
+import {
+  deriveNativeDoubleClickBuild,
+  isDerivedNativeDoubleClickBuild,
+} from "./native-double-click.js";
 
 interface ParentPort {
   postMessage(value: unknown): void;
@@ -27,8 +31,8 @@ const parentPort = (
 ).parentPort;
 
 async function main(): Promise<void> {
-  const [wasmPath, expectedSha256] = process.argv.slice(2);
-  if (!parentPort || !wasmPath || !expectedSha256) {
+  const [mode, wasmPath, expectedSha256] = process.argv.slice(2);
+  if (!parentPort || !mode || !wasmPath || !expectedSha256) {
     process.exitCode = 2;
     return;
   }
@@ -36,16 +40,33 @@ async function main(): Promise<void> {
   const bytes = await readFile(wasmPath);
   const actualSha256 = createHash("sha256").update(bytes).digest("hex");
   if (actualSha256 !== expectedSha256) {
+    parentPort.postMessage(null);
     process.exitCode = 3;
     return;
   }
 
-  const result = verifyLocalClientBytes(bytes);
-  if (!isLocalClientVerification(result, expectedSha256)) {
-    process.exitCode = 4;
+  if (mode === "client") {
+    const result = verifyLocalClientBytes(bytes);
+    if (!isLocalClientVerification(result, expectedSha256)) {
+      parentPort.postMessage(null);
+      process.exitCode = 4;
+      return;
+    }
+    parentPort.postMessage(result);
     return;
   }
-  parentPort.postMessage(result);
+  if (mode === "native-double-click") {
+    const result = deriveNativeDoubleClickBuild(bytes);
+    if (!isDerivedNativeDoubleClickBuild(result, expectedSha256)) {
+      parentPort.postMessage(null);
+      process.exitCode = 4;
+      return;
+    }
+    parentPort.postMessage(result);
+    return;
+  }
+  parentPort.postMessage(null);
+  process.exitCode = 2;
 }
 
 await main().catch(() => {

--- a/src/main/certification/native-double-click.ts
+++ b/src/main/certification/native-double-click.ts
@@ -165,6 +165,45 @@ export function nativeDoubleClickOutputSha256(
   return build.derivations[inputSha256] ?? null;
 }
 
+function sameStrings(left: unknown, right: readonly string[]): boolean {
+  return Array.isArray(left)
+    && left.length === right.length
+    && left.every((value, index) => value === right[index]);
+}
+
+/** Validate a relocated record that crossed the isolated-process boundary. */
+export function isDerivedNativeDoubleClickBuild(
+  value: unknown,
+  inputSha256: string,
+  baselines: readonly NativeDoubleClickBuild[] = NATIVE_DOUBLE_CLICK_BUILDS,
+): value is NativeDoubleClickBuild {
+  if (!value || typeof value !== "object") return false;
+  const build = value as Partial<NativeDoubleClickBuild>;
+  if (
+    !Number.isSafeInteger(build.callbackTableSlot)
+    || (build.callbackTableSlot as number) < 0
+    || !Number.isSafeInteger(build.callbackFunctionIndex)
+    || (build.callbackFunctionIndex as number) < 0
+    || !Number.isSafeInteger(build.flagStoreOffset)
+    || (build.flagStoreOffset as number) < 0
+    || !Number.isSafeInteger(build.flagStoreFrameOffset)
+    || (build.flagStoreFrameOffset as number) < 0
+    || typeof build.callbackBodySha256 !== "string"
+    || !/^[0-9a-f]{64}$/.test(build.callbackBodySha256)
+    || !build.derivations
+    || typeof build.derivations !== "object"
+    || Object.keys(build.derivations).length !== 1
+    || !/^[0-9a-f]{64}$/.test(build.derivations[inputSha256] ?? "")
+  ) return false;
+  return baselines.some((baseline) =>
+    build.callbackBodySha256 === baseline.callbackBodySha256
+    && build.flagStoreOffset === baseline.flagStoreOffset
+    && build.flagStoreFrameOffset === baseline.flagStoreFrameOffset
+    && sameStrings(build.callbackParams, baseline.callbackParams)
+    && sameStrings(build.callbackResults, baseline.callbackResults)
+  );
+}
+
 /** Locate an unchanged callback semantically when only the predecessor hash moved. */
 export function deriveNativeDoubleClickBuild(
   input: Uint8Array,
@@ -299,6 +338,15 @@ export function rewriteWithBuild(
   const localIndex = build.callbackFunctionIndex - importCount;
   const body = bodies[localIndex];
   if (!body) fail(`function ${build.callbackFunctionIndex} has no body`);
+  const functionTypes = parseIndexVector(sectionById(sections, 3));
+  const type = parseTypes(sectionById(sections, 1))[functionTypes[localIndex]!];
+  if (
+    !type
+    || type.params.some((value) => value !== 0x7f)
+    || type.results.some((value) => value !== 0x7f)
+    || !sameStrings(type.params.map(() => "i32"), build.callbackParams)
+    || !sameStrings(type.results.map(() => "i32"), build.callbackResults)
+  ) fail("the mousedown callback does not have the certified signature");
   if (sha256(body) !== build.callbackBodySha256) {
     fail("the mousedown callback is not the certified body");
   }

--- a/src/main/client-runtime.ts
+++ b/src/main/client-runtime.ts
@@ -90,7 +90,10 @@ import {
   startClientUpdateSpan,
 } from "./diagnostics.js";
 import type { GamePaths } from "./paths.js";
-import { verifyClientLocally } from "./certification/local-client-verifier-host.js";
+import {
+  verifyClientLocally,
+  verifyNativeDoubleClickLocally,
+} from "./certification/local-client-verifier-host.js";
 import { extendedMemoryRuntimeStatus } from "./extended-memory-runtime.js";
 import { supportedEnhancementCapabilities } from "./certification/enhancement-builds.js";
 
@@ -333,7 +336,7 @@ export class ClientRuntime {
       nativeDoubleClickCacheRoot: this.options.paths.nativeDoubleClick,
       extendedMemoryCacheRoot: this.options.paths.extendedMemory,
       extendedMemoryEnabled: this.options.extendedMemoryEnabled,
-    });
+    }, verifyNativeDoubleClickLocally);
     const preparationFailed = prepared.failure?.stage === "enhancement";
     const supported = prepared.enhancementBuild
       ? supportedEnhancementCapabilities(prepared.enhancementBuild)

--- a/tests/electron/fixtures/local-verifier-app/main.mjs
+++ b/tests/electron/fixtures/local-verifier-app/main.mjs
@@ -7,10 +7,10 @@ const hostUrl = new URL(
   "../../../../build/main/certification/local-client-verifier-host.js",
   import.meta.url,
 );
-const { verifyClientLocally } = await import(hostUrl.href);
+const { verifyClientLocally, verifyNativeDoubleClickLocally } = await import(hostUrl.href);
 
-const [officialWasmPath, officialSha256] = process.argv.slice(-2);
-if (!officialWasmPath || !officialSha256) {
+const [mode, officialWasmPath, officialSha256] = process.argv.slice(-3);
+if (!mode || !officialWasmPath || !officialSha256) {
   throw new Error("local verifier fixture requires wasm and hash");
 }
 
@@ -21,10 +21,12 @@ const state = /** @type {{
 state.localVerifierCompleted = false;
 state.localVerifierOutcome = null;
 void app.whenReady().then(async () => {
-  state.localVerifierOutcome = await verifyClientLocally({
-    officialWasmPath,
-    officialSha256,
-  });
+  state.localVerifierOutcome = mode === "native-double-click"
+    ? await verifyNativeDoubleClickLocally({
+        wasmPath: officialWasmPath,
+        inputSha256: officialSha256,
+      })
+    : await verifyClientLocally({ officialWasmPath, officialSha256 });
   state.localVerifierCompleted = true;
   const window = new BrowserWindow({ show: false });
   await window.loadURL("data:text/html,local-verifier-complete");

--- a/tests/electron/local-client-verifier.spec.ts
+++ b/tests/electron/local-client-verifier.spec.ts
@@ -35,7 +35,7 @@ test("re-verifies an unknown exact hash in an isolated process", async () => {
     }
     const application = await electron.launch({
       cwd: path.resolve("."),
-      args: [fixture, wasmPath, sha256],
+      args: [fixture, "client", wasmPath, sha256],
       executablePath: electronPath,
       env,
     });
@@ -65,6 +65,33 @@ test("re-verifies an unknown exact hash in an isolated process", async () => {
     const second = await run();
     expect(second).toBeNull();
   } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("refuses an unknown native callback inside the isolated process", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "gw-double-click-verifier-"));
+  const wasmPath = path.join(root, "unknown.wasm");
+  const wasm = Uint8Array.of(0, 97, 115, 109, 1, 0, 0, 0);
+  const sha256 = createHash("sha256").update(wasm).digest("hex");
+  await writeFile(wasmPath, wasm);
+  const env = Object.fromEntries(
+    Object.entries(process.env).filter(
+      (entry): entry is [string, string] =>
+        entry[1] !== undefined && entry[0] !== "ELECTRON_RUN_AS_NODE",
+    ),
+  );
+  const application = await electron.launch({
+    cwd: path.resolve("."),
+    args: [fixture, "native-double-click", wasmPath, sha256],
+    executablePath: electronPath,
+    env,
+  });
+  try {
+    await expect.poll(() => completed(application), { timeout: 10_000 }).toBe(true);
+    expect(await outcome(application)).toBeNull();
+  } finally {
+    await application.close();
     await rm(root, { recursive: true, force: true });
   }
 });

--- a/tests/unit/client-module.test.ts
+++ b/tests/unit/client-module.test.ts
@@ -37,6 +37,11 @@ import {
   transformEnhancementWasm,
 } from "../../src/main/certification/enhancement-transform.js";
 import {
+  DOUBLE_CLICK_FLAG_EXPORT,
+  rewriteWithBuild,
+  type NativeDoubleClickBuild,
+} from "../../src/main/certification/native-double-click.js";
+import {
   parseCode,
   sectionById,
   splitSections,
@@ -149,7 +154,9 @@ function officialFixture(): Uint8Array {
     ...paddedCall(1),
     0x0b,
   ];
-  const loop = [0, 0x0b];
+  // Two parameters plus two locals make local 3 valid for the native
+  // double-click store used by the preparation-path test below.
+  const loop = [1, 2, 0x7f, 0x0b];
   const slashParser = [0, 0x41, 0, 0x0b];
   const code = section(10, [
     12,
@@ -285,8 +292,7 @@ function enhancementBuild(input: Uint8Array): KnownEnhancementBuild {
         params: ["i32", "i32"],
         results: [],
         tableSlot: 4,
-        bodySha256:
-          "f09a7a12954169ae595d12d870e69a4c0092003157d72523d626d2a3990241e2",
+        bodySha256: sha256(parseCode(sectionById(splitSections(input), 10))[5]!),
       },
     },
     teamApply: {
@@ -572,6 +578,45 @@ describe("client module preparation", () => {
     await assertMissing(value.enhancementCacheRoot);
   });
 
+  it("uses an isolated derived native record through the complete cache path", async () => {
+    const value = await fixture();
+    let verifierCalls = 0;
+    const prepared = await prepareClientModule(
+      options(
+        value,
+        { templateSaveBuild: value.templateSaveBuild, enhancementBuild: null },
+        CURSOR_TOOLBOX,
+      ),
+      async ({ wasmPath, inputSha256 }) => {
+        verifierCalls += 1;
+        const input = new Uint8Array(await readFile(wasmPath));
+        assert.equal(sha256(input), inputSha256);
+        const body = parseCode(sectionById(splitSections(input), 10))[5]!;
+        const draft: NativeDoubleClickBuild = {
+          callbackTableSlot: 4,
+          callbackFunctionIndex: 6,
+          callbackParams: ["i32", "i32"],
+          callbackResults: [],
+          callbackBodySha256: sha256(body),
+          flagStoreOffset: 3,
+          flagStoreFrameOffset: 24,
+          derivations: {},
+        };
+        return {
+          ...draft,
+          derivations: { [inputSha256]: sha256(rewriteWithBuild(input, draft)) },
+        };
+      },
+    );
+
+    assert.equal(verifierCalls, 1);
+    assert.equal(prepared.nativeDoubleClick, true);
+    const output = await readFile(prepared.wasmPath);
+    assert.ok(WebAssembly.Module.exports(new WebAssembly.Module(output)).some(
+      (entry) => entry.name === DOUBLE_CLICK_FLAG_EXPORT,
+    ));
+  });
+
   it("serves official bytes and drops both caches when uncertified", async () => {
     const value = await fixture();
     await Promise.all([
@@ -591,9 +636,8 @@ describe("client module preparation", () => {
       enhancementBuild: null,
       requestedCapabilities: CURSOR_TOOLBOX,
       effectiveCapabilities: NO_CAPABILITIES,
-      // An unrecognised client is served exactly as downloaded, so it also
-      // never receives the double-click transform: the renderer keeps
-      // synthesising taps rather than being handed a module nothing certified.
+      // An unrecognised client is served exactly as downloaded, so it receives
+      // neither the double-click transform nor substitute touch input.
       nativeDoubleClick: false,
       failure: null,
     });

--- a/tests/unit/native-double-click-transform.test.ts
+++ b/tests/unit/native-double-click-transform.test.ts
@@ -14,6 +14,7 @@ import test from "node:test";
 import {
   DOUBLE_CLICK_FLAG_EXPORT,
   deriveNativeDoubleClickBuild,
+  isDerivedNativeDoubleClickBuild,
   NATIVE_DOUBLE_CLICK_BUILDS,
   rewriteWithBuild,
   type NativeDoubleClickBuild,
@@ -143,7 +144,35 @@ test("locates an unchanged callback without a predecessor hash", () => {
   assert.equal(located.callbackFunctionIndex, baseline.callbackFunctionIndex);
   assert.equal(located.callbackTableSlot, baseline.callbackTableSlot);
   assert.match(located.derivations[sha256(bytes)] ?? "", /^[0-9a-f]{64}$/);
+  assert.equal(
+    isDerivedNativeDoubleClickBuild(located, sha256(bytes), [baseline]),
+    true,
+  );
   assert.equal(deriveNativeDoubleClickBuild(bytes, [baseline, baseline]), null);
+});
+
+test("rejects malformed or over-broad isolated verifier records", () => {
+  const { bytes, body } = buildModule();
+  const inputSha256 = sha256(bytes);
+  const baseline = entryFor(body);
+  const located = deriveNativeDoubleClickBuild(bytes, [baseline]);
+  assert.ok(located);
+  assert.equal(isDerivedNativeDoubleClickBuild(located, inputSha256, [baseline]), true);
+  assert.equal(isDerivedNativeDoubleClickBuild({
+    ...located,
+    flagStoreFrameOffset: located.flagStoreFrameOffset + 4,
+  }, inputSha256, [baseline]), false);
+  assert.equal(isDerivedNativeDoubleClickBuild({
+    ...located,
+    derivations: {
+      ...located.derivations,
+      ["0".repeat(64)]: "1".repeat(64),
+    },
+  }, inputSha256, [baseline]), false);
+  assert.equal(isDerivedNativeDoubleClickBuild({
+    ...located,
+    derivations: { [inputSha256]: "not-a-digest" },
+  }, inputSha256, [baseline]), false);
 });
 
 test("refuses a callback whose body is not the certified one", () => {
@@ -155,6 +184,14 @@ test("refuses a callback whose body is not the certified one", () => {
     () => rewriteWithBuild(bytes, wrong),
     /not the certified body/,
     "a body that changed by any byte must not be edited",
+  );
+});
+
+test("rechecks the isolated record's callback signature during production", () => {
+  const { bytes, body } = buildModule();
+  assert.throws(
+    () => rewriteWithBuild(bytes, entryFor(body, { callbackParams: ["i32"] })),
+    /certified signature/,
   );
 });
 


### PR DESCRIPTION
## What changed

Native double-click preparation carries the structurally derived callback record into the production transform and verifies it in the isolated utility process.

## Why

Routine ArenaNet rebuilds could derive the correct callback and then discard it in favor of an exact-hash lookup. Synthetic touch fallback is intentionally rejected.

## Invariant

One unique callback, signature, active table role, frame insertion point, and valid output are required. Refusal leaves ordinary client input byte-for-byte unchanged.

## Verification

- Exact-head PR package, CodeQL, and Vercel checks passed.
- Preparation-path, ambiguity, malformed-boundary, and no-touch tests pass.
- No synthetic input fallback exists.

Stack layer 2 of 13.
