### PR TITLE
fix(accounts): roll back incomplete profile creation

### DIFF
--- a/docs/multiple-accounts.md
+++ b/docs/multiple-accounts.md
@@ -55,7 +55,10 @@ from Single Account mode.
 
 The app publishes the workspace before it publishes the selected mode. A
 cancelled or failed enable action leaves Single Account mode selected. A failed
-first-account import does not change its source or publish the account.
+first-account import never changes its source or overwrites existing Multiple
+Accounts data. When Main confirms that the workspace was not published, it
+attempts to remove only destinations created by that attempt. If publication
+cannot be confirmed, it preserves those destinations and requires a restart.
 
 Returning to Single Account mode preserves the complete Multiple Accounts
 workspace. Re-enabling it restores the profiles and libraries. Neither

--- a/src/main/core/account-profile-creation.ts
+++ b/src/main/core/account-profile-creation.ts
@@ -1,0 +1,209 @@
+/**
+ * The filesystem transaction that creates one Multiple Accounts profile.
+ * The workspace document is the commit record; everything published before it
+ * is removed on a confirmed pre-commit failure.
+ */
+import { lstat, mkdir, readFile, rm } from "node:fs/promises";
+import { isDeepStrictEqual } from "node:util";
+import type { BuildLibrary } from "../../shared/builds/library.js";
+import { parseBuildLibrary } from "../../shared/builds/parse-library.js";
+import type { AccountProfileCreateRequest } from "../../shared/contracts.js";
+import type { MultiWorkspace } from "../../shared/multiple-accounts.js";
+import {
+  loadAccountTemplateLibrary,
+  saveAccountTemplateLibraryExclusive,
+} from "./account-template-library.js";
+import { AtomicExclusiveWriteError } from "./atomic-file.js";
+import { saveBuildLibraryExclusive } from "./build-library.js";
+import {
+  addMultiProfile,
+  loadMultiWorkspace,
+  saveMultiWorkspace,
+} from "./multiple-accounts.js";
+import { multiProfilePaths, type GamePaths } from "./paths.js";
+
+export interface AccountProfileCreationDependencies {
+  readonly addProfile: typeof addMultiProfile;
+  readonly remove: (path: string, recursive: boolean) => Promise<void>;
+  readonly saveBuilds: typeof saveBuildLibraryExclusive;
+  readonly saveTemplates: typeof saveAccountTemplateLibraryExclusive;
+  readonly saveWorkspace: typeof saveMultiWorkspace;
+  readonly loadWorkspace: typeof loadMultiWorkspace;
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await lstat(path);
+    return true;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+export const nodeAccountProfileCreationDependencies: AccountProfileCreationDependencies = {
+  addProfile: addMultiProfile,
+  async remove(path, recursive) {
+    await rm(path, { recursive, force: true });
+  },
+  saveBuilds: saveBuildLibraryExclusive,
+  saveTemplates: saveAccountTemplateLibraryExclusive,
+  saveWorkspace: saveMultiWorkspace,
+  loadWorkspace: loadMultiWorkspace,
+};
+
+async function createRoot(parent: string, root: string): Promise<void> {
+  await mkdir(parent, { recursive: true });
+  await mkdir(root);
+}
+
+async function loadBuildImport(path: string): Promise<BuildLibrary | null> {
+  let bytes: string;
+  try {
+    bytes = await readFile(path, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+  return parseBuildLibrary(JSON.parse(bytes) as unknown);
+}
+
+interface OwnedPath {
+  readonly path: string;
+  readonly recursive: boolean;
+}
+
+export class AmbiguousAccountCreationError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "AmbiguousAccountCreationError";
+  }
+}
+
+async function rollback(
+  owned: readonly OwnedPath[],
+  primary: unknown,
+  dependencies: AccountProfileCreationDependencies,
+): Promise<never> {
+  const cleanupErrors: unknown[] = [];
+  for (let index = owned.length - 1; index >= 0; index -= 1) {
+    const target = owned[index]!;
+    try {
+      await dependencies.remove(target.path, target.recursive);
+    } catch (error) {
+      cleanupErrors.push(
+        new Error(`Could not remove ${target.path}`, { cause: error }),
+      );
+    }
+  }
+  if (cleanupErrors.length === 0) throw primary;
+  throw new AggregateError(
+    [primary, ...cleanupErrors],
+    "Account creation failed and some newly created files could not be removed",
+  );
+}
+
+/** Create one profile without ever replacing an unowned destination. */
+export async function createAccountProfile(
+  workspace: MultiWorkspace,
+  request: AccountProfileCreateRequest,
+  paths: GamePaths,
+  dependencies: AccountProfileCreationDependencies = nodeAccountProfileCreationDependencies,
+): Promise<MultiWorkspace> {
+  const firstAccount = workspace.profiles.length === 0;
+  if (!firstAccount && (request.copySingleBuilds || request.copySingleTemplates)) {
+    throw new Error("Single Account data can be copied only into the first account");
+  }
+
+  const next = dependencies.addProfile(workspace, request);
+  const profile = next.profiles.at(-1)!;
+  const profilePaths = multiProfilePaths(paths, profile.id);
+  const buildDestination = profile.builds === "shared"
+    ? paths.multiSharedBuildLibrary
+    : profilePaths.buildLibrary;
+  const templateDestination = profile.templates === "shared"
+    ? paths.multiSharedTemplates
+    : profilePaths.templates;
+
+  // Validate every requested source before creating any destination.
+  const builds = firstAccount && request.copySingleBuilds
+    ? await loadBuildImport(paths.buildLibrary)
+    : null;
+  const templates = firstAccount && request.copySingleTemplates
+    ? await loadAccountTemplateLibrary(paths.multiSingleTemplateImport)
+    : null;
+  const destinations = [
+    ...(builds === null ? [] : [buildDestination]),
+    ...(templates === null ? [] : [templateDestination]),
+  ];
+
+  for (const target of [profilePaths.root, ...destinations]) {
+    if (await pathExists(target)) {
+      throw new Error(
+        `Account creation refused existing Multiple Accounts data at ${target}`,
+      );
+    }
+  }
+
+  const owned: OwnedPath[] = [];
+  try {
+    await createRoot(paths.multiProfiles, profilePaths.root);
+    owned.push({ path: profilePaths.root, recursive: true });
+
+    if (builds !== null) {
+      try {
+        await dependencies.saveBuilds(buildDestination, builds);
+        owned.push({ path: buildDestination, recursive: false });
+      } catch (error) {
+        if (error instanceof AtomicExclusiveWriteError && error.published) {
+          owned.push({ path: buildDestination, recursive: false });
+        }
+        throw error;
+      }
+    }
+    if (templates !== null) {
+      try {
+        await dependencies.saveTemplates(templateDestination, {
+          revision: 1,
+          entries: templates.entries,
+        });
+        owned.push({ path: templateDestination, recursive: false });
+      } catch (error) {
+        if (error instanceof AtomicExclusiveWriteError && error.published) {
+          owned.push({ path: templateDestination, recursive: false });
+        }
+        throw error;
+      }
+    }
+
+    try {
+      await dependencies.saveWorkspace(paths.multiWorkspace, next);
+      return next;
+    } catch (error) {
+      let durable: MultiWorkspace | null;
+      try {
+        durable = await dependencies.loadWorkspace(paths.multiWorkspace);
+      } catch (reloadError) {
+        throw new AmbiguousAccountCreationError(
+          "Account creation commit is unclear; restart before retrying",
+          { cause: new AggregateError([error, reloadError]) },
+        );
+      }
+      if (isDeepStrictEqual(durable, next)) return next;
+      if (!isDeepStrictEqual(durable, workspace)) {
+        throw new AmbiguousAccountCreationError(
+          "Account creation commit is unclear; restart before retrying",
+          { cause: error },
+        );
+      }
+      throw error;
+    }
+  } catch (error) {
+    // Ambiguous commit errors deliberately preserve resources: deleting them
+    // could break a workspace that was published before directory fsync failed.
+    if (error instanceof AmbiguousAccountCreationError) {
+      throw error;
+    }
+    return await rollback(owned, error, dependencies);
+  }
+}

--- a/src/main/core/account-template-library.ts
+++ b/src/main/core/account-template-library.ts
@@ -15,7 +15,7 @@ import type {
 } from "../../shared/contracts.js";
 import { AppError } from "../../shared/errors.js";
 import { parseTemplateEntries } from "../../shared/template-entries.js";
-import { writeAtomicJson } from "./atomic-file.js";
+import { writeAtomicJson, writeAtomicJsonExclusive } from "./atomic-file.js";
 
 const DOCUMENT_MODE = 0o600;
 
@@ -57,6 +57,17 @@ export async function saveAccountTemplateLibrary(
   const entries = parseTemplateEntries(library.entries);
   const value = { formatVersion: 1, revision: library.revision, entries };
   await writeAtomicJson(filePath, value, DOCUMENT_MODE);
+  return { revision: value.revision, entries: value.entries };
+}
+
+/** First-account import: publish a complete snapshot without replacing recovery data. */
+export async function saveAccountTemplateLibraryExclusive(
+  filePath: string,
+  library: AccountTemplateLibrary,
+): Promise<AccountTemplateLibrary> {
+  const entries = parseTemplateEntries(library.entries);
+  const value = { formatVersion: 1, revision: library.revision, entries };
+  await writeAtomicJsonExclusive(filePath, value, DOCUMENT_MODE);
   return { revision: value.revision, entries: value.entries };
 }
 

--- a/src/main/core/atomic-file.ts
+++ b/src/main/core/atomic-file.ts
@@ -10,7 +10,7 @@
  * pruning deliberately ignores names that are not content hashes.
  */
 import { randomBytes } from "node:crypto";
-import { mkdir, open, readdir, rename, unlink } from "node:fs/promises";
+import { link, mkdir, open, readdir, rename, unlink } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { AppError } from "../../shared/errors.js";
 
@@ -81,6 +81,21 @@ export async function writeAtomic(
   data: string | Uint8Array,
   mode?: number,
 ): Promise<void> {
+  const { dir, tmp } = await writeTemporary(path, data, mode);
+  try {
+    await rename(tmp, path);
+    await syncDirectory(dir);
+  } catch (error) {
+    await unlink(tmp).catch(() => undefined);
+    throw error;
+  }
+}
+
+async function writeTemporary(
+  path: string,
+  data: string | Uint8Array,
+  mode?: number,
+): Promise<{ readonly dir: string; readonly tmp: string }> {
   const dir = dirname(path);
   await mkdir(dir, { recursive: true });
   const tmp = tempPath(path);
@@ -96,11 +111,43 @@ export async function writeAtomic(
     } finally {
       await handle.close();
     }
-    await rename(tmp, path);
-    await syncDirectory(dir);
+    return { dir, tmp };
   } catch (error) {
     await unlink(tmp).catch(() => undefined);
     throw error;
+  }
+}
+
+/** A create-only publication reports whether its final name became owned. */
+export class AtomicExclusiveWriteError extends Error {
+  readonly published: boolean;
+
+  constructor(
+    published: boolean,
+    options: ErrorOptions,
+  ) {
+    super("create-only atomic publication failed", options);
+    this.name = "AtomicExclusiveWriteError";
+    this.published = published;
+  }
+}
+
+/** Publish a complete file only when the final name does not already exist. */
+export async function writeAtomicExclusive(
+  path: string,
+  data: string | Uint8Array,
+  mode?: number,
+): Promise<void> {
+  const { dir, tmp } = await writeTemporary(path, data, mode);
+  let published = false;
+  try {
+    await link(tmp, path);
+    published = true;
+    await syncDirectory(dir);
+  } catch (cause) {
+    throw new AtomicExclusiveWriteError(published, { cause });
+  } finally {
+    await unlink(tmp).catch(() => undefined);
   }
 }
 
