### PR TITLE
chore(release): prepare 2026.8.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "guild-wars",
   "productName": "Guild Wars Reforged",
-  "version": "2026.8.8",
+  "version": "2026.8.9",
   "private": true,
   "packageManager": "pnpm@11.13.1",
   "type": "module",


### PR DESCRIPTION
`main` still reports `2026.8.8`, which is already published, so the versioned release workflow refuses a new run.

This prepares the next Stable release as `2026.8.9`. It contains no product behavior changes.

## Verification

- `pnpm check`
- `pnpm test:release`
- macOS bundle version: `2026.8.9` / `2608.9.99`

Prepared with Codex.
