### PR TITLE
docs(certification): record ArenaNet compatibility playbook

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ its rules.
 | How do Single and Multiple Accounts mode isolate player data? | [Multiple Accounts](multiple-accounts.md) |
 | How do ArenaNet client files and game data update? | [Content pipeline](content-pipeline.md) |
 | How does the official client host and certification work? | [WASM host](wasm-host.md) |
+| How do client features remain safe across ArenaNet updates? | [ArenaNet compatibility](arenanet-compatibility.md) |
 | What can diagnostics record and export? | [Diagnostics](diagnostics.md) |
 | How do I change or recertify an Enhancement? | [Enhancement development](enhancement-development.md) |
 | How do application releases, Stable, and Beta work? | [Release verification](release-verification.md) |

--- a/docs/arenanet-compatibility.md
+++ b/docs/arenanet-compatibility.md
@@ -1,0 +1,208 @@
+# ArenaNet client compatibility
+
+This document defines how `gwonmac` proves that its client-side repairs and
+Tools remain safe after ArenaNet rebuilds the official WebAssembly client.
+
+Audience: contributors who change client certification, deterministic
+transforms, patch-day automation, diagnostics, or release qualification.
+
+This document owns proof authority, feature refusal boundaries, retained
+evidence, and the patch-day playbook. Code and tests own exact signatures,
+message identifiers, offsets, hashes, ABI numbers, and time limits.
+
+Read [WASM host and client certification](wasm-host.md) for the wider hosting
+architecture and [Core and Tools development](enhancement-development.md) for
+feature-development rules.
+
+## Product guarantee
+
+An ArenaNet rebuild can change file hashes, function indices, table positions,
+and static addresses without changing game behavior. `gwonmac` must recover
+from those routine changes locally and keep every independently proved feature
+available. This must not require a source change, pull request, or application
+release.
+
+No verifier can safely promise compatibility with an arbitrary future semantic
+change. When a protected behavior genuinely changes, only the feature whose
+proof fails must refuse. The untouched official client remains playable. If the
+4 GB transform cannot be proved, the normal 2 GB mode remains playable.
+
+Synthetic touch input is not a fallback for native double-click. Exact historic
+hashes are regression fixtures, not launch authority.
+
+## One runtime authority
+
+The isolated local semantic verifier is the only component that can grant a
+client capability. It runs in the existing bounded utility process and receives
+the exact official bytes selected for one immutable client generation.
+
+These inputs can provide evidence but cannot grant authority:
+
+- compiled exact-build tables;
+- CI results and workflow summaries;
+- generated reports, attestations, caches, or diagnostics;
+- GitHub issues and pull requests;
+- a successful result from an older client generation.
+
+The verifier binds every verdict to the official input SHA-256 and verifier ABI.
+Main validates that boundary before it accepts a result. Production performs
+each transform again, checks every transform invariant, validates the resulting
+WASM, and requires the locally computed output hash.
+
+The runtime chain is:
+
+```text
+official JS/WASM generation
+  -> isolated template semantic proof and transform
+  -> isolated per-feature semantic proofs
+  -> typed manifest containing only proved capabilities
+  -> Main repeats transforms and checks output hashes
+  -> renderer validates the instantiated manifest
+```
+
+Derived modules and reports are rebuildable caches. Corruption or an ABI change
+discards them without changing player settings, saved files, accounts, Builds,
+or Teams.
+
+## Per-feature verdicts
+
+Each requested feature returns one of these results:
+
+- `proved`: one unique candidate satisfies every required invariant;
+- `changed`: no candidate satisfies the required semantics;
+- `ambiguous`: more than one candidate satisfies the locator, so selection is
+  unsafe.
+
+A refusal includes the feature-local invariant and, for ambiguity, the candidate
+count. A top-level successful verification means that at least one safe module
+can be built. It does not mean every requested feature proved.
+
+Capability manifests compare every field in both directions. A requested
+capability that is missing from an otherwise valid exact regression record must
+still trigger local proof.
+
+## Evidence rules
+
+Relocation is accepted only when the new value is independently derived:
+
+- A function index can move when one unique signature, call relation, or table
+  role identifies it.
+- An immutable-data pointer can move when the uniquely referenced content is
+  unchanged.
+- A mutable or static address needs a complete feature-local occurrence ledger
+  with one consistent derived value.
+- A structure offset must be extracted from an independently identified reader
+  or writer. It is never ignored or copied from a baseline.
+
+Proof normalization must preserve control flow, branches, signatures, call
+order, cardinality, table relationships, message semantics, packet opcodes,
+payload order, pointer expressions, structure offsets, and unexplained
+constants. A common relocation delta is not evidence by itself.
+
+Every memory-layout word in a certificate needs a typed witness. Adding an
+unwitnessed field must fail TypeScript compilation or boundary validation.
+
+## Feature boundaries
+
+| Feature | Required proof | Refusal behavior |
+| --- | --- | --- |
+| Template saving | Unique bridge stubs, all 11 call sites, signatures, argument modes, control flow, and independently derived static storage | Serve the untouched official module; do not claim persistent template repair |
+| Native double-click | Unique callback, signature, active table role, frame insertion point, and valid transformed output | Keep ordinary client input; never synthesize touch events |
+| Guild Wars cursor | Unique loop/callback/table/neighbour graph, both producers, and independently derived globals, buffer, and layout | Use the normal macOS pointer |
+| Target Distance | Complete observation base, target-field ledger, precedence, and bounded finite snapshot behavior | Disable Target Distance only |
+| Party capture | Complete roster, ownership, profession, unlock, flag, skill, attribute, dirty-message, and transition lifecycle | Disable party observation and dependent Team Apply |
+| Travel | Exact four-field producer, Travel message role, dispatcher, bounded mailbox/drain, and transition confirmation | Disable Travel; aliases may retain only independently available Xunlai commands |
+| Xunlai | Three readers, player/area layouts, fixed DataWindow action, handler, bounded drain, and fresh tri-state lifecycle | Disable Xunlai; aliases may retain only independently available Travel commands |
+| Chat aliases | Exact parser relation, bounded comparisons, handled result, original-parser preservation, and at least one proved local action | Rewrite only aliases for proved actions; otherwise preserve the original parser |
+| Team Apply | Seven named builders, exact opcodes/payloads, sender, bounded drain, fresh complete Party proof, and runtime confirmations | Disable Team Apply only; Builds and Teams remain editable |
+| 4 GB mode | Manifest-bound JS/WASM pair, normalized Emscripten glue, every audited pointer-conversion site, one memory shape, and memory-only rewrite | Retain safe 2 GB mode |
+
+Chat aliases never own a dispatcher or mailbox. The transform specializes the
+parser to the effective Travel and Xunlai capabilities. It must not read or
+write an official client global when an action is absent.
+
+Team Apply depends on complete fresh Party proof. Travel and Xunlai do not
+depend on Party. Host-owned authoring, accounts, settings, updater behavior, and
+other non-memory features remain available regardless of client verdicts.
+
+## Patch-day playbook
+
+The scheduled recertification workflow detects a changed ArenaNet code
+generation and runs the same non-authoritative evidence tools used locally.
+It never uploads ArenaNet binaries and cannot publish source authority.
+
+For an equivalent rebuild:
+
+1. Verify the official manifest and exact JS/WASM pair.
+2. Run the isolated verifier with exact regression shortcuts disabled.
+3. Record each feature verdict, invariant, input hash, verifier ABI, and derived
+   output hash.
+4. Transform every effective capability profile and validate each output.
+5. Run native double-click and 4 GB pair qualification independently.
+6. Store the signed machine-readable report and mark the generation as already
+   processed. The report remains evidence only.
+7. Open no source PR. Players use the locally proved features immediately.
+
+For a refusal:
+
+1. Keep the official client playable and disable only the refusing feature and
+   its explicit dependants.
+2. Open or update one tracking issue naming the failed invariant and candidate
+   count when applicable.
+3. Preserve the preceding and current artifacts locally. Never commit or upload
+   them.
+4. Reproduce with the exact shortcut tables disabled.
+5. Classify every changed operand. Do not approve a common delta, copied
+   address, unexplained constant, or partial occurrence ledger.
+6. Add positive equivalent-relocation tests and adversarial change, duplicate,
+   ambiguity, timeout, malformed-boundary, and output-mismatch tests.
+7. Run the complete acceptance chain before publishing a verifier change.
+
+The workflow's durable success ledger prevents repeated expensive derivation.
+It is bound to the verifier ABI and generation hash and cannot grant runtime
+authority.
+
+## Retained evidence and lessons
+
+| Generation | Available evidence | Valid claim |
+| --- | --- | --- |
+| AEC predecessor | Retained official JS/WASM pair and full structural/mutation replay | All current feature proofs and all supported 4 GB profiles pass structurally |
+| fc931 | Non-binary workflow evidence only | Useful relationship evidence; no retrospective binary-pass claim |
+| e017 current | Retained official JS/WASM pair and full structural/mutation replay | All current feature proofs and all supported 4 GB profiles pass structurally |
+
+The retained generations taught these rules:
+
+- Whole-body hashes fail safe but cannot survive routine function-index or
+  static-address relocation. Relocatable operands need explicit relationships.
+- A shared movement of mutable addresses is not ownership proof. Complete
+  occurrence ledgers and independent content anchors are required.
+- A locator that collapses zero and multiple candidates hides the difference
+  between changed and ambiguous behavior. Candidate counts belong in reports.
+- A capability can be proved yet ineffective because a dependency refused.
+  Status, manifest, parser generation, and runtime exports must all use the same
+  effective capability set.
+- Exact-known clients are the most important place to disable exact shortcuts;
+  otherwise regression fixtures can hide a missing structural witness.
+- Parse once and share an input-bound proof context. This keeps all-feature
+  verification comfortably within the utility-process timeout without weakening
+  evidence.
+- Preparation and production are separate trust boundaries. Preparation may
+  derive a candidate once; production must repeat the transform and validate
+  the exact output.
+
+## Acceptance before merge or release
+
+The stack is mergeable only when:
+
+- full repository verification and exact-head CI pass for every layer;
+- retained AEC and e017 artifacts pass with exact shortcuts disabled;
+- every proof-anchor mutation disables only its owning capability;
+- clicks, double-clicks, bursts, and drags emit no synthetic touch events;
+- all supported 4 GB profiles allocate above 3 GB, reject mixed generations and
+  corrupt caches, and prove that only the WASM memory maximum changes;
+- the Preview signing credentials are available without a code bypass;
+- a signed, notarized, stapled Preview passes the feature QA checklist in
+  [Release verification](release-verification.md).
+
+Stable publication remains a human product decision. Automation cannot decide
+whether the game looks and behaves correctly.

