### PR TITLE
fix(party): prove party state and team apply

### DIFF
--- a/src/companion-kernel/abi.rs
+++ b/src/companion-kernel/abi.rs
@@ -183,7 +183,7 @@ pub(crate) struct Layout {
     pub(crate) party_henchmen: u32,
     pub(crate) party_flag: u32,
     // GameContext -> AccountContext -> account-wide unlocked-skill bitset.
-    pub(crate) account_context: u32,
+    pub(crate) account_context_slot: u32,
     pub(crate) account_unlocked_skills: u32,
     // GameContext -> WorldContext, and the three arrays hanging off it that
     // describe heroes rather than party membership.
@@ -282,7 +282,7 @@ impl Layout {
         party_players: 0,
         party_henchmen: 0,
         party_flag: 0,
-        account_context: 0,
+        account_context_slot: 0,
         account_unlocked_skills: 0,
         world_context: 0,
         world_hero_flags: 0,

--- a/src/companion-kernel/party.rs
+++ b/src/companion-kernel/party.rs
@@ -458,8 +458,9 @@ unsafe fn collect(
     // while WorldContext carries what this character has learned. They are
     // independent observations: losing one pointer must not erase the other or
     // make an otherwise valid party unreadable.
-    if layout.account_context != 0 && layout.account_unlocked_skills != 0 {
-        let observed = offset(game, layout.account_context)
+    if layout.account_context_slot != 0 && layout.account_unlocked_skills != 0 {
+        let observed = unsafe { pointer(layout.context_root, 28) }
+            .and_then(|contexts| indexed(contexts, layout.account_context_slot, 4))
             .and_then(|at| unsafe { pointer(at, 4) })
             .and_then(|account| offset(account, layout.account_unlocked_skills))
             .and_then(|at| unsafe { read_skill_unlocks(at) });

--- a/src/main/certification/enhancement-builds.ts
+++ b/src/main/certification/enhancement-builds.ts
@@ -46,39 +46,39 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
         cursorTarget:
           "90d18263253dce61edc09b00f1c935ac2f12a0705ce9f4e5d8ff8b21f180e249",
         party:
-          "b680d690206fca0006af95a13528c5a732cfed7ddfced34aa539027fd2ce933e",
+          "7c31b9222d6e0cb4f169b297b9260e42ab2e342ae61577cfcaeac85fa00d0f50",
         cursorParty:
-          "cd53eb12fb586283a1702b2b0f2c458a21b580049302adff32012fea38323f0d",
+          "2b031e5c3f583a0d040eae1a082d60ef98dc566814c89673f59b371fdeda7af6",
         targetParty:
-          "95ec0955ac10b1a4512ff6516ec209b8d1aa514cf1aedf9e50d573b543d103aa",
+          "7ab9daa70ecbac8c837a1406529ae23fbbc74649b71fce42cbe17f3278e168f3",
         cursorTargetParty:
-          "6a4fde6f84ea0c80fdabc1d6321433451277e66dda84af321b8c1c1644566f0a",
+          "483013e5a7160f403bb14a8feb8837b9ed1ae30e0d480f3be09e1590d5dd6efa",
         partyCommands:
-          "135fcba260909006d90fb91b070cd189eaddf3e4aafee6f5b9382f9757f29fe1",
+          "b254187358d7e86e8476fbfc799d3900c06e12de079892d4e8f9f9162af6e92f",
         cursorPartyCommands:
-          "9cdafd9b1aa862b0375c0f8770299a636fe192092bc752f2b64ea1c61cb30105",
+          "58a913958ffc36375ad9c82c5d658269287b93ee965688b5fe7325c7dcfc8b5e",
         targetPartyCommands:
-          "16c170b2366b56b82ce11ee6a3ea90e784abcddc4fb50cb6e632dab28e775a27",
+          "98acd48ed441c3a6dcf0b2201f10baf757527051b245659b621e57c90a5b6374",
         cursorTargetPartyCommands:
-          "cb0a06886885552b9c58c4161d5304ca3f6ba9f49c186ba9087fa479bf446f33",
+          "bfe923af52a66b9d579ff6157d52d579327c30ff8c9cab9a0d56cd37d743f77f",
         storage:
           "596eb73ce9d087891d6f28706091b53e8958a806ece24d1accd67015a774dbb1",
         partyStorage:
-          "3e67a53794661071d6c162cc227ec0585294f3d5d9423948d33ac6724aeb9f7e",
+          "b7d480740e68739cf829807c302955e1408fc08c22bf0677d33887c25d68fec8",
         cursorPartyStorage:
-          "7d6defca157712ece078256d67fc62ad93b759e044ea0e7a78f8e4163fec6952",
+          "603af439da0bf2e32fd4dc86d62df17488ecfb916ab3e262e4a82fe14d7bab13",
         targetPartyStorage:
-          "98a510e8a202ffcf54e961ce616fb76f8cd663f10bcb2dcea431702cc03ad2c7",
+          "75156a5ee8bf36153bf79b846ce6dbd8b23de9daf3f59caba6f34a80b8334a88",
         cursorTargetPartyStorage:
-          "84330b6f5340a5d683977888cb9c6cc81bef0964aaeaec7da80d0ebd0165bce8",
+          "9fbd0650ffed617637fc9dec52dc08c38de0c5bd21e05716260325c0e23f96e9",
         partyCommandsStorage:
-          "0b7a69c7d8787f9dc7c1b337e7c1cdfa9a76a71bae3c720988324947f5f991c5",
+          "fd04467165fbd80f2f8ef089f9453068f8242f8d30e459168a329b133b7d59fc",
         cursorPartyCommandsStorage:
-          "740d8f6222a40db2deb94f5c81b42d82693c6282f59dfdca0fac680ac79a2c9f",
+          "6c0d21e7fb5cd574187289ab28d6e2fd53ec5509d49c13e6170aa859f720d3a2",
         targetPartyCommandsStorage:
-          "233e4100a6f131b768258217d688354cf2e46db36c6106941bc3fb2ae84ced9a",
+          "33594cef21497fbdcc38455e4eafbf7bc37a1cb154a31890d92a0441cc3e1195",
         cursorTargetPartyCommandsStorage:
-          "6be8ce224d7d6ca0a47cbc13fcd319590896786ccbcc709588493df1c84a169a",
+          "e9344c0c274eae0a0d652d212aa029f0a9866446c99f9df48215506c9c594ea2",
       }),
       programId: 1,
       // Function #477 returns 38,833 as a single i32 constant. The same function
@@ -414,7 +414,9 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
           // GameContext::account and AccountContext::unlocked_account_skills.
           // GWCA exposes this exact array through GetIsSkillUnlocked: one bit per
           // skill id, account-wide and therefore usable by heroes.
-          accountContext: 0x28,
+          // AccountContext is independently registered in context slot 10.
+          // Using that slot avoids trusting a copied GameContext pointer offset.
+          accountContextSlot: 10,
           accountUnlockedSkills: 0x124,
           // Its hero ids *and* agent ids matched the party array exactly.
           worldHeroFlags: 0x584,

--- a/src/main/certification/enhancement-structural-evidence.ts
+++ b/src/main/certification/enhancement-structural-evidence.ts
@@ -35,6 +35,7 @@ import {
 import type {
   EnhancementCursorLayout,
   EnhancementObservationBaseLayout,
+  EnhancementPartyLayout,
   EnhancementTargetLayout,
 } from "../../shared/enhancement-config.js";
 
@@ -169,6 +170,8 @@ export interface AutomaticLocalActionsLocation {
   readonly travelAction: KnownEnhancementBuild["travelAction"] | null;
   readonly xunlaiAction: KnownEnhancementBuild["xunlaiAction"] | null;
   readonly chatAliases: KnownEnhancementBuild["chatAliases"] | null;
+  readonly partyObservation: KnownEnhancementBuild["partyObservation"] | null;
+  readonly teamApply: KnownEnhancementBuild["teamApply"] | null;
 }
 
 const MAX_INPUT_BYTES = 64 * 1024 * 1024;
@@ -204,6 +207,7 @@ interface ModuleShape {
   readonly functionTypeIndices: number[];
   readonly functionImportCount: number;
   readonly bodies: Uint8Array[];
+  readonly bodySha256: (string | undefined)[];
   readonly exports: WasmExport[];
   readonly elementSection: Uint8Array | null;
   readonly dataSegments: readonly Readonly<{
@@ -437,6 +441,7 @@ function parseModule(input: Uint8Array): ModuleShape {
     functionTypeIndices,
     functionImportCount: importedTypeIndices.length,
     bodies,
+    bodySha256: new Array<string | undefined>(bodies.length),
     exports: parseExports(optionalSection(sections, 7)),
     elementSection: optionalSection(sections, 9),
     dataSegments: parseStaticData(optionalSection(sections, 11)),
@@ -515,9 +520,14 @@ function functionHasSignature(
 }
 
 function functionBodySha256(module: ModuleShape, functionIndex: number): string {
-  const body = module.bodies[functionIndex - module.functionImportCount];
+  const localIndex = functionIndex - module.functionImportCount;
+  const body = module.bodies[localIndex];
   if (!body) throw new EvidenceError("module-shape-unsupported");
-  return createHash("sha256").update(body).digest("hex");
+  const cached = module.bodySha256[localIndex];
+  if (cached) return cached;
+  const digest = createHash("sha256").update(body).digest("hex");
+  module.bodySha256[localIndex] = digest;
+  return digest;
 }
 
 function tickEvidence(module: ModuleShape): TickEvidenceReport {
@@ -570,12 +580,11 @@ function readInstructionUnsigned(bytes: Uint8Array, cursor: Offset): number {
 
 function decodeFunctions(
   module: ModuleShape,
-  messageAnchors: PlayerChatMessageAnchors,
+  messageAnchors: PlayerChatMessageAnchors | readonly number[],
 ): DecodedFunction[] {
-  const trackedMessages = new Set<number>([
-    messageAnchors.playerChatMessage,
-    ...messageAnchors.nearbyPlayerMessages,
-  ]);
+  const trackedMessages = new Set<number>("playerChatMessage" in messageAnchors
+    ? [messageAnchors.playerChatMessage, ...messageAnchors.nearbyPlayerMessages]
+    : messageAnchors);
   let instructionCount = 0;
   const decoded: DecodedFunction[] = [];
   for (let localIndex = 0; localIndex < module.bodies.length; localIndex += 1) {
@@ -1400,6 +1409,123 @@ const LOCAL_ACTION_HASHES = Object.freeze({
   xunlaiAssertion: "df83cbe4386b6f8641568f5d2b6444c941f6d448a7efffd9f4737e343b0972d2",
 });
 
+const PARTY_WORLD_LIFECYCLE_ROLE = semanticRole(
+  3_279,
+  "878f00dc4ea68f51e5a79f507e37b0a5df3c32b561ca6d35c966a888d0cd022b",
+  Object.freeze([
+    { start: 1_342, end: 1_347, role: "world.assert-a", addressClass: "immutable-data" },
+    { start: 1_395, end: 1_400, role: "world.assert-b", addressClass: "immutable-data" },
+  ]),
+  ["i32"],
+  ["i32"],
+);
+
+const PARTY_PLAYER_PARTY_ROLE = semanticRole(
+  338,
+  "bb32ba98f1f72dc96a720d9b81c2513b6ff6ab59e7d14c63a125274a6f0b2ce4",
+  Object.freeze([
+    { start: 241, end: 246, role: "party.membership-assertion", addressClass: "immutable-data" },
+  ]),
+  ["i32", "i32", "i32", "i32"],
+  [],
+);
+
+const PARTY_SKILLBAR_UPDATE_ROLE = semanticRole(
+  468,
+  "c5076fb582377edf6be0a51464ecae499039e7523bc4473b035ba8054381053e",
+  Object.freeze([
+    { start: 45, end: 50, role: "skillbar.assertion", addressClass: "immutable-data" },
+  ]),
+  [],
+  [],
+);
+
+const TEAM_SENDER_ROLE = semanticRole(
+  4_425,
+  "1dbcd6d20afed3f8edc323c4ddaa323e24809c439041a069f1eace6d127cc73f",
+  Object.freeze([
+    { start: 115, end: 120, role: "sender.assert-bytes", addressClass: "immutable-data" },
+    { start: 3_526, end: 3_531, role: "sender.assert-string-length", addressClass: "immutable-data" },
+    { start: 4_198, end: 4_203, role: "sender.assert-struct-count", addressClass: "immutable-data" },
+    { start: 4_390, end: 4_395, role: "sender.assert-switch", addressClass: "immutable-data" },
+  ]),
+  ["i32", "i32", "i32"],
+  [],
+);
+
+const PARTY_EXACT_ROLES = Object.freeze({
+  partyInfoLifecycle: { bodySha256: "02c381bb2f7b2a7edea00c8de3d72838189ba696f9ce2b0177d7425d45267cb2", params: ["i32"], results: ["i32"] },
+  partyFlagWriter: { bodySha256: "00c8389a18427716101fe4df4176a5b87f3752776e93fe06105610e0d45a363e", params: ["i32", "i32"], results: [] },
+  accountUnlockWriter: { bodySha256: "1f8e8bf7fe1ca37a0f266812bc3e1bff28c14104aeb38d009a340851e8f5c582", params: ["i32"], results: [] },
+  heroFlagWriter: { bodySha256: "070a5db14e06aeec2fa812e6c82d5f17964585ea277381485f2b1707d54ceef1", params: ["i32", "i32", "i32"], results: [] },
+  attributesWriter: { bodySha256: "2db063ee4b22d5eb7a5376313fdacc32377153dc3981b5dfe852729a17369c23", params: ["i32", "i32", "i32"], results: [] },
+  professionAgent: { bodySha256: "ff540acea56ffbc5947288f9d461495e1970006fba7799ffd9d2b1dae1d06b93", params: ["i32", "i32"], results: ["i32"] },
+  professionPrimary: { bodySha256: "5b3490ae4c66dad083b8cbea456d2e47d41ff794e9c03aa15acdf2b6523915ec", params: ["i32", "i32"], results: ["i32"] },
+  professionSecondary: { bodySha256: "92fe2aa71777d546d797a4f7850cb59b1693f3b2937021dd5cebc85933403e07", params: ["i32", "i32"], results: ["i32"] },
+  professionUnlocked: { bodySha256: "7a1b17e51097a6599a036629fdcc630afa0850bacb0f2998d0ad8107d39ec9b5", params: ["i32", "i32"], results: ["i32"] },
+  skillbarReader: { bodySha256: "7b8b5c65a126fae2edfa517a4706244a0d2352c628fde208d049ecf82dfa4e72", params: ["i32", "i32", "i32"], results: ["i32"] },
+  skillSlotReader: { bodySha256: "ee41be1f4dcaf8e5822fc024e41cbbad74cf293cdafb2b89a8691aeb680e68b5", params: ["i32", "i32", "i32"], results: ["i32"] },
+  characterUnlockReader: { bodySha256: "0b6f7cf85a4b4f8c34b1cfadc63857a043a1b7fd710ba94c8db3a409d6bd092b", params: ["i32", "i32"], results: [] },
+} as const);
+
+const PARTY_DIRTY_ROLES = Object.freeze([
+  semanticRole(622, "07d8d87f5575c572d3f53fcff464cd07fba710f1a01e451d94a414f28b55ba26", Object.freeze([
+    { start: 580, end: 585, role: "party.ui", addressClass: "function-index" },
+  ]), ["i32", "i32", "i32", "i32", "i32"], []),
+  semanticRole(683, "4276027f9ac9dada4d236934c4a7170f22004934fdba19376e620e0aa14f6654", Object.freeze([
+    { start: 665, end: 670, role: "party.ui", addressClass: "function-index" },
+  ]), Array.from({ length: 15 }, () => "i32"), []),
+  semanticRole(127, "509bab21ca8be2a1f6287793e50f88825bb1d9f4432d3b29e3a394b117a72d3a", Object.freeze([
+    { start: 88, end: 93, role: "map.lifecycle-static", addressClass: "mutable-static" },
+    { start: 119, end: 124, role: "party.ui", addressClass: "function-index" },
+  ]), ["i32", "i32"], ["i32"]),
+  semanticRole(262, "157e15c62319c9bdff7b46e8b0ce504c52af0b6eee0faddd1b1d94eb90f2df7b", Object.freeze([
+    { start: 120, end: 125, role: "party.ui", addressClass: "function-index" },
+  ]), ["i32", "i32", "i32", "f32", "i32", "i32"], []),
+  semanticRole(186, "6f06eff3b66948891fe3e291a62709706f41b2a47dfb20c00054655f917ed187", Object.freeze([
+    { start: 169, end: 174, role: "party.ui", addressClass: "function-index" },
+  ]), ["i32", "i32"], []),
+  semanticRole(288, "3891f1163ce484f0244b5e16308b3a8d08eb95dbebf143fe2681af6112099468", Object.freeze([
+    { start: 109, end: 114, role: "party.ui", addressClass: "function-index" },
+  ]), Array.from({ length: 9 }, () => "i32"), []),
+  semanticRole(305, "4b39d0c5b6cd8be2bdbf8d6289b06f0206074ef0fa24e772cb4d34f2b774bb7f", Object.freeze([
+    { start: 279, end: 284, role: "party.ui", addressClass: "function-index" },
+  ]), Array.from({ length: 8 }, () => "i32"), []),
+  semanticRole(459, "a24e6314fed15093fce5c54faefe9ed8936e243b2a06e96c2401214b254b9125", Object.freeze([
+    { start: 408, end: 413, role: "party.ui", addressClass: "function-index" },
+  ]), Array.from({ length: 4 }, () => "i32"), []),
+  semanticRole(279, "ff174e8924bfb8ccdec3614b64ec884f499348d0430c137019295d451860b35e", Object.freeze([
+    { start: 238, end: 243, role: "party.ui", addressClass: "function-index" },
+  ]), Array.from({ length: 3 }, () => "i32"), []),
+  semanticRole(256, "c6c049152fba5d01560c74f2bc4ffac8a9133671f7d9ee8fc1e5d0c09b4e2b8b", Object.freeze([
+    { start: 238, end: 243, role: "party.ui", addressClass: "function-index" },
+  ]), Array.from({ length: 3 }, () => "i32"), []),
+] as const);
+
+const PARTY_IMMUTABLE_HASHES = Object.freeze({
+  playerPartyAssertion: "11e293befd3a98a58c54d320146aab4746f2456cfe5fefd40eca2c48d28366bb",
+  skillbarAssertion: "f450663f1e90de4ae2e581b6dc777b81f6c9e019bff3e5d2e60665099862e3f0",
+  worldAssertionA: "435ae0e5b5663ba229fe0a312a2f3d83b4896302f9517b56d88f996ba7ea896d",
+  worldAssertionB: "f7d0c7a8263c7a799862d8a513123d901e4f1cc30bc1d86da870bf5f2ec5aad6",
+});
+
+const TEAM_SENDER_IMMUTABLE_HASHES = Object.freeze([
+  "1627a8bdcb297de40efb0cab4028bd069275d993bfe52cf1ea517e738427af4f",
+  "52cfe327ad6c66540cb88272f04b99f45fcc9c0d3a2f6d2cc1d43d0d6d57ba75",
+  "3be8fd491431691c04b545a9c691266e90592a747c964587f21f408067fda424",
+  "3a27ab5c8418fcef888b2aff7a1dfd56fc9de2aa53789b29f4f0c4debe2c3dc4",
+] as const);
+
+const TEAM_BUILDER_ROLES = Object.freeze([
+  { opcode: 31, length: 65, fingerprint: "008cb3c8aa865ef17bf262bde0eeb10d29cd4f19a89a9ed22132a811835a39c6", opcodeAt: 30, constructorAt: 35, senderAt: 48 },
+  { opcode: 30, length: 65, fingerprint: "f7f2072bfcde3b833ff1c388e9e1190936fde208e69e8363b732ea3944ce4f7b", opcodeAt: 30, constructorAt: 35, senderAt: 48 },
+  { opcode: 21, length: 72, fingerprint: "91693fa5820bda13bf3b39eede0b8b9fb36d7f82a8a5c23e086505f0510a3cb2", opcodeAt: 37, constructorAt: 42, senderAt: 55 },
+  { opcode: 93, length: 218, fingerprint: "b5406c64785a6e2559a238e271085d119d34fc45c36a2a4dd404ec2f09a67625", opcodeAt: 30, constructorAt: 188, senderAt: 201 },
+  { opcode: 65, length: 73, fingerprint: "66d6960cf4f889c97977b4f8ae79461e0f7034b22c24af50bc19ac9ea4803226", opcodeAt: 37, constructorAt: 43, senderAt: 56 },
+  { opcode: 16, length: 289, fingerprint: "711990b1affb366ad198616fd59fa6802e0ff1644070b2fa46d844556d5be8f7", opcodeAt: 31, constructorAt: 260, senderAt: 271 },
+  { opcode: 155, length: 66, fingerprint: "b2ec78d3eaa13c6a4ec8265dd5bfbbc7611d17a61e8361b37849522f43dc38d2", opcodeAt: 30, constructorAt: 36, senderAt: 49 },
+] as const);
+
 function functionBody(module: ModuleShape, functionIndex: number): Uint8Array {
   const body = module.bodies[functionIndex - module.functionImportCount];
   if (!body) throw new EvidenceError("module-shape-unsupported");
@@ -1478,6 +1604,11 @@ function unsignedOperand(body: Uint8Array, start: number): number {
   return readUnsigned(body, cursor);
 }
 
+function signedOperand(body: Uint8Array, start: number): number {
+  const cursor = { value: start };
+  return readSigned(body, cursor, 5);
+}
+
 function paddedOperand(value: number): Uint8Array {
   const bytes = new Uint8Array(5);
   let remaining = value >>> 0;
@@ -1528,6 +1659,15 @@ function staticCStringHash(module: ModuleShape, address: number): string | null 
       .digest("hex");
   }
   return null;
+}
+
+function staticBytesHash(
+  module: ModuleShape,
+  address: number,
+  length: number,
+): string | null {
+  const bytes = staticBytes(module, address, length);
+  return bytes ? createHash("sha256").update(bytes).digest("hex") : null;
 }
 
 function valuesForRole(body: Uint8Array, role: CursorRole): Map<string, number[]> {
@@ -1870,6 +2010,294 @@ function deriveXunlaiAccess(
       results: [] as const,
       bodySha256: functionBodySha256(module, handlerFunction),
     }),
+  });
+}
+
+function exactPartyFunction(
+  module: ModuleShape,
+  role: (typeof PARTY_EXACT_ROLES)[keyof typeof PARTY_EXACT_ROLES],
+): number | null {
+  return uniqueExactFunction(module, role.bodySha256, role.params, role.results);
+}
+
+function exactStaticBytesHash(
+  module: ModuleShape,
+  values: Map<string, number[]>,
+  role: string,
+  length: number,
+  expected: string,
+): boolean {
+  return staticBytesHash(module, soleValue(values, role), length) === expected;
+}
+
+function derivePartyObservation(
+  module: ModuleShape,
+  baseline: KnownEnhancementBuild,
+  observation: EnhancementObservationBaseLayout,
+  uiDispatcher: NonNullable<KnownEnhancementBuild["uiDispatcher"]>,
+  uiEvidence: NonNullable<PlayerChatUiEvidenceReport["candidate"]>,
+): KnownEnhancementBuild["partyObservation"] | null {
+  const expected = baseline.partyObservation;
+  const baselineObservation = baseline.observationBase?.layout;
+  if (!expected || !baselineObservation) return null;
+
+  const partyInfoFunction = exactPartyFunction(module, PARTY_EXACT_ROLES.partyInfoLifecycle);
+  const partyFlagFunction = exactPartyFunction(module, PARTY_EXACT_ROLES.partyFlagWriter);
+  const accountFunction = exactPartyFunction(module, PARTY_EXACT_ROLES.accountUnlockWriter);
+  const flagFunction = exactPartyFunction(module, PARTY_EXACT_ROLES.heroFlagWriter);
+  const attributesFunction = exactPartyFunction(module, PARTY_EXACT_ROLES.attributesWriter);
+  const professionFunctions = [
+    exactPartyFunction(module, PARTY_EXACT_ROLES.professionAgent),
+    exactPartyFunction(module, PARTY_EXACT_ROLES.professionPrimary),
+    exactPartyFunction(module, PARTY_EXACT_ROLES.professionSecondary),
+    exactPartyFunction(module, PARTY_EXACT_ROLES.professionUnlocked),
+  ];
+  const skillbarReaderFunction = exactPartyFunction(module, PARTY_EXACT_ROLES.skillbarReader);
+  const skillSlotReaderFunction = exactPartyFunction(module, PARTY_EXACT_ROLES.skillSlotReader);
+  const characterUnlockFunction = exactPartyFunction(module, PARTY_EXACT_ROLES.characterUnlockReader);
+  const worldFunction = uniqueRoleFunction(module, PARTY_WORLD_LIFECYCLE_ROLE);
+  const playerPartyFunction = uniqueRoleFunction(module, PARTY_PLAYER_PARTY_ROLE);
+  const skillbarUpdateFunction = uniqueRoleFunction(module, PARTY_SKILLBAR_UPDATE_ROLE);
+  const dirtyFunctions = PARTY_DIRTY_ROLES.map((role) => uniqueRoleFunction(module, role));
+  const infoFunction = dirtyFunctions[1] ?? null;
+  const mapLoadedFunction = dirtyFunctions[2] ?? null;
+  if (
+    partyInfoFunction === null || partyFlagFunction === null || accountFunction === null
+    || flagFunction === null || infoFunction === null || attributesFunction === null
+    || professionFunctions.some((value) => value === null)
+    || skillbarReaderFunction === null || skillSlotReaderFunction === null
+    || characterUnlockFunction === null || worldFunction === null
+    || playerPartyFunction === null || skillbarUpdateFunction === null
+    || mapLoadedFunction === null || dirtyFunctions.some((value) => value === null)
+  ) return null;
+
+  const worldBody = functionBody(module, worldFunction);
+  const playerPartyBody = functionBody(module, playerPartyFunction);
+  const skillbarUpdateBody = functionBody(module, skillbarUpdateFunction);
+  const mapLoadedBody = functionBody(module, mapLoadedFunction);
+  const worldValues = valuesForRole(worldBody, PARTY_WORLD_LIFECYCLE_ROLE);
+  const playerPartyValues = valuesForRole(playerPartyBody, PARTY_PLAYER_PARTY_ROLE);
+  const skillbarValues = valuesForRole(skillbarUpdateBody, PARTY_SKILLBAR_UPDATE_ROLE);
+  const mapValues = valuesForRole(mapLoadedBody, PARTY_DIRTY_ROLES[2]);
+  if (
+    staticCStringHash(module, soleValue(playerPartyValues, "party.membership-assertion"))
+      !== PARTY_IMMUTABLE_HASHES.playerPartyAssertion
+    || staticCStringHash(module, soleValue(skillbarValues, "skillbar.assertion"))
+      !== PARTY_IMMUTABLE_HASHES.skillbarAssertion
+    || !exactStaticBytesHash(module, worldValues, "world.assert-a", 12, PARTY_IMMUTABLE_HASHES.worldAssertionA)
+    || !exactStaticBytesHash(module, worldValues, "world.assert-b", 12, PARTY_IMMUTABLE_HASHES.worldAssertionB)
+    || commonRelocationDelta([
+      [soleValue(mapValues, "map.lifecycle-static"), 1_447_112],
+      [observation.contextRoot, baselineObservation.contextRoot],
+    ]) === null
+  ) return null;
+
+  const dirtyMessages = [...expected.partyDirtyMessages];
+  const decoded = decodeFunctions(module, dirtyMessages);
+  for (let index = 0; index < dirtyMessages.length; index += 1) {
+    const roleValues = valuesForRole(
+      functionBody(module, dirtyFunctions[index]!),
+      PARTY_DIRTY_ROLES[index]!,
+    );
+    if (soleValue(roleValues, "party.ui") !== uiDispatcher.functionIndex) return null;
+    const relation = messageRelations(decoded, uiDispatcher.functionIndex, dirtyMessages[index]!)
+      .filter((candidate) => candidate.producerFunctionIndex === dirtyFunctions[index]);
+    if (relation.length !== 1 || relation[0]!.messageSites !== 1) return null;
+  }
+
+  const heroAddBody = functionBody(module, dirtyFunctions[6]!);
+  const partyInfoBody = functionBody(module, partyInfoFunction);
+  const partyFlagBody = functionBody(module, partyFlagFunction);
+  const accountBody = functionBody(module, accountFunction);
+  const flagBody = functionBody(module, flagFunction);
+  const infoBody = functionBody(module, infoFunction);
+  const attributesBody = functionBody(module, attributesFunction);
+  const professionBodies = professionFunctions.map((value) => functionBody(module, value!));
+  const skillbarReaderBody = functionBody(module, skillbarReaderFunction);
+  const skillSlotReaderBody = functionBody(module, skillSlotReaderFunction);
+  const characterUnlockBody = functionBody(module, characterUnlockFunction);
+
+  const heroMemberStride = signedOperand(heroAddBody, 142);
+  const skillbarSkills = unsignedOperand(skillbarUpdateBody, 352);
+  const slotTotalOffset = unsignedOperand(skillSlotReaderBody, 144);
+  const professionStateStride = unsignedOperand(professionBodies[0]!, 18);
+  const layout: EnhancementPartyLayout = {
+    partyContext: unsignedOperand(heroAddBody, 30),
+    playerParty: unsignedOperand(playerPartyBody, 56),
+    partyHeroes: unsignedOperand(heroAddBody, 111),
+    heroMemberStride,
+    heroAgentId: heroMemberStride + signedOperand(heroAddBody, 188),
+    heroOwnerPlayerId: heroMemberStride + signedOperand(heroAddBody, 200),
+    heroId: heroMemberStride + signedOperand(heroAddBody, 178),
+    heroLevel: heroMemberStride + signedOperand(heroAddBody, 148),
+    partyPlayers: unsignedOperand(partyInfoBody, 277),
+    partyHenchmen: unsignedOperand(partyInfoBody, 242),
+    partyFlag: unsignedOperand(partyFlagBody, 7),
+    accountContextSlot: unsignedOperand(accountBody, 4),
+    accountUnlockedSkills: unsignedOperand(accountBody, 12),
+    worldHeroFlags: unsignedOperand(worldBody, 1_991),
+    heroFlagStride: unsignedOperand(flagBody, 18),
+    flagHeroId: 0,
+    flagAgentId: unsignedOperand(flagBody, 63),
+    flagBehavior: unsignedOperand(flagBody, 131),
+    worldHeroInfo: unsignedOperand(worldBody, 1_953),
+    heroInfoStride: unsignedOperand(infoBody, 35),
+    infoHeroId: unsignedOperand(infoBody, 475),
+    infoAgentId: unsignedOperand(infoBody, 468),
+    infoLevel: unsignedOperand(infoBody, 461),
+    infoPrimary: unsignedOperand(infoBody, 454),
+    infoSecondary: unsignedOperand(infoBody, 447),
+    infoAppearanceBitmap: unsignedOperand(infoBody, 412),
+    worldSkillbars: unsignedOperand(worldBody, 983),
+    skillbarStride: unsignedOperand(skillbarUpdateBody, 236),
+    skillbarAgentId: unsignedOperand(skillbarReaderBody, 126),
+    skillbarSkills,
+    skillSlotStride: unsignedOperand(skillSlotReaderBody, 137),
+    skillSlotId: slotTotalOffset - skillbarSkills,
+    skillbarDisabled: unsignedOperand(skillbarReaderBody, 136),
+    worldAttributes: unsignedOperand(worldBody, 2_826),
+    attributeStride: unsignedOperand(attributesBody, 35),
+    attributeAgentId: 0,
+    attributeEntries: unsignedOperand(attributesBody, 198),
+    attributeEntryStride: unsignedOperand(attributesBody, 181),
+    attributeEntryId: 0,
+    attributeEntryRank: 4,
+    worldProfessionStates: unsignedOperand(worldBody, 1_213),
+    professionStateStride,
+    worldCharacterSkills: unsignedOperand(worldBody, 925),
+  };
+  if (
+    unsignedOperand(playerPartyBody, 318) !== layout.playerParty
+    || unsignedOperand(heroAddBody, 135) !== layout.partyHeroes
+    || unsignedOperand(flagBody, 103) !== layout.heroFlagStride
+    || unsignedOperand(flagBody, 119) !== layout.flagAgentId
+    || [1, 2, 3].some((index) => unsignedOperand(professionBodies[index]!, 18) !== professionStateStride)
+    || unsignedOperand(skillbarUpdateBody, 269) !== layout.skillbarStride
+    || unsignedOperand(skillbarUpdateBody, 323) !== layout.skillbarStride
+    || unsignedOperand(skillbarReaderBody, 18) !== layout.skillbarStride
+    || unsignedOperand(skillSlotReaderBody, 18) !== layout.skillbarStride
+    || unsignedOperand(characterUnlockBody, 70) !== layout.worldCharacterSkills
+    || unsignedOperand(skillbarUpdateBody, 223) !== layout.worldSkillbars
+  ) return null;
+
+  const verified = verifyLayout(layout, {
+    partyContext: { sourceRole: "PartyAddHero", expression: "GameContext PartyContext load", occurrences: [30, 213] },
+    playerParty: { sourceRole: "party membership writer", expression: "matched load/store with shared party updater", occurrences: [56, 318] },
+    partyHeroes: { sourceRole: "PartyAddHero+PartyInfo lifecycle", expression: "hero array field", occurrences: [111, 135, 207] },
+    heroMemberStride: { sourceRole: "PartyAddHero", expression: "hero row multiplier", occurrences: [142] },
+    heroAgentId: { sourceRole: "PartyAddHero", expression: "row end minus 24", occurrences: [188] },
+    heroOwnerPlayerId: { sourceRole: "PartyAddHero", expression: "row end minus 20", occurrences: [200] },
+    heroId: { sourceRole: "PartyAddHero", expression: "row end minus 16", occurrences: [178] },
+    heroLevel: { sourceRole: "PartyAddHero", expression: "row end minus 4", occurrences: [148] },
+    partyPlayers: { sourceRole: "PartyInfo lifecycle", expression: "player array clear", occurrences: [277] },
+    partyHenchmen: { sourceRole: "PartyInfo lifecycle", expression: "henchman array clear", occurrences: [242] },
+    partyFlag: { sourceRole: "party flag writer", expression: "field store followed by party updater", occurrences: [7] },
+    accountContextSlot: { sourceRole: "account unlock writer", expression: "registered AccountContext slot", occurrences: [4] },
+    accountUnlockedSkills: { sourceRole: "account unlock writer", expression: "AccountContext array field", occurrences: [12] },
+    worldHeroFlags: { sourceRole: "WorldContext lifecycle", expression: "array clear field", occurrences: [1_991] },
+    heroFlagStride: { sourceRole: "hero flag writer", expression: "binary-search row stride", occurrences: [18, 103] },
+    flagHeroId: { sourceRole: "hero flag writer", expression: "first row key", occurrences: [0] },
+    flagAgentId: { sourceRole: "hero flag writer", expression: "binary-search agent key", occurrences: [63, 119] },
+    flagBehavior: { sourceRole: "hero flag writer", expression: "behavior store", occurrences: [131] },
+    worldHeroInfo: { sourceRole: "WorldContext lifecycle", expression: "array clear field", occurrences: [1_953] },
+    heroInfoStride: { sourceRole: "HeroDataAdded", expression: "hero-info row multiplier", occurrences: [35] },
+    infoHeroId: { sourceRole: "HeroDataAdded", expression: "hero id store", occurrences: [475] },
+    infoAgentId: { sourceRole: "HeroDataAdded", expression: "agent id store", occurrences: [468] },
+    infoLevel: { sourceRole: "HeroDataAdded", expression: "level store", occurrences: [461] },
+    infoPrimary: { sourceRole: "HeroDataAdded", expression: "primary profession store", occurrences: [454] },
+    infoSecondary: { sourceRole: "HeroDataAdded", expression: "secondary profession store", occurrences: [447] },
+    infoAppearanceBitmap: { sourceRole: "HeroDataAdded", expression: "appearance bitmap store", occurrences: [412] },
+    worldSkillbars: { sourceRole: "WorldContext lifecycle+skillbar update", expression: "array field", occurrences: [983, 223] },
+    skillbarStride: { sourceRole: "skillbar update+readers", expression: "row multiplier", occurrences: [236, 269, 323, 18] },
+    skillbarAgentId: { sourceRole: "skillbar reader", expression: "first row key", occurrences: [126] },
+    skillbarSkills: { sourceRole: "skillbar update", expression: "first repeated slot field", occurrences: [352] },
+    skillSlotStride: { sourceRole: "skill slot reader", expression: "slot index multiplier", occurrences: [137] },
+    skillSlotId: { sourceRole: "skillbar update+slot reader", expression: "total id offset minus slot base", occurrences: [144, 352] },
+    skillbarDisabled: { sourceRole: "skillbar reader", expression: "disabled field load", occurrences: [136] },
+    worldAttributes: { sourceRole: "WorldContext lifecycle", expression: "array clear field", occurrences: [2_826] },
+    attributeStride: { sourceRole: "attribute writer", expression: "row multiplier", occurrences: [35, 68, 124] },
+    attributeAgentId: { sourceRole: "attribute writer", expression: "first row key", occurrences: [0] },
+    attributeEntries: { sourceRole: "attribute writer", expression: "entry table base", occurrences: [198] },
+    attributeEntryStride: { sourceRole: "attribute writer", expression: "entry index multiplier", occurrences: [181] },
+    attributeEntryId: { sourceRole: "attribute writer", expression: "first entry field", occurrences: [0] },
+    attributeEntryRank: { sourceRole: "attribute writer", expression: "rank field following id", occurrences: [4] },
+    worldProfessionStates: { sourceRole: "WorldContext lifecycle", expression: "array clear field", occurrences: [1_213] },
+    professionStateStride: { sourceRole: "four profession readers", expression: "binary-search row stride", occurrences: [18, 18, 18, 18] },
+    worldCharacterSkills: { sourceRole: "WorldContext lifecycle+unlock reader", expression: "bitset array field", occurrences: [925, 70] },
+  }).layout;
+  return Object.freeze({
+    ...expected,
+    partyDirtyMessages: Object.freeze(dirtyMessages) as typeof expected.partyDirtyMessages,
+    playerChatProducer: uiEvidence.playerChatProducerFunctionIndex,
+    nearbyPlayerMessageProducers: Object.freeze([
+      uiEvidence.nearby7fProducerFunctionIndices[0]!,
+      uiEvidence.nearby80ProducerFunctionIndices[0]!,
+    ] as const),
+    layout: verified,
+  });
+}
+
+function deriveTeamApply(
+  module: ModuleShape,
+  baseline: KnownEnhancementBuild,
+): KnownEnhancementBuild["teamApply"] | null {
+  const expected = baseline.teamApply;
+  if (!expected || expected.entries.length !== TEAM_BUILDER_ROLES.length) return null;
+  const senderFunction = uniqueRoleFunction(module, TEAM_SENDER_ROLE);
+  if (senderFunction === null) return null;
+  const senderBody = functionBody(module, senderFunction);
+  const senderValues = valuesForRole(senderBody, TEAM_SENDER_ROLE);
+  const senderRoles = [
+    "sender.assert-bytes", "sender.assert-string-length",
+    "sender.assert-struct-count", "sender.assert-switch",
+  ];
+  if (senderRoles.some((role, index) =>
+    staticCStringHash(module, soleValue(senderValues, role))
+      !== TEAM_SENDER_IMMUTABLE_HASHES[index])) return null;
+
+  let constructorFunction: number | null = null;
+  const entries = TEAM_BUILDER_ROLES.map((role, index) => {
+    const expectedEntry = expected.entries[index]!;
+    const semantic = semanticRole(
+      role.length,
+      role.fingerprint,
+      Object.freeze([
+        { start: role.constructorAt, end: role.constructorAt + 5, role: "packet.constructor", addressClass: "function-index" },
+        { start: role.senderAt, end: role.senderAt + 5, role: "packet.sender", addressClass: "function-index" },
+      ]),
+      expectedEntry.params,
+      expectedEntry.results,
+    );
+    const functionIndex = uniqueRoleFunction(module, semantic);
+    if (functionIndex === null) return null;
+    const body = functionBody(module, functionIndex);
+    const values = valuesForRole(body, semantic);
+    const constructor = soleValue(values, "packet.constructor");
+    if (constructorFunction !== null && constructorFunction !== constructor) return null;
+    constructorFunction = constructor;
+    if (
+      soleValue(values, "packet.sender") !== senderFunction
+      || unsignedOperand(body, role.opcodeAt) !== role.opcode
+      || role.opcode !== expectedEntry.opcode
+    ) return null;
+    return Object.freeze({
+      ...expectedEntry,
+      functionIndex,
+      bodySha256: functionBodySha256(module, functionIndex),
+    });
+  });
+  if (constructorFunction === null || entries.some((entry) => entry === null)) return null;
+  return Object.freeze({
+    ...expected,
+    professionTrace: Object.freeze({
+      ...expected.professionTrace,
+      sender: Object.freeze({
+        ...expected.professionTrace.sender,
+        functionIndex: senderFunction,
+        bodySha256: functionBodySha256(module, senderFunction),
+      }),
+    }),
+    entries: Object.freeze(entries) as typeof expected.entries,
   });
 }
 
@@ -2228,17 +2656,27 @@ export function locateAutomaticLocalActions(
             }),
           })
         : null;
-      if (!travelAction && !xunlaiAction && !chatAliases) continue;
+      const partyObservation = uiDispatcher && observationLayout && uiEvidence
+        ? isolatedProof(() => derivePartyObservation(
+            module, baseline, observationLayout, uiDispatcher, uiEvidence,
+          ))
+        : null;
+      const teamApply = partyObservation && gameThread
+        ? isolatedProof(() => deriveTeamApply(module, baseline))
+        : null;
+      if (!travelAction && !xunlaiAction && !chatAliases && !partyObservation) continue;
       locations.push(Object.freeze({
         baseline,
         hookFunction: tick.functionIndex,
         hookBodySha256: tick.bodySha256,
-        observationLayout: xunlaiAction ? observationLayout : null,
+        observationLayout: xunlaiAction || partyObservation ? observationLayout : null,
         uiDispatcher,
-        gameThread: travelAction || xunlaiAction ? gameThread : null,
+        gameThread: travelAction || xunlaiAction || teamApply ? gameThread : null,
         travelAction,
         xunlaiAction,
         chatAliases,
+        partyObservation,
+        teamApply,
       }));
     }
     if (locations.length === 0) return null;
@@ -2250,6 +2688,8 @@ export function locateAutomaticLocalActions(
       travelAction: value.travelAction,
       xunlaiAction: value.xunlaiAction,
       chatAliases: value.chatAliases,
+      partyObservation: value.partyObservation,
+      teamApply: value.teamApply,
     });
     return locations.every((match) => identity(match) === identity(locations[0]!))
       ? locations[0]!

--- a/src/main/certification/local-client-verifier-host.ts
+++ b/src/main/certification/local-client-verifier-host.ts
@@ -21,12 +21,17 @@ import {
   isDerivedNativeDoubleClickBuild,
   type NativeDoubleClickBuild,
 } from "./native-double-click.js";
+import {
+  enhancementCapabilityProfile,
+  type EnhancementCapabilities,
+} from "../../shared/enhancement-contracts.js";
 
 const VERIFIER_TIMEOUT_MS = 5_000;
 
 function runVerifierProcess(
   officialWasmPath: string,
   officialSha256: string,
+  requestedCapabilities: EnhancementCapabilities,
 ): Promise<LocalClientVerification | null> {
   return new Promise((resolve) => {
     const entry = fileURLToPath(
@@ -34,7 +39,12 @@ function runVerifierProcess(
     );
     const child = utilityProcess.fork(
       entry,
-      ["client", officialWasmPath, officialSha256],
+      [
+        "client",
+        officialWasmPath,
+        officialSha256,
+        enhancementCapabilityProfile(requestedCapabilities) ?? "none",
+      ],
       { serviceName: "Guild Wars client compatibility verifier" },
     );
     let settled = false;
@@ -92,10 +102,12 @@ function runNativeDoubleClickVerifierProcess(
 export async function verifyClientLocally(options: {
   officialWasmPath: string;
   officialSha256: string;
+  requestedCapabilities: EnhancementCapabilities;
 }): Promise<LocalClientVerification | null> {
   return runVerifierProcess(
     options.officialWasmPath,
     options.officialSha256,
+    options.requestedCapabilities,
   ).catch(() => null);
 }
 

--- a/src/main/certification/local-client-verifier-process.ts
+++ b/src/main/certification/local-client-verifier-process.ts
@@ -21,6 +21,10 @@ import {
   deriveNativeDoubleClickBuild,
   isDerivedNativeDoubleClickBuild,
 } from "./native-double-click.js";
+import {
+  enhancementCapabilitiesForProfile,
+  type EnhancementCapabilities,
+} from "../../shared/enhancement-contracts.js";
 
 interface ParentPort {
   postMessage(value: unknown): void;
@@ -31,7 +35,7 @@ const parentPort = (
 ).parentPort;
 
 async function main(): Promise<void> {
-  const [mode, wasmPath, expectedSha256] = process.argv.slice(2);
+  const [mode, wasmPath, expectedSha256, requestedProfile] = process.argv.slice(2);
   if (!parentPort || !mode || !wasmPath || !expectedSha256) {
     process.exitCode = 2;
     return;
@@ -46,7 +50,25 @@ async function main(): Promise<void> {
   }
 
   if (mode === "client") {
-    const result = verifyLocalClientBytes(bytes);
+    const requestedCapabilities: EnhancementCapabilities | null = requestedProfile === "none"
+      ? Object.freeze({
+          nativeCursor: false,
+          targetObservation: false,
+          partyObservation: false,
+          teamApply: false,
+          travelAction: false,
+          xunlaiAction: false,
+          chatAliases: false,
+        })
+      : requestedProfile
+        ? enhancementCapabilitiesForProfile(requestedProfile)
+        : null;
+    if (!requestedCapabilities) {
+      parentPort.postMessage(null);
+      process.exitCode = 2;
+      return;
+    }
+    const result = verifyLocalClientBytes(bytes, requestedCapabilities);
     if (!isLocalClientVerification(result, expectedSha256)) {
       parentPort.postMessage(null);
       process.exitCode = 4;

--- a/src/main/certification/local-client-verifier.ts
+++ b/src/main/certification/local-client-verifier.ts
@@ -10,8 +10,8 @@
  * The two answers are not symmetric and must not be merged. Template save is
  * shape-verifiable, so a client whose affected call sites still match is
  * accepted by proof. Cursor and read-only Target Distance each have a strict,
- * independent structural locator; party observation and actions remain
- * exact-build only.
+ * independent structural locator; Party and Team Apply join that path only
+ * after their complete field and packet ledgers prove independently.
  *
  * `isLocalClientVerification` re-validates every field of a result that crossed
  * the process boundary. Profile state is never consulted.
@@ -20,6 +20,7 @@ import { createHash } from "node:crypto";
 import {
   enhancementCapabilityProfile,
   enhancementCapabilitiesForProfile,
+  enhancementCapabilitiesRequested,
   type EnhancementCapabilities,
 } from "../../shared/enhancement-contracts.js";
 import {
@@ -84,6 +85,7 @@ function sameJson(left: unknown, right: unknown): boolean {
 function deriveEnhancementBuild(
   official: Uint8Array,
   templateOutput: Uint8Array,
+  requestedCapabilities: EnhancementCapabilities,
 ): KnownEnhancementBuild | null {
   const report = inspectEnhancementCandidate(templateOutput);
   if (!report.validWasm) return null;
@@ -150,46 +152,43 @@ function deriveEnhancementBuild(
     ...(locatedLocal?.travelAction ? { travelAction: locatedLocal.travelAction } : {}),
     ...(locatedLocal?.xunlaiAction ? { xunlaiAction: locatedLocal.xunlaiAction } : {}),
     ...(locatedLocal?.chatAliases ? { chatAliases: locatedLocal.chatAliases } : {}),
-  });
-  const none = (): EnhancementCapabilities => ({
-    nativeCursor: false, targetObservation: false, partyObservation: false,
-    teamApply: false, travelAction: false, xunlaiAction: false, chatAliases: false,
+    ...(locatedLocal?.partyObservation ? {
+      partyObservation: locatedLocal.partyObservation,
+    } : {}),
+    ...(locatedLocal?.teamApply ? { teamApply: locatedLocal.teamApply } : {}),
   });
   const maximum: EnhancementCapabilities = Object.freeze({
     nativeCursor: locatedCursor !== null,
     targetObservation: locatedTarget !== null,
-    partyObservation: false,
-    teamApply: false,
+    partyObservation: locatedLocal?.partyObservation !== null
+      && locatedLocal?.partyObservation !== undefined,
+    teamApply: locatedLocal?.teamApply !== null
+      && locatedLocal?.teamApply !== undefined,
     travelAction: locatedLocal?.travelAction !== null && locatedLocal?.travelAction !== undefined,
     xunlaiAction: locatedLocal?.xunlaiAction !== null && locatedLocal?.xunlaiAction !== undefined,
     chatAliases: locatedLocal?.chatAliases !== null && locatedLocal?.chatAliases !== undefined,
   });
-  const featureSets = (["nativeCursor", "targetObservation"] as const)
-    .filter((feature) => maximum[feature])
-    .map((feature) => Object.freeze({ ...none(), [feature]: true }));
-  const localBundle = Object.freeze({
-    ...none(),
-    travelAction: maximum.travelAction,
-    xunlaiAction: maximum.xunlaiAction,
-    chatAliases: maximum.chatAliases,
+  const effective: EnhancementCapabilities = Object.freeze({
+    nativeCursor: requestedCapabilities.nativeCursor && maximum.nativeCursor,
+    targetObservation:
+      requestedCapabilities.targetObservation && maximum.targetObservation,
+    partyObservation:
+      requestedCapabilities.partyObservation && maximum.partyObservation,
+    teamApply: requestedCapabilities.teamApply
+      && maximum.teamApply && maximum.partyObservation,
+    travelAction: requestedCapabilities.travelAction && maximum.travelAction,
+    xunlaiAction: requestedCapabilities.xunlaiAction && maximum.xunlaiAction,
+    chatAliases: requestedCapabilities.chatAliases && maximum.chatAliases,
   });
-  const capabilitySets = [...featureSets, localBundle, maximum].filter(
-    (capabilities, index, values) =>
-      Object.values(capabilities).some(Boolean)
-      && values.findIndex((candidate) => sameJson(candidate, capabilities)) === index,
-  );
-  const outputSha256 = Object.fromEntries(capabilitySets.map((capabilities) => {
-    const profile = enhancementCapabilityProfile(capabilities);
-    if (profile === null) throw new Error("automatic capability profile is invalid");
-    return [
-      profile,
-    sha256(transformEnhancementWasm(
+  const profile = enhancementCapabilityProfile(effective);
+  if (profile === null || !enhancementCapabilitiesRequested(effective)) return null;
+  const outputSha256 = Object.freeze({
+    [profile]: sha256(transformEnhancementWasm(
       templateOutput,
       provisional,
-        capabilities,
+      effective,
     )),
-    ];
-  }));
+  });
   return Object.freeze({
     ...provisional,
     outputSha256: Object.freeze(outputSha256),
@@ -202,6 +201,15 @@ function deriveEnhancementBuild(
  */
 export function verifyLocalClientBytes(
   official: Uint8Array,
+  requestedCapabilities: EnhancementCapabilities = Object.freeze({
+    nativeCursor: true,
+    targetObservation: true,
+    partyObservation: true,
+    teamApply: true,
+    travelAction: true,
+    xunlaiAction: true,
+    chatAliases: true,
+  }),
 ): LocalClientVerification {
   const officialSha256 = sha256(official);
   const reasons: LocalVerificationReason[] = [];
@@ -240,7 +248,11 @@ export function verifyLocalClientBytes(
 
   let enhancementBuild: KnownEnhancementBuild | null = null;
   try {
-    enhancementBuild = deriveEnhancementBuild(official, templateOutput);
+    enhancementBuild = deriveEnhancementBuild(
+      official,
+      templateOutput,
+      requestedCapabilities,
+    );
     if (!enhancementBuild) reasons.push("enhancement-layout-changed");
   } catch {
     reasons.push("enhancement-transform-failed");
@@ -335,8 +347,6 @@ function isAutomaticSemanticBuild(
   if (
     build.sha256 !== inputSha256
     || !build.outputSha256
-    || build.partyObservation !== undefined
-    || build.teamApply !== undefined
     || !isIndex(build.programId)
     || !isIndex(build.buildId)
     || !isIndex(build.hookFunction)
@@ -349,12 +359,17 @@ function isAutomaticSemanticBuild(
   const hasTravel = build.travelAction !== undefined;
   const hasXunlai = build.xunlaiAction !== undefined;
   const hasAliases = build.chatAliases !== undefined;
-  if (!hasCursor && !hasTarget && !hasTravel && !hasXunlai && !hasAliases) return false;
+  const hasParty = build.partyObservation !== undefined;
+  const hasTeam = build.teamApply !== undefined;
+  if (!hasCursor && !hasTarget && !hasTravel && !hasXunlai && !hasAliases
+    && !hasParty && !hasTeam) return false;
   if (
     Object.keys(build.outputSha256).length === 0
     || !Object.values(build.outputSha256).every(isDigest)
     || (hasTarget && !hasObservation)
     || (hasXunlai && !hasObservation)
+    || (hasParty && (!hasObservation || build.uiDispatcher === undefined))
+    || (hasTeam && (!hasParty || build.gameThread === undefined))
     || ((hasTravel || hasXunlai) && build.gameThread === undefined)
     || ((hasTravel || hasXunlai || hasAliases) && build.uiDispatcher === undefined)
   ) return false;
@@ -441,6 +456,8 @@ function isAutomaticSemanticBuild(
     const travel = baseline.travelAction;
     const xunlai = baseline.xunlaiAction;
     const aliases = baseline.chatAliases;
+    const party = baseline.partyObservation;
+    const team = baseline.teamApply;
     const uiMatches = build.uiDispatcher === undefined || (
       ui !== undefined
       && isIndex(build.uiDispatcher.functionIndex)
@@ -507,9 +524,47 @@ function isAutomaticSemanticBuild(
       && sameJson(build.chatAliases.parser.params, aliases.parser.params)
       && sameJson(build.chatAliases.parser.results, aliases.parser.results)
     );
+    const partyMatches = !hasParty || (
+      party !== undefined
+      && build.partyObservation !== undefined
+      && build.partyObservation.playerChatSites === 3
+      && isIndex(build.partyObservation.playerChatProducer)
+      && build.partyObservation.nearbyPlayerMessageProducers.length === 2
+      && build.partyObservation.nearbyPlayerMessageProducers.every(isIndex)
+      && sameJson(build.partyObservation.partyDirtyMessages, party.partyDirtyMessages)
+      && sameJson(build.partyObservation.nearbyPlayerMessages, party.nearbyPlayerMessages)
+      && sameJson(build.partyObservation.layout, party.layout)
+    );
+    const teamMatches = !hasTeam || (
+      team !== undefined
+      && build.teamApply !== undefined
+      && build.teamApply.thunkExport === team.thunkExport
+      && build.teamApply.professionTrace.readerExport === team.professionTrace.readerExport
+      && isIndex(build.teamApply.professionTrace.sender.functionIndex)
+      && isDigest(build.teamApply.professionTrace.sender.bodySha256)
+      && sameJson(
+        build.teamApply.professionTrace.sender.params,
+        team.professionTrace.sender.params,
+      )
+      && sameJson(
+        build.teamApply.professionTrace.sender.results,
+        team.professionTrace.sender.results,
+      )
+      && build.teamApply.entries.length === team.entries.length
+      && build.teamApply.entries.every((entry, index) => {
+        const expected = team.entries[index];
+        return expected !== undefined
+          && entry.opcode === expected.opcode
+          && entry.label === expected.label
+          && isIndex(entry.functionIndex)
+          && isDigest(entry.bodySha256)
+          && sameJson(entry.params, expected.params)
+          && sameJson(entry.results, expected.results);
+      })
+    );
     return cursorMatches && observationMatches && targetMatches
       && uiMatches && gameThreadMatches && travelMatches
-      && xunlaiMatches && aliasesMatches;
+      && xunlaiMatches && aliasesMatches && partyMatches && teamMatches;
   });
 }
 

--- a/src/main/client-runtime.ts
+++ b/src/main/client-runtime.ts
@@ -319,6 +319,7 @@ export class ClientRuntime {
       const local = await verifyClientLocally({
         officialWasmPath: officialWasm,
         officialSha256,
+        requestedCapabilities: this.options.enhancementCapabilities,
       });
       if (local) {
         certification = certificationFromLocalVerification(local);

--- a/src/shared/enhancement-config.ts
+++ b/src/shared/enhancement-config.ts
@@ -43,7 +43,7 @@ export interface EnhancementLayout {
   partyPlayers: number;
   partyHenchmen: number;
   partyFlag: number;
-  accountContext: number;
+  accountContextSlot: number;
   accountUnlockedSkills: number;
   worldContext: number;
   worldHeroFlags: number;
@@ -155,7 +155,7 @@ export const ENHANCEMENT_CONFIG_FIELDS = Object.freeze([
   ...observation("agentX", "agentY", "agentType"),
   ...observation("agentPlayerNumber", "agentModelType"),
   ...cursor("cursorActiveArt", "cursorSoftwareModel", "cursorShowCount", "cursorColorBuffer", "cursorArtHotspot", "cursorArtTexture", "cursorHandleKey", "cursorHandleObject", "cursorViewTexture", "cursorTextureType", "cursorTextureWidth", "cursorTextureHeight"),
-  ...party("partyContext", "playerParty", "partyHeroes", "heroMemberStride", "heroAgentId", "heroOwnerPlayerId", "heroId", "heroLevel", "partyPlayers", "partyHenchmen", "partyFlag", "accountContext", "accountUnlockedSkills"),
+  ...party("partyContext", "playerParty", "partyHeroes", "heroMemberStride", "heroAgentId", "heroOwnerPlayerId", "heroId", "heroLevel", "partyPlayers", "partyHenchmen", "partyFlag", "accountContextSlot", "accountUnlockedSkills"),
   ...observation("worldContext"),
   ...party("worldHeroFlags", "heroFlagStride", "flagHeroId", "flagAgentId", "flagBehavior", "worldHeroInfo", "heroInfoStride", "infoHeroId", "infoAgentId", "infoLevel", "infoPrimary", "infoSecondary", "infoAppearanceBitmap", "worldSkillbars", "skillbarStride", "skillbarAgentId", "skillbarSkills", "skillSlotStride", "skillSlotId", "skillbarDisabled", "worldAttributes", "attributeStride", "attributeAgentId", "attributeEntries", "attributeEntryStride", "attributeEntryId", "attributeEntryRank"),
   ...observation("areaInfo", "areaInfoCount", "areaInfoStride", "areaInfoFlags"),

--- a/src/shared/enhancement-contracts.ts
+++ b/src/shared/enhancement-contracts.ts
@@ -299,7 +299,7 @@ export {
   ENHANCEMENT_LAYOUT_WORD_COUNT,
   ENHANCEMENT_PARTY_DIRTY_MESSAGE_COUNT,
 } from "./enhancement-config.js";
-export const ENHANCEMENT_TRANSFORM_ABI = 35;
+export const ENHANCEMENT_TRANSFORM_ABI = 36;
 
 export function enhancementConfigWordActive(
   capabilities: EnhancementCapabilities,

--- a/tests/client-artifact/template-save-recert.test.ts
+++ b/tests/client-artifact/template-save-recert.test.ts
@@ -248,6 +248,8 @@ test("the template-save verifier makes a fail-closed decision for a real client"
   assert.equal(drainRefusal.travelAction, false);
   assert.equal(drainRefusal.xunlaiAction, false);
   assert.equal(drainRefusal.chatAliases, true);
+  assert.equal(drainRefusal.partyObservation, true);
+  assert.equal(drainRefusal.teamApply, false);
 
   const changedDispatcher = rewriteCode(bytes, (bodies) => {
     const body = bodies[6842 - derived.importCount]!;
@@ -260,6 +262,34 @@ test("the template-save verifier makes a fail-closed decision for a real client"
   assert.equal(dispatcherRefusal.travelAction, false);
   assert.equal(dispatcherRefusal.xunlaiAction, false);
   assert.equal(dispatcherRefusal.chatAliases, false);
+  assert.equal(dispatcherRefusal.partyObservation, false);
+  assert.equal(dispatcherRefusal.teamApply, false);
+
+  const changedPartyField = rewriteCode(bytes, (bodies) => {
+    const body = bodies[8787 - derived.importCount]!;
+    body[35] = body[35]! ^ 1;
+  });
+  assert.equal(WebAssembly.validate(new Uint8Array(changedPartyField)), true);
+  const partyRefusal = capabilitiesOf(verifyLocalClientBytes(changedPartyField))!;
+  assert.equal(partyRefusal.nativeCursor, true);
+  assert.equal(partyRefusal.targetObservation, true);
+  assert.equal(partyRefusal.partyObservation, false);
+  assert.equal(partyRefusal.teamApply, false);
+  assert.equal(partyRefusal.travelAction, true);
+  assert.equal(partyRefusal.xunlaiAction, true);
+  assert.equal(partyRefusal.chatAliases, true);
+
+  const changedTeamOpcode = rewriteCode(bytes, (bodies) => {
+    const body = bodies[6887 - derived.importCount]!;
+    body[30] = body[30]! ^ 1;
+  });
+  assert.equal(WebAssembly.validate(new Uint8Array(changedTeamOpcode)), true);
+  const teamRefusal = capabilitiesOf(verifyLocalClientBytes(changedTeamOpcode))!;
+  assert.equal(teamRefusal.partyObservation, true);
+  assert.equal(teamRefusal.teamApply, false);
+  assert.equal(teamRefusal.travelAction, true);
+  assert.equal(teamRefusal.xunlaiAction, true);
+  assert.equal(teamRefusal.chatAliases, true);
 });
 
 test("every certified runtime profile reproduces the real client chain", async () => {

--- a/tests/electron/fixtures/local-verifier-app/main.mjs
+++ b/tests/electron/fixtures/local-verifier-app/main.mjs
@@ -26,7 +26,19 @@ void app.whenReady().then(async () => {
         wasmPath: officialWasmPath,
         inputSha256: officialSha256,
       })
-    : await verifyClientLocally({ officialWasmPath, officialSha256 });
+    : await verifyClientLocally({
+        officialWasmPath,
+        officialSha256,
+        requestedCapabilities: {
+          nativeCursor: true,
+          targetObservation: true,
+          partyObservation: true,
+          teamApply: true,
+          travelAction: true,
+          xunlaiAction: true,
+          chatAliases: true,
+        },
+      });
   state.localVerifierCompleted = true;
   const window = new BrowserWindow({ show: false });
   await window.loadURL("data:text/html,local-verifier-complete");

--- a/tests/fixtures/enhancement-transform.ts
+++ b/tests/fixtures/enhancement-transform.ts
@@ -455,7 +455,7 @@ export function manifest(bytes: Uint8Array): KnownEnhancementBuild {
       // fixture padded with zeros would let a mis-ordered field pass.
       heroLevel: 42,
       partyPlayers: 43, partyHenchmen: 44, partyFlag: 45,
-      accountContext: 78, accountUnlockedSkills: 79,
+      accountContextSlot: 78, accountUnlockedSkills: 79,
       worldHeroFlags: 47, heroFlagStride: 48,
       flagHeroId: 49, flagAgentId: 50, flagBehavior: 51,
       worldHeroInfo: 52, heroInfoStride: 53, infoHeroId: 54,

--- a/tests/fixtures/enhancements.ts
+++ b/tests/fixtures/enhancements.ts
@@ -287,7 +287,7 @@ export const ADDRESSES = Object.freeze({
 export const DETAIL = Object.freeze({
   heroLevel: 0x14,
   partyPlayers: 0x04, partyHenchmen: 0x14, partyFlag: 0x14,
-  accountContext: 0x28, accountUnlockedSkills: 0x124,
+  accountContextSlot: 10, accountUnlockedSkills: 0x124,
   worldContext: 0x2c,
   heroFlags: 0x584, flagStride: 0x24,
   flagHeroId: 0x00, flagAgentId: 0x04, flagBehavior: 0x0c,
@@ -444,7 +444,7 @@ export async function createKernel(
   if (partyDetail) {
     config.set([
       DETAIL.heroLevel, DETAIL.partyPlayers, DETAIL.partyHenchmen, DETAIL.partyFlag,
-      DETAIL.accountContext, DETAIL.accountUnlockedSkills,
+      DETAIL.accountContextSlot, DETAIL.accountUnlockedSkills,
       DETAIL.worldContext,
       DETAIL.heroFlags, DETAIL.flagStride,
       DETAIL.flagHeroId, DETAIL.flagAgentId, DETAIL.flagBehavior,
@@ -546,6 +546,11 @@ export async function createKernel(
 export function installGameGraph(view: DataView) {
   view.setUint32(ADDRESSES.contextRoot, ADDRESSES.contexts, true);
   view.setUint32(ADDRESSES.contexts + 24, ADDRESSES.game, true);
+  view.setUint32(
+    ADDRESSES.contexts + DETAIL.accountContextSlot * 4,
+    ADDRESSES.account,
+    true,
+  );
   view.setUint32(ADDRESSES.game + 0x44, ADDRESSES.character, true);
   view.setUint32(ADDRESSES.character + 0x198, 133, true);
   view.setUint32(ADDRESSES.character + 0x19c, 0, true);
@@ -577,7 +582,6 @@ export function installGameGraph(view: DataView) {
   view.setUint32(ADDRESSES.target + 0x9c, 0xdb, true);
   view.setUint32(ADDRESSES.manualTargetId, 9, true);
   view.setUint32(ADDRESSES.game + 0x4c, ADDRESSES.partyContext, true);
-  view.setUint32(ADDRESSES.game + DETAIL.accountContext, ADDRESSES.account, true);
   view.setUint32(ADDRESSES.game + DETAIL.worldContext, ADDRESSES.world, true);
   view.setUint32(ADDRESSES.world + DETAIL.players, ADDRESSES.playerRecordBuffer, true);
   view.setUint32(ADDRESSES.world + DETAIL.players + 4, 1, true);

--- a/tests/unit/client-module.test.ts
+++ b/tests/unit/client-module.test.ts
@@ -421,7 +421,7 @@ function enhancementBuild(input: Uint8Array): KnownEnhancementBuild {
       partyPlayers: 43,
       partyHenchmen: 44,
       partyFlag: 45,
-      accountContext: 78,
+      accountContextSlot: 78,
       accountUnlockedSkills: 79,
       worldHeroFlags: 47,
       heroFlagStride: 48,

--- a/tests/unit/local-client-verifier.test.ts
+++ b/tests/unit/local-client-verifier.test.ts
@@ -128,6 +128,43 @@ function automaticLocalActions(): LocalClientVerification {
   };
 }
 
+function automaticPartyTeam(): LocalClientVerification {
+  const localActions = automaticLocalActions();
+  const party = ENHANCEMENT.partyObservation!;
+  const team = ENHANCEMENT.teamApply!;
+  return {
+    ...localActions,
+    enhancementBuild: {
+      ...localActions.enhancementBuild!,
+      outputSha256: { partyCommands: "b".repeat(64) },
+      partyObservation: {
+        ...party,
+        playerChatProducer: party.playerChatProducer + 1,
+        nearbyPlayerMessageProducers: [
+          party.nearbyPlayerMessageProducers[0] + 1,
+          party.nearbyPlayerMessageProducers[1] + 1,
+        ],
+      },
+      teamApply: {
+        ...team,
+        professionTrace: {
+          ...team.professionTrace,
+          sender: {
+            ...team.professionTrace.sender,
+            functionIndex: team.professionTrace.sender.functionIndex + 1,
+            bodySha256: "c".repeat(64),
+          },
+        },
+        entries: team.entries.map((entry) => ({
+          ...entry,
+          functionIndex: entry.functionIndex + 1,
+          bodySha256: "d".repeat(64),
+        })),
+      },
+    },
+  };
+}
+
 describe("local client verification boundary", () => {
   it("accepts the verifier's complete baseline proof", () => {
     assert.equal(isLocalClientVerification(valid(), TEMPLATE.sha256), true);
@@ -155,12 +192,20 @@ describe("local client verification boundary", () => {
     }, TEMPLATE.sha256), false);
   });
 
-  it("rejects any certificate other than the exact shipped build", () => {
-    assert.equal(isLocalClientVerification({
+  it("accepts a relocated hook but rejects an incompatible signature", () => {
+    const relocated = {
       ...valid(),
       enhancementBuild: {
         ...ENHANCEMENT,
         hookFunction: ENHANCEMENT.hookFunction + 1,
+      },
+    };
+    assert.equal(isLocalClientVerification(relocated, TEMPLATE.sha256), true);
+    assert.equal(isLocalClientVerification({
+      ...relocated,
+      enhancementBuild: {
+        ...relocated.enhancementBuild,
+        hookParams: ["i64"],
       },
     }, TEMPLATE.sha256), false);
   });
@@ -218,6 +263,39 @@ describe("local client verification boundary", () => {
               playerRecordAccessFlags: 0x38,
             },
           },
+        },
+      },
+    }, TEMPLATE.sha256), false);
+  });
+
+  it("accepts complete Party and Team proofs and rejects each independently", () => {
+    const derived = automaticPartyTeam();
+    assert.equal(isLocalClientVerification(derived, TEMPLATE.sha256), true);
+    assert.equal(isLocalClientVerification({
+      ...derived,
+      enhancementBuild: {
+        ...derived.enhancementBuild!,
+        partyObservation: {
+          ...derived.enhancementBuild!.partyObservation!,
+          layout: {
+            ...derived.enhancementBuild!.partyObservation!.layout,
+            heroInfoStride:
+              derived.enhancementBuild!.partyObservation!.layout.heroInfoStride + 4,
+          },
+        },
+      },
+    }, TEMPLATE.sha256), false);
+    assert.equal(isLocalClientVerification({
+      ...derived,
+      enhancementBuild: {
+        ...derived.enhancementBuild!,
+        teamApply: {
+          ...derived.enhancementBuild!.teamApply!,
+          entries: derived.enhancementBuild!.teamApply!.entries.map(
+            (entry, index) => index === 0
+              ? { ...entry, opcode: entry.opcode + 1 }
+              : entry,
+          ),
         },
       },
     }, TEMPLATE.sha256), false);


### PR DESCRIPTION
## What changed

Party capture proves the complete roster/detail lifecycle across retained generations. Team Apply becomes available only after fresh complete Party proof and seven named packet-builder proofs.

## Why

Partial roster facts, copied static addresses, or an ambiguous packet constructor could make Team Apply unsafe after an ArenaNet rebuild.

## Invariant

Every Party field and lifecycle clear has a witness. Team Apply binds all seven builders, exact opcodes and payloads, sender, drain, map policy, and runtime confirmations.

## Verification

- Exact-head PR package, CodeQL, and Vercel checks passed.
- Retained AEC and e017 artifacts prove Party and Team independently.
- Complete static ledgers, coherent dispatcher relocation, retarget, ambiguity, and stale-state mutations pass.

Stack layer 9 of 13.
