### PR TITLE
fix(ci): record ArenaNet recertification results

### DIFF
--- a/.github/workflows/client-recertification.yml
+++ b/.github/workflows/client-recertification.yml
@@ -187,6 +187,7 @@ jobs:
       contents: read
       issues: write
     env:
+      GH_REPO: ${{ github.repository }}
       RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: Receive the verification evidence

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -913,6 +913,8 @@ test("client recertification reports evidence but cannot grant authority", () =>
   // Reporting can write issues only. It has no checkout credentials, source
   // write permission, branch command, pull-request command, or workflow token.
   assert.match(publish, /permissions:\n {6}contents: read\n {6}issues: write/);
+  assert.match(publish, /GH_REPO: \$\{\{ github\.repository \}\}/);
+  assert.doesNotMatch(publish, /actions\/checkout/);
   assert.doesNotMatch(publish, /pnpm install|pnpm build|pnpm certification/);
   assert.match(publish, /if: always\(\) && needs\.derive\.result != 'skipped'/);
   assert.doesNotMatch(workflow, /persist-credentials: true/);


### PR DESCRIPTION
## What changed

ArenaNet recertification reporting now gives GitHub CLI an explicit repository context, so its checkout-free publish job can create and close evidence issues.

## Why

The macOS derivation succeeded, but the Ubuntu reporting job failed because it was not inside a Git repository. The missing record caused every scheduled run to repeat the expensive derivation.

## Invariant

The policy suite requires the publish job to set GH_REPO from github.repository and forbids adding a checkout to that source-independent reporting boundary.

## Verification

- pnpm check
- Focused client-recertification policy test
- Independent subagent review: approved, no blockers

- [x] I kept this pull request focused.
- [x] I ran the relevant checks.
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [x] Documentation does not need an update because authority and behavior are unchanged.