### PR TITLE
test(electron): allow the full account journey to finish

### DIFF
--- a/tests/electron/multiple-accounts.spec.ts
+++ b/tests/electron/multiple-accounts.spec.ts
@@ -290,6 +290,7 @@ test("renderer recovery stays with its account and a second crash needs attentio
 });
 
 test("Multi starts at the Hub and isolates two profile windows from Single", async () => {
+  test.setTimeout(60_000);
   const fixture = await launchOffline("gw-multi-e2e-", {
     GW_BACKGROUND_LAUNCH: "0",
   }, async (userData) => {


### PR DESCRIPTION
The first post-promotion Main run found the same cold-run timeout previously observed in the large Multiple Accounts journey. The journey passed immediately on retry, but `failOnFlakyTests` correctly failed the gate.

Give only this bounded journey 60 seconds instead of the suite-wide 30-second default. It now launches two isolated profiles, reconciles shared templates, and reloads one renderer; retries, one-worker execution, and strict flaky-test failure remain unchanged.

Verification:
- `pnpm exec eslint tests/electron/multiple-accounts.spec.ts`
- `pnpm exec tsc -p tsconfig.tests.json --noEmit`
- `git diff --check`
- Local Electron launch was blocked by the desktop/sandbox environment before assertions; the hosted PR gate is the authoritative runtime proof.

Failure evidence: https://github.com/Mat4m0/gwonmac/actions/runs/32508442456