### PR TITLE
fix(target): derive bounded target observation

### DIFF
--- a/internal/upstream/client-internals.md
+++ b/internal/upstream/client-internals.md
@@ -402,6 +402,7 @@ through the active table. Automatic cursor recovery therefore uses a separate,
 narrow proof. It requires one exported main-loop body, one callback with its
 exact signature and active table neighbourhood, and the two measured producer
 body fingerprints. Both certified builds must agree on all semantic anchors.
-Changing or duplicating any anchor rejects recovery. The result authorizes only
-the cursor; memory observation and commands remain exact-build-only and still
-require bounded live review before release.
+Changing or duplicating any anchor rejects recovery. That original result
+authorized only the cursor. Target Distance now has a separate proof for its
+selector, bounded context and agent readers, and immutable area table. Party
+observation and actions remain exact-build-only until their own proof layers.

--- a/src/main/certification/enhancement-structural-evidence.ts
+++ b/src/main/certification/enhancement-structural-evidence.ts
@@ -3,9 +3,9 @@
  * shape says about where the Enhancement hooks belong.
  *
  * The broad comparison report is evidence with a status attached, never a
- * conclusion. The separate `locateAutomaticCursor` export is intentionally
- * narrower: it is launch authority only for cursor after all signed semantic
- * fingerprints, signatures, table relations and uniqueness checks match.
+ * conclusion. The separate feature locators are intentionally narrower: each
+ * is launch authority only after all of its signed semantic fingerprints,
+ * signatures, relationships and uniqueness checks match.
  * `candidate` means one location survived all the anchors; `ambiguous` means
  * several did and a human must choose; `unavailable` names the specific reason
  * the analysis could not run. A single best guess is deliberately not offered —
