### PR TITLE
refactor(tools): share embedded bundle contracts

### DIFF
--- a/apps/tools/src/embedded.ts
+++ b/apps/tools/src/embedded.ts
@@ -2,24 +2,12 @@ import { createNativeHost } from "./host";
 import { mountToolsApp as mount } from "./mount";
 import { createNativeTravelHost } from "./travel-host";
 import { mountTravelPalette as mountTravel } from "./travel-mount";
-import type { TravelCommand } from "../../../src/shared/travel-command";
+import type {
+  EmbeddedToolsBundle,
+} from "../../../src/shared/tools-bundle-contracts";
 
-export { type ToolsAppHandle } from "./mount";
-
-export function mountToolsApp(
-  target: HTMLElement,
-  options: {
-    initiallyVisible?: boolean;
-    onVisibilityChange?: (visible: boolean) => void;
-    publishTemplate: Parameters<typeof createNativeHost>[1];
-    commands: Parameters<typeof createNativeHost>[2];
-    storage: Parameters<typeof createNativeHost>[3];
-    applyUnavailable: Parameters<typeof createNativeHost>[4];
-    observationUnavailable: string | null;
-    development: boolean;
-  },
-) {
-  return mount(target, {
+const embedded: EmbeddedToolsBundle<HTMLElement> = Object.freeze({
+  mountToolsApp: (target, options) => mount(target, {
     host: createNativeHost(
       window.gwNative,
       options.publishTemplate,
@@ -31,20 +19,15 @@ export function mountToolsApp(
     ),
     mode: "embedded",
     ...options,
-  });
-}
-
-export function mountTravelPalette(
-  target: HTMLElement,
-  options: {
-    command: TravelCommand;
-    development: boolean;
-    initiallyVisible?: boolean;
-    onVisibilityChange?: (visible: boolean) => void;
-  },
-) {
-  return mountTravel(target, {
+  }),
+  mountTravelPalette: (target, options) => mountTravel(target, {
     ...options,
-    host: createNativeTravelHost(window.gwNative, options.command, options.development),
-  });
-}
+    host: createNativeTravelHost(
+      window.gwNative,
+      options.command,
+      options.development,
+    ),
+  }),
+});
+
+export const { mountToolsApp, mountTravelPalette } = embedded;

--- a/apps/tools/src/host.ts
+++ b/apps/tools/src/host.ts
@@ -19,6 +19,10 @@ import type {
   TeamApplyResult,
 } from "../../../src/shared/builds/team-apply";
 import type { StorageCommand } from "../../../src/shared/storage-command";
+import type {
+  PublishedTemplate,
+  PublishableTemplate,
+} from "../../../src/shared/tools-bundle-contracts";
 import { encodeSkillTemplate } from "../../../src/shared/builds/skill-template";
 import {
   runTeamApply,
@@ -33,11 +37,6 @@ import {
   type SkillCatalogue,
   type SkillPresentation,
 } from "./skill-catalog";
-
-export type PublishedTemplate = Readonly<{
-  fileName: string;
-  location: string;
-}>;
 
 const PUBLISH_UNAVAILABLE =
   "GWonMac can’t add this build to Guild Wars after this game update. "
@@ -234,8 +233,6 @@ export function createDemoHost(storage: Storage | null = null): ToolsHost {
  * this bundle and is deliberately not on the protocol's shared-module
  * allowlist, so the encoding happens here and the host receives a string.
  */
-export type PublishableTemplate = Readonly<{ name: string; code: string }>;
-
 export function createNativeHost(
   api: GwNativeApi,
   publishTemplate:

--- a/apps/tools/src/mount.ts
+++ b/apps/tools/src/mount.ts
@@ -5,24 +5,9 @@ import {
   type ToolboxObservation,
 } from "../../../src/shared/builds/live-party";
 import type { ToolsHost } from "./host";
+import type { ToolsAppHandle } from "../../../src/shared/tools-bundle-contracts";
 import { devTrace } from "./dev-trace";
 import "./styles.css";
-
-export type ToolsAppHandle = Readonly<{
-  show(): void;
-  hide(): void;
-  toggle(): void;
-  requestClose(): void;
-  /**
-   * The companion's latest projection of the running game, from the overlay.
-   *
-   * The raw observation crosses the boundary and is read into the domain here,
-   * because this bundle is where the domain lives. The renderer side stays a
-   * courier that never learns what a hero is.
-   */
-  update(observation: ToolboxObservation): void;
-  dispose(): void;
-}>;
 
 export function mountToolsApp(
   target: HTMLElement,

--- a/apps/tools/src/travel-mount.ts
+++ b/apps/tools/src/travel-mount.ts
@@ -1,16 +1,8 @@
 /** Mounts the Vue Travel palette and exposes its small lifecycle to the renderer. */
 import { createApp, h, ref } from "vue";
-import type { TravelGameState } from "../../../src/shared/travel-command";
 import TravelPalette from "./components/TravelPalette.vue";
 import type { TravelHost } from "./travel-host";
-
-export type TravelPaletteHandle = Readonly<{
-  show(): void;
-  hide(): void;
-  toggle(): void;
-  update(state: TravelGameState): void;
-  dispose(): void;
-}>;
+import type { TravelPaletteHandle } from "../../../src/shared/tools-bundle-contracts";
 
 export function mountTravelPalette(
   target: HTMLElement,

--- a/src/renderer/tools-host.ts
+++ b/src/renderer/tools-host.ts
@@ -19,9 +19,13 @@
  * observation of that game — which passes straight through, unread. The bundle
  * owns what a party means.
  */
-import type { ToolboxObservation } from "../shared/builds/live-party.js";
 import type { TeamApplyCommands } from "../shared/builds/team-apply-runner.js";
 import type { StorageCommand } from "../shared/storage-command.js";
+import type {
+  PublishedTemplate,
+  PublishableTemplate,
+  EmbeddedToolsBundle,
+} from "../shared/tools-bundle-contracts.js";
 import {
   createToolboxLifecycle,
   type MountedTool,
@@ -32,38 +36,6 @@ import {
   templateFilesystem,
 } from "./template-store.js";
 import { sanitiseTemplateName } from "./template-format.js";
-
-type PublishedTemplate = Readonly<{ fileName: string; location: string }>;
-
-/** A build the bundle has already encoded. See apps/tools/src/host.ts. */
-type PublishableTemplate = Readonly<{ name: string; code: string }>;
-
-type ToolsAppHandle = Readonly<{
-  show(): void;
-  hide(): void;
-  toggle(): void;
-  requestClose(): void;
-  update(observation: ToolboxObservation): void;
-  dispose(): void;
-}>;
-
-type ToolsBundle = Readonly<{
-  mountToolsApp(
-    target: HTMLElement,
-    options: {
-      initiallyVisible?: boolean;
-      onVisibilityChange?(visible: boolean): void;
-      publishTemplate:
-        | ((template: PublishableTemplate) => Promise<PublishedTemplate>)
-        | null;
-      commands: TeamApplyCommands | null;
-      storage: StorageCommand | null;
-      applyUnavailable: string | null;
-      observationUnavailable: string | null;
-      development: boolean;
-    },
-  ): ToolsAppHandle;
-}>;
 
 /**
  * Writes one build where the game's own template dialog will find it.
@@ -150,7 +122,7 @@ export function mountToolsInto(
   // not try to resolve a file that only exists after the build step.
   const specifier = "./tools/tools-app.js";
   return Promise.all([import(specifier), window.gwNative.client.session()])
-    .then(([bundle, session]: [ToolsBundle, Awaited<ReturnType<typeof window.gwNative.client.session>>]) => {
+    .then(([bundle, session]: [EmbeddedToolsBundle<HTMLElement>, Awaited<ReturnType<typeof window.gwNative.client.session>>]) => {
       const applyStatus = session.compatibility?.features.teamApply;
       const applyUnavailable = commands === null
         ? applyStatus?.status === 'unavailable'

--- a/src/renderer/travel-palette.ts
+++ b/src/renderer/travel-palette.ts
@@ -6,26 +6,10 @@ import type {
   TravelCommand,
   TravelGameState,
 } from "../shared/travel-command.js";
-
-type TravelPaletteHandle = Readonly<{
-  show(): void;
-  hide(): void;
-  toggle(): void;
-  update(state: TravelGameState): void;
-  dispose(): void;
-}>;
-
-type TravelBundle = Readonly<{
-  mountTravelPalette(
-    target: HTMLElement,
-    options: {
-      command: TravelCommand;
-      development: boolean;
-      initiallyVisible?: boolean;
-      onVisibilityChange?: (visible: boolean) => void;
-    },
-  ): TravelPaletteHandle;
-}>;
+import type {
+  EmbeddedToolsBundle,
+  TravelPaletteHandle,
+} from "../shared/tools-bundle-contracts.js";
 
 export function createTravelPalette(
   parent: HTMLElement,
@@ -72,7 +56,7 @@ export function createTravelPalette(
     if (next && !requested) {
       requested = true;
       const specifier = "./tools/tools-app.js";
-      void import(specifier).then((bundle: TravelBundle) => {
+      void import(specifier).then((bundle: EmbeddedToolsBundle<HTMLElement>) => {
         if (disposed) return;
         app = bundle.mountTravelPalette(host, {
           command,

--- a/src/shared/tools-bundle-contracts.ts
+++ b/src/shared/tools-bundle-contracts.ts
@@ -1,0 +1,67 @@
+/**
+ * Type-only boundary between the classic renderer and the independently built
+ * Tools bundle. The runtime import uses a generated file name, so both builds
+ * import these shapes directly instead of restating them on either side.
+ */
+import type { ToolboxObservation } from "./builds/live-party.js";
+import type { TeamApplyCommands } from "./builds/team-apply-runner.js";
+import type { StorageCommand } from "./storage-command.js";
+import type { TravelCommand, TravelGameState } from "./travel-command.js";
+
+export type PublishedTemplate = Readonly<{
+  fileName: string;
+  location: string;
+}>;
+
+/** A build the Tools bundle has already encoded for the renderer to publish. */
+export type PublishableTemplate = Readonly<{ name: string; code: string }>;
+
+export type ToolsAppHandle = Readonly<{
+  show: () => void;
+  hide: () => void;
+  toggle: () => void;
+  requestClose: () => void;
+  /** The companion's latest game projection; the Tools domain interprets it. */
+  update: (observation: ToolboxObservation) => void;
+  dispose: () => void;
+}>;
+
+export type ToolsAppMountOptions = Readonly<{
+  initiallyVisible?: boolean;
+  onVisibilityChange?: (visible: boolean) => void;
+  publishTemplate:
+    | ((template: PublishableTemplate) => Promise<PublishedTemplate>)
+    | null;
+  commands: TeamApplyCommands | null;
+  storage: StorageCommand | null;
+  applyUnavailable: string | null;
+  observationUnavailable: string | null;
+  development: boolean;
+}>;
+
+export type TravelPaletteHandle = Readonly<{
+  show: () => void;
+  hide: () => void;
+  toggle: () => void;
+  update: (state: TravelGameState) => void;
+  dispose: () => void;
+}>;
+
+export type TravelPaletteMountOptions = Readonly<{
+  command: TravelCommand;
+  development: boolean;
+  initiallyVisible?: boolean;
+  onVisibilityChange?: (visible: boolean) => void;
+}>;
+
+/** The exact named exports of the generated Tools module. */
+export type EmbeddedToolsBundle<Target> = Readonly<{
+  mountToolsApp: (
+    target: Target,
+    options: ToolsAppMountOptions,
+  ) => ToolsAppHandle;
+  mountTravelPalette: (
+    target: Target,
+    options: TravelPaletteMountOptions,
+  ) => TravelPaletteHandle;
+}>;


### PR DESCRIPTION
The embedded Tools module described its exports separately in the producer and both renderer consumers. A signature or export-name change could therefore compile in one side while leaving the shipped dynamic import stale.

This change gives the embedded module one shared, type-only contract. The producer satisfies both named exports as one object, and both renderer consumers use that same contract. It removes the duplicate handle and option declarations without changing the emitted runtime exports.

Verification:

- `pnpm run check`
- `pnpm verify`
- 96 Tools unit tests
- 33 Tools browser tests
- 139 Electron tests passed, 1 live-client test skipped
- packaged application smoke
- packaged Enhancement runtime
- two independent Codex reviewer passes

Harness: Codex multi-agent implementation and skeptical review.
