### PR TITLE
ci: qualify changed ArenaNet clients hourly

### DIFF
--- a/.github/workflows/client-recertification.yml
+++ b/.github/workflows/client-recertification.yml
@@ -6,7 +6,7 @@ name: ArenaNet client recertification
 
 on:
   schedule:
-    - cron: "*/15 * * * *"
+    - cron: "17 * * * *"
   workflow_dispatch:
 
 permissions:
@@ -97,6 +97,32 @@ jobs:
         id: official
         run: pnpm client:official --download "$RUNNER_TEMP/official"
 
+      # This adversarial suite mutates the exact downloaded WASM to prove the
+      # structural checks still reject plausible near-misses. It is an
+      # additional fail-closed qualification gate, not launch authority: only
+      # the production runtime verifier below can prove a protected feature.
+      - name: Qualify the exact published client artifact
+        id: qualification
+        continue-on-error: true
+        env:
+          GW_CLIENT_WASM: ${{ steps.official.outputs.wasm }}
+        run: |
+          mkdir -p "$EVIDENCE"
+          set +e
+          pnpm test:client-artifact > "$EVIDENCE/client-artifact.txt" 2>&1
+          qualification_exit=$?
+          set -e
+          if [ "$qualification_exit" -eq 0 ]; then
+            qualification_status=proved
+          else
+            qualification_status=refused
+          fi
+          jq -n --arg status "$qualification_status" \
+            --argjson exitCode "$qualification_exit" \
+            '{status: $status, exitCode: $exitCode}' \
+            > "$EVIDENCE/client-artifact.json"
+          exit "$qualification_exit"
+
       # Both commands inspect the same original bytes. Neither writes source.
       # `recertify` composes template preparation and Enhancement analysis in
       # one process, so an Enhancement verdict cannot outlive a refused
@@ -104,6 +130,7 @@ jobs:
       - name: Verify what the published build proves
         id: derive
         env:
+          QUALIFICATION_OUTCOME: ${{ steps.qualification.outcome }}
           WASM: ${{ steps.official.outputs.wasm }}
         run: |
           mkdir -p "$EVIDENCE"
@@ -116,10 +143,13 @@ jobs:
             > "$EVIDENCE/runtime-verdicts.json" 2> "$EVIDENCE/runtime-verdicts.txt"
           set -e
           build="$(jq -er '.sha256' "$EVIDENCE/template-save.json")"
-          if jq -e '.templateSaving and (.features != null) and (.features | to_entries | all(.value.status == "proved"))' \
+          if [ "$QUALIFICATION_OUTCOME" != "success" ]; then
+            outcome=investigation
+            summary="the real-client qualification suite refused the exact downloaded artifact"
+          elif jq -e '.templateSaving and (.features != null) and (.features | to_entries | all(.value.status == "proved"))' \
             "$EVIDENCE/runtime-verdicts.json" >/dev/null; then
             outcome=ready
