### PR TITLE
perf(test): stop Electron CI after the first failure

### DIFF
--- a/tests/electron/playwright.config.ts
+++ b/tests/electron/playwright.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
   globalSetup: "./global-setup.ts",
   timeout: 30_000,
   workers: 1,
+  ...(process.env.CI ? { maxFailures: 1 } : {}),
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   failOnFlakyTests: !!process.env.CI,


### PR DESCRIPTION
## What changed

Electron tests now stop after the first exhausted failure in CI. Local runs still report all failures.

## Why

A red Electron run could continue through dozens of unrelated tests and waste up to roughly two minutes. Retries still classify the failure before Playwright stops the suite.

## Invariant

CI resolves maxFailures to 1. Non-CI config omits the property. The existing single worker, retry, flake detection, and trace settings are unchanged.

## Verification

- Direct resolved-config assertions for CI and non-CI
- pnpm typecheck
- pnpm check
- Independent subagent review: approved, no blockers

- [x] I kept this pull request focused.
- [x] I ran the relevant checks.
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [x] Documentation does not need an update for this CI-only failure policy.