### PR TITLE
fix(actions): prove local client actions

### DIFF
--- a/internal/upstream/client-internals.md
+++ b/internal/upstream/client-internals.md
@@ -396,13 +396,19 @@ range was `0x15a318..0x15a397`, outside every certified layout root. The
 recomputed outputs for all seven capability profiles, native double-click and
 extended memory were pinned rather than copied from build 38,797.
 
-The general review report still describes the cursor callback as unavailable:
-its broad heuristic looks for direct calls, while this callback is reached
-through the active table. Automatic cursor recovery therefore uses a separate,
-narrow proof. It requires one exported main-loop body, one callback with its
-exact signature and active table neighbourhood, and the two measured producer
-body fingerprints. Both certified builds must agree on all semantic anchors.
-Changing or duplicating any anchor rejects recovery. That original result
-authorized only the cursor. Target Distance now has a separate proof for its
-selector, bounded context and agent readers, and immutable area table. Party
-observation and actions remain exact-build-only until their own proof layers.
+The broad historic report could not locate the cursor callback because it is
+reached through the active table instead of a direct call. The shipped verifier
+now proves cursor ownership from the exported main loop, callback signature,
+active table neighbourhood, both producers, and a complete relocation ledger.
+Target Distance has a separate proof for its selector, bounded context and
+agent readers, and immutable area table.
+
+Travel, Xunlai, and chat aliases are also independent proofs. Travel requires
+the exact four-field producer, Travel message, dispatcher calls, and the
+game-thread drain. Xunlai requires three access readers, all player and area
+layout words, its fixed DataWindow handler, dispatcher, and the same proved
+drain. Chat aliases require both bounded parser comparisons, their handled
+messages, and the original dispatcher relationship; they do not inherit action
+authority from the drain. A changed or duplicated anchor disables only its
+owning capability. Party observation and Team Apply remain unavailable to an
+unknown build until their complete proof layer is present.

