### PR TITLE
test(input): tolerate duplicate provider mouse moves

### DIFF
--- a/tests/electron/steam-login.spec.ts
+++ b/tests/electron/steam-login.spec.ts
@@ -373,8 +373,12 @@ test.describe("the Steam credential seam", () => {
         },
       };
     });
-    expect(result.events?.map(({ type }) => type)).toEqual([
-      "mousemove",
+    const eventTypes = result.events?.map(({ type }) => type) ?? [];
+    const mouseDownIndex = eventTypes.indexOf("mousedown");
+    expect(mouseDownIndex).toBeGreaterThan(0);
+    expect(eventTypes.slice(0, mouseDownIndex).every((type) => type === "mousemove"))
+      .toBe(true);
+    expect(eventTypes.slice(mouseDownIndex)).toEqual([
       "mousedown",
       "mouseup",
       "click",


### PR DESCRIPTION
## What changed

Makes the keyboard-provider Electron test accept one or more OS-generated pointer moves before the same synthetic click sequence.

## Why

Electron can emit a duplicate harmless `mousemove` depending on timing. Requiring exactly one made the full gate flaky even though the meaningful keyboard activation behavior was correct.

## Invariant

At least one pointer move must precede exactly `mousedown`, `mouseup`, and `click`; every event remains untrusted and the final coordinates remain exact.

## Verification

- Focused test passed three consecutive repetitions.
- Full `pnpm verify` passes on this exact head: 137 Electron tests passed and one live-client test was intentionally skipped.
- Packaged startup and Enhancement runtime tests pass.

Stack layer 13 of 13.