--- a/docs/enhancement-development.md
+++ b/docs/enhancement-development.md
@@ -6,9 +6,9 @@ optional Tools.
 Audience: contributors who change client transforms, companion snapshots,
 read-only observation, Tools presentation, or named game commands.
 
-This document owns the development and recertification procedure. The build
-certificate in `src/main/certification/enhancement-builds.ts` owns build-local
-facts. Tests own exact acceptance thresholds.
+This document owns the feature-development procedure. The local semantic
+verifier owns runtime proof. Exact build records are regression expectations.
+Tests own exact acceptance thresholds.
 
 Read [WASM host and client certification](wasm-host.md) before you change the
 architecture.
@@ -108,8 +108,9 @@ Each region needs these properties:
 - explicit invalid and overflow states;
 - no game pointer in published output.
 
-The official WASM and build certificate remain canonical. Every derived output
-must be rebuildable from them.
+The official WASM remains canonical. Feature certificates and transformed
+outputs are derived from those bytes and the verifier ABI and must be
+rebuildable.
 
 Do not build a speculative global game model. Use a tick snapshot for current
 state. Add an event ring only when a proven user feature cannot be represented
@@ -208,6 +209,10 @@ Start from the exact official artifact that triggered the compatibility notice.
 Do not clear the downloaded game data: the unsupported artifact and the
 retained preceding artifact are the most useful migration evidence.
 