--- a/src/main/certification/client-module.ts
+++ b/src/main/certification/client-module.ts
@@ -13,6 +13,7 @@
  */
 import {
   ENHANCEMENT_CAPABILITY_PROFILES,
+  enhancementCapabilitiesForProfile,
   enhancementCapabilitiesRequested,
   intersectEnhancementCapabilities,
   ENHANCEMENT_TRANSFORM_ABI,
@@ -129,7 +130,10 @@ function enhancementCandidates(
   );
   return (Object.keys(ENHANCEMENT_CAPABILITY_PROFILES) as
     EnhancementCapabilityProfile[])
-    .map((profile) => ENHANCEMENT_CAPABILITY_PROFILES[profile])
+    .flatMap((profile) => {
+      const capabilities = enhancementCapabilitiesForProfile(profile);
+      return capabilities ? [capabilities] : [];
+    })
     .filter((candidate) =>
       isSubset(candidate, maximum)
       && enhancementOutputSha256(build, candidate) !== null)
@@ -199,6 +203,10 @@ function enhancementCache(
     nativeCursor: capabilities.nativeCursor,
     targetObservation: capabilities.targetObservation,
     partyObservation: capabilities.partyObservation,
+    teamApply: capabilities.teamApply,
+    travelAction: capabilities.travelAction,
+    xunlaiAction: capabilities.xunlaiAction,
+    chatAliases: capabilities.chatAliases,
   };
   return {
     inputSha256: build.sha256,

--- a/src/main/certification/enhancement-build-model.ts
+++ b/src/main/certification/enhancement-build-model.ts
@@ -14,6 +14,7 @@
  */
 import {
   ENHANCEMENT_CAPABILITY_PROFILES,
+  enhancementCapabilitiesForProfile,
   enhancementCapabilityProfile,
   enhancementConfigWordActive,
   type EnhancementCapabilityProfile,
@@ -40,7 +41,7 @@ export function enhancementOutputSha256(
   build: KnownEnhancementBuild,
   capabilities: EnhancementCapabilities,
 ): string | null {
-  if (!hasCompleteEnhancementProfileHashes(build)) return null;
+  if (!hasValidEnhancementProfileHashes(build)) return null;
   const profile = enhancementCapabilityProfile(capabilities);
   if (profile === null) return null;
   const output = build.outputSha256?.[profile];
@@ -288,7 +289,7 @@ export function supportedEnhancementCapabilities(
     teamApply: partyObservation && gameThread && build.teamApply !== undefined,
     travelAction,
     xunlaiAction,
-    chatAliases: gameThread && build.chatAliases !== undefined,
+    chatAliases: build.uiDispatcher !== undefined && build.chatAliases !== undefined,
   });
 }
 
@@ -301,7 +302,8 @@ export function enhancementProfilesForBuild(
       ENHANCEMENT_CAPABILITY_PROFILES,
     ) as EnhancementCapabilityProfile[]
   ).filter((profile) => {
-    const value = ENHANCEMENT_CAPABILITY_PROFILES[profile];
+    const value = enhancementCapabilitiesForProfile(profile);
+    if (!value) return false;
     return (
       (!value.nativeCursor || supported.nativeCursor) &&
       (!value.targetObservation || supported.targetObservation) &&
@@ -310,17 +312,17 @@ export function enhancementProfilesForBuild(
       (!value.travelAction || supported.travelAction) &&
       (!value.xunlaiAction || supported.xunlaiAction) &&
       (!value.chatAliases || supported.chatAliases)
+      && typeof build.outputSha256[profile] === "string"
     );
   });
 }
 
 /**
- * A certificate carries one hash for every profile its optional fact groups
- * authorize, and no hash for a profile those groups do not authorize. This is
- * the authoring boundary that keeps a stale or copied hash from granting a
- * capability whose facts are absent.
+ * A certificate may carry only the profile outputs it actually derived. Every
+ * stored profile must be supported by its feature-local facts; omitted profile
+ * combinations are a safe loss of availability, never implicit authority.
  */
-export function hasCompleteEnhancementProfileHashes(
+export function hasValidEnhancementProfileHashes(
   build: KnownEnhancementBuild,
 ): boolean {
   const storageReaders = build.xunlaiAction?.accessProof?.readers;
@@ -364,19 +366,21 @@ export function hasCompleteEnhancementProfileHashes(
   ) return false;
   if (
     build.chatAliases !== undefined
-    && build.gameThread === undefined
+    && build.uiDispatcher === undefined
   ) return false;
-  const expected = enhancementProfilesForBuild(build);
-  if (expected.length === 0) return false;
-  const expectedSet = new Set<string>(expected);
   const actual = Object.entries(build.outputSha256);
+  if (actual.length === 0) return false;
+  const supported = supportedEnhancementCapabilities(build);
   return (
-    actual.length === expected.length &&
     actual.every(
       ([profile, digest]) =>
-        expectedSet.has(profile) &&
-        typeof digest === "string" &&
-        /^[0-9a-f]{64}$/.test(digest),
+        Object.hasOwn(ENHANCEMENT_CAPABILITY_PROFILES, profile)
+        && typeof digest === "string"
+        && /^[0-9a-f]{64}$/.test(digest)
+        && Object.entries(enhancementCapabilitiesForProfile(profile) ?? {}).every(
+          ([feature, enabled]) => !enabled
+            || supported[feature as keyof EnhancementCapabilities],
+        ),
     )
   );
 }

--- a/src/main/certification/enhancement-builds.ts
+++ b/src/main/certification/enhancement-builds.ts
@@ -3,7 +3,7 @@
  * Certificate structure and validation live in enhancement-build-model.
  */
 import {
-  hasCompleteEnhancementProfileHashes,
+  hasValidEnhancementProfileHashes,
   type KnownEnhancementBuild,
 } from "./enhancement-build-model.js";
 export * from "./enhancement-build-model.js";
@@ -474,7 +474,7 @@ export function findEnhancementBuild(
   return (
     ENHANCEMENT_BUILDS.find(
       (build) =>
-        build.sha256 === sha256 && hasCompleteEnhancementProfileHashes(build),
+        build.sha256 === sha256 && hasValidEnhancementProfileHashes(build),
     ) ?? null
   );
 }

--- a/src/main/certification/enhancement-structural-evidence.ts
+++ b/src/main/certification/enhancement-structural-evidence.ts
@@ -159,6 +159,18 @@ export interface AutomaticTargetLocation {
   readonly targetLayout: EnhancementTargetLayout;
 }
 
+export interface AutomaticLocalActionsLocation {
+  readonly baseline: KnownEnhancementBuild;
+  readonly hookFunction: number;
+  readonly hookBodySha256: string;
+  readonly observationLayout: EnhancementObservationBaseLayout | null;
+  readonly uiDispatcher: KnownEnhancementBuild["uiDispatcher"] | null;
+  readonly gameThread: KnownEnhancementBuild["gameThread"] | null;
+  readonly travelAction: KnownEnhancementBuild["travelAction"] | null;
+  readonly xunlaiAction: KnownEnhancementBuild["xunlaiAction"] | null;
+  readonly chatAliases: KnownEnhancementBuild["chatAliases"] | null;
+}
+
 const MAX_INPUT_BYTES = 64 * 1024 * 1024;
 const MAX_TYPES = 100_000;
 const MAX_FUNCTIONS = 100_000;
@@ -1315,6 +1327,79 @@ const TARGET_IMMUTABLE_HASHES = Object.freeze({
   areaTable: "3a4564fe4b92b8e2a4e048000ccd924d1f1ee68d15e24a63dd6e05a9683a88bc",
 });
 
+const GAME_THREAD_DRAIN_ROLE = semanticRole(
+  764,
+  "aa1694915623017676dffcba6b54ef5570b4029e9c9258f8b8e00480e5d37c99",
+  Object.freeze([
+    ...mutableSpans([
+      [29, 34, "frame.clock"], [80, 85, "frame.clock"],
+      [108, 113, "frame.previous"], [136, 141, "frame.previous"],
+      [153, 158, "frame.ready"], [166, 171, "frame.clock"],
+      [175, 180, "frame.elapsed"], [183, 188, "frame.elapsed"],
+      [199, 204, "frame.elapsed"], [220, 225, "frame.elapsed"],
+      [232, 237, "frame.clock"], [365, 370, "frame.flag"],
+      [396, 401, "frame.guard"], [432, 437, "frame.guard"],
+      [442, 447, "frame.flag"], [469, 474, "frame.state"],
+      [483, 488, "frame.counter"], [495, 500, "frame.counter"],
+      [516, 521, "frame.buffer.end"], [536, 541, "frame.buffer.payload"],
+      [560, 565, "frame.buffer.start"], [569, 574, "frame.state"],
+      [589, 594, "frame.pending"], [623, 628, "frame.pending"],
+      [641, 646, "frame.state"], [651, 656, "frame.buffer.start"],
+      [675, 680, "frame.pending"], [685, 690, "frame.buffer.start"],
+      [706, 711, "frame.flag"],
+    ]),
+    { start: 253, end: 258, role: "frame.assertion", addressClass: "immutable-data" },
+  ]),
+  ["i32", "i32"],
+  [],
+);
+
+const CHAT_ALIASES_ROLE = semanticRole(
+  380,
+  "c35aa3256d466c5fd5d704d5b069b0faed1d7884c62158b38b3ba0aecf307545",
+  mutableSpans([
+    [50, 55, "aliases.flag"], [63, 68, "aliases.state"],
+    [74, 79, "aliases.cursor"], [85, 90, "aliases.end"],
+    [96, 101, "aliases.enabled"], [102, 107, "aliases.state"],
+    [110, 115, "aliases.buffer"], [148, 153, "aliases.flag"],
+    [195, 200, "aliases.compare"], [248, 253, "aliases.state"],
+  ]),
+  ["i32", "i32"],
+  ["i32"],
+);
+
+const XUNLAI_AGENT_READER_ROLE = semanticRole(
+  418,
+  "fde5f7f940fb4ab5b55f85290897f47f341056b983514a6b0e03bb6f149aff8d",
+  Object.freeze([
+    { start: 17, end: 22, role: "xunlai.assertion", addressClass: "immutable-data" },
+    { start: 29, end: 31, role: "xunlai.source-line", addressClass: "immutable-data" },
+  ]),
+  ["i32"],
+  ["i32"],
+);
+
+const XUNLAI_ACCESS_READER_ROLE = semanticRole(
+  85,
+  "ea782429f5a29731780e4c962909963b7a00b01f59b5122ec0c9ae292905ba09",
+  Object.freeze([
+    { start: 17, end: 22, role: "xunlai.assertion", addressClass: "immutable-data" },
+    { start: 29, end: 31, role: "xunlai.source-line", addressClass: "immutable-data" },
+  ]),
+  ["i32"],
+  ["i32"],
+);
+
+const LOCAL_ACTION_HASHES = Object.freeze({
+  uiDispatcher: "ba41a2237bc91373cdee67ad8cfff700b80a2e351b7e980f37d68690307de4c0",
+  travelProducer: "47c2f33dc98226fbb1596d60b2dfe76a9a19f645e94330a0582a6dc50d5be595",
+  xunlaiHandler: "0a46adca4dd597f9430c23457f6ce6ff7ccdfbdaf4a77b449a8158e2c595189a",
+  xunlaiPlayerReader: "b98af3eb50f4c2aa1bc09f0a88712e32a2a14fe0d013126e1e4c0e842008e01f",
+  areaTypeReader: "9786e68238b6a2559646f8e0594b3d4ee808003f11ec775a475e337e7dd9aa90",
+  frameAssertion: "1db4beca1a3d246ce3f4df09cfdd2a3e60c5cef5564d0361474f7f9cb3c95026",
+  xunlaiAssertion: "df83cbe4386b6f8641568f5d2b6444c941f6d448a7efffd9f4737e343b0972d2",
+});
+
 function functionBody(module: ModuleShape, functionIndex: number): Uint8Array {
   const body = module.bodies[functionIndex - module.functionImportCount];
   if (!body) throw new EvidenceError("module-shape-unsupported");
@@ -1379,10 +1464,10 @@ function uniqueExactFunction(
   return matches.length === 1 ? matches[0]! : null;
 }
 
-function paddedU32(body: Uint8Array, start: number): number {
+function encodedU32(body: Uint8Array, start: number, end: number): number {
   const cursor = { value: start };
   const value = readUnsigned(body, cursor);
-  if (cursor.value !== start + 5) {
+  if (cursor.value !== end) {
     throw new EvidenceError("module-shape-unsupported");
   }
   return value;
@@ -1449,7 +1534,7 @@ function valuesForRole(body: Uint8Array, role: CursorRole): Map<string, number[]
   const values = new Map<string, number[]>();
   for (const span of role.spans) {
     const group = values.get(span.role) ?? [];
-    group.push(paddedU32(body, span.start));
+    group.push(encodedU32(body, span.start, span.end));
     values.set(span.role, group);
   }
   return values;
@@ -1477,38 +1562,25 @@ function exactTargetFunction(
   return uniqueExactFunction(module, role.bodySha256, role.params, role.results);
 }
 
-function deriveTargetLayouts(
+function deriveObservationLayout(
   module: ModuleShape,
-): Readonly<{
-  observation: EnhancementObservationBaseLayout;
-  target: EnhancementTargetLayout;
-}> | null {
+): EnhancementObservationBaseLayout | null {
   const contextFunction = uniqueRoleFunction(module, TARGET_CONTEXT_ROOT_ROLE);
-  const selectorFunction = uniqueRoleFunction(module, TARGET_SELECTOR_ROLE);
-  const resetFunction = uniqueRoleFunction(module, TARGET_RESET_ROLE);
-  const callerFunction = uniqueRoleFunction(module, TARGET_CALLER_ROLE);
   const agentAccessorFunction = uniqueRoleFunction(module, AGENT_ARRAY_ACCESSOR_ROLE);
   const areaLookupFunction = uniqueRoleFunction(module, AREA_LOOKUP_ROLE);
   const exact = Object.fromEntries(Object.entries(EXACT_TARGET_ROLES).map(
     ([name, role]) => [name, exactTargetFunction(module, role)],
   )) as Record<keyof typeof EXACT_TARGET_ROLES, number | null>;
   if (
-    contextFunction === null || selectorFunction === null
-    || resetFunction === null || callerFunction === null
-    || agentAccessorFunction === null
+    contextFunction === null || agentAccessorFunction === null
     || areaLookupFunction === null
     || Object.values(exact).some((value) => value === null)
   ) return null;
 
   const context = valuesForRole(functionBody(module, contextFunction), TARGET_CONTEXT_ROOT_ROLE);
-  const selector = valuesForRole(functionBody(module, selectorFunction), TARGET_SELECTOR_ROLE);
-  const reset = valuesForRole(functionBody(module, resetFunction), TARGET_RESET_ROLE);
-  const caller = valuesForRole(functionBody(module, callerFunction), TARGET_CALLER_ROLE);
   const accessor = valuesForRole(functionBody(module, agentAccessorFunction), AGENT_ARRAY_ACCESSOR_ROLE);
   const area = valuesForRole(functionBody(module, areaLookupFunction), AREA_LOOKUP_ROLE);
   const contextRoot = soleValue(context, "context.root");
-  const manualTargetAgentId = soleValue(selector, "target.manual");
-  const automaticTargetAgentId = soleValue(selector, "target.automatic");
   const agentArray = soleValue(accessor, "agent-array.base");
   const agentArraySize = soleValue(accessor, "agent-array.size");
   const lifecycleMatches = roleFunctions(module, AGENT_ARRAY_LIFECYCLE_ROLE).filter(
@@ -1523,41 +1595,19 @@ function deriveTargetLayouts(
   if (lifecycleMatches.length !== 1) return null;
   const areaInfo = soleValue(area, "area.table");
   if (
-    manualTargetAgentId !== soleValue(reset, "target.manual")
-    || manualTargetAgentId !== soleValue(caller, "target.manual")
-    || automaticTargetAgentId !== soleValue(reset, "target.automatic")
-    || automaticTargetAgentId !== soleValue(caller, "target.automatic")
-    || manualTargetAgentId !== automaticTargetAgentId + 4
-    || agentArraySize !== agentArray + 8
+    agentArraySize !== agentArray + 8
     || codeOperandOccurrences(module, contextRoot) !== 6
     || codeOperandOccurrences(module, agentArray) !== 41
     || codeOperandOccurrences(module, agentArraySize) !== 41
-    || codeOperandOccurrences(module, manualTargetAgentId) !== 16
-    || codeOperandOccurrences(module, automaticTargetAgentId) !== 18
     || codeOperandOccurrences(module, areaInfo) !== 1
     || commonRelocationDelta([
-      [contextRoot, 0x5a0ee0], [manualTargetAgentId, 0x5a394c],
-      [automaticTargetAgentId, 0x5a3948], [agentArray, 0x5a4e58],
+      [contextRoot, 0x5a0ee0], [agentArray, 0x5a4e58],
       [agentArraySize, 0x5a4e60], [areaInfo, 0x1cc630],
     ]) === null
   ) return null;
 
-  const selectorImmutable = valuesForRole(
-    functionBody(module, selectorFunction), TARGET_SELECTOR_ROLE,
-  );
-  const resetImmutable = valuesForRole(
-    functionBody(module, resetFunction), TARGET_RESET_ROLE,
-  );
   if (
-    staticCStringHash(module, soleValue(selectorImmutable, "target.assert-manual"))
-      !== TARGET_IMMUTABLE_HASHES.manualAssertion
-    || staticCStringHash(module, soleValue(selectorImmutable, "target.assert-automatic"))
-      !== TARGET_IMMUTABLE_HASHES.automaticAssertion
-    || staticCStringHash(module, soleValue(resetImmutable, "target.reset-name-a"))
-      !== TARGET_IMMUTABLE_HASHES.resetNameA
-    || staticCStringHash(module, soleValue(resetImmutable, "target.reset-name-b"))
-      !== TARGET_IMMUTABLE_HASHES.resetNameB
-    || staticCStringHash(module, soleValue(area, "area.assert-name"))
+    staticCStringHash(module, soleValue(area, "area.assert-name"))
       !== TARGET_IMMUTABLE_HASHES.areaAssertion
   ) return null;
 
@@ -1602,7 +1652,7 @@ function deriveTargetLayouts(
       !== TARGET_IMMUTABLE_HASHES.areaTable
   ) return null;
 
-  const verifiedObservation = verifyLayout(observation, {
+  return verifyLayout(observation, {
     contextRoot: { sourceRole: "context-root-writer", expression: "relocated static store", occurrences: [11] },
     agentArray: { sourceRole: "agent-array lifecycle+accessor", expression: "base static", occurrences: [9, 34, 27] },
     gameContextSlot: { sourceRole: "context-root-writer", expression: "context registration slot", occurrences: [17] },
@@ -1624,11 +1674,203 @@ function deriveTargetLayouts(
     areaInfoStride: { sourceRole: "area lookup", expression: "index multiplier", occurrences: [36] },
     areaInfoFlags: { sourceRole: "area flags reader", expression: "post-lookup load", occurrences: [21] },
   }).layout;
+}
+
+function deriveTargetLayout(
+  module: ModuleShape,
+  observation: EnhancementObservationBaseLayout,
+): EnhancementTargetLayout | null {
+  const selectorFunction = uniqueRoleFunction(module, TARGET_SELECTOR_ROLE);
+  const resetFunction = uniqueRoleFunction(module, TARGET_RESET_ROLE);
+  const callerFunction = uniqueRoleFunction(module, TARGET_CALLER_ROLE);
+  if (
+    selectorFunction === null || resetFunction === null || callerFunction === null
+  ) return null;
+  const selector = valuesForRole(functionBody(module, selectorFunction), TARGET_SELECTOR_ROLE);
+  const reset = valuesForRole(functionBody(module, resetFunction), TARGET_RESET_ROLE);
+  const caller = valuesForRole(functionBody(module, callerFunction), TARGET_CALLER_ROLE);
+  const manualTargetAgentId = soleValue(selector, "target.manual");
+  const automaticTargetAgentId = soleValue(selector, "target.automatic");
+  if (
+    manualTargetAgentId !== soleValue(reset, "target.manual")
+    || manualTargetAgentId !== soleValue(caller, "target.manual")
+    || automaticTargetAgentId !== soleValue(reset, "target.automatic")
+    || automaticTargetAgentId !== soleValue(caller, "target.automatic")
+    || manualTargetAgentId !== automaticTargetAgentId + 4
+    || codeOperandOccurrences(module, manualTargetAgentId) !== 16
+    || codeOperandOccurrences(module, automaticTargetAgentId) !== 18
+    || commonRelocationDelta([
+      [observation.contextRoot, 0x5a0ee0],
+      [manualTargetAgentId, 0x5a394c],
+      [automaticTargetAgentId, 0x5a3948],
+    ]) === null
+  ) return null;
+  const selectorImmutable = valuesForRole(
+    functionBody(module, selectorFunction), TARGET_SELECTOR_ROLE,
+  );
+  const resetImmutable = valuesForRole(
+    functionBody(module, resetFunction), TARGET_RESET_ROLE,
+  );
+  if (
+    staticCStringHash(module, soleValue(selectorImmutable, "target.assert-manual"))
+      !== TARGET_IMMUTABLE_HASHES.manualAssertion
+    || staticCStringHash(module, soleValue(selectorImmutable, "target.assert-automatic"))
+      !== TARGET_IMMUTABLE_HASHES.automaticAssertion
+    || staticCStringHash(module, soleValue(resetImmutable, "target.reset-name-a"))
+      !== TARGET_IMMUTABLE_HASHES.resetNameA
+    || staticCStringHash(module, soleValue(resetImmutable, "target.reset-name-b"))
+      !== TARGET_IMMUTABLE_HASHES.resetNameB
+  ) return null;
   const target = verifyLayout({ manualTargetAgentId, automaticTargetAgentId }, {
     manualTargetAgentId: { sourceRole: "target selector+reset+caller", expression: "manual target static", occurrences: [132, 312, 636, 7, 23, 40, 60] },
     automaticTargetAgentId: { sourceRole: "target selector+reset+caller", expression: "automatic target static", occurrences: [147, 332, 647, 18, 9, 76, 93] },
   }).layout;
-  return Object.freeze({ observation: verifiedObservation, target });
+  return target;
+}
+
+function callsAt(
+  body: Uint8Array,
+  operands: readonly number[],
+  target: number,
+): boolean {
+  return operands.every((offset) => unsignedOperand(body, offset) === target);
+}
+
+function isolatedProof<Value>(proof: () => Value | null): Value | null {
+  try {
+    return proof();
+  } catch {
+    return null;
+  }
+}
+
+function deriveGameThread(
+  module: ModuleShape,
+  baseline: KnownEnhancementBuild,
+): KnownEnhancementBuild["gameThread"] | null {
+  const functionIndex = uniqueRoleFunction(module, GAME_THREAD_DRAIN_ROLE);
+  const expected = baseline.gameThread?.drain;
+  if (functionIndex === null || !expected) return null;
+  const body = functionBody(module, functionIndex);
+  const values = valuesForRole(body, GAME_THREAD_DRAIN_ROLE);
+  const delta = commonRelocationDelta([
+    [soleValue(values, "frame.clock"), 0x5a2248],
+    [soleValue(values, "frame.previous"), 0x5a2244],
+    [soleValue(values, "frame.ready"), 0x5a21ec],
+    [soleValue(values, "frame.elapsed"), 0x5a2250],
+    [soleValue(values, "frame.flag"), 0x5a21f0],
+    [soleValue(values, "frame.guard"), 0x5a2254],
+    [soleValue(values, "frame.state"), 0x5a223c],
+    [soleValue(values, "frame.counter"), 0x5a2258],
+    [soleValue(values, "frame.buffer.end"), 0x15ac30],
+    [soleValue(values, "frame.buffer.payload"), 0x15ac20],
+    [soleValue(values, "frame.buffer.start"), 0x15ac10],
+    [soleValue(values, "frame.pending"), 0x5a2240],
+  ]);
+  const slots = parseActiveTableRelations(module.elementSection).get(functionIndex) ?? [];
+  if (
+    delta === null
+    || staticCStringHash(module, soleValue(values, "frame.assertion"))
+      !== LOCAL_ACTION_HASHES.frameAssertion
+    || slots.length !== 1
+  ) return null;
+  return Object.freeze({
+    drain: Object.freeze({
+      functionIndex,
+      params: expected.params,
+      results: expected.results,
+      tableSlot: slots[0]!,
+      bodySha256: functionBodySha256(module, functionIndex),
+    }),
+  });
+}
+
+function deriveXunlaiAccess(
+  module: ModuleShape,
+  baseline: KnownEnhancementBuild,
+  observation: EnhancementObservationBaseLayout,
+  handlerFunction: number,
+): KnownEnhancementBuild["xunlaiAction"] | null {
+  const expected = baseline.xunlaiAction;
+  if (!expected) return null;
+  const agentFunction = uniqueRoleFunction(module, XUNLAI_AGENT_READER_ROLE);
+  const accessFunction = uniqueRoleFunction(module, XUNLAI_ACCESS_READER_ROLE);
+  const playerFunction = uniqueExactFunction(
+    module, LOCAL_ACTION_HASHES.xunlaiPlayerReader, ["i32"], ["i32"],
+  );
+  const areaTypeFunction = uniqueExactFunction(
+    module, LOCAL_ACTION_HASHES.areaTypeReader, ["i32"], ["i32"],
+  );
+  if (
+    agentFunction === null || accessFunction === null
+    || playerFunction === null || areaTypeFunction === null
+  ) return null;
+  const agentBody = functionBody(module, agentFunction);
+  const accessBody = functionBody(module, accessFunction);
+  const playerBody = functionBody(module, playerFunction);
+  const agentValues = valuesForRole(agentBody, XUNLAI_AGENT_READER_ROLE);
+  const accessValues = valuesForRole(accessBody, XUNLAI_ACCESS_READER_ROLE);
+  const agentLine = soleValue(agentValues, "xunlai.source-line");
+  const accessLine = soleValue(accessValues, "xunlai.source-line");
+  if (
+    staticCStringHash(module, soleValue(agentValues, "xunlai.assertion"))
+      !== LOCAL_ACTION_HASHES.xunlaiAssertion
+    || staticCStringHash(module, soleValue(accessValues, "xunlai.assertion"))
+      !== LOCAL_ACTION_HASHES.xunlaiAssertion
+    || agentLine - 4_822 !== accessLine - 4_850
+  ) return null;
+  const worldPlayers = unsignedOperand(agentBody, 49);
+  const playerRecordStride = unsignedOperand(agentBody, 146);
+  const layout = verifyLayout({
+    worldPlayers,
+    playerRecordStride,
+    playerRecordAgentId: unsignedOperand(agentBody, 416),
+    playerRecordAccessFlags: unsignedOperand(accessBody, 78),
+    playerRecordNumber: unsignedOperand(playerBody, 123),
+    areaInfoType: unsignedOperand(functionBody(module, areaTypeFunction), 54),
+  }, {
+    worldPlayers: { sourceRole: "three player-record readers", expression: "WorldContext array field", occurrences: [49, 67, 108] },
+    playerRecordStride: { sourceRole: "three player-record readers", expression: "record index multiplier", occurrences: [146, 72, 69, 118] },
+    playerRecordAgentId: { sourceRole: "agent-id reader", expression: "record field load", occurrences: [416] },
+    playerRecordAccessFlags: { sourceRole: "access-flags reader", expression: "record field load", occurrences: [78] },
+    playerRecordNumber: { sourceRole: "player-number reader", expression: "record field address", occurrences: [123] },
+    areaInfoType: { sourceRole: "area type reader", expression: "post-lookup field load", occurrences: [54] },
+  }).layout;
+  if (
+    unsignedOperand(accessBody, 67) !== worldPlayers
+    || unsignedOperand(playerBody, 108) !== worldPlayers
+    || unsignedOperand(accessBody, 72) !== playerRecordStride
+    || unsignedOperand(playerBody, 69) !== playerRecordStride
+    || unsignedOperand(playerBody, 118) !== playerRecordStride
+    || layout.areaInfoType >= observation.areaInfoStride
+  ) return null;
+  return Object.freeze({
+    openExport: expected.openExport,
+    configureExport: expected.configureExport,
+    accessProof: Object.freeze({
+      layout,
+      readers: Object.freeze({
+        "agent-id": Object.freeze({
+          functionIndex: agentFunction, params: ["i32"] as const,
+          results: ["i32"] as const, bodySha256: functionBodySha256(module, agentFunction),
+        }),
+        "access-flags": Object.freeze({
+          functionIndex: accessFunction, params: ["i32"] as const,
+          results: ["i32"] as const, bodySha256: functionBodySha256(module, accessFunction),
+        }),
+        "player-number": Object.freeze({
+          functionIndex: playerFunction, params: ["i32"] as const,
+          results: ["i32"] as const, bodySha256: functionBodySha256(module, playerFunction),
+        }),
+      }),
+    }),
+    handler: Object.freeze({
+      functionIndex: handlerFunction,
+      params: ["i32"] as const,
+      results: [] as const,
+      bodySha256: functionBodySha256(module, handlerFunction),
+    }),
+  });
 }
 
 
@@ -1863,8 +2105,10 @@ export function locateAutomaticTarget(
     if (!tick) return null;
     const tickBody = functionBody(module, tick.functionIndex);
     if (!bodyMatchesRole(tickBody, CURSOR_TICK_ROLE)) return null;
-    const layouts = deriveTargetLayouts(module);
-    if (!layouts) return null;
+    const observationLayout = deriveObservationLayout(module);
+    if (!observationLayout) return null;
+    const targetLayout = deriveTargetLayout(module, observationLayout);
+    if (!targetLayout) return null;
     const matches = baselines.flatMap((baseline): AutomaticTargetLocation[] =>
       baseline.observationBase && baseline.targetObservation
       && signatureMatches(module, tick.functionIndex, baseline.hookParams, baseline.hookResults)
@@ -1872,8 +2116,8 @@ export function locateAutomaticTarget(
             baseline,
             hookFunction: tick.functionIndex,
             hookBodySha256: tick.bodySha256,
-            observationLayout: layouts.observation,
-            targetLayout: layouts.target,
+            observationLayout,
+            targetLayout,
           }]
         : []);
     if (matches.length === 0) return null;
@@ -1884,6 +2128,131 @@ export function locateAutomaticTarget(
     });
     return matches.every((match) => identity(match) === identity(matches[0]!))
       ? matches[0]!
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Strict, independent authority for the three local action surfaces. */
+export function locateAutomaticLocalActions(
+  input: Uint8Array,
+  baselines: readonly KnownEnhancementBuild[],
+): AutomaticLocalActionsLocation | null {
+  if (!WebAssembly.validate(input) || input.byteLength > MAX_INPUT_BYTES) return null;
+  try {
+    const module = parseModule(input);
+    const tick = tickEvidence(module).candidate;
+    if (!tick || !bodyMatchesRole(functionBody(module, tick.functionIndex), CURSOR_TICK_ROLE)) {
+      return null;
+    }
+    const locations: AutomaticLocalActionsLocation[] = [];
+    for (const baseline of baselines) {
+      const expectedUi = baseline.uiDispatcher;
+      const party = baseline.partyObservation;
+      if (!expectedUi || !party) continue;
+      const decoded = decodeFunctions(module, {
+        playerChatMessage: expectedUi.playerChatMessage,
+        nearbyPlayerMessages: party.nearbyPlayerMessages,
+      });
+      const uiEvidence = playerChatUiEvidence(module, decoded, {
+        playerChatMessage: expectedUi.playerChatMessage,
+        nearbyPlayerMessages: party.nearbyPlayerMessages,
+      }).candidate;
+      const uiFunction = uiEvidence?.dispatcherFunctionIndex ?? null;
+      const uiDispatcher = uiFunction !== null
+        && functionBodySha256(module, uiFunction) === LOCAL_ACTION_HASHES.uiDispatcher
+        ? Object.freeze({
+            ...expectedUi,
+            functionIndex: uiFunction,
+            bodySha256: functionBodySha256(module, uiFunction),
+          })
+        : null;
+      const gameThread = isolatedProof(() => deriveGameThread(module, baseline));
+
+      const travelExpected = baseline.travelAction;
+      const travelFunction = travelExpected
+        ? uniqueExactFunction(
+            module, LOCAL_ACTION_HASHES.travelProducer,
+            travelExpected.producer.params, travelExpected.producer.results,
+          )
+        : null;
+      const travelBody = travelFunction === null ? null : functionBody(module, travelFunction);
+      const travelAction = uiDispatcher && gameThread && travelExpected && travelBody
+        && unsignedOperand(travelBody, 169) === travelExpected.messageId
+        && callsAt(travelBody, [132, 179], uiDispatcher.functionIndex)
+        ? Object.freeze({
+            ...travelExpected,
+            producer: Object.freeze({
+              ...travelExpected.producer,
+              functionIndex: travelFunction!,
+              bodySha256: functionBodySha256(module, travelFunction!),
+            }),
+          })
+        : null;
+
+      const handlerExpected = baseline.xunlaiAction?.handler;
+      const handlerFunction = handlerExpected
+        ? uniqueExactFunction(
+            module, LOCAL_ACTION_HASHES.xunlaiHandler,
+            handlerExpected.params, handlerExpected.results,
+          )
+        : null;
+      const handlerBody = handlerFunction === null ? null : functionBody(module, handlerFunction);
+      const observationLayout = isolatedProof(() => deriveObservationLayout(module));
+      const xunlaiAction = uiDispatcher && gameThread && observationLayout
+        && handlerBody
+        && [85, 117, 159, 181, 200, 219].every(
+          (offset, index) => unsignedOperand(handlerBody, offset) === 0x1000_0040 + index,
+        )
+        && callsAt(handlerBody, [98, 130, 172, 191, 210, 229], uiDispatcher.functionIndex)
+        ? isolatedProof(() => deriveXunlaiAccess(
+            module, baseline, observationLayout, handlerFunction!,
+          ))
+        : null;
+
+      const aliasesExpected = baseline.chatAliases;
+      const aliasFunction = aliasesExpected
+        ? uniqueRoleFunction(module, CHAT_ALIASES_ROLE)
+        : null;
+      const aliasBody = aliasFunction === null ? null : functionBody(module, aliasFunction);
+      const chatAliases = uiDispatcher && aliasesExpected && aliasBody
+        && unsignedOperand(aliasBody, 316) === 0x1000_019d
+        && unsignedOperand(aliasBody, 335) === 0x1000_019e
+        && callsAt(aliasBody, [326, 345], uiDispatcher.functionIndex)
+        ? Object.freeze({
+            parser: Object.freeze({
+              ...aliasesExpected.parser,
+              functionIndex: aliasFunction!,
+              bodySha256: functionBodySha256(module, aliasFunction!),
+            }),
+          })
+        : null;
+      if (!travelAction && !xunlaiAction && !chatAliases) continue;
+      locations.push(Object.freeze({
+        baseline,
+        hookFunction: tick.functionIndex,
+        hookBodySha256: tick.bodySha256,
+        observationLayout: xunlaiAction ? observationLayout : null,
+        uiDispatcher,
+        gameThread: travelAction || xunlaiAction ? gameThread : null,
+        travelAction,
+        xunlaiAction,
+        chatAliases,
+      }));
+    }
+    if (locations.length === 0) return null;
+    const identity = (value: AutomaticLocalActionsLocation) => JSON.stringify({
+      hookFunction: value.hookFunction,
+      observationLayout: value.observationLayout,
+      uiDispatcher: value.uiDispatcher,
+      gameThread: value.gameThread,
+      travelAction: value.travelAction,
+      xunlaiAction: value.xunlaiAction,
+      chatAliases: value.chatAliases,
+    });
+    return locations.every((match) => identity(match) === identity(locations[0]!))
+      ? locations[0]!
       : null;
   } catch {
     return null;

--- a/src/main/certification/enhancement-transform.ts
+++ b/src/main/certification/enhancement-transform.ts
@@ -6,7 +6,7 @@
  * The input hash is checked against the build entry before a byte is read, and
  * every hook's function signature is re-verified against the certified one, so
  * a table entry that has gone stale fails loudly instead of producing a module
- * that traps at runtime. Capability selection is exact — five fields, no
+ * that traps at runtime. Capability selection is exact — seven fields, no
  * extra keys, and a profile that has no certified output hash is refused rather
  * than derived.
  *

--- a/src/main/certification/local-client-verifier.ts
+++ b/src/main/certification/local-client-verifier.ts
@@ -17,15 +17,21 @@
  * the process boundary. Profile state is never consulted.
  */
 import { createHash } from "node:crypto";
-import { ENHANCEMENT_CAPABILITY_PROFILES } from "../../shared/enhancement-contracts.js";
+import {
+  enhancementCapabilityProfile,
+  enhancementCapabilitiesForProfile,
+  type EnhancementCapabilities,
+} from "../../shared/enhancement-contracts.js";
 import {
   ENHANCEMENT_BUILDS,
   findEnhancementBuild,
   enhancementProfilesForBuild,
+  supportedEnhancementCapabilities,
   type KnownEnhancementBuild,
 } from "./enhancement-builds.js";
 import {
   locateAutomaticCursor,
+  locateAutomaticLocalActions,
   locateAutomaticTarget,
 } from "./enhancement-structural-evidence.js";
 import { inspectEnhancementCandidate } from "./enhancement-candidate.js";
@@ -82,20 +88,28 @@ function deriveEnhancementBuild(
   const report = inspectEnhancementCandidate(templateOutput);
   if (!report.validWasm) return null;
   // A common address delta alone proves nothing. The isolated feature locators
-  // below own their complete cursor and Target evidence independently.
+  // below own their complete cursor, Target, and local-action evidence independently.
   const build = findEnhancementBuild(report.sha256);
   if (build) {
     const profile = enhancementProfilesForBuild(build)[0];
     if (!profile) return null;
-    transformEnhancementWasm(templateOutput, build, ENHANCEMENT_CAPABILITY_PROFILES[profile]);
+    const capabilities = enhancementCapabilitiesForProfile(profile);
+    if (!capabilities) return null;
+    transformEnhancementWasm(templateOutput, build, capabilities);
     return build;
   }
   const locatedCursor = locateAutomaticCursor(templateOutput, ENHANCEMENT_BUILDS);
   const locatedTarget = locateAutomaticTarget(templateOutput, ENHANCEMENT_BUILDS);
-  if ((!locatedCursor && !locatedTarget) || !report.table || report.table.max === null) {
+  const locatedLocal = locateAutomaticLocalActions(templateOutput, ENHANCEMENT_BUILDS);
+  if (
+    (!locatedCursor && !locatedTarget && !locatedLocal)
+    || !report.table || report.table.max === null
+  ) {
     return null;
   }
-  const baseline = locatedCursor?.baseline ?? locatedTarget!.baseline;
+  const baseline = locatedCursor?.baseline
+    ?? locatedTarget?.baseline
+    ?? locatedLocal!.baseline;
   const cursor = locatedCursor?.baseline.cursorEvent;
   if (locatedCursor && !cursor) return null;
   const provisional: KnownEnhancementBuild = Object.freeze({
@@ -103,10 +117,10 @@ function deriveEnhancementBuild(
     outputSha256: Object.freeze({}),
     programId: baseline.programId,
     buildId: Number.parseInt(sha256(official).slice(0, 8), 16) || 1,
-    hookFunction: (locatedCursor ?? locatedTarget)!.hookFunction,
+    hookFunction: (locatedCursor ?? locatedTarget ?? locatedLocal)!.hookFunction,
     hookParams: Object.freeze(["i32"] as const),
     hookResults: Object.freeze([] as const),
-    hookBodySha256: (locatedCursor ?? locatedTarget)!.hookBodySha256,
+    hookBodySha256: (locatedCursor ?? locatedTarget ?? locatedLocal)!.hookBodySha256,
     tableSlot: report.table.min,
     ...(locatedCursor && cursor ? {
       cursorEvent: Object.freeze({
@@ -123,24 +137,59 @@ function deriveEnhancementBuild(
         layout: locatedCursor.layout,
       }),
     } : {}),
+    ...(locatedTarget || locatedLocal?.observationLayout ? {
+      observationBase: Object.freeze({
+        layout: locatedTarget?.observationLayout ?? locatedLocal!.observationLayout!,
+      }),
+    } : {}),
     ...(locatedTarget ? {
-      observationBase: Object.freeze({ layout: locatedTarget.observationLayout }),
       targetObservation: Object.freeze({ layout: locatedTarget.targetLayout }),
     } : {}),
+    ...(locatedLocal?.uiDispatcher ? { uiDispatcher: locatedLocal.uiDispatcher } : {}),
+    ...(locatedLocal?.gameThread ? { gameThread: locatedLocal.gameThread } : {}),
+    ...(locatedLocal?.travelAction ? { travelAction: locatedLocal.travelAction } : {}),
+    ...(locatedLocal?.xunlaiAction ? { xunlaiAction: locatedLocal.xunlaiAction } : {}),
+    ...(locatedLocal?.chatAliases ? { chatAliases: locatedLocal.chatAliases } : {}),
   });
-  const profiles = [
-    ...(locatedCursor ? ["cursor" as const] : []),
-    ...(locatedTarget ? ["target" as const] : []),
-    ...(locatedCursor && locatedTarget ? ["cursorTarget" as const] : []),
-  ];
-  const outputSha256 = Object.fromEntries(profiles.map((profile) => [
-    profile,
+  const none = (): EnhancementCapabilities => ({
+    nativeCursor: false, targetObservation: false, partyObservation: false,
+    teamApply: false, travelAction: false, xunlaiAction: false, chatAliases: false,
+  });
+  const maximum: EnhancementCapabilities = Object.freeze({
+    nativeCursor: locatedCursor !== null,
+    targetObservation: locatedTarget !== null,
+    partyObservation: false,
+    teamApply: false,
+    travelAction: locatedLocal?.travelAction !== null && locatedLocal?.travelAction !== undefined,
+    xunlaiAction: locatedLocal?.xunlaiAction !== null && locatedLocal?.xunlaiAction !== undefined,
+    chatAliases: locatedLocal?.chatAliases !== null && locatedLocal?.chatAliases !== undefined,
+  });
+  const featureSets = (["nativeCursor", "targetObservation"] as const)
+    .filter((feature) => maximum[feature])
+    .map((feature) => Object.freeze({ ...none(), [feature]: true }));
+  const localBundle = Object.freeze({
+    ...none(),
+    travelAction: maximum.travelAction,
+    xunlaiAction: maximum.xunlaiAction,
+    chatAliases: maximum.chatAliases,
+  });
+  const capabilitySets = [...featureSets, localBundle, maximum].filter(
+    (capabilities, index, values) =>
+      Object.values(capabilities).some(Boolean)
+      && values.findIndex((candidate) => sameJson(candidate, capabilities)) === index,
+  );
+  const outputSha256 = Object.fromEntries(capabilitySets.map((capabilities) => {
+    const profile = enhancementCapabilityProfile(capabilities);
+    if (profile === null) throw new Error("automatic capability profile is invalid");
+    return [
+      profile,
     sha256(transformEnhancementWasm(
       templateOutput,
       provisional,
-      ENHANCEMENT_CAPABILITY_PROFILES[profile],
+        capabilities,
     )),
-  ]));
+    ];
+  }));
   return Object.freeze({
     ...provisional,
     outputSha256: Object.freeze(outputSha256),
@@ -288,11 +337,6 @@ function isAutomaticSemanticBuild(
     || !build.outputSha256
     || build.partyObservation !== undefined
     || build.teamApply !== undefined
-    || build.travelAction !== undefined
-    || build.xunlaiAction !== undefined
-    || build.chatAliases !== undefined
-    || build.gameThread !== undefined
-    || build.uiDispatcher !== undefined
     || !isIndex(build.programId)
     || !isIndex(build.buildId)
     || !isIndex(build.hookFunction)
@@ -300,18 +344,28 @@ function isAutomaticSemanticBuild(
     || !isDigest(build.hookBodySha256)
   ) return false;
   const hasCursor = build.cursorEvent !== undefined;
-  const hasTarget = build.targetObservation !== undefined
-    && build.observationBase !== undefined;
-  if (!hasCursor && !hasTarget) return false;
-  const expectedProfiles = [
-    ...(hasCursor ? ["cursor"] : []),
-    ...(hasTarget ? ["target"] : []),
-    ...(hasCursor && hasTarget ? ["cursorTarget"] : []),
-  ];
+  const hasObservation = build.observationBase !== undefined;
+  const hasTarget = build.targetObservation !== undefined;
+  const hasTravel = build.travelAction !== undefined;
+  const hasXunlai = build.xunlaiAction !== undefined;
+  const hasAliases = build.chatAliases !== undefined;
+  if (!hasCursor && !hasTarget && !hasTravel && !hasXunlai && !hasAliases) return false;
   if (
-    Object.keys(build.outputSha256).join(",") !== expectedProfiles.join(",")
+    Object.keys(build.outputSha256).length === 0
     || !Object.values(build.outputSha256).every(isDigest)
+    || (hasTarget && !hasObservation)
+    || (hasXunlai && !hasObservation)
+    || ((hasTravel || hasXunlai) && build.gameThread === undefined)
+    || ((hasTravel || hasXunlai || hasAliases) && build.uiDispatcher === undefined)
   ) return false;
+  const supported = supportedEnhancementCapabilities(build as KnownEnhancementBuild);
+  if (!Object.keys(build.outputSha256).every((profile) => {
+    const capabilities = enhancementCapabilitiesForProfile(profile);
+    return capabilities !== null
+      && (Object.keys(capabilities) as (keyof EnhancementCapabilities)[]).every(
+        (feature) => !capabilities[feature] || supported[feature],
+      );
+  })) return false;
   return ENHANCEMENT_BUILDS.some((baseline) => {
     const cursor = baseline.cursorEvent;
     const cursorMatches = !hasCursor || (
@@ -351,31 +405,111 @@ function isAutomaticSemanticBuild(
     const target = baseline.targetObservation?.layout;
     const candidateObservation = build.observationBase?.layout;
     const candidateTarget = build.targetObservation?.layout;
-    const targetMatches = !hasTarget || (
+    const observationMatches = !hasObservation || (
       observation !== undefined
-      && target !== undefined
       && candidateObservation !== undefined
-      && candidateTarget !== undefined
       && Object.keys(candidateObservation).sort().join()
         === Object.keys(observation).sort().join()
-      && Object.keys(candidateTarget).sort().join()
-        === Object.keys(target).sort().join()
       && Object.values(candidateObservation).every(isIndex)
-      && Object.values(candidateTarget).every(isIndex)
-      && candidateTarget.manualTargetAgentId
-        === candidateTarget.automaticTargetAgentId + 4
       && [
         candidateObservation.contextRoot - observation.contextRoot,
         candidateObservation.agentArray - observation.agentArray,
         candidateObservation.areaInfo - observation.areaInfo,
-        candidateTarget.manualTargetAgentId - target.manualTargetAgentId,
-        candidateTarget.automaticTargetAgentId - target.automaticTargetAgentId,
       ].every((delta, _index, deltas) => delta === deltas[0])
       && Object.entries(observation).every(([key, expected]) =>
         key === "contextRoot" || key === "agentArray" || key === "areaInfo"
           || candidateObservation[key as keyof typeof candidateObservation] === expected)
     );
-    return cursorMatches && targetMatches;
+    const targetMatches = !hasTarget || (
+      observationMatches
+      && target !== undefined
+      && candidateTarget !== undefined
+      && candidateObservation !== undefined
+      && Object.keys(candidateTarget).sort().join()
+        === Object.keys(target).sort().join()
+      && Object.values(candidateTarget).every(isIndex)
+      && candidateTarget.manualTargetAgentId
+        === candidateTarget.automaticTargetAgentId + 4
+      && [
+        candidateTarget.manualTargetAgentId - target.manualTargetAgentId,
+        candidateTarget.automaticTargetAgentId - target.automaticTargetAgentId,
+        candidateObservation.contextRoot - observation!.contextRoot,
+      ].every((delta, _index, deltas) => delta === deltas[0])
+    );
+    const ui = baseline.uiDispatcher;
+    const gameThread = baseline.gameThread;
+    const travel = baseline.travelAction;
+    const xunlai = baseline.xunlaiAction;
+    const aliases = baseline.chatAliases;
+    const uiMatches = build.uiDispatcher === undefined || (
+      ui !== undefined
+      && isIndex(build.uiDispatcher.functionIndex)
+      && build.uiDispatcher.bodySha256 === ui.bodySha256
+      && sameJson(build.uiDispatcher.params, ui.params)
+      && sameJson(build.uiDispatcher.results, ui.results)
+      && build.uiDispatcher.playerChatMessage === ui.playerChatMessage
+      && build.uiDispatcher.hideHeroPanelMessage === ui.hideHeroPanelMessage
+      && build.uiDispatcher.showHeroPanelMessage === ui.showHeroPanelMessage
+    );
+    const gameThreadMatches = build.gameThread === undefined || (
+      gameThread !== undefined
+      && isIndex(build.gameThread.drain.functionIndex)
+      && isIndex(build.gameThread.drain.tableSlot)
+      && isDigest(build.gameThread.drain.bodySha256)
+      && sameJson(build.gameThread.drain.params, gameThread.drain.params)
+      && sameJson(build.gameThread.drain.results, gameThread.drain.results)
+    );
+    const travelMatches = !hasTravel || (
+      travel !== undefined
+      && build.travelAction !== undefined
+      && build.travelAction.enqueueExport === travel.enqueueExport
+      && build.travelAction.configureExport === travel.configureExport
+      && build.travelAction.toggleExport === travel.toggleExport
+      && build.travelAction.messageId === travel.messageId
+      && isIndex(build.travelAction.producer.functionIndex)
+      && build.travelAction.producer.bodySha256 === travel.producer.bodySha256
+      && sameJson(build.travelAction.producer.params, travel.producer.params)
+      && sameJson(build.travelAction.producer.results, travel.producer.results)
+    );
+    const readers = build.xunlaiAction?.accessProof?.readers;
+    const baselineReaders = xunlai?.accessProof?.readers;
+    const xunlaiLayout = build.xunlaiAction?.accessProof?.layout;
+    const baselineXunlaiLayout = xunlai?.accessProof?.layout;
+    const xunlaiMatches = !hasXunlai || (
+      xunlai !== undefined
+      && build.xunlaiAction !== undefined
+      && readers !== undefined
+      && baselineReaders !== undefined
+      && xunlaiLayout !== undefined
+      && baselineXunlaiLayout !== undefined
+      && build.xunlaiAction.openExport === xunlai.openExport
+      && build.xunlaiAction.configureExport === xunlai.configureExport
+      && Object.keys(readers).sort().join() === Object.keys(baselineReaders).sort().join()
+      && Object.entries(readers).every(([name, reader]) => {
+        const expected = baselineReaders[name as keyof typeof baselineReaders];
+        return expected !== undefined
+          && isIndex(reader.functionIndex)
+          && isDigest(reader.bodySha256)
+          && sameJson(reader.params, expected.params)
+          && sameJson(reader.results, expected.results);
+      })
+      && sameJson(xunlaiLayout, baselineXunlaiLayout)
+      && isIndex(build.xunlaiAction.handler.functionIndex)
+      && build.xunlaiAction.handler.bodySha256 === xunlai.handler.bodySha256
+      && sameJson(build.xunlaiAction.handler.params, xunlai.handler.params)
+      && sameJson(build.xunlaiAction.handler.results, xunlai.handler.results)
+    );
+    const aliasesMatches = !hasAliases || (
+      aliases !== undefined
+      && build.chatAliases !== undefined
+      && isIndex(build.chatAliases.parser.functionIndex)
+      && isDigest(build.chatAliases.parser.bodySha256)
+      && sameJson(build.chatAliases.parser.params, aliases.parser.params)
+      && sameJson(build.chatAliases.parser.results, aliases.parser.results)
+    );
+    return cursorMatches && observationMatches && targetMatches
+      && uiMatches && gameThreadMatches && travelMatches
+      && xunlaiMatches && aliasesMatches;
   });
 }
 

--- a/src/shared/enhancement-contracts.ts
+++ b/src/shared/enhancement-contracts.ts
@@ -33,7 +33,7 @@ export type EnhancementCapabilities = Readonly<{
   chatAliases: boolean;
 }>;
 
-export const ENHANCEMENT_CAPABILITY_PROFILES = Object.freeze({
+const LEGACY_CAPABILITY_PROFILES = Object.freeze({
   cursor: Object.freeze({
     nativeCursor: true,
     targetObservation: false,
@@ -216,8 +216,57 @@ export const ENHANCEMENT_CAPABILITY_PROFILES = Object.freeze({
   }),
 } as const satisfies Readonly<Record<string, EnhancementCapabilities>>);
 
+const CAPABILITY_FIELDS = Object.freeze([
+  "nativeCursor",
+  "targetObservation",
+  "partyObservation",
+  "teamApply",
+  "travelAction",
+  "xunlaiAction",
+  "chatAliases",
+] as const satisfies readonly (keyof EnhancementCapabilities)[]);
+
+function sameCapabilities(
+  left: EnhancementCapabilities,
+  right: EnhancementCapabilities,
+): boolean {
+  return CAPABILITY_FIELDS.every((field) => left[field] === right[field]);
+}
+
+const generatedProfiles = Object.fromEntries(
+  Array.from({ length: 1 << CAPABILITY_FIELDS.length }, (_, mask) => {
+    const capabilities = Object.freeze(Object.fromEntries(
+      CAPABILITY_FIELDS.map((field, index) => [field, (mask & (1 << index)) !== 0]),
+    )) as EnhancementCapabilities;
+    return [mask, capabilities] as const;
+  })
+    .filter(([mask, capabilities]) =>
+      mask !== 0
+      && validEnhancementCapabilities(capabilities)
+      && !Object.values(LEGACY_CAPABILITY_PROFILES).some(
+        (legacy) => sameCapabilities(legacy, capabilities),
+      ))
+    .map(([mask, capabilities]) => [`features-${mask.toString(16).padStart(2, "0")}`, capabilities]),
+);
+
+/** Every valid feature subset has one deterministic transform identity. */
 export type EnhancementCapabilityProfile =
-  keyof typeof ENHANCEMENT_CAPABILITY_PROFILES;
+  | keyof typeof LEGACY_CAPABILITY_PROFILES
+  | `features-${string}`;
+
+export const ENHANCEMENT_CAPABILITY_PROFILES: typeof LEGACY_CAPABILITY_PROFILES
+  & Readonly<Record<EnhancementCapabilityProfile, EnhancementCapabilities>> = Object.freeze({
+  ...LEGACY_CAPABILITY_PROFILES,
+  ...generatedProfiles,
+});
+
+export function enhancementCapabilitiesForProfile(
+  profile: string,
+): EnhancementCapabilities | null {
+  return (ENHANCEMENT_CAPABILITY_PROFILES as Readonly<
+    Record<string, EnhancementCapabilities | undefined>
+  >)[profile] ?? null;
+}
 
 const NONE: EnhancementCapabilities = Object.freeze({
   nativeCursor: false,
@@ -234,16 +283,9 @@ export function enhancementCapabilityProfile(
 ): EnhancementCapabilityProfile | null {
   for (const profile of Object.keys(ENHANCEMENT_CAPABILITY_PROFILES) as
     EnhancementCapabilityProfile[]) {
-    const candidate = ENHANCEMENT_CAPABILITY_PROFILES[profile];
-    if (
-      candidate.nativeCursor === capabilities.nativeCursor
-      && candidate.targetObservation === capabilities.targetObservation
-      && candidate.partyObservation === capabilities.partyObservation
-      && candidate.teamApply === capabilities.teamApply
-      && candidate.travelAction === capabilities.travelAction
-      && candidate.xunlaiAction === capabilities.xunlaiAction
-      && candidate.chatAliases === capabilities.chatAliases
-    ) return profile;
+    const candidate = enhancementCapabilitiesForProfile(profile);
+    if (!candidate) continue;
+    if (sameCapabilities(candidate, capabilities)) return profile;
   }
   return null;
 }

--- a/src/tools/enhancement-recert.ts
+++ b/src/tools/enhancement-recert.ts
@@ -17,7 +17,7 @@
  */
 import { createHash } from "node:crypto";
 import {
-  ENHANCEMENT_CAPABILITY_PROFILES,
+  enhancementCapabilitiesForProfile,
   type EnhancementCapabilityProfile,
 } from "../shared/enhancement-contracts.js";
 import {
@@ -161,7 +161,8 @@ function finishPostTemplateEnhancementReport(
     try {
       const derived: Partial<Record<EnhancementCapabilityProfile, string>> = {};
       for (const profile of enhancementProfilesForBuild(certified)) {
-        const capabilities = ENHANCEMENT_CAPABILITY_PROFILES[profile];
+        const capabilities = enhancementCapabilitiesForProfile(profile);
+        if (!capabilities) throw new Error(`unknown capability profile ${profile}`);
         const output = transformEnhancementWasm(
           postTemplate,
           certified,
@@ -173,7 +174,7 @@ function finishPostTemplateEnhancementReport(
       for (const profile of enhancementProfilesForBuild(certified)) {
         const expected = enhancementOutputSha256(
           certified,
-          ENHANCEMENT_CAPABILITY_PROFILES[profile],
+          enhancementCapabilitiesForProfile(profile)!,
         );
         if (expected === null || derivedOutputSha256[profile] !== expected) {
           throw new Error(

--- a/tests/client-artifact/template-save-recert.test.ts
+++ b/tests/client-artifact/template-save-recert.test.ts
@@ -31,9 +31,10 @@ import {
   WASM_HEADER,
 } from "../../src/main/core/wasm-binary.js";
 import {
-  ENHANCEMENT_BUILDS,
+  enhancementProfilesForBuild,
   findEnhancementBuild,
   enhancementOutputSha256,
+  supportedEnhancementCapabilities,
 } from "../../src/main/certification/enhancement-builds.js";
 import { transformEnhancementWasm } from "../../src/main/certification/enhancement-transform.js";
 import { rewriteNativeDoubleClickWasm } from "../../src/main/certification/native-double-click.js";
@@ -42,7 +43,7 @@ import {
   findTemplateSaveBuild,
   rewriteTemplateSaveWasm,
 } from "../../src/main/certification/template-save-compat.js";
-import { ENHANCEMENT_CAPABILITY_PROFILES } from "../../src/shared/enhancement-contracts.js";
+import { enhancementCapabilitiesForProfile } from "../../src/shared/enhancement-contracts.js";
 
 const sha256 = (bytes: Uint8Array): string =>
   createHash("sha256").update(bytes).digest("hex");
@@ -63,7 +64,9 @@ function rewriteCode(
   );
 }
 
-test("the template-save verifier makes a fail-closed decision for a real client", async () => {
+test("the template-save verifier makes a fail-closed decision for a real client", {
+  timeout: 120_000,
+}, async () => {
   const artifact = process.env.GW_CLIENT_WASM;
   assert.ok(
     artifact,
@@ -74,6 +77,10 @@ test("the template-save verifier makes a fail-closed decision for a real client"
   const report = inspectTemplateSaveCandidate(bytes);
   const local = verifyLocalClientBytes(bytes);
   assert.equal(isLocalClientVerification(local, local.officialSha256), true);
+  const capabilitiesOf = (value: ReturnType<typeof verifyLocalClientBytes>) =>
+    value.enhancementBuild
+      ? supportedEnhancementCapabilities(value.enhancementBuild)
+      : null;
 
   // If this is a statically shipped build, the shape locator must still
   // reproduce that record exactly. Unknown builds are intentionally decided
@@ -122,8 +129,8 @@ test("the template-save verifier makes a fail-closed decision for a real client"
   assert.equal(WebAssembly.validate(new Uint8Array(changedImmutable)), true);
   assert.equal(deriveEquivalentTemplateSaveBuild(changedImmutable), null);
 
-  const observationBase = ENHANCEMENT_BUILDS[ENHANCEMENT_BUILDS.length - 1]!
-    .observationBase!;
+  const observationBase = local.enhancementBuild?.observationBase;
+  assert.ok(observationBase, "the real client must prove its observation base");
   const needle = paddedIndex(observationBase.layout.agentArray);
   const touched = new Set(
     derived.bridges.flatMap((bridge) =>
@@ -150,13 +157,16 @@ test("the template-save verifier makes a fail-closed decision for a real client"
   assert.equal(addressDecision.enhancementBuild.targetObservation, undefined);
   assert.equal(addressDecision.enhancementBuild.partyObservation, undefined);
   assert.equal(addressDecision.enhancementBuild.teamApply, undefined);
-  assert.deepEqual(Object.keys(addressDecision.enhancementBuild.outputSha256), ["cursor"]);
+  assert.deepEqual(capabilitiesOf(addressDecision), {
+    nativeCursor: true, targetObservation: false, partyObservation: false,
+    teamApply: false, travelAction: true, xunlaiAction: false, chatAliases: true,
+  });
   assert.deepEqual(addressDecision.reasons, []);
 
   const targetMutations = [
-    { local: 7327 - derived.importCount, offset: 132, label: "target occurrence ledger" },
-    { local: 5109 - derived.importCount, offset: 39, label: "map field offset" },
-    { local: 17524 - derived.importCount, offset: 36, label: "area table stride" },
+    { local: 7327 - derived.importCount, offset: 132, label: "target occurrence ledger", shared: false },
+    { local: 5109 - derived.importCount, offset: 39, label: "map field offset", shared: true },
+    { local: 17524 - derived.importCount, offset: 36, label: "area table stride", shared: true },
   ] as const;
   for (const mutation of targetMutations) {
     const changedTargetProof = rewriteCode(bytes, (bodies) => {
@@ -172,11 +182,9 @@ test("the template-save verifier makes a fail-closed decision for a real client"
     assert.ok(refusal.templateSaveBuild, mutation.label);
     assert.ok(refusal.enhancementBuild?.cursorEvent, mutation.label);
     assert.equal(refusal.enhancementBuild.targetObservation, undefined, mutation.label);
-    assert.deepEqual(
-      Object.keys(refusal.enhancementBuild.outputSha256),
-      ["cursor"],
-      mutation.label,
-    );
+    assert.equal(capabilitiesOf(refusal)?.travelAction, true, mutation.label);
+    assert.equal(capabilitiesOf(refusal)?.chatAliases, true, mutation.label);
+    assert.equal(capabilitiesOf(refusal)?.xunlaiAction, !mutation.shared, mutation.label);
     assert.deepEqual(refusal.reasons, [], mutation.label);
   }
 
@@ -203,14 +211,55 @@ test("the template-save verifier makes a fail-closed decision for a real client"
     } else {
       assert.ok(refusal.enhancementBuild?.targetObservation, mutation.label);
       assert.equal(refusal.enhancementBuild.cursorEvent, undefined, mutation.label);
-      assert.deepEqual(
-        Object.keys(refusal.enhancementBuild.outputSha256),
-        ["target"],
-        mutation.label,
-      );
+      assert.equal(capabilitiesOf(refusal)?.travelAction, true, mutation.label);
+      assert.equal(capabilitiesOf(refusal)?.xunlaiAction, true, mutation.label);
+      assert.equal(capabilitiesOf(refusal)?.chatAliases, true, mutation.label);
       assert.deepEqual(refusal.reasons, [], mutation.label);
     }
   }
+
+  const localActionMutations = [
+    { local: 16199 - derived.importCount, offset: 169, feature: "travelAction", label: "Travel message" },
+    { local: 9196 - derived.importCount, offset: 78, feature: "xunlaiAction", label: "Xunlai access field" },
+    { local: 13703 - derived.importCount, offset: 316, feature: "chatAliases", label: "alias message" },
+  ] as const;
+  for (const mutation of localActionMutations) {
+    const changed = rewriteCode(bytes, (bodies) => {
+      const body = bodies[mutation.local]!;
+      body[mutation.offset] = body[mutation.offset]! ^ 1;
+    });
+    assert.equal(WebAssembly.validate(new Uint8Array(changed)), true, mutation.label);
+    const refusal = verifyLocalClientBytes(changed);
+    const capabilities = capabilitiesOf(refusal)!;
+    assert.ok(refusal.enhancementBuild?.cursorEvent, mutation.label);
+    assert.ok(refusal.enhancementBuild?.targetObservation, mutation.label);
+    assert.equal(capabilities[mutation.feature], false, mutation.label);
+    for (const feature of ["travelAction", "xunlaiAction", "chatAliases"] as const) {
+      if (feature !== mutation.feature) assert.equal(capabilities[feature], true, mutation.label);
+    }
+  }
+
+  const changedDrain = rewriteCode(bytes, (bodies) => {
+    const body = bodies[6661 - derived.importCount]!;
+    body[330] = body[330]! ^ 1;
+  });
+  assert.equal(WebAssembly.validate(new Uint8Array(changedDrain)), true);
+  const drainRefusal = capabilitiesOf(verifyLocalClientBytes(changedDrain))!;
+  assert.equal(drainRefusal.travelAction, false);
+  assert.equal(drainRefusal.xunlaiAction, false);
+  assert.equal(drainRefusal.chatAliases, true);
+
+  const changedDispatcher = rewriteCode(bytes, (bodies) => {
+    const body = bodies[6842 - derived.importCount]!;
+    body[6] = body[6]! ^ 1;
+  });
+  assert.equal(WebAssembly.validate(new Uint8Array(changedDispatcher)), true);
+  const dispatcherRefusal = capabilitiesOf(verifyLocalClientBytes(changedDispatcher))!;
+  assert.equal(dispatcherRefusal.nativeCursor, true);
+  assert.equal(dispatcherRefusal.targetObservation, true);
+  assert.equal(dispatcherRefusal.travelAction, false);
+  assert.equal(dispatcherRefusal.xunlaiAction, false);
+  assert.equal(dispatcherRefusal.chatAliases, false);
 });
 
 test("every certified runtime profile reproduces the real client chain", async () => {
@@ -231,7 +280,9 @@ test("every certified runtime profile reproduces the real client chain", async (
   // what catches an ABI/config edit whose source tests pass but whose authored
   // certificate hashes were not regenerated.
   rewriteExtendedMemoryWasm(rewriteNativeDoubleClickWasm(template));
-  for (const capabilities of Object.values(ENHANCEMENT_CAPABILITY_PROFILES)) {
+  for (const profile of enhancementProfilesForBuild(enhancementBuild)) {
+    const capabilities = enhancementCapabilitiesForProfile(profile);
+    assert.ok(capabilities, `certified profile ${profile} must be valid`);
     const enhanced = transformEnhancementWasm(
       template,
       enhancementBuild,

--- a/tests/unit/client-module.test.ts
+++ b/tests/unit/client-module.test.ts
@@ -14,6 +14,7 @@ import { after, describe, it } from "node:test";
 import {
   ENHANCEMENT_CAPABILITY_PROFILES,
   ENHANCEMENT_TRANSFORM_ABI,
+  enhancementCapabilitiesForProfile,
   type EnhancementCapabilityProfile,
   type EnhancementCapabilities,
 } from "../../src/shared/enhancement-contracts.js";
@@ -461,7 +462,7 @@ function enhancementBuild(input: Uint8Array): KnownEnhancementBuild {
     derived[profile] = sha256(transformEnhancementWasm(
       input,
       draft,
-      ENHANCEMENT_CAPABILITY_PROFILES[profile],
+      enhancementCapabilitiesForProfile(profile)!,
     ));
   }
   return {

--- a/tests/unit/enhancement-client-chain.test.ts
+++ b/tests/unit/enhancement-client-chain.test.ts
@@ -8,7 +8,7 @@ import {
   enhancementOutputSha256,
   enhancementProfilesForBuild,
   ENHANCEMENT_BUILDS,
-  hasCompleteEnhancementProfileHashes,
+  hasValidEnhancementProfileHashes,
   supportedEnhancementCapabilities,
   type KnownEnhancementBuild,
 } from "../../src/main/certification/enhancement-builds.js";
@@ -25,46 +25,14 @@ const NO_CAPABILITIES = Object.freeze({
 });
 describe("Enhancement client chain", () => {
   it("source-pins every executable capability profile", () => {
-    // Adding a profile costs an
-    // `outputSha256` entry and a review; this list is where that becomes
-    // unavoidable rather than incidental.
-    assert.deepEqual(Object.keys(ENHANCEMENT_CAPABILITY_PROFILES), [
-      "cursor",
-      "target",
-      "cursorTarget",
-      "party",
-      "cursorParty",
-      "targetParty",
-      "cursorTargetParty",
-      "partyCommands",
-      "cursorPartyCommands",
-      "targetPartyCommands",
-      "cursorTargetPartyCommands",
-      "storage",
-      "partyStorage",
-      "cursorPartyStorage",
-      "targetPartyStorage",
-      "cursorTargetPartyStorage",
-      "partyCommandsStorage",
-      "cursorPartyCommandsStorage",
-      "targetPartyCommandsStorage",
-      "cursorTargetPartyCommandsStorage",
-    ]);
-    assert.deepEqual(
-      Object.entries(ENHANCEMENT_CAPABILITY_PROFILES)
-        .filter(([, capabilities]) => capabilities.teamApply)
-        .map(([profile]) => profile),
-      [
-        "partyCommands",
-        "cursorPartyCommands",
-        "targetPartyCommands",
-        "cursorTargetPartyCommands",
-        "partyCommandsStorage",
-        "cursorPartyCommandsStorage",
-        "targetPartyCommandsStorage",
-        "cursorTargetPartyCommandsStorage",
-      ],
-    );
+    const profiles = Object.entries(ENHANCEMENT_CAPABILITY_PROFILES);
+    // Seven independent booleans have 127 non-empty combinations. The only
+    // invalid 32 are Team Apply without its required Party observation.
+    assert.equal(profiles.length, 95);
+    assert.equal(new Set(profiles.map(([, value]) => JSON.stringify(value))).size, 95);
+    const teamProfiles = profiles.filter(([, capabilities]) => capabilities.teamApply);
+    assert.equal(teamProfiles.length, 32);
+    assert.ok(teamProfiles.every(([, capabilities]) => capabilities.partyObservation));
     for (const [profile, capabilities] of Object.entries(
       ENHANCEMENT_CAPABILITY_PROFILES,
     )) {
@@ -114,7 +82,7 @@ describe("Enhancement client chain", () => {
 
   it("requires all and only the hashes implied by optional capability facts", () => {
     const full = ENHANCEMENT_BUILDS[0]!;
-    assert.equal(hasCompleteEnhancementProfileHashes(full), true);
+    assert.equal(hasValidEnhancementProfileHashes(full), true);
 
     const cursorOnly: KnownEnhancementBuild = {
       ...full,
@@ -128,7 +96,7 @@ describe("Enhancement client chain", () => {
     delete cursorOnly.travelAction;
     delete cursorOnly.chatAliases;
     assert.deepEqual(enhancementProfilesForBuild(cursorOnly), ["cursor"]);
-    assert.equal(hasCompleteEnhancementProfileHashes(cursorOnly), true);
+    assert.equal(hasValidEnhancementProfileHashes(cursorOnly), true);
 
     const partyOnly: KnownEnhancementBuild = {
       ...full,
@@ -142,12 +110,12 @@ describe("Enhancement client chain", () => {
     delete partyOnly.travelAction;
     delete partyOnly.chatAliases;
     assert.deepEqual(enhancementProfilesForBuild(partyOnly), ["party"]);
-    assert.equal(hasCompleteEnhancementProfileHashes(partyOnly), true);
+    assert.equal(hasValidEnhancementProfileHashes(partyOnly), true);
 
     const missingObservationBase = { ...partyOnly };
     delete missingObservationBase.observationBase;
     assert.equal(
-      hasCompleteEnhancementProfileHashes(missingObservationBase),
+      hasValidEnhancementProfileHashes(missingObservationBase),
       false,
       "party facts require their shared observation base",
     );
@@ -155,7 +123,7 @@ describe("Enhancement client chain", () => {
     const missingPartyDispatcher = { ...partyOnly };
     delete missingPartyDispatcher.uiDispatcher;
     assert.equal(
-      hasCompleteEnhancementProfileHashes(missingPartyDispatcher),
+      hasValidEnhancementProfileHashes(missingPartyDispatcher),
       false,
       "party facts require their shared UI dispatcher",
     );
@@ -178,7 +146,7 @@ describe("Enhancement client chain", () => {
       xunlaiAction: prooflessXunlai,
     };
     assert.equal(
-      hasCompleteEnhancementProfileHashes(storageWithoutAccessProof),
+      hasValidEnhancementProfileHashes(storageWithoutAccessProof),
       false,
       "a legacy bundled output cannot claim the missing Xunlai proof",
     );
@@ -209,13 +177,13 @@ describe("Enhancement client chain", () => {
       },
     };
     assert.equal(
-      hasCompleteEnhancementProfileHashes(storageWithDuplicateReaders),
+      hasValidEnhancementProfileHashes(storageWithDuplicateReaders),
       false,
       "storage requires three independent player-record readers",
     );
 
     assert.equal(
-      hasCompleteEnhancementProfileHashes({
+      hasValidEnhancementProfileHashes({
         ...cursorOnly,
         outputSha256: Object.freeze({}),
       }),
@@ -223,7 +191,7 @@ describe("Enhancement client chain", () => {
       "a supported profile cannot omit its output hash",
     );
     assert.equal(
-      hasCompleteEnhancementProfileHashes({
+      hasValidEnhancementProfileHashes({
         ...cursorOnly,
         outputSha256: Object.freeze({
           cursor: full.outputSha256.cursor!,
@@ -234,7 +202,7 @@ describe("Enhancement client chain", () => {
       "an unsupported profile cannot retain an output hash",
     );
     assert.equal(
-      hasCompleteEnhancementProfileHashes({
+      hasValidEnhancementProfileHashes({
         ...cursorOnly,
         outputSha256: Object.freeze({ cursor: "not-a-digest" }),
       }),
@@ -244,7 +212,7 @@ describe("Enhancement client chain", () => {
     const commonOnly = { ...cursorOnly };
     delete commonOnly.cursorEvent;
     assert.equal(
-      hasCompleteEnhancementProfileHashes({
+      hasValidEnhancementProfileHashes({
         ...commonOnly,
         outputSha256: Object.freeze({}),
       }),

--- a/tests/unit/extended-memory.test.ts
+++ b/tests/unit/extended-memory.test.ts
@@ -11,8 +11,10 @@ import {
   rewriteExtendedMemoryWasm,
 } from "../../src/main/certification/extended-memory.js";
 import { NATIVE_DOUBLE_CLICK_BUILDS } from "../../src/main/certification/native-double-click.js";
-import { ENHANCEMENT_BUILDS } from "../../src/main/certification/enhancement-builds.js";
-import { ENHANCEMENT_CAPABILITY_PROFILES } from "../../src/shared/enhancement-contracts.js";
+import {
+  ENHANCEMENT_BUILDS,
+  enhancementProfilesForBuild,
+} from "../../src/main/certification/enhancement-builds.js";
 import { diagnosticEventRecord } from "../../src/main/diagnostics/schema.js";
 
 describe("certified extended memory transform", () => {
@@ -24,7 +26,7 @@ describe("certified extended memory transform", () => {
   it("certifies every post-double-click variant the production chain emits", () => {
     const expectedProfiles = [
       "off",
-      ...Object.keys(ENHANCEMENT_CAPABILITY_PROFILES),
+      ...enhancementProfilesForBuild(ENHANCEMENT_BUILDS[0]!),
     ].sort();
     const builds = new Map<number, typeof EXTENDED_MEMORY_WASM_BUILDS[number][]>();
     for (const build of EXTENDED_MEMORY_WASM_BUILDS) {

--- a/tests/unit/local-client-verifier.test.ts
+++ b/tests/unit/local-client-verifier.test.ts
@@ -90,6 +90,44 @@ function automaticTarget(): LocalClientVerification {
   };
 }
 
+function automaticLocalActions(): LocalClientVerification {
+  const target = automaticTarget();
+  const xunlai = ENHANCEMENT.xunlaiAction!;
+  const readers = xunlai.accessProof!.readers;
+  return {
+    ...target,
+    enhancementBuild: {
+      ...target.enhancementBuild!,
+      outputSha256: { storage: "7".repeat(64) },
+      uiDispatcher: ENHANCEMENT.uiDispatcher!,
+      gameThread: {
+        drain: {
+          ...ENHANCEMENT.gameThread!.drain,
+          bodySha256: "8".repeat(64),
+        },
+      },
+      travelAction: ENHANCEMENT.travelAction!,
+      xunlaiAction: {
+        ...xunlai,
+        accessProof: {
+          ...xunlai.accessProof!,
+          readers: {
+            "agent-id": { ...readers["agent-id"], bodySha256: "9".repeat(64) },
+            "access-flags": { ...readers["access-flags"], bodySha256: "9".repeat(64) },
+            "player-number": readers["player-number"],
+          },
+        },
+      },
+      chatAliases: {
+        parser: {
+          ...ENHANCEMENT.chatAliases!.parser,
+          bodySha256: "a".repeat(64),
+        },
+      },
+    },
+  };
+}
+
 describe("local client verification boundary", () => {
   it("accepts the verifier's complete baseline proof", () => {
     assert.equal(isLocalClientVerification(valid(), TEMPLATE.sha256), true);
@@ -158,6 +196,27 @@ describe("local client verification boundary", () => {
             ...derived.enhancementBuild!.targetObservation!.layout,
             manualTargetAgentId:
               derived.enhancementBuild!.targetObservation!.layout.manualTargetAgentId + 4,
+          },
+        },
+      },
+    }, TEMPLATE.sha256), false);
+  });
+
+  it("accepts independent local-action proofs and rejects one bad Xunlai field", () => {
+    const derived = automaticLocalActions();
+    assert.equal(isLocalClientVerification(derived, TEMPLATE.sha256), true);
+    assert.equal(isLocalClientVerification({
+      ...derived,
+      enhancementBuild: {
+        ...derived.enhancementBuild!,
+        xunlaiAction: {
+          ...derived.enhancementBuild!.xunlaiAction!,
+          accessProof: {
+            ...derived.enhancementBuild!.xunlaiAction!.accessProof!,
+            layout: {
+              ...derived.enhancementBuild!.xunlaiAction!.accessProof!.layout,
+              playerRecordAccessFlags: 0x38,
+            },
           },
         },
       },


### PR DESCRIPTION
## What changed

Travel, Xunlai, chat aliases, their handlers, dispatcher roles, and game-thread drain now use feature-local relocation-aware proof.

## Why

Raw function-body hashes broke on harmless function-index movement, while bundled local-action authority made degraded combinations unsafe.

## Invariant

Travel proves four-field order and message role. Xunlai proves all readers, layouts, fixed DataWindow action, and fresh lifecycle. Aliases preserve the original parser and include only proved actions.

## Verification

- Exact-head PR package, CodeQL, and Vercel checks passed.
- Coherent function-index relocation passes; changed-call and duplicate-role mutations refuse.
- Travel-only, Xunlai-only, aliases-disabled, and transition cases pass.

Stack layer 8 of 13.