-            summary="the runtime semantic verifier proved every protected feature"
+            summary="the runtime semantic verifier proved every protected feature and exact-artifact qualification passed"
           else
             outcome=investigation
             summary="$(jq -cr '{templateSaving, verifierAbi, features, reasons}' \
@@ -218,8 +248,9 @@ jobs:
             --description "An ArenaNet client generation proved by the runtime verifier"
           {
             printf 'Published client generation `%s`, WASM `%s`.\n\n' "$short" "$BUILD"
-            printf '%s\n' '- outcome: every protected feature proved independently'
+            printf '%s\n' '- outcome: every protected feature proved independently and exact-artifact qualification passed'
             printf '%s\n' '- authority: evidence only; the shipped runtime verifier remains sole launch authority'
+            printf '%s\n' '- qualification evidence: `client-artifact.json` and `client-artifact.txt` in that run artifact'
             printf '%s\n' "- signed report: $RUN_URL"
             echo
             printf '%s\n' '```json'
@@ -256,6 +287,7 @@ jobs:
             printf '%s\n' "- outcome: $SUMMARY"
             printf '%s\n' '- source branch: none; this workflow cannot grant capabilities'
             printf '%s\n' "- evidence: $RUN_URL"
+            printf '%s\n' '- exact-artifact qualification: `client-artifact.json` and `client-artifact.txt` in that run artifact'
             printf '%s\n' '- semantic verdicts: `runtime-verdicts.json` in that run artifact'
             echo
             cat evidence/carry-forward.md

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -853,11 +853,11 @@ test("client recertification reports evidence but cannot grant authority", () =>
   assert.doesNotMatch(workflow, /secrets\./);
   assert.match(workflow, /GH_TOKEN: \$\{\{ github\.token \}\}/);
   assert.match(workflow, /^permissions:\n {2}contents: read$/mu);
-  assert.match(workflow, /schedule:[\s\S]*cron: "\*\/15 \* \* \* \*"/);
+  assert.match(workflow, /schedule:[\s\S]*cron: "17 \* \* \* \*"/);
   assert.match(workflow, /workflow_dispatch:/);
   assert.match(workflow, /group: arenanet-client-recertification/);
 
-  // The unchanged path runs ninety-six times a day. It reads one manifest:
+  // The unchanged path runs hourly. It reads one manifest:
   // no packages, no compiler, no client bytes, and nothing out of the
   // certification command line, which builds the companion kernel first.
   assert.match(detect, /runs-on: ubuntu-latest/);
@@ -897,10 +897,30 @@ test("client recertification reports evidence but cannot grant authority", () =>
   );
   assert.doesNotMatch(derive, /contents: write|issues: write|pull-requests: write/);
   assert.match(derive, /pnpm client:official --download "\$RUNNER_TEMP\/official"/);
+  // The existing real-client suite has this one explicit execution owner. It
+  // receives the exact path emitted by the downloader, runs only in the
+  // changed-generation job, and can veto a proved report without becoming
+  // launch authority itself.
+  assert.equal(
+    [...derive.matchAll(/pnpm test:client-artifact/g)].length,
+    1,
+    "the changed-generation job must qualify the artifact exactly once",
+  );
+  assert.match(
+    derive,
+    /name: Qualify the exact published client artifact[\s\S]*continue-on-error: true[\s\S]*GW_CLIENT_WASM: \$\{\{ steps\.official\.outputs\.wasm \}\}/,
+  );
+  assert.match(derive, /QUALIFICATION_OUTCOME: \$\{\{ steps\.qualification\.outcome \}\}/);
+  assert.match(
+    derive,
+    /if \[ "\$QUALIFICATION_OUTCOME" != "success" \]; then[\s\S]*outcome=investigation[\s\S]*real-client qualification suite refused/,
+  );
+  assert.match(derive, /client-artifact\.json/);
+  assert.match(derive, /client-artifact\.txt/);
   assert.match(derive, /certification\.js template "\$WASM" --emit-ts/);
   assert.match(derive, /certification\.js recertify "\$WASM"/);
   assert.match(derive, /certification\.js verify "\$WASM"/);
-  assert.doesNotMatch(derive, /--write|test:client-artifact|tables\.patch|SOURCE_COMMIT/);
+  assert.doesNotMatch(derive, /--write|tables\.patch|SOURCE_COMMIT/);
   // Only the production runtime verifier can publish a positive report, and
   // every protected feature must carry its own proved verdict.
   assert.match(derive, /runtime-verdicts\.json/);
@@ -956,6 +976,8 @@ test("client recertification reports evidence but cannot grant authority", () =>
   );
   assert.match(publish, /gh issue close "\$issue" --reason completed/);
   assert.match(publish, /semantic proof passed/);
+  assert.match(publish, /exact-artifact qualification passed/);
+  assert.match(publish, /exact-artifact qualification: `client-artifact\.json` and `client-artifact\.txt`/);
   assert.match(publish, /v\$VERIFIER_ABI: invariant refused/);
   assert.match(
     publish,


### PR DESCRIPTION
ArenaNet recertification still checked every 15 minutes, while the existing adversarial real-client suite had no workflow owner. This makes unchanged checks hourly and cheap, and gives each changed official client one explicit qualification pass.

The changed-generation macOS job now runs the existing client-artifact suite against the exact downloaded WASM, retains its evidence, and vetoes a proved result when qualification fails. Production verification continues regardless, and remains the sole launch authority; unchanged generations still stop after detection.

Verified locally:

- frozen install
- `pnpm run check`
- `pnpm verify`
- 138 Electron tests passed, one expected live skip
- package and packaged smoke
- packaged Enhancement runtime
