### PR TITLE
fix(ci): build previews after stack rebases

### DIFF
--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -3,5 +3,5 @@
   "git": {
     "deploymentEnabled": true
   },
-  "ignoreCommand": "if [ -z \"$VERCEL_GIT_PREVIOUS_SHA\" ]; then exit 1; fi; git diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" HEAD -- . ../../src/shared ../../package.json ../../pnpm-lock.yaml ../../pnpm-workspace.yaml"
+  "ignoreCommand": "if [ -z \"$VERCEL_GIT_PREVIOUS_SHA\" ]; then exit 1; fi; git cat-file -e \"$VERCEL_GIT_PREVIOUS_SHA^{commit}\" 2>/dev/null || exit 1; git diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" HEAD -- . ../../src/shared ../../package.json ../../pnpm-lock.yaml ../../pnpm-workspace.yaml"
 }

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -13,6 +13,7 @@
 // a real window in tests/electron/sandbox.spec.ts), and the three assertions
 // that still need the compiled build (tests/release/).
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
@@ -756,7 +757,32 @@ test("the website suite runs on its own path-filtered workflow", () => {
   assert.equal(vercel.git?.deploymentEnabled, true);
   assert.equal(
     vercel.ignoreCommand,
-    'if [ -z "$VERCEL_GIT_PREVIOUS_SHA" ]; then exit 1; fi; git diff --quiet "$VERCEL_GIT_PREVIOUS_SHA" HEAD -- . ../../src/shared ../../package.json ../../pnpm-lock.yaml ../../pnpm-workspace.yaml',
+    'if [ -z "$VERCEL_GIT_PREVIOUS_SHA" ]; then exit 1; fi; git cat-file -e "$VERCEL_GIT_PREVIOUS_SHA^{commit}" 2>/dev/null || exit 1; git diff --quiet "$VERCEL_GIT_PREVIOUS_SHA" HEAD -- . ../../src/shared ../../package.json ../../pnpm-lock.yaml ../../pnpm-workspace.yaml',
+  );
+  const head = spawnSync("git", ["rev-parse", "HEAD"], {
+    cwd: root,
+    encoding: "utf8",
+  });
+  assert.equal(head.status, 0);
+  const runIgnore = (previousSha: string): number | null => spawnSync(
+    "sh",
+    ["-c", vercel.ignoreCommand ?? "exit 2"],
+    {
+      cwd: path.join(root, "apps/website"),
+      env: { ...process.env, VERCEL_GIT_PREVIOUS_SHA: previousSha },
+      stdio: "ignore",
+    },
+  ).status;
+  assert.equal(runIgnore(""), 1, "a first deployment must build");
+  assert.equal(
+    runIgnore("0000000000000000000000000000000000000000"),
+    1,
+    "a rebased-away previous commit must build instead of failing",
+  );
+  assert.equal(
+    runIgnore(head.stdout.trim()),
+    0,
+    "an unchanged website may skip its build",
   );
 });
 


### PR DESCRIPTION
## What changed

Vercel preview filtering now builds when a stack rebase removes the previously deployed commit from the shallow checkout.

## Why

The old ignored-build command ran `git diff` against an unavailable previous SHA. Git exited fatally, so valid rebased PRs received a red Vercel deployment before their website build could start.

## Invariant

An empty or unavailable previous SHA returns the documented build-required result. Only a reachable unchanged predecessor may skip the website build.

## Verification

- The policy test executes the real command for first deploy, rebased-away predecessor, and unchanged predecessor cases.
- Focused policy test, test TypeScript compilation, and ESLint pass.
- The failure was reproduced and diagnosed from the authoritative Vercel deployment log.

Stack layer 14 of 14.
