### PR TITLE
chore(lint): remove stale ESLint ownership

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -273,7 +273,7 @@ export default tseslint.config(
     },
   },
   {
-    // The six page singletons index.html loads with a `<script>` tag, listed
+    // The five page singletons index.html loads with a `<script>` tag, listed
     // rather than globbed because being a classic script is a property of these
     // files and not of a directory. A classic script is exactly a file with no
     // top-level `import` or `export`: one of either makes it an ES module, and
@@ -293,7 +293,6 @@ export default tseslint.config(
       "src/renderer/harness.ts",
       "src/renderer/loading.ts",
       "src/renderer/settings.ts",
-      "src/renderer/enhancement-settings.ts",
     ],
     rules: {
       "no-var": "off",

--- a/package.json
+++ b/package.json
@@ -73,8 +73,6 @@
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.55.0",
     "@types/node": "^24.13.3",
-    "@typescript-eslint/eslint-plugin": "^8.43.0",
-    "@typescript-eslint/parser": "^8.43.0",
     "electron": "^43.2.0",
     "eslint": "^10.7.0",
     "eslint-plugin-vue": "^10.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,12 +47,6 @@ importers:
       '@types/node':
         specifier: ^24.13.3
         version: 24.13.3
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^8.43.0
-        version: 8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/parser':
-        specifier: ^8.43.0
-        version: 8.65.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)
       electron:
         specifier: ^43.2.0
         version: 43.2.0


### PR DESCRIPTION
The lint configuration still exempted a renderer file that no longer exists, and the root package directly declared parser packages already owned by the imported `typescript-eslint` meta package.

This removes the stale exception, corrects the classic-script count, and leaves one dependency owner for the ESLint TypeScript stack. No package resolution changes; only the root importer entries disappear.

Verified:

- frozen install
- `pnpm run check`
- `pnpm verify`
- 138 Electron tests passed, one expected live skip
- package and packaged smoke
- packaged Enhancement runtime
