### PR TITLE
fix(cursor): derive relocated client layout

### DIFF
--- a/src/main/certification/enhancement-structural-evidence.ts
+++ b/src/main/certification/enhancement-structural-evidence.ts
@@ -25,6 +25,12 @@ import {
   type Section,
 } from "../core/wasm-binary.js";
 import type { KnownEnhancementBuild } from "./enhancement-builds.js";
+import {
+  relocationAwareFingerprint,
+  verifyLayout,
+  type RelocationSpan,
+} from "./semantic-proof.js";
+import type { EnhancementCursorLayout } from "../../shared/enhancement-config.js";
 
 declare const WebAssembly: {
   validate(bytes: Uint8Array): boolean;
@@ -131,9 +137,12 @@ export interface EnhancementStructuralEvidenceReport {
 export interface AutomaticCursorLocation {
   readonly baseline: KnownEnhancementBuild;
   readonly hookFunction: number;
+  readonly hookBodySha256: string;
   readonly cursorFunction: number;
   readonly cursorTableSlot: number;
   readonly producerFunctions: readonly [number, number];
+  readonly producerBodySha256: readonly [string, string];
+  readonly layout: EnhancementCursorLayout;
 }
 
 const MAX_INPUT_BYTES = 64 * 1024 * 1024;
@@ -1033,6 +1042,293 @@ export function inspectEnhancementStructuralEvidence(
   }
 }
 
+type CursorRole = Readonly<{
+  bodyLength: number;
+  fingerprint: string;
+  spans: readonly RelocationSpan[];
+  params: readonly string[];
+  results: readonly string[];
+}>;
+
+const mutableSpans = (
+  entries: readonly (readonly [number, number, string])[],
+): readonly RelocationSpan[] => Object.freeze(entries.map(([start, end, role]) =>
+  Object.freeze({ start, end, role, addressClass: "mutable-static" as const })));
+
+const CURSOR_TICK_ROLE: CursorRole = Object.freeze({
+  bodyLength: 218,
+  fingerprint: "55a9bca40e9e16713b0473d83afbe7264cd9578f0077d99075afafb076d5fa66",
+  spans: mutableSpans([
+    [27, 32, "tick.work-count"],
+    [60, 65, "tick.work-list"],
+    [146, 151, "tick.quit-flag"],
+    [185, 190, "tick.tail-callback"],
+  ]),
+  params: Object.freeze(["i32"]),
+  results: Object.freeze([]),
+});
+
+const CURSOR_PRODUCER_ROLES: readonly [CursorRole, CursorRole] = Object.freeze([
+  Object.freeze({
+    bodyLength: 1_099,
+    fingerprint: "a9d848f87b08aba9b6eb08cbca0bb89208004df8fbdb83b8f8505001e6c4b91b",
+    spans: mutableSpans([
+      [68, 73, "producer.busy"], [104, 109, "producer.busy"],
+      [688, 693, "producer.scratch"], [712, 717, "cursor.color-buffer"],
+      [742, 747, "producer.scratch"], [761, 766, "cursor.color-buffer"],
+      [772, 777, "producer.scratch-plus-one"],
+      [798, 803, "cursor.color-buffer"], [829, 834, "cursor.color-buffer"],
+      [835, 840, "producer.scratch"], [1075, 1080, "producer.busy"],
+    ]),
+    params: Object.freeze(["i32", "i32"]),
+    results: Object.freeze(["i32"]),
+  }),
+  Object.freeze({
+    bodyLength: 254,
+    fingerprint: "7f1603650a1e2428354420bdc3ca9d4b4c9e678a2736234277cdf46755090311",
+    spans: mutableSpans([
+      [78, 83, "producer.scratch"], [102, 107, "cursor.color-buffer"],
+      [132, 137, "producer.scratch"], [151, 156, "cursor.color-buffer"],
+      [162, 167, "producer.scratch-plus-one"],
+      [188, 193, "cursor.color-buffer"], [219, 224, "cursor.color-buffer"],
+      [225, 230, "producer.scratch"],
+    ]),
+    params: Object.freeze(["i32", "i32"]),
+    results: Object.freeze(["i32"]),
+  }),
+]);
+
+const CURSOR_ART_RENDERER_ROLE: CursorRole = Object.freeze({
+  bodyLength: 277,
+  fingerprint: "a4a80470eeec29fe6a691a8da454ec80b478046343b5f8422ef3382d9e9780e6",
+  spans: mutableSpans([
+    [84, 89, "cursor.art-cache-a"],
+    [90, 95, "cursor.art-cache-b"],
+    [148, 153, "cursor.scale"],
+  ]),
+  params: Object.freeze(["i32", "i32"]),
+  results: Object.freeze([]),
+});
+
+const CURSOR_STATE_READER_ROLE: CursorRole = Object.freeze({
+  bodyLength: 102,
+  fingerprint: "39a2f1f0bdb8526c7de7616c6fb4da03c746c5debd78c29cc81006b2f65a4804",
+  spans: mutableSpans([
+    [9, 14, "cursor.software-model"],
+    [20, 25, "cursor.show-count"],
+    [36, 41, "cursor.active-art"],
+  ]),
+  params: Object.freeze([]),
+  results: Object.freeze([]),
+});
+
+const CURSOR_TABLE_AFTER_ROLE: CursorRole = Object.freeze({
+  bodyLength: 155,
+  fingerprint: "27ad597ce36f810602ece7a1f39259e3ecc9381332ad4cdf7fc461b4a6bd9cef",
+  spans: mutableSpans([[116, 121, "cursor.table-after-vtable"]]),
+  params: Object.freeze(["i32"]),
+  results: Object.freeze(["i32"]),
+});
+
+const CURSOR_HANDLE_READER_SHA256 =
+  "140a325a163f8eaec410ad40908b993e4a5d3532f51c675be0019e166253b173";
+const CURSOR_TEXTURE_WRITER_SHA256 =
+  "f1d4d25243aeb652707797683ed6118569f606e9e3a69040eaa3789f737dcc7a";
+
+function functionBody(module: ModuleShape, functionIndex: number): Uint8Array {
+  const body = module.bodies[functionIndex - module.functionImportCount];
+  if (!body) throw new EvidenceError("module-shape-unsupported");
+  return body;
+}
+
+function signatureMatches(
+  module: ModuleShape,
+  functionIndex: number,
+  params: readonly string[],
+  results: readonly string[],
+): boolean {
+  const signature = signatureEvidence(module, functionIndex);
+  return signature !== null
+    && signature.params.join() === params.join()
+    && signature.results.join() === results.join();
+}
+
+function bodyMatchesRole(body: Uint8Array, role: CursorRole): boolean {
+  return body.byteLength === role.bodyLength
+    && relocationAwareFingerprint(body, role.spans) === role.fingerprint;
+}
+
+function uniqueRoleFunction(module: ModuleShape, role: CursorRole): number | null {
+  const matches: number[] = [];
+  for (
+    let functionIndex = module.functionImportCount;
+    functionIndex < module.functionTypeIndices.length;
+    functionIndex += 1
+  ) {
+    if (
+      signatureMatches(module, functionIndex, role.params, role.results)
+      && bodyMatchesRole(functionBody(module, functionIndex), role)
+    ) matches.push(functionIndex);
+    if (matches.length > 1) return null;
+  }
+  return matches.length === 1 ? matches[0]! : null;
+}
+
+function uniqueExactFunction(
+  module: ModuleShape,
+  bodySha256: string,
+  params: readonly string[],
+  results: readonly string[],
+): number | null {
+  const matches: number[] = [];
+  for (
+    let functionIndex = module.functionImportCount;
+    functionIndex < module.functionTypeIndices.length;
+    functionIndex += 1
+  ) {
+    if (
+      signatureMatches(module, functionIndex, params, results)
+      && functionBodySha256(module, functionIndex) === bodySha256
+    ) matches.push(functionIndex);
+    if (matches.length > 1) return null;
+  }
+  return matches.length === 1 ? matches[0]! : null;
+}
+
+function paddedU32(body: Uint8Array, start: number): number {
+  const cursor = { value: start };
+  const value = readUnsigned(body, cursor);
+  if (cursor.value !== start + 5) {
+    throw new EvidenceError("module-shape-unsupported");
+  }
+  return value;
+}
+
+function valuesForRole(body: Uint8Array, role: CursorRole): Map<string, number[]> {
+  const values = new Map<string, number[]>();
+  for (const span of role.spans) {
+    const group = values.get(span.role) ?? [];
+    group.push(paddedU32(body, span.start));
+    values.set(span.role, group);
+  }
+  return values;
+}
+
+function soleValue(values: Map<string, number[]>, role: string): number {
+  const found = values.get(role) ?? [];
+  if (found.length === 0 || found.some((value) => value !== found[0])) {
+    throw new EvidenceError("module-shape-unsupported");
+  }
+  return found[0]!;
+}
+
+function commonRelocationDelta(
+  entries: readonly (readonly [number, number])[],
+): number | null {
+  const deltas = entries.map(([candidate, baseline]) => candidate - baseline);
+  return deltas.every((delta) => delta === deltas[0]) ? deltas[0]! : null;
+}
+
+function deriveCursorLayout(
+  module: ModuleShape,
+  tickFunction: number,
+  producerFunctions: readonly [number, number],
+): EnhancementCursorLayout | null {
+  const rendererFunction = uniqueRoleFunction(module, CURSOR_ART_RENDERER_ROLE);
+  const stateReaderFunction = uniqueRoleFunction(module, CURSOR_STATE_READER_ROLE);
+  const handleReaderFunction = uniqueExactFunction(
+    module, CURSOR_HANDLE_READER_SHA256, ["i32"], ["i32"],
+  );
+  const textureWriterFunction = uniqueExactFunction(
+    module, CURSOR_TEXTURE_WRITER_SHA256, ["i32", "i32", "i32"], [],
+  );
+  if (
+    rendererFunction === null || stateReaderFunction === null
+    || handleReaderFunction === null || textureWriterFunction === null
+  ) return null;
+
+  const producerOne = valuesForRole(
+    functionBody(module, producerFunctions[0]), CURSOR_PRODUCER_ROLES[0],
+  );
+  const producerTwo = valuesForRole(
+    functionBody(module, producerFunctions[1]), CURSOR_PRODUCER_ROLES[1],
+  );
+  const state = valuesForRole(
+    functionBody(module, stateReaderFunction), CURSOR_STATE_READER_ROLE,
+  );
+  const renderer = valuesForRole(
+    functionBody(module, rendererFunction), CURSOR_ART_RENDERER_ROLE,
+  );
+  const tick = valuesForRole(
+    functionBody(module, tickFunction), CURSOR_TICK_ROLE,
+  );
+  const colorBuffer = soleValue(producerOne, "cursor.color-buffer");
+  if (
+    colorBuffer !== soleValue(producerTwo, "cursor.color-buffer")
+    || soleValue(producerOne, "producer.scratch") + 1
+      !== soleValue(producerOne, "producer.scratch-plus-one")
+    || soleValue(producerTwo, "producer.scratch") + 1
+      !== soleValue(producerTwo, "producer.scratch-plus-one")
+  ) return null;
+
+  const cursorActiveArt = soleValue(state, "cursor.active-art");
+  const cursorSoftwareModel = soleValue(state, "cursor.software-model");
+  const cursorShowCount = soleValue(state, "cursor.show-count");
+  if (
+    cursorSoftwareModel !== cursorActiveArt + 4
+    || cursorShowCount !== cursorActiveArt + 8
+    || soleValue(renderer, "cursor.art-cache-b")
+      !== soleValue(renderer, "cursor.art-cache-a") + 4
+  ) return null;
+
+  const delta = commonRelocationDelta([
+    [colorBuffer, 0x298e50],
+    [soleValue(producerOne, "producer.scratch"), 0x298a50],
+    [soleValue(producerTwo, "producer.scratch"), 0x298a50],
+    [soleValue(producerOne, "producer.busy"), 0x298a40],
+    [cursorActiveArt, 0x5a16e0],
+    [cursorSoftwareModel, 0x5a16e4],
+    [cursorShowCount, 0x5a16e8],
+    [soleValue(renderer, "cursor.art-cache-a"), 0x15a5dc],
+    [soleValue(renderer, "cursor.art-cache-b"), 0x15a5e0],
+    [soleValue(renderer, "cursor.scale"), 0x5a13a4],
+    [soleValue(tick, "tick.work-count"), 0x28cde4],
+    [soleValue(tick, "tick.work-list"), 0x28cddc],
+    [soleValue(tick, "tick.quit-flag"), 0x28cdec],
+    [soleValue(tick, "tick.tail-callback"), 0x28cdf0],
+  ]);
+  if (delta === null) return null;
+
+  const layout: EnhancementCursorLayout = {
+    cursorActiveArt,
+    cursorSoftwareModel,
+    cursorShowCount,
+    cursorColorBuffer: colorBuffer,
+    cursorArtHotspot: 0,
+    cursorArtTexture: 12,
+    cursorHandleKey: 8,
+    cursorHandleObject: 0,
+    cursorViewTexture: 8,
+    cursorTextureType: 12,
+    cursorTextureWidth: 20,
+    cursorTextureHeight: 24,
+  };
+  return verifyLayout(layout, {
+    cursorActiveArt: { sourceRole: "cursor-state-reader", expression: "i32.load static", occurrences: [36] },
+    cursorSoftwareModel: { sourceRole: "cursor-state-reader", expression: "i32.load static", occurrences: [9] },
+    cursorShowCount: { sourceRole: "cursor-state-reader", expression: "i32.load static", occurrences: [20] },
+    cursorColorBuffer: { sourceRole: "cursor-pixel-producers", expression: "i32.const/static store", occurrences: [712, 761, 798, 829, 102, 151, 188, 219] },
+    cursorArtHotspot: { sourceRole: "cursor-art-renderer", expression: "direct art loads at +0/+4", occurrences: [139, 132] },
+    cursorArtTexture: { sourceRole: "cursor-state-reader+renderer", expression: "art texture load +12", occurrences: [43, 26, 68] },
+    cursorHandleKey: { sourceRole: "cursor-art-renderer", expression: "cached handle load/store +8", occurrences: [57, 114] },
+    cursorHandleObject: { sourceRole: "cursor-handle-reader", expression: "handle base dereference +0", occurrences: [3] },
+    cursorViewTexture: { sourceRole: "cursor-handle-reader", expression: "two linked loads +8", occurrences: [5, 8] },
+    cursorTextureType: { sourceRole: "cursor-texture-writer", expression: "texture type store +12", occurrences: [12] },
+    cursorTextureWidth: { sourceRole: "cursor-texture-descriptor", expression: "certified descriptor width +20", occurrences: [20] },
+    cursorTextureHeight: { sourceRole: "cursor-texture-descriptor", expression: "certified descriptor height +24", occurrences: [24] },
+  }).layout;
+}
+
 /**
  * Strict launch authority for cursor-only recovery on an unknown build.
  * Locations come from the candidate module; only semantic body fingerprints
@@ -1044,6 +1340,7 @@ export function locateAutomaticCursor(
 ): AutomaticCursorLocation | null {
   if (!WebAssembly.validate(input) || input.byteLength > MAX_INPUT_BYTES) return null;
   try {
+    const inputSha256 = createHash("sha256").update(input).digest("hex");
     const module = parseModule(input);
     const tick = tickEvidence(module).candidate;
     if (!tick) return null;
@@ -1051,7 +1348,12 @@ export function locateAutomaticCursor(
     const matches: AutomaticCursorLocation[] = [];
     for (const baseline of baselines) {
       const cursor = baseline.cursorEvent;
-      if (!cursor || tick.bodySha256 !== baseline.hookBodySha256) continue;
+      if (!cursor) continue;
+      const tickBody = functionBody(module, tick.functionIndex);
+      const exactFamily = tick.bodySha256 === baseline.hookBodySha256;
+      const exactCertifiedInput = exactFamily && inputSha256 === baseline.sha256;
+      const semanticFamily = bodyMatchesRole(tickBody, CURSOR_TICK_ROLE);
+      if (!exactFamily && !semanticFamily) continue;
       const cursorFunctions = module.functionTypeIndices.flatMap((_, index) => {
         const slots = relations.get(index) ?? [];
         if (
@@ -1071,16 +1373,24 @@ export function locateAutomaticCursor(
         const after = functionAt(slot + 1);
         return before !== null && after !== null
           && functionBodySha256(module, before) === cursor.tableNeighbourBodySha256[0]
-          && functionBodySha256(module, after) === cursor.tableNeighbourBodySha256[1]
+          && (
+            functionBodySha256(module, after) === cursor.tableNeighbourBodySha256[1]
+            || bodyMatchesRole(functionBody(module, after), CURSOR_TABLE_AFTER_ROLE)
+          )
           ? [index]
           : [];
       });
-      const producers = cursor.producerBodySha256.map((fingerprint) =>
-        module.functionTypeIndices.flatMap((_, index) =>
-          index >= module.functionImportCount
-          && functionBodySha256(module, index) === fingerprint
-            ? [index]
-            : []));
+      const producers = exactFamily
+        ? cursor.producerBodySha256.map((fingerprint) =>
+            module.functionTypeIndices.flatMap((_, index) =>
+              index >= module.functionImportCount
+              && functionBodySha256(module, index) === fingerprint
+                ? [index]
+                : []))
+        : CURSOR_PRODUCER_ROLES.map((role) => {
+            const found = uniqueRoleFunction(module, role);
+            return found === null ? [] : [found];
+          });
       const producerSignaturesMatch = producers.every((matches, index) => {
         const functionIndex = matches[0];
         const signature = functionIndex === undefined
@@ -1098,12 +1408,23 @@ export function locateAutomaticCursor(
         || !producerSignaturesMatch
       ) continue;
       const cursorFunction = cursorFunctions[0]!;
+      const producerFunctions = [producers[0][0]!, producers[1][0]!] as const;
+      const layout = exactCertifiedInput
+        ? cursor.layout
+        : deriveCursorLayout(module, tick.functionIndex, producerFunctions);
+      if (!layout) continue;
       matches.push({
         baseline,
         hookFunction: tick.functionIndex,
+        hookBodySha256: tick.bodySha256,
         cursorFunction,
         cursorTableSlot: relations.get(cursorFunction)![0]!,
-        producerFunctions: [producers[0][0]!, producers[1][0]!],
+        producerFunctions,
+        producerBodySha256: [
+          functionBodySha256(module, producerFunctions[0]),
+          functionBodySha256(module, producerFunctions[1]),
+        ],
+        layout,
       });
     }
     if (matches.length === 0) return null;
@@ -1112,7 +1433,7 @@ export function locateAutomaticCursor(
       cursorFunction: value.cursorFunction,
       cursorTableSlot: value.cursorTableSlot,
       producerFunctions: value.producerFunctions,
-      cursorLayout: value.baseline.cursorEvent?.layout,
+      cursorLayout: value.layout,
     });
     return matches.every((match) => identity(match) === identity(matches[0]!))
       ? matches[0]!

--- a/src/main/certification/local-client-verifier.ts
+++ b/src/main/certification/local-client-verifier.ts
@@ -97,7 +97,7 @@ function deriveEnhancementBuild(
     hookFunction: located.hookFunction,
     hookParams: Object.freeze(["i32"] as const),
     hookResults: Object.freeze([] as const),
-    hookBodySha256: located.baseline.hookBodySha256,
+    hookBodySha256: located.hookBodySha256,
     tableSlot: report.table.min,
     cursorEvent: Object.freeze({
       functionIndex: located.cursorFunction,
@@ -108,9 +108,9 @@ function deriveEnhancementBuild(
       producerParams: cursor.producerParams,
       producerResults: cursor.producerResults,
       bodySha256: cursor.bodySha256,
-      producerBodySha256: cursor.producerBodySha256,
+      producerBodySha256: located.producerBodySha256,
       tableNeighbourBodySha256: cursor.tableNeighbourBodySha256,
-      layout: cursor.layout,
+      layout: located.layout,
     }),
   });
   const output = transformEnhancementWasm(
@@ -272,26 +272,41 @@ function isAutomaticCursorBuild(
     || !isIndex(build.buildId)
     || !isIndex(build.hookFunction)
     || !isIndex(build.tableSlot)
+    || !isDigest(build.hookBodySha256)
     || !build.cursorEvent
     || !isIndex(build.cursorEvent.functionIndex)
     || !isIndex(build.cursorEvent.tableSlot)
     || build.cursorEvent.producerFunctions.length !== 2
     || !build.cursorEvent.producerFunctions.every(isIndex)
+    || build.cursorEvent.producerBodySha256.length !== 2
+    || !build.cursorEvent.producerBodySha256.every(isDigest)
+    || !Object.values(build.cursorEvent.layout).every(isIndex)
   ) return false;
   return ENHANCEMENT_BUILDS.some((baseline) => {
     const cursor = baseline.cursorEvent;
     return cursor !== undefined
-      && build.hookBodySha256 === baseline.hookBodySha256
+      && Object.keys(build.cursorEvent!.layout).sort().join()
+        === Object.keys(cursor.layout).sort().join()
       && sameJson(build.hookParams, baseline.hookParams)
       && sameJson(build.hookResults, baseline.hookResults)
       && sameJson(build.cursorEvent?.params, cursor.params)
       && sameJson(build.cursorEvent?.results, cursor.results)
       && build.cursorEvent?.bodySha256 === cursor.bodySha256
-      && sameJson(build.cursorEvent?.producerBodySha256, cursor.producerBodySha256)
       && sameJson(build.cursorEvent?.producerParams, cursor.producerParams)
       && sameJson(build.cursorEvent?.producerResults, cursor.producerResults)
       && sameJson(build.cursorEvent?.tableNeighbourBodySha256, cursor.tableNeighbourBodySha256)
-      && sameJson(build.cursorEvent?.layout, cursor.layout);
+      && build.cursorEvent.layout.cursorSoftwareModel
+        === build.cursorEvent.layout.cursorActiveArt + 4
+      && build.cursorEvent.layout.cursorShowCount
+        === build.cursorEvent.layout.cursorActiveArt + 8
+      && build.cursorEvent.layout.cursorArtHotspot === cursor.layout.cursorArtHotspot
+      && build.cursorEvent.layout.cursorArtTexture === cursor.layout.cursorArtTexture
+      && build.cursorEvent.layout.cursorHandleKey === cursor.layout.cursorHandleKey
+      && build.cursorEvent.layout.cursorHandleObject === cursor.layout.cursorHandleObject
+      && build.cursorEvent.layout.cursorViewTexture === cursor.layout.cursorViewTexture
+      && build.cursorEvent.layout.cursorTextureType === cursor.layout.cursorTextureType
+      && build.cursorEvent.layout.cursorTextureWidth === cursor.layout.cursorTextureWidth
+      && build.cursorEvent.layout.cursorTextureHeight === cursor.layout.cursorTextureHeight;
   });
 }
 

--- a/tests/client-artifact/template-save-recert.test.ts
+++ b/tests/client-artifact/template-save-recert.test.ts
@@ -146,18 +146,32 @@ test("the template-save verifier makes a fail-closed decision for a real client"
   assert.equal(WebAssembly.validate(new Uint8Array(changedAddressReference)), true);
   const addressDecision = verifyLocalClientBytes(changedAddressReference);
   assert.ok(addressDecision.templateSaveBuild);
-  if (addressDecision.enhancementBuild) {
-    assert.ok(addressDecision.enhancementBuild.cursorEvent);
-    assert.equal(addressDecision.enhancementBuild.targetObservation, undefined);
-    assert.equal(addressDecision.enhancementBuild.partyObservation, undefined);
-    assert.equal(addressDecision.enhancementBuild.teamApply, undefined);
-    assert.deepEqual(
-      Object.keys(addressDecision.enhancementBuild.outputSha256),
-      ["cursor"],
+  assert.ok(addressDecision.enhancementBuild?.cursorEvent);
+  assert.equal(addressDecision.enhancementBuild.targetObservation, undefined);
+  assert.equal(addressDecision.enhancementBuild.partyObservation, undefined);
+  assert.equal(addressDecision.enhancementBuild.teamApply, undefined);
+  assert.deepEqual(Object.keys(addressDecision.enhancementBuild.outputSha256), ["cursor"]);
+  assert.deepEqual(addressDecision.reasons, []);
+
+  const cursorMutations = [
+    { local: 446 - derived.importCount, offset: 10, label: "main-loop control flow" },
+    { local: 2828 - derived.importCount, offset: 68, label: "one producer static" },
+    { local: 6234 - derived.importCount, offset: 45, label: "cursor art offset" },
+  ] as const;
+  for (const mutation of cursorMutations) {
+    const changedCursorProof = rewriteCode(bytes, (bodies) => {
+      const body = bodies[mutation.local]!;
+      body[mutation.offset] = body[mutation.offset]! ^ 1;
+    });
+    assert.equal(
+      WebAssembly.validate(new Uint8Array(changedCursorProof)),
+      true,
+      mutation.label,
     );
-    assert.deepEqual(addressDecision.reasons, []);
-  } else {
-    assert.deepEqual(addressDecision.reasons, ["enhancement-layout-changed"]);
+    const refusal = verifyLocalClientBytes(changedCursorProof);
+    assert.ok(refusal.templateSaveBuild, mutation.label);
+    assert.equal(refusal.enhancementBuild, null, mutation.label);
+    assert.deepEqual(refusal.reasons, ["enhancement-layout-changed"], mutation.label);
   }
 });
 

--- a/tests/unit/enhancement-structural-evidence.test.ts
+++ b/tests/unit/enhancement-structural-evidence.test.ts
@@ -520,6 +520,7 @@ describe("review-only Enhancement structural evidence", () => {
     const tick = evidence.tick.candidate!;
     const baseline = Object.freeze({
       ...shipped,
+      sha256: createHash("sha256").update(input.bytes).digest("hex"),
       hookBodySha256: tick.bodySha256,
       cursorEvent: Object.freeze({
         ...shippedCursor,
@@ -537,9 +538,12 @@ describe("review-only Enhancement structural evidence", () => {
     assert.deepEqual(locateAutomaticCursor(input.bytes, [baseline]), {
       baseline,
       hookFunction: input.tick,
+      hookBodySha256: tick.bodySha256,
       cursorFunction: input.cursor,
       cursorTableSlot: 2,
       producerFunctions: input.cursorProducers,
+      producerBodySha256: cursor.producerBodySha256,
+      layout: shippedCursor.layout,
     });
   });
 
@@ -555,6 +559,7 @@ describe("review-only Enhancement structural evidence", () => {
       .digest("hex");
     const baseline = {
       ...shipped,
+      sha256: createHash("sha256").update(input.bytes).digest("hex"),
       hookBodySha256: tick.bodySha256,
       cursorEvent: {
         ...shippedCursor,

--- a/tests/unit/local-client-verifier.test.ts
+++ b/tests/unit/local-client-verifier.test.ts
@@ -22,6 +22,40 @@ function valid(): LocalClientVerification {
   };
 }
 
+function automaticCursor(): LocalClientVerification {
+  const cursor = ENHANCEMENT.cursorEvent!;
+  return {
+    ...valid(),
+    enhancementBuild: {
+      sha256: ENHANCEMENT.sha256,
+      outputSha256: { cursor: "1".repeat(64) },
+      programId: ENHANCEMENT.programId,
+      buildId: ENHANCEMENT.buildId + 1,
+      hookFunction: ENHANCEMENT.hookFunction + 1,
+      hookParams: ENHANCEMENT.hookParams,
+      hookResults: ENHANCEMENT.hookResults,
+      hookBodySha256: "2".repeat(64),
+      tableSlot: ENHANCEMENT.tableSlot,
+      cursorEvent: {
+        ...cursor,
+        functionIndex: cursor.functionIndex + 1,
+        producerFunctions: [
+          cursor.producerFunctions[0] + 1,
+          cursor.producerFunctions[1] + 1,
+        ],
+        producerBodySha256: ["3".repeat(64), "4".repeat(64)],
+        layout: {
+          ...cursor.layout,
+          cursorActiveArt: cursor.layout.cursorActiveArt - 112,
+          cursorSoftwareModel: cursor.layout.cursorSoftwareModel - 112,
+          cursorShowCount: cursor.layout.cursorShowCount - 112,
+          cursorColorBuffer: cursor.layout.cursorColorBuffer - 112,
+        },
+      },
+    },
+  };
+}
+
 describe("local client verification boundary", () => {
   it("accepts the verifier's complete baseline proof", () => {
     assert.equal(isLocalClientVerification(valid(), TEMPLATE.sha256), true);
@@ -55,6 +89,25 @@ describe("local client verification boundary", () => {
       enhancementBuild: {
         ...ENHANCEMENT,
         hookFunction: ENHANCEMENT.hookFunction + 1,
+      },
+    }, TEMPLATE.sha256), false);
+  });
+
+  it("accepts a structurally derived cursor proof and rejects malformed layouts", () => {
+    const derived = automaticCursor();
+    assert.equal(isLocalClientVerification(derived, TEMPLATE.sha256), true);
+    assert.equal(isLocalClientVerification({
+      ...derived,
+      enhancementBuild: {
+        ...derived.enhancementBuild!,
+        cursorEvent: {
+          ...derived.enhancementBuild!.cursorEvent!,
+          layout: {
+            ...derived.enhancementBuild!.cursorEvent!.layout,
+            cursorShowCount:
+              derived.enhancementBuild!.cursorEvent!.layout.cursorShowCount + 4,
+          },
+        },
       },
     }, TEMPLATE.sha256), false);
   });


### PR DESCRIPTION
## What changed

Guild Wars cursor proof derives the main-loop role graph, producers, globals, buffer, and layout from the current client instead of copying a historic layout.

## Why

ArenaNet moved cursor storage while preserving behavior. Whole-body hashes and copied addresses refused safe rebuilds or hid missing witnesses.

## Invariant

The loop, callback/table/neighbour graph, both producers, and every layout word must be uniquely and independently proved.

## Verification

- Exact-head PR package, CodeQL, and Vercel checks passed.
- Retained AEC and e017 layouts derive independently.
- Field, relationship, ambiguity, and control-flow mutations refuse.

Stack layer 5 of 13.
