### PR TITLE
fix(window): keep feedback with its owning account

### DIFF
--- a/docs/multiple-accounts.md
+++ b/docs/multiple-accounts.md
@@ -158,6 +158,10 @@ authority from the trusted sender and resolves socket delivery to that exact
 registered window. A renderer cannot choose a profile ID, native path,
 Electron partition, Keychain item, or socket owner.
 
+Warnings, native dialogs, renderer commands, input state, and diagnostics stay
+with the game window that initiated them. Application updates and shared game
+downloads remain application-wide and report progress to every game window.
+
 The Account Picker cannot access game sockets, saved login, player files, or
 build writes. Diagnostics use ephemeral window identifiers. They do not record
 profile names, stable profile IDs, account identifiers, credentials, template

--- a/src/main/diagnostics-export.ts
+++ b/src/main/diagnostics-export.ts
@@ -2,13 +2,14 @@
  * Saves the diagnostics the recorder already holds. This module owns the
  * one-at-a-time guard and the player-facing export failure.
  */
-import { dialog } from "electron";
+import { dialog, type BrowserWindow } from "electron";
 import { errorCode } from "../shared/errors.js";
 import { logEvent } from "./diagnostics.js";
 
 let diagnosticsExportInFlight = false;
 
 export async function exportDiagnosticsReport(
+  win: BrowserWindow,
   exportDiagnostics: () => Promise<string>,
 ): Promise<void> {
   if (diagnosticsExportInFlight) return;
@@ -19,10 +20,12 @@ export async function exportDiagnosticsReport(
     logEvent({ k: "diagnostics.exported" });
   } catch (error) {
     logEvent({ k: "diagnostics.exportFailed", code: errorCode(error) });
-    dialog.showErrorBox(
-      "Diagnostics export failed",
-      error instanceof Error ? error.message : String(error),
-    );
+    await dialog.showMessageBox(win, {
+      type: "error",
+      buttons: ["OK"],
+      message: "Diagnostics export failed",
+      detail: error instanceof Error ? error.message : String(error),
+    }).catch(() => undefined);
   } finally {
     diagnosticsExportInFlight = false;
   }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -782,7 +782,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
         detail: "Export it now while the capture context is fresh.",
       });
       if (response === 0) {
-        await exportDiagnosticsReport(() =>
+        await exportDiagnosticsReport(win, () =>
           exportDiagnosticsForWindow(win, () => preferences.getSettings())
         );
       }

--- a/src/main/window-menu.ts
+++ b/src/main/window-menu.ts
@@ -228,7 +228,7 @@ export function installApplicationMenu({
               label: "Export Recent Diagnostics…",
               click: async () => {
                 await resetGameInput(win);
-                await exportDiagnosticsReport(() => host.exportDiagnostics(win));
+                await exportDiagnosticsReport(win, () => host.exportDiagnostics(win));
               },
             },
             { type: "separator" },
@@ -238,10 +238,12 @@ export function installApplicationMenu({
               click: async () => {
                 await resetGameInput(win);
                 void host.startCapture(1).catch((error) => {
-                  dialog.showErrorBox(
-                    "Capture could not start",
-                    error instanceof Error ? error.message : String(error),
-                  );
+                  void dialog.showMessageBox(win, {
+                    type: "error",
+                    buttons: ["OK"],
+                    message: "Capture could not start",
+                    detail: error instanceof Error ? error.message : String(error),
+                  }).catch(() => undefined);
                 });
               },
             },
@@ -260,10 +262,12 @@ export function installApplicationMenu({
               click: async () => {
                 await resetGameInput(win);
                 void host.startCapture(2).catch((error) => {
-                  dialog.showErrorBox(
-                    "Trace could not start",
-                    error instanceof Error ? error.message : String(error),
-                  );
+                  void dialog.showMessageBox(win, {
+                    type: "error",
+                    buttons: ["OK"],
+                    message: "Trace could not start",
+                    detail: error instanceof Error ? error.message : String(error),
+                  }).catch(() => undefined);
                 });
               },
             },

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -578,10 +578,13 @@ export function createMainWindow(
       }, 500);
     } else if (details.reason !== "clean-exit") {
       options.onRendererFailure?.();
-      dialog.showErrorBox(
-        "Guild Wars stopped unexpectedly",
-        "Use View → Reload Game to try again. If it repeats, choose Help → Report a Bug.",
-      );
+      void dialog.showMessageBox(win, {
+        type: "error",
+        buttons: ["OK"],
+        message: "Guild Wars stopped unexpectedly",
+        detail:
+          "Use View → Reload Game to try again. If it repeats, choose Help → Report a Bug.",
+      }).catch(() => undefined);
     }
   });
 

--- a/tests/electron/multiple-accounts.spec.ts
+++ b/tests/electron/multiple-accounts.spec.ts
@@ -5,6 +5,8 @@ import path from "node:path";
 import type { ProfileId } from "../../src/shared/multiple-accounts.js";
 import { closeOffline, launchOffline } from "./fixtures.mjs";
 
