### PR TITLE
fix(diagnostics): bind captures to their initiating window

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -49,6 +49,13 @@ It cannot prove an improvement.
 For a short hitch, record Level 2 for only the reproduction window. Stop soon
 after the problem. A trace that stops before the hitch cannot explain it.
 
+In Multiple Accounts mode, a capture belongs to the registered game window
+that started it for its complete lifetime. Focus changes cannot move its
+status, marker, export, or completion prompt to another profile. Closing or
+crashing the owner stops the capture without falling back to another game.
+Automation uses the focused registered game, or the sole game when exactly one
+exists; it refuses an ambiguous set of unfocused games.
+
 ## Export contents
 
 A current ZIP contains a manifest, report, summary, current events,

--- a/docs/multiple-accounts.md
+++ b/docs/multiple-accounts.md
@@ -162,6 +162,11 @@ Warnings, native dialogs, renderer commands, input state, and diagnostics stay
 with the game window that initiated them. Application updates and shared game
 downloads remain application-wide and report progress to every game window.
 
+A performance capture keeps its initiating game window as its owner until it
+stops. Mark, stop, export, and completion feedback cannot move to whichever
+profile gains focus later. Closing or crashing that owner performs bounded
+cleanup and never selects another account as a fallback.
+
 The Account Picker cannot access game sockets, saved login, player files, or
 build writes. Diagnostics use ephemeral window identifiers. They do not record
 profile names, stable profile IDs, account identifiers, credentials, template

