### PR TITLE
refactor(window): make the registry the only window authority

### DIFF
--- a/docs/multiple-accounts.md
+++ b/docs/multiple-accounts.md
@@ -153,9 +153,10 @@ and does not clear player files or saved login.
 
 ## Security and privacy
 
-The window registry derives profile authority from the trusted sender. A
-renderer cannot choose a profile ID, native path, Electron partition, Keychain
-item, or socket owner.
+The window registry owns every live Hub and game window. It derives profile
+authority from the trusted sender and resolves socket delivery to that exact
+registered window. A renderer cannot choose a profile ID, native path,
+Electron partition, Keychain item, or socket owner.
 
 The Account Picker cannot access game sockets, saved login, player files, or
 build writes. Diagnostics use ephemeral window identifiers. They do not record

--- a/docs/process-model.md
+++ b/docs/process-model.md
@@ -63,6 +63,11 @@ Both modes use the same verified client generation, chunk store, derived
 client artifacts, and application updater. These stores contain rebuildable
 client infrastructure. They do not contain player account state.
 
+The main-process window registry owns the Single game window, the Multiple
+Accounts Hub, and every profile game window. Native code resolves a renderer
+only through this registry. It does not infer ownership from Electron's global
+window list or from the current focus.
+
 [Multiple Accounts](multiple-accounts.md) owns the complete data and transition
 contract.
 

--- a/src/main/accounts-window.ts
+++ b/src/main/accounts-window.ts
@@ -13,7 +13,6 @@ import { sendRendererCommand } from "./renderer-commands.js";
 import { windowRegistry } from "./window-registry.js";
 
 const HUB_URL = "gw://app/accounts.html";
