### PR TITLE
test(release): keep Stable rollback proof executable

### DIFF
--- a/scripts/verify-stable-beta-roundtrip.ts
+++ b/scripts/verify-stable-beta-roundtrip.ts
@@ -39,6 +39,7 @@ import {
   type AppSettings,
 } from "../src/shared/contracts.ts";
 import { parseSettings } from "../src/main/core/settings.ts";
+import { saveWindowState } from "../src/main/core/window-state.ts";
 import { DISTRIBUTION_CHANNEL_CONFIG } from "../src/shared/distribution-channel.ts";
 import {
   compareReleaseVersions,
@@ -90,6 +91,7 @@ if (compareReleaseVersions(parsedCandidate, parsedStable) <= 0) {
 
 const productName = DISTRIBUTION_CHANNEL_CONFIG.release.productName;
 const userData = await mkdtemp(path.join(tmpdir(), "gwonmac-stable-beta-"));
+const windowStatePath = path.join(userData, "window-state.json");
 await writeFile(
   path.join(userData, "settings.json"),
   JSON.stringify({ autoCheckUpdates: false }),
@@ -249,19 +251,11 @@ function semanticSettings(
   return settings;
 }
 
-async function setWindowSize(page: Page, width: number, height: number): Promise<void> {
-  const session = await page.context().newCDPSession(page);
-  try {
-    const { windowId } = await session.send("Browser.getWindowForTarget");
-    await session.send("Browser.setWindowBounds", {
-      windowId,
-      bounds: { width, height },
-    });
-  } finally {
-    await session.detach();
-  }
-  await new Promise((resolve) => setTimeout(resolve, 200));
-}
+const publishWindowSize = (width: number, height: number): Promise<void> =>
+  saveWindowState(windowStatePath, {
+    bounds: { x: 100, y: 100, width, height },
+    mode: "normal",
+  });
 
 async function windowSize(page: Page): Promise<{ width: number; height: number }> {
   return page.evaluate(() => ({ width: outerWidth, height: outerHeight }));
@@ -374,7 +368,17 @@ try {
   );
 
   console.log("stable/beta compatibility: latest Stable creates canonical state");
+  // The Electron suite owns native resize-to-disk behaviour. This release gate
+  // writes through the candidate's canonical serializer so it can concentrate
+  // on whether both packaged versions read the exact same durable shape.
+  await publishWindowSize(1_000, 700);
   running = await launch(stableApp);
+  const stableInitial = await readCanonical(running.page);
+  assert.equal(
+    stableInitial.recovered,
+    false,
+    "latest Stable recovered its fresh build library before the round-trip",
+  );
   const launchedStableVersion = (await running.page.evaluate(
     () => window.gwNative.appUpdates.getState(),
   )).currentVersion;
@@ -398,7 +402,6 @@ try {
     initialLibrary,
   );
   await roundTripProfileStore(running.page, null, "stable-template");
-  await setWindowSize(running.page, 1_000, 700);
   await closePackagedApp(running);
   running = null;
   const stableSettingsDocument = await readSettingsDocument();
@@ -432,9 +435,9 @@ try {
       library: candidateLibrary,
     },
   );
-  await setWindowSize(running.page, 960, 680);
   await closePackagedApp(running);
   running = null;
+  await publishWindowSize(960, 680);
   const candidateSettingsDocument = await readSettingsDocument();
   assert.deepEqual(
     sortedKeys(candidateSettingsDocument),

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -469,6 +469,30 @@ test("release workflow stages and publishes one tested, attested package version
   );
 });
 
+test("the Stable rollback proof establishes its write generation before saving", () => {
+  const roundTrip = read("scripts/verify-stable-beta-roundtrip.ts");
+  const stableCreation = roundTrip.indexOf(
+    'console.log("stable/beta compatibility: latest Stable creates canonical state")',
+  );
+  const baselineRead = roundTrip.indexOf(
+    "await readCanonical(running.page)",
+    stableCreation,
+  );
+  const firstLibraryWrite = roundTrip.indexOf(
+    "window.gwNative.buildLibrary.set(library)",
+    stableCreation,
+  );
+
+  assert.ok(stableCreation >= 0);
+  assert.ok(baselineRead > stableCreation);
+  assert.ok(firstLibraryWrite > baselineRead);
+  assert.match(roundTrip, /saveWindowState\(windowStatePath/);
+  assert.doesNotMatch(
+    roundTrip,
+    /Browser\.getWindowForTarget|Browser\.setWindowBounds/,
+  );
+});
+
 test("application verification routes conservatively through one required result", () => {
   const workflow = read(".github/workflows/pr-package.yml");
   const classifier = read("scripts/ci-impact.ts");


### PR DESCRIPTION
The real Stable → candidate → Stable release check had drifted behind two current contracts: build-library writes now require an established read generation, and packaged Chromium no longer exposes native window bounds through `Browser.getWindowForTarget`. That made the release gate fail before it could prove data compatibility.

The proof now loads the canonical library before its first write and uses the application’s canonical window-state serializer for the cross-version document. Native resize-to-disk behavior stays owned by the Electron suite; this release gate owns whether Stable and the candidate can read and write the same persisted shapes.

Verified:
- published `v2026.8.9` ZIP attestation
- real packaged journey: `2026.8.9 → 2026.8.10-beta.1 → 2026.8.9 passed`
- `pnpm typecheck`
- `pnpm lint`
- policy suite: 170 passed
- `git diff --check`