### PR TITLE
fix(website): make Preview cleanup idempotent

### DIFF
--- a/.github/workflows/vercel-preview.yml
+++ b/.github/workflows/vercel-preview.yml
@@ -113,5 +113,7 @@ jobs:
             try {
               await github.rest.git.deleteRef({ owner, repo, ref });
             } catch (error) {
-              if (error.status !== 404) throw error;
+              // GitHub currently reports a missing ref as 422 from DELETE,
+              // while GET reports 404. Either means cleanup is complete.
+              if (![404, 422].includes(error.status)) throw error;
             }

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -813,6 +813,7 @@ test("Vercel Previews are explicit, exact-head, and collaborator-only", () => {
   assert.match(workflow, /const ref = `heads\/preview\/pr-\$\{issueNumber\}`/);
   assert.match(workflow, /github\.rest\.git\.(?:createRef|updateRef)/);
   assert.match(workflow, /github\.rest\.git\.deleteRef/);
+  assert.match(workflow, /\[404, 422\]\.includes\(error\.status\)/);
   assert.match(
     workflow,
     /actions\/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd/,


### PR DESCRIPTION
The on-demand Vercel workflow correctly refuses automatic ordinary-branch deployments, but its first post-merge cleanup run exposed GitHub's missing-reference behavior: DELETE returns HTTP 422 rather than 404.

Cleanup now treats both documented missing-reference responses as an already-clean state. Other errors still fail loudly.

This PR is also the controlled end-to-end fixture for `/vercel`: after it opens, the command will request one exact Preview, a repeated command will prove idempotency, and merging will prove derived-branch cleanup.

## Verification

- `actionlint .github/workflows/vercel-preview.yml`
- `pnpm test:policy` — 169 passed
- targeted ESLint
- `git diff --check`

Prepared with Codex.