--- a/src/main/diagnostics.ts
+++ b/src/main/diagnostics.ts
@@ -31,6 +31,7 @@ export {
   setDiagnosticCaptureStoppedHandler,
   startDiagnosticCapture,
   stopDiagnosticCapture,
+  stopDiagnosticCaptureForWindow,
 } from "./diagnostics/capture.js";
 export {
   startClientUpdateSpan,

--- a/src/main/diagnostics/capture.ts
+++ b/src/main/diagnostics/capture.ts
@@ -10,7 +10,7 @@
  */
 import { rm, stat } from "node:fs/promises";
 import path from "node:path";
-import { contentTracing } from "electron";
+import { contentTracing, type BrowserWindow, type WebContents } from "electron";
 import type { RendererCommand } from "../../shared/contracts.js";
 import { errorCode } from "../../shared/errors.js";
 import { gamePaths } from "../paths.js";
@@ -28,7 +28,42 @@ let traceGuard: ReturnType<typeof setInterval> | null = null;
 let captureTimer: ReturnType<typeof setTimeout> | null = null;
 let captureStopPromise: Promise<void> | null = null;
 let captureStartPromise: Promise<void> | null = null;
-let captureStoppedHandler: (() => void | Promise<void>) | null = null;
+let captureStoppedHandler: ((win: BrowserWindow) => void | Promise<void>) | null = null;
+
+interface CaptureOwner {
+  readonly win: BrowserWindow;
+  readonly contents: WebContents;
+  readonly stopped: () => void;
+}
+
+let captureOwner: CaptureOwner | null = null;
+
+function registeredGameWindow(win: BrowserWindow): boolean {
+  const id = win.webContents.id;
+  return windowRegistry.windowForWebContents(id) === win
+    && windowRegistry.contextForWebContents(id)?.role === "game";
+}
+
+function releaseCaptureOwner(owner: CaptureOwner): void {
+  owner.win.off("closed", owner.stopped);
+  owner.contents.off("render-process-gone", owner.stopped);
+  if (captureOwner === owner) captureOwner = null;
+}
+
+function ownCapture(win: BrowserWindow): CaptureOwner {
+  const contents = win.webContents;
+  const owner: CaptureOwner = {
+    win,
+    contents,
+    stopped: () => {
+      void stopDiagnosticCapture("owner-gone");
+    },
+  };
+  captureOwner = owner;
+  win.once("closed", owner.stopped);
+  contents.once("render-process-gone", owner.stopped);
+  return owner;
+}
 
 /** The level a capture is running at right now, `0` when none is. */
 export function activeCaptureLevel(): 0 | 1 | 2 {
@@ -47,17 +82,14 @@ export function completedTracePath(): string {
 
 /**
  * The renderer half of a capture. `level` crosses as a number inside a typed
- * event rather than spliced into a string of JavaScript. The focused registered
- * game receives it; a sole background game is unambiguous, while multiple
- * unfocused games are refused.
+ * event rather than spliced into a string of JavaScript. Its explicit owner is
+ * retained for the whole capture; later focus changes cannot retarget it.
  */
 const rendererCaptureCommand = (
+  win: BrowserWindow,
   command: Extract<RendererCommand, { type: "diagnostics.capture" }>,
 ): Promise<void> =>
-  sendRendererCommand(
-    windowRegistry.focusedOrSoleGameWindow(),
-    command,
-  ).then((outcome) => {
+  sendRendererCommand(win, command).then((outcome) => {
     if (outcome !== "completed") {
       logEvent({
         k: "renderer.commandIncomplete",
@@ -67,16 +99,19 @@ const rendererCaptureCommand = (
     }
   });
 
-export function markPerformanceProblem(): void {
+export function markPerformanceProblem(win: BrowserWindow): void {
+  if (!registeredGameWindow(win)) return;
+  const owner = captureOwner?.win ?? win;
+  if (owner !== win) return;
   logEvent({ k: "performance.problemMarked" });
-  void rendererCaptureCommand({
+  void rendererCaptureCommand(owner, {
     type: "diagnostics.capture",
     action: "problem-marked",
   });
 }
 
 export function setDiagnosticCaptureStoppedHandler(
-  handler: (() => void | Promise<void>) | null,
+  handler: ((win: BrowserWindow) => void | Promise<void>) | null,
 ): void {
   captureStoppedHandler = handler;
 }
@@ -127,20 +162,32 @@ export async function discardTrace(): Promise<void> {
   }
 }
 
-export function startDiagnosticCapture(level: 1 | 2): Promise<void> {
+export function startDiagnosticCapture(
+  win: BrowserWindow,
+  level: 1 | 2,
+): Promise<void> {
   if (captureLevel !== 0 || captureStopPromise || captureStartPromise) {
     return Promise.reject(new Error("a diagnostics capture is already active"));
   }
+  if (!registeredGameWindow(win)) {
+    return Promise.reject(
+      new Error("diagnostics capture requires a registered game window"),
+    );
+  }
+  const owner = ownCapture(win);
   const operation = (async () => {
     // Beginning a capture replaces the previous capture result. Its raw trace
     // must be deleted first; clearing only the pointer would orphan a file that
     // can contain Chromium process data.
     await discardTrace();
-    await rendererCaptureCommand({ type: "diagnostics.capture", action: "reset" });
+    await rendererCaptureCommand(win, {
+      type: "diagnostics.capture",
+      action: "reset",
+    });
     await recorder.beginCapture();
     resetEventLoopWindow();
     captureLevel = level;
-    await rendererCaptureCommand({
+    await rendererCaptureCommand(win, {
       type: "diagnostics.capture",
       action: "started",
       level,
@@ -187,7 +234,7 @@ export function startDiagnosticCapture(level: 1 | 2): Promise<void> {
       if (captureTimer) clearTimeout(captureTimer);
       captureTimer = null;
       captureLevel = 0;
-      await rendererCaptureCommand({
+      await rendererCaptureCommand(win, {
         type: "diagnostics.capture",
         action: "stopped",
       });
@@ -201,9 +248,14 @@ export function startDiagnosticCapture(level: 1 | 2): Promise<void> {
       throw error;
     }
   })();
-  captureStartPromise = operation.finally(() => {
-    captureStartPromise = null;
-  });
+  captureStartPromise = operation
+    .catch((error: unknown) => {
+      releaseCaptureOwner(owner);
+      throw error;
+    })
+    .finally(() => {
+      captureStartPromise = null;
+    });
   return captureStartPromise;
 }
 
@@ -218,35 +270,59 @@ export function stopDiagnosticCapture(
     );
   }
   if (captureLevel === 0) return Promise.resolve();
+  const owner = captureOwner;
+  if (!owner) return Promise.reject(new Error("diagnostics capture has no owner"));
   const stoppedLevel = captureLevel;
   captureStopPromise = (async () => {
     if (captureTimer) clearTimeout(captureTimer);
     captureTimer = null;
-    await rendererCaptureCommand({ type: "diagnostics.capture", action: "flush" });
+    await rendererCaptureCommand(owner.win, {
+      type: "diagnostics.capture",
+      action: "flush",
+    });
     const traceCompleted = await stopTrace();
     const completedLevel =
       stoppedLevel === 2 && !traceCompleted ? 1 : stoppedLevel;
     recordedLevel = completedLevel;
-    logEvent({ k: "capture.stopped",
+    logEvent({
+      k: "capture.stopped",
       level: completedLevel,
       reason,
     });
     recorder.endCapture(completedLevel, reason);
     captureLevel = 0;
-    await rendererCaptureCommand({
-        type: "diagnostics.capture",
-        action: "stopped",
-      });
+    await rendererCaptureCommand(owner.win, {
+      type: "diagnostics.capture",
+      action: "stopped",
+    });
     if (
       captureStoppedHandler &&
       (reason === "manual" ||
         reason === "automatic" ||
         reason === "buffer-full")
     ) {
-      queueMicrotask(() => void captureStoppedHandler?.());
+      queueMicrotask(() => void captureStoppedHandler?.(owner.win));
     }
   })().finally(() => {
+    releaseCaptureOwner(owner);
     captureStopPromise = null;
   });
   return captureStopPromise;
+}
+
+export function stopDiagnosticCaptureForWindow(
+  win: BrowserWindow,
+  reason: CaptureMetadata["stopReason"] = "manual",
+): Promise<void> {
+  if (!registeredGameWindow(win)) {
+    return Promise.reject(
+      new Error("diagnostics capture requires a registered game window"),
+    );
+  }
+  if (captureOwner && captureOwner.win !== win) {
+    return Promise.reject(
+      new Error("diagnostics capture belongs to another game window"),
+    );
+  }
+  return stopDiagnosticCapture(reason);
 }

--- a/src/main/diagnostics/export.ts
+++ b/src/main/diagnostics/export.ts
@@ -28,6 +28,7 @@ import {
   completedTracePath,
   exportedCaptureLevel,
   stopDiagnosticCapture,
+  stopDiagnosticCaptureForWindow,
 } from "./capture.js";
 import { inspectEventLog, type RedactionResult } from "./detector.js";
 import { runtimeVersions } from "./flight-recorder.js";
@@ -265,6 +266,9 @@ export async function exportDiagnosticsForWindow(
   win: BrowserWindow,
   readSettings: () => Promise<AppSettings>,
 ): Promise<string> {
+  if (activeCaptureLevel() !== 0) {
+    await stopDiagnosticCaptureForWindow(win, "export");
+  }
   // The report has always been a PKZIP archive; `.zip` is the name that lets
   // GitHub accept it as an attachment without a Finder round-trip.
   const { canceled, filePath } = await dialog.showSaveDialog(win, {

--- a/src/main/diagnostics/schema-fields.ts
+++ b/src/main/diagnostics/schema-fields.ts
@@ -230,6 +230,7 @@ export const CAPTURE_STOP_REASONS = [
   "buffer-full",
   "export",
   "shutdown",
+  "owner-gone",
 ] as const;
 export type CaptureStopReason = (typeof CAPTURE_STOP_REASONS)[number];
 export const captureStopReason = literal(CAPTURE_STOP_REASONS);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -48,6 +48,7 @@ import {
   startDiagnosticCapture,
   startDiagnostics,
   stopDiagnosticCapture,
+  stopDiagnosticCaptureForWindow,
   stopDiagnostics,
 } from "./diagnostics.js";
 import type { AppPhase } from "./diagnostics/schema-fields.js";
@@ -328,7 +329,7 @@ function buildWindowHost(
       exportDiagnosticsForWindow(win, () => preferences.getSettings()),
     markPerformanceProblem,
     startCapture: startDiagnosticCapture,
-    stopCapture: stopDiagnosticCapture,
+    stopCapture: stopDiagnosticCaptureForWindow,
     reloadGame: (win) => {
       void (async () => {
         // A refused template generation specifically asks for a reload. The
@@ -756,7 +757,12 @@ if (primaryInstance) void app.whenReady().then(async () => {
   if (ENHANCEMENT_AUTOMATION_ENABLED) {
     process.on("message", (message) => {
       if (message === AUTOMATION_COMMAND.startLevel1Capture) {
-        void startDiagnosticCapture(1).catch((error) => {
+        const win = windowRegistry.focusedOrSoleGameWindow();
+        if (!win) {
+          logEvent({ k: "capture.automationStartFailed", code: "validation" });
+          return;
+        }
+        void startDiagnosticCapture(win, 1).catch((error) => {
           logEvent({
             k: "capture.automationStartFailed",
             code: errorCode(error),
@@ -767,10 +773,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
       }
     });
   } else {
-    setDiagnosticCaptureStoppedHandler(async () => {
-      const gameWindows = windowRegistry.gameWindows();
-      const win = gameWindows.find((candidate) => candidate.isFocused())
-        ?? gameWindows[0];
+    setDiagnosticCaptureStoppedHandler(async (win) => {
       if (!win || win.isDestroyed()) return;
       await resetGameInput(win);
       const { response } = await dialog.showMessageBox(win, {

--- a/src/main/window-menu.ts
+++ b/src/main/window-menu.ts
@@ -237,7 +237,7 @@ export function installApplicationMenu({
               label: "Start Performance Capture",
               click: async () => {
                 await resetGameInput(win);
-                void host.startCapture(1).catch((error) => {
+                void host.startCapture(win, 1).catch((error) => {
                   void dialog.showMessageBox(win, {
                     type: "error",
                     buttons: ["OK"],
@@ -253,7 +253,7 @@ export function installApplicationMenu({
               accelerator: "CmdOrCtrl+Shift+M",
               click: async () => {
                 await resetGameInput(win);
-                host.markPerformanceProblem();
+                host.markPerformanceProblem(win);
               },
             },
             {
@@ -261,7 +261,7 @@ export function installApplicationMenu({
               label: "Start Chromium Trace",
               click: async () => {
                 await resetGameInput(win);
-                void host.startCapture(2).catch((error) => {
+                void host.startCapture(win, 2).catch((error) => {
                   void dialog.showMessageBox(win, {
                     type: "error",
                     buttons: ["OK"],
@@ -288,7 +288,7 @@ export function installApplicationMenu({
               label: "Stop Capture",
               click: async () => {
                 await resetGameInput(win);
-                void host.stopCapture();
+                void host.stopCapture(win).catch(() => undefined);
               },
             },
           ],

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -68,9 +68,9 @@ export interface WindowHost {
   getSettings: () => Promise<AppSettings>;
   updateSettings: (value: AppSettingsPatch) => Promise<AppSettings>;
   exportDiagnostics: (win: BrowserWindow) => Promise<string>;
-  markPerformanceProblem: () => void;
-  startCapture: (level: 1 | 2) => Promise<void>;
-  stopCapture: () => Promise<void>;
+  markPerformanceProblem: (win: BrowserWindow) => void;
+  startCapture: (win: BrowserWindow, level: 1 | 2) => Promise<void>;
+  stopCapture: (win: BrowserWindow) => Promise<void>;
   reloadGame: (win: BrowserWindow) => void;
   prepareRendererRecovery: () => Promise<void>;
   gameWindowClosed?: () => void;

--- a/tests/electron/diagnostics.spec.ts
+++ b/tests/electron/diagnostics.spec.ts
@@ -229,13 +229,15 @@ test.describe("diagnostics", () => {
       const modulePath = path.join(root, "build/main/diagnostics.js");
       const contractsPath = path.join(root, "build/shared/contracts.js");
       const stopped = await fixture.app.evaluate(
-        async ({ app: electronApp, contentTracing }, args) => {
+        async ({ app: electronApp, BrowserWindow, contentTracing }, args) => {
           const load = process
             .getBuiltinModule("node:module")
             .createRequire(args.modulePath);
           const diagnostics = load(args.modulePath);
           const { DEFAULT_SETTINGS } = load(args.contractsPath);
-          await diagnostics.startDiagnosticCapture(2);
+          const owner = BrowserWindow.getAllWindows()[0];
+          if (!owner) throw new Error("diagnostics owner is unavailable");
+          await diagnostics.startDiagnosticCapture(owner, 2);
 
           const originalStopRecording = contentTracing.stopRecording;
           let attemptedTarget = "";

--- a/tests/electron/multiple-accounts.spec.ts
+++ b/tests/electron/multiple-accounts.spec.ts
@@ -476,6 +476,61 @@ test("Multi starts at the Hub and isolates two profile windows from Single", asy
     await expect(altGame.locator("#memory-notice")).toBeHidden();
     await expect(nonTargetGame.locator("#memory-notice")).toBeHidden();
 
+    const focusGame = async (title: string) => {
+      await fixture.app.evaluate(({ app, BrowserWindow }, targetTitle) => {
+        const win = BrowserWindow.getAllWindows().find((candidate) =>
+          candidate.getTitle() === targetTitle);
+        if (!win) throw new Error(`${targetTitle} is unavailable`);
+        win.show();
+        app.focus({ steal: true });
+        win.focus();
+      }, title);
+      await expect.poll(() => fixture.app.evaluate(({ BrowserWindow }) =>
+        BrowserWindow.getFocusedWindow()?.getTitle(),
+      )).toBe(title);
+    };
+    const clickMenu = (id: string) => fixture.app.evaluate(({ Menu }, itemId) => {
+      const item = Menu.getApplicationMenu()?.getMenuItemById(itemId);
+      if (!item?.click) throw new Error(`${itemId} menu item is unavailable`);
+      item.click(item, undefined, {} as Electron.KeyboardEvent);
+    }, id);
+
+    await fixture.app.evaluate(({ BrowserWindow, dialog }) => {
+      Object.defineProperty(dialog, "showMessageBox", {
+        configurable: true,
+        value: async (first: unknown) => {
+          globalThis.__runtimeDialogParent = first instanceof BrowserWindow
+            ? first.getTitle()
+            : null;
+          return { response: 1, checkboxChecked: false };
+        },
+      });
+      globalThis.__runtimeDialogParent = null;
+    });
+    await focusGame("Guild Wars Reforged — Alt");
+    await clickMenu("start-performance-capture");
+    await expect(altGame.locator("#capture-status")).toBeVisible();
+    await expect(nonTargetGame.locator("#capture-status")).toBeHidden();
+
+    await focusGame("Guild Wars Reforged — Primary");
+    await clickMenu("mark-performance-problem");
+    await clickMenu("stop-capture");
+    await expect(altGame.locator("#capture-status")).toBeVisible();
+    await expect(altGame.locator("#capture-marker")).toBeHidden();
+    await expect(nonTargetGame.locator("#capture-status")).toBeHidden();
+    expect(await fixture.app.evaluate(() => globalThis.__runtimeDialogParent))
+      .toBeNull();
+
+    await focusGame("Guild Wars Reforged — Alt");
+    await clickMenu("mark-performance-problem");
+    await expect(altGame.locator("#capture-marker")).toBeVisible();
+    await clickMenu("stop-capture");
+    await expect(altGame.locator("#capture-status")).toBeHidden();
+    await expect(nonTargetGame.locator("#capture-status")).toBeHidden();
+    await expect.poll(() => fixture.app.evaluate(() =>
+      globalThis.__runtimeDialogParent,
+    )).toBe("Guild Wars Reforged — Alt");
+
     await Promise.all(ownedGames.map(({ game }) => game.evaluate(() => {
       (window as typeof window & { __reloadProof?: boolean }).__reloadProof = true;
     })));
@@ -560,11 +615,24 @@ test("Multi starts at the Hub and isolates two profile windows from Single", asy
     const altPage = identifiedGames.find(({ credentials }) =>
       credentials?.username === "second@example.test")?.game;
     if (!primaryPage || !altPage) throw new Error("profile pages not found");
+    await focusGame("Guild Wars Reforged — Primary");
+    await clickMenu("start-performance-capture");
+    await expect(primaryPage.locator("#capture-status")).toBeVisible();
+    await expect(altPage.locator("#capture-status")).toBeHidden();
+    await fixture.app.evaluate(() => {
+      globalThis.__runtimeDialogParent = null;
+    });
     const primaryClosed = primaryPage.waitForEvent("close", { timeout: 12_000 });
     await primaryPage.evaluate(() => {
       void window.gwNative.app.requestQuit();
     });
     await primaryClosed;
+    await expect.poll(() => altPage.evaluate(() =>
+      window.gwNative.diagnostics.current().then((summary) => summary.captureLevel),
+    )).toBe(0);
+    await expect(altPage.locator("#capture-status")).toBeHidden();
+    expect(await fixture.app.evaluate(() => globalThis.__runtimeDialogParent))
+      .toBeNull();
     expect(await altPage.evaluate(() => window.gwNative.credentials.load())).toEqual({
       username: "second@example.test",
       password: "two",


### PR DESCRIPTION
## Problem

In Multiple Accounts mode, a diagnostics capture could change owners when focus moved. Capture commands, markers, export flow, and completion feedback could therefore reach a different profile from the one that started the capture.

## Solution

The capture now retains its initiating registered game window for its complete lifetime. Mark, Stop, and Export refuse a different caller; automatic and shutdown cleanup use the stored owner. Closing or crashing that owner stops the capture without selecting another profile. Automation uses the focused registered game, or the sole game when exactly one exists, and refuses ambiguity.

The two-account Electron journey proves that focus changes do not retarget a capture, the wrong profile cannot mark or stop it, the completion dialog stays with the owner, and owner closure cleans up without fallback.

## Verification

- `pnpm run check`
- `pnpm build`
- diagnostics and Multiple Accounts Electron suites: 17/18 passed in one run; one Chromium Level 2 stop exceeded the 5-second UI wait
- exact delayed Level 2 test rerun: passed
- two-profile diagnostics ownership journey: passed
- `git diff --check`

Stack: #230 → #231 → this PR.

Authored with Codex.