@@ -19,6 +19,8 @@ import {
   parseCode,
   parseIndexVector,
   parseTypes,
+  readSleb,
+  readUleb,
   splitSections,
   valueTypeName,
   type FunctionType,
@@ -30,7 +32,11 @@ import {
   verifyLayout,
   type RelocationSpan,
 } from "./semantic-proof.js";
-import type { EnhancementCursorLayout } from "../../shared/enhancement-config.js";
+import type {
+  EnhancementCursorLayout,
+  EnhancementObservationBaseLayout,
+  EnhancementTargetLayout,
+} from "../../shared/enhancement-config.js";
 
 declare const WebAssembly: {
   validate(bytes: Uint8Array): boolean;
@@ -145,6 +151,14 @@ export interface AutomaticCursorLocation {
   readonly layout: EnhancementCursorLayout;
 }
 
+export interface AutomaticTargetLocation {
+  readonly baseline: KnownEnhancementBuild;
+  readonly hookFunction: number;
+  readonly hookBodySha256: string;
+  readonly observationLayout: EnhancementObservationBaseLayout;
+  readonly targetLayout: EnhancementTargetLayout;
+}
+
 const MAX_INPUT_BYTES = 64 * 1024 * 1024;
 const MAX_TYPES = 100_000;
 const MAX_FUNCTIONS = 100_000;
@@ -180,6 +194,10 @@ interface ModuleShape {
   readonly bodies: Uint8Array[];
   readonly exports: WasmExport[];
   readonly elementSection: Uint8Array | null;
+  readonly dataSegments: readonly Readonly<{
+    base: number;
+    bytes: Uint8Array;
+  }>[];
 }
 
 interface DecodedFunction {
@@ -409,7 +427,41 @@ function parseModule(input: Uint8Array): ModuleShape {
     bodies,
     exports: parseExports(optionalSection(sections, 7)),
     elementSection: optionalSection(sections, 9),
+    dataSegments: parseStaticData(optionalSection(sections, 11)),
   };
+}
+
+function parseStaticData(
+  bytes: Uint8Array | null,
+): readonly Readonly<{ base: number; bytes: Uint8Array }>[] {
+  if (!bytes) return [];
+  const cursor = { offset: 0 };
+  const count = readUleb(bytes, cursor);
+  if (count > MAX_FUNCTIONS) throw new EvidenceError("analysis-limit-exceeded");
+  const segments: Readonly<{ base: number; bytes: Uint8Array }>[] = [];
+  for (let index = 0; index < count; index += 1) {
+    if (readUleb(bytes, cursor) !== 0 || bytes[cursor.offset++] !== 0x41) {
+      throw new EvidenceError("module-shape-unsupported");
+    }
+    const base = readSleb(bytes, cursor);
+    if (base < 0 || bytes[cursor.offset++] !== 0x0b) {
+      throw new EvidenceError("module-shape-unsupported");
+    }
+    const size = readUleb(bytes, cursor);
+    const end = cursor.offset + size;
+    if (end > bytes.byteLength) {
+      throw new EvidenceError("module-shape-unsupported");
+    }
+    segments.push(Object.freeze({
+      base,
+      bytes: bytes.slice(cursor.offset, end),
+    }));
+    cursor.offset = end;
+  }
+  if (cursor.offset !== bytes.byteLength) {
+    throw new EvidenceError("module-shape-unsupported");
+  }
+  return Object.freeze(segments);
 }
 
 function exactSignature(
@@ -1135,6 +1187,134 @@ const CURSOR_HANDLE_READER_SHA256 =
 const CURSOR_TEXTURE_WRITER_SHA256 =
   "f1d4d25243aeb652707797683ed6118569f606e9e3a69040eaa3789f737dcc7a";
 
+const semanticRole = (
+  bodyLength: number,
+  fingerprint: string,
+  spans: readonly RelocationSpan[],
+  params: readonly string[],
+  results: readonly string[],
+): CursorRole => Object.freeze({ bodyLength, fingerprint, spans, params, results });
+
+const TARGET_CONTEXT_ROOT_ROLE = semanticRole(
+  33,
+  "3ec691dd53ed9441774e334e1cf646e9c5f62ca715c6069c2cc1080713852d36",
+  mutableSpans([[11, 16, "context.root"]]),
+  [],
+  [],
+);
+
+const TARGET_SELECTOR_ROLE = semanticRole(
+  726,
+  "b288186a735fa6f304715f330643f3cd71d0520579ee2dbfd559313c9dba148b",
+  Object.freeze([
+    { start: 38, end: 43, role: "target.assert-manual", addressClass: "immutable-data" },
+    { start: 77, end: 82, role: "target.assert-automatic", addressClass: "immutable-data" },
+    ...mutableSpans([
+      [111, 116, "target.related-0"],
+      [132, 137, "target.manual"], [147, 152, "target.automatic"],
+      [312, 317, "target.manual"], [332, 337, "target.automatic"],
+      [381, 386, "target.related-1"], [451, 456, "target.related-1"],
+      [501, 506, "target.related-2"],
+      [636, 641, "target.manual"], [647, 652, "target.automatic"],
+    ]),
+  ]),
+  ["i32", "i32"],
+  [],
+);
+
+const TARGET_RESET_ROLE = semanticRole(
+  136,
+  "d3cae3aed2485fa4b3a309b096a5f6c3d542bb09c46e2d03c92790a05e53112f",
+  Object.freeze([
+    ...mutableSpans([
+      [7, 12, "target.manual"], [18, 23, "target.automatic"],
+      [29, 34, "target.related-0"], [40, 45, "target.related-3"],
+      [51, 56, "target.related-4"], [62, 67, "target.related-5"],
+      [73, 78, "target.related-6"], [84, 89, "target.related-7"],
+      [107, 112, "target.related-8"], [130, 135, "target.related-9"],
+    ]),
+    { start: 92, end: 97, role: "target.reset-name-a", addressClass: "immutable-data" },
+    { start: 115, end: 120, role: "target.reset-name-b", addressClass: "immutable-data" },
+  ]),
+  [],
+  [],
+);
+
+const TARGET_CALLER_ROLE = semanticRole(
+  214,
+  "7d1f1ffe2fe47663ddf06a6ad4940dd26fcb64958578b9f7027c20facfefd25e",
+  mutableSpans([
+    [9, 14, "target.automatic"], [23, 28, "target.manual"],
+    [40, 45, "target.manual"], [60, 65, "target.manual"],
+    [76, 81, "target.automatic"], [93, 98, "target.automatic"],
+    [111, 116, "target.related-3"], [136, 141, "target.related-3"],
+    [198, 203, "target.related-3"],
+  ]),
+  ["i32"],
+  [],
+);
+
+const AGENT_ARRAY_LIFECYCLE_ROLE = semanticRole(
+  51,
+  "90bf935b288798d9383a84eefe73856cbe2048635aa7702bac56b1e0d5498436",
+  mutableSpans([
+    [9, 14, "agent-array.base"], [34, 39, "agent-array.base"],
+    [45, 50, "agent-array.size"],
+  ]),
+  ["i32"],
+  [],
+);
+
+const AGENT_ARRAY_ACCESSOR_ROLE = semanticRole(
+  47,
+  "e2d3a0903dd7eb7595e118466ce74d0e90f9f38c81068c8cd2fd1f8ab0570338",
+  mutableSpans([
+    [15, 20, "agent-array.size"], [27, 32, "agent-array.base"],
+  ]),
+  ["i32"],
+  ["i32"],
+);
+
+const AREA_LOOKUP_ROLE = semanticRole(
+  47,
+  "40dbe1dc1bc07cc9115aa44d89cd64673246c6f6c04a46e646fa1939e49dcf6f",
+  Object.freeze([
+    { start: 12, end: 17, role: "area.assert-name", addressClass: "immutable-data" },
+    { start: 40, end: 45, role: "area.table", addressClass: "immutable-data" },
+  ]),
+  ["i32"],
+  ["i32"],
+);
+
+type ExactTargetRole = Readonly<{
+  bodySha256: string;
+  params: readonly string[];
+  results: readonly string[];
+}>;
+
+const EXACT_TARGET_ROLES = Object.freeze({
+  gameCharacter: { bodySha256: "f234e09fc78c540418d7ee1e02bb339caf4e95b91dad5803dd87f1b1f229eede", params: ["i32"], results: ["i32"] },
+  mapId: { bodySha256: "6698663ffed7669e3fa3922260e1e773179b41a5147fd961af44acc157839914", params: ["i32"], results: ["i32"] },
+  mapState: { bodySha256: "35cea95a660e3e1964f2fab0342b60c9a96ebc563638feceb328231fb97b27cd", params: ["i32", "i32"], results: [] },
+  currentMap: { bodySha256: "c6e2e54332d133eb208974890b255570fb2fcc9a802ea52957b4a64116f7e72c", params: [], results: ["i32"] },
+  instanceType: { bodySha256: "b9898076fd712f74e586f60df2a7e551c68db82b3726025815f46b78f32b8413", params: ["i32"], results: ["i32"] },
+  playerNumber: { bodySha256: "3656f5655d9704c608247be52aaf1654141bce2db8f085c6cef4c967c7068acf", params: [], results: ["i32"] },
+  worldContext: { bodySha256: "35541e26cd5badf9bbf37b1e7a57489cb762e5ecffcb0f90e4069d4c63bd4c09", params: ["i32"], results: ["i32"] },
+  agentFields: { bodySha256: "b9d3e9ffd560b43d918aa004088193c11e51da699d754682f651b02b5cdb8ab4", params: ["i32"], results: [] },
+  agentModel: { bodySha256: "cf152611218510e0d086fb2808834d0381f64c237c9b4ee185eabcd58a850a6b", params: ["i32", "i32", "i32"], results: ["i32"] },
+  areaCount: { bodySha256: "dc05263b317b11744dc07fdd0ee520bf3d9811e9869580c570ff81959ef2fd9b", params: ["i32", "i32", "i32"], results: ["i32"] },
+  areaFlags: { bodySha256: "1cc6aeaa4c4f9228ee4984a26506f2f72d2b6ad4aeec4e50b1dd019504516382", params: [], results: ["i32"] },
+} as const satisfies Readonly<Record<string, ExactTargetRole>>);
+
+const TARGET_IMMUTABLE_HASHES = Object.freeze({
+  manualAssertion: "d78c3ee557d2b4d2c335ea85a1c6e7088d894236e0225360d92942da98c54b7d",
+  automaticAssertion: "ee8a8e207854674610e42099c03590270b556c9cd482de0bfca76959939d74c6",
+  resetNameA: "b940a3cd95df2f76fb27d3e23ef929c3c97753dde164ca08802c0b2554833642",
+  resetNameB: "9ffea7f8a640d2d966ff61fb7479893422ac8aae7b39f74205e41095926d7f7c",
+  areaAssertion: "bbba85bc88debef8198061f3c1c86cf0c7051c7cb0752f8ca670bcace10d03fe",
+  areaTable: "3a4564fe4b92b8e2a4e048000ccd924d1f1ee68d15e24a63dd6e05a9683a88bc",
+});
+
 function functionBody(module: ModuleShape, functionIndex: number): Uint8Array {
   const body = module.bodies[functionIndex - module.functionImportCount];
   if (!body) throw new EvidenceError("module-shape-unsupported");
@@ -1159,6 +1339,11 @@ function bodyMatchesRole(body: Uint8Array, role: CursorRole): boolean {
 }
 
 function uniqueRoleFunction(module: ModuleShape, role: CursorRole): number | null {
+  const matches = roleFunctions(module, role);
+  return matches.length === 1 ? matches[0]! : null;
+}
+
+function roleFunctions(module: ModuleShape, role: CursorRole): number[] {
   const matches: number[] = [];
   for (
     let functionIndex = module.functionImportCount;
@@ -1169,9 +1354,8 @@ function uniqueRoleFunction(module: ModuleShape, role: CursorRole): number | nul
       signatureMatches(module, functionIndex, role.params, role.results)
       && bodyMatchesRole(functionBody(module, functionIndex), role)
     ) matches.push(functionIndex);
-    if (matches.length > 1) return null;
   }
-  return matches.length === 1 ? matches[0]! : null;
+  return matches;
 }
 
 function uniqueExactFunction(
@@ -1204,6 +1388,63 @@ function paddedU32(body: Uint8Array, start: number): number {
   return value;
 }
 
+function unsignedOperand(body: Uint8Array, start: number): number {
+  const cursor = { value: start };
+  return readUnsigned(body, cursor);
+}
+
+function paddedOperand(value: number): Uint8Array {
+  const bytes = new Uint8Array(5);
+  let remaining = value >>> 0;
+  for (let index = 0; index < 4; index += 1) {
+    bytes[index] = (remaining & 0x7f) | 0x80;
+    remaining >>>= 7;
+  }
+  bytes[4] = remaining & 0x0f;
+  return bytes;
+}
+
+function codeOperandOccurrences(module: ModuleShape, value: number): number {
+  const needle = paddedOperand(value);
+  let count = 0;
+  for (const body of module.bodies) {
+    for (let offset = 0; offset <= body.byteLength - needle.byteLength; offset += 1) {
+      if (needle.every((byte, index) => body[offset + index] === byte)) count += 1;
+    }
+  }
+  return count;
+}
+
+function staticBytes(
+  module: ModuleShape,
+  address: number,
+  length: number,
+): Uint8Array | null {
+  if (!Number.isSafeInteger(address) || !Number.isSafeInteger(length) || length < 0) {
+    return null;
+  }
+  for (const segment of module.dataSegments) {
+    const offset = address - segment.base;
+    if (offset >= 0 && offset + length <= segment.bytes.byteLength) {
+      return segment.bytes.subarray(offset, offset + length);
+    }
+  }
+  return null;
+}
+
+function staticCStringHash(module: ModuleShape, address: number): string | null {
+  for (const segment of module.dataSegments) {
+    const offset = address - segment.base;
+    if (offset < 0 || offset >= segment.bytes.byteLength) continue;
+    const end = segment.bytes.indexOf(0, offset);
+    if (end < 0 || end - offset > 4_096) return null;
+    return createHash("sha256")
+      .update(segment.bytes.subarray(offset, end + 1))
+      .digest("hex");
+  }
+  return null;
+}
+
 function valuesForRole(body: Uint8Array, role: CursorRole): Map<string, number[]> {
   const values = new Map<string, number[]>();
   for (const span of role.spans) {
@@ -1228,6 +1469,168 @@ function commonRelocationDelta(
   const deltas = entries.map(([candidate, baseline]) => candidate - baseline);
   return deltas.every((delta) => delta === deltas[0]) ? deltas[0]! : null;
 }
+
+function exactTargetFunction(
+  module: ModuleShape,
+  role: ExactTargetRole,
+): number | null {
+  return uniqueExactFunction(module, role.bodySha256, role.params, role.results);
+}
+
+function deriveTargetLayouts(
+  module: ModuleShape,
+): Readonly<{
+  observation: EnhancementObservationBaseLayout;
+  target: EnhancementTargetLayout;
+}> | null {
+  const contextFunction = uniqueRoleFunction(module, TARGET_CONTEXT_ROOT_ROLE);
+  const selectorFunction = uniqueRoleFunction(module, TARGET_SELECTOR_ROLE);
+  const resetFunction = uniqueRoleFunction(module, TARGET_RESET_ROLE);
+  const callerFunction = uniqueRoleFunction(module, TARGET_CALLER_ROLE);
+  const agentAccessorFunction = uniqueRoleFunction(module, AGENT_ARRAY_ACCESSOR_ROLE);
+  const areaLookupFunction = uniqueRoleFunction(module, AREA_LOOKUP_ROLE);
+  const exact = Object.fromEntries(Object.entries(EXACT_TARGET_ROLES).map(
+    ([name, role]) => [name, exactTargetFunction(module, role)],
+  )) as Record<keyof typeof EXACT_TARGET_ROLES, number | null>;
+  if (
+    contextFunction === null || selectorFunction === null
+    || resetFunction === null || callerFunction === null
+    || agentAccessorFunction === null
+    || areaLookupFunction === null
+    || Object.values(exact).some((value) => value === null)
+  ) return null;
+
+  const context = valuesForRole(functionBody(module, contextFunction), TARGET_CONTEXT_ROOT_ROLE);
+  const selector = valuesForRole(functionBody(module, selectorFunction), TARGET_SELECTOR_ROLE);
+  const reset = valuesForRole(functionBody(module, resetFunction), TARGET_RESET_ROLE);
+  const caller = valuesForRole(functionBody(module, callerFunction), TARGET_CALLER_ROLE);
+  const accessor = valuesForRole(functionBody(module, agentAccessorFunction), AGENT_ARRAY_ACCESSOR_ROLE);
+  const area = valuesForRole(functionBody(module, areaLookupFunction), AREA_LOOKUP_ROLE);
+  const contextRoot = soleValue(context, "context.root");
+  const manualTargetAgentId = soleValue(selector, "target.manual");
+  const automaticTargetAgentId = soleValue(selector, "target.automatic");
+  const agentArray = soleValue(accessor, "agent-array.base");
+  const agentArraySize = soleValue(accessor, "agent-array.size");
+  const lifecycleMatches = roleFunctions(module, AGENT_ARRAY_LIFECYCLE_ROLE).filter(
+    (functionIndex) => {
+      const values = valuesForRole(
+        functionBody(module, functionIndex), AGENT_ARRAY_LIFECYCLE_ROLE,
+      );
+      return soleValue(values, "agent-array.base") === agentArray
+        && soleValue(values, "agent-array.size") === agentArraySize;
+    },
+  );
+  if (lifecycleMatches.length !== 1) return null;
+  const areaInfo = soleValue(area, "area.table");
+  if (
+    manualTargetAgentId !== soleValue(reset, "target.manual")
+    || manualTargetAgentId !== soleValue(caller, "target.manual")
+    || automaticTargetAgentId !== soleValue(reset, "target.automatic")
+    || automaticTargetAgentId !== soleValue(caller, "target.automatic")
+    || manualTargetAgentId !== automaticTargetAgentId + 4
+    || agentArraySize !== agentArray + 8
+    || codeOperandOccurrences(module, contextRoot) !== 6
+    || codeOperandOccurrences(module, agentArray) !== 41
+    || codeOperandOccurrences(module, agentArraySize) !== 41
+    || codeOperandOccurrences(module, manualTargetAgentId) !== 16
+    || codeOperandOccurrences(module, automaticTargetAgentId) !== 18
+    || codeOperandOccurrences(module, areaInfo) !== 1
+    || commonRelocationDelta([
+      [contextRoot, 0x5a0ee0], [manualTargetAgentId, 0x5a394c],
+      [automaticTargetAgentId, 0x5a3948], [agentArray, 0x5a4e58],
+      [agentArraySize, 0x5a4e60], [areaInfo, 0x1cc630],
+    ]) === null
+  ) return null;
+
+  const selectorImmutable = valuesForRole(
+    functionBody(module, selectorFunction), TARGET_SELECTOR_ROLE,
+  );
+  const resetImmutable = valuesForRole(
+    functionBody(module, resetFunction), TARGET_RESET_ROLE,
+  );
+  if (
+    staticCStringHash(module, soleValue(selectorImmutable, "target.assert-manual"))
+      !== TARGET_IMMUTABLE_HASHES.manualAssertion
+    || staticCStringHash(module, soleValue(selectorImmutable, "target.assert-automatic"))
+      !== TARGET_IMMUTABLE_HASHES.automaticAssertion
+    || staticCStringHash(module, soleValue(resetImmutable, "target.reset-name-a"))
+      !== TARGET_IMMUTABLE_HASHES.resetNameA
+    || staticCStringHash(module, soleValue(resetImmutable, "target.reset-name-b"))
+      !== TARGET_IMMUTABLE_HASHES.resetNameB
+    || staticCStringHash(module, soleValue(area, "area.assert-name"))
+      !== TARGET_IMMUTABLE_HASHES.areaAssertion
+  ) return null;
+
+  const body = (name: keyof typeof EXACT_TARGET_ROLES) =>
+    functionBody(module, exact[name]!);
+  const contextBody = functionBody(module, contextFunction);
+  const areaBody = functionBody(module, areaLookupFunction);
+  const observation: EnhancementObservationBaseLayout = {
+    contextRoot,
+    agentArray,
+    gameContextSlot: unsignedOperand(contextBody, 17),
+    characterContext: unsignedOperand(body("gameCharacter"), 5),
+    mapId: unsignedOperand(body("mapId"), 39),
+    isExplorable: unsignedOperand(body("mapState"), 37),
+    currentMapId: unsignedOperand(body("currentMap"), 11),
+    currentInstanceType: unsignedOperand(body("instanceType"), 5),
+    playerNumber: unsignedOperand(body("playerNumber"), 11),
+    agentId: unsignedOperand(body("agentFields"), 899),
+    agentX: unsignedOperand(body("agentFields"), 395),
+    agentY: unsignedOperand(body("agentFields"), 367),
+    agentType: unsignedOperand(body("agentFields"), 99),
+    agentPlayerNumber: unsignedOperand(body("agentFields"), 927),
+    agentModelType: unsignedOperand(body("agentModel"), 393),
+    worldContext: unsignedOperand(body("worldContext"), 81),
+    areaInfo,
+    areaInfoCount: unsignedOperand(body("areaCount"), 36),
+    areaInfoStride: unsignedOperand(areaBody, 36),
+    areaInfoFlags: unsignedOperand(body("areaFlags"), 21),
+  };
+  if (
+    unsignedOperand(body("agentModel"), 365) !== observation.agentPlayerNumber
+    || unsignedOperand(areaBody, 6) < observation.areaInfoCount
+  ) return null;
+  const table = staticBytes(
+    module,
+    observation.areaInfo,
+    unsignedOperand(areaBody, 6) * observation.areaInfoStride,
+  );
+  if (
+    !table
+    || createHash("sha256").update(table).digest("hex")
+      !== TARGET_IMMUTABLE_HASHES.areaTable
+  ) return null;
+
+  const verifiedObservation = verifyLayout(observation, {
+    contextRoot: { sourceRole: "context-root-writer", expression: "relocated static store", occurrences: [11] },
+    agentArray: { sourceRole: "agent-array lifecycle+accessor", expression: "base static", occurrences: [9, 34, 27] },
+    gameContextSlot: { sourceRole: "context-root-writer", expression: "context registration slot", occurrences: [17] },
+    characterContext: { sourceRole: "game-context character reader", expression: "i32.load offset", occurrences: [5] },
+    mapId: { sourceRole: "map-id reader", expression: "i32.load offset", occurrences: [39] },
+    isExplorable: { sourceRole: "map-state reader", expression: "map availability field", occurrences: [37] },
+    currentMapId: { sourceRole: "character-context map reader", expression: "i32.load offset", occurrences: [11] },
+    currentInstanceType: { sourceRole: "character-context instance reader", expression: "i32.load offset", occurrences: [5] },
+    playerNumber: { sourceRole: "character-context player reader", expression: "i32.load offset", occurrences: [11] },
+    agentId: { sourceRole: "agent snapshot copier", expression: "i32.load offset", occurrences: [899] },
+    agentX: { sourceRole: "agent snapshot copier", expression: "f32.load offset", occurrences: [395] },
+    agentY: { sourceRole: "agent snapshot copier", expression: "f32.load offset", occurrences: [367] },
+    agentType: { sourceRole: "agent snapshot copier", expression: "i32.load offset", occurrences: [99] },
+    agentPlayerNumber: { sourceRole: "agent snapshot+model readers", expression: "u16 offset", occurrences: [927, 365] },
+    agentModelType: { sourceRole: "agent model reader", expression: "u16 offset", occurrences: [393] },
+    worldContext: { sourceRole: "world-context slot reader", expression: "slot 19 field load", occurrences: [81] },
+    areaInfo: { sourceRole: "area lookup+static content", expression: "unique immutable table", occurrences: [40] },
+    areaInfoCount: { sourceRole: "published-area bound", expression: "finite exact bound", occurrences: [36] },
+    areaInfoStride: { sourceRole: "area lookup", expression: "index multiplier", occurrences: [36] },
+    areaInfoFlags: { sourceRole: "area flags reader", expression: "post-lookup load", occurrences: [21] },
+  }).layout;
+  const target = verifyLayout({ manualTargetAgentId, automaticTargetAgentId }, {
+    manualTargetAgentId: { sourceRole: "target selector+reset+caller", expression: "manual target static", occurrences: [132, 312, 636, 7, 23, 40, 60] },
+    automaticTargetAgentId: { sourceRole: "target selector+reset+caller", expression: "automatic target static", occurrences: [147, 332, 647, 18, 9, 76, 93] },
+  }).layout;
+  return Object.freeze({ observation: verifiedObservation, target });
+}
+
 
 function deriveCursorLayout(
   module: ModuleShape,
@@ -1434,6 +1837,50 @@ export function locateAutomaticCursor(
       cursorTableSlot: value.cursorTableSlot,
       producerFunctions: value.producerFunctions,
       cursorLayout: value.layout,
+    });
+    return matches.every((match) => identity(match) === identity(matches[0]!))
+      ? matches[0]!
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Strict launch authority for read-only Target Distance on an unknown build.
+ * Every pointer and structure offset is recovered from an independently
+ * fingerprinted reader or writer. Relocated static data is accepted only when
+ * its complete immutable content still matches.
+ */
+export function locateAutomaticTarget(
+  input: Uint8Array,
+  baselines: readonly KnownEnhancementBuild[],
+): AutomaticTargetLocation | null {
+  if (!WebAssembly.validate(input) || input.byteLength > MAX_INPUT_BYTES) return null;
+  try {
+    const module = parseModule(input);
+    const tick = tickEvidence(module).candidate;
+    if (!tick) return null;
+    const tickBody = functionBody(module, tick.functionIndex);
+    if (!bodyMatchesRole(tickBody, CURSOR_TICK_ROLE)) return null;
+    const layouts = deriveTargetLayouts(module);
+    if (!layouts) return null;
+    const matches = baselines.flatMap((baseline): AutomaticTargetLocation[] =>
+      baseline.observationBase && baseline.targetObservation
+      && signatureMatches(module, tick.functionIndex, baseline.hookParams, baseline.hookResults)
+        ? [{
+            baseline,
+            hookFunction: tick.functionIndex,
+            hookBodySha256: tick.bodySha256,
+            observationLayout: layouts.observation,
+            targetLayout: layouts.target,
+          }]
+        : []);
+    if (matches.length === 0) return null;
+    const identity = (value: AutomaticTargetLocation) => JSON.stringify({
+      hookFunction: value.hookFunction,
+      observationLayout: value.observationLayout,
+      targetLayout: value.targetLayout,
     });
     return matches.every((match) => identity(match) === identity(matches[0]!))
       ? matches[0]!

--- a/src/main/certification/local-client-verifier.ts
+++ b/src/main/certification/local-client-verifier.ts
@@ -9,8 +9,9 @@
  *
  * The two answers are not symmetric and must not be merged. Template save is
  * shape-verifiable, so a client whose affected call sites still match is
- * accepted by proof. Of the optional features, only the cursor has a strict
- * structural locator; memory observation and commands remain exact-build only.
+ * accepted by proof. Cursor and read-only Target Distance each have a strict,
+ * independent structural locator; party observation and actions remain
+ * exact-build only.
  *
  * `isLocalClientVerification` re-validates every field of a result that crossed
  * the process boundary. Profile state is never consulted.
@@ -23,7 +24,10 @@ import {
   enhancementProfilesForBuild,
   type KnownEnhancementBuild,
 } from "./enhancement-builds.js";
-import { locateAutomaticCursor } from "./enhancement-structural-evidence.js";
+import {
+  locateAutomaticCursor,
+  locateAutomaticTarget,
+} from "./enhancement-structural-evidence.js";
 import { inspectEnhancementCandidate } from "./enhancement-candidate.js";
 import { transformEnhancementWasm } from "./enhancement-transform.js";
 import {
@@ -77,8 +81,8 @@ function deriveEnhancementBuild(
 ): KnownEnhancementBuild | null {
   const report = inspectEnhancementCandidate(templateOutput);
   if (!report.validWasm) return null;
-  // A common address delta is not proof of memory layouts or commands. Those
-  // remain exact-build only; the isolated cursor proof below owns only cursor.
+  // A common address delta alone proves nothing. The isolated feature locators
+  // below own their complete cursor and Target evidence independently.
   const build = findEnhancementBuild(report.sha256);
   if (build) {
     const profile = enhancementProfilesForBuild(build)[0];
@@ -86,41 +90,60 @@ function deriveEnhancementBuild(
     transformEnhancementWasm(templateOutput, build, ENHANCEMENT_CAPABILITY_PROFILES[profile]);
     return build;
   }
-  const located = locateAutomaticCursor(templateOutput, ENHANCEMENT_BUILDS);
-  if (!located || !report.table || report.table.max === null) return null;
-  const cursor = located.baseline.cursorEvent!;
+  const locatedCursor = locateAutomaticCursor(templateOutput, ENHANCEMENT_BUILDS);
+  const locatedTarget = locateAutomaticTarget(templateOutput, ENHANCEMENT_BUILDS);
+  if ((!locatedCursor && !locatedTarget) || !report.table || report.table.max === null) {
+    return null;
+  }
+  const baseline = locatedCursor?.baseline ?? locatedTarget!.baseline;
+  const cursor = locatedCursor?.baseline.cursorEvent;
+  if (locatedCursor && !cursor) return null;
   const provisional: KnownEnhancementBuild = Object.freeze({
     sha256: report.sha256,
     outputSha256: Object.freeze({}),
-    programId: located.baseline.programId,
+    programId: baseline.programId,
     buildId: Number.parseInt(sha256(official).slice(0, 8), 16) || 1,
-    hookFunction: located.hookFunction,
+    hookFunction: (locatedCursor ?? locatedTarget)!.hookFunction,
     hookParams: Object.freeze(["i32"] as const),
     hookResults: Object.freeze([] as const),
-    hookBodySha256: located.hookBodySha256,
+    hookBodySha256: (locatedCursor ?? locatedTarget)!.hookBodySha256,
     tableSlot: report.table.min,
-    cursorEvent: Object.freeze({
-      functionIndex: located.cursorFunction,
-      params: cursor.params,
-      results: cursor.results,
-      tableSlot: located.cursorTableSlot,
-      producerFunctions: located.producerFunctions,
-      producerParams: cursor.producerParams,
-      producerResults: cursor.producerResults,
-      bodySha256: cursor.bodySha256,
-      producerBodySha256: located.producerBodySha256,
-      tableNeighbourBodySha256: cursor.tableNeighbourBodySha256,
-      layout: located.layout,
-    }),
+    ...(locatedCursor && cursor ? {
+      cursorEvent: Object.freeze({
+        functionIndex: locatedCursor.cursorFunction,
+        params: cursor.params,
+        results: cursor.results,
+        tableSlot: locatedCursor.cursorTableSlot,
+        producerFunctions: locatedCursor.producerFunctions,
+        producerParams: cursor.producerParams,
+        producerResults: cursor.producerResults,
+        bodySha256: cursor.bodySha256,
+        producerBodySha256: locatedCursor.producerBodySha256,
+        tableNeighbourBodySha256: cursor.tableNeighbourBodySha256,
+        layout: locatedCursor.layout,
+      }),
+    } : {}),
+    ...(locatedTarget ? {
+      observationBase: Object.freeze({ layout: locatedTarget.observationLayout }),
+      targetObservation: Object.freeze({ layout: locatedTarget.targetLayout }),
+    } : {}),
   });
-  const output = transformEnhancementWasm(
-    templateOutput,
-    provisional,
-    ENHANCEMENT_CAPABILITY_PROFILES.cursor,
-  );
+  const profiles = [
+    ...(locatedCursor ? ["cursor" as const] : []),
+    ...(locatedTarget ? ["target" as const] : []),
+    ...(locatedCursor && locatedTarget ? ["cursorTarget" as const] : []),
+  ];
+  const outputSha256 = Object.fromEntries(profiles.map((profile) => [
+    profile,
+    sha256(transformEnhancementWasm(
+      templateOutput,
+      provisional,
+      ENHANCEMENT_CAPABILITY_PROFILES[profile],
+    )),
+  ]));
   return Object.freeze({
     ...provisional,
-    outputSha256: Object.freeze({ cursor: sha256(output) }),
+    outputSha256: Object.freeze(outputSha256),
   });
 }
 
@@ -254,7 +277,7 @@ function isExactEnhancementBuild(
   return exact !== null && sameJson(value, exact);
 }
 
-function isAutomaticCursorBuild(
+function isAutomaticSemanticBuild(
   value: unknown,
   inputSha256: string,
 ): value is KnownEnhancementBuild {
@@ -262,29 +285,45 @@ function isAutomaticCursorBuild(
   const build = value as Partial<KnownEnhancementBuild>;
   if (
     build.sha256 !== inputSha256
-    || !isDigest(build.outputSha256?.cursor)
-    || Object.keys(build.outputSha256 ?? {}).join(",") !== "cursor"
-    || build.targetObservation !== undefined
+    || !build.outputSha256
     || build.partyObservation !== undefined
     || build.teamApply !== undefined
-    || build.observationBase !== undefined
+    || build.travelAction !== undefined
+    || build.xunlaiAction !== undefined
+    || build.chatAliases !== undefined
+    || build.gameThread !== undefined
+    || build.uiDispatcher !== undefined
     || !isIndex(build.programId)
     || !isIndex(build.buildId)
     || !isIndex(build.hookFunction)
     || !isIndex(build.tableSlot)
     || !isDigest(build.hookBodySha256)
-    || !build.cursorEvent
-    || !isIndex(build.cursorEvent.functionIndex)
-    || !isIndex(build.cursorEvent.tableSlot)
-    || build.cursorEvent.producerFunctions.length !== 2
-    || !build.cursorEvent.producerFunctions.every(isIndex)
-    || build.cursorEvent.producerBodySha256.length !== 2
-    || !build.cursorEvent.producerBodySha256.every(isDigest)
-    || !Object.values(build.cursorEvent.layout).every(isIndex)
+  ) return false;
+  const hasCursor = build.cursorEvent !== undefined;
+  const hasTarget = build.targetObservation !== undefined
+    && build.observationBase !== undefined;
+  if (!hasCursor && !hasTarget) return false;
+  const expectedProfiles = [
+    ...(hasCursor ? ["cursor"] : []),
+    ...(hasTarget ? ["target"] : []),
+    ...(hasCursor && hasTarget ? ["cursorTarget"] : []),
+  ];
+  if (
+    Object.keys(build.outputSha256).join(",") !== expectedProfiles.join(",")
+    || !Object.values(build.outputSha256).every(isDigest)
   ) return false;
   return ENHANCEMENT_BUILDS.some((baseline) => {
     const cursor = baseline.cursorEvent;
-    return cursor !== undefined
+    const cursorMatches = !hasCursor || (
+      cursor !== undefined
+      && build.cursorEvent !== undefined
+      && isIndex(build.cursorEvent.functionIndex)
+      && isIndex(build.cursorEvent.tableSlot)
+      && build.cursorEvent.producerFunctions.length === 2
+      && build.cursorEvent.producerFunctions.every(isIndex)
+      && build.cursorEvent.producerBodySha256.length === 2
+      && build.cursorEvent.producerBodySha256.every(isDigest)
+      && Object.values(build.cursorEvent.layout).every(isIndex)
       && Object.keys(build.cursorEvent!.layout).sort().join()
         === Object.keys(cursor.layout).sort().join()
       && sameJson(build.hookParams, baseline.hookParams)
@@ -306,7 +345,37 @@ function isAutomaticCursorBuild(
       && build.cursorEvent.layout.cursorViewTexture === cursor.layout.cursorViewTexture
       && build.cursorEvent.layout.cursorTextureType === cursor.layout.cursorTextureType
       && build.cursorEvent.layout.cursorTextureWidth === cursor.layout.cursorTextureWidth
-      && build.cursorEvent.layout.cursorTextureHeight === cursor.layout.cursorTextureHeight;
+      && build.cursorEvent.layout.cursorTextureHeight === cursor.layout.cursorTextureHeight
+    );
+    const observation = baseline.observationBase?.layout;
+    const target = baseline.targetObservation?.layout;
+    const candidateObservation = build.observationBase?.layout;
+    const candidateTarget = build.targetObservation?.layout;
+    const targetMatches = !hasTarget || (
+      observation !== undefined
+      && target !== undefined
+      && candidateObservation !== undefined
+      && candidateTarget !== undefined
+      && Object.keys(candidateObservation).sort().join()
+        === Object.keys(observation).sort().join()
+      && Object.keys(candidateTarget).sort().join()
+        === Object.keys(target).sort().join()
+      && Object.values(candidateObservation).every(isIndex)
+      && Object.values(candidateTarget).every(isIndex)
+      && candidateTarget.manualTargetAgentId
+        === candidateTarget.automaticTargetAgentId + 4
+      && [
+        candidateObservation.contextRoot - observation.contextRoot,
+        candidateObservation.agentArray - observation.agentArray,
+        candidateObservation.areaInfo - observation.areaInfo,
+        candidateTarget.manualTargetAgentId - target.manualTargetAgentId,
+        candidateTarget.automaticTargetAgentId - target.automaticTargetAgentId,
+      ].every((delta, _index, deltas) => delta === deltas[0])
+      && Object.entries(observation).every(([key, expected]) =>
+        key === "contextRoot" || key === "agentArray" || key === "areaInfo"
+          || candidateObservation[key as keyof typeof candidateObservation] === expected)
+    );
+    return cursorMatches && targetMatches;
   });
 }
 
@@ -354,7 +423,7 @@ export function isLocalClientVerification(
         result.enhancementBuild,
         result.templateSaveBuild.outputSha256,
       )
-      || isAutomaticCursorBuild(
+      || isAutomaticSemanticBuild(
         result.enhancementBuild,
         result.templateSaveBuild.outputSha256,
       )

--- a/tests/client-artifact/template-save-recert.test.ts
+++ b/tests/client-artifact/template-save-recert.test.ts
@@ -153,10 +153,37 @@ test("the template-save verifier makes a fail-closed decision for a real client"
   assert.deepEqual(Object.keys(addressDecision.enhancementBuild.outputSha256), ["cursor"]);
   assert.deepEqual(addressDecision.reasons, []);
 
+  const targetMutations = [
+    { local: 7327 - derived.importCount, offset: 132, label: "target occurrence ledger" },
+    { local: 5109 - derived.importCount, offset: 39, label: "map field offset" },
+    { local: 17524 - derived.importCount, offset: 36, label: "area table stride" },
+  ] as const;
+  for (const mutation of targetMutations) {
+    const changedTargetProof = rewriteCode(bytes, (bodies) => {
+      const body = bodies[mutation.local]!;
+      body[mutation.offset] = body[mutation.offset]! ^ 1;
+    });
+    assert.equal(
+      WebAssembly.validate(new Uint8Array(changedTargetProof)),
+      true,
+      mutation.label,
+    );
+    const refusal = verifyLocalClientBytes(changedTargetProof);
+    assert.ok(refusal.templateSaveBuild, mutation.label);
+    assert.ok(refusal.enhancementBuild?.cursorEvent, mutation.label);
+    assert.equal(refusal.enhancementBuild.targetObservation, undefined, mutation.label);
+    assert.deepEqual(
+      Object.keys(refusal.enhancementBuild.outputSha256),
+      ["cursor"],
+      mutation.label,
+    );
+    assert.deepEqual(refusal.reasons, [], mutation.label);
+  }
+
   const cursorMutations = [
-    { local: 446 - derived.importCount, offset: 10, label: "main-loop control flow" },
-    { local: 2828 - derived.importCount, offset: 68, label: "one producer static" },
-    { local: 6234 - derived.importCount, offset: 45, label: "cursor art offset" },
+    { local: 446 - derived.importCount, offset: 10, label: "main-loop control flow", shared: true },
+    { local: 2828 - derived.importCount, offset: 68, label: "one producer static", shared: false },
+    { local: 6234 - derived.importCount, offset: 45, label: "cursor art offset", shared: false },
   ] as const;
   for (const mutation of cursorMutations) {
     const changedCursorProof = rewriteCode(bytes, (bodies) => {
@@ -170,8 +197,19 @@ test("the template-save verifier makes a fail-closed decision for a real client"
     );
     const refusal = verifyLocalClientBytes(changedCursorProof);
     assert.ok(refusal.templateSaveBuild, mutation.label);
-    assert.equal(refusal.enhancementBuild, null, mutation.label);
-    assert.deepEqual(refusal.reasons, ["enhancement-layout-changed"], mutation.label);
+    if (mutation.shared) {
+      assert.equal(refusal.enhancementBuild, null, mutation.label);
+      assert.deepEqual(refusal.reasons, ["enhancement-layout-changed"], mutation.label);
+    } else {
+      assert.ok(refusal.enhancementBuild?.targetObservation, mutation.label);
+      assert.equal(refusal.enhancementBuild.cursorEvent, undefined, mutation.label);
+      assert.deepEqual(
+        Object.keys(refusal.enhancementBuild.outputSha256),
+        ["target"],
+        mutation.label,
+      );
+      assert.deepEqual(refusal.reasons, [], mutation.label);
+    }
   }
 });
 

--- a/tests/policy/source-wasm-host.test.ts
+++ b/tests/policy/source-wasm-host.test.ts
@@ -326,7 +326,7 @@ test("Enhancement re-certification inspects only post-template bytes", async () 
   );
 });
 
-test("only the strict cursor locator may turn structural evidence into launch authority", async () => {
+test("only strict feature locators may turn structural evidence into launch authority", async () => {
   const analyzer = await readFile(
     path.join(root, "src/main/certification/enhancement-structural-evidence.ts"),
     "utf8",
@@ -347,6 +347,7 @@ test("only the strict cursor locator may turn structural evidence into launch au
     "utf8",
   );
   assert.match(verifier, /locateAutomaticCursor/);
+  assert.match(verifier, /locateAutomaticTarget/);
 });
 
 test("the WASM section codec has exactly one home", async () => {

--- a/tests/unit/local-client-verifier.test.ts
+++ b/tests/unit/local-client-verifier.test.ts
@@ -56,6 +56,40 @@ function automaticCursor(): LocalClientVerification {
   };
 }
 
+function automaticTarget(): LocalClientVerification {
+  const observation = ENHANCEMENT.observationBase!.layout;
+  const target = ENHANCEMENT.targetObservation!.layout;
+  const delta = -112;
+  return {
+    ...valid(),
+    enhancementBuild: {
+      sha256: ENHANCEMENT.sha256,
+      outputSha256: { target: "5".repeat(64) },
+      programId: ENHANCEMENT.programId,
+      buildId: ENHANCEMENT.buildId + 1,
+      hookFunction: ENHANCEMENT.hookFunction + 1,
+      hookParams: ENHANCEMENT.hookParams,
+      hookResults: ENHANCEMENT.hookResults,
+      hookBodySha256: "6".repeat(64),
+      tableSlot: ENHANCEMENT.tableSlot,
+      observationBase: {
+        layout: {
+          ...observation,
+          contextRoot: observation.contextRoot + delta,
+          agentArray: observation.agentArray + delta,
+          areaInfo: observation.areaInfo + delta,
+        },
+      },
+      targetObservation: {
+        layout: {
+          manualTargetAgentId: target.manualTargetAgentId + delta,
+          automaticTargetAgentId: target.automaticTargetAgentId + delta,
+        },
+      },
+    },
+  };
+}
+
 describe("local client verification boundary", () => {
   it("accepts the verifier's complete baseline proof", () => {
     assert.equal(isLocalClientVerification(valid(), TEMPLATE.sha256), true);
@@ -106,6 +140,24 @@ describe("local client verification boundary", () => {
             ...derived.enhancementBuild!.cursorEvent!.layout,
             cursorShowCount:
               derived.enhancementBuild!.cursorEvent!.layout.cursorShowCount + 4,
+          },
+        },
+      },
+    }, TEMPLATE.sha256), false);
+  });
+
+  it("accepts a field-complete Target proof and rejects one bad relocation", () => {
+    const derived = automaticTarget();
+    assert.equal(isLocalClientVerification(derived, TEMPLATE.sha256), true);
+    assert.equal(isLocalClientVerification({
+      ...derived,
+      enhancementBuild: {
+        ...derived.enhancementBuild!,
+        targetObservation: {
+          layout: {
+            ...derived.enhancementBuild!.targetObservation!.layout,
+            manualTargetAgentId:
+              derived.enhancementBuild!.targetObservation!.layout.manualTargetAgentId + 4,
           },
         },
       },


### PR DESCRIPTION
## What changed

Target Distance derives its bounded observation base, target fields, precedence, and snapshot behavior from semantic reader relationships.

## Why

Target observation must survive relocated functions and addresses without accepting a partial or ambiguous layout.

## Invariant

Every root, offset, flag, and reader role is witnessed. Duplicate candidates report `ambiguous` with the owning invariant and candidate count.

## Verification

- Exact-head PR package, CodeQL, and Vercel checks passed.
- Current and retained client artifacts pass structural proof.
- Missing-field, duplicate-role, invalid-snapshot, and ambiguity mutations refuse Target only.

Stack layer 7 of 13.
