### PR TITLE
docs: make the fast check command explicit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,10 +161,10 @@ Run the narrowest relevant proof while you work. Then run the repository gate
 before you finish.
 
 ```bash
-pnpm check
+pnpm run check
 ```
 
-`pnpm check` runs type checks, lint, Markdown links, unit tests, policy tests,
+`pnpm run check` runs type checks, lint, Markdown links, unit tests, policy tests,
 and Tools unit tests. It does not build or open a window.
 
 Run the complete local application gate before a pull request:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,10 +80,10 @@ Start with the smallest relevant proof:
 | Website behavior | Run `pnpm test:website`. |
 | Markdown | Run `pnpm check:links`. |
 
-Use `pnpm check` while you work:
+Use `pnpm run check` while you work:
 
 ```bash
-pnpm check
+pnpm run check
 ```
 
 Run the complete local gate before you open the pull request:

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ pnpm exec playwright install chromium
 pnpm dev
 ```
 
-Use `pnpm check` for the fast source gate. Use `pnpm verify` before a pull
+Use `pnpm run check` for the fast source gate. Use `pnpm verify` before a pull
 request. The complete contributor setup is in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Documentation

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -231,7 +231,7 @@ Use the fastest level that executes the invariant.
 | Current ArenaNet client playability and certified Core behavior | Opt-in live canary | Release canary with a real account |
 | Performance improvement | Repeated clean Level 1 comparison | Level 2 attribution before the change |
 
-Do not put signed, live-account, or production-updater checks in `pnpm check`.
+Do not put signed, live-account, or production-updater checks in `pnpm run check`.
 They are release or patch-day gates because local fixtures cannot prove those
 external boundaries.
 

--- a/docs/enhancement-development.md
+++ b/docs/enhancement-development.md
@@ -55,7 +55,7 @@ Start with:
 
 ```bash
 pnpm certification doctor
-pnpm check
+pnpm run check
 pnpm build
 pnpm test:integration
 ```
@@ -276,7 +276,7 @@ Run the downstream chain with exact regression shortcuts disabled:
 ```bash
 pnpm certification recertify "/absolute/path/Gw.jspi.wasm"
 pnpm certification double-click "/absolute/path/Gw.jspi.wasm"
-pnpm check
+pnpm run check
 ```
 
 `recertify` must report per-feature ABI/input-hash-bound verdicts, and


### PR DESCRIPTION
pnpm 11 has a built-in `check` command, so maintainer instructions that say `pnpm check` can run the package-manager command instead of this repository’s verification script.

This changes only the documented command to `pnpm run check`. It also gives the impact-aware workflow a representative documentation-only pull request, so we can prove the required fast route on GitHub without changing application code.

Local verification:
- `pnpm install --frozen-lockfile`
- `pnpm check:links`
- focused Markdown policy tests (13 passed)
- full policy suite (169 passed)
- `pnpm run check`
- `git diff --check`