### PR TITLE
fix(memory): prove manifest-bound 4 GB pairs

### DIFF
--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -3,5 +3,5 @@
   "git": {
     "deploymentEnabled": true
   },
-  "ignoreCommand": "if [ -z \"$VERCEL_GIT_PREVIOUS_SHA\" ]; then exit 1; fi; git diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" HEAD -- . ../../src/shared ../../package.json ../../pnpm-lock.yaml ../../pnpm-workspace.yaml"
+  "ignoreCommand": "[ -n \"$VERCEL_GIT_PREVIOUS_SHA\" ] || exit 1; git cat-file -e \"$VERCEL_GIT_PREVIOUS_SHA\" 2>/dev/null || exit 1; git diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" HEAD -- . ../../src/shared ../../package.json ../../pnpm-lock.yaml ../../pnpm-workspace.yaml"
 }

--- a/scripts/qualify-extended-memory.ts
+++ b/scripts/qualify-extended-memory.ts
@@ -2,32 +2,36 @@
 import { createHash } from "node:crypto";
 import {
   mkdtemp,
-  mkdir,
   readFile,
   rm,
-  stat,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
-  EXTENDED_MEMORY_JS_BUILD,
+  deriveExtendedMemoryStructuralProof,
+  EXTENDED_MEMORY_JS_PROOF,
   EXTENDED_MEMORY_MAX_BYTES,
-  findExtendedMemoryWasmBuild,
   prepareExtendedMemoryArtifacts,
   rewriteExtendedMemoryJs,
   rewriteExtendedMemoryWasm,
 } from "../src/main/certification/extended-memory.js";
 import {
-  findTemplateSaveBuild,
-  rewriteTemplateSaveWasm,
-} from "../src/main/certification/template-save-compat.js";
-import { findEnhancementBuild } from "../src/main/certification/enhancement-builds.js";
+  preparePostTemplateSaveModule,
+} from "../src/main/certification/template-save-verifier.js";
 import { transformEnhancementWasm } from "../src/main/certification/enhancement-transform.js";
-import { rewriteNativeDoubleClickWasm } from "../src/main/certification/native-double-click.js";
+import {
+  deriveNativeDoubleClickBuild,
+  rewriteWithBuild,
+} from "../src/main/certification/native-double-click.js";
 import { ENHANCEMENT_CAPABILITY_PROFILES } from "../src/shared/enhancement-contracts.js";
-import { certifyClientBuild } from "../src/main/certification/client-certification.js";
+import {
+  certificationFromLocalVerification,
+} from "../src/main/certification/client-certification.js";
 import { prepareClientModule } from "../src/main/certification/client-module.js";
