### PR TITLE
chore(workspace): make leaf tooling ownership explicit

### DIFF
--- a/apps/tools/package.json
+++ b/apps/tools/package.json
@@ -17,9 +17,12 @@
     "vue": "^3.5.40"
   },
   "devDependencies": {
+    "@playwright/test": "^1.55.0",
+    "@types/node": "^24.13.3",
     "@vitejs/plugin-vue": "^6.0.8",
     "@vue/test-utils": "^2.4.6",
     "happy-dom": "^20.8.4",
+    "typescript": "^5.9.2",
     "vite": "^8.1.5",
     "vitest": "^4.0.18",
     "vue-tsc": "^3.3.8"

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -21,19 +21,5 @@
     "vue": "^3.5.35",
     "vue-router": "^5.1.0",
     "vue-tsc": "^3.3.7"
-  },
-  "pnpm": {
-    "overrides": {
-      "brace-expansion": "5.0.9",
-      "sharp": "0.35.3",
-      "tar": "7.5.21",
-      "tmp": "0.2.7"
-    },
-    "onlyBuiltDependencies": [
-      "@parcel/watcher",
-      "esbuild",
-      "sharp",
-      "vue-demi"
-    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,12 @@ importers:
         specifier: ^3.5.40
         version: 3.5.40(typescript@5.9.3)
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.55.0
+        version: 1.61.1
+      '@types/node':
+        specifier: ^24.13.3
+        version: 24.13.3
       '@vitejs/plugin-vue':
         specifier: ^6.0.8
         version: 6.0.8(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(vue@3.5.40(typescript@5.9.3))
@@ -93,6 +99,9 @@ importers:
       happy-dom:
         specifier: ^20.8.4
         version: 20.11.1
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.3
       vite:
         specifier: ^8.1.5
         version: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)


### PR DESCRIPTION
The Website package carried an ignored pnpm policy block, while Tools relied on root hoisting for packages it imports and executes directly. That made ownership misleading even though installs happened to work.

This deletes the ineffective Website settings and gives Tools direct ownership of TypeScript, Node types, and Playwright. The lockfile changes only the Tools importer; no package resolutions move.

Verified:

- frozen install
- Tools typecheck, 96 component tests, build, and 33 browser tests
- Website certification and 224-route prerender
- 168 policy tests
- `pnpm verify`
- 138 Electron tests passed, one expected live skip
- package and packaged smoke
- packaged Enhancement runtime
