### PR TITLE
fix(tools): reveal live action failure boundaries

### DIFF
--- a/apps/tools/src/components/TravelPalette.test.ts
+++ b/apps/tools/src/components/TravelPalette.test.ts
@@ -12,15 +12,17 @@ function fixture(initial: TravelShortcuts = DEFAULT_TRAVEL_SHORTCUTS) {
     shortcuts = next;
     return shortcuts;
   });
+  const traceSearch = vi.fn<TravelHost["traceSearch"]>();
   const host: TravelHost = {
     state: ref({ status: "ready", mapId: 55 }),
     unavailable: null,
     async loadShortcuts() { return shortcuts; },
     saveShortcuts,
     travel,
+    traceSearch,
   };
   const wrapper = mount(TravelPalette, { props: { host, visible: true } });
-  return { wrapper, travel, saveShortcuts };
+  return { wrapper, travel, saveShortcuts, traceSearch };
 }
 
 describe("TravelPalette", () => {
@@ -29,7 +31,7 @@ describe("TravelPalette", () => {
     await flushPromises();
 
     expect(wrapper.findAll('[role="option"]')).toHaveLength(0);
-    expect(wrapper.text()).toContain("Start typing to search all outposts");
+    expect(wrapper.text()).toContain("Start typing to search available destinations");
     expect(wrapper.get('label[for="travel-search-input"]').text())
       .toBe("Search destinations");
     expect(wrapper.get('[aria-label="Close Travel"]').element.closest("label"))
@@ -51,6 +53,17 @@ describe("TravelPalette", () => {
       district: "international",
       districtNumber: 0,
     });
+    wrapper.unmount();
+  });
+
+  it("reports bounded search evidence when the catalogue has no match", async () => {
+    const { wrapper, traceSearch } = fixture();
+    await flushPromises();
+
+    await wrapper.get('[role="combobox"]').setValue("Ruins");
+
+    expect(traceSearch).toHaveBeenLastCalledWith("Ruins", []);
+    expect(wrapper.text()).toContain("No matching destination");
     wrapper.unmount();
   });
 

--- a/apps/tools/src/components/TravelPalette.vue
+++ b/apps/tools/src/components/TravelPalette.vue
@@ -66,6 +66,9 @@ const statusLevel = computed(() => {
 });
 
 watch(query, () => { active.value = 0; });
+watch(results, (next) => {
+  props.host.traceSearch(query.value, next.map((destination) => destination.mapId));
+});
 
 watch(() => props.visible, async (visible) => {
   if (!visible) return;
@@ -305,7 +308,7 @@ onBeforeUnmount(() => {
     </section>
 
     <p v-if="!hasQuery" class="travel-search-prompt">
-      Start typing to search all outposts.
+      Start typing to search available destinations.
     </p>
 
     <div

--- a/apps/tools/src/embedded.ts
+++ b/apps/tools/src/embedded.ts
@@ -38,12 +38,13 @@ export function mountTravelPalette(
   target: HTMLElement,
   options: {
     command: TravelCommand;
+    development: boolean;
     initiallyVisible?: boolean;
     onVisibilityChange?: (visible: boolean) => void;
   },
 ) {
   return mountTravel(target, {
     ...options,
-    host: createNativeTravelHost(window.gwNative, options.command),
+    host: createNativeTravelHost(window.gwNative, options.command, options.development),
   });
 }

--- a/apps/tools/src/travel-host.ts
+++ b/apps/tools/src/travel-host.ts
@@ -8,6 +8,7 @@ import type { GwNativeApi } from "../../../src/shared/contracts";
 import type { TravelCommand } from "../../../src/shared/travel-command";
 import {
   DEFAULT_TRAVEL_SHORTCUTS,
+  TRAVEL_DESTINATIONS,
   type TravelRequest,
   type TravelShortcuts,
 } from "../../../src/shared/travel";
@@ -24,11 +25,13 @@ export interface TravelHost {
   loadShortcuts(): Promise<TravelShortcuts>;
   saveShortcuts(shortcuts: TravelShortcuts): Promise<TravelShortcuts>;
   travel(request: TravelRequest): Promise<void>;
+  traceSearch(query: string, resultMapIds: readonly number[]): void;
 }
 
 export function createNativeTravelHost(
   api: GwNativeApi,
   command: TravelCommand,
+  development = false,
 ): TravelHost {
   const state = ref<TravelState>({ status: "waiting", reason: "game" });
   return {
@@ -43,7 +46,35 @@ export function createNativeTravelHost(
       return (await api.settings.set({ travelShortcuts: shortcuts })).travelShortcuts;
     },
     async travel(request) {
-      command.travel(request);
+      try {
+        command.travel(request);
+        if (development) {
+          console.debug(`[tools:dev] travel.queued ${JSON.stringify({
+            mapId: request.mapId,
+            district: request.district,
+            districtNumber: request.districtNumber,
+          })}`);
+        }
+      } catch (error) {
+        if (development) {
+          console.debug(`[tools:dev] travel.refused ${JSON.stringify({
+            mapId: request.mapId,
+            reason: error instanceof Error ? error.message : "unknown travel error",
+          })}`);
+        }
+        throw error;
+      }
+    },
+    traceSearch(query, resultMapIds) {
+      if (!development) return;
+      const trimmed = query.trim();
+      console.debug(`[tools:dev] travel.search ${JSON.stringify({
+        queryLength: trimmed.length,
+        tokenCount: trimmed === "" ? 0 : trimmed.split(/\s+/u).length,
+        catalogueSize: TRAVEL_DESTINATIONS.length,
+        resultCount: resultMapIds.length,
+        resultMapIds: resultMapIds.slice(0, 12),
+      })}`);
     },
   };
 }
@@ -70,5 +101,6 @@ export function createDemoTravelHost(): TravelHost {
         state.value = { status: "ready", mapId: request.mapId };
       }, 600);
     },
+    traceSearch() {},
   };
 }

--- a/docs/enhancement-development.md
+++ b/docs/enhancement-development.md
@@ -83,12 +83,17 @@ character names, account data, chat, packet bytes, or Travel search text.
 
 - Xunlai emits `storage.availability`, `storage.configured`, and then either
   `storage.queued` or `storage.refused`. A refusal includes the policy state and
-  the tri-state access result that caused the Controls fallback.
+  the tri-state access result that caused the Controls fallback. The certified
+  player-record readers index their array by the live login/player number;
+  record zero is not a valid shortcut for a real character.
 - Team Apply first emits `command` when the renderer queues an opcode. The
   `team command trace` then reports `drain.count` and `drain.opcode` when the
   certified game-thread boundary consumes it. Builder and sender counters show
   the next boundary reached. This separates queue, drain, builder, sender, and
   observer-confirmation failures.
+  Ordinary live publications have been observed just beyond one second, so
+  their confirmation window is two seconds. Profession and skill transitions
+  retain their feature-specific stability and retry windows.
 - Travel emits `travel.search` with query length, token count, catalogue size,
   result count, and bounded result map IDs. It never includes the query itself.
   `travel.queued` or `travel.refused` then identifies the named command result.

--- a/docs/enhancement-development.md
+++ b/docs/enhancement-development.md
@@ -74,6 +74,32 @@ pnpm enhancements:visual -- map
 The fixture is developer-only. It must not become packaged navigation or a
 second production UI.
 
+## Live Tools feedback loop
+
+Use an unpackaged development launch when a named action behaves differently
+in the real client. Open the renderer console and keep only lines beginning
+with `[tools:dev]`. These events are bounded scalar evidence; they do not log
+character names, account data, chat, packet bytes, or Travel search text.
+
+- Xunlai emits `storage.availability`, `storage.configured`, and then either
+  `storage.queued` or `storage.refused`. A refusal includes the policy state and
+  the tri-state access result that caused the Controls fallback.
+- Team Apply first emits `command` when the renderer queues an opcode. The
+  `team command trace` then reports `drain.count` and `drain.opcode` when the
+  certified game-thread boundary consumes it. Builder and sender counters show
+  the next boundary reached. This separates queue, drain, builder, sender, and
+  observer-confirmation failures.
+- Travel emits `travel.search` with query length, token count, catalogue size,
+  result count, and bounded result map IDs. It never includes the query itself.
+  `travel.queued` or `travel.refused` then identifies the named command result.
+  A zero search result is a host-catalogue gap, not a refused ArenaNet command;
+  the current catalogue is intentionally static and is not yet exhaustive.
+
+For a report, reproduce one operation at a time and copy the lines from its
+first request through its final success, refusal, or timeout. Also record the
+visible map/outpost and whether the character should have Xunlai access. Do not
+paste the complete console or account/login screens.
+
 ## Add or change a feature
 
 For each field, observer, widget, or command:

--- a/docs/enhancement-development.md
+++ b/docs/enhancement-development.md
@@ -85,7 +85,9 @@ character names, account data, chat, packet bytes, or Travel search text.
   `storage.queued` or `storage.refused`. A refusal includes the policy state and
   the tri-state access result that caused the Controls fallback. The certified
   player-record readers index their array by the live login/player number;
-  record zero is not a valid shortcut for a real character.
+  record zero is not a valid shortcut for a real character. Each request also
+  has a session-local sequence and elapsed time since the preceding request, so
+  an accidental double-open is visible without logging an account identifier.
 - Team Apply first emits `command` when the renderer queues an opcode. The
   `team command trace` then reports `drain.count` and `drain.opcode` when the
   certified game-thread boundary consumes it. Builder and sender counters show
@@ -104,6 +106,19 @@ For a report, reproduce one operation at a time and copy the lines from its
 first request through its final success, refusal, or timeout. Also record the
 visible map/outpost and whether the character should have Xunlai access. Do not
 paste the complete console or account/login screens.
+
+For an input or Xunlai interaction failure, also open
+**Help → Diagnostics → Show Input Trace**. Clear it, then open Xunlai once,
+close the native storage window with Escape, click empty ground, hold both
+mouse buttons briefly, and interact with one merchant. Pause and copy the
+trace. Pointer rows name only `canvas`, `surface`, `text`, `secret`, or `other`.
+`canvas` proves the event reached Guild Wars; it does not prove the client
+accepted the world action. This distinction separates a hidden GWonMac surface
+from a stuck native game UI state without copying coordinates or UI text.
+For a keyboard shortcut, every `modifier down` must have either a matching
+`modifier up` or an `input released (command)` row before the named action.
+Command-Shift-C deliberately resets held game input before it opens Xunlai,
+because macOS can consume a physical modifier release while Command is held.
 
 ## Add or change a feature
 
@@ -291,14 +306,25 @@ certified Travel action remains available. Never substitute party state or a
 guessed offset.
 
 Run `pnpm enhancements:live xunlai-storage` from a supported PvE outpost. The
-scenario records only the tri-state access result and two outcomes from the
-same named action used by the button and shortcut. Also enter `/chest`,
+scenario records only the tri-state access result and two complete action
+cycles from the same named action used by the button and shortcut. Each cycle
+opens storage, closes it with Escape, and proves that bounded two-button
+movement changes the certified player position. A queued command is not a
+semantic success. Also enter `/chest`,
 `/xunlai`, and one near miss such as `/storage`; the first two must be consumed
 locally only after access is confirmed and the near miss must remain a normal
 Guild Wars command. Check one eligible character and the known restricted
 character, then switch accounts or characters without restarting and confirm
 that access is revoked and restored. A one-gold deposit and withdrawal requires
 explicit confirmation from the person operating the client.
+
+STOP if closing storage does not immediately restore click-to-walk, two-button
+movement, and merchant interaction. The DataWindow handler consumes two account
+pane flags in addition to the character/outpost access proof. Do not infer
+those flags from access, hard-code a different payload, or call the action safe
+because the mailbox drained. A release claim needs independent proof of those
+flags and the native storage open/close lifecycle, plus the recovery cycle
+above on accounts with and without each pane.
 
 Party certification must prove the complete owned roster, player and hero
 professions, hero unlocks, behaviour, skill bars, and attributes. Proving only

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -321,7 +321,9 @@ opens its GitHub issue form immediately. GitHub issues are public.
 - Use **Show Input Trace** for keyboard, text, pointer, shortcut, or gamepad
   problems. Reproduce the problem, pause the bounded timeline, then copy it
   into the issue. It omits text, secrets, field lengths, coordinates, account
-  identifiers, and controller identifiers. Closing it discards the trace.
+  identifiers, and controller identifiers. Pointer rows say only whether the
+  click belonged to the game canvas, a GWonMac surface, a text or secret field,
+  or another element. Closing it discards the trace.
 - Holding a character, Backspace, or Delete in Guild Wars text fields follows
   the repeat delay and speed configured in macOS Keyboard settings.
 

--- a/scripts/enhancements-live/scenarios.ts
+++ b/scripts/enhancements-live/scenarios.ts
@@ -549,32 +549,38 @@ const noEvidence = async () => null;
 const acceptEvidence = () => {};
 
 async function runXunlaiStorage({ page }: AutomationContext) {
-  return page.evaluate(async () => {
-    const attempt = () => {
-      const detail: { error?: unknown } = {};
-      const event = new CustomEvent("gw:storage-open", {
-        cancelable: true,
-        detail,
-      });
-      window.dispatchEvent(event);
-      return {
-        handled: event.defaultPrevented,
-        error: detail.error instanceof Error
-          ? detail.error.message
-          : detail.error
-            ? String(detail.error)
-            : null,
-      };
-    };
-    const first = attempt();
-    await new Promise((resolve) => setTimeout(resolve, 1_500));
+  const xunlaiAccess = await page.evaluate(
+    () => window.gwCompanionRuntime?.xunlaiAccess ?? null,
+  );
+  const attempt = () => page.evaluate(() => {
+    const detail: { error?: unknown } = {};
+    const event = new CustomEvent("gw:storage-open", {
+      cancelable: true,
+      detail,
+    });
+    window.dispatchEvent(event);
     return {
-      xunlaiAccess: window.gwCompanionRuntime?.xunlaiAccess ?? null,
-      commandOutcomes: [first, attempt()],
+      handled: event.defaultPrevented,
+      error: detail.error instanceof Error
+        ? detail.error.message
+        : detail.error
+          ? String(detail.error)
+          : null,
     };
   });
+  const commandOutcomes: Awaited<ReturnType<typeof attempt>>[] = [];
+  const recoveries: Awaited<ReturnType<typeof runMovement>>[] = [];
+  for (let cycle = 0; cycle < 2; cycle += 1) {
+    commandOutcomes.push(await attempt());
+    if (xunlaiAccess !== true) continue;
+    await page.waitForTimeout(750);
+    await page.locator("#canvas").focus();
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(250);
+    recoveries.push(await runMovement({ page }));
+  }
+  return { xunlaiAccess, commandOutcomes, recoveries };
 }
-
 
 export const SCENARIOS: Readonly<Record<string, LiveScenario>> = Object.freeze({
   // Reaching a playable character is itself a keypress, so the scenarios that
@@ -676,6 +682,16 @@ export const SCENARIOS: Readonly<Record<string, LiveScenario>> = Object.freeze({
       );
       if (!outcomesMatch) {
         throw new Error("Xunlai command outcome did not match certified access");
+      }
+      if (
+        evidence.xunlaiAccess
+          ? evidence.recoveries.length !== 2
+            || evidence.recoveries.some((recovery) => !(recovery.distance > 5))
+          : evidence.recoveries.length !== 0
+      ) {
+        throw new Error(
+          "Xunlai storage did not surrender world interaction after closing",
+        );
       }
     },
   }),

--- a/src/companion-kernel/lib.rs
+++ b/src/companion-kernel/lib.rs
@@ -250,14 +250,23 @@ unsafe fn observe_xunlai_access(
     let buffer = unsafe { read_u32(players) }?;
     let capacity = offset(players, 4).and_then(|at| unsafe { read_u32(at) })?;
     let size = offset(players, 8).and_then(|at| unsafe { read_u32(at) })?;
-    if size == 0 || size > capacity || capacity > 2_048 || buffer == 0 || buffer & 3 != 0 {
+    if size == 0
+        || size > capacity
+        || player_number >= size
+        || capacity > 2_048
+        || buffer == 0
+        || buffer & 3 != 0
+    {
         return None;
     }
     let bytes = checked_mul(capacity, layout.player_record_stride)?;
     if !contains(buffer, bytes) {
         return None;
     }
-    let player = indexed(buffer, 0, layout.player_record_stride)?;
+    // The official readers take the login/player number as the array index.
+    // Record zero is only correct for the first synthetic fixture, not for a
+    // live account whose player number is ordinarily non-zero.
+    let player = indexed(buffer, player_number, layout.player_record_stride)?;
     let agent_id = offset(player, layout.player_record_agent_id)
         .and_then(|at| unsafe { read_u32(at) })?;
     let access_flags = offset(player, layout.player_record_access_flags)

--- a/src/main/certification/enhancement-command-trace-transform.ts
+++ b/src/main/certification/enhancement-command-trace-transform.ts
@@ -6,8 +6,15 @@
  * copying their bounded scalar evidence into caller-owned globals.
  */
 import { concat, sleb, uleb } from "../core/wasm-binary.js";
+import {
+  PROFESSION_TRACE_PAYLOAD_WORDS,
+  PROFESSION_TRACE_SCHEMA,
+  PROFESSION_TRACE_WORD,
+  PROFESSION_TRACE_WORDS,
+  type ProfessionTraceScalar,
+} from "../../shared/profession-command-trace.js";
 
-export const PROFESSION_TRACE_WORDS = 32;
+export { PROFESSION_TRACE_WORDS } from "../../shared/profession-command-trace.js";
 
 export type ProfessionTraceGlobals = Readonly<{
   origin: number;
@@ -33,6 +40,34 @@ export type ProfessionTraceGlobals = Readonly<{
   drainCount: number;
   drainOpcode: number;
 }>;
+
+/** Derives every trace global from the shared word layout and one allocated base. */
+export function professionTraceGlobals(base: number): ProfessionTraceGlobals {
+  return Object.freeze({
+    origin: base + PROFESSION_TRACE_WORD.schema,
+    builderCount: base + PROFESSION_TRACE_WORD.builderCount,
+    builderOrigin: base + PROFESSION_TRACE_WORD.builderOrigin,
+    builderTarget: base + PROFESSION_TRACE_WORD.builderTarget,
+    builderProfession: base + PROFESSION_TRACE_WORD.builderProfession,
+    skillBuilderCount: base + PROFESSION_TRACE_WORD.skillBuilderCount,
+    skillBuilderOrigin: base + PROFESSION_TRACE_WORD.skillBuilderOrigin,
+    skillBuilderTarget: base + PROFESSION_TRACE_WORD.skillBuilderTarget,
+    skillBuilderSkillCount: base + PROFESSION_TRACE_WORD.skillBuilderSkillCount,
+    senderCount: base + PROFESSION_TRACE_WORD.senderCount,
+    senderOrigin: base + PROFESSION_TRACE_WORD.senderOrigin,
+    senderConnection: base + PROFESSION_TRACE_WORD.senderConnection,
+    senderState: base + PROFESSION_TRACE_WORD.senderState,
+    senderTransport: base + PROFESSION_TRACE_WORD.senderTransport,
+    senderCursorBefore: base + PROFESSION_TRACE_WORD.senderCursorBefore,
+    senderCursorAfter: base + PROFESSION_TRACE_WORD.senderCursorAfter,
+    senderFlagBefore: base + PROFESSION_TRACE_WORD.senderFlagBefore,
+    senderFlagAfter: base + PROFESSION_TRACE_WORD.senderFlagAfter,
+    senderSize: base + PROFESSION_TRACE_WORD.senderSize,
+    senderPayload: base + PROFESSION_TRACE_WORD.senderPayload,
+    drainCount: base + PROFESSION_TRACE_WORD.drainCount,
+    drainOpcode: base + PROFESSION_TRACE_WORD.drainOpcode,
+  });
+}
 
 /** Records both raw arguments before preserving the exact profession builder. */
 export function tracedProfessionBuilder(
@@ -112,7 +147,7 @@ export function tracedPacketSender(
     Uint8Array.of(0x24), uleb(globals.senderFlagBefore),
     Uint8Array.of(0x20), uleb(1),
     Uint8Array.of(0x24), uleb(globals.senderSize),
-    ...Array.from({ length: 11 }, (_, index) => concat(
+    ...Array.from({ length: PROFESSION_TRACE_PAYLOAD_WORDS }, (_, index) => concat(
       index < words ? load(index * 4) : concat(Uint8Array.of(0x41), sleb(0)),
       Uint8Array.of(0x24), uleb(globals.senderPayload + index),
     )),
@@ -164,37 +199,26 @@ export function tracedPacketSender(
 
 /** Writes one consistent trace snapshot into caller-owned scratch memory. */
 export function professionTraceReader(globals: ProfessionTraceGlobals): Uint8Array {
-  const fields = [
-    null,
-    globals.builderCount,
-    globals.builderOrigin,
-    globals.builderTarget,
-    globals.builderProfession,
-    globals.skillBuilderCount,
-    globals.skillBuilderOrigin,
-    globals.skillBuilderTarget,
-    globals.skillBuilderSkillCount,
-    globals.senderCount,
-    globals.senderOrigin,
-    globals.senderConnection,
-    globals.senderState,
-    globals.senderTransport,
-    globals.senderCursorBefore,
-    globals.senderCursorAfter,
-    globals.senderFlagBefore,
-    globals.senderFlagAfter,
-    globals.senderSize,
-    ...Array.from({ length: 11 }, (_, index) => globals.senderPayload + index),
-    globals.drainCount,
-    globals.drainOpcode,
-  ] as const;
+  const fields = Array<number | null>(PROFESSION_TRACE_WORDS).fill(null);
+  for (const [name, offset] of Object.entries(PROFESSION_TRACE_WORD)) {
+    if (name === "schema" || name === "senderPayload") continue;
+    fields[offset] = globals[name as ProfessionTraceScalar];
+  }
+  for (let index = 0; index < PROFESSION_TRACE_PAYLOAD_WORDS; index += 1) {
+    fields[PROFESSION_TRACE_WORD.senderPayload + index] = globals.senderPayload + index;
+  }
+  if (fields.some((globalIndex, index) =>
+    index !== PROFESSION_TRACE_WORD.schema && globalIndex === null
+  )) {
+    throw new Error("profession trace layout is incomplete");
+  }
   return concat(
     uleb(0),
     ...fields.map((globalIndex, index) => concat(
       Uint8Array.of(0x20), uleb(0),
-      globalIndex === null
-        ? concat(Uint8Array.of(0x41), sleb(1))
-        : concat(Uint8Array.of(0x23), uleb(globalIndex)),
+      index === PROFESSION_TRACE_WORD.schema
+        ? concat(Uint8Array.of(0x41), sleb(PROFESSION_TRACE_SCHEMA))
+        : concat(Uint8Array.of(0x23), uleb(globalIndex!)),
       Uint8Array.of(0x36), uleb(2), uleb(index * 4),
     )),
     Uint8Array.of(0x41), sleb(PROFESSION_TRACE_WORDS),

--- a/src/main/certification/enhancement-command-trace-transform.ts
+++ b/src/main/certification/enhancement-command-trace-transform.ts
@@ -7,7 +7,7 @@
  */
 import { concat, sleb, uleb } from "../core/wasm-binary.js";
 
-export const PROFESSION_TRACE_WORDS = 30;
+export const PROFESSION_TRACE_WORDS = 32;
 
 export type ProfessionTraceGlobals = Readonly<{
   origin: number;
@@ -30,6 +30,8 @@ export type ProfessionTraceGlobals = Readonly<{
   senderFlagAfter: number;
   senderSize: number;
   senderPayload: number;
+  drainCount: number;
+  drainOpcode: number;
 }>;
 
 /** Records both raw arguments before preserving the exact profession builder. */
@@ -183,6 +185,8 @@ export function professionTraceReader(globals: ProfessionTraceGlobals): Uint8Arr
     globals.senderFlagAfter,
     globals.senderSize,
     ...Array.from({ length: 11 }, (_, index) => globals.senderPayload + index),
+    globals.drainCount,
+    globals.drainOpcode,
   ] as const;
   return concat(
     uleb(0),

--- a/src/main/certification/enhancement-command-transform.ts
+++ b/src/main/certification/enhancement-command-transform.ts
@@ -246,7 +246,11 @@ export function commandDrain(
   entries: readonly CommandEntry[],
   pendingGlobalIndex: number,
   argumentGlobalBase: number,
-  traceOriginGlobalIndex: number | null,
+  trace: Readonly<{
+    origin: number;
+    drainCount: number;
+    drainOpcode: number;
+  }> | null,
   storage: Readonly<{ functionIndex: number; payloadGlobalIndex: number }> | null,
   travel: Readonly<{
     dispatcherFunctionIndex: number;
@@ -289,20 +293,25 @@ export function commandDrain(
       Uint8Array.of(0x46, 0x04, 0x40),
       Uint8Array.of(0x41), sleb(0),
       Uint8Array.of(0x24), uleb(pendingGlobalIndex),
-      ...(traceOriginGlobalIndex === null
+      ...(trace === null
         ? []
         : [concat(
+            Uint8Array.of(0x23), uleb(trace.drainCount),
             Uint8Array.of(0x41), sleb(1),
-            Uint8Array.of(0x24), uleb(traceOriginGlobalIndex),
+            Uint8Array.of(0x6a, 0x24), uleb(trace.drainCount),
+            Uint8Array.of(0x41), sleb(entry.opcode),
+            Uint8Array.of(0x24), uleb(trace.drainOpcode),
+            Uint8Array.of(0x41), sleb(1),
+            Uint8Array.of(0x24), uleb(trace.origin),
           )]),
       ...entry.params.map((_, index) =>
         concat(Uint8Array.of(0x23), uleb(argumentGlobalBase + index))),
       Uint8Array.of(0x10), uleb(entry.functionIndex),
-      ...(traceOriginGlobalIndex === null
+      ...(trace === null
         ? []
         : [concat(
             Uint8Array.of(0x41), sleb(0),
-            Uint8Array.of(0x24), uleb(traceOriginGlobalIndex),
+            Uint8Array.of(0x24), uleb(trace.origin),
           )]),
       Uint8Array.of(0x0f, 0x0b),
     )),

--- a/src/main/certification/enhancement-transform-features.ts
+++ b/src/main/certification/enhancement-transform-features.ts
@@ -139,7 +139,13 @@ export function applyFeatureContributions(
       commands,
       globalIndices.commandPending,
       globalIndices.commandArgumentBase,
-      traceGlobals?.origin ?? null,
+      traceGlobals === null
+        ? null
+        : {
+            origin: traceGlobals.origin,
+            drainCount: traceGlobals.drainCount,
+            drainOpcode: traceGlobals.drainOpcode,
+          },
       capabilities.xunlaiAction
         ? {
             functionIndex: xunlaiAction.handler.functionIndex,

--- a/src/main/certification/enhancement-transform.ts
+++ b/src/main/certification/enhancement-transform.ts
@@ -31,6 +31,7 @@ import {
 import { applyFeatureContributions } from "./enhancement-transform-features.js";
 import {
   PROFESSION_TRACE_WORDS,
+  professionTraceGlobals,
   type ProfessionTraceGlobals,
 } from "./enhancement-command-trace-transform.js";
 import {
@@ -730,30 +731,7 @@ function assembleEnhancementTransform(
     ? allocateGlobals(PROFESSION_TRACE_WORDS)
     : 0;
   const traceGlobals: ProfessionTraceGlobals | null = capabilities.teamApply
-    ? {
-        origin: traceGlobalBase,
-        builderCount: traceGlobalBase + 1,
-        builderOrigin: traceGlobalBase + 2,
-        builderTarget: traceGlobalBase + 3,
-        builderProfession: traceGlobalBase + 4,
-        skillBuilderCount: traceGlobalBase + 5,
-        skillBuilderOrigin: traceGlobalBase + 6,
-        skillBuilderTarget: traceGlobalBase + 7,
-        skillBuilderSkillCount: traceGlobalBase + 8,
-        senderCount: traceGlobalBase + 9,
-        senderOrigin: traceGlobalBase + 10,
-        senderConnection: traceGlobalBase + 11,
-        senderState: traceGlobalBase + 12,
-        senderTransport: traceGlobalBase + 13,
-        senderCursorBefore: traceGlobalBase + 14,
-        senderCursorAfter: traceGlobalBase + 15,
-        senderFlagBefore: traceGlobalBase + 16,
-        senderFlagAfter: traceGlobalBase + 17,
-        senderSize: traceGlobalBase + 18,
-        senderPayload: traceGlobalBase + 19,
-        drainCount: traceGlobalBase + 30,
-        drainOpcode: traceGlobalBase + 31,
-      }
+    ? professionTraceGlobals(traceGlobalBase)
     : null;
 
   const nextTypes = [...types];

--- a/src/main/certification/enhancement-transform.ts
+++ b/src/main/certification/enhancement-transform.ts
@@ -751,6 +751,8 @@ function assembleEnhancementTransform(
         senderFlagAfter: traceGlobalBase + 17,
         senderSize: traceGlobalBase + 18,
         senderPayload: traceGlobalBase + 19,
+        drainCount: traceGlobalBase + 30,
+        drainOpcode: traceGlobalBase + 31,
       }
     : null;
 

--- a/src/main/protocol.ts
+++ b/src/main/protocol.ts
@@ -73,6 +73,7 @@ const RENDERER_SHARED_MODULES = new Set([
   "enhancement-config.js",
   "enhancement-contracts.js",
   "keyboard-shortcuts.js",
+  "profession-command-trace.js",
   "travel.js",
   "project-identity.js",
   "proxy-routes.js",

--- a/src/main/renderer-commands.ts
+++ b/src/main/renderer-commands.ts
@@ -160,10 +160,16 @@ export async function toggleTools(win: BrowserWindow): Promise<void> {
  * Command-Shift-C had been misrouted to the hero-build shortcut.
  */
 export async function openStorage(win: BrowserWindow): Promise<void> {
+  // Command-Shift-C can lose its physical modifier releases in AppKit after
+  // Chromium has already forwarded Shift to the game. Clear the renderer's
+  // held-key ledger before either the native Xunlai UI or the fallback dialog
+  // opens, so Guild Wars cannot keep a synthetic Shift pressed for the rest of
+  // the session. The Tools button takes the same harmless reset-free domain
+  // action directly because it carries no held keyboard chord.
+  await resetGameInput(win);
   if (await sendRendererCommand(win, { type: "storage.open" }) === "completed") {
     return;
   }
-  await resetGameInput(win);
   await sendRendererCommand(win, { type: "settings.open", pane: "controls" });
 }
 

--- a/src/renderer/certified-companion-installation.ts
+++ b/src/renderer/certified-companion-installation.ts
@@ -188,7 +188,7 @@ export async function installCertifiedCompanion(
     : null;
   const storageInstallation: StorageInstallation | null = capabilities.xunlaiAction
     ? (await import("./enhancement-storage-installation.js"))
-        .createStorageInstallation(exports, true)
+        .createStorageInstallation(exports, true, window.gwNative.init.development)
     : null;
   const travelInstallation: TravelInstallation | null = capabilities.travelAction
     ? (await import("./enhancement-travel-installation.js"))

--- a/src/renderer/enhancement-storage-controller.ts
+++ b/src/renderer/enhancement-storage-controller.ts
@@ -66,6 +66,8 @@ export function createStorageController(
   };
   let configuredEnabled: boolean | null = null;
   let availabilityTraceKey: string | null = null;
+  let request = 0;
+  let previousRequestAt: number | null = null;
   const unavailable = () => unavailableReason(active, availability);
   const trace = (event: string, fields: Readonly<Record<string, unknown>>) => {
     if (!development) return;
@@ -89,17 +91,26 @@ export function createStorageController(
   const onCommand = (event: Event) => {
     if (!(event instanceof CustomEvent)) return;
     event.preventDefault();
+    const requestedAt = performance.now();
+    const fields = {
+      request: ++request,
+      sincePreviousMs: previousRequestAt === null
+        ? null
+        : Math.round(requestedAt - previousRequestAt),
+      state: availability.state?.status ?? "missing",
+      access: availability.state?.status === "ready"
+        ? availability.state.xunlaiAccess
+        : "unknown",
+    } as const;
+    previousRequestAt = requestedAt;
     try {
       command.open();
-      trace("queued", { accepted: true });
+      trace("queued", { ...fields, accepted: true });
     } catch (error) {
       trace("refused", {
+        ...fields,
         reason: error instanceof Error ? error.message : "unknown storage error",
         enabled: availability.enabled,
-        state: availability.state?.status ?? "missing",
-        access: availability.state?.status === "ready"
-          ? availability.state.xunlaiAccess
-          : "unknown",
       });
       if (event.detail !== null && typeof event.detail === "object") {
         (event.detail as { error?: unknown }).error = error;

--- a/src/renderer/enhancement-storage-controller.ts
+++ b/src/renderer/enhancement-storage-controller.ts
@@ -65,6 +65,7 @@ export function createStorageController(
     state: null,
   };
   let configuredEnabled: boolean | null = null;
+  let availabilityTraceKey: string | null = null;
   const unavailable = () => unavailableReason(active, availability);
   const trace = (event: string, fields: Readonly<Record<string, unknown>>) => {
     if (!development) return;
@@ -112,11 +113,16 @@ export function createStorageController(
     command,
     update(next: StorageAvailability) {
       availability = next;
-      trace("availability", {
+      const fields = {
         enabled: next.enabled,
         state: next.state?.status ?? "missing",
         access: next.state?.status === "ready" ? next.state.xunlaiAccess : "unknown",
-      });
+      } as const;
+      const traceKey = JSON.stringify(fields);
+      if (traceKey !== availabilityTraceKey) {
+        availabilityTraceKey = traceKey;
+        trace("availability", fields);
+      }
       sync();
     },
     dispose() {

--- a/src/renderer/enhancement-storage-controller.ts
+++ b/src/renderer/enhancement-storage-controller.ts
@@ -57,6 +57,7 @@ export function createStorageController(
   open: EnhancementStorageOpen,
   configure: EnhancementStorageConfigure,
   payloadPointer: number,
+  development = false,
 ): StorageController {
   let active = true;
   let availability: StorageAvailability = {
@@ -65,19 +66,40 @@ export function createStorageController(
   };
   let configuredEnabled: boolean | null = null;
   const unavailable = () => unavailableReason(active, availability);
+  const trace = (event: string, fields: Readonly<Record<string, unknown>>) => {
+    if (!development) return;
+    console.debug(`[tools:dev] storage.${event} ${JSON.stringify(fields)}`);
+  };
   const command = createStorageCommand(open, unavailable);
   const sync = () => {
     const enabled = unavailable() === null;
     if (enabled === configuredEnabled) return;
-    configure(payloadPointer, enabled ? 1 : 0);
+    const result = configure(payloadPointer, enabled ? 1 : 0);
     configuredEnabled = enabled;
+    trace("configured", {
+      enabled,
+      accepted: result === 1,
+      state: availability.state?.status ?? "missing",
+      access: availability.state?.status === "ready"
+        ? availability.state.xunlaiAccess
+        : "unknown",
+    });
   };
   const onCommand = (event: Event) => {
     if (!(event instanceof CustomEvent)) return;
     event.preventDefault();
     try {
       command.open();
+      trace("queued", { accepted: true });
     } catch (error) {
+      trace("refused", {
+        reason: error instanceof Error ? error.message : "unknown storage error",
+        enabled: availability.enabled,
+        state: availability.state?.status ?? "missing",
+        access: availability.state?.status === "ready"
+          ? availability.state.xunlaiAccess
+          : "unknown",
+      });
       if (event.detail !== null && typeof event.detail === "object") {
         (event.detail as { error?: unknown }).error = error;
       }
@@ -90,6 +112,11 @@ export function createStorageController(
     command,
     update(next: StorageAvailability) {
       availability = next;
+      trace("availability", {
+        enabled: next.enabled,
+        state: next.state?.status ?? "missing",
+        access: next.state?.status === "ready" ? next.state.xunlaiAccess : "unknown",
+      });
       sync();
     },
     dispose() {

--- a/src/renderer/enhancement-storage-installation.ts
+++ b/src/renderer/enhancement-storage-installation.ts
@@ -29,6 +29,7 @@ export interface StorageInstallation {
 export function createStorageInstallation(
   exports: WebAssembly.Exports,
   enabled: boolean,
+  development = false,
 ): StorageInstallation | null {
   if (!enabled) return null;
   const open = typeof exports.enhancement_open_storage === "function"
@@ -55,7 +56,7 @@ export function createStorageInstallation(
       configure(payloadPointer, 0);
     },
     mount() {
-      controller = createStorageController(open, configure, payloadPointer);
+      controller = createStorageController(open, configure, payloadPointer, development);
     },
     update(availability) {
       controller?.update(availability);

--- a/src/renderer/input-trace.ts
+++ b/src/renderer/input-trace.ts
@@ -69,12 +69,12 @@ const label = (record: InputTraceRecord): { text: string; tone: string } => {
     case 'press':
       return {
         tone: 'event',
-        text: `${prefix} press ${BUTTON_NAMES[record.button] ?? 'other'}`
+        text: `${prefix} press ${BUTTON_NAMES[record.button] ?? 'other'} ${record.owner}`
           + ` run=${record.detail}`
           + record.modifiers.map((modifier) => ` +${modifier}`).join(''),
       };
     case 'release':
-      return { tone: 'event', text: `${prefix} release ${BUTTON_NAMES[record.button] ?? 'other'} travel=${record.travel} remaining=${record.buttonsRemaining}` };
+      return { tone: 'event', text: `${prefix} release ${BUTTON_NAMES[record.button] ?? 'other'} ${record.owner} travel=${record.travel} remaining=${record.buttonsRemaining}` };
     case 'modifier':
       return { tone: 'event', text: `${prefix} ${record.key} ${record.down ? 'down' : 'up'}` };
     case 'double-click':

--- a/src/renderer/input.ts
+++ b/src/renderer/input.ts
@@ -555,6 +555,7 @@ export const installGameInput = ({
     trace?.record({
       source: 'renderer',
       kind: 'press',
+      owner: traceOwner(event.target),
       button: event.button,
       detail: event.detail,
       modifiers: tracedModifiers(event),
@@ -580,6 +581,7 @@ export const installGameInput = ({
     trace?.record({
       source: 'renderer',
       kind: 'release',
+      owner: traceOwner(event.target),
       button: event.button,
       travel: held
         ? (() => {

--- a/src/renderer/profession-command-trace.ts
+++ b/src/renderer/profession-command-trace.ts
@@ -9,7 +9,7 @@
  */
 import type { ToolboxObservation } from "../shared/builds/live-party.js";
 
-const TRACE_WORDS = 30;
+const TRACE_WORDS = 32;
 export const PROFESSION_COMMAND_TRACE_BYTES =
   TRACE_WORDS * Uint32Array.BYTES_PER_ELEMENT;
 
@@ -25,6 +25,7 @@ export function createProfessionCommandTrace(
   let lastProfessionBuilderCount = 0;
   let lastSkillBuilderCount = 0;
   let lastSenderCount = 0;
+  let lastDrainCount = 0;
   let disposed = false;
 
   Reflect.set(window, "gwProfessionCommandTrace", Object.freeze({
@@ -63,22 +64,28 @@ export function createProfessionCommandTrace(
         0,
         Math.min(11, Math.floor(senderSize / 4)),
       );
+      const drainCount = words[30]!;
+      const drainOpcode = words[31]!;
       const professionChanged = professionBuilderCount !== lastProfessionBuilderCount;
       const skillChanged = skillBuilderCount !== lastSkillBuilderCount;
       const senderChanged = senderCount !== lastSenderCount;
+      const drainChanged = drainCount !== lastDrainCount;
       if (
         schema !== 1
-        || (!professionChanged && !skillChanged && !senderChanged)
+        || (!professionChanged && !skillChanged && !senderChanged && !drainChanged)
       ) return;
       lastProfessionBuilderCount = professionBuilderCount;
       lastSkillBuilderCount = skillBuilderCount;
       lastSenderCount = senderCount;
+      lastDrainCount = drainCount;
       const observedTarget = skillChanged
         ? skillBuilderTarget
         : professionChanged
           ? professionBuilderTarget
-          : (senderPayload[1] ?? 0);
-      const target = state.party?.slots?.find(
+          : senderChanged
+            ? (senderPayload[1] ?? 0)
+            : null;
+      const target = observedTarget === null ? undefined : state.party?.slots?.find(
         (slot) => slot.occupied && slot.agentId === observedTarget,
       );
       const entry = Object.freeze({
@@ -87,7 +94,9 @@ export function createProfessionCommandTrace(
           professionBuilder: professionChanged,
           skillBuilder: skillChanged,
           sender: senderChanged,
+          drain: drainChanged,
         }),
+        drain: Object.freeze({ count: drainCount, opcode: drainOpcode }),
         professionBuilder: Object.freeze({
           count: professionBuilderCount,
           origin: professionBuilderOrigin === 1 ? "gwonmac" : "native",

--- a/src/renderer/profession-command-trace.ts
+++ b/src/renderer/profession-command-trace.ts
@@ -8,10 +8,15 @@
  * Nothing is persisted or diagnosed.
  */
 import type { ToolboxObservation } from "../shared/builds/live-party.js";
+import {
+  PROFESSION_TRACE_PAYLOAD_WORDS,
+  PROFESSION_TRACE_SCHEMA,
+  PROFESSION_TRACE_WORD,
+  PROFESSION_TRACE_WORDS,
+} from "../shared/profession-command-trace.js";
 
-const TRACE_WORDS = 32;
 export const PROFESSION_COMMAND_TRACE_BYTES =
-  TRACE_WORDS * Uint32Array.BYTES_PER_ELEMENT;
+  PROFESSION_TRACE_WORDS * Uint32Array.BYTES_PER_ELEMENT;
 
 export type ProfessionCommandTraceReader = (pointer: number) => number;
 
@@ -29,7 +34,7 @@ export function createProfessionCommandTrace(
   let disposed = false;
 
   Reflect.set(window, "gwProfessionCommandTrace", Object.freeze({
-    schema: 1,
+    schema: PROFESSION_TRACE_SCHEMA,
     entries: Object.freeze([]),
   }));
 
@@ -37,41 +42,46 @@ export function createProfessionCommandTrace(
     poll(state: ToolboxObservation) {
       if (disposed) return;
       const written = read(pointer);
-      if (written !== TRACE_WORDS) {
+      if (written !== PROFESSION_TRACE_WORDS) {
         throw new Error(`team command trace wrote ${written} words`);
       }
-      const words = new Uint32Array(memory.buffer, pointer, TRACE_WORDS);
-      const schema = words[0]!;
-      const professionBuilderCount = words[1]!;
-      const professionBuilderOrigin = words[2]!;
-      const professionBuilderTarget = words[3]!;
-      const builderProfession = words[4]!;
-      const skillBuilderCount = words[5]!;
-      const skillBuilderOrigin = words[6]!;
-      const skillBuilderTarget = words[7]!;
-      const skillBuilderSkillCount = words[8]!;
-      const senderCount = words[9]!;
-      const senderOrigin = words[10]!;
-      const senderConnection = words[11]!;
-      const senderState = words[12]!;
-      const senderTransport = words[13]!;
-      const senderCursorBefore = words[14]!;
-      const senderCursorAfter = words[15]!;
-      const senderFlagBefore = words[16]!;
-      const senderFlagAfter = words[17]!;
-      const senderSize = words[18]!;
-      const senderPayload = [...words.slice(19, 30)].slice(
+      const words = new Uint32Array(memory.buffer, pointer, PROFESSION_TRACE_WORDS);
+      const at = (name: keyof typeof PROFESSION_TRACE_WORD) =>
+        words[PROFESSION_TRACE_WORD[name]]!;
+      const schema = at("schema");
+      const professionBuilderCount = at("builderCount");
+      const professionBuilderOrigin = at("builderOrigin");
+      const professionBuilderTarget = at("builderTarget");
+      const builderProfession = at("builderProfession");
+      const skillBuilderCount = at("skillBuilderCount");
+      const skillBuilderOrigin = at("skillBuilderOrigin");
+      const skillBuilderTarget = at("skillBuilderTarget");
+      const skillBuilderSkillCount = at("skillBuilderSkillCount");
+      const senderCount = at("senderCount");
+      const senderOrigin = at("senderOrigin");
+      const senderConnection = at("senderConnection");
+      const senderState = at("senderState");
+      const senderTransport = at("senderTransport");
+      const senderCursorBefore = at("senderCursorBefore");
+      const senderCursorAfter = at("senderCursorAfter");
+      const senderFlagBefore = at("senderFlagBefore");
+      const senderFlagAfter = at("senderFlagAfter");
+      const senderSize = at("senderSize");
+      const senderPayload = [...words.slice(
+        PROFESSION_TRACE_WORD.senderPayload,
+        PROFESSION_TRACE_WORD.senderPayload + PROFESSION_TRACE_PAYLOAD_WORDS,
+      )].slice(
         0,
-        Math.min(11, Math.floor(senderSize / 4)),
+        Math.min(PROFESSION_TRACE_PAYLOAD_WORDS, Math.floor(senderSize / 4)),
       );
-      const drainCount = words[30]!;
-      const drainOpcode = words[31]!;
+      const drainCount = at("drainCount");
+      const drainOpcode = at("drainOpcode");
       const professionChanged = professionBuilderCount !== lastProfessionBuilderCount;
       const skillChanged = skillBuilderCount !== lastSkillBuilderCount;
       const senderChanged = senderCount !== lastSenderCount;
       const drainChanged = drainCount !== lastDrainCount;
       if (
-        schema !== 1
+        schema !== PROFESSION_TRACE_SCHEMA
         || (!professionChanged && !skillChanged && !senderChanged && !drainChanged)
       ) return;
       lastProfessionBuilderCount = professionBuilderCount;
@@ -133,7 +143,7 @@ export function createProfessionCommandTrace(
       entries.push(entry);
       if (entries.length > 24) entries.shift();
       Reflect.set(window, "gwProfessionCommandTrace", Object.freeze({
-        schema: 1,
+        schema: PROFESSION_TRACE_SCHEMA,
         entries: Object.freeze([...entries]),
       }));
       console.info(`[tools:dev] team command trace ${JSON.stringify(entry)}`);

--- a/src/renderer/surface-controller.ts
+++ b/src/renderer/surface-controller.ts
@@ -114,6 +114,10 @@ export function installSurfaceController(
     register(surface: Surface): GwonmacSurfaceHandle {
       const id = Symbol("surface");
       let open = false;
+      // Input diagnostics report only this coarse ownership category. The
+      // marker carries no UI text or selector, and lets a player distinguish
+      // "Guild Wars received the click" from "a GWonMac surface owned it".
+      surface.root.dataset.gwonmacSurface = "";
       return Object.freeze({
         setOpen(next: boolean) {
           if (next === open) return;
@@ -124,6 +128,7 @@ export function installSurfaceController(
         dispose() {
           open = false;
           surfaces.delete(id);
+          delete surface.root.dataset.gwonmacSurface;
         },
       });
     },

--- a/src/renderer/travel-palette.ts
+++ b/src/renderer/travel-palette.ts
@@ -20,6 +20,7 @@ type TravelBundle = Readonly<{
     target: HTMLElement,
     options: {
       command: TravelCommand;
+      development: boolean;
       initiallyVisible?: boolean;
       onVisibilityChange?: (visible: boolean) => void;
     },
@@ -75,6 +76,7 @@ export function createTravelPalette(
         if (disposed) return;
         app = bundle.mountTravelPalette(host, {
           command,
+          development: window.gwNative.init.development,
           initiallyVisible: open,
           onVisibilityChange: (visible) => setOpen(visible),
         });

--- a/src/shared/builds/team-apply-runner.ts
+++ b/src/shared/builds/team-apply-runner.ts
@@ -91,8 +91,8 @@ export type TeamApplyEvent = Readonly<{
   elapsedMs: number;
 }>;
 
-/** Matches GWToolbox++'s per-hero budget; a roster change is a server round trip. */
-const CONFIRM_MS = 1_000;
+/** Live QA observed ordinary roster publications just beyond one second. */
+const CONFIRM_MS = 2_000;
 /** Live profession changes can arrive well after the command was accepted. */
 const PROFESSION_CONFIRM_MS = 15_000;
 /** A published profession leads the client state rebuilt from that profession. */

--- a/src/shared/enhancement-contracts.ts
+++ b/src/shared/enhancement-contracts.ts
@@ -132,7 +132,7 @@ export {
   ENHANCEMENT_LAYOUT_WORD_COUNT,
   ENHANCEMENT_PARTY_DIRTY_MESSAGE_COUNT,
 } from "./enhancement-config.js";
-export const ENHANCEMENT_TRANSFORM_ABI = 36;
+export const ENHANCEMENT_TRANSFORM_ABI = 37;
 
 export function enhancementConfigWordActive(
   capabilities: EnhancementCapabilities,

--- a/src/shared/input-trace.ts
+++ b/src/shared/input-trace.ts
@@ -68,6 +68,7 @@ export type InputTraceEntry =
   | {
       source: 'renderer';
       kind: 'press';
+      owner: InputTraceOwner;
       button: number;
       detail: number;
       modifiers: readonly InputTraceModifier[];
@@ -75,6 +76,7 @@ export type InputTraceEntry =
   | {
       source: 'renderer';
       kind: 'release';
+      owner: InputTraceOwner;
       button: number;
       travel: 'still' | 'short' | 'far';
       buttonsRemaining: number;

--- a/src/shared/profession-command-trace.ts
+++ b/src/shared/profession-command-trace.ts
@@ -1,0 +1,38 @@
+/**
+ * Defines the development-only Team Apply trace ABI.
+ * Keeps Wasm writers and renderer readers on one named layout.
+ */
+export const PROFESSION_TRACE_SCHEMA = 2;
+
+export const PROFESSION_TRACE_WORD = Object.freeze({
+  schema: 0,
+  builderCount: 1,
+  builderOrigin: 2,
+  builderTarget: 3,
+  builderProfession: 4,
+  skillBuilderCount: 5,
+  skillBuilderOrigin: 6,
+  skillBuilderTarget: 7,
+  skillBuilderSkillCount: 8,
+  senderCount: 9,
+  senderOrigin: 10,
+  senderConnection: 11,
+  senderState: 12,
+  senderTransport: 13,
+  senderCursorBefore: 14,
+  senderCursorAfter: 15,
+  senderFlagBefore: 16,
+  senderFlagAfter: 17,
+  senderSize: 18,
+  senderPayload: 19,
+  drainCount: 30,
+  drainOpcode: 31,
+} as const);
+
+export const PROFESSION_TRACE_PAYLOAD_WORDS = 11;
+export const PROFESSION_TRACE_WORDS = PROFESSION_TRACE_WORD.drainOpcode + 1;
+
+export type ProfessionTraceScalar = Exclude<
+  keyof typeof PROFESSION_TRACE_WORD,
+  "schema" | "senderPayload"
+>;

--- a/tests/electron/input-toolbox.spec.ts
+++ b/tests/electron/input-toolbox.spec.ts
@@ -359,7 +359,7 @@ test.describe("renderer Tools input", () => {
   test("mounts the shipped embedded Tools window and persists one library change", async () => {
     const fixture = await launchCachedClient("gw-toolbox-embedded-e2e-");
     try {
-      const { page } = fixture;
+      const { app, page } = fixture;
       await startGameInput(page);
       await page.evaluate(async () => {
         globalThis.document.getElementById("loading")?.classList.add("gone");
@@ -373,9 +373,62 @@ test.describe("renderer Tools input", () => {
             typeof import("../../src/renderer/tools-host.js")
           >,
         ]);
+        const canvas = document.getElementById("canvas");
+        if (!(canvas instanceof HTMLCanvasElement)) {
+          throw new Error("#canvas is missing");
+        }
+        document.body.dataset.storageOpens = "0";
+        document.body.dataset.canvasPressesAfterStorage = "0";
+        document.body.dataset.storageInputResets = "0";
+        document.body.dataset.storageOrder = "";
+        document.body.dataset.storageShiftDowns = "0";
+        document.body.dataset.storageShiftUps = "0";
+        const appendStorageOrder = (value: string) => {
+          document.body.dataset.storageOrder = [
+            ...(document.body.dataset.storageOrder?.split(",").filter(Boolean) ?? []),
+            value,
+          ].join(",");
+        };
+        const openStorage = () => {
+          document.body.dataset.storageOpens = String(
+            Number(document.body.dataset.storageOpens ?? "0") + 1,
+          );
+          appendStorageOrder("storage");
+        };
+        window.addEventListener("gw:input-reset", () => {
+          document.body.dataset.storageInputResets = String(
+            Number(document.body.dataset.storageInputResets ?? "0") + 1,
+          );
+          appendStorageOrder("reset");
+        });
+        window.addEventListener("gw:storage-open", (event) => {
+          event.preventDefault();
+          openStorage();
+        });
+        canvas.addEventListener("keydown", (event) => {
+          if (event.key !== "Shift") return;
+          document.body.dataset.storageShiftDowns = String(
+            Number(document.body.dataset.storageShiftDowns ?? "0") + 1,
+          );
+        });
+        canvas.addEventListener("keyup", (event) => {
+          if (event.key !== "Shift") return;
+          document.body.dataset.storageShiftUps = String(
+            Number(document.body.dataset.storageShiftUps ?? "0") + 1,
+          );
+        });
+        window.addEventListener("mousedown", (event) => {
+          if (event.target !== canvas) return;
+          document.body.dataset.canvasPressesAfterStorage = String(
+            Number(document.body.dataset.canvasPressesAfterStorage ?? "0") + 1,
+          );
+        });
         foundation.createToolboxFoundation(document.body, {
           mountTool: (host, onVisibilityChange) =>
-            toolsHost.mountToolsInto(host, onVisibilityChange, null, null, true),
+            toolsHost.mountToolsInto(host, onVisibilityChange, null, {
+              open: openStorage,
+              unavailable: () => null,
+            }, true),
         });
       });
 
@@ -445,6 +498,74 @@ test.describe("renderer Tools input", () => {
       await page.keyboard.press("Escape");
       await expect(panel).toBeHidden();
       await expect.poll(() => isDomActiveElement(canvas)).toBe(true);
+
+      // The real Xunlai route closes Tools after it queues the named command.
+      // Hiding the panel must also surrender every pixel to the game: the next
+      // world press reaches the canvas instead of an invisible Tools surface.
+      await page.keyboard.press("Control+Shift+Space");
+      await expect(panel).toBeVisible();
+      await page.getByRole("button", { name: "Open Xunlai Storage" }).click();
+      await expect(page.locator("body")).toHaveAttribute("data-storage-opens", "1");
+      await expect(root).toHaveAttribute("data-open", "false");
+      await expect(panel).toBeHidden();
+      const canvasBox = await canvas.boundingBox();
+      if (!canvasBox) throw new Error("The game canvas has no bounds");
+      await page.mouse.click(canvasBox.x + canvasBox.width - 80, canvasBox.y + 120);
+      await expect(page.locator("body")).toHaveAttribute(
+        "data-canvas-presses-after-storage",
+        "1",
+      );
+      await expect.poll(() => isDomActiveElement(canvas)).toBe(true);
+
+      // The successful Command-Shift-C route must release Shift before it
+      // opens native storage. macOS can consume the physical release while
+      // Command is held; without this reset Guild Wars keeps Shift pressed and
+      // then refuses ordinary click-to-walk and NPC interaction.
+      await page.evaluate(() => {
+        document.body.dataset.storageOpens = "0";
+        document.body.dataset.storageInputResets = "0";
+        document.body.dataset.storageOrder = "";
+        document.body.dataset.storageShiftDowns = "0";
+        document.body.dataset.storageShiftUps = "0";
+        document.getElementById("canvas")?.focus();
+      });
+      await app.evaluate(({ BrowserWindow }) => {
+        const contents = BrowserWindow.getAllWindows()[0]?.webContents;
+        contents?.sendInputEvent({
+          type: "keyDown",
+          keyCode: "Shift",
+          modifiers: ["shift"],
+        });
+        contents?.sendInputEvent({
+          type: "keyDown",
+          keyCode: "C",
+          modifiers: ["meta", "shift"],
+        });
+        contents?.sendInputEvent({
+          type: "keyUp",
+          keyCode: "C",
+          modifiers: ["meta", "shift"],
+        });
+        // Deliberately omit Shift-up. This is the AppKit loss the production
+        // reset must contain rather than relying on a later physical event.
+      });
+      await expect(page.locator("body")).toHaveAttribute("data-storage-opens", "1");
+      await expect(page.locator("body")).toHaveAttribute(
+        "data-storage-input-resets",
+        "1",
+      );
+      await expect(page.locator("body")).toHaveAttribute(
+        "data-storage-order",
+        "reset,storage",
+      );
+      await expect(page.locator("body")).toHaveAttribute(
+        "data-storage-shift-downs",
+        "1",
+      );
+      await expect(page.locator("body")).toHaveAttribute(
+        "data-storage-shift-ups",
+        "1",
+      );
     } finally {
       await closeOffline(fixture);
     }

--- a/tests/electron/input-trace.spec.ts
+++ b/tests/electron/input-trace.spec.ts
@@ -82,6 +82,20 @@ test.describe("input trace", () => {
       expect(rows[flagged - 1]).toContain("run=2");
       const afterDouble = await traceText(page);
       expect(afterDouble).toContain("run=2");
+      expect(afterDouble).toContain("press left canvas");
+
+      // A privacy-safe owner category is enough to diagnose an invisible
+      // overlay without copying selectors, labels, or coordinates.
+      await page.evaluate(() => {
+        const surface = document.createElement("button");
+        surface.type = "button";
+        surface.dataset.gwonmacSurface = "";
+        surface.dataset.testid = "trace-surface";
+        surface.style.cssText = "position:fixed;left:20px;top:20px;width:40px;height:40px";
+        document.body.append(surface);
+      });
+      await page.locator('[data-testid="trace-surface"]').click();
+      await expectTrace(page).toContain("press left surface");
 
       // The flag rides on the press itself, so a three-click run flags the
       // second press and the fourth, exactly as Windows raises its own

--- a/tests/electron/input-travel.spec.ts
+++ b/tests/electron/input-travel.spec.ts
@@ -91,7 +91,7 @@ test.describe("renderer Travel input", () => {
       );
       await expect(search).toHaveAccessibleName("Search destinations");
       await expect(palette.getByRole("listbox")).toHaveCount(0);
-      await expect(page.getByText("Start typing to search all outposts."))
+      await expect(page.getByText("Start typing to search available destinations."))
         .toBeVisible();
 
       // Native modal work is above non-modal surfaces. The first Escape closes

--- a/tests/fixtures/enhancements.ts
+++ b/tests/fixtures/enhancements.ts
@@ -330,6 +330,9 @@ export const DETAIL_CONFIG_START = ENHANCEMENT_LAYOUT_FIELDS.indexOf("heroLevel"
 export const POLICY_CONFIG_START = ENHANCEMENT_LAYOUT_FIELDS.indexOf("areaInfo");
 export const PLAYER_CONFIG_START = ENHANCEMENT_LAYOUT_FIELDS.indexOf("worldProfessionStates");
 export const XUNLAI_CONFIG_START = ENHANCEMENT_LAYOUT_FIELDS.indexOf("worldPlayers");
+export const PLAYER_RECORD_INDEX = 42;
+export const PLAYER_RECORD_ADDRESS =
+  ADDRESSES.playerRecordBuffer + PLAYER_RECORD_INDEX * DETAIL.playerStride;
 export const CONFIG_WORDS = ENHANCEMENT_CONFIG_WORD_COUNT;
 export const CONFIG_BYTES = CONFIG_WORDS * 4;
 export const MESSAGE_CONFIG_START = ENHANCEMENT_LAYOUT_WORD_COUNT;
@@ -584,21 +587,21 @@ export function installGameGraph(view: DataView) {
   view.setUint32(ADDRESSES.game + 0x4c, ADDRESSES.partyContext, true);
   view.setUint32(ADDRESSES.game + DETAIL.worldContext, ADDRESSES.world, true);
   view.setUint32(ADDRESSES.world + DETAIL.players, ADDRESSES.playerRecordBuffer, true);
-  view.setUint32(ADDRESSES.world + DETAIL.players + 4, 1, true);
-  view.setUint32(ADDRESSES.world + DETAIL.players + 8, 1, true);
+  view.setUint32(ADDRESSES.world + DETAIL.players + 4, 64, true);
+  view.setUint32(ADDRESSES.world + DETAIL.players + 8, PLAYER_RECORD_INDEX + 1, true);
   view.setUint32(
-    ADDRESSES.playerRecordBuffer + DETAIL.playerAgentId,
+    PLAYER_RECORD_ADDRESS + DETAIL.playerAgentId,
     7,
     true,
   );
   view.setUint32(
-    ADDRESSES.playerRecordBuffer + DETAIL.playerAccessFlags,
+    PLAYER_RECORD_ADDRESS + DETAIL.playerAccessFlags,
     0,
     true,
   );
   view.setUint32(
-    ADDRESSES.playerRecordBuffer + DETAIL.playerNumber,
-    42,
+    PLAYER_RECORD_ADDRESS + DETAIL.playerNumber,
+    PLAYER_RECORD_INDEX,
     true,
   );
   view.setUint32(ADDRESSES.partyContext + 0x54, ADDRESSES.partyInfo, true);

--- a/tests/integration/enhancements-xunlai-kernel.test.ts
+++ b/tests/integration/enhancements-xunlai-kernel.test.ts
@@ -7,6 +7,7 @@ import {
   DETAIL,
   FEATURE_GAME_SNAPSHOT,
   installGameGraph,
+  PLAYER_RECORD_ADDRESS,
   readCompanionSnapshot,
   XUNLAI_CONFIG_START,
 } from "../fixtures/enhancements.ts";
@@ -27,7 +28,7 @@ describe("Companion Xunlai access kernel", () => {
     assert.equal(storageOnly.targetId, 0);
 
     kernel.view.setUint32(
-      ADDRESSES.playerRecordBuffer + DETAIL.playerAccessFlags,
+      PLAYER_RECORD_ADDRESS + DETAIL.playerAccessFlags,
       0x2,
       true,
     );
@@ -39,7 +40,7 @@ describe("Companion Xunlai access kernel", () => {
     );
 
     kernel.view.setUint32(
-      ADDRESSES.playerRecordBuffer + DETAIL.playerAccessFlags,
+      PLAYER_RECORD_ADDRESS + DETAIL.playerAccessFlags,
       0,
       true,
     );
@@ -92,7 +93,7 @@ describe("Companion Xunlai access kernel", () => {
     assert.equal(access(), true);
 
     kernel.view.setUint32(
-      ADDRESSES.playerRecordBuffer + DETAIL.playerAgentId,
+      PLAYER_RECORD_ADDRESS + DETAIL.playerAgentId,
       9,
       true,
     );
@@ -100,12 +101,12 @@ describe("Companion Xunlai access kernel", () => {
     assert.equal(access(), null);
 
     kernel.view.setUint32(
-      ADDRESSES.playerRecordBuffer + DETAIL.playerAgentId,
+      PLAYER_RECORD_ADDRESS + DETAIL.playerAgentId,
       7,
       true,
     );
     kernel.view.setUint32(
-      ADDRESSES.playerRecordBuffer + DETAIL.playerNumber,
+      PLAYER_RECORD_ADDRESS + DETAIL.playerNumber,
       43,
       true,
     );
@@ -113,7 +114,7 @@ describe("Companion Xunlai access kernel", () => {
     assert.equal(access(), null);
 
     kernel.view.setUint32(
-      ADDRESSES.playerRecordBuffer + DETAIL.playerNumber,
+      PLAYER_RECORD_ADDRESS + DETAIL.playerNumber,
       42,
       true,
     );
@@ -121,9 +122,9 @@ describe("Companion Xunlai access kernel", () => {
     kernel.tick();
     assert.equal(access(), null);
 
-    kernel.view.setUint32(ADDRESSES.world + DETAIL.players + 4, 1, true);
+    kernel.view.setUint32(ADDRESSES.world + DETAIL.players + 4, 64, true);
     kernel.view.setUint32(
-      ADDRESSES.playerRecordBuffer + DETAIL.playerAccessFlags,
+      PLAYER_RECORD_ADDRESS + DETAIL.playerAccessFlags,
       0x2,
       true,
     );

--- a/tests/unit/apply-believes-the-roster-not-the-return-value.test.ts
+++ b/tests/unit/apply-believes-the-roster-not-the-return-value.test.ts
@@ -338,6 +338,32 @@ test("attributes the game never applies are a refusal too", async () => {
   assert.deepEqual(game.sent.at(-1), "attributes:11:17=7,19=12");
 });
 
+test("an ordinary attribute publication just after one second is not a false refusal", async () => {
+  const initial = {
+    hero: 6, agentId: 11, behaviour: 1, skills: [1, 2, 3, 4, 5, 6, 7, 8],
+    professions: [1, 2] as const, attributes: [],
+  };
+  const changed = {
+    ...initial,
+    attributes: [[17, 7], [19, 12]] as readonly (readonly number[])[],
+  };
+  const game = harness([initial]);
+  const sleep = game.environment.confirmationTime!.sleep;
+  game.environment.confirmationTime!.sleep = async (milliseconds) => {
+    await sleep(milliseconds);
+    if (game.environment.confirmationTime!.now() >= 1_250) game.set([changed]);
+  };
+
+  const result = await runTeamApply(
+    plan([member({ hero: heroId(6), build: build(), behaviour: "guard" })]),
+    game.environment,
+    1,
+  );
+
+  assert.equal(result.completedChanges, 1);
+  assert.deepEqual(game.sent, ["attributes:11:17=7,19=12"]);
+});
+
 test("an empty attribute plan clears the player's invested ranks", async () => {
   const game = harness([]);
   game.setPlayer({

--- a/tests/unit/enhancement-command-transform.test.ts
+++ b/tests/unit/enhancement-command-transform.test.ts
@@ -14,6 +14,10 @@ import {
   intersectEnhancementCapabilities,
 } from "../../src/shared/enhancement-contracts.js";
 import {
+  PROFESSION_TRACE_SCHEMA,
+  PROFESSION_TRACE_WORDS,
+} from "../../src/shared/profession-command-trace.js";
+import {
   commandBody,
   CURSOR_ONLY,
   CURSOR_TARGET,
@@ -512,14 +516,14 @@ describe("Enhancement command transform", () => {
     const readTrace = instance.exports[build.teamApply!.professionTrace.readerExport] as
       (pointer: number) => number;
     const trace = () => {
-      assert.equal(readTrace(64), 32);
-      return [...new Uint32Array(wasmMemory.buffer, 64, 32)];
+      assert.equal(readTrace(64), PROFESSION_TRACE_WORDS);
+      return [...new Uint32Array(wasmMemory.buffer, 64, PROFESSION_TRACE_WORDS)];
     };
 
     new Uint32Array(wasmMemory.buffer, 0, 2).set([31, 38]);
     nativeSender(999, 8, 0);
     assert.deepEqual(trace(), [
-      1,
+      PROFESSION_TRACE_SCHEMA,
       0, 0, 0, 0,
       0, 0, 0, 0,
       1, 0, 999, 0, 0, 0, 0, 0, 0, 8,
@@ -531,7 +535,7 @@ describe("Enhancement command transform", () => {
     assert.deepEqual(packets, [[999, 8, 0], [999, 12, 0]]);
     assert.deepEqual([...new Uint32Array(wasmMemory.buffer, 0, 3)], [65, 77, 2]);
     assert.deepEqual(trace(), [
-      1,
+      PROFESSION_TRACE_SCHEMA,
       1, 0, 77, 2,
       0, 0, 0, 0,
       2, 0, 999, 0, 0, 0, 0, 0, 0, 12,
@@ -548,7 +552,7 @@ describe("Enhancement command transform", () => {
     ]);
     assert.deepEqual([...new Uint32Array(wasmMemory.buffer, 0, 3)], [65, 88, 3]);
     assert.deepEqual(trace(), [
-      1,
+      PROFESSION_TRACE_SCHEMA,
       2, 1, 88, 3,
       0, 0, 0, 0,
       3, 1, 999, 0, 0, 0, 0, 0, 0, 12,
@@ -560,7 +564,7 @@ describe("Enhancement command transform", () => {
     skillWords.set([1, 2, 3, 4, 5, 6, 446, 8]);
     nativeSkill(77, 8, 256);
     assert.deepEqual(trace(), [
-      1,
+      PROFESSION_TRACE_SCHEMA,
       2, 1, 88, 3,
       1, 0, 77, 8,
       4, 0, 999, 0, 0, 0, 0, 0, 0, 44,
@@ -573,7 +577,7 @@ describe("Enhancement command transform", () => {
       93, 77, 8, 1, 2, 3, 4, 5, 6, 446, 8,
     ]);
     assert.deepEqual(trace(), [
-      1,
+      PROFESSION_TRACE_SCHEMA,
       2, 1, 88, 3,
       2, 1, 77, 8,
       5, 1, 999, 0, 0, 0, 0, 0, 0, 44,

--- a/tests/unit/enhancement-command-transform.test.ts
+++ b/tests/unit/enhancement-command-transform.test.ts
@@ -512,8 +512,8 @@ describe("Enhancement command transform", () => {
     const readTrace = instance.exports[build.teamApply!.professionTrace.readerExport] as
       (pointer: number) => number;
     const trace = () => {
-      assert.equal(readTrace(64), 30);
-      return [...new Uint32Array(wasmMemory.buffer, 64, 30)];
+      assert.equal(readTrace(64), 32);
+      return [...new Uint32Array(wasmMemory.buffer, 64, 32)];
     };
 
     new Uint32Array(wasmMemory.buffer, 0, 2).set([31, 38]);
@@ -524,6 +524,7 @@ describe("Enhancement command transform", () => {
       0, 0, 0, 0,
       1, 0, 999, 0, 0, 0, 0, 0, 0, 8,
       31, 38, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0,
     ]);
 
     nativeProfession(77, 2);
@@ -535,6 +536,7 @@ describe("Enhancement command transform", () => {
       0, 0, 0, 0,
       2, 0, 999, 0, 0, 0, 0, 0, 0, 12,
       65, 77, 2, 0, 0, 0, 0, 0, 0, 0, 0,
+      0, 0,
     ]);
 
     assert.equal(enqueue(65, 88, 3, 0, 0), 1);
@@ -551,6 +553,7 @@ describe("Enhancement command transform", () => {
       0, 0, 0, 0,
       3, 1, 999, 0, 0, 0, 0, 0, 0, 12,
       65, 88, 3, 0, 0, 0, 0, 0, 0, 0, 0,
+      1, 65,
     ]);
 
     const skillWords = new Uint32Array(wasmMemory.buffer, 256, 8);
@@ -562,6 +565,7 @@ describe("Enhancement command transform", () => {
       1, 0, 77, 8,
       4, 0, 999, 0, 0, 0, 0, 0, 0, 44,
       93, 77, 8, 1, 2, 3, 4, 5, 6, 446, 8,
+      1, 65,
     ]);
     assert.equal(enqueue(93, 77, 8, 256, 0), 1);
     frame(3, 4);
@@ -574,6 +578,7 @@ describe("Enhancement command transform", () => {
       2, 1, 77, 8,
       5, 1, 999, 0, 0, 0, 0, 0, 0, 44,
       93, 77, 8, 1, 2, 3, 4, 5, 6, 446, 8,
+      2, 93,
     ]);
   });
 

--- a/tests/unit/enhancement-storage-controller.test.ts
+++ b/tests/unit/enhancement-storage-controller.test.ts
@@ -138,6 +138,8 @@ test("storage development traces identify the live refusal without account data"
     }));
     assert.ok(messages.some((message) =>
       message.includes("storage.refused")
+      && message.includes('"request":1')
+      && message.includes('"sincePreviousMs":null')
       && message.includes('"state":"ready"')
       && message.includes('"access":false')
       && message.includes("cannot access Xunlai storage")

--- a/tests/unit/enhancement-storage-controller.test.ts
+++ b/tests/unit/enhancement-storage-controller.test.ts
@@ -106,3 +106,44 @@ test("storage fails closed without a confirmed character access proof", () => {
     });
   }
 });
+
+test("storage development traces identify the live refusal without account data", () => {
+  const previousWindow = globalThis.window;
+  const previousDebug = console.debug;
+  const messages: string[] = [];
+  const eventTarget = new EventTarget();
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: eventTarget,
+  });
+  console.debug = (message?: unknown) => { messages.push(String(message)); };
+  try {
+    const controller = createStorageController(
+      () => 1,
+      () => 1,
+      512,
+      true,
+    );
+    controller.update({
+      enabled: true,
+      state: { status: "ready", xunlaiAccess: false },
+    });
+    eventTarget.dispatchEvent(new CustomEvent("gw:storage-open", {
+      cancelable: true,
+      detail: {},
+    }));
+    assert.ok(messages.some((message) =>
+      message.includes("storage.refused")
+      && message.includes('"state":"ready"')
+      && message.includes('"access":false')
+      && message.includes("cannot access Xunlai storage")
+    ));
+    controller.dispose();
+  } finally {
+    console.debug = previousDebug;
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: previousWindow,
+    });
+  }
+});

--- a/tests/unit/enhancement-storage-controller.test.ts
+++ b/tests/unit/enhancement-storage-controller.test.ts
@@ -128,6 +128,10 @@ test("storage development traces identify the live refusal without account data"
       enabled: true,
       state: { status: "ready", xunlaiAccess: false },
     });
+    controller.update({
+      enabled: true,
+      state: { status: "ready", xunlaiAccess: false },
+    });
     eventTarget.dispatchEvent(new CustomEvent("gw:storage-open", {
       cancelable: true,
       detail: {},
@@ -138,6 +142,10 @@ test("storage development traces identify the live refusal without account data"
       && message.includes('"access":false')
       && message.includes("cannot access Xunlai storage")
     ));
+    assert.equal(
+      messages.filter((message) => message.includes("storage.availability")).length,
+      1,
+    );
     controller.dispose();
   } finally {
     console.debug = previousDebug;

--- a/tests/unit/profession-command-trace.test.ts
+++ b/tests/unit/profession-command-trace.test.ts
@@ -11,12 +11,15 @@ const professionSnapshot = (
   origin: number,
   target: number,
   profession: number,
+  drainCount = 0,
+  drainOpcode = 0,
 ): number[] => [
   1,
   count, origin, target, profession,
   0, 0, 0, 0,
   count, origin, 999, 2, 555, 10, 22, 0, 1, 12,
   65, target, profession, 0, 0, 0, 0, 0, 0, 0, 0,
+  drainCount, drainOpcode,
 ];
 
 test("the command trace publishes exact profession and skill payloads", () => {
@@ -56,7 +59,7 @@ test("the command trace publishes exact profession and skill payloads", () => {
       },
     };
 
-    assert.equal(PROFESSION_COMMAND_TRACE_BYTES, 120);
+    assert.equal(PROFESSION_COMMAND_TRACE_BYTES, 128);
     trace.poll(state);
     trace.poll(state);
     snapshot = professionSnapshot(2, 1, 77, 4);
@@ -67,6 +70,7 @@ test("the command trace publishes exact profession and skill payloads", () => {
       1, 0, 77, 8,
       3, 0, 999, 2, 555, 10, 22, 0, 1, 44,
       93, 77, 8, 1, 2, 3, 4, 5, 6, 7, 8,
+      1, 93,
     ];
     trace.poll(state);
 
@@ -76,7 +80,13 @@ test("the command trace publishes exact profession and skill payloads", () => {
     assert.equal(probe.entries.length, 3, "an unchanged poll adds no record");
     assert.deepEqual(probe.entries[0], {
       sequence: 1,
-      changed: { professionBuilder: true, skillBuilder: false, sender: true },
+      changed: {
+        professionBuilder: true,
+        skillBuilder: false,
+        sender: true,
+        drain: false,
+      },
+      drain: { count: 0, opcode: 0 },
       professionBuilder: { count: 1, origin: "native", target: 77, profession: 2 },
       skillBuilder: { count: 0, origin: "native", target: 0, skillCount: 0 },
       sender: {
@@ -96,7 +106,13 @@ test("the command trace publishes exact profession and skill payloads", () => {
     });
     assert.deepEqual(probe.entries[2], {
       sequence: 3,
-      changed: { professionBuilder: false, skillBuilder: true, sender: true },
+      changed: {
+        professionBuilder: false,
+        skillBuilder: true,
+        sender: true,
+        drain: true,
+      },
+      drain: { count: 1, opcode: 93 },
       professionBuilder: { count: 2, origin: "gwonmac", target: 77, profession: 4 },
       skillBuilder: { count: 1, origin: "native", target: 77, skillCount: 8 },
       sender: {
@@ -117,7 +133,7 @@ test("the command trace publishes exact profession and skill payloads", () => {
     assert.match(logs[1]!, /"origin":"gwonmac"/);
 
     for (let count = 4; count <= 28; count += 1) {
-      snapshot = professionSnapshot(count - 1, 1, 77, 4);
+      snapshot = professionSnapshot(count - 1, 1, 77, 4, count - 2, 16);
       trace.poll(state);
     }
     const boundedProbe = Reflect.get(fakeWindow, "gwProfessionCommandTrace") as {
@@ -129,6 +145,33 @@ test("the command trace publishes exact profession and skill payloads", () => {
 
     trace.dispose();
     assert.equal(Reflect.has(fakeWindow, "gwProfessionCommandTrace"), false);
+  } finally {
+    console.info = previousInfo;
+    if (previousWindow) Object.defineProperty(globalThis, "window", previousWindow);
+    else Reflect.deleteProperty(globalThis, "window");
+  }
+});
+
+test("a drained attribute opcode does not invent an observed target", () => {
+  const previousWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  const previousInfo = console.info;
+  const fakeWindow = {};
+  const logs: string[] = [];
+  Object.defineProperty(globalThis, "window", { configurable: true, value: fakeWindow });
+  console.info = (message?: unknown) => { logs.push(String(message)); };
+  try {
+    const memory = new WebAssembly.Memory({ initial: 1 });
+    const snapshot = professionSnapshot(0, 0, 0, 0, 1, 16);
+    const trace = createProfessionCommandTrace(memory, 128, (pointer) => {
+      new Uint32Array(memory.buffer, pointer, snapshot.length).set(snapshot);
+      return snapshot.length;
+    });
+    trace.poll({ status: "ready" });
+
+    assert.equal(logs.length, 1);
+    assert.match(logs[0]!, /"drain":\{"count":1,"opcode":16\}/u);
+    assert.match(logs[0]!, /"observed":null/u);
+    trace.dispose();
   } finally {
     console.info = previousInfo;
     if (previousWindow) Object.defineProperty(globalThis, "window", previousWindow);

--- a/tests/unit/profession-command-trace.test.ts
+++ b/tests/unit/profession-command-trace.test.ts
@@ -5,6 +5,7 @@ import {
   PROFESSION_COMMAND_TRACE_BYTES,
 } from "../../src/renderer/profession-command-trace.js";
 import type { ToolboxObservation } from "../../src/shared/builds/live-party.js";
+import { PROFESSION_TRACE_SCHEMA } from "../../src/shared/profession-command-trace.js";
 
 const professionSnapshot = (
   count: number,
@@ -14,7 +15,7 @@ const professionSnapshot = (
   drainCount = 0,
   drainOpcode = 0,
 ): number[] => [
-  1,
+  PROFESSION_TRACE_SCHEMA,
   count, origin, target, profession,
   0, 0, 0, 0,
   count, origin, 999, 2, 555, 10, 22, 0, 1, 12,
@@ -65,7 +66,7 @@ test("the command trace publishes exact profession and skill payloads", () => {
     snapshot = professionSnapshot(2, 1, 77, 4);
     trace.poll(state);
     snapshot = [
-      1,
+      PROFESSION_TRACE_SCHEMA,
       2, 1, 77, 4,
       1, 0, 77, 8,
       3, 0, 999, 2, 555, 10, 22, 0, 1, 44,


### PR DESCRIPTION
Xunlai falls back to Controls without explaining its refusal, Team Apply proves only that a command was queued, and Travel search can look like a game-command failure when the static catalogue has no match. This leaves live QA unable to identify the boundary that actually failed.

This change adds bounded development-only evidence for each action. Xunlai reports policy, access, configuration, and queue outcomes. Team Apply records the last opcode consumed at the certified game-thread drain, alongside the existing builder and sender counters. Travel reports privacy-safe search counts and command outcomes without logging the typed query. The misleading “all outposts” copy now says “available destinations,” and the contributor playbook documents the complete reproduction workflow.

The Enhancement transform ABI is bumped so no stale cache can be read with the expanded trace layout.

Live evidence from the new trace then identified and fixed two production bugs:

- Xunlai's certified player-record readers index by the live player number, but the kernel incorrectly read record zero. The kernel and realistic fixture now use the proved index relationship.
- Team Apply consumed opcode 16 correctly. Normal state publication was observed at 1,002 ms, just outside the one-second deadline, so the ordinary confirmation window is now two seconds with a delayed-publication regression test.

Repeated identical Xunlai availability events are deduplicated so one state change produces one useful line.

Verification:

- `pnpm check`
- `pnpm build`
- current e017 ArenaNet artifact: all 3 client-artifact suites passed
- focused storage, Team transform, Team trace, and Travel tests passed
- 45/45 integration tests and reproducible companion-kernel verification passed
- `git diff --check`

Live QA is intentionally still required before merge. Rebuild/restart and verify that Xunlai changes from `access:null` to a boolean and opens the chest, and that Team Apply no longer refuses a normal attribute publication just beyond one second. Travel's exhaustive catalogue remains separate follow-up work.

Implemented and verified with Codex.