@@ -110,6 +157,14 @@ export async function writeAtomicJson(
   mode?: number,
 ): Promise<void> {
   await writeAtomic(path, JSON.stringify(value), mode);
+}
+
+export async function writeAtomicJsonExclusive(
+  path: string,
+  value: unknown,
+  mode?: number,
+): Promise<void> {
+  await writeAtomicExclusive(path, JSON.stringify(value), mode);
 }
 
 /** Chunk publication: write under a unique temp name in the same directory, then rename. */

--- a/src/main/core/build-library.ts
+++ b/src/main/core/build-library.ts
@@ -41,7 +41,7 @@ import {
   EMPTY_LIBRARY,
   parseBuildLibrary,
 } from "../../shared/builds/parse-library.js";
-import { writeAtomicJson } from "./atomic-file.js";
+import { writeAtomicJson, writeAtomicJsonExclusive } from "./atomic-file.js";
 
 /** Owner-only: a build library is a player's own work, not shared state. */
 const LIBRARY_MODE = 0o600;
@@ -127,6 +127,16 @@ export async function saveBuildLibrary(
 ): Promise<BuildLibrary> {
   const cleaned = parseBuildLibrary(value);
   await writeAtomicJson(path, cleaned, LIBRARY_MODE);
+  return cleaned;
+}
+
+/** First-account import: publish a complete library without replacing recovery data. */
+export async function saveBuildLibraryExclusive(
+  path: string,
+  value: BuildLibrary,
+): Promise<BuildLibrary> {
+  const cleaned = parseBuildLibrary(value);
+  await writeAtomicJsonExclusive(path, cleaned, LIBRARY_MODE);
   return cleaned;
 }
 

