### PR TITLE
feat(website): add on-demand Vercel previews

### DIFF
--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -1,0 +1,117 @@
+# Automatic branch previews are intentionally disabled to control Vercel cost.
+# A trusted maintainer can request one exact preview by commenting `/vercel` on
+# a same-repository pull request. The derived branch is only a Git ref: the PR
+# commit remains the single source of code, and Vercel's Git integration builds
+# it through the reviewed preview/* allowlist in apps/website/vercel.json.
+name: Vercel preview
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: read
+
+concurrency:
+  group: vercel-preview-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  request:
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      github.event.comment.body == '/vercel'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Request the exact PR head
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const trustedAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+            const association = context.payload.comment.author_association;
+            const issueNumber = context.payload.issue.number;
+            const { owner, repo } = context.repo;
+
+            if (!trustedAssociations.has(association)) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                body: "Only repository collaborators can request a Vercel Preview.",
+              });
+              return;
+            }
+
+            const { data: pullRequest } = await github.rest.pulls.get({
+              owner,
+              repo,
+              pull_number: issueNumber,
+            });
+            if (pullRequest.state !== "open") {
+              core.setFailed("The pull request is no longer open.");
+              return;
+            }
+            if (pullRequest.head.repo?.full_name !== `${owner}/${repo}`) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: issueNumber,
+                body: "Vercel Previews are limited to branches in this repository. Fork pull requests are not deployed.",
+              });
+              return;
+            }
+
+            const headSha = pullRequest.head.sha;
+            const shortSha = headSha.slice(0, 8);
+            const ref = `heads/preview/pr-${issueNumber}`;
+            let changed = true;
+            try {
+              const { data: current } = await github.rest.git.getRef({ owner, repo, ref });
+              if (current.object.sha === headSha) {
+                changed = false;
+              } else {
+                await github.rest.git.updateRef({ owner, repo, ref, sha: headSha, force: true });
+              }
+            } catch (error) {
+              if (error.status !== 404) throw error;
+              await github.rest.git.createRef({
+                owner,
+                repo,
+                ref: `refs/${ref}`,
+                sha: headSha,
+              });
+            }
+
+            const checksUrl = `https://github.com/${owner}/${repo}/pull/${issueNumber}/checks`;
+            const message = changed
+              ? `Vercel Preview requested for \`${shortSha}\`. The deployment link will appear in the [PR checks](${checksUrl}).`
+              : `A Vercel Preview was already requested for \`${shortSha}\`. See the [PR checks](${checksUrl}).`;
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              body: message,
+            });
+
+  cleanup:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Remove the derived Preview branch
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const ref = `heads/preview/pr-${context.payload.pull_request.number}`;
+            try {
+              await github.rest.git.deleteRef({ owner, repo, ref });
+            } catch (error) {
+              if (error.status !== 404) throw error;
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,17 @@ If you changed `apps/website`, also run:
 pnpm test:website
 ```
 
+Automatic Vercel Preview deployments are disabled for ordinary branches. A
+repository collaborator can request one for the current pull-request head by
+commenting `/vercel` on a same-repository pull request. Comment again after a
+new commit to update the Preview. The Vercel link appears in the PR checks, and
+the derived `preview/pr-<number>` branch is removed when the PR closes.
+
+For a branch that should receive a Preview after every push, name it
+`preview/<topic>` before opening the pull request. Fork pull requests are not
+deployed because Preview environment values must not be exposed to untrusted
+code.
+
 Do not run live ArenaNet tests unless the invariant requires them. Live tests
 must be deliberate, bounded, and named in the pull request.
 

--- a/apps/website/vercel.json
+++ b/apps/website/vercel.json
@@ -2,7 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "git": {
     "deploymentEnabled": {
-      "*": false,
+      "**": false,
       "main": true,
       "preview/*": true
     }

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -757,7 +757,7 @@ test("the website suite runs on its own path-filtered workflow", () => {
   assert.deepEqual(
     vercel.git?.deploymentEnabled,
     {
-      "*": false,
+      "**": false,
       main: true,
       "preview/*": true,
     },

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -798,6 +798,28 @@ test("the website suite runs on its own path-filtered workflow", () => {
   );
 });
 
+test("Vercel Previews are explicit, exact-head, and collaborator-only", () => {
+  const workflow = read(".github/workflows/vercel-preview.yml");
+  assert.match(workflow, /issue_comment:\n {4}types: \[created\]/);
+  assert.match(workflow, /pull_request:\n {4}types: \[closed\]/);
+  assert.match(
+    workflow,
+    /permissions:\n {2}contents: write\n {2}issues: write\n {2}pull-requests: read/,
+  );
+  assert.match(workflow, /github\.event\.comment\.body == '\/vercel'/);
+  assert.match(workflow, /"OWNER", "MEMBER", "COLLABORATOR"/);
+  assert.match(workflow, /pullRequest\.head\.repo\?\.full_name !== `\$\{owner\}\/\$\{repo\}`/);
+  assert.match(workflow, /const headSha = pullRequest\.head\.sha/);
+  assert.match(workflow, /const ref = `heads\/preview\/pr-\$\{issueNumber\}`/);
+  assert.match(workflow, /github\.rest\.git\.(?:createRef|updateRef)/);
+  assert.match(workflow, /github\.rest\.git\.deleteRef/);
+  assert.match(
+    workflow,
+    /actions\/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd/,
+  );
+  assert.doesNotMatch(workflow, /pull_request_target|actions\/checkout|VERCEL_TOKEN/);
+});
+
 test("client recertification reports evidence but cannot grant authority", () => {
   const workflow = read(".github/workflows/client-recertification.yml");
   // Blanked rather than dropped, so a reported offset is the one an editor


### PR DESCRIPTION
Automatic Vercel branch previews are intentionally disabled to control cost, but that left no convenient way to request one from an existing pull request.

This adds an explicit `/vercel` pull-request comment command. For a trusted same-repository PR, it moves a derived `preview/pr-<number>` ref to the PR's exact head commit. The existing Vercel Git integration performs the deployment and exposes its URL through the PR checks. Repeating the command on the same commit does not create another build, and the derived branch is deleted when the PR closes.

The workflow receives no Vercel credential, never checks out or executes PR code, and refuses fork PRs. Ordinary branch previews remain disabled.

## Verification

- `actionlint .github/workflows/vercel-preview.yml`
- `pnpm test:policy` — 169 passed
- targeted ESLint
- `pnpm typecheck`
- `git diff --check`

Prepared with Codex.