+Read and follow the [ArenaNet compatibility patch-day playbook](arenanet-compatibility.md#patch-day-playbook).
+Routine equivalent rebuilds must pass locally without a source change. Use the
+commands below to investigate a refusal, not to publish a new hash allowlist.
+
 Run the bounded chain in order:
 
 ```bash
@@ -219,19 +224,7 @@ pnpm certification recertify "/absolute/path/Gw.jspi.wasm"
 The tool first selects or derives file compatibility. It then inspects that
 output as the Core and Tools candidate. The transforms are not alternatives.
 
-If the template report derives one unambiguous entry, review it and write it:
-
-```bash
-pnpm certification template "/absolute/path/Gw.jspi.wasm" --write
-```
-
-Then add one complete exact-build Enhancement entry. Do not make a new build
-inherit addresses from the preceding build. Compare the old and new modules
-and record which function bodies, signatures, table slots, data roots and
-message anchors stayed exact. Recompute every capability output; a copied hash
-is not evidence.
-
-Finish the downstream chain only after the Enhancement entry exists:
+Run the downstream chain with exact regression shortcuts disabled:
 
 ```bash
 pnpm certification recertify "/absolute/path/Gw.jspi.wasm"
@@ -239,25 +232,27 @@ pnpm certification double-click "/absolute/path/Gw.jspi.wasm"
 pnpm check
 ```
 
-`recertify` must report `bundleVerified: true`, and `double-click` must prove
-one unique callback, active table slot, signature, insertion point, and valid
-output. A shipped hash-table match is regression evidence, not authority.
+`recertify` must report per-feature ABI/input-hash-bound verdicts, and
+`double-click` must prove one unique callback, active table role, signature,
+insertion point, and valid output. A shipped hash-table match is regression
+evidence, not authority.
 
 Each recovered fact needs an independent semantic anchor. A common movement is
 not enough. Automated candidates are review evidence and cannot create runtime
 authority.
 
-Recertification requires exact identities, signatures, caller semantics,
-original-call preservation, table and allocation invariants, positive and
-negative layout evidence, lifecycle clearing, offline tests, clean teardown,
-and one bounded live semantic check per changed domain.
+Recertification requires semantic identities, signatures, caller relationships,
+original-call preservation, complete address occurrence ledgers, table and
+allocation invariants, positive and negative layout evidence, lifecycle
+clearing, offline tests, clean teardown, and one bounded live semantic check per
+changed domain.
 
 For Xunlai storage, independently recover the player-record array, record
-stride, agent identifier, player number, access flags, and area type from the
-exact supported Guild Wars build. External projects such as GWCA can explain
-semantics, but they are never runtime authority. Record the exact reader and
-command-handler indices, signatures, body hashes, and game-thread drain
-evidence in the new certificate. Do not infer them from the preceding build.
+stride, agent identifier, player number, access flags, and area type. External
+projects such as GWCA can explain semantics, but they are never runtime
+authority. Prove reader and handler roles, signatures, field offsets, and the
+game-thread drain from the current bytes. Do not copy them from a preceding
+build.
 The three player-record readers form one optional, all-or-nothing access proof.
 If that proof cannot be certified, omit it: the generated configuration then
 contains zero access words, Xunlai stays disabled, and the independently
@@ -294,7 +289,7 @@ must remain playable.
 
 A Core or Tools change is done when all applicable statements are true:
 
-- one source owns every new build-local fact;
+- every client-local fact has one typed semantic witness;
 - invalid and loading state cannot publish stale data;
 - disabled behavior stops its observer or command path;
 - no raw pointer, packet, secret, or memory view crosses IPC;

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -132,8 +132,13 @@ On the maintainer Mac:
 4. Play for ten minutes and check rendering, input, audio, templates, and saved
    login.
 5. Confirm current Core certification.
-6. If the release claims Tools support, test the claimed Target Distance and
-   Team Management behavior.
+6. Test template save/load and confirm native double-click and the Guild Wars
+   cursor.
+7. If the release claims Tools support, test Target Distance, party and map
+   transitions, Travel, eligible and restricted Xunlai states plus aliases, and
+   one minimal reversible Team Apply operation.
+8. If 4 GB mode is requested, confirm it is effective. Also confirm that a
+   refused pair keeps the game playable in normal 2 GB mode.
 
 A 16 GB Apple Silicon MacBook Pro is sufficient for this owned check. Record the
 actual model, memory, and macOS version. Do not imply that this one device proves

--- a/docs/wasm-host.md
+++ b/docs/wasm-host.md
@@ -93,8 +93,9 @@ IDBFS operations. It preserves the original routines for other callers.
 The transform validates each complete changed caller. A change to control flow,
 flags, path handling, or an unrelated call makes the proof refuse.
 
-For an unknown hash, one isolated utility process re-reads and verifies the
-artifact. It writes no profile state.
+For every selected hash, one isolated utility process re-reads and verifies the
+artifact. It writes no profile state. Known hashes take the same structural
+path as unknown hashes.
 
 A crash, timeout, changed file, malformed result, ambiguous match, unexpected
 layout, or transform error means no proof. The app then serves the verified
@@ -105,35 +106,38 @@ that archive before changing the transform.
 
 ## Effective feature status
 
-Main reports the effective served status for file saving, cursor, target
-observation, party observation, and Apply team. Each optional feature is
-`available`, `off`, or `unavailable`; unavailable features also say whether a
-Guild Wars update or a preparation failure caused the refusal. The renderer
-never reconstructs these answers from settings, hashes, or another feature.
+Main reports the effective served status for file saving, native double-click,
+cursor, Target, Party, Team Apply, Travel, Xunlai, aliases, and 4 GB mode. Each
+optional feature is `available`, `off`, or `unavailable`; unavailable features
+also say whether a Guild Wars update or a preparation failure caused the
+refusal. The renderer never reconstructs these answers from settings, hashes,
+or another feature.
 
-The exact-build entry carries independent optional facts. The runtime selects
-the largest certified subset, removes Apply when party observation is absent,
-and retries from the clean post-template module after a feature-local failure.
-A common hook or final integrity failure disables all optional features while
-preserving proven file saving.
+The verifier returns independent feature facts. The runtime selects the largest
+proved subset, removes Team Apply when Party is absent, and removes aliases when
+both Travel and Xunlai are absent. It retries from the clean post-template
+module after a feature-local failure. A common hook or final integrity failure
+disables the dependent features while preserving independent proofs.
 
 The renderer verifies the instantiated module's exact capability manifest.
 Launch intent is not runtime proof.
 
 ## Certification authority
 
-Compiled certification facts and the isolated local file-compatibility verifier
-are the only runtime authorities.
-
-The local verifier can authorize only the bounded file repair that it proves.
-Cursor, observation, and Apply hooks use exact shipped facts until each hook and address
-can be recovered from an independent semantic anchor.
+The isolated local semantic verifier is the sole runtime authority for file
+compatibility, Core, and Tools capabilities. Compiled exact-build facts are
+regression expectations only. Every requested capability is proved from the
+selected official bytes and bound to their hash and the verifier ABI.
 
 There is no remote certificate feed. A CI result, cache file, diagnostics file,
 or GitHub issue cannot grant runtime authority.
 
-New observation or Apply facts require an application release. When those facts are
-missing, the official ArenaNet client remains playable.
+An equivalent ArenaNet rebuild therefore needs no source change or application
+release. A semantic change disables only the affected capability and its
+explicit dependants. The official ArenaNet client remains playable.
+
+[ArenaNet client compatibility](arenanet-compatibility.md) owns the proof rules,
+feature refusal boundaries, retained evidence, and patch-day procedure.
 
 ## Required compatibility and optional Tools
 
@@ -198,12 +202,13 @@ function call, shared-memory packet bus, or second game model.
 
 ## Command boundary
 
-Team Apply and local actions are separate certified capabilities. Xunlai and
-Travel share one local-action profile, bounded game-thread mailbox, and drain
-proof; each still has its own setting and runtime gate. The profile exports only
-the named Xunlai and Travel operations. It does not export the Team Apply
-packet-builder thunk, and Team Apply alone does not export local actions.
-Neither profile carries a generic opcode, packet, dispatcher, or address surface.
+Team Apply, Travel, Xunlai, and chat aliases are separate certified
+capabilities. Travel and Xunlai share a private bounded game-thread mailbox and
+drain implementation, but each has its own proof, setting, manifest status, and
+runtime gate. Chat aliases are effective only when at least one of those local
+actions proves, and parser generation includes only commands backed by proved
+actions. The profile exports no generic opcode, packet, dispatcher, or address
+surface.
 
 The same named storage action backs the Tools button and Command-Shift-C. It
 queues a fixed `{ agent: 0, type: 0, data: 3 }` DataWindow payload, then calls
@@ -214,10 +219,10 @@ in a supported PvE outpost and can access storage. Every snapshot update
 resynchronizes the action, so loading, character, account, and map transitions
 revoke stale access immediately.
 
-The player-record access proof is an optional, all-or-nothing part of the exact
-build certificate. If it is absent, its six configuration words are zero and
-the kernel can publish only `null` for Xunlai. The local-action profile and its
-certified Travel dispatcher remain usable; no party-state fallback is allowed.
+The player-record access proof is an optional, all-or-nothing feature
+certificate. If it is absent, its six configuration words are zero and the
+kernel can publish only `null` for Xunlai. A separately proved Travel dispatcher
+remains usable; no party-state fallback is allowed.
 
 Travel accepts only four bounded scalar values: map, region, language, and
 district. The exact `/tp` command sets one named, one-shot palette toggle that
@@ -227,9 +232,9 @@ the transform writes the four words to its installer-owned payload. It then
 calls the exact client Travel dispatcher with `kTravel`. It cannot dispatch
 another client UI message.
 
-Team Apply requires enabled Tools and Apply teams in Guild Wars, an exact commands
-profile, a positively classified PvE outpost, fresh party state, and an explicit
-player action.
+Team Apply requires enabled Tools and Apply teams in Guild Wars, a proved Team
+Apply capability, a positively classified PvE outpost, fresh party state, and
+an explicit player action.
 
 The runner checks policy before each command and while it confirms results. A
 map transition or policy change stops the operation. A refusal is an explicit
@@ -240,31 +245,13 @@ their named domains.
 
 ## Patch-day flow
 
-The scheduled workflow detects ArenaNet code changes. It ignores normal content
-changes. For a new generation it downloads verified code artifacts, runs the
-file derivation, and produces bounded candidate evidence. It cannot edit
-source, push a branch, open a pull request, or grant runtime authority.
+The scheduled workflow detects ArenaNet code changes, runs the isolated
+per-feature verifier, and retains signed machine-readable evidence. It never
+uploads ArenaNet client bytes and cannot grant runtime authority. Equivalent
+rebuilds require no source PR; a refusal opens a tracking issue naming the exact
+failed invariant.
 
-Automation cannot publish a runtime certificate. The isolated verifier makes
-the runtime decision from the official bytes; a maintainer investigates only
-an invariant it refuses.
-
-The carry-forward report has separate **Apply team** and **local actions**
-rows. A changed Team Apply builder must not block local-action recertification,
-and a changed slash parser, DataWindow handler, or Travel producer must not
-block Team Apply. For storage, independently certify the exact player-record
-array, stride, agent identifier, player number, access flags, and area type.
-Confirm both exact aliases are consumed only after the snapshot proves access,
-a near miss still reaches the normal parser, the fixed DataWindow payload runs
-at the certified drain, and `pnpm enhancements:live xunlai-storage` opens the
-normal window only for an eligible character in a PvE outpost. For Travel,
-confirm `/tp` is consumed only while
-Travel is enabled and its one-shot toggle reaches the palette. Confirm the
-producer still writes `{ map, region, language, district }` and sends `kTravel`.
-Then perform one bounded live trip to an unlocked outpost.
-
-The workflow never uploads ArenaNet client bytes. It uploads reports and source
-changes only.
+Follow the complete [patch-day playbook](arenanet-compatibility.md#patch-day-playbook).
 
 ## Failure and teardown
 


### PR DESCRIPTION
## What changed

Adds the canonical ArenaNet compatibility and patch-day playbook and updates hosting, feature-development, and release QA documentation to match the shipped verifier.

## Why

The old documentation still described exact build certificates as runtime authority and did not record the refusal boundaries or lessons from the retained generations.

## Invariant

One document owns proof authority, evidence classes, feature dependencies, patch-day handling, retained evidence limits, and merge/release acceptance. Other documents link to it instead of duplicating rules.

## Verification

- Markdown link validation passes.
- Full `pnpm verify` passes on this exact head.
- The fc931 binary limitation is documented without claiming a retrospective binary run.

Stack layer 12 of 13.
