### PR TITLE
refactor(certification): add bounded semantic proof primitives

### DIFF
--- a/src/main/certification/semantic-proof.ts
+++ b/src/main/certification/semantic-proof.ts
@@ -1,0 +1,159 @@
+/**
+ * Shared vocabulary and limits for feature-local semantic proofs.
+ *
+ * These primitives grant no capability. A feature verifier must still own its
+ * semantic anchors and production transform. This file only makes three safety
+ * rules hard to bypass: every verdict is input/ABI bound, every layout field
+ * has a named witness, and byte canonicalization can hide only explicit,
+ * non-overlapping relocation operands.
+ */
+import { createHash } from "node:crypto";
+
+export const SEMANTIC_VERIFIER_ABI = 1;
+
+export type ProofRefusal = Readonly<{
+  inputSha256: string;
+  verifierAbi: number;
+  invariant: string;
+}>;
+
+export type ProofVerdict<Value> =
+  | Readonly<{
+      status: "proved";
+      inputSha256: string;
+      verifierAbi: number;
+      value: Value;
+    }>
+  | (Readonly<{ status: "changed" }> & ProofRefusal)
+  | (Readonly<{ status: "ambiguous"; candidates: number }> & ProofRefusal);
+
+export type AddressClass =
+  | "function-index"
+  | "immutable-data"
+  | "mutable-static";
+
+export type FieldWitness = Readonly<{
+  sourceRole: string;
+  expression: string;
+  occurrences: readonly number[];
+}>;
+
+/** Adding a layout field makes every witness ledger a TypeScript error. */
+export type FieldWitnesses<Layout extends Readonly<Record<string, number>>> = {
+  readonly [Field in keyof Layout]: FieldWitness;
+};
+
+export type VerifiedLayout<Layout extends Readonly<Record<string, number>>> =
+  Readonly<{
+    layout: Layout;
+    witnesses: FieldWitnesses<Layout>;
+  }>;
+
+function exactOwnKeys(
+  left: Readonly<Record<string, unknown>>,
+  right: Readonly<Record<string, unknown>>,
+): boolean {
+  const leftKeys = Object.keys(left).sort();
+  const rightKeys = Object.keys(right).sort();
+  return leftKeys.length === rightKeys.length
+    && leftKeys.every((key, index) => key === rightKeys[index]);
+}
+
+export function verifyLayout<Layout extends Readonly<Record<string, number>>>(
+  layout: Layout,
+  witnesses: FieldWitnesses<Layout>,
+): VerifiedLayout<Layout> {
+  if (!exactOwnKeys(layout, witnesses)) {
+    throw new Error("semantic proof: layout witness keys do not match");
+  }
+  for (const [field, value] of Object.entries(layout)) {
+    const witness = witnesses[field]!;
+    if (
+      !Number.isSafeInteger(value)
+      || !witness.sourceRole
+      || !witness.expression
+      || witness.occurrences.length === 0
+      || !witness.occurrences.every(
+        (occurrence) => Number.isSafeInteger(occurrence) && occurrence >= 0,
+      )
+    ) {
+      throw new Error(`semantic proof: invalid witness for ${field}`);
+    }
+  }
+  return Object.freeze({
+    layout: Object.freeze({ ...layout }),
+    witnesses: Object.freeze({ ...witnesses }),
+  });
+}
+
+export class ProofLimitError extends Error {
+  readonly limit: string;
+
+  constructor(limit: string) {
+    super(`semantic proof: ${limit} limit exceeded`);
+    this.limit = limit;
+  }
+}
+
+export class ProofBudget {
+  #remaining: number;
+  readonly limit: number;
+
+  constructor(limit: number) {
+    if (!Number.isSafeInteger(limit) || limit < 0) {
+      throw new Error("semantic proof: invalid analysis limit");
+    }
+    this.limit = limit;
+    this.#remaining = limit;
+  }
+
+  spend(units = 1): void {
+    if (!Number.isSafeInteger(units) || units < 0) {
+      throw new Error("semantic proof: invalid analysis cost");
+    }
+    if (units > this.#remaining) throw new ProofLimitError("analysis-work");
+    this.#remaining -= units;
+  }
+}
+
+export type RelocationSpan = Readonly<{
+  start: number;
+  end: number;
+  addressClass: AddressClass;
+  role: string;
+}>;
+
+const text = new TextEncoder();
+
+/**
+ * Hash bytes while replacing only caller-supplied relocation operands with a
+ * typed role marker. Branches, opcodes, call order, cardinality, constants,
+ * and every byte outside those operands remain exact.
+ */
+export function relocationAwareFingerprint(
+  bytes: Uint8Array,
+  spans: readonly RelocationSpan[],
+  budget = new ProofBudget(4_096),
+): string {
+  const ordered = [...spans].sort((left, right) => left.start - right.start);
+  const hash = createHash("sha256");
+  let cursor = 0;
+  for (const span of ordered) {
+    budget.spend();
+    if (
+      !span.role
+      || !Number.isSafeInteger(span.start)
+      || !Number.isSafeInteger(span.end)
+      || span.start < cursor
+      || span.end <= span.start
+      || span.end > bytes.byteLength
+    ) {
+      throw new Error("semantic proof: invalid or overlapping relocation span");
+    }
+    hash.update(bytes.subarray(cursor, span.start));
+    hash.update(text.encode(`\0${span.addressClass}:${span.role}\0`));
+    cursor = span.end;
+  }
+  hash.update(bytes.subarray(cursor));
+  return hash.digest("hex");
+}

--- a/tests/unit/semantic-proof.test.ts
+++ b/tests/unit/semantic-proof.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  ProofBudget,
+  ProofLimitError,
+  relocationAwareFingerprint,
+  verifyLayout,
+  type FieldWitnesses,
+  type ProofVerdict,
+} from "../../src/main/certification/semantic-proof.js";
+
+describe("semantic proof primitives", () => {
+  it("binds every verdict to one input and verifier ABI", () => {
+    const verdict: ProofVerdict<{ functionIndex: number }> = {
+      status: "proved",
+      inputSha256: "a".repeat(64),
+      verifierAbi: 1,
+      value: { functionIndex: 42 },
+    };
+    assert.equal(verdict.inputSha256, "a".repeat(64));
+    assert.equal(verdict.verifierAbi, 1);
+  });
+
+  it("requires an exact, non-empty witness ledger", () => {
+    const layout = { root: 12, field: 20 } as const;
+    const witnesses = {
+      root: { sourceRole: "reader", expression: "global + 12", occurrences: [4] },
+      field: { sourceRole: "writer", expression: "object + 20", occurrences: [9] },
+    } satisfies FieldWitnesses<typeof layout>;
+    assert.deepEqual(verifyLayout(layout, witnesses).layout, layout);
+    const overbroad = { ...witnesses, extra: witnesses.root };
+    assert.throws(
+      () => verifyLayout(layout, overbroad),
+      /witness keys do not match/,
+    );
+    assert.throws(
+      () => verifyLayout(layout, {
+        ...witnesses,
+        field: { ...witnesses.field, occurrences: [] },
+      }),
+      /invalid witness for field/,
+    );
+  });
+
+  it("canonicalizes only explicit relocation operands", () => {
+    const baseline = Uint8Array.of(0x10, 1, 0x41, 10, 0x0b);
+    const relocated = Uint8Array.of(0x10, 9, 0x41, 10, 0x0b);
+    const spans = [{
+      start: 1,
+      end: 2,
+      addressClass: "function-index" as const,
+      role: "unique callback",
+    }];
+    assert.equal(
+      relocationAwareFingerprint(baseline, spans),
+      relocationAwareFingerprint(relocated, spans),
+    );
+    const changedBranch = Uint8Array.of(0x0c, 9, 0x41, 10, 0x0b);
+    assert.notEqual(
+      relocationAwareFingerprint(baseline, spans),
+      relocationAwareFingerprint(changedBranch, spans),
+    );
+    assert.throws(
+      () => relocationAwareFingerprint(baseline, [
+        spans[0]!,
+        { ...spans[0]!, role: "duplicate" },
+      ]),
+      /overlapping relocation span/,
+    );
+  });
+
+  it("fails closed at the analysis ceiling", () => {
+    const budget = new ProofBudget(1);
+    budget.spend();
+    assert.throws(() => budget.spend(), ProofLimitError);
+    assert.throws(() => new ProofBudget(-1), /invalid analysis limit/);
+  });
+});


### PR DESCRIPTION
## What changed

Adds bounded WASM proof primitives, typed per-feature verdicts, field witnesses, parser limits, and adversarial fixtures without granting new feature authority.

## Why

Per-release hash allowlists cannot distinguish harmless relocation from semantic change and make feature-local refusal impossible.

## Invariant

Proofs preserve control flow, signatures, call relationships, cardinality, table roles, message semantics, offsets, and unexplained constants. Every certificate field needs a typed witness.

## Verification

- Exact-head PR package, CodeQL, and Vercel checks passed.
- Boundary, parser-limit, ambiguity, and mutation tests pass.
- This foundation grants no additional runtime capability by itself.

Stack layer 3 of 13.