-let hubWindow: BrowserWindow | null = null;
 let protocolInstalled = false;
 
 function installAccountsMenu(): void {
@@ -29,7 +28,7 @@ function installAccountsMenu(): void {
               label: "Settings…",
               accelerator: "CommandOrControl+,",
               click: () => {
-                void sendRendererCommand(getAccountsWindow(), {
+                void sendRendererCommand(windowRegistry.hubWindow(), {
                   type: "accounts.settings.open",
                 });
               },
@@ -55,12 +54,8 @@ function installAccountsMenu(): void {
   ]));
 }
 
-export function getAccountsWindow(): BrowserWindow | null {
-  return hubWindow && !hubWindow.isDestroyed() ? hubWindow : null;
-}
-
 export function revealAccountsWindow(): boolean {
-  const win = getAccountsWindow();
+  const win = windowRegistry.hubWindow();
   if (!win) return false;
   if (win.isMinimized()) win.restore();
   win.show();
@@ -69,7 +64,7 @@ export function revealAccountsWindow(): boolean {
 }
 
 export function createAccountsWindow(deps: ProtocolDeps): BrowserWindow {
-  const existing = getAccountsWindow();
+  const existing = windowRegistry.hubWindow();
   if (existing) {
     revealAccountsWindow();
     return existing;
@@ -103,7 +98,6 @@ export function createAccountsWindow(deps: ProtocolDeps): BrowserWindow {
       experimentalFeatures: false,
     },
   });
-  hubWindow = win;
   windowRegistry.register(win, { mode: "multi", role: "hub" });
   win.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
   win.webContents.on("will-navigate", (event, url) => {
@@ -121,7 +115,6 @@ export function createAccountsWindow(deps: ProtocolDeps): BrowserWindow {
   });
   win.on("closed", () => {
     windowRegistry.unregister(win);
-    if (hubWindow === win) hubWindow = null;
   });
   void win.loadURL(HUB_URL);
   return win;

--- a/src/main/diagnostics/capture.ts
+++ b/src/main/diagnostics/capture.ts
@@ -14,10 +14,8 @@ import { contentTracing } from "electron";
 import type { RendererCommand } from "../../shared/contracts.js";
 import { errorCode } from "../../shared/errors.js";
 import { gamePaths } from "../paths.js";
-import {
-  canonicalRendererWindow,
-  sendRendererCommand,
-} from "../renderer-commands.js";
+import { sendRendererCommand } from "../renderer-commands.js";
+import { windowRegistry } from "../window-registry.js";
 import type { CaptureMetadata } from "./flight-recorder.js";
 import { logEvent, recorder } from "./recorder.js";
 import { resetEventLoopWindow } from "./samplers.js";
@@ -49,13 +47,17 @@ export function completedTracePath(): string {
 
 /**
  * The renderer half of a capture. `level` crosses as a number inside a typed
- * event rather than spliced into a string of JavaScript, and the target window
- * is chosen by the same trust test the inbound direction uses.
+ * event rather than spliced into a string of JavaScript. The focused registered
+ * game receives it; a sole background game is unambiguous, while multiple
+ * unfocused games are refused.
  */
 const rendererCaptureCommand = (
   command: Extract<RendererCommand, { type: "diagnostics.capture" }>,
 ): Promise<void> =>
-  sendRendererCommand(canonicalRendererWindow(), command).then((outcome) => {
+  sendRendererCommand(
+    windowRegistry.focusedOrSoleGameWindow(),
+    command,
+  ).then((outcome) => {
     if (outcome !== "completed") {
       logEvent({
         k: "renderer.commandIncomplete",

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -13,7 +13,7 @@
  * arguments and either forwards one owner-local capability directly or calls
  * the workflow owner; it returns codes rather than inventing prose.
  */
-import { BrowserWindow, clipboard, ipcMain, shell } from "electron";
+import { clipboard, ipcMain, shell, type BrowserWindow } from "electron";
 import { statfs } from "node:fs/promises";
 import type {
   AppSettings,
@@ -194,7 +194,7 @@ function assertSender(
   event: Electron.IpcMainInvokeEvent,
   role: "game" | "hub" | "any",
 ): BrowserWindow {
-  const win = BrowserWindow.fromWebContents(event.sender);
+  const win = registry.windowForWebContents(event.sender.id);
   const context = registry.contextForWebContents(event.sender.id);
   if (!win || !context || (role !== "any" && context.role !== role)) {
     throw new AllowlistError("unowned ipc sender");
@@ -969,10 +969,6 @@ export function registerSteamIpcHandlers(
 }
 
 export function emitSocketEvent(ownerId: number, event: SocketEvent): void {
-  for (const win of BrowserWindow.getAllWindows()) {
-    if (win.isDestroyed() || win.webContents.isDestroyed()) continue;
-    if (win.webContents.id === ownerId) {
-      sendIfLive(win, IPC.socketEvent, toWireSocketEvent(event));
-    }
-  }
+  const win = windowRegistry.windowForWebContents(ownerId);
+  if (win) sendIfLive(win, IPC.socketEvent, toWireSocketEvent(event));
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -10,7 +10,6 @@
 import {
   app,
   autoUpdater,
-  BrowserWindow,
   dialog,
   Notification,
   powerMonitor,
@@ -80,7 +79,6 @@ import {
 import {
   createMainWindow,
   flushWindowState,
-  getMainWindow,
   prepareWindowState,
   RENDERER_URL,
   type WindowHost,
@@ -171,8 +169,8 @@ const INJECT_STARTUP_FAILURE =
 
 function revealMainWindow(): void {
   if (activeAccountMode === "multi" && revealAccountsWindow()) return;
-  const win = getMainWindow();
-  if (!win || win.isDestroyed()) {
+  const win = windowRegistry.singleGameWindow();
+  if (!win) {
     secondInstanceRequested = true;
     return;
   }
@@ -373,10 +371,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
   });
   const stopCommandKeyUps = installMacosCommandKeyUps(nativeHost, {
     focusedGameTarget() {
-      const win = BrowserWindow.getFocusedWindow();
-      return win && windowRegistry.contextForWebContents(win.webContents.id)?.role === "game"
-        ? win
-        : null;
+      return windowRegistry.focusedGameWindow();
     },
     release(win, code) {
       releaseWindowShortcutKey(win, code);
@@ -698,7 +693,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
 
   onAppQuit(async () => {
     if (activeAccountMode === "single") {
-      const win = getMainWindow();
+      const win = windowRegistry.singleGameWindow();
       if (win && !win.isDestroyed()) {
         const outcome = await sendRendererCommand(win, {
           type: "filesystem.sync",
@@ -708,7 +703,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
         }
       }
       await ipcCleanup.drainSecrets();
-      await flushWindowState();
+      if (win) await flushWindowState(win);
     } else {
       const gameWindows = windowRegistry.gameWindows();
       await Promise.all(gameWindows.map(async (win) => {
@@ -724,7 +719,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
       await Promise.all(gameWindows.map((win) => flushWindowState(win)));
     }
     sockets.closeAll();
-    updateLongRunningTaskFeedback(INITIAL_PROGRESS);
+    updateLongRunningTaskFeedback(INITIAL_PROGRESS, null);
     await clientRuntime.shutdown();
     if (activeAccountMode === "single") await clearBrowserCookies("quit");
     await stopDiagnostics();
@@ -732,7 +727,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
 
   const win = activeAccountMode === "multi"
     ? createAccountsWindow(protocolDeps)
-    : createMainWindow(host);
+    : createMainWindow(host, { context: { mode: "single", role: "game" } });
   if (settings.autoCheckUpdates) {
     void checkForAppUpdates(settings.updateTrack);
   }
@@ -804,8 +799,8 @@ if (primaryInstance) void app.whenReady().then(async () => {
   app.on("activate", () => {
     if (activeAccountMode === "multi") {
       if (!revealAccountsWindow()) createAccountsWindow(protocolDeps);
-    } else if (!getMainWindow()) {
-      createMainWindow(host);
+    } else if (!windowRegistry.singleGameWindow()) {
+      createMainWindow(host, { context: { mode: "single", role: "game" } });
     }
   });
   app.on("child-process-gone", (_event, details) => {

--- a/src/main/multiple-accounts-controller.ts
+++ b/src/main/multiple-accounts-controller.ts
@@ -18,10 +18,7 @@ import type {
   MultiWorkspace,
   ProfileId,
 } from "../shared/multiple-accounts.js";
-import {
-  getAccountsWindow,
-  revealAccountsWindow,
-} from "./accounts-window.js";
+import { revealAccountsWindow } from "./accounts-window.js";
 import type { ClientRuntime } from "./client-runtime.js";
 import {
   AccountTemplateSessions,
@@ -223,7 +220,7 @@ export class MultipleAccountsController {
       revealAccountsWindow();
       throw firstFailure;
     }
-    const hub = getAccountsWindow();
+    const hub = windowRegistry.hubWindow();
     if (hub && !hub.isDestroyed()) hub.hide();
     if (firstSelectedWindow && !firstSelectedWindow.isDestroyed()) {
       if (firstSelectedWindow.isMinimized()) firstSelectedWindow.restore();
@@ -479,10 +476,10 @@ export class MultipleAccountsController {
         windowStatePath: profilePaths.windowState,
         showInactive: true,
         onRendererRecoveryStart: () => {
-          hubWasVisibleBeforeRecovery = getAccountsWindow()?.isVisible() ?? false;
+          hubWasVisibleBeforeRecovery = windowRegistry.hubWindow()?.isVisible() ?? false;
         },
         onRendererRecovered: () => {
-          if (!hubWasVisibleBeforeRecovery) getAccountsWindow()?.hide();
+          if (!hubWasVisibleBeforeRecovery) windowRegistry.hubWindow()?.hide();
         },
         onRendererFailure: () => {
           this.profileRuntime.set(profileId, "failed", launchIssueForStage("crashed"));

--- a/src/main/renderer-commands.ts
+++ b/src/main/renderer-commands.ts
@@ -8,14 +8,13 @@
  * directions cannot drift into different ideas of what the renderer is. Only
  * the renderer a command was sent to may complete it.
  */
-import { BrowserWindow, ipcMain } from "electron";
+import { ipcMain, type BrowserWindow } from "electron";
 import {
   IPC,
   type RendererCommand,
   type RendererCommandCompletion,
   type RendererCommandOutcome,
 } from "../shared/contracts.js";
-import { isCanonicalRendererUrl } from "./core/renderer-trust.js";
 import { logEvent } from "./diagnostics/recorder.js";
 
 interface Pending {
@@ -39,17 +38,6 @@ ipcMain.on(IPC.rendererCommandDone, (event, id: unknown, outcome: unknown) => {
   if (!entry || entry.webContentsId !== event.sender.id) return;
   entry.settle(outcome as RendererCommandCompletion);
 });
-
-export function canonicalRendererWindow(): BrowserWindow | null {
-  return (
-    BrowserWindow.getAllWindows().find(
-      (win) =>
-        !win.isDestroyed()
-        && !win.webContents.isDestroyed()
-        && isCanonicalRendererUrl(win.webContents.getURL()),
-    ) ?? null
-  );
-}
 
 /**
  * Resolves with the renderer's truthful completion, failure when the page that

--- a/src/main/window-registry.ts
+++ b/src/main/window-registry.ts
@@ -17,24 +17,37 @@ export type WindowContext =
 interface RegisteredWindow {
   readonly webContents: { readonly id: number };
   isDestroyed(): boolean;
+  isFocused(): boolean;
 }
 
-interface Entry {
-  readonly win: RegisteredWindow;
+interface Entry<Window extends RegisteredWindow> {
+  readonly win: Window;
   readonly context: WindowContext;
 }
 
-export class WindowRegistry {
-  readonly #byWebContents = new Map<number, Entry>();
-  readonly #profileWindows = new Map<ProfileId, RegisteredWindow>();
-  readonly #webContentsIds = new WeakMap<RegisteredWindow, number>();
+export class WindowRegistry<Window extends RegisteredWindow = BrowserWindow> {
+  readonly #byWebContents = new Map<number, Entry<Window>>();
+  readonly #profileWindows = new Map<ProfileId, Window>();
+  readonly #webContentsIds = new WeakMap<Window, number>();
+  #singleGameWindow: Window | null = null;
+  #hubWindow: Window | null = null;
 
-  register(win: RegisteredWindow, context: WindowContext): void {
+  register(win: Window, context: WindowContext): void {
     const id = win.webContents.id;
     if (this.#byWebContents.has(id)) {
       throw new AppError("validation", "window is already registered");
     }
-    if (context.mode === "multi" && context.role === "game") {
+    if (context.mode === "single") {
+      if (this.#singleGameWindow && !this.#singleGameWindow.isDestroyed()) {
+        throw new AppError("validation", "Single Account already has a game window");
+      }
+      this.#singleGameWindow = win;
+    } else if (context.role === "hub") {
+      if (this.#hubWindow && !this.#hubWindow.isDestroyed()) {
+        throw new AppError("validation", "Multiple Accounts already has a Hub window");
+      }
+      this.#hubWindow = win;
+    } else {
       const existing = this.#profileWindows.get(context.profileId);
       if (existing && !existing.isDestroyed()) {
         throw new AppError("validation", "profile already has a game window");
@@ -45,14 +58,18 @@ export class WindowRegistry {
     this.#byWebContents.set(id, { win, context });
   }
 
-  unregister(win: RegisteredWindow): void {
+  unregister(win: Window): void {
     const id = this.#webContentsIds.get(win);
     if (id === undefined) return;
     const entry = this.#byWebContents.get(id);
     if (!entry || entry.win !== win) return;
     this.#byWebContents.delete(id);
     this.#webContentsIds.delete(win);
-    if (entry.context.mode === "multi" && entry.context.role === "game") {
+    if (entry.context.mode === "single") {
+      if (this.#singleGameWindow === win) this.#singleGameWindow = null;
+    } else if (entry.context.role === "hub") {
+      if (this.#hubWindow === win) this.#hubWindow = null;
+    } else {
       if (this.#profileWindows.get(entry.context.profileId) === win) {
         this.#profileWindows.delete(entry.context.profileId);
       }
@@ -64,25 +81,52 @@ export class WindowRegistry {
     return entry && !entry.win.isDestroyed() ? entry.context : null;
   }
 
-  profileWindow(profileId: ProfileId): BrowserWindow | null {
+  windowForWebContents(id: number): Window | null {
+    const entry = this.#byWebContents.get(id);
+    return entry && !entry.win.isDestroyed() ? entry.win : null;
+  }
+
+  singleGameWindow(): Window | null {
+    return this.#singleGameWindow && !this.#singleGameWindow.isDestroyed()
+      ? this.#singleGameWindow
+      : null;
+  }
+
+  hubWindow(): Window | null {
+    return this.#hubWindow && !this.#hubWindow.isDestroyed()
+      ? this.#hubWindow
+      : null;
+  }
+
+  profileWindow(profileId: ProfileId): Window | null {
     const win = this.#profileWindows.get(profileId);
-    return win && !win.isDestroyed() ? win as BrowserWindow : null;
+    return win && !win.isDestroyed() ? win : null;
   }
 
   windows(
     predicate: (context: WindowContext) => boolean = () => true,
-  ): BrowserWindow[] {
-    const result: BrowserWindow[] = [];
+  ): Window[] {
+    const result: Window[] = [];
     for (const { win, context } of this.#byWebContents.values()) {
-      if (!win.isDestroyed() && predicate(context)) result.push(win as BrowserWindow);
+      if (!win.isDestroyed() && predicate(context)) result.push(win);
     }
     return result;
   }
 
-  gameWindows(): BrowserWindow[] {
+  gameWindows(): Window[] {
     return this.windows((context) => context.role === "game");
+  }
+
+  focusedGameWindow(): Window | null {
+    return this.gameWindows().find((win) => win.isFocused()) ?? null;
+  }
+
+  focusedOrSoleGameWindow(): Window | null {
+    const games = this.gameWindows();
+    return games.find((win) => win.isFocused())
+      ?? (games.length === 1 ? games[0] ?? null : null);
   }
 }
 
 /** The process has one native-window authority. */
-export const windowRegistry = new WindowRegistry();
+export const windowRegistry = new WindowRegistry<BrowserWindow>();

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -76,7 +76,6 @@ export interface WindowHost {
   gameWindowClosed?: () => void;
 }
 
-let mainWindow: BrowserWindow | null = null;
 const rendererRecoveryUsed = new Set<string>();
 
 /** A deliberate player retry gets one fresh automatic renderer recovery. */
@@ -101,7 +100,7 @@ let downloadPowerBlockerId: number | null = null;
 
 export function updateLongRunningTaskFeedback(
   value: DownloadProgress,
-  win = mainWindow,
+  win: BrowserWindow | null,
 ): boolean {
   const feedback = longRunningTaskFeedback(value);
   if (feedback.preventAppSuspension && downloadPowerBlockerId === null) {
@@ -208,7 +207,7 @@ function scheduleWindowStateSave(win: BrowserWindow): void {
   }, 300);
 }
 
-export async function flushWindowState(win = mainWindow): Promise<void> {
+export async function flushWindowState(win: BrowserWindow): Promise<void> {
   if (!win || win.isDestroyed()) return;
   const owner = windowStateOwners.get(win);
   if (!owner) return;
@@ -221,7 +220,7 @@ export async function flushWindowState(win = mainWindow): Promise<void> {
   await owner.write;
 }
 
-export function resetWindowState(win = mainWindow): Promise<void> {
+export function resetWindowState(win: BrowserWindow): Promise<void> {
   if (!win || win.isDestroyed()) return Promise.resolve();
   const owner = windowStateOwners.get(win);
   if (!owner) return Promise.resolve();
@@ -285,10 +284,6 @@ export function resetWindowState(win = mainWindow): Promise<void> {
   return reset;
 }
 
-export function getMainWindow(): BrowserWindow | null {
-  return mainWindow;
-}
-
 export function setOwnedWindowTitle(win: BrowserWindow, title: string): void {
   ownedWindowTitles.set(win, title);
   win.setTitle(title);
@@ -342,7 +337,7 @@ export function rendererInitArgument(options: {
 export function createMainWindow(
   host: WindowHost,
   options: {
-    readonly context?: WindowContext;
+    readonly context: WindowContext;
     readonly session?: Electron.Session;
     readonly title?: string;
     readonly windowStatePath?: string;
@@ -350,9 +345,9 @@ export function createMainWindow(
     readonly onRendererRecoveryStart?: () => void;
     readonly onRendererRecovered?: () => void;
     readonly onRendererFailure?: () => void;
-  } = {},
+  },
 ): BrowserWindow {
-  const context = options.context ?? { mode: "single", role: "game" };
+  const context = options.context;
   const statePath = options.windowStatePath ?? gamePaths().windowState;
   const restoredWindowState = preparedWindowStates.get(statePath) ?? null;
   const initialState = restoredWindowState
@@ -388,7 +383,6 @@ export function createMainWindow(
     },
   });
 
-  mainWindow = win;
   const stateOwner: WindowStateOwner = {
     path: statePath,
     restored: initialState,
@@ -606,7 +600,6 @@ export function createMainWindow(
   win.on("closed", () => {
     windowRegistry.unregister(win);
     windowStateOwners.delete(win);
-    if (mainWindow === win) mainWindow = null;
     if (
       context.mode === "multi"
       && context.role === "game"

--- a/tests/policy/source-main-process-security-guards.test.ts
+++ b/tests/policy/source-main-process-security-guards.test.ts
@@ -8,13 +8,24 @@
 // that admits what they are, rather than deleted — a call site nothing checks
 // is exactly how a guard gets dropped in a refactor and noticed in an incident.
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 import { test } from "node:test";
 import { fileURLToPath } from "node:url";
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../..");
 const read = (file: string) => readFileSync(path.join(root, file), "utf8");
+
+function sourceFiles(directory: string): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const target = path.join(directory, entry.name);
+    return entry.isDirectory()
+      ? sourceFiles(target)
+      : entry.isFile() && entry.name.endsWith(".ts")
+        ? [target]
+        : [];
+  });
+}
 
 test("IPC still refuses a sender that is not the main frame at the canonical URL", () => {
   // Not reachable from a test: `frame-src 'none'` means the renderer cannot
@@ -25,6 +36,18 @@ test("IPC still refuses a sender that is not the main frame at the canonical URL
   const ipc = read("src/main/ipc.ts");
   assert.match(ipc, /event\.senderFrame !== event\.sender\.mainFrame/u);
   assert.match(ipc, /isCanonicalRendererUrl\(event\.senderFrame\.url\)/u);
+});
+
+test("production resolves native windows only through the window registry", () => {
+  const sources = sourceFiles(path.join(root, "src/main"));
+  for (const file of sources) {
+    const source = readFileSync(file, "utf8");
+    assert.doesNotMatch(source, /BrowserWindow\.(?:getAllWindows|getFocusedWindow|fromWebContents)\(/u, file);
+  }
+  assert.match(
+    read("src/main/ipc.ts"),
+    /registry\.windowForWebContents\(event\.sender\.id\)/u,
+  );
 });
 
 test("the proxy still answers only fetches", () => {

--- a/tests/unit/window-registry.test.ts
+++ b/tests/unit/window-registry.test.ts
@@ -10,13 +10,14 @@ function fake(id: number) {
   return {
     webContents: { id },
     isDestroyed: () => destroyed,
+    isFocused: () => false,
     destroy: () => { destroyed = true; },
   };
 }
 
 describe("window registry", () => {
   it("resolves immutable context from the native sender id", () => {
-    const registry = new WindowRegistry();
+    const registry = new WindowRegistry<ReturnType<typeof fake>>();
     const win = fake(7);
     const profileId = parseProfileId("2d31e565-9fc8-4dde-9fd4-9d644f8283ae");
     registry.register(win, { mode: "multi", role: "game", profileId });
@@ -29,7 +30,7 @@ describe("window registry", () => {
   });
 
   it("enforces one live game window for a profile", () => {
-    const registry = new WindowRegistry();
+    const registry = new WindowRegistry<ReturnType<typeof fake>>();
     const profileId = parseProfileId("2d31e565-9fc8-4dde-9fd4-9d644f8283ae");
     const first = fake(1);
     registry.register(first, { mode: "multi", role: "game", profileId });
@@ -42,7 +43,7 @@ describe("window registry", () => {
   });
 
   it("unregisters only the exact native window", () => {
-    const registry = new WindowRegistry();
+    const registry = new WindowRegistry<ReturnType<typeof fake>>();
     const win = fake(1);
     registry.register(win, { mode: "single", role: "game" });
     registry.unregister(fake(1));
@@ -52,7 +53,6 @@ describe("window registry", () => {
   });
 
   it("unregisters after Electron has made webContents unreadable", () => {
-    const registry = new WindowRegistry();
     let readable = true;
     const win = {
       get webContents() {
@@ -60,7 +60,9 @@ describe("window registry", () => {
         return { id: 1 };
       },
       isDestroyed: () => !readable,
+      isFocused: () => false,
     };
+    const registry = new WindowRegistry<typeof win>();
     registry.register(win, { mode: "single", role: "game" });
     readable = false;
     assert.doesNotThrow(() => registry.unregister(win));
@@ -68,7 +70,7 @@ describe("window registry", () => {
   });
 
   it("does not return destroyed windows", () => {
-    const registry = new WindowRegistry();
+    const registry = new WindowRegistry<ReturnType<typeof fake>>();
     const hub = fake(1);
     const game = fake(2);
     registry.register(hub, { mode: "multi", role: "hub" });
@@ -81,5 +83,55 @@ describe("window registry", () => {
     game.destroy();
     assert.equal(registry.gameWindows().length, 0);
     assert.equal(registry.windows().length, 1);
+  });
+
+  it("owns the one Single game window and the one Multiple Accounts Hub", () => {
+    const registry = new WindowRegistry<ReturnType<typeof fake>>();
+    const single = fake(1);
+    const hub = fake(2);
+    registry.register(single, { mode: "single", role: "game" });
+    registry.register(hub, { mode: "multi", role: "hub" });
+    assert.equal(registry.singleGameWindow(), single);
+    assert.equal(registry.hubWindow(), hub);
+    assert.throws(
+      () => registry.register(fake(3), { mode: "single", role: "game" }),
+      AppError,
+    );
+    assert.throws(
+      () => registry.register(fake(4), { mode: "multi", role: "hub" }),
+      AppError,
+    );
+  });
+
+  it("resolves only registered senders and the focused game", () => {
+    let focused = false;
+    const win = {
+      webContents: { id: 7 },
+      isDestroyed: () => false,
+      isFocused: () => focused,
+    };
+    const registry = new WindowRegistry<typeof win>();
+    registry.register(win, { mode: "single", role: "game" });
+    assert.equal(registry.windowForWebContents(7), win);
+    assert.equal(registry.windowForWebContents(8), null);
+    assert.equal(registry.focusedGameWindow(), null);
+    assert.equal(registry.focusedOrSoleGameWindow(), win);
+    focused = true;
+    assert.equal(registry.focusedGameWindow(), win);
+  });
+
+  it("refuses an ambiguous game selection", () => {
+    const registry = new WindowRegistry<ReturnType<typeof fake>>();
+    registry.register(fake(1), {
+      mode: "multi",
+      role: "game",
+      profileId: parseProfileId("2d31e565-9fc8-4dde-9fd4-9d644f8283ae"),
+    });
+    registry.register(fake(2), {
+      mode: "multi",
+      role: "game",
+      profileId: parseProfileId("b2521fbf-50a8-424c-823a-bd5be4b58ace"),
+    });
+    assert.equal(registry.focusedOrSoleGameWindow(), null);
   });
 });


### PR DESCRIPTION
Multiple Accounts code could still infer a window from Electron's global window list. That made ownership depend on focus or creation order instead of the registered account context.

This change makes `WindowRegistry` the only native-window authority. It now owns the Single game, the Accounts Hub, and one game per profile; resolves exact IPC and socket senders; and selects only a focused or unambiguous sole game. The old module-level window variables, renderer scan, implicit window defaults, and production Electron window scans are deleted.

The result is a smaller trust boundary: an unregistered renderer cannot acquire IPC or socket ownership, and ambiguous Multiple Accounts selection fails closed. A policy test prevents production global-window scans from returning.

## Verification

- `pnpm run check`
- `pnpm build`
- focused registry and main-process policy tests: 12 passed
- focused diagnostics Electron suite: 10 passed
- `pnpm package:built && pnpm test:packaged`
- packaged main/protocol/preload/renderer/diagnostics smoke passed
- packaged Enhancement isolation and lifecycle smoke passed
- full `pnpm verify` reached 136 passed Electron tests and one expected skip; two macOS focus/pointer-lock timing cases failed in the long run and each passed immediately when rerun alone

Implemented and verified with Codex desktop against the repository's Node, Playwright, Electron Forge, and packaged-runtime harnesses.