+type MemoryWarningModule = typeof import("../../src/renderer/memory-warning.js");
+
 declare global {
   var __multiModeRestart: {
     quit: boolean;
@@ -12,6 +14,7 @@ declare global {
     originalQuit: Electron.App["quit"];
     originalRelaunch: Electron.App["relaunch"];
   };
+  var __runtimeDialogParent: string | null | undefined;
 }
 
 const FIRST = "00000000-0000-4000-8000-000000000001";
@@ -252,7 +255,15 @@ test("renderer recovery stays with its account and a second crash needs attentio
       [FIRST, SECOND] as const,
     );
     const firstRenderer = await fixture.app.evaluate(({ BrowserWindow, dialog }) => {
-      dialog.showErrorBox = () => undefined;
+      Object.defineProperty(dialog, "showMessageBox", {
+        configurable: true,
+        value: async (first: unknown) => {
+          globalThis.__runtimeDialogParent = first instanceof BrowserWindow
+            ? first.getTitle()
+            : null;
+          return { response: 0, checkboxChecked: false };
+        },
+      });
       const win = BrowserWindow.getAllWindows().find((candidate) => candidate.getTitle().endsWith("Primary"));
       if (!win) throw new Error("Primary window not found");
       const id = win.webContents.id;
@@ -277,6 +288,8 @@ test("renderer recovery stays with its account and a second crash needs attentio
     await expect.poll(() => fixture.page.evaluate(() =>
       window.gwNative.accounts.get().then((state) => state.profiles.find((profile) => profile.name === "Primary")),
     )).toMatchObject({ state: "failed", launchIssue: "renderer-crash" });
+    await expect.poll(() => fixture.app.evaluate(() => globalThis.__runtimeDialogParent))
+      .toBe("Guild Wars Reforged — Primary");
     expect(await fixture.app.evaluate(({ BrowserWindow }) =>
       BrowserWindow.getAllWindows().find((win) => win.getTitle().endsWith("Accounts"))?.isVisible(),
     )).toBe(true);
@@ -445,6 +458,24 @@ test("Multi starts at the Hub and isolates two profile windows from Single", asy
     const nonTargetGame = ownedGames.find(({ credentials }) =>
       credentials?.username === "first@example.test")?.game;
     if (!altGame || !nonTargetGame) throw new Error("profile pages not found");
+
+    await altGame.evaluate(async () => {
+      const moduleUrl: string = "gw://app/memory-warning.js";
+      const { bindMemoryWarning } = await import(moduleUrl) as MemoryWarningModule;
+      const presenter = bindMemoryWarning(document, () => undefined, window.gwSurfaces);
+      if (!presenter) throw new Error("memory warning is unavailable");
+      presenter.present("critical", 2_147_483_648);
+    });
+    await expect(altGame.locator("#memory-notice")).toBeVisible();
+    await expect(altGame.locator("#memory-notice-label"))
+      .toHaveText("Guild Wars is almost out of memory.");
+    await expect(nonTargetGame.locator("#memory-notice")).toBeHidden();
+    await altGame.locator("#memory-notice-later").evaluate((button) => {
+      (button as HTMLButtonElement).click();
+    });
+    await expect(altGame.locator("#memory-notice")).toBeHidden();
+    await expect(nonTargetGame.locator("#memory-notice")).toBeHidden();
+
     await Promise.all(ownedGames.map(({ game }) => game.evaluate(() => {
       (window as typeof window & { __reloadProof?: boolean }).__reloadProof = true;
     })));

--- a/tests/policy/source-main-process-security-guards.test.ts
+++ b/tests/policy/source-main-process-security-guards.test.ts
@@ -50,6 +50,14 @@ test("production resolves native windows only through the window registry", () =
   );
 });
 
+test("runtime error dialogs keep their owning game window", () => {
+  assert.doesNotMatch(read("src/main/window.ts"), /dialog\.showErrorBox\(/u);
+  assert.doesNotMatch(read("src/main/window-menu.ts"), /dialog\.showErrorBox\(/u);
+  assert.doesNotMatch(read("src/main/diagnostics-export.ts"), /dialog\.showErrorBox\(/u);
+  assert.match(read("src/main/window.ts"), /dialog\.showMessageBox\(win,/u);
+  assert.match(read("src/main/diagnostics-export.ts"), /dialog\.showMessageBox\(win,/u);
+});
+
 test("the proxy still answers only fetches", () => {
   // `isProxyFetchDestination` is executed over every destination Chromium can
   // set in tests/unit/proxy-routes.test.ts. The complete accepted path, cookie


### PR DESCRIPTION
Multiple Accounts feedback could escape its account context. Runtime failures used unparented native error boxes, and the reported memory-warning problem needed a real two-profile isolation proof.

This change parents every post-startup runtime error dialog to the game window that initiated it. Renderer crash, capture, trace, and diagnostics-export failures can no longer appear over another profile. Startup-fatal dialogs remain unparented because no window exists yet.

The memory banner remains renderer-local. The Multiple Accounts Electron journey now injects a critical warning into Alt, proves it never appears in Primary, dismisses it only in Alt, and separately proves a second Primary renderer crash opens its native dialog with Primary as the parent. Application-global update and download broadcasts remain unchanged.

## Verification

- `pnpm run check` — 172 policy tests and 96 Tools tests included
- `pnpm build`
- focused runtime-dialog policy: 5 passed
- focused renderer-recovery and native-parent Electron test passed
- focused two-profile memory-warning isolation Electron test passed
- `git diff --check`

Implemented and verified with Codex desktop against the repository's Node, Playwright, and Electron harnesses.