+import {
+  verifyLocalClientBytes,
+} from "../src/main/certification/local-client-verifier.js";
 
 const [jsPath, wasmPath] = process.argv.slice(2);
 if (!jsPath || !wasmPath) {
@@ -42,26 +46,40 @@ const [officialJs, officialWasm] = await Promise.all([
   readFile(jsPath, "utf8"),
   readFile(wasmPath),
 ]);
+const verifyExtendedMemory = async (options: {
+  jsPath: string;
+  wasmPath: string;
+}) => deriveExtendedMemoryStructuralProof(
+  await readFile(options.jsPath, "utf8"),
+  await readFile(options.wasmPath),
+);
 const transformedJs = rewriteExtendedMemoryJs(officialJs);
-if (sha256(transformedJs) !== EXTENDED_MEMORY_JS_BUILD.outputSha256) {
-  throw new Error("transformed JavaScript does not match its certified hash");
-}
+const jsInputSha256 = sha256(officialJs);
+const jsOutputSha256 = sha256(transformedJs);
 new Function(transformedJs);
 
-const templateBuild = findTemplateSaveBuild(sha256(officialWasm));
-if (!templateBuild) throw new Error("official WASM is not template-save certified");
-const templateWasm = rewriteTemplateSaveWasm(officialWasm, templateBuild);
-const enhancementBuild = findEnhancementBuild(sha256(templateWasm));
-if (!enhancementBuild) throw new Error("template output is not Enhancement certified");
+const verification = verifyLocalClientBytes(officialWasm);
+const preparedTemplate = preparePostTemplateSaveModule(officialWasm);
+const enhancementBuild = verification.enhancementBuild;
+if (!preparedTemplate || !enhancementBuild) {
+  throw new Error("official WASM did not pass the local semantic verifier");
+}
+const templateWasm = preparedTemplate.bytes;
+
+function withNativeDoubleClick(input: Uint8Array): Uint8Array {
+  const build = deriveNativeDoubleClickBuild(input);
+  if (!build) throw new Error("native double-click proof failed");
+  return rewriteWithBuild(input, build);
+}
 
 const predecessors = new Map<string, Uint8Array>();
-predecessors.set("off", rewriteNativeDoubleClickWasm(templateWasm));
+predecessors.set("off", withNativeDoubleClick(templateWasm));
 for (const [profile, capabilities] of Object.entries(
   ENHANCEMENT_CAPABILITY_PROFILES,
 )) {
   predecessors.set(
     profile,
-    rewriteNativeDoubleClickWasm(
+    withNativeDoubleClick(
       transformEnhancementWasm(templateWasm, enhancementBuild, capabilities),
     ),
   );
@@ -76,13 +94,19 @@ try {
   await writeFile(predecessorPath, predecessor);
   const first = await prepareExtendedMemoryArtifacts(
     jsPath,
+    wasmPath,
     predecessorPath,
+    "off",
     cacheRoot,
+    verifyExtendedMemory,
   );
   const cached = await prepareExtendedMemoryArtifacts(
     jsPath,
+    wasmPath,
     predecessorPath,
+    "off",
     cacheRoot,
+    verifyExtendedMemory,
   );
   if (
     first?.profile !== "off"
@@ -90,15 +114,12 @@ try {
     || cached?.wasmPath !== first.wasmPath
   ) throw new Error("paired artifact cache did not reproduce its exact output");
 
-  const changed = Uint8Array.from(predecessor);
-  changed[changed.byteLength - 1] = changed[changed.byteLength - 1]! ^ 1;
-  await writeFile(predecessorPath, changed);
-  if (
-    await prepareExtendedMemoryArtifacts(jsPath, predecessorPath, cacheRoot)
-    !== null
-  ) throw new Error("changed WASM pair was not refused");
-  if (await stat(cacheRoot).then(() => true, () => false)) {
-    throw new Error("refused pair left a stale derived cache");
+  await writeFile(first.jsPath, "corrupt");
+  const repaired = await prepareExtendedMemoryArtifacts(
+    jsPath, wasmPath, predecessorPath, "off", cacheRoot, verifyExtendedMemory,
+  );
+  if (!repaired || sha256(await readFile(repaired.jsPath)) !== jsOutputSha256) {
+    throw new Error("corrupt paired cache was not rebuilt from proof");
   }
 } finally {
   await rm(scratch, { recursive: true, force: true });
@@ -108,23 +129,18 @@ const variants = [];
 let allocatorModule: Uint8Array | null = null;
 let offOutputSha256: string | null = null;
 for (const [profile, predecessor] of predecessors) {
-  const build = findExtendedMemoryWasmBuild(sha256(predecessor));
-  if (!build || build.profile !== profile) {
-    throw new Error(`${profile} predecessor does not match certification`);
-  }
   const output = rewriteExtendedMemoryWasm(predecessor);
-  if (
-    sha256(output) !== build.outputSha256
-    || !WebAssembly.validate(Uint8Array.from(output))
-  ) {
-    throw new Error(`${build.profile} output does not match certification`);
+  if (!WebAssembly.validate(Uint8Array.from(output))) {
+    throw new Error(`${profile} output does not validate`);
   }
-  if (build.profile === "off") offOutputSha256 = build.outputSha256;
-  if (build.profile === "cursorParty") allocatorModule = output;
+  const inputSha256 = sha256(predecessor);
+  const outputSha256 = sha256(output);
+  if (profile === "off") offOutputSha256 = outputSha256;
+  if (profile === "cursorParty") allocatorModule = output;
   variants.push({
-    profile: build.profile,
-    inputSha256: build.inputSha256,
-    outputSha256: build.outputSha256,
+    profile,
+    inputSha256,
+    outputSha256,
   });
 }
 if (!allocatorModule || !offOutputSha256) {
@@ -133,19 +149,14 @@ if (!allocatorModule || !offOutputSha256) {
 
 const selectionScratch = await mkdtemp(join(tmpdir(), "gwonmac-4gb-selection-"));
 try {
-  const officialJsPath = join(selectionScratch, "official", "Gw.jspi.js");
-  const officialWasmPath = join(selectionScratch, "official", "Gw.jspi.wasm");
-  await mkdir(join(selectionScratch, "official"), { recursive: true });
-  await Promise.all([
-    writeFile(officialJsPath, officialJs),
-    writeFile(officialWasmPath, officialWasm),
-  ]);
+  const officialJsPath = jsPath;
+  const officialWasmPath = wasmPath;
   const officialSha256 = sha256(officialWasm);
   const selected = await prepareClientModule({
     officialJsPath,
     officialWasmPath,
     officialSha256,
-    certification: certifyClientBuild(officialSha256),
+    certification: certificationFromLocalVerification(verification),
     enhancementCapabilities: {
       nativeCursor: false,
       targetObservation: false,
@@ -160,11 +171,12 @@ try {
     nativeDoubleClickCacheRoot: join(selectionScratch, "double-click"),
     extendedMemoryCacheRoot: join(selectionScratch, "extended-memory"),
     extendedMemoryEnabled: true,
-  });
+  }, async ({ wasmPath: candidatePath }) =>
+    deriveNativeDoubleClickBuild(await readFile(candidatePath)), verifyExtendedMemory);
   if (
     selected.extendedMemory.status !== "active"
     || selected.extendedMemory.profile !== "off"
-    || sha256(await readFile(selected.jsPath)) !== EXTENDED_MEMORY_JS_BUILD.outputSha256
+    || sha256(await readFile(selected.jsPath)) !== jsOutputSha256
     || sha256(await readFile(selected.wasmPath))
       !== offOutputSha256
   ) throw new Error("production client selection did not publish the certified pair");
@@ -205,14 +217,14 @@ state.memory = memory;
 const allocationBytes = 480 * 1_024 * 1_024;
 const pointers: number[] = [];
 let highPointer: number | undefined;
-for (let index = 0; index < 6; index += 1) {
+for (let index = 0; index < 7; index += 1) {
   const raw = exports.malloc(allocationBytes);
   if (raw === 0) throw new Error(`allocation ${index + 1} failed`);
   pointers.push(raw);
   if ((raw >>> 0) >= 0x8000_0000) highPointer ??= raw;
 }
-if (highPointer === undefined || memory.buffer.byteLength <= 0x8000_0000) {
-  throw new Error("allocator did not cross 2 GiB");
+if (highPointer === undefined || memory.buffer.byteLength <= 0xc000_0000) {
+  throw new Error("allocator did not grow above 3 GiB");
 }
 
 const highAddress = highPointer >>> 0;
@@ -230,11 +242,12 @@ if (reused === 0 || memory.buffer.byteLength !== capacityBeforeFree) {
 exports.free(reused);
 
 console.log(JSON.stringify({
-  jsInputSha256: EXTENDED_MEMORY_JS_BUILD.inputSha256,
-  jsOutputSha256: EXTENDED_MEMORY_JS_BUILD.outputSha256,
+  jsInputSha256,
+  jsOutputSha256,
+  normalizedJsSha256: EXTENDED_MEMORY_JS_PROOF.normalizedSha256,
   variants,
   heapBytes: capacityBeforeFree,
   highPointerUnsigned: highAddress,
-  crossed2GiB: true,
+  crossed3GiB: true,
   freedBlockReusedWithoutGrowth: true,
 }, null, 2));

--- a/src/main/certification/client-module.ts
+++ b/src/main/certification/client-module.ts
@@ -13,6 +13,7 @@
  */
 import {
   ENHANCEMENT_CAPABILITY_PROFILES,
+  enhancementCapabilityProfile,
   enhancementCapabilitiesForProfile,
   enhancementCapabilitiesRequested,
   intersectEnhancementCapabilities,
@@ -51,6 +52,7 @@ import {
   EXTENDED_MEMORY_MAX_BYTES,
   prepareExtendedMemoryArtifacts,
   type ExtendedMemoryProfile,
+  type ExtendedMemoryStructuralProof,
 } from "./extended-memory.js";
 
 /**
@@ -315,6 +317,12 @@ export async function prepareClientModule(
     wasmPath: string;
     inputSha256: string;
   }) => Promise<NativeDoubleClickBuild | null> = async () => null,
+  verifyUnknownExtendedMemory: (options: {
+    jsPath: string;
+    jsInputSha256: string;
+    wasmPath: string;
+    wasmInputSha256: string;
+  }) => Promise<ExtendedMemoryStructuralProof | null> = async () => null,
 ): Promise<PreparedClientModule> {
   const prepared = await withNativeDoubleClick(
     await prepareCertifiedChain(options),
@@ -331,8 +339,11 @@ export async function prepareClientModule(
   try {
     const extended = await prepareExtendedMemoryArtifacts(
       options.officialJsPath,
+      options.officialWasmPath,
       prepared.wasmPath,
+      enhancementCapabilityProfile(prepared.effectiveCapabilities) ?? "off",
       options.extendedMemoryCacheRoot,
+      verifyUnknownExtendedMemory,
     );
     return extended
       ? {

--- a/src/main/certification/enhancement-builds.ts
+++ b/src/main/certification/enhancement-builds.ts
@@ -40,45 +40,45 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
       // ENHANCEMENT_TRANSFORM_ABI or any config word changes.
       outputSha256: Object.freeze({
         cursor:
-          "ff933198b990083b7318bf93e09e7edf052aa2fc4aba1b0a544238a80bfdf8fa",
+          "e1122d8128c482bb70dd86ded6ca28d49256999899a2d492971f6e0173b4e758",
         target:
-          "094d504377bfb90efb2a1cc4a29cbf129fc3113d1b1900d53b786dd9d0392ea5",
+          "e954703ee701260194dc677c10ae9dc7f0229ac4734beabdc7b34464f1591e36",
         cursorTarget:
-          "90d18263253dce61edc09b00f1c935ac2f12a0705ce9f4e5d8ff8b21f180e249",
+          "2b6bfa11cbfc19a6dfb2f24de2fc9568d6ee3fcbd8e95c18fee576532e1aff1d",
         party:
-          "7c31b9222d6e0cb4f169b297b9260e42ab2e342ae61577cfcaeac85fa00d0f50",
+          "3710b2721f9758aad0c7158d86804f62818c7c5215ea0777c29ef2e2c6e9ee39",
         cursorParty:
-          "2b031e5c3f583a0d040eae1a082d60ef98dc566814c89673f59b371fdeda7af6",
+          "5540ea16565a2ed586a5e5556b58194b4f586337694c3f2c66bb63b01aec08f1",
         targetParty:
-          "7ab9daa70ecbac8c837a1406529ae23fbbc74649b71fce42cbe17f3278e168f3",
+          "e60119e58bdeb87109dfc715935eeb2fbe33a3906173d05f74678f7cdcebe32a",
         cursorTargetParty:
-          "483013e5a7160f403bb14a8feb8837b9ed1ae30e0d480f3be09e1590d5dd6efa",
+          "4e880853ea9f37cebb923b008b30b6e5bd2da657c8976b5129dd39698f91f397",
         partyCommands:
-          "b254187358d7e86e8476fbfc799d3900c06e12de079892d4e8f9f9162af6e92f",
+          "ec8431fe028151439b8e09e8fe171facb01ab28842f9f0175c1739f26f8b185c",
         cursorPartyCommands:
-          "58a913958ffc36375ad9c82c5d658269287b93ee965688b5fe7325c7dcfc8b5e",
+          "28ec655aa68bc3fb5df4337be1421893715f4b7379bde8955b23a64ed922e6e6",
         targetPartyCommands:
-          "98acd48ed441c3a6dcf0b2201f10baf757527051b245659b621e57c90a5b6374",
+          "fc2a879e1cb2ec6020f72a96136442b7cdbedbf3891767a31ac8298cad79c98a",
         cursorTargetPartyCommands:
-          "bfe923af52a66b9d579ff6157d52d579327c30ff8c9cab9a0d56cd37d743f77f",
+          "52d1cca841a68be0179aeceab1f749c8873f51e7c056dfed354d2ededbdf306d",
         storage:
-          "596eb73ce9d087891d6f28706091b53e8958a806ece24d1accd67015a774dbb1",
+          "2e29d4af024f6e05bc017b6cdc2363b071e9fee9c6548be78623bc9f046a59b3",
         partyStorage:
-          "b7d480740e68739cf829807c302955e1408fc08c22bf0677d33887c25d68fec8",
+          "ed8eedf6d75878c77c99aca898d72931d9ff7e2f5d566d56e15fccc0bf03052c",
         cursorPartyStorage:
-          "603af439da0bf2e32fd4dc86d62df17488ecfb916ab3e262e4a82fe14d7bab13",
+          "d83360909ff5a1d30f204189be9e01c615f471714c500a1af3dc9f20b5d5a91d",
         targetPartyStorage:
-          "75156a5ee8bf36153bf79b846ce6dbd8b23de9daf3f59caba6f34a80b8334a88",
+          "bcc5ecb2ff83fcda0fc406b735328e34c3a9d72d16a0ed168ca8190e35b86c3a",
         cursorTargetPartyStorage:
-          "9fbd0650ffed617637fc9dec52dc08c38de0c5bd21e05716260325c0e23f96e9",
+          "829845f4c8aba0fd747ee8f2b9223a3da5c2769d73e2689c06943096339e3fe7",
         partyCommandsStorage:
-          "fd04467165fbd80f2f8ef089f9453068f8242f8d30e459168a329b133b7d59fc",
+          "37bb6d011d76c4070b39f980bdfaeeaac640a0ab33b63dcdf99c91eeaf364f82",
         cursorPartyCommandsStorage:
-          "6c0d21e7fb5cd574187289ab28d6e2fd53ec5509d49c13e6170aa859f720d3a2",
+          "b5d8dc42e540a8fc0c39b3c22e2fecd7da213b0904108f8fa5bca72981cc006f",
         targetPartyCommandsStorage:
-          "33594cef21497fbdcc38455e4eafbf7bc37a1cb154a31890d92a0441cc3e1195",
+          "1871c89305a5cdc14d83d6e0337c194549707c71599cd1543869bd2c7d50bf44",
         cursorTargetPartyCommandsStorage:
-          "e9344c0c274eae0a0d652d212aa029f0a9866446c99f9df48215506c9c594ea2",
+          "5ec27d6b0ecdf928ff74113fcee052bcbc1b185e098c9d422528bb06e59e9511",
       }),
       programId: 1,
       // Function #477 returns 38,833 as a single i32 constant. The same function

--- a/src/main/certification/extended-memory.ts
+++ b/src/main/certification/extended-memory.ts
@@ -1,14 +1,25 @@
 /**
- * Opt-in 4 GiB research profile for exact, reproducible ArenaNet derivatives.
+ * Opt-in 4 GiB profile for structurally equivalent ArenaNet generations.
  *
  * This is one paired transform. wasm32 addresses above 2 GiB arrive in
  * JavaScript as negative i32 values, so publishing the larger WASM memory
- * without the matching unsigned-pointer glue is never allowed.
+ * without the matching unsigned-pointer glue is never allowed. The installed
+ * manifest binds that glue to its official WASM generation; the isolated proof
+ * then checks every audited conversion before Main repeats the transform.
  */
 import { createHash } from "node:crypto";
 import { mkdir, readFile, rm, stat } from "node:fs/promises";
 import path from "node:path";
+import {
+  ENHANCEMENT_CAPABILITY_PROFILES,
+  type EnhancementCapabilityProfile,
+} from "../../shared/enhancement-contracts.js";
 import { writeAtomic, writeAtomicJson } from "../core/atomic-file.js";
+import {
+  readPublishedClientManifest,
+  verifyPublishedClientArtifacts,
+} from "../core/published-client.js";
+import { clientManifestPath } from "../core/paths.js";
 import {
   concat,
   encodeSection,
@@ -21,102 +32,20 @@ import {
 
 declare const WebAssembly: { validate(bytes: Uint8Array): boolean };
 
-export const EXTENDED_MEMORY_TRANSFORM_ABI = 1;
+export const EXTENDED_MEMORY_TRANSFORM_ABI = 2;
 export const EXTENDED_MEMORY_MAX_PAGES = 65_535;
 export const EXTENDED_MEMORY_MAX_BYTES = EXTENDED_MEMORY_MAX_PAGES * 65_536;
-export const EXTENDED_MEMORY_PROFILES = [
+export const EXTENDED_MEMORY_PROFILES = Object.freeze([
   "off",
-  "cursor",
-  "target",
-  "cursorTarget",
-  "party",
-  "cursorParty",
-  "targetParty",
-  "cursorTargetParty",
-  "partyCommands",
-  "cursorPartyCommands",
-  "targetPartyCommands",
-  "cursorTargetPartyCommands",
-  "storage",
-  "partyStorage",
-  "cursorPartyStorage",
-  "targetPartyStorage",
-  "cursorTargetPartyStorage",
-  "partyCommandsStorage",
-  "cursorPartyCommandsStorage",
-  "targetPartyCommandsStorage",
-  "cursorTargetPartyCommandsStorage",
-] as const;
-export type ExtendedMemoryProfile = (typeof EXTENDED_MEMORY_PROFILES)[number];
+  ...Object.keys(ENHANCEMENT_CAPABILITY_PROFILES),
+] as ("off" | EnhancementCapabilityProfile)[]);
+export type ExtendedMemoryProfile = "off" | EnhancementCapabilityProfile;
 
-export interface ExtendedMemoryWasmBuild {
-  readonly buildId: 38_797 | 38_833;
-  readonly profile: ExtendedMemoryProfile;
-  readonly inputSha256: string;
-  readonly outputSha256: string;
-}
-
-type ExtendedMemoryRow = readonly [
-  profile: Exclude<ExtendedMemoryProfile, "off">,
-  inputSha256: string,
-  outputSha256: string,
-];
-
-function rows(
-  buildId: ExtendedMemoryWasmBuild["buildId"],
-  entries: readonly ExtendedMemoryRow[],
-): readonly ExtendedMemoryWasmBuild[] {
-  return entries.map(([profile, inputSha256, outputSha256]) => Object.freeze({
-    buildId,
-    profile,
-    inputSha256,
-    outputSha256,
-  }));
-}
-
-/** Every post-double-click variant the current production chain can emit. */
-export const EXTENDED_MEMORY_WASM_BUILDS: readonly ExtendedMemoryWasmBuild[] =
-  Object.freeze([
-    Object.freeze({
-      buildId: 38_797 as const,
-      profile: "off" as const,
-      inputSha256: "e7d86cfcf7b09abbedd3afca758dbf4a3f3c6e1aa4d44e53b31e45e886d7f250",
-      outputSha256: "862f97fc87267e3b4d342ea01f15834cc60a7be982fd9741cf0ae31b8a18a00b",
-    }),
-    Object.freeze({
-      buildId: 38_833 as const,
-      profile: "off" as const,
-      inputSha256: "eeeb4b70edbba53d5ee98a50dbba395dd175e8eebdd3e3bf93f8f9fcfa428a7b",
-      outputSha256: "99ac8364243d7755ad0869b6a4b0edc00e8037823d0cea2e560ffc5edeb1bda4",
-    }),
-    ...rows(38_833, [
-      ["cursor", "ddf3bbc72299bf6e06e55e22248681e90eae93b80b560cf9a821650b420bddbb", "20754c8cf5f06475408a3b0232ed470a56df2e7e2613c120cea8dfa5fff61342"],
-      ["target", "cd0f6854903ff49e356f4c600f3dfd821472e901119e8d9986f81b1fd8ad4991", "16d74f3379591866f0c4d45485937f0a042b36cdf49ceee2621728e81cc6d63a"],
-      ["cursorTarget", "0582a836960b76d001871690ba3f28b720a7087ce4274fc9f0030e455010fdf5", "b9e7136d0dafd753b2911d93a31d4802490604db4449c66c4d89df9a09dbc6e0"],
-      ["party", "e11f644ae081698e9f24e53ad68a0606bdcbcf3bf54d4bdd9751db3b098223ee", "404a679073821971f687d1437c04d0ec73bbcf7c56778786024bce7dbecd96f5"],
-      ["cursorParty", "77c4ce9b579c451ef27a48fe889ff4e137267ea8c75f3ebaf832b9679fab2937", "a83c4261ebbdb7076b1772585d5059a551f8f15f6fd888b5854d2fcd7f39571e"],
-      ["targetParty", "8d6e2fac4cb99459b139f9f29ed608973eec6c189e210d7d62fe5bdd8f3b05f6", "424f1bd263006d8dab544b0fd07f0402d482df7ebfdc466c9a22cf333a7ed5e9"],
-      ["cursorTargetParty", "b93ea4cf880024c74324bbc24b468533539ae6c7dd284018a91d6a8bc000393b", "59b6bba939df57d7d4efb32b79717bef75a84ecefa5c0352d5940955f7b87f45"],
-      ["partyCommands", "bf8dfec78038f79e93b8d85e416f6bc0b95bd69b1bbad98fa40e8d74fb063b6e", "6010a866dd572e419cf0a815d01435bc9d84cf30dfc1a59e338f4b9d5b4bea5b"],
-      ["cursorPartyCommands", "b7384d00dcfd5245d3e329901f3875088bba3bb33ea27dc36e89e13e2e2122f7", "1e4e37044d98c8bb1d3819aecd38cf8c567e6a5bd3381ad1c56caf209ef221ae"],
-      ["targetPartyCommands", "03287bd899c7247006fb7ccbee1b6c51841aacef24d1631062b096f70eecd650", "99c28c2d22f9e0eae5fa58f60df65b592373e738ebb48929b4ffd87e35b6f2e1"],
-      ["cursorTargetPartyCommands", "78e5d183071ddd9e6fc83611058e96d61ac2b630bbd8a42bc8b35a6a06adc620", "a1b2eb4fab238524fe9eb0e39f8a1fce28a91d0aaf918c0d96ba9004db137209"],
-      ["storage", "89cb4e6d802e99dc3b40f6cb0fc0f8e56da471574a726bbcffe222e1af836d28", "103fc4f309d3ecd6eba6ad4593ec537583f922fdd49770a18b24170ba4585270"],
-      ["partyStorage", "e32e1cf2225666e86413df9555550bf697f820ec5951c49044555d82fd22dfad", "10a694d1c20e20ae86f4dda02c98daef1233df0dee1aac05d87448439eec2980"],
-      ["cursorPartyStorage", "515e579f2892ae8ce6d6eaea9445642e018337024ad921c61b09c00afa10fa0e", "58495dee230de14fac572660dd33a0deb4de20cd1e8f2abba701ae4247859b8a"],
-      ["targetPartyStorage", "4319456e9b9759a837f099fecad05502aa9060e20a0bfd037a254227e1b6bd68", "48a31dd10f6385f25ecb67ce441fee9dd5b8a3c0ca2aff7020f2a6ac49676eb9"],
-      ["cursorTargetPartyStorage", "8e3702861e38dfd67099a5f2b69ff60927bc2edde14875c2e51d12fd95aff869", "d97fd566136d9dc000b70bd7f2e59447da592461c4a182e9160e2bef335ca0c2"],
-      ["partyCommandsStorage", "12ac351d160721eab874dc8243a0887dbc4ed5b54f38d4df6f01dbf8c7417bf9", "6316583221d4c2990d2db2e5d545b09675349d35edc83aa724a353dbbeefbfc7"],
-      ["cursorPartyCommandsStorage", "850801fb84893e257dc9214d681628793aca2e61194cf81516f408ec05e2077a", "abb5270a621c70f73abef167f9041d1c922cf5e7fd2720da278c41d871f9d0ce"],
-      ["targetPartyCommandsStorage", "26bcee5c721a4fa6bea809008af35b9cd762a530eb8595fa8b53f0d6f8c3aef2", "638560bd09d8267511b9f18a82408729deb4de6a1eeb9926ef1ff7e9859c95f6"],
-      ["cursorTargetPartyCommandsStorage", "8b4bc57bd679144a34b00d2c1bd30eab5b4e290c261ad73c7d47ea20202d5024", "64f5808bca1dfc2b4d492be9e8e9c03cde222813960afc172661f2c03cd0ce54"],
-    ]),
-  ]);
-
-export const EXTENDED_MEMORY_JS_BUILD = Object.freeze({
-  buildId: 38_797,
-  inputSha256: "58ecc6377397f01919d8def58e802e19fbfd6ce13f421dbf14123a667e34f7d0",
-  outputSha256: "1dd5d798b1491f46a7c128c641053c8488211bbc193fe40bdf1d7a886517993d",
+/** Exact generated-glue semantics, with only relocatable ASM_CONSTS keys erased. */
+export const EXTENDED_MEMORY_JS_PROOF = Object.freeze({
+  asmConstCount: 59,
+  normalizedSha256:
+    "5ce37be431dfc71f1cef5294ffc112953faaffe22f09d0dd7b07ae7f40bc1db8",
 });
 
 const sha256 = (bytes: Uint8Array | string): string =>
@@ -139,15 +68,7 @@ function replaceExactly(
   return parts.join(replacement);
 }
 
-export function findExtendedMemoryWasmBuild(
-  inputSha256: string,
-): ExtendedMemoryWasmBuild | null {
-  return EXTENDED_MEMORY_WASM_BUILDS.find(
-    (build) => build.inputSha256 === inputSha256,
-  ) ?? null;
-}
-
-/** Derive the candidate bytes; callers still need an exact input/output certificate. */
+/** Derive the candidate bytes from the sole exact memory declaration. */
 export function deriveExtendedMemoryWasm(input: Uint8Array): Uint8Array {
   const sections = splitSections(input);
   const memory = sections.find((section) => section.id === 5)
@@ -176,13 +97,36 @@ export function deriveExtendedMemoryWasm(input: Uint8Array): Uint8Array {
   return output;
 }
 
-/** Raise the sole defined memory from 32,768 to 65,535 pages. */
+/** Raise only the sole defined memory from 32,768 to 65,535 pages. */
 export function rewriteExtendedMemoryWasm(input: Uint8Array): Uint8Array {
-  const build = findExtendedMemoryWasmBuild(sha256(input));
-  if (!build) fail("uncertified WASM input");
-  const output = deriveExtendedMemoryWasm(input);
-  if (sha256(output) !== build.outputSha256) fail("derived WASM hash changed");
-  return output;
+  return deriveExtendedMemoryWasm(input);
+}
+
+/**
+ * Erases only the numeric keys ArenaNet's linker assigns to ASM_CONSTS.
+ * Function bodies, order, whitespace, counts and all pointer expressions stay
+ * byte-for-byte significant.
+ */
+export function normalizeExtendedMemoryJsForProof(input: string): string | null {
+  const startMarker = "var ASM_CONSTS = {\r\n";
+  const endMarker = "\r\n};\r\nfunction __asyncjs__";
+  const start = input.indexOf(startMarker);
+  const end = input.indexOf(endMarker, start + startMarker.length);
+  if (
+    start < 0 || end < 0
+    || input.indexOf(startMarker, start + startMarker.length) !== -1
+    || input.indexOf(endMarker, end + endMarker.length) !== -1
+  ) return null;
+  let count = 0;
+  const normalizedBlock = input.slice(start, end).replace(
+    /^(\s*)\d+: /gm,
+    (_whole, whitespace: string) => {
+      count += 1;
+      return `${whitespace}<asm-const-key>: `;
+    },
+  );
+  if (count !== EXTENDED_MEMORY_JS_PROOF.asmConstCount) return null;
+  return input.slice(0, start) + normalizedBlock + input.slice(end);
 }
 
 /**
@@ -191,8 +135,12 @@ export function rewriteExtendedMemoryWasm(input: Uint8Array): Uint8Array {
  * input; this function never accepts an arbitrary script.
  */
 export function rewriteExtendedMemoryJs(input: string): string {
-  if (sha256(input) !== EXTENDED_MEMORY_JS_BUILD.inputSha256) {
-    fail("uncertified JavaScript input");
+  const normalized = normalizeExtendedMemoryJsForProof(input);
+  if (
+    normalized === null
+    || sha256(normalized) !== EXTENDED_MEMORY_JS_PROOF.normalizedSha256
+  ) {
+    fail("JavaScript glue semantics changed");
   }
   let output = replaceExactly(input, "      2147483648;", "      4294901760;", 1);
   output = replaceExactly(
@@ -266,10 +214,42 @@ export function rewriteExtendedMemoryJs(input: string): string {
     "Module.image.readAsync(imageId, offset, null, buffer >>> 0, bytes)",
     2,
   );
-  if (sha256(output) !== EXTENDED_MEMORY_JS_BUILD.outputSha256) {
-    fail("derived JavaScript hash changed");
-  }
   return output;
+}
+
+export interface ExtendedMemoryStructuralProof {
+  readonly jsInputSha256: string;
+  readonly jsOutputSha256: string;
+  readonly wasmInputSha256: string;
+  readonly wasmOutputSha256: string;
+}
+
+/** Pure structural proof used inside the bounded utility process. */
+export function deriveExtendedMemoryStructuralProof(
+  jsInput: string,
+  wasmInput: Uint8Array,
+): ExtendedMemoryStructuralProof {
+  return Object.freeze({
+    jsInputSha256: sha256(jsInput),
+    jsOutputSha256: sha256(rewriteExtendedMemoryJs(jsInput)),
+    wasmInputSha256: sha256(wasmInput),
+    wasmOutputSha256: sha256(rewriteExtendedMemoryWasm(wasmInput)),
+  });
+}
+
+export function isExtendedMemoryStructuralProof(
+  value: unknown,
+  jsInputSha256: string,
+  wasmInputSha256: string,
+): value is ExtendedMemoryStructuralProof {
+  if (!value || typeof value !== "object") return false;
+  const proof = value as Partial<ExtendedMemoryStructuralProof>;
+  return proof.jsInputSha256 === jsInputSha256
+    && proof.wasmInputSha256 === wasmInputSha256
+    && typeof proof.jsOutputSha256 === "string"
+    && /^[0-9a-f]{64}$/.test(proof.jsOutputSha256)
+    && typeof proof.wasmOutputSha256 === "string"
+    && /^[0-9a-f]{64}$/.test(proof.wasmOutputSha256);
 }
 
 export interface ExtendedMemoryArtifacts {
@@ -280,6 +260,7 @@ export interface ExtendedMemoryArtifacts {
 
 interface ExtendedMemoryMetadata {
   abi?: unknown;
+  generationFingerprint?: unknown;
   jsInputSha256?: unknown;
   jsOutputSha256?: unknown;
   wasmInputSha256?: unknown;
@@ -287,15 +268,24 @@ interface ExtendedMemoryMetadata {
   profile?: unknown;
 }
 
+interface ExtendedMemoryProof {
+  readonly generationFingerprint: string;
+  readonly jsInputSha256: string;
+  readonly jsOutputSha256: string;
+  readonly wasmInputSha256: string;
+  readonly wasmOutputSha256: string;
+  readonly profile: ExtendedMemoryProfile;
+}
+
 function artifactPaths(
   cacheRoot: string,
-  build: ExtendedMemoryWasmBuild,
+  proof: ExtendedMemoryProof,
 ): Omit<ExtendedMemoryArtifacts, "profile"> & {
   readonly cacheDir: string;
   readonly metadataPath: string;
 } {
   const identity = sha256(
-    `${EXTENDED_MEMORY_JS_BUILD.inputSha256}:${build.inputSha256}`,
+    `${proof.generationFingerprint}:${proof.profile}:${proof.jsInputSha256}:${proof.wasmInputSha256}`,
   );
   const cacheDir = path.join(cacheRoot, identity, String(EXTENDED_MEMORY_TRANSFORM_ABI));
   return {
@@ -312,20 +302,21 @@ async function fileSha256(filePath: string): Promise<string> {
 
 async function usable(
   cacheRoot: string,
-  build: ExtendedMemoryWasmBuild,
+  proof: ExtendedMemoryProof,
 ): Promise<boolean> {
-  const files = artifactPaths(cacheRoot, build);
+  const files = artifactPaths(cacheRoot, proof);
   try {
     const metadata = JSON.parse(
       await readFile(files.metadataPath, "utf8"),
     ) as ExtendedMemoryMetadata;
     if (
       metadata.abi !== EXTENDED_MEMORY_TRANSFORM_ABI
-      || metadata.jsInputSha256 !== EXTENDED_MEMORY_JS_BUILD.inputSha256
-      || metadata.jsOutputSha256 !== EXTENDED_MEMORY_JS_BUILD.outputSha256
-      || metadata.wasmInputSha256 !== build.inputSha256
-      || metadata.wasmOutputSha256 !== build.outputSha256
-      || metadata.profile !== build.profile
+      || metadata.generationFingerprint !== proof.generationFingerprint
+      || metadata.jsInputSha256 !== proof.jsInputSha256
+      || metadata.jsOutputSha256 !== proof.jsOutputSha256
+      || metadata.wasmInputSha256 !== proof.wasmInputSha256
+      || metadata.wasmOutputSha256 !== proof.wasmOutputSha256
+      || metadata.profile !== proof.profile
     ) return false;
     const [jsStat, wasmStat, jsHash, wasmHash] = await Promise.all([
       stat(files.jsPath),
@@ -334,38 +325,101 @@ async function usable(
       fileSha256(files.wasmPath),
     ]);
     return jsStat.isFile() && wasmStat.isFile()
-      && jsHash === EXTENDED_MEMORY_JS_BUILD.outputSha256
-      && wasmHash === build.outputSha256;
+      && jsHash === proof.jsOutputSha256
+      && wasmHash === proof.wasmOutputSha256;
   } catch {
     return false;
   }
 }
 
+async function verifiedGenerationFingerprint(
+  officialJsPath: string,
+  officialWasmPath: string,
+): Promise<string | null> {
+  const artifactsDir = path.dirname(officialJsPath);
+  if (
+    path.dirname(officialWasmPath) !== artifactsDir
+    || path.basename(officialJsPath) !== "Gw.jspi.js"
+    || path.basename(officialWasmPath) !== "Gw.jspi.wasm"
+  ) return null;
+  try {
+    const manifest = await readPublishedClientManifest(
+      clientManifestPath(artifactsDir),
+    );
+    return manifest.clientFingerprint
+      && await verifyPublishedClientArtifacts(artifactsDir, manifest) === true
+      ? manifest.clientFingerprint
+      : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
- * Atomically selects a certified JS/WASM pair. `null` means this exact pair is
- * unsupported and both official artifacts must be served unchanged.
+ * Atomically selects a proved JS/WASM pair. `null` means the pair is unsupported
+ * and both official artifacts must be served unchanged.
  */
 export async function prepareExtendedMemoryArtifacts(
   officialJsPath: string,
+  officialWasmPath: string,
   inputWasmPath: string,
+  profile: ExtendedMemoryProfile,
   cacheRoot: string,
+  verifyUnknown: (options: {
+    jsPath: string;
+    jsInputSha256: string;
+    wasmPath: string;
+    wasmInputSha256: string;
+  }) => Promise<ExtendedMemoryStructuralProof | null> = async () => null,
 ): Promise<ExtendedMemoryArtifacts | null> {
-  const [jsInput, wasmInput] = await Promise.all([
+  const [generationFingerprint, jsInput, wasmInput] = await Promise.all([
+    verifiedGenerationFingerprint(officialJsPath, officialWasmPath),
     readFile(officialJsPath, "utf8"),
     readFile(inputWasmPath),
   ]);
-  const build = findExtendedMemoryWasmBuild(sha256(wasmInput));
-  if (sha256(jsInput) !== EXTENDED_MEMORY_JS_BUILD.inputSha256 || !build) {
+  if (!generationFingerprint || !EXTENDED_MEMORY_PROFILES.includes(profile)) {
     await rm(cacheRoot, { recursive: true, force: true });
     return null;
   }
-  const files = artifactPaths(cacheRoot, build);
-  if (await usable(cacheRoot, build)) {
-    return { jsPath: files.jsPath, wasmPath: files.wasmPath, profile: build.profile };
+  const jsInputSha256 = sha256(jsInput);
+  const wasmInputSha256 = sha256(wasmInput);
+  const structural = await verifyUnknown({
+    jsPath: officialJsPath,
+    jsInputSha256,
+    wasmPath: inputWasmPath,
+    wasmInputSha256,
+  });
+  if (!isExtendedMemoryStructuralProof(
+    structural,
+    jsInputSha256,
+    wasmInputSha256,
+  )) {
+    await rm(cacheRoot, { recursive: true, force: true });
+    return null;
+  }
+  let jsOutput: string;
+  let wasmOutput: Uint8Array;
+  try {
+    jsOutput = rewriteExtendedMemoryJs(jsInput);
+    wasmOutput = rewriteExtendedMemoryWasm(wasmInput);
+  } catch {
+    await rm(cacheRoot, { recursive: true, force: true });
+    return null;
+  }
+  if (
+    sha256(jsOutput) !== structural.jsOutputSha256
+    || sha256(wasmOutput) !== structural.wasmOutputSha256
+  ) fail("production transform disagrees with isolated proof");
+  const proof: ExtendedMemoryProof = Object.freeze({
+    generationFingerprint,
+    ...structural,
+    profile,
+  });
+  const files = artifactPaths(cacheRoot, proof);
+  if (await usable(cacheRoot, proof)) {
+    return { jsPath: files.jsPath, wasmPath: files.wasmPath, profile };
   }
 
-  const jsOutput = rewriteExtendedMemoryJs(jsInput);
-  const wasmOutput = rewriteExtendedMemoryWasm(wasmInput);
   await rm(cacheRoot, { recursive: true, force: true });
   await mkdir(files.cacheDir, { recursive: true });
   await Promise.all([
@@ -374,14 +428,10 @@ export async function prepareExtendedMemoryArtifacts(
   ]);
   await writeAtomicJson(files.metadataPath, {
     abi: EXTENDED_MEMORY_TRANSFORM_ABI,
-    jsInputSha256: EXTENDED_MEMORY_JS_BUILD.inputSha256,
-    jsOutputSha256: EXTENDED_MEMORY_JS_BUILD.outputSha256,
-    wasmInputSha256: build.inputSha256,
-    wasmOutputSha256: build.outputSha256,
-    profile: build.profile,
+    ...proof,
   });
-  if (!await usable(cacheRoot, build)) {
+  if (!await usable(cacheRoot, proof)) {
     fail("published artifact pair failed verification");
   }
-  return { jsPath: files.jsPath, wasmPath: files.wasmPath, profile: build.profile };
+  return { jsPath: files.jsPath, wasmPath: files.wasmPath, profile };
 }

--- a/src/main/certification/local-client-verifier-host.ts
+++ b/src/main/certification/local-client-verifier-host.ts
@@ -2,8 +2,8 @@
  * Runs the local client proof and owns everything the proof itself may not:
  * the bounded child process and its timeout.
  *
- * The child gets the proof mode, module path, and hash it must match, and
- * nothing else.
+ * The child gets the proof mode plus only the artifact paths and hashes that
+ * proof needs.
  * A result is accepted only if it arrives from this launch's process and
  * survives `isLocalClientVerification` against that same hash. Profile state is
  * never certification authority, so every unknown exact hash runs the proof.
@@ -25,6 +25,10 @@ import {
   enhancementCapabilityProfile,
   type EnhancementCapabilities,
 } from "../../shared/enhancement-contracts.js";
+import {
+  isExtendedMemoryStructuralProof,
+  type ExtendedMemoryStructuralProof,
+} from "./extended-memory.js";
 
 const VERIFIER_TIMEOUT_MS = 5_000;
 
@@ -94,6 +98,47 @@ function runNativeDoubleClickVerifierProcess(
   });
 }
 
+function runExtendedMemoryVerifierProcess(options: {
+  jsPath: string;
+  jsInputSha256: string;
+  wasmPath: string;
+  wasmInputSha256: string;
+}): Promise<ExtendedMemoryStructuralProof | null> {
+  return new Promise((resolve) => {
+    const entry = fileURLToPath(
+      new URL("./local-client-verifier-process.js", import.meta.url),
+    );
+    const child = utilityProcess.fork(
+      entry,
+      [
+        "extended-memory",
+        options.jsPath,
+        options.jsInputSha256,
+        options.wasmPath,
+        options.wasmInputSha256,
+      ],
+      { serviceName: "Guild Wars extended-memory verifier" },
+    );
+    let settled = false;
+    const finish = (value: ExtendedMemoryStructuralProof | null): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      child.kill();
+      resolve(value);
+    };
+    const timeout = setTimeout(() => finish(null), VERIFIER_TIMEOUT_MS);
+    child.once("message", (value: unknown) => finish(
+      isExtendedMemoryStructuralProof(
+        value,
+        options.jsInputSha256,
+        options.wasmInputSha256,
+      ) ? value : null,
+    ));
+    child.once("exit", () => finish(null));
+  });
+}
+
 /**
  * Runs the expensive parsers outside the main and renderer processes for every
  * unknown exact hash. A crash, timeout or malformed reply is simply "no proof";
@@ -120,4 +165,14 @@ export async function verifyNativeDoubleClickLocally(options: {
     options.wasmPath,
     options.inputSha256,
   ).catch(() => null);
+}
+
+/** Qualifies the manifest-bound 4 GB pair without parsing it in Main. */
+export async function verifyExtendedMemoryLocally(options: {
+  jsPath: string;
+  jsInputSha256: string;
+  wasmPath: string;
+  wasmInputSha256: string;
+}): Promise<ExtendedMemoryStructuralProof | null> {
+  return runExtendedMemoryVerifierProcess(options).catch(() => null);
 }

--- a/src/main/certification/local-client-verifier-process.ts
+++ b/src/main/certification/local-client-verifier-process.ts
@@ -25,6 +25,10 @@ import {
   enhancementCapabilitiesForProfile,
   type EnhancementCapabilities,
 } from "../../shared/enhancement-contracts.js";
+import {
+  deriveExtendedMemoryStructuralProof,
+  isExtendedMemoryStructuralProof,
+} from "./extended-memory.js";
 
 interface ParentPort {
   postMessage(value: unknown): void;
@@ -35,11 +39,42 @@ const parentPort = (
 ).parentPort;
 
 async function main(): Promise<void> {
-  const [mode, wasmPath, expectedSha256, requestedProfile] = process.argv.slice(2);
-  if (!parentPort || !mode || !wasmPath || !expectedSha256) {
+  const [mode, firstPath, firstSha256, secondPath, secondSha256] =
+    process.argv.slice(2);
+  if (!parentPort || !mode || !firstPath || !firstSha256) {
     process.exitCode = 2;
     return;
   }
+
+  if (mode === "extended-memory") {
+    if (!secondPath || !secondSha256) {
+      process.exitCode = 2;
+      return;
+    }
+    const [jsInput, wasmInput] = await Promise.all([
+      readFile(firstPath, "utf8"),
+      readFile(secondPath),
+    ]);
+    const actualJsSha256 = createHash("sha256").update(jsInput).digest("hex");
+    const actualWasmSha256 = createHash("sha256").update(wasmInput).digest("hex");
+    if (actualJsSha256 !== firstSha256 || actualWasmSha256 !== secondSha256) {
+      parentPort.postMessage(null);
+      process.exitCode = 3;
+      return;
+    }
+    const result = deriveExtendedMemoryStructuralProof(jsInput, wasmInput);
+    if (!isExtendedMemoryStructuralProof(result, firstSha256, secondSha256)) {
+      parentPort.postMessage(null);
+      process.exitCode = 4;
+      return;
+    }
+    parentPort.postMessage(result);
+    return;
+  }
+
+  const wasmPath = firstPath;
+  const expectedSha256 = firstSha256;
+  const requestedProfile = secondPath;
 
   const bytes = await readFile(wasmPath);
   const actualSha256 = createHash("sha256").update(bytes).digest("hex");

--- a/src/main/client-runtime.ts
+++ b/src/main/client-runtime.ts
@@ -92,6 +92,7 @@ import {
 import type { GamePaths } from "./paths.js";
 import {
   verifyClientLocally,
+  verifyExtendedMemoryLocally,
   verifyNativeDoubleClickLocally,
 } from "./certification/local-client-verifier-host.js";
 import { extendedMemoryRuntimeStatus } from "./extended-memory-runtime.js";
@@ -339,7 +340,7 @@ export class ClientRuntime {
       nativeDoubleClickCacheRoot: this.options.paths.nativeDoubleClick,
       extendedMemoryCacheRoot: this.options.paths.extendedMemory,
       extendedMemoryEnabled: this.options.extendedMemoryEnabled,
-    }, verifyNativeDoubleClickLocally);
+    }, verifyNativeDoubleClickLocally, verifyExtendedMemoryLocally);
     const preparationFailed = prepared.failure?.stage === "enhancement";
     const supported = prepared.enhancementBuild
       ? supportedEnhancementCapabilities(prepared.enhancementBuild)

--- a/tests/electron/fixtures/local-verifier-app/main.mjs
+++ b/tests/electron/fixtures/local-verifier-app/main.mjs
@@ -7,9 +7,19 @@ const hostUrl = new URL(
   "../../../../build/main/certification/local-client-verifier-host.js",
   import.meta.url,
 );
-const { verifyClientLocally, verifyNativeDoubleClickLocally } = await import(hostUrl.href);
+const {
+  verifyClientLocally,
+  verifyExtendedMemoryLocally,
+  verifyNativeDoubleClickLocally,
+} = await import(hostUrl.href);
 
-const [mode, officialWasmPath, officialSha256] = process.argv.slice(-3);
+const extendedArgs = process.argv.slice(-5);
+const compactArgs = process.argv.slice(-3);
+const mode = extendedArgs[0] === "extended-memory"
+  ? extendedArgs[0]
+  : compactArgs[0];
+const officialWasmPath = compactArgs[1];
+const officialSha256 = compactArgs[2];
 if (!mode || !officialWasmPath || !officialSha256) {
   throw new Error("local verifier fixture requires wasm and hash");
 }
@@ -21,7 +31,14 @@ const state = /** @type {{
 state.localVerifierCompleted = false;
 state.localVerifierOutcome = null;
 void app.whenReady().then(async () => {
-  state.localVerifierOutcome = mode === "native-double-click"
+  state.localVerifierOutcome = mode === "extended-memory"
+    ? await verifyExtendedMemoryLocally({
+        jsPath: extendedArgs[1],
+        jsInputSha256: extendedArgs[2],
+        wasmPath: extendedArgs[3],
+        wasmInputSha256: extendedArgs[4],
+      })
+    : mode === "native-double-click"
     ? await verifyNativeDoubleClickLocally({
         wasmPath: officialWasmPath,
         inputSha256: officialSha256,

--- a/tests/electron/input-trace.spec.ts
+++ b/tests/electron/input-trace.spec.ts
@@ -182,13 +182,22 @@ test.describe("input trace", () => {
       await expectTrace(page).toContain('text secret input');
 
       const count = page.locator('#input-trace [data-role="count"]');
-      await page.locator('#input-trace [data-role="pause"]').click();
+      // Pause without generating another traced hardware gesture. A real
+      // pointer click is reported by Main over IPC, so its in-flight entries
+      // can repaint the count after the pause handler has already run and
+      // make this assertion depend on delivery timing instead of pause
+      // behavior.
+      await page.locator('#input-trace [data-role="pause"]').evaluate((button) => {
+        (button as HTMLButtonElement).click();
+      });
       await page.evaluate(() => new Promise<void>((resolve) =>
         requestAnimationFrame(() => requestAnimationFrame(() => resolve()))));
       const beforePause = await count.textContent();
       await page.mouse.click(100, 100);
       expect(await count.textContent()).toBe(beforePause);
-      await page.locator('#input-trace [data-role="pause"]').click();
+      await page.locator('#input-trace [data-role="pause"]').evaluate((button) => {
+        (button as HTMLButtonElement).click();
+      });
 
       await page.evaluate(() => {
         const field = document.getElementById('osk-input-password');

--- a/tests/electron/local-client-verifier.spec.ts
+++ b/tests/electron/local-client-verifier.spec.ts
@@ -96,6 +96,43 @@ test("refuses an unknown native callback inside the isolated process", async () 
   }
 });
 
+test("refuses changed 4 GB glue inside the isolated process", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "gw-extended-memory-verifier-"));
+  const jsPath = path.join(root, "Gw.jspi.js");
+  const wasmPath = path.join(root, "Gw.jspi.wasm");
+  const js = "var getHeapMax = () => 2147483648;";
+  const wasm = Uint8Array.of(0, 97, 115, 109, 1, 0, 0, 0);
+  const digest = (value: Uint8Array | string) =>
+    createHash("sha256").update(value).digest("hex");
+  await Promise.all([writeFile(jsPath, js), writeFile(wasmPath, wasm)]);
+  const env = Object.fromEntries(
+    Object.entries(process.env).filter(
+      (entry): entry is [string, string] =>
+        entry[1] !== undefined && entry[0] !== "ELECTRON_RUN_AS_NODE",
+    ),
+  );
+  const application = await electron.launch({
+    cwd: path.resolve("."),
+    args: [
+      fixture,
+      "extended-memory",
+      jsPath,
+      digest(js),
+      wasmPath,
+      digest(wasm),
+    ],
+    executablePath: electronPath,
+    env,
+  });
+  try {
+    await expect.poll(() => completed(application), { timeout: 10_000 }).toBe(true);
+    expect(await outcome(application)).toBeNull();
+  } finally {
+    await application.close();
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 function completed(application: ElectronApplication): Promise<boolean> {
   return application.evaluate(
     () => Boolean(

--- a/tests/electron/settings-memory.spec.ts
+++ b/tests/electron/settings-memory.spec.ts
@@ -30,7 +30,7 @@ test.describe("extended memory settings", () => {
       const { page } = fixture;
       await expect.poll(() => page.evaluate(async () =>
         (await window.gwNative.client.session()).extendedMemory,
-      )).toMatchObject({
+      ), { timeout: 30_000 }).toMatchObject({
         requestedAtLaunch: true,
         status: "unavailable",
         effectiveCapBytes: 2_147_483_648,

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -13,6 +13,7 @@
 // a real window in tests/electron/sandbox.spec.ts), and the three assertions
 // that still need the compiled build (tests/release/).
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
@@ -756,7 +757,36 @@ test("the website suite runs on its own path-filtered workflow", () => {
   assert.equal(vercel.git?.deploymentEnabled, true);
   assert.equal(
     vercel.ignoreCommand,
-    'if [ -z "$VERCEL_GIT_PREVIOUS_SHA" ]; then exit 1; fi; git diff --quiet "$VERCEL_GIT_PREVIOUS_SHA" HEAD -- . ../../src/shared ../../package.json ../../pnpm-lock.yaml ../../pnpm-workspace.yaml',
+    '[ -n "$VERCEL_GIT_PREVIOUS_SHA" ] || exit 1; git cat-file -e "$VERCEL_GIT_PREVIOUS_SHA" 2>/dev/null || exit 1; git diff --quiet "$VERCEL_GIT_PREVIOUS_SHA" HEAD -- . ../../src/shared ../../package.json ../../pnpm-lock.yaml ../../pnpm-workspace.yaml',
+  );
+  assert.ok(
+    vercel.ignoreCommand.length <= 256,
+    "the root Vercel ignoreCommand schema caps commands at 256 characters",
+  );
+  const head = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: root,
+    encoding: "utf8",
+  });
+  assert.equal(head.status, 0);
+  const runIgnore = (previousSha: string): number | null => spawnSync(
+    "sh",
+    ["-c", vercel.ignoreCommand ?? "exit 2"],
+    {
+      cwd: path.join(root, "apps/website"),
+      env: { ...process.env, VERCEL_GIT_PREVIOUS_SHA: previousSha },
+      stdio: "ignore",
+    },
+  ).status;
+  assert.equal(runIgnore(""), 1, "a first deployment must build");
+  assert.equal(
+    runIgnore("0000000000000000000000000000000000000000"),
+    1,
+    "a rebased-away previous commit must build instead of failing",
+  );
+  assert.equal(
+    runIgnore(head.stdout.trim()),
+    0,
+    "an unchanged website may skip its build",
   );
 });
 

--- a/tests/unit/extended-memory.test.ts
+++ b/tests/unit/extended-memory.test.ts
@@ -1,21 +1,37 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
-  EXTENDED_MEMORY_JS_BUILD,
+  deriveExtendedMemoryWasm,
+  EXTENDED_MEMORY_JS_PROOF,
   EXTENDED_MEMORY_MAX_BYTES,
   EXTENDED_MEMORY_MAX_PAGES,
   EXTENDED_MEMORY_PROFILES,
-  EXTENDED_MEMORY_WASM_BUILDS,
-  findExtendedMemoryWasmBuild,
+  normalizeExtendedMemoryJsForProof,
   rewriteExtendedMemoryJs,
   rewriteExtendedMemoryWasm,
 } from "../../src/main/certification/extended-memory.js";
-import { NATIVE_DOUBLE_CLICK_BUILDS } from "../../src/main/certification/native-double-click.js";
 import {
-  ENHANCEMENT_BUILDS,
-  enhancementProfilesForBuild,
-} from "../../src/main/certification/enhancement-builds.js";
+  ENHANCEMENT_CAPABILITY_PROFILES,
+} from "../../src/shared/enhancement-contracts.js";
+import {
+  concat,
+  encodeSection,
+  splitSections,
+  uleb,
+  WASM_HEADER,
+} from "../../src/main/core/wasm-binary.js";
 import { diagnosticEventRecord } from "../../src/main/diagnostics/schema.js";
+
+function memoryModule(initial = 4_096, maximum = 32_768): Uint8Array {
+  return concat(
+    WASM_HEADER,
+    encodeSection({
+      id: 5,
+      body: concat(uleb(1), uleb(1), uleb(initial), uleb(maximum)),
+    }),
+    encodeSection({ id: 7, body: uleb(0) }),
+  );
+}
 
 describe("certified extended memory transform", () => {
   it("stops one page short of 4 GiB", () => {
@@ -23,56 +39,58 @@ describe("certified extended memory transform", () => {
     assert.equal(EXTENDED_MEMORY_MAX_BYTES, 4_294_901_760);
   });
 
-  it("certifies every post-double-click variant the production chain emits", () => {
-    const expectedProfiles = [
-      "off",
-      ...enhancementProfilesForBuild(ENHANCEMENT_BUILDS[0]!),
-    ].sort();
-    const builds = new Map<number, typeof EXTENDED_MEMORY_WASM_BUILDS[number][]>();
-    for (const build of EXTENDED_MEMORY_WASM_BUILDS) {
-      const entries = builds.get(build.buildId) ?? [];
-      entries.push(build);
-      builds.set(build.buildId, entries);
-    }
-    for (const [buildId, entries] of builds) {
-      const expected = ENHANCEMENT_BUILDS.some((build) => build.buildId === buildId)
-        ? expectedProfiles
-        : ["off"];
-      assert.deepEqual(entries.map((build) => build.profile).sort(), expected);
-    }
-    assert.deepEqual([...EXTENDED_MEMORY_PROFILES].sort(), expectedProfiles);
-    const doubleClickOutputs = new Set(
-      Object.values(NATIVE_DOUBLE_CLICK_BUILDS[0]!.derivations),
-    );
+  it("covers every valid runtime feature profile without a hash cross-product", () => {
     assert.deepEqual(
-      new Set(EXTENDED_MEMORY_WASM_BUILDS.map((build) => build.inputSha256)),
-      doubleClickOutputs,
+      [...EXTENDED_MEMORY_PROFILES].sort(),
+      ["off", ...Object.keys(ENHANCEMENT_CAPABILITY_PROFILES)].sort(),
     );
   });
 
-  it("pins unique exact inputs and outputs", () => {
-    const hashes = [
-      EXTENDED_MEMORY_JS_BUILD.inputSha256,
-      EXTENDED_MEMORY_JS_BUILD.outputSha256,
-      ...EXTENDED_MEMORY_WASM_BUILDS.flatMap((build) => [
-        build.inputSha256,
-        build.outputSha256,
-      ]),
-    ];
-    assert.equal(new Set(hashes).size, hashes.length);
-    for (const hash of hashes) assert.match(hash, /^[0-9a-f]{64}$/);
+  it("normalizes only all 59 ASM_CONSTS keys", () => {
+    const entries = Array.from({ length: 59 }, (_, index) =>
+      `  ${1000 + index}: () => ${index},  `).join("\r\n");
+    const first = `prefix\r\nvar ASM_CONSTS = {\r\n${entries}\r\n};\r\nfunction __asyncjs__tail`;
+    const relocated = first.replace(/^ {2}\d+: /gm, (entry) =>
+      entry.replace(/\d+/, (value) => String(Number(value) + 5000)));
+    assert.equal(
+      normalizeExtendedMemoryJsForProof(first),
+      normalizeExtendedMemoryJsForProof(relocated),
+    );
+    assert.equal(
+      normalizeExtendedMemoryJsForProof(first.replace("() => 12", "() => 13"))
+        === normalizeExtendedMemoryJsForProof(first),
+      false,
+    );
+    assert.match(EXTENDED_MEMORY_JS_PROOF.normalizedSha256, /^[0-9a-f]{64}$/);
   });
 
-  it("refuses unknown JavaScript and WASM before rewriting either", () => {
+  it("refuses changed JavaScript semantics and a changed memory shape", () => {
     assert.throws(
       () => rewriteExtendedMemoryJs("var getHeapMax = () => 2147483648;"),
-      /uncertified JavaScript input/,
+      /JavaScript glue semantics changed/,
     );
     assert.throws(
       () => rewriteExtendedMemoryWasm(Uint8Array.of(0, 97, 115, 109)),
-      /uncertified WASM input/,
+      /memory declaration|unexpected end|invalid/i,
     );
-    assert.equal(findExtendedMemoryWasmBuild("0".repeat(64)), null);
+    assert.throws(() => rewriteExtendedMemoryWasm(memoryModule(4_096, 32_767)));
+  });
+
+  it("changes only the sole memory maximum and validates the result", () => {
+    const input = memoryModule();
+    const output = deriveExtendedMemoryWasm(input);
+    assert.equal(WebAssembly.validate(Uint8Array.from(output)), true);
+    const before = splitSections(input);
+    const after = splitSections(output);
+    assert.equal(after.length, before.length);
+    assert.deepEqual(
+      after.filter((section) => section.id !== 5),
+      before.filter((section) => section.id !== 5),
+    );
+    assert.notDeepEqual(
+      after.find((section) => section.id === 5),
+      before.find((section) => section.id === 5),
+    );
   });
 
   it("records the effective mode and cap with a closed profile", () => {


### PR DESCRIPTION
## What changed

4 GB mode qualifies the exact published JS/WASM pair structurally and changes only the WASM memory maximum after all audited Emscripten pointer conversions prove.

## Why

A JS/WASM hash cross-product cannot safely survive routine rebuilds and must never combine mixed generations. Refusal must retain the normal 2 GB client.

## Invariant

The official manifest binds the pair. Normalized glue, every pointer-conversion site, the sole memory shape, production output hashes, and cache metadata must all agree.

## Verification

- Both retained JS/WASM generations qualify every supported profile plus `off`.
- Allocator qualification crosses 3 GB and reuses freed memory without growth.
- Mixed-generation, corrupt-cache, changed-glue, and memory-shape tests refuse to safe 2 GB mode.
- The memory-settings test waits for the bounded client-preparation window instead of assuming immediate preparation.
- The Vercel preview rule builds safely when a stack rebase removes the previous commit from a shallow checkout.
- The input-trace pause test no longer races its own in-flight hardware events; the focused case passes five repeated runs.

Stack layer 10 of 13.