--- a/src/main/multiple-accounts-controller.ts
+++ b/src/main/multiple-accounts-controller.ts
@@ -4,7 +4,7 @@
  * and destructive cleanup out of the application composition root.
  */
 import { app, dialog, session, type BrowserWindow } from "electron";
-import { mkdir, readFile, rm } from "node:fs/promises";
+import { mkdir, rm } from "node:fs/promises";
 import type {
   AccountProfileCreateRequest,
   AccountProfileUpdateRequest,
@@ -28,10 +28,12 @@ import {
   reconcileAccountTemplates,
   saveAccountTemplateLibrary,
 } from "./core/account-template-library.js";
-import { saveBuildLibrary } from "./core/build-library.js";
+import {
+  AmbiguousAccountCreationError,
+  createAccountProfile,
+} from "./core/account-profile-creation.js";
 import { CredentialsStore } from "./core/credentials.js";
 import {
-  addMultiProfile,
   archiveMultiProfile,
   beginArchivedProfileDeletion,
   createMultiWorkspace,
@@ -55,7 +57,6 @@ import {
   installGwProtocolHandlerForSession,
   type ProtocolDeps,
 } from "./protocol.js";
-import { parseBuildLibrary } from "../shared/builds/parse-library.js";
 import { applyPendingSessionStorageReset } from "./settings-actions.js";
 import {
   closeProfileWindow,
@@ -248,31 +249,17 @@ export class MultipleAccountsController {
       const workspace = this.activeWorkspace();
       const { paths } = this.options;
       const firstAccount = workspace.profiles.length === 0;
-      if (!firstAccount && (request.copySingleBuilds || request.copySingleTemplates)) {
-        throw new Error("Single Account data can be copied only into the first account");
+      let next: MultiWorkspace;
+      try {
+        next = await createAccountProfile(workspace, request, paths);
+      } catch (error) {
+        if (error instanceof AmbiguousAccountCreationError) {
+          // No later mutation may publish the stale in-memory workspace over a
+          // profile whose final workspace rename may already have succeeded.
+          this.workspace = null;
+        }
+        throw error;
       }
-      const next = addMultiProfile(workspace, request);
-      const profile = next.profiles.at(-1)!;
-      const profilePaths = multiProfilePaths(paths, profile.id);
-      await mkdir(profilePaths.root, { recursive: true });
-      if (firstAccount && request.copySingleBuilds) {
-        await this.importBuildLibraryIfPresent(
-          paths.buildLibrary,
-          profile.builds === "shared"
-            ? paths.multiSharedBuildLibrary
-            : profilePaths.buildLibrary,
-        );
-      }
-      if (firstAccount && request.copySingleTemplates) {
-        const source = await loadAccountTemplateLibrary(paths.multiSingleTemplateImport);
-        await saveAccountTemplateLibrary(
-          profile.templates === "shared"
-            ? paths.multiSharedTemplates
-            : profilePaths.templates,
-          { revision: 1, entries: source.entries },
-        );
-      }
-      await saveMultiWorkspace(paths.multiWorkspace, next);
       this.workspace = next;
       if (firstAccount) {
         await rm(paths.multiSingleTemplateImport, { force: true }).catch(() => undefined);
@@ -540,21 +527,6 @@ export class MultipleAccountsController {
     await saveAccountMode(this.options.paths.launcherMode, mode);
     app.relaunch();
     app.quit();
-  }
-
-  private async importBuildLibraryIfPresent(
-    source: string,
-    destination: string,
-  ): Promise<void> {
-    let bytes: string;
-    try {
-      bytes = await readFile(source, "utf8");
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
-      throw error;
-    }
-    const library = parseBuildLibrary(JSON.parse(bytes) as unknown);
-    await saveBuildLibrary(destination, library);
   }
 
   private async cleanupProfile(profileId: ProfileId): Promise<void> {

--- a/src/renderer/accounts.ts
+++ b/src/renderer/accounts.ts
@@ -326,7 +326,9 @@ import type { AccountProfileSummary } from '../shared/contracts.js';
       setStatus(wasEditing ? 'Account updated.' : 'Account created.', 'success');
       await refresh();
     } catch {
-      profileStatus.textContent = 'The account could not be saved. Use a unique name and close it before changing sharing.';
+      profileStatus.textContent = wasEditing
+        ? 'The account could not be saved. Use a unique name and close it before changing sharing.'
+        : 'The account could not be created. Existing data was kept. Review the name and options; restart before retrying if they were already valid.';
     } finally {
       profileSave.disabled = false;
     }

--- a/tests/policy/forbidden-artifacts.test.ts
+++ b/tests/policy/forbidden-artifacts.test.ts
@@ -109,6 +109,7 @@ test("only public identifiers and explicit profile-id fixtures are UUID-shaped",
   const profileIdFixtures = new Set([
     "tests/electron/multiple-accounts.spec.ts",
     "tests/release/preload-behaviour.test.ts",
+    "tests/unit/account-profile-creation.test.ts",
     "tests/unit/credentials.test.ts",
     "tests/unit/multiple-accounts.test.ts",
     "tests/unit/native-keychain.test.ts",

--- a/tests/unit/account-profile-creation.test.ts
+++ b/tests/unit/account-profile-creation.test.ts
@@ -1,0 +1,398 @@
+import assert from "node:assert/strict";
+import { lstat, mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import {
+  createAccountProfile,
+  nodeAccountProfileCreationDependencies,
+  type AccountProfileCreationDependencies,
+} from "../../src/main/core/account-profile-creation.js";
+import { AtomicExclusiveWriteError } from "../../src/main/core/atomic-file.js";
+import {
+  addMultiProfile,
+  createMultiWorkspace,
+  loadMultiWorkspace,
+  saveMultiWorkspace,
+} from "../../src/main/core/multiple-accounts.js";
+import { gamePaths, multiProfilePaths } from "../../src/main/core/paths.js";
+import { EMPTY_LIBRARY } from "../../src/shared/builds/parse-library.js";
+import { parseProfileId } from "../../src/shared/multiple-accounts.js";
+
+const PROFILE_ID = parseProfileId("2d31e565-9fc8-4dde-9fd4-9d644f8283ae");
+
+const deterministicDependencies: AccountProfileCreationDependencies = {
+  ...nodeAccountProfileCreationDependencies,
+  addProfile: (workspace, request) => addMultiProfile(workspace, {
+    ...request,
+    id: PROFILE_ID,
+  }),
+};
+
+async function absent(path: string): Promise<boolean> {
+  try {
+    await lstat(path);
+    return false;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return true;
+    throw error;
+  }
+}
+
+async function setup() {
+  const root = await mkdtemp(join(tmpdir(), "gw-account-create-"));
+  const paths = gamePaths(root);
+  const workspace = createMultiWorkspace();
+  await saveMultiWorkspace(paths.multiWorkspace, workspace);
+  await writeFile(paths.buildLibrary, JSON.stringify(EMPTY_LIBRARY));
+  await mkdir(join(paths.multiRoot), { recursive: true });
+  await writeFile(paths.multiSingleTemplateImport, JSON.stringify({
+    formatVersion: 1,
+    revision: 1,
+    entries: [{ path: "Main/Build.txt", contents: "OQAA" }],
+  }));
+  const request = {
+    name: "Main",
+    builds: "shared" as const,
+    templates: "shared" as const,
+    copySingleBuilds: true,
+    copySingleTemplates: true,
+  };
+  return { paths, request, root, workspace };
+}
+
+describe("Multiple Accounts profile creation", () => {
+  it("validates every Single Account source before creating destinations", async () => {
+    const test = await setup();
+    await writeFile(test.paths.multiSingleTemplateImport, "{broken");
+
+    await assert.rejects(
+      createAccountProfile(
+        test.workspace,
+        test.request,
+        test.paths,
+        deterministicDependencies,
+      ),
+    );
+
+    const profile = multiProfilePaths(test.paths, PROFILE_ID);
+    assert.equal(await absent(profile.root), true);
+    assert.equal(await absent(test.paths.multiSharedBuildLibrary), true);
+    assert.deepEqual(await loadMultiWorkspace(test.paths.multiWorkspace), test.workspace);
+    assert.deepEqual(JSON.parse(await readFile(test.paths.buildLibrary, "utf8")), EMPTY_LIBRARY);
+  });
+
+  it("rolls back both imported libraries when workspace publication fails", async () => {
+    const test = await setup();
+    const workspaceBytes = await readFile(test.paths.multiWorkspace, "utf8");
+    const buildSourceBytes = await readFile(test.paths.buildLibrary, "utf8");
+    const templateSourceBytes = await readFile(
+      test.paths.multiSingleTemplateImport,
+      "utf8",
+    );
+    const failure = new Error("workspace publication failed");
+    const dependencies: AccountProfileCreationDependencies = {
+      ...deterministicDependencies,
+      saveWorkspace: async () => { throw failure; },
+    };
+
+    await assert.rejects(
+      createAccountProfile(test.workspace, test.request, test.paths, dependencies),
+      failure,
+    );
+
+    const profile = multiProfilePaths(test.paths, PROFILE_ID);
+    assert.equal(await absent(profile.root), true);
+    assert.equal(await absent(test.paths.multiSharedBuildLibrary), true);
+    assert.equal(await absent(test.paths.multiSharedTemplates), true);
+    assert.deepEqual(await loadMultiWorkspace(test.paths.multiWorkspace), test.workspace);
+    assert.equal(await readFile(test.paths.multiWorkspace, "utf8"), workspaceBytes);
+    assert.equal(await readFile(test.paths.buildLibrary, "utf8"), buildSourceBytes);
+    assert.equal(
+      await readFile(test.paths.multiSingleTemplateImport, "utf8"),
+      templateSourceBytes,
+    );
+  });
+
+  it("rolls back after each library publication boundary", async () => {
+    const buildFailure = await setup();
+    await assert.rejects(
+      createAccountProfile(
+        buildFailure.workspace,
+        buildFailure.request,
+        buildFailure.paths,
+        {
+          ...deterministicDependencies,
+          saveBuilds: async () => { throw new Error("build failed"); },
+        },
+      ),
+      /build failed/u,
+    );
+    assert.equal(
+      await absent(multiProfilePaths(buildFailure.paths, PROFILE_ID).root),
+      true,
+    );
+
+    const templateFailure = await setup();
+    await assert.rejects(
+      createAccountProfile(
+        templateFailure.workspace,
+        templateFailure.request,
+        templateFailure.paths,
+        {
+          ...deterministicDependencies,
+          saveTemplates: async () => { throw new Error("template failed"); },
+        },
+      ),
+      /template failed/u,
+    );
+    assert.equal(await absent(templateFailure.paths.multiSharedBuildLibrary), true);
+    assert.equal(
+      await absent(multiProfilePaths(templateFailure.paths, PROFILE_ID).root),
+      true,
+    );
+
+    const publishedTemplateFailure = await setup();
+    await assert.rejects(
+      createAccountProfile(
+        publishedTemplateFailure.workspace,
+        publishedTemplateFailure.request,
+        publishedTemplateFailure.paths,
+        {
+          ...deterministicDependencies,
+          saveTemplates: async (path, library) => {
+            await nodeAccountProfileCreationDependencies.saveTemplates(path, library);
+            throw new AtomicExclusiveWriteError(true, {
+              cause: new Error("directory fsync failed"),
+            });
+          },
+        },
+      ),
+      AtomicExclusiveWriteError,
+    );
+    assert.equal(
+      await absent(publishedTemplateFailure.paths.multiSharedTemplates),
+      true,
+    );
+    assert.equal(
+      await absent(publishedTemplateFailure.paths.multiSharedBuildLibrary),
+      true,
+    );
+  });
+
+  it("refuses a requested destination without changing its existing bytes", async () => {
+    const test = await setup();
+    await mkdir(join(test.paths.multiRoot, "shared"), { recursive: true });
+    await writeFile(test.paths.multiSharedBuildLibrary, "player recovery data");
+
+    await assert.rejects(
+      createAccountProfile(
+        test.workspace,
+        test.request,
+        test.paths,
+        deterministicDependencies,
+      ),
+      /refused existing Multiple Accounts data/u,
+    );
+
+    assert.equal(
+      await readFile(test.paths.multiSharedBuildLibrary, "utf8"),
+      "player recovery data",
+    );
+    assert.equal(await absent(test.paths.multiSharedTemplates), true);
+    assert.equal(
+      await absent(multiProfilePaths(test.paths, PROFILE_ID).root),
+      true,
+    );
+  });
+
+  it("refuses pre-existing profile roots and template destinations", async () => {
+    const rootCollision = await setup();
+    const profileRoot = multiProfilePaths(rootCollision.paths, PROFILE_ID).root;
+    await mkdir(profileRoot, { recursive: true });
+    await writeFile(join(profileRoot, "recovered.txt"), "keep me");
+    await assert.rejects(
+      createAccountProfile(
+        rootCollision.workspace,
+        rootCollision.request,
+        rootCollision.paths,
+        deterministicDependencies,
+      ),
+      /refused existing Multiple Accounts data/u,
+    );
+    assert.equal(await readFile(join(profileRoot, "recovered.txt"), "utf8"), "keep me");
+
+    const templateCollision = await setup();
+    await mkdir(join(templateCollision.paths.multiRoot, "shared"), {
+      recursive: true,
+    });
+    await writeFile(templateCollision.paths.multiSharedTemplates, "template recovery");
+    await assert.rejects(
+      createAccountProfile(
+        templateCollision.workspace,
+        { ...templateCollision.request, copySingleBuilds: false },
+        templateCollision.paths,
+        deterministicDependencies,
+      ),
+      /refused existing Multiple Accounts data/u,
+    );
+    assert.equal(
+      await readFile(templateCollision.paths.multiSharedTemplates, "utf8"),
+      "template recovery",
+    );
+
+    const symlinkCollision = await setup();
+    const symlinkRoot = multiProfilePaths(symlinkCollision.paths, PROFILE_ID).root;
+    const recoveryRoot = join(symlinkCollision.root, "recovered-profile");
+    await mkdir(join(symlinkCollision.paths.multiProfiles), { recursive: true });
+    await mkdir(recoveryRoot);
+    await writeFile(join(recoveryRoot, "kept.txt"), "symlink data");
+    await symlink(recoveryRoot, symlinkRoot, "dir");
+    await assert.rejects(
+      createAccountProfile(
+        symlinkCollision.workspace,
+        symlinkCollision.request,
+        symlinkCollision.paths,
+        deterministicDependencies,
+      ),
+      /refused existing Multiple Accounts data/u,
+    );
+    assert.equal(await readFile(join(recoveryRoot, "kept.txt"), "utf8"), "symlink data");
+  });
+
+  it("loses a publication race without replacing the competing file", async () => {
+    const test = await setup();
+    const sentinel = "created by another owner";
+    const dependencies: AccountProfileCreationDependencies = {
+      ...deterministicDependencies,
+      saveBuilds: async (path, library) => {
+        await mkdir(join(test.paths.multiRoot, "shared"), { recursive: true });
+        await writeFile(path, sentinel);
+        return await nodeAccountProfileCreationDependencies.saveBuilds(path, library);
+      },
+    };
+
+    await assert.rejects(
+      createAccountProfile(test.workspace, test.request, test.paths, dependencies),
+      (error) => error instanceof AtomicExclusiveWriteError && !error.published,
+    );
+    assert.equal(await readFile(test.paths.multiSharedBuildLibrary, "utf8"), sentinel);
+    assert.equal(
+      await absent(multiProfilePaths(test.paths, PROFILE_ID).root),
+      true,
+    );
+  });
+
+  it("treats a workspace rename followed by an error as committed", async () => {
+    const test = await setup();
+    const dependencies: AccountProfileCreationDependencies = {
+      ...deterministicDependencies,
+      saveWorkspace: async (path, workspace) => {
+        await saveMultiWorkspace(path, workspace);
+        throw new Error("directory fsync failed");
+      },
+    };
+
+    const committed = await createAccountProfile(
+      test.workspace,
+      test.request,
+      test.paths,
+      dependencies,
+    );
+
+    assert.deepEqual(await loadMultiWorkspace(test.paths.multiWorkspace), committed);
+    assert.equal(await absent(test.paths.multiSharedBuildLibrary), false);
+    assert.equal(await absent(test.paths.multiSharedTemplates), false);
+  });
+
+  it("removes a later account root when its workspace write fails", async () => {
+    const test = await setup();
+    const existing = addMultiProfile(test.workspace, {
+      id: "6038c349-435a-4483-933f-0a792563a370",
+      name: "Existing",
+      builds: "private",
+      templates: "private",
+    });
+    await saveMultiWorkspace(test.paths.multiWorkspace, existing);
+    const dependencies: AccountProfileCreationDependencies = {
+      ...deterministicDependencies,
+      saveWorkspace: async () => { throw new Error("workspace failed"); },
+    };
+
+    await assert.rejects(
+      createAccountProfile(
+        existing,
+        {
+          ...test.request,
+          copySingleBuilds: false,
+          copySingleTemplates: false,
+        },
+        test.paths,
+        dependencies,
+      ),
+      /workspace failed/u,
+    );
+    assert.equal(
+      await absent(multiProfilePaths(test.paths, PROFILE_ID).root),
+      true,
+    );
+    assert.deepEqual(await loadMultiWorkspace(test.paths.multiWorkspace), existing);
+  });
+
+  it("preserves created resources when the workspace commit is ambiguous", async () => {
+    const test = await setup();
+    const dependencies: AccountProfileCreationDependencies = {
+      ...deterministicDependencies,
+      saveWorkspace: async () => { throw new Error("save failed"); },
+      loadWorkspace: async () => { throw new Error("reload failed"); },
+    };
+
+    await assert.rejects(
+      createAccountProfile(test.workspace, test.request, test.paths, dependencies),
+      /commit is unclear; restart before retrying/u,
+    );
+
+    assert.equal(await absent(test.paths.multiSharedBuildLibrary), false);
+    assert.equal(await absent(test.paths.multiSharedTemplates), false);
+    assert.equal(
+      await absent(multiProfilePaths(test.paths, PROFILE_ID).root),
+      false,
+    );
+  });
+
+  it("continues reverse cleanup and keeps the primary failure", async () => {
+    const test = await setup();
+    const removed: string[] = [];
+    const primary = new Error("workspace failed");
+    const dependencies: AccountProfileCreationDependencies = {
+      ...deterministicDependencies,
+      saveWorkspace: async () => { throw primary; },
+      remove: async (path, recursive) => {
+        removed.push(path);
+        if (path === test.paths.multiSharedTemplates) {
+          throw new Error("template cleanup failed");
+        }
+        await nodeAccountProfileCreationDependencies.remove(path, recursive);
+      },
+    };
+
+    await assert.rejects(
+      createAccountProfile(test.workspace, test.request, test.paths, dependencies),
+      (error) => {
+        assert.ok(error instanceof AggregateError);
+        assert.equal(error.errors[0], primary);
+        return true;
+      },
+    );
+    assert.deepEqual(removed, [
+      test.paths.multiSharedTemplates,
+      test.paths.multiSharedBuildLibrary,
+      multiProfilePaths(test.paths, PROFILE_ID).root,
+    ]);
+    assert.equal(await absent(test.paths.multiSharedBuildLibrary), true);
+    assert.equal(
+      await absent(multiProfilePaths(test.paths, PROFILE_ID).root),
+      true,
+    );
+  });
+});

--- a/tests/unit/atomic-file.test.ts
+++ b/tests/unit/atomic-file.test.ts
@@ -18,8 +18,10 @@ import { fileURLToPath } from "node:url";
 import {
   sweepOrphanDirectories,
   sweepOrphans,
+  AtomicExclusiveWriteError,
   writeAll,
   writeAtomic,
+  writeAtomicExclusive,
   writeAtomicInDir,
   writeAtomicJson,
 } from "../../src/main/core/atomic-file.js";
@@ -112,6 +114,18 @@ describe("atomic-file", () => {
     assert.equal((await stat(path)).mode & 0o777, 0o600);
   });
 
+  it("creates a complete file without replacing an existing target", async () => {
+    const dir = await scratch();
+    const target = join(dir, "exclusive.json");
+    await writeAtomicExclusive(target, '{"first":true}', 0o600);
+    await assert.rejects(
+      writeAtomicExclusive(target, '{"second":true}', 0o600),
+      (error) => error instanceof AtomicExclusiveWriteError && !error.published,
+    );
+    assert.equal(await readFile(target, "utf8"), '{"first":true}');
+    assert.deepEqual(await readdir(dir), ["exclusive.json"]);
+  });
+
   it("writes large payloads through writeAtomicInDir", async () => {
     const dir = await scratch();
     const data = new Uint8Array(512 * 1024).map((_, i) => i & 0xff);
@@ -180,6 +194,15 @@ describe("atomic-file durability", () => {
     const target = join(dir, "durable.bin");
     const events = await recordSyncs(target, () =>
       writeAtomic(target, new Uint8Array([1, 2, 3])),
+    );
+    assert.deepEqual(events, ["file:before-rename", "dir:after-rename"]);
+  });
+
+  it("syncs a create-only temp before publishing its final name", async () => {
+    const dir = await scratch();
+    const target = join(dir, "exclusive.bin");
+    const events = await recordSyncs(target, () =>
+      writeAtomicExclusive(target, new Uint8Array([1, 2, 3])),
     );
     assert.deepEqual(events, ["file:before-rename", "dir:after-rename"]);
   });


### PR DESCRIPTION
## What changed

Account creation now behaves as one explicit filesystem transaction. It validates all requested Single Account imports before writing, publishes complete libraries without replacing existing recovery data, writes the workspace last, and removes only paths owned by a confirmed failed attempt.

If the workspace save fails after its atomic rename, Main reloads the durable workspace before cleanup. A confirmed commit succeeds; a confirmed old workspace rolls back; an unclear result preserves files and blocks further account mutations until restart.

## Why

The old flow could leave a profile directory or imported libraries behind when a later step failed. It could also overwrite recovered Multiple Accounts files that were not referenced by the current workspace.

This change favors recoverable orphan data over deletion and never treats a failed fsync as proof that an atomic rename did not commit.

## Invariant

- Create-only atomic publication hard-links a fully written and fsynced temp file into an absent final name.
- Existing files, directories, and symlinks are refused and remain byte-identical.
- Rollback runs in reverse order, attempts every owned cleanup, and preserves the primary error.
- An ambiguous workspace commit poisons the controller workspace so stale state cannot be published later.

## Verification

- pnpm check
- 1,125 unit tests passed
- 169 policy tests passed
- 94 Tools tests passed
- Focused account and atomic suite: 28 tests passed
- Two independent skeptical reviews: no blockers

- [x] I kept this pull request focused.
- [x] I ran the relevant checks.
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [x] I updated documentation when behavior or an invariant changed.