### PR TITLE
fix(renderer): withdraw native cursor state on rollback

### DIFF
--- a/src/renderer/certified-companion-installation.ts
+++ b/src/renderer/certified-companion-installation.ts
@@ -231,6 +231,7 @@ export async function installCertifiedCompanion(
   let disposeCursorRefresh = () => {};
   let professionTrace: ReturnType<typeof createProfessionCommandTrace> | null = null;
   let installedCallback: CallableFunction | null = null;
+  let installedCursorState: NonNullable<typeof window.gwCursorState> | null = null;
   let installedRuntime: object | null = null;
   let cleaned = false;
   let telemetryInstalled = false;
@@ -239,6 +240,12 @@ export async function installCertifiedCompanion(
     cleaned = true;
     // Disable dispatch before releasing any callback-owned state.
     hookSlot.value = 0;
+    if (
+      installedCursorState !== null
+      && window.gwCursorState === installedCursorState
+    ) {
+      delete window.gwCursorState;
+    }
     stopObserver();
     disposeCursorRefresh();
     disposeCursor();
@@ -555,7 +562,8 @@ export async function installCertifiedCompanion(
       // pan (measured 2026-08-03: mouse-look hides the client cursor within a
       // tick of the right press; a map pan never does). Bounded presentation
       // state only — no pixels, no pointers.
-      window.gwCursorState = () => cursor?.state ?? null;
+      installedCursorState = () => cursor?.state ?? null;
+      window.gwCursorState = installedCursorState;
     }
     let optionalSettings = window.gwToolsSettings();
     let snapshotPlayRegion: RuntimePlayRegion | null = observeState

--- a/tests/helpers/packaged-enhancement-scenarios.ts
+++ b/tests/helpers/packaged-enhancement-scenarios.ts
@@ -627,6 +627,7 @@ export async function assertToolboxFoundationLifecycle() {
       const before = {
         allocations,
         companionStatePublished: window.gwCompanionState !== undefined,
+        cursorStatePublished: typeof window.gwCursorState === "function",
         cursor: runtime.cursor,
         cursorStyle:
           canvas instanceof HTMLCanvasElement ? canvas.style.cursor : null,
@@ -658,6 +659,7 @@ export async function assertToolboxFoundationLifecycle() {
 
       dispatchEvent(new Event("pagehide"));
       const after = {
+        cursorStatePublished: typeof window.gwCursorState === "function",
         cursorStyle:
           canvas instanceof HTMLCanvasElement ? canvas.style.cursor : null,
         freed,
@@ -736,6 +738,7 @@ export async function assertToolboxFoundationLifecycle() {
     );
     assert.deepEqual(result.before.travelConfigurations.at(-1), [travelPointer, 1]);
     assert.equal(result.before.companionStatePublished, false);
+    assert.equal(result.before.cursorStatePublished, true);
     assert.equal(result.before.globalRuntimeIsRuntime, false);
     assert.equal(result.before.hook, ENHANCEMENT_BUILD.tableSlot + 1);
     assert.match(result.before.kernelSha256, /^[0-9a-f]{64}$/u);
@@ -820,6 +823,7 @@ export async function assertToolboxFoundationLifecycle() {
     assert.deepEqual(result.after.storageConfigurations.at(-1), [0, 0]);
     assert.deepEqual(result.after.travelConfigurations.at(-1), [0, 0]);
     assert.equal(result.after.hook, 0);
+    assert.equal(result.after.cursorStatePublished, false);
     assert.equal(result.after.runtime, undefined);
     assert.equal(result.after.tableEmpty, true);
     assert.equal(result.after.targetCount, 0);
@@ -919,6 +923,8 @@ export async function assertRollbackAfterTablePublication() {
         setTable(index, value);
       }) as typeof table.set;
       const requestFrame = globalThis.requestAnimationFrame;
+      const replacementCursorState = () => null;
+      let installedCursorStatePublished = false;
       let rejected = false;
       try {
         globalThis.dispatchEvent(new Event("pagehide"));
@@ -930,6 +936,8 @@ export async function assertRollbackAfterTablePublication() {
           targetReadout: false,
         });
         globalThis.requestAnimationFrame = () => {
+          installedCursorStatePublished = typeof window.gwCursorState === "function";
+          window.gwCursorState = replacementCursorState;
           throw new Error("intentional post-table failure");
         };
         await installCertifiedCompanion(
@@ -955,7 +963,10 @@ export async function assertRollbackAfterTablePublication() {
         allocations,
         freed,
         hook: hookSlot.value,
+        installedCursorStatePublished,
         rejected,
+        replacementCursorStatePreserved:
+          window.gwCursorState === replacementCursorState,
         runtime: window.gwCompanionRuntime,
         readoutCount: globalThis.document.querySelectorAll(
           "#enhancement-target",
@@ -968,16 +979,15 @@ export async function assertRollbackAfterTablePublication() {
         ).length,
       };
     }, {
-      bytes: [...installableManifestModule({
-        ...TOOLBOX_PROGRAM_CAPABILITIES,
-        nativeCursor: false,
-      })],
-      capabilities: { ...TOOLBOX_PROGRAM_CAPABILITIES, nativeCursor: false },
+      bytes: [...installableManifestModule(TOOLBOX_PROGRAM_CAPABILITIES)],
+      capabilities: TOOLBOX_PROGRAM_CAPABILITIES,
       tableSize: ENHANCEMENT_BUILD.tableSlot + 1,
     });
     const rollbackConfigPointer = 0x11_010;
-    const rollbackToolboxPointer =
+    const rollbackCursorPointer =
       (rollbackConfigPointer + CONFIG_BYTES + 7) & ~7;
+    const rollbackToolboxPointer =
+      (rollbackCursorPointer + COMPANION_CURSOR_BYTES + 7) & ~7;
     const rollbackPartyPointer =
       rollbackToolboxPointer + COMPANION_TOOLBOX_BYTES;
     assert.deepEqual(result, {
@@ -987,17 +997,21 @@ export async function assertRollbackAfterTablePublication() {
           pointer: rollbackConfigPointer,
           size: CONFIG_BYTES,
         },
+        { pointer: rollbackCursorPointer, size: COMPANION_CURSOR_BYTES },
         { pointer: rollbackToolboxPointer, size: COMPANION_TOOLBOX_BYTES },
         { pointer: rollbackPartyPointer, size: COMPANION_PARTY_BYTES },
       ],
       freed: [
         rollbackToolboxPointer,
         rollbackPartyPointer,
+        rollbackCursorPointer,
         rollbackConfigPointer,
         0x1000,
       ],
       hook: 0,
+      installedCursorStatePublished: true,
       rejected: true,
+      replacementCursorStatePreserved: true,
       runtime: undefined,
       readoutCount: 0,
       replaced: true,


### PR DESCRIPTION
## What changed

Failed or torn-down Enhancement installations now withdraw the native cursor-state reader they published. Cleanup removes it only when this installation still owns the exact function, so a newer replacement survives.

## Why

The cursor reader remained reachable after its backing cursor resources were disposed. Input code could therefore observe stale state after rollback.

## Invariant

Dispatch is disabled first. The owned cursor reader is withdrawn before cursor resources are disposed. Normal pagehide removes it; injected post-table rollback preserves a replacement reader by identity and still frees every allocation.

## Verification

- pnpm check
- pnpm verify
- 1,113 unit tests; 169 policy tests; 94 Tools tests
- 33 Tools browser tests; 138 Electron tests passed; 1 live test skipped
- Packaged app and packaged Enhancement lifecycle/rollback proofs
- Independent architecture review: approved after adding the explicit non-null ownership guard

- [x] I kept this pull request focused.
- [x] I ran the relevant checks.
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [x] Documentation does not need an update because this restores the documented all-or-nothing lifecycle.