### PR TITLE
test(native): detect companion ABI drift

### DIFF
--- a/src/main/certification/enhancement-transform.ts
+++ b/src/main/certification/enhancement-transform.ts
@@ -16,6 +16,7 @@
  *
  */
 import { createHash } from "node:crypto";
+import { COMPANION_DISPATCH_KINDS } from "../../shared/companion-abi.js";
 import {
   enhancementCapabilityProfile,
   enhancementHooksFor,
@@ -73,9 +74,6 @@ const DISPATCH_PARAMS = 6;
  *  command; the widest builder we have takes four scalars. */
 const COMMAND_PARAMS = 5;
 const COMMAND_ARGS = COMMAND_PARAMS - 1;
-const DISPATCH_TICK = 0;
-const DISPATCH_CURSOR = 1;
-const DISPATCH_UI = 2;
 
 function fail(message: string): never {
   throw new Error(`enhancement transform: ${message}`);
@@ -333,7 +331,7 @@ function resolveEnhancementTransform(
         build.hookParams,
         build.hookResults,
       ),
-      dispatchKind: DISPATCH_TICK,
+      dispatchKind: COMPANION_DISPATCH_KINDS.tick,
     });
   }
   if (selectedHooks.cursor) {
@@ -344,7 +342,7 @@ function resolveEnhancementTransform(
         cursorEvent.params,
         cursorEvent.results,
       ),
-      dispatchKind: DISPATCH_CURSOR,
+      dispatchKind: COMPANION_DISPATCH_KINDS.cursor,
     });
   }
   const uiDispatcherHook = selectedHooks.ui || capabilities.travelAction
