### PR TITLE
fix(website): restore consumer icon rendering

### DIFF
--- a/apps/website/nuxt.config.ts
+++ b/apps/website/nuxt.config.ts
@@ -1,7 +1,22 @@
+import { icons as lucideCollection } from "@iconify-json/lucide";
+import { useNuxt } from "nuxt/kit";
 import site from "./site.json" with { type: "json" };
 
 export default defineNuxtConfig({
   extends: ["@lupinum/ginko-docs"],
+  hooks: {
+    "modules:before"() {
+      const nuxt = useNuxt();
+      const collections: Array<{ prefix?: string }> =
+        nuxt.options.icon.customCollections ?? [];
+      // Ginko 0.2.3 snapshots a pruned Lucide collection before it discovers
+      // consumer icons. Replace that collection before Nuxt installs modules.
+      nuxt.options.icon.customCollections = [
+        lucideCollection,
+        ...collections.filter((collection) => collection.prefix !== "lucide"),
+      ];
+    },
+  },
   site: { url: site.url },
   app: {
     head: {

--- a/apps/website/nuxt.config.ts
+++ b/apps/website/nuxt.config.ts
@@ -7,13 +7,16 @@ export default defineNuxtConfig({
   hooks: {
     "modules:before"() {
       const nuxt = useNuxt();
-      const collections: Array<{ prefix?: string }> =
-        nuxt.options.icon.customCollections ?? [];
+      const icon = nuxt.options.icon;
+      if (!icon) throw new Error("Ginko Docs must enable Nuxt Icon");
+      const collections = icon.customCollections ?? [];
       // Ginko 0.2.3 snapshots a pruned Lucide collection before it discovers
       // consumer icons. Replace that collection before Nuxt installs modules.
-      nuxt.options.icon.customCollections = [
+      icon.customCollections = [
         lucideCollection,
-        ...collections.filter((collection) => collection.prefix !== "lucide"),
+        ...collections.filter(
+          (collection: { prefix?: string }) => collection.prefix !== "lucide",
+        ),
       ];
     },
   },

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -11,9 +11,11 @@
     "prepare": "vp exec nuxt prepare"
   },
   "devDependencies": {
+    "@iconify-json/lucide": "1.2.121",
     "@lupinum/ginko-content": "0.3.2",
     "@lupinum/ginko-docs": "0.2.3",
     "nuxt": "4.5.1",
+    "nuxt-site-config": "4.1.2",
     "typescript": "^5.9.3",
     "vite-plus": "0.1.24",
     "vue": "^3.5.35",

--- a/apps/website/scripts/assert-release-output.mjs
+++ b/apps/website/scripts/assert-release-output.mjs
@@ -1,4 +1,4 @@
-import { access, readFile } from "node:fs/promises";
+import { access, readFile, readdir } from "node:fs/promises";
 import { join } from "node:path";
 
 const output = join(import.meta.dirname, "..", ".output", "public");
@@ -25,6 +25,31 @@ const requiredFiles = [
 ];
 
 await Promise.all(requiredFiles.map((file) => access(join(output, file))));
+
+const missingIcons = new Set();
+const renderedIcons = new Set();
+for (const entry of await readdir(output, { recursive: true, withFileTypes: true })) {
+  if (!entry.isFile() || !entry.name.endsWith(".html")) continue;
+  const html = await readFile(join(entry.parentPath, entry.name), "utf8");
+  for (const match of html.matchAll(
+    /class="[^"]*\bi-([a-z0-9-]+:[a-z0-9-]+)\b[^"]*"/g,
+  )) {
+    const name = match[1];
+    renderedIcons.add(name);
+    const selector = `.i-${name.replace(":", "\\:")}`;
+    if (!html.includes(selector)) missingIcons.add(name);
+  }
+}
+
+if (renderedIcons.size === 0) {
+  throw new Error("No rendered icon classes were found in the generated website");
+}
+
+if (missingIcons.size > 0) {
+  throw new Error(
+    `Rendered icons missing their generated CSS: ${[...missingIcons].sort().join(", ")}`,
+  );
+}
 
 const english = await readFile(join(output, "__sitemap__/en-US.xml"), "utf8");
 const german = await readFile(join(output, "__sitemap__/de-DE.xml"), "utf8");

--- a/internals/migrations.md
+++ b/internals/migrations.md
@@ -1,0 +1,13 @@
+# Active migrations
+
+## Ginko consumer icon compatibility
+
+- Why: Ginko Docs 0.2.3 gives Nuxt Icon a pruned Lucide collection before it
+  discovers icons used by the consuming website. Those icons otherwise render
+  without CSS.
+- Introduced: 2026-08-21, with the website icon certification fix.
+- Depends on it: the website's app and content-specific Lucide icons.
+- Remove when: a Ginko Docs version at or above 0.2.5, together with its
+  required Ginko Content version, passes the repository's strict website
+  typecheck and certification. Remove the `modules:before` hook and the direct
+  `@iconify-json/lucide` dependency with this entry.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
 
   apps/website:
     devDependencies:
+      '@iconify-json/lucide':
+        specifier: 1.2.121
+        version: 1.2.121
       '@lupinum/ginko-content':
         specifier: 0.3.2
         version: 0.3.2(8bc4c488b294eac47e7cc73f79c4e365)
@@ -117,6 +120,9 @@ importers:
       nuxt:
         specifier: 4.5.1
         version: 4.5.1(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(@types/node@24.13.3)(@vue/compiler-sfc@3.5.40)(cac@7.0.0)(db0@0.3.4)(encoding@0.1.13)(esbuild@0.28.1)(eslint@10.7.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.3)(optionator@0.9.4)(oxc-parser@0.140.0)(oxlint@1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.13.3)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(terser@5.49.0)(typescript@5.9.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(yaml@2.9.0)))(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.62.2))(rollup@4.62.2)(srvx@0.11.22)(terser@5.49.0)(typescript@5.9.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript@5.9.3))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23))(yaml@2.9.0)
+      nuxt-site-config:
+        specifier: 4.1.2
+        version: 4.1.2(38d876099acb84eabfe1153710d64b28)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3


### PR DESCRIPTION
## What changed

Website-specific Lucide icons now render instead of becoming empty spans. The website supplies its complete local Lucide collection before Nuxt installs the icon module, while the generated client bundle remains usage-pruned.

Website certification now inspects every generated HTML page and fails when an icon class has no matching generated CSS selector. A non-empty check prevents the invariant from passing when icon discovery breaks entirely.

## Why

Ginko Docs 0.2.3 snapshots its pruned Lucide collection before it discovers icons used by the consuming site. Twenty consumer icons were omitted from the bundle, which produced `undefined/lucide.json` requests and invisible navigation/content glyphs even though the website gate passed.

Ginko Docs 0.2.5 fixes that ordering upstream, but its compatible Ginko Content versions currently fail this repository's strict blog-feed typecheck. The local compatibility hook and its exact removal condition are recorded in `internals/migrations.md` instead of weakening typechecking or enabling a remote icon fallback.

The website also declares `nuxt-site-config` directly. A frozen install without that host dependency reproducibly failed Nuxt prepare with `NUXT_B8017` because the inherited `nuxt-og-image` module is resolved from the host application.

## Invariant

Every prerendered `i-collection:name` class must have its escaped CSS selector in the same generated page. The current artifact contains 38 distinct rendered icon classes across 53 HTML pages, with no missing selectors.

## Verification

- `pnpm --store-dir /Users/matthias/Library/pnpm/store/v11 install --frozen-lockfile`
- `pnpm --filter gw-website check`
- `pnpm --filter gw-website certify`
- `node --import ./scripts/ts-hook.mjs --experimental-strip-types tests/website-smoke.ts`
- Headless Chromium inspection of `/docs/project/safety`: no missing icon masks, icon warnings, or `undefined/` requests
- `git diff --check`

- [x] I kept this pull request focused.
- [x] I ran the relevant checks.
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [x] I updated documentation when behavior or an invariant changed.
