### PR TITLE
fix(website): stop automatic branch previews

### DIFF
--- a/apps/tools/tests/workbench.spec.ts
+++ b/apps/tools/tests/workbench.spec.ts
@@ -50,8 +50,7 @@ test("offers destination autocomplete and numbered Travel shortcuts", async ({ p
   await expect(palette).toBeVisible();
   await expect(palette.locator('label[for="travel-search-input"] > span')).toHaveCount(0);
   await expect(palette.getByRole("status")).toHaveCount(0);
-  const paletteBox = await palette.boundingBox();
-  expect(paletteBox?.y).toBeGreaterThanOrEqual(95);
+  await expect.poll(async () => (await palette.boundingBox())?.y).toBeGreaterThanOrEqual(95);
   await page.getByRole("combobox", { name: "Destination or search phrase" }).fill("kama");
   await expect(page.getByRole("option", { name: /Kamadan, Jewel of Istan/ })).toBeVisible();
   await page.keyboard.press("Meta+9");

--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -1,7 +1,11 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
-    "deploymentEnabled": true
+    "deploymentEnabled": {
+      "*": false,
+      "main": true,
+      "preview/*": true
+    }
   },
   "ignoreCommand": "[ -n \"$VERCEL_GIT_PREVIOUS_SHA\" ] || exit 1; git cat-file -e \"$VERCEL_GIT_PREVIOUS_SHA\" 2>/dev/null || exit 1; git diff --quiet \"$VERCEL_GIT_PREVIOUS_SHA\" HEAD -- . ../../src/shared ../../package.json ../../pnpm-lock.yaml ../../pnpm-workspace.yaml"
 }

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -37,7 +37,7 @@ type Manifest = {
   scripts?: Record<string, string>;
 };
 type VercelConfig = {
-  git?: { deploymentEnabled?: boolean };
+  git?: { deploymentEnabled?: boolean | Record<string, boolean> };
   ignoreCommand?: string;
 };
 const json = (file: string): Manifest => JSON.parse(read(file));
@@ -754,7 +754,15 @@ test("the website suite runs on its own path-filtered workflow", () => {
     false,
     "the workspace root lockfile is the website's dependency truth",
   );
-  assert.equal(vercel.git?.deploymentEnabled, true);
+  assert.deepEqual(
+    vercel.git?.deploymentEnabled,
+    {
+      "*": false,
+      main: true,
+      "preview/*": true,
+    },
+    "only main and deliberately named preview branches may spend a Vercel build",
+  );
   assert.equal(
     vercel.ignoreCommand,
     '[ -n "$VERCEL_GIT_PREVIOUS_SHA" ] || exit 1; git cat-file -e "$VERCEL_GIT_PREVIOUS_SHA" 2>/dev/null || exit 1; git diff --quiet "$VERCEL_GIT_PREVIOUS_SHA" HEAD -- . ../../src/shared ../../package.json ../../pnpm-lock.yaml ../../pnpm-workspace.yaml',


### PR DESCRIPTION
Vercel built at least 40 deployments in roughly 8.2 hours while the stacked Travel work was landing. Thirty-seven were Preview deployments; only three were Production deployments.

This keeps automatic Production deployments on `main`, disables automatic deployments for ordinary branches, and leaves `preview/*` as the explicit opt-in path when a hosted preview is useful. The existing path-filtered GitHub Website workflow continues to test pull requests without spending a Vercel build.

The current branch creates one final Preview because it was branched from the old all-branches configuration. Once this lands on `main`, new branches inherit the cost guard.

## Verification

- `pnpm test:policy` — 168 passed
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:website`
- Vercel project and recent deployments inspected through the connected Vercel app

Prepared with Codex.