@@ -358,7 +356,7 @@ function resolveEnhancementTransform(
   if (selectedHooks.ui) {
     selected.push({
       ...uiDispatcherHook!,
-      dispatchKind: DISPATCH_UI,
+      dispatchKind: COMPANION_DISPATCH_KINDS.ui,
     });
   }
   const bodyHash = (functionIndex: number): string => {
@@ -793,8 +791,10 @@ function assembleEnhancementTransform(
   };
   const selectedOriginalIndices = selected.map((hook) =>
     appendFunction(hook.typeIndex, bodies[hook.localIndex]!));
+  const uiHookIndex = selected.findIndex((hook) =>
+    hook.dispatchKind === COMPANION_DISPATCH_KINDS.ui);
   const uiOriginalIndex = selectedHooks.ui
-    ? selectedOriginalIndices[selected.findIndex((hook) => hook.dispatchKind === DISPATCH_UI)]!
+    ? selectedOriginalIndices[uiHookIndex]!
     : null;
   selected.forEach((hook, index) => {
     nextBodies[hook.localIndex] = dispatcher(

--- a/src/renderer/certified-companion-installation.ts
+++ b/src/renderer/certified-companion-installation.ts
@@ -50,6 +50,8 @@ import type { TravelInstallation } from "./enhancement-travel-installation.js";
 import { travelGameState } from "../shared/travel-command.js";
 import {
   COMPANION_ABI as COMPANION_DESCRIPTOR,
+  COMPANION_DISPATCH_KINDS,
+  COMPANION_FEATURE_BITS,
 } from "../shared/companion-abi.js";
 import {
   COMPANION_KERNEL_EXPORTS,
@@ -67,10 +69,6 @@ import {
   type ProfessionCommandTraceReader,
 } from "./profession-command-trace.js";
 
-const ENHANCEMENT_FEATURE_NATIVE_CURSOR = 1 << 0;
-const ENHANCEMENT_FEATURE_GAME_SNAPSHOT = 1 << 1;
-const ENHANCEMENT_FEATURE_TOOLBOX_FOUNDATION = 1 << 2;
-const ENHANCEMENT_FEATURE_TARGET_OBSERVATION = 1 << 3;
 const COMPANION_ABI = COMPANION_DESCRIPTOR.kernel;
 const COMPANION_RUNTIME_BYTES = 65_536;
 /**
@@ -136,10 +134,10 @@ export async function installCertifiedCompanion(
   const observeState = capabilities.targetObservation || capabilities.xunlaiAction;
   const publishObserverState = program === "target-observer";
   const featureFlags =
-    (capabilities.nativeCursor ? ENHANCEMENT_FEATURE_NATIVE_CURSOR : 0)
-    | (observeState ? ENHANCEMENT_FEATURE_GAME_SNAPSHOT : 0)
-    | (foundation ? ENHANCEMENT_FEATURE_TOOLBOX_FOUNDATION : 0)
-    | (capabilities.targetObservation ? ENHANCEMENT_FEATURE_TARGET_OBSERVATION : 0);
+    (capabilities.nativeCursor ? COMPANION_FEATURE_BITS.nativeCursor : 0)
+    | (observeState ? COMPANION_FEATURE_BITS.gameSnapshot : 0)
+    | (foundation ? COMPANION_FEATURE_BITS.toolboxFoundation : 0)
+    | (capabilities.targetObservation ? COMPANION_FEATURE_BITS.targetObservation : 0);
   if (featureFlags === 0) return null;
 
   const manifest = decodeEnhancementManifest(module, capabilities);
@@ -616,13 +614,20 @@ export async function installCertifiedCompanion(
     const teamEnabled = () => policy().teamManagement;
     const syncActiveObservers = () => {
       const active =
-        (capabilities.nativeCursor ? ENHANCEMENT_FEATURE_NATIVE_CURSOR : 0)
+        (capabilities.nativeCursor ? COMPANION_FEATURE_BITS.nativeCursor : 0)
         // Keep the bounded policy observer alive even while optional UI and
         // commands are denied. It is the only way an unknown region can later
         // prove that it became PvE without restarting.
-        | (foundation ? ENHANCEMENT_FEATURE_TOOLBOX_FOUNDATION : 0)
-        | (targetEnabled() ? ENHANCEMENT_FEATURE_TARGET_OBSERVATION : 0);
-      kernelDispatch(3, active, 0, 0, 0, 0);
+        | (foundation ? COMPANION_FEATURE_BITS.toolboxFoundation : 0)
+        | (targetEnabled() ? COMPANION_FEATURE_BITS.targetObservation : 0);
+      kernelDispatch(
+        COMPANION_DISPATCH_KINDS.activeFeatures,
+        active,
+        0,
+        0,
+        0,
+        0,
+      );
     };
     const commands = commandEnqueue === null ? null : teamCommands!.createTeamApplyCommands({
       memory,

--- a/src/shared/companion-abi.ts
+++ b/src/shared/companion-abi.ts
@@ -10,3 +10,17 @@ export const COMPANION_ABI = Object.freeze({
   toolbox: Object.freeze({ abi: 4, bytes: 64 }),
   party: Object.freeze({ abi: 7, bytes: 1_560 }),
 });
+
+export const COMPANION_FEATURE_BITS = Object.freeze({
+  nativeCursor: 1 << 0,
+  gameSnapshot: 1 << 1,
+  toolboxFoundation: 1 << 2,
+  targetObservation: 1 << 3,
+});
+
+export const COMPANION_DISPATCH_KINDS = Object.freeze({
+  tick: 0,
+  cursor: 1,
+  ui: 2,
+  activeFeatures: 3,
+});

--- a/tests/fixtures/enhancements.ts
+++ b/tests/fixtures/enhancements.ts
@@ -1,5 +1,9 @@
 import { readFile } from "node:fs/promises";
 import {
+  COMPANION_DISPATCH_KINDS,
+  COMPANION_FEATURE_BITS,
+} from "../../src/shared/companion-abi.ts";
+import {
   readCompanionCursorHeader,
   readCompanionCursorPixels,
   readChangedCompanionParty,
@@ -89,10 +93,12 @@ export function readyToolbox(read: ToolboxRead) {
 }
 
 export const MAGIC = 0x42545747;
-export const FEATURE_NATIVE_CURSOR = 1 << 0;
-export const FEATURE_GAME_SNAPSHOT = 1 << 1;
-export const FEATURE_TOOLBOX_FOUNDATION = 1 << 2;
-export const FEATURE_TARGET_OBSERVATION = 1 << 3;
+export const FEATURE_NATIVE_CURSOR = COMPANION_FEATURE_BITS.nativeCursor;
+export const FEATURE_GAME_SNAPSHOT = COMPANION_FEATURE_BITS.gameSnapshot;
+export const FEATURE_TOOLBOX_FOUNDATION =
+  COMPANION_FEATURE_BITS.toolboxFoundation;
+export const FEATURE_TARGET_OBSERVATION =
+  COMPANION_FEATURE_BITS.targetObservation;
 export const ALL_FEATURES = FEATURE_NATIVE_CURSOR
   | FEATURE_GAME_SNAPSHOT
   | FEATURE_TARGET_OBSERVATION;
@@ -523,14 +529,41 @@ export async function createKernel(
         features,
       );
     },
-    tick: () => exports.dispatch(0, 123, 0, 0, 0, 0),
+    tick: () => exports.dispatch(
+      COMPANION_DISPATCH_KINDS.tick,
+      123,
+      0,
+      0,
+      0,
+      0,
+    ),
     cursorEvent: (...args: number[]) =>
-      exports.dispatch(1, args[0] ?? 1, args[1] ?? 2, args[2] ?? 3,
-        args[3] ?? 4, args[4] ?? 5),
+      exports.dispatch(
+        COMPANION_DISPATCH_KINDS.cursor,
+        args[0] ?? 1,
+        args[1] ?? 2,
+        args[2] ?? 3,
+        args[3] ?? 4,
+        args[4] ?? 5,
+      ),
     uiEvent: (message: number, wparam: number, lparam: number) =>
-      exports.dispatch(2, message, wparam, lparam, 0, 0),
+      exports.dispatch(
+        COMPANION_DISPATCH_KINDS.ui,
+        message,
+        wparam,
+        lparam,
+        0,
+        0,
+      ),
     activeFeatures: (features: number) =>
-      exports.dispatch(3, features, 0, 0, 0, 0),
+      exports.dispatch(
+        COMPANION_DISPATCH_KINDS.activeFeatures,
+        features,
+        0,
+        0,
+        0,
+        0,
+      ),
     toolbox: () => readCompanionToolbox(memory.buffer, ADDRESSES.toolbox),
     party: () => readCompanionParty(memory.buffer, ADDRESSES.party),
     field: (offset: number) => view.getUint32(ADDRESSES.cursor + offset, true),

--- a/tests/unit/the-companion-abi-is-exact-across-typescript-and-rust.test.ts
+++ b/tests/unit/the-companion-abi-is-exact-across-typescript-and-rust.test.ts
@@ -1,0 +1,180 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import {
+  COMPANION_DISPATCH_KINDS,
+  COMPANION_FEATURE_BITS,
+} from "../../src/shared/companion-abi.ts";
+import {
+  ENHANCEMENT_CONFIG_FIELDS,
+} from "../../src/shared/enhancement-config.ts";
+
+const rustSource = readFileSync(
+  new URL("../../src/companion-kernel/abi.rs", import.meta.url),
+  "utf8",
+);
+
+const FEATURE_NAMES = Object.freeze({
+  nativeCursor: "FEATURE_NATIVE_CURSOR",
+  gameSnapshot: "FEATURE_GAME_SNAPSHOT",
+  toolboxFoundation: "FEATURE_TOOLBOX_FOUNDATION",
+  targetObservation: "FEATURE_TARGET_OBSERVATION",
+} as const);
+
+const DISPATCH_NAMES = Object.freeze({
+  tick: "DISPATCH_TICK",
+  cursor: "DISPATCH_CURSOR",
+  ui: "DISPATCH_UI",
+  activeFeatures: "DISPATCH_ACTIVE_FEATURES",
+} as const);
+
+function withoutComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//gu, "")
+    .replace(/\/\/.*$/gmu, "");
+}
+
+function captured(match: RegExpMatchArray | null, label: string): string {
+  const value = match?.[1];
+  if (value === undefined) throw new Error(`missing ${label}`);
+  return value;
+}
+
+function camelToSnake(value: string): string {
+  return value.replace(/[A-Z]/gu, (letter) => `_${letter.toLowerCase()}`);
+}
+
+function typescriptConfigSlots(): string[] {
+  return ENHANCEMENT_CONFIG_FIELDS.map((field) => {
+    if (field.source === "party-dirty") {
+      return `party_dirty_messages[${field.index}]`;
+    }
+    return camelToSnake(field.key);
+  });
+}
+
+function rustConfigSlots(source: string): string[] {
+  const clean = withoutComments(source);
+  const count = Number(captured(
+    clean.match(/const PARTY_DIRTY_MESSAGE_COUNT: usize = (\d+);/u),
+    "Rust party dirty-message count",
+  ));
+  const body = captured(
+    clean.match(/pub\(crate\) struct Layout\s*\{([\s\S]*?)\n\}/u),
+    "Rust Layout",
+  );
+
+  return body.split("\n").map((line) => line.trim()).filter(Boolean)
+    .flatMap((line) => {
+      const declaration = line.match(
+        /^pub\(crate\) ([a-z0-9_]+): (u32|\[u32; PARTY_DIRTY_MESSAGE_COUNT\]),$/u,
+      );
+      if (declaration === null) {
+        throw new Error(`unsupported Rust Layout declaration: ${line}`);
+      }
+      const [, name, type] = declaration;
+      if (name === undefined || type === undefined) {
+        throw new Error(`incomplete Rust Layout declaration: ${line}`);
+      }
+      if (type === "u32") return [name];
+      if (name !== "party_dirty_messages") {
+        throw new Error(`unexpected Rust config array: ${name}`);
+      }
+      return Array.from({ length: count }, (_, index) => `${name}[${index}]`);
+    });
+}
+
+function integerConstant(expression: string): number {
+  const value = expression.trim();
+  const decimal = value.match(/^(\d+)$/u)?.[1];
+  if (decimal !== undefined) return Number(decimal);
+  const shift = value.match(/^1\s*<<\s*(\d+)$/u)?.[1];
+  if (shift !== undefined) return 2 ** Number(shift);
+  throw new Error(`unsupported Rust integer constant: ${value}`);
+}
+
+function rustConstants(source: string, prefix: "FEATURE" | "DISPATCH") {
+  const constants = new Map<string, number>();
+  const pattern = new RegExp(
+    `pub\\(crate\\) const (${prefix}_[A-Z_]+): u32 = ([^;]+);`,
+    "gu",
+  );
+  for (const match of withoutComments(source).matchAll(pattern)) {
+    const name = match[1];
+    const expression = match[2];
+    if (name === undefined || expression === undefined) {
+      throw new Error(`incomplete Rust ${prefix} constant`);
+    }
+    constants.set(name, integerConstant(expression));
+  }
+  return constants;
+}
+
+function expectedConstants<T extends Record<string, number>>(
+  values: T,
+  names: { readonly [K in keyof T]: string },
+): Map<string, number> {
+  return new Map(
+    Object.keys(values).map((key) => {
+      const typedKey = key as keyof T;
+      return [names[typedKey], values[typedKey]];
+    }),
+  );
+}
+
+function assertExactContract(source: string): void {
+  assert.deepEqual(rustConfigSlots(source), typescriptConfigSlots());
+
+  const features = expectedConstants(COMPANION_FEATURE_BITS, FEATURE_NAMES);
+  assert.deepEqual(rustConstants(source, "FEATURE"), features);
+  assert.deepEqual(
+    rustConstants(source, "DISPATCH"),
+    expectedConstants(COMPANION_DISPATCH_KINDS, DISPATCH_NAMES),
+  );
+
+  const knownFeatures = captured(
+    withoutComments(source).match(
+      /const KNOWN_FEATURES: u32 =([\s\S]*?);/u,
+    ),
+    "Rust KNOWN_FEATURES",
+  ).match(/FEATURE_[A-Z_]+/gu) ?? [];
+  assert.deepEqual(knownFeatures.sort(), [...features.keys()].sort());
+}
+
+function replaced(source: string, from: string, to: string): string {
+  assert.ok(source.includes(from), `mutation target is present: ${from}`);
+  return source.replace(from, to);
+}
+
+test("the independent TypeScript and Rust companion contracts match exactly", () => {
+  assertExactContract(rustSource);
+  assert.equal(typescriptConfigSlots().length, 96);
+});
+
+test("same-size field swaps, bit drift, opcode drift, and new names are rejected", () => {
+  assert.throws(() => assertExactContract(replaced(
+    rustSource,
+    "    pub(crate) context_root: u32,\n    pub(crate) agent_array: u32,",
+    "    pub(crate) agent_array: u32,\n    pub(crate) context_root: u32,",
+  )));
+  assert.throws(() => assertExactContract(replaced(
+    rustSource,
+    "const FEATURE_TARGET_OBSERVATION: u32 = 1 << 3;",
+    "const FEATURE_TARGET_OBSERVATION: u32 = 1 << 4;",
+  )));
+  assert.throws(() => assertExactContract(replaced(
+    rustSource,
+    "const DISPATCH_ACTIVE_FEATURES: u32 = 3;",
+    "const DISPATCH_ACTIVE_FEATURES: u32 = 4;",
+  )));
+  assert.throws(() => assertExactContract(replaced(
+    rustSource,
+    "const FEATURE_NATIVE_CURSOR: u32 = 1 << 0;",
+    "const FEATURE_FUTURE: u32 = 1 << 4;\nconst FEATURE_NATIVE_CURSOR: u32 = 1 << 0;",
+  )));
+  assert.throws(() => assertExactContract(replaced(
+    rustSource,
+    "const PARTY_DIRTY_MESSAGE_COUNT: usize = 10;",
+    "const PARTY_DIRTY_MESSAGE_COUNT: usize = 9;",
+  )));
+});


### PR DESCRIPTION
TypeScript and Rust both described the 384-byte companion configuration, but existing checks proved only its size. Two same-sized fields could swap and still pass while the kernel read plausible values from the wrong positions. Feature bits and dispatch kinds had the same silent-drift risk.

## What changed

- Added one shared TypeScript source for companion feature bits and dispatch kinds.
- Updated the renderer installer, Wasm transform, and kernel fixtures to consume it.
- Kept Rust independently authored.
- Added an exact cross-language test for all 96 configuration positions and the closed feature/opcode sets.
- Added mutation proofs for same-size field swaps, bit drift, opcode drift, new feature names, and array-count drift.

## Invariant

The test parses only the Rust `Layout`, `FEATURE_*`, `DISPATCH_*`, and `KNOWN_FEATURES` declarations through a closed grammar—no evaluation and no generated cross-language source. Every TypeScript config position must equal the normalized Rust position, including all ten expanded dirty-message slots.

## Verification

- Focused ABI contract tests — 2 passed
- `pnpm typecheck`
- Focused ESLint — passed
- `pnpm check` — passed
- `pnpm build && node scripts/verify-companion-kernel.mjs` — sealed ABI and reproducible bytes passed
- Independent ABI review — approved, no blockers
- Local full verify: all unit, policy, build, kernel, integration, release, and browser layers passed; the desktop Electron environment then slowed to 6–15 seconds per unchanged test and produced unrelated diagnostics timeouts, so that invalid local run was stopped. Hosted `verify / verify` is the representative full boundary gate for this PR.

- [x] I kept this pull request focused.
- [x] I ran the relevant checks.
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [x] I updated documentation when behavior or an invariant changed.
