### PR TITLE
refactor(contracts): make runtime states exact

### DIFF
--- a/scripts/enhancements-live.ts
+++ b/scripts/enhancements-live.ts
@@ -181,17 +181,21 @@ try {
     );
   }
 
-  const before = await page.evaluate(() => ({
-    tickCount: window.gwCompanionState?.tickCount ?? null,
-    at: performance.now(),
-  }));
+  const before = await page.evaluate(() => {
+    const state = window.gwCompanionState;
+    return {
+      tickCount: state?.status === "ready" ? state.tickCount : null,
+      at: performance.now(),
+    };
+  });
   await page.waitForTimeout(2_000);
   const cadence = await page.evaluate((start) => {
     // The Enhancement can be gone by the second read — a reload, or a client that
     // tore the hook down — and reading through it unguarded made that a page
     // TypeError that said nothing. No tick count means no ticks measured, the
     // same answer the first read already gives for the same state.
-    const tickCount = window.gwCompanionState?.tickCount ?? null;
+    const state = window.gwCompanionState;
+    const tickCount = state?.status === "ready" ? state.tickCount : null;
     return {
       ticks: start.tickCount === null || tickCount === null
         ? 0

--- a/scripts/enhancements-live/performance.ts
+++ b/scripts/enhancements-live/performance.ts
@@ -76,7 +76,8 @@ async function setCapture(
  */
 function readTickCount(page: Page): Promise<number> {
   return page.evaluate(() => {
-    const ticks = window.gwCompanionState?.tickCount;
+    const state = window.gwCompanionState;
+    const ticks = state?.status === "ready" ? state.tickCount : undefined;
     if (typeof ticks !== "number") {
       throw new Error("Enhancement state published no tick count");
     }

--- a/scripts/enhancements-live/result.ts
+++ b/scripts/enhancements-live/result.ts
@@ -14,6 +14,7 @@ export function projectLiveResult(
 ) {
   return page.evaluate(async ({ ticks, elapsedMs, scenario: name }) => {
     const state = window.gwCompanionState;
+    const ready = state?.status === "ready" ? state : null;
     const runtime = window.gwCompanionRuntime;
     const diagnostics = await window.gwNative.diagnostics.current();
     const settings = await window.gwNative.settings.get();
@@ -36,24 +37,24 @@ export function projectLiveResult(
       companionAbi: numeric(runtime?.companionAbi),
       kernelSha256:
         typeof runtime?.kernelSha256 === "string" ? runtime.kernelSha256 : null,
-      hookCount: numeric(state?.tickCount),
+      hookCount: numeric(ready?.tickCount),
       hookHertz: Number(((ticks * 1_000) / elapsedMs).toFixed(2)),
-      sequence: numeric(state?.sequence),
-      map: state?.status === "ready"
+      sequence: numeric(ready?.sequence),
+      map: ready
         ? {
-            id: state.mapId,
-            instance: state.instanceName,
-            player: { id: state.playerId, x: state.playerX, y: state.playerY },
+            id: ready.mapId,
+            instance: ready.instanceName,
+            player: { id: ready.playerId, x: ready.playerX, y: ready.playerY },
           }
         : null,
-      target: state?.targetValid
+      target: ready?.targetValid
         ? {
-            id: state.targetId,
-            type: state.targetKind,
-            x: state.targetX,
-            y: state.targetY,
-            distance: state.distance,
-            range: state.rangeName,
+            id: ready.targetId,
+            type: ready.targetKind,
+            x: ready.targetX,
+            y: ready.targetY,
+            distance: ready.distance,
+            range: ready.rangeName,
           }
         : null,
       renderUs: Number(numeric(runtime?.lastRenderUs).toFixed(2)),

--- a/scripts/enhancements-live/scenarios.ts
+++ b/scripts/enhancements-live/scenarios.ts
@@ -189,11 +189,9 @@ export async function waitForPlayable(
 /**
  * The acquired target, or the absence of one.
  *
- * Every field below is read out of the Enhancement snapshot, which the renderer
- * publishes through a global declared with an open index signature: the values
- * cross into Node as `unknown`. They are converted once, here, so that the
- * scenarios and their acceptance checks work in numbers and strings rather than
- * re-deciding what a snapshot field is at every use.
+ * Every field below is read out of the exact Enhancement snapshot. The ready
+ * discriminant is checked once here so scenarios cannot accidentally treat a
+ * waiting or installation-failure state as a partial target.
  */
 type TargetRead = { valid: false } | {
   valid: true;
@@ -208,7 +206,7 @@ type TargetRead = { valid: false } | {
 async function readTarget(page: Page): Promise<TargetRead> {
   return page.evaluate((): TargetRead => {
     const state = window.gwCompanionState;
-    return state?.targetValid
+    return state?.status === "ready" && state.targetValid
       ? {
           valid: true,
           id: Number(state.targetId),
@@ -317,10 +315,13 @@ function validateTargetAcquisition(
 }
 
 async function runMovement({ page }: { page: Page }) {
-  const before = await page.evaluate(() => ({
-    x: Number(window.gwCompanionState?.playerX),
-    y: Number(window.gwCompanionState?.playerY),
-  }));
+  const before = await page.evaluate(() => {
+    const state = window.gwCompanionState;
+    return {
+      x: Number(state?.status === "ready" ? state.playerX : undefined),
+      y: Number(state?.status === "ready" ? state.playerY : undefined),
+    };
+  });
   const viewport = await page.evaluate(() => ({
     width: window.innerWidth,
     height: window.innerHeight,
@@ -335,10 +336,13 @@ async function runMovement({ page }: { page: Page }) {
     await page.mouse.up({ button: "right" });
   }
   await page.waitForTimeout(500);
-  const after = await page.evaluate(() => ({
-    x: Number(window.gwCompanionState?.playerX),
-    y: Number(window.gwCompanionState?.playerY),
-  }));
+  const after = await page.evaluate(() => {
+    const state = window.gwCompanionState;
+    return {
+      x: Number(state?.status === "ready" ? state.playerX : undefined),
+      y: Number(state?.status === "ready" ? state.playerY : undefined),
+    };
+  });
   const distance = Math.hypot(after.x - before.x, after.y - before.y);
   // Negated rather than `distance <= 5`: a snapshot without player coordinates
   // — the state the client is in while a map loads — makes this NaN, and NaN
@@ -353,15 +357,16 @@ async function runMovement({ page }: { page: Page }) {
 async function runMapTransition({ page }: { page: Page }) {
   const readState = () => page.evaluate(() => {
     const state = window.gwCompanionState;
+    const ready = state?.status === "ready" ? state : null;
     return {
       status: state?.status ?? null,
-      reason: state?.reason ?? null,
-      mapId: Number(state?.mapId),
-      instance: state?.instanceName ?? null,
-      playerId: Number(state?.playerId),
-      x: Number(state?.playerX),
-      y: Number(state?.playerY),
-      targetValid: state?.targetValid === true,
+      reason: state && "reason" in state ? state.reason : null,
+      mapId: Number(ready?.mapId),
+      instance: ready?.instanceName ?? null,
+      playerId: Number(ready?.playerId),
+      x: Number(ready?.playerX),
+      y: Number(ready?.playerY),
+      targetValid: ready?.targetValid === true,
       // The point of the scenario: a loading snapshot must carry no map,
       // player, or target field at all. An absent state exposes nothing, which
       // is the same answer.
@@ -460,12 +465,16 @@ async function runMapTransition({ page }: { page: Page }) {
     before.mapId,
     { timeout: 5 * 60_000, polling: 100 },
   );
-  const after = await page.evaluate(() => ({
-    mapId: Number(window.gwCompanionState?.mapId),
-    instance: window.gwCompanionState?.instanceName ?? null,
-    playerId: Number(window.gwCompanionState?.playerId),
-    targetValid: window.gwCompanionState?.targetValid === true,
-  }));
+  const after = await page.evaluate(() => {
+    const state = window.gwCompanionState;
+    const ready = state?.status === "ready" ? state : null;
+    return {
+      mapId: Number(ready?.mapId),
+      instance: ready?.instanceName ?? null,
+      playerId: Number(ready?.playerId),
+      targetValid: ready?.targetValid === true,
+    };
+  });
   return {
     route: {
       fromMapId: before.mapId,

--- a/src/main/client-runtime.ts
+++ b/src/main/client-runtime.ts
@@ -23,6 +23,7 @@ import { net } from "electron";
 import {
   type ClientCompatibility,
   type ClientHealthToken,
+  type ClientSession,
   type DownloadActivity,
   type DownloadFailure,
   type ExtendedMemoryRuntimeStatus,
@@ -221,6 +222,24 @@ export class ClientRuntime {
 
   get extendedMemory(): ExtendedMemoryRuntimeStatus | null {
     return this.activeSlot.current?.extendedMemory ?? null;
+  }
+
+  session(appVersion: string): ClientSession {
+    const active = this.activeSlot.current;
+    if (!active) {
+      return {
+        appVersion,
+        compatibility: null,
+        extendedMemory: null,
+        healthToken: null,
+      };
+    }
+    return {
+      appVersion,
+      compatibility: this.compatibility,
+      extendedMemory: active.extendedMemory,
+      healthToken: this.candidateHealthToken,
+    };
   }
 
   get progress(): DownloadProgress {

--- a/src/main/core/steam-session.ts
+++ b/src/main/core/steam-session.ts
@@ -112,15 +112,14 @@ export type SteamResolutionNote =
   | { note: "acquireFailed"; code: ErrorCode }
   | { note: "storeFailed"; code: ErrorCode };
 
-export interface SteamResolution {
-  token: string | null;
+export type SteamTokenAcquisition =
+  | { token: string; refusal?: never }
+  | { token: null; refusal?: never }
+  | { token: null; refusal: SteamRefusalReason };
+
+export type SteamResolution = SteamTokenAcquisition & {
   notes: SteamResolutionNote[];
-  /**
-   * Why an interactive sign-in produced no token, for the renderer's status
-   * line. Absent when a token was vended or when nothing interactive ran.
-   */
-  refusal?: SteamRefusalReason;
-}
+};
 
 export interface SteamResolutionOptions {
   /**
@@ -130,7 +129,7 @@ export interface SteamResolutionOptions {
    */
   silent: boolean;
   /** Runs the sign-in flow. A `null` token carries why it did not complete. */
-  acquire: () => Promise<{ token: string | null; refusal?: SteamRefusalReason }>;
+  acquire: () => Promise<SteamTokenAcquisition>;
   now?: number;
 }
 
@@ -188,7 +187,7 @@ export async function resolveSteamToken(
     await store.clear().catch(() => undefined);
   }
 
-  let acquired: { token: string | null; refusal?: SteamRefusalReason };
+  let acquired: SteamTokenAcquisition;
   try {
     acquired = await options.acquire();
   } catch (error) {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -37,7 +37,6 @@ import type {
   RevealKind,
   SocketEvent,
   SettingsResetOutcome,
-  SteamRefusalReason,
   SteamTokenResult,
   StoredCredentials,
   TemplateExportEntry,
@@ -89,6 +88,7 @@ import { exportTemplates, parseExportEntries } from "./template-export.js";
 import {
   MAX_TOKEN_LENGTH,
   SteamSessionCoordinator,
+  type SteamTokenAcquisition,
   type SteamSessionStore,
   steamTokenOutcome,
 } from "./core/steam-session.js";
@@ -891,7 +891,7 @@ export function registerSteamIpcHandlers(
 
   const runSteamSignIn = async (
     win: BrowserWindow,
-  ): Promise<{ token: string | null; refusal?: SteamRefusalReason }> => {
+  ): Promise<SteamTokenAcquisition> => {
     const result = await acquireSteamToken(win, (event) => {
       if (event.k === "opened") logEvent({ k: "steam.signInOpened" });
       if (event.k === "blocked") {
@@ -936,10 +936,16 @@ export function registerSteamIpcHandlers(
         outcome: steamTokenOutcome(resolution),
         silent,
       });
-      return {
-        token: resolution.token,
-        ...(resolution.refusal ? { reason: resolution.refusal } : {}),
-      } satisfies SteamTokenResult;
+      if (resolution.token) {
+        return { token: resolution.token } satisfies SteamTokenResult;
+      }
+      if (resolution.refusal) {
+        return {
+          token: null,
+          reason: resolution.refusal,
+        } satisfies SteamTokenResult;
+      }
+      return { token: null } satisfies SteamTokenResult;
     }),
 
     steamStore: channel(asSteamStoreback, async (win, { token, expiry }) => {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -667,12 +667,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
       updateRestartInFlight = operation;
       return operation;
     },
-    getClientSession: () => ({
-      appVersion: HOST_VERSION,
-      compatibility: clientRuntime.compatibility,
-      extendedMemory: clientRuntime.extendedMemory,
-      healthToken: clientRuntime.healthToken,
-    }),
+    getClientSession: () => clientRuntime.session(HOST_VERSION),
     recordClientFeatureFailure: (features) => {
       clientRuntime.recordRendererFeatureFailure(features);
     },

--- a/src/renderer/companion-observer.ts
+++ b/src/renderer/companion-observer.ts
@@ -15,6 +15,7 @@ import {
   type CompanionPartyState,
   type CompanionSnapshot,
   type CompanionToolboxState,
+  type PublishedCompanionState,
   readChangedCompanionParty,
   readChangedCompanionToolbox,
   readCompanionSnapshot,
@@ -52,12 +53,12 @@ type ToolboxConsumer = {
   }): void;
 };
 
-export function recordCompanionLifecycle(state: CompanionState) {
+export function recordCompanionLifecycle(state: PublishedCompanionState) {
   if (state.status === "ready") {
     window.gwAutomation?.set(
       state.instanceType === 1 ? "game.explorable" : "game.outpost",
     );
-  } else if (state.reason === "loading") {
+  } else if ("reason" in state && state.reason === "loading") {
     window.gwAutomation?.set("game.loading");
   } else if (state.status === "unsupported") {
     window.gwAutomation?.set("enhancement.unsupported");
@@ -79,7 +80,7 @@ export function observeCompanion(
   let toolboxSequence: number | null = null;
   let previousParty: CompanionPartyState | null = null;
   let partySequence: number | null = null;
-  let publishedState: CompanionState | null = null;
+  let publishedState: PublishedCompanionState | null = null;
   const observe = () => {
     if (observeState) {
       const started = performance.now();

--- a/src/renderer/companion-snapshot.ts
+++ b/src/renderer/companion-snapshot.ts
@@ -186,6 +186,12 @@ export function readCompanionSnapshot(buffer: ArrayBuffer, pointer: number) {
 /** The decoder-owned, discriminated game-state contract used by consumers. */
 export type CompanionSnapshot = ReturnType<typeof readCompanionSnapshot>;
 
+/** The exact state an observer may publish outside the installer. */
+export type PublishedCompanionState =
+  | CompanionSnapshot
+  | Readonly<{ status: "unsupported" }>
+  | Readonly<{ status: "error"; reason: string }>;
+
 /* The cursor bitmap lives in its own region: the core snapshot is full, and
    4 KB of pixels do not belong in a per-frame read. */
 export const COMPANION_CURSOR_ABI = COMPANION_ABI.cursor.abi;

--- a/src/renderer/gw-native.d.ts
+++ b/src/renderer/gw-native.d.ts
@@ -17,6 +17,7 @@ import type {
   RendererMetrics,
 } from "../shared/diagnostics.js";
 import type { ToolboxObservation } from "../shared/builds/live-party.js";
+import type { PublishedCompanionState } from "./companion-snapshot.js";
 import type {
   InputTrace as SharedInputTrace,
   InputTraceEntry as SharedInputTraceEntry,
@@ -130,14 +131,6 @@ declare global {
     flush(): Promise<void>;
   }
 
-  interface CompanionState {
-    status?: string;
-    reason?: string;
-    instanceType?: number;
-    tickCount?: number;
-    [key: string]: unknown;
-  }
-
   interface CompanionDeveloperRuntime {
     readonly status: "installed";
     readonly buildId: number;
@@ -221,7 +214,7 @@ declare global {
       buildId: number;
     }>;
     gwCompanionRuntime?: CompanionDeveloperRuntime | CompanionObserverRuntime | null;
-    gwCompanionState?: CompanionState;
+    gwCompanionState?: PublishedCompanionState;
     /** The cursor's bounded presentation state; present once the nativeCursor enhancement installs. */
     gwCursorState?(): Readonly<{
       generation: number;

--- a/src/renderer/loading.ts
+++ b/src/renderer/loading.ts
@@ -25,7 +25,9 @@ window.gwAutomation = (function (): EnhancementAutomation {
         sequence,
         transitions: history.slice(),
         enhancementStatus: enhancement?.status ?? 'not-installed',
-        tickCount: enhancement?.tickCount ?? 0,
+        tickCount: enhancement && "tickCount" in enhancement
+          ? enhancement.tickCount
+          : 0,
       });
     },
   });

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -451,10 +451,10 @@ export type SteamRefusalReason =
  * interactive sign-in ran and did not complete; a silent probe with nothing
  * stored answers `{ token: null }` alone, which is a normal launch, not news.
  */
-export interface SteamTokenResult {
-  token: string | null;
-  reason?: SteamRefusalReason;
-}
+export type SteamTokenResult =
+  | { token: string; reason?: never }
+  | { token: null; reason?: never }
+  | { token: null; reason: SteamRefusalReason };
 
 export type ExternalLinkKind =
   | "github"
@@ -634,17 +634,26 @@ export interface ClientHealthToken {
 }
 
 /**
- * What this session is running. `compatibility` is `null` only before a client
- * has been activated; `appVersion` is always known, because a user filing a bug
- * should not have to hunt through the menu bar for it. `healthToken` exists
- * only while the active generation is awaiting renderer health evidence.
+ * What this session is running. A `null` memory result identifies preparation;
+ * an active client always carries the selected memory result. Compatibility
+ * may still be `null` for the official fallback when its hash cannot be read.
+ * `appVersion` is always known, because a user filing a bug should not have to
+ * hunt through the menu bar for it. `healthToken` exists only while the active
+ * generation is awaiting renderer health evidence.
  */
-export interface ClientSession {
-  appVersion: string;
-  compatibility: ClientCompatibility | null;
-  extendedMemory: ExtendedMemoryRuntimeStatus | null;
-  healthToken: ClientHealthToken | null;
-}
+export type ClientSession =
+  | {
+      appVersion: string;
+      compatibility: null;
+      extendedMemory: null;
+      healthToken: null;
+    }
+  | {
+      appVersion: string;
+      compatibility: ClientCompatibility | null;
+      extendedMemory: ExtendedMemoryRuntimeStatus;
+      healthToken: ClientHealthToken | null;
+    };
 
 /**
  * Everything the renderer must know before its first script runs. It used to

--- a/tests/electron/client-runtime-concurrency.spec.ts
+++ b/tests/electron/client-runtime-concurrency.spec.ts
@@ -71,6 +71,7 @@ test.describe("client generation coordination", () => {
             },
             onPrefetch: () => undefined,
           });
+          const preparingSession = runtime.session("test-app");
           let refusal: string | null = null;
           try {
             runtime.publishProgress({
@@ -84,7 +85,7 @@ test.describe("client generation coordination", () => {
               ? String(error.code)
               : null;
           }
-          runtime.activeSlot.publish({
+          const active = runtime.activeSlot.publish({
             artifactsDir: paths.artifacts,
             store: {
               stop: () => undefined,
@@ -100,6 +101,11 @@ test.describe("client generation coordination", () => {
               fallbackReason: null,
             },
           });
+          runtime.candidateHealthToken = Object.freeze({
+            generation: active.generation,
+            fingerprint: "f".repeat(64),
+          });
+          const activeSession = runtime.session("test-app");
           runtime.publishProgress({
             phase: "ready",
             received: 0,
@@ -108,13 +114,33 @@ test.describe("client generation coordination", () => {
           });
           await runtime.shutdown();
           await fs.rm(root, { recursive: true, force: true });
-          return { refusal, readyObservations };
+          return { refusal, readyObservations, preparingSession, activeSession };
         },
         { clientRuntime: clientRuntimeModule, paths: pathsModule },
       );
       expect(result).toEqual({
         refusal: "not_ready",
         readyObservations: [true],
+        preparingSession: {
+          appVersion: "test-app",
+          compatibility: null,
+          extendedMemory: null,
+          healthToken: null,
+        },
+        activeSession: {
+          appVersion: "test-app",
+          compatibility: null,
+          extendedMemory: {
+            requestedAtLaunch: false,
+            status: "standard",
+            effectiveCapBytes: 2_147_483_648,
+            fallbackReason: null,
+          },
+          healthToken: {
+            generation: 1,
+            fingerprint: "f".repeat(64),
+          },
+        },
       });
     } finally {
       await closeOffline(fixture);
@@ -655,6 +681,7 @@ test.describe("client generation coordination", () => {
             preparedExtendedMemory: prepared.extendedMemory,
             activeCompatibility: runtime.compatibility,
             activeExtendedMemory: runtime.extendedMemory,
+            session: runtime.session("test-app"),
           };
           await runtime.shutdown();
           await fs.rm(root, { recursive: true, force: true });
@@ -675,6 +702,17 @@ test.describe("client generation coordination", () => {
       expect(result.activeExtendedMemory).toMatchObject({
         status: "active",
         effectiveCapBytes: 4_294_967_296,
+      });
+      expect(result.session).toMatchObject({
+        appVersion: "test-app",
+        compatibility: {
+          clientSha256: "a".repeat(64),
+        },
+        extendedMemory: {
+          status: "active",
+          effectiveCapBytes: 4_294_967_296,
+        },
+        healthToken: null,
       });
     } finally {
       await closeOffline(fixture);

--- a/tests/unit/client-compatibility-notice.test.ts
+++ b/tests/unit/client-compatibility-notice.test.ts
@@ -7,6 +7,13 @@ import {
 } from "../../src/renderer/client-compatibility-notice.js";
 import type { ClientCompatibility, ClientSession } from "../../src/shared/contracts.js";
 
+const STANDARD_MEMORY = Object.freeze({
+  requestedAtLaunch: false,
+  status: "standard",
+  effectiveCapBytes: 2_147_483_648,
+  fallbackReason: null,
+} as const);
+
 const available = { status: "available" } as const;
 const off = { status: "off" } as const;
 const unavailable = (reason: "game-update" | "preparation-failed") =>
@@ -240,6 +247,7 @@ describe("client compatibility notice", () => {
 
     const session: ClientSession = {
       ...before,
+      extendedMemory: STANDARD_MEMORY,
       compatibility: compatibility({ nativeCursor: unavailable("game-update") }),
     };
     const report = renderClientCompatibility(dom.root, session);

--- a/tests/unit/effective-enhancement-capabilities.test.ts
+++ b/tests/unit/effective-enhancement-capabilities.test.ts
@@ -14,6 +14,12 @@ import {
 
 const available = Object.freeze({ status: "available" } as const);
 const off = Object.freeze({ status: "off" } as const);
+const standardMemory = Object.freeze({
+  requestedAtLaunch: false,
+  status: "standard",
+  effectiveCapBytes: 2_147_483_648,
+  fallbackReason: null,
+} as const);
 
 function session(capabilities: EnhancementCapabilities): ClientSession {
   const selected = (active: boolean): OptionalFeatureStatus =>
@@ -34,7 +40,7 @@ function session(capabilities: EnhancementCapabilities): ClientSession {
   return {
     appVersion: "test",
     compatibility,
-    extendedMemory: null,
+    extendedMemory: standardMemory,
     healthToken: null,
   };
 }
@@ -56,6 +62,7 @@ describe("effective Enhancement capability boundary", () => {
     const original = session(capabilities);
     const value: ClientSession = {
       ...original,
+      extendedMemory: standardMemory,
       compatibility: {
         ...original.compatibility!,
         features: {

--- a/tests/unit/enhancements-are-derived-from-their-registry.test.ts
+++ b/tests/unit/enhancements-are-derived-from-their-registry.test.ts
@@ -258,7 +258,12 @@ test("renderer consumes main's effective subset instead of launch intent", () =>
   assert.deepEqual(effectiveCapabilities({
     appVersion: "test",
     healthToken: null,
-    extendedMemory: null,
+    extendedMemory: {
+      requestedAtLaunch: false,
+      status: "standard",
+      effectiveCapBytes: 2_147_483_648,
+      fallbackReason: null,
+    },
     compatibility: {
       clientSha256: "a".repeat(64),
       features: {

--- a/tests/unit/runtime-states-are-exact.test.ts
+++ b/tests/unit/runtime-states-are-exact.test.ts
@@ -1,0 +1,48 @@
+/** Compile-time and runtime proofs for exact renderer-facing state unions. */
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {
+  ClientSession,
+  SteamTokenResult,
+} from "../../src/shared/contracts.js";
+import type {
+  PublishedCompanionState,
+} from "../../src/renderer/companion-snapshot.js";
+
+const preparing = {
+  appVersion: "test",
+  compatibility: null,
+  extendedMemory: null,
+  healthToken: null,
+} satisfies ClientSession;
+
+const unsupported = {
+  status: "unsupported",
+} satisfies PublishedCompanionState;
+
+const refused = {
+  token: null,
+  reason: "cancelled",
+} satisfies SteamTokenResult;
+
+// @ts-expect-error a refusal and a token cannot describe one Steam result.
+const tokenWithRefusal: SteamTokenResult = { token: "secret", reason: "failed" };
+// @ts-expect-error a preparing session cannot already carry a health token.
+const preparingWithHealth: ClientSession = {
+  ...preparing,
+  healthToken: { generation: 1, fingerprint: "candidate" },
+};
+const unsupportedWithTick: PublishedCompanionState = {
+  status: "unsupported",
+  // @ts-expect-error an unsupported installation cannot invent snapshot fields.
+  tickCount: 1,
+};
+
+test("runtime states admit only their complete valid phases", () => {
+  assert.equal(preparing.extendedMemory, null);
+  assert.equal(unsupported.status, "unsupported");
+  assert.deepEqual(refused, { token: null, reason: "cancelled" });
+  assert.equal(tokenWithRefusal.token, "secret");
+  assert.equal(preparingWithHealth.healthToken?.generation, 1);
+  assert.equal(unsupportedWithTick.status, "unsupported");
+});

--- a/tests/unit/steam-session.test.ts
+++ b/tests/unit/steam-session.test.ts
@@ -14,6 +14,7 @@ import {
   SteamSessionStore,
   steamTokenOutcome,
   type SteamSessionReader,
+  type SteamTokenAcquisition,
   type StoredSteamSession,
 } from "../../src/main/core/steam-session.js";
 import { AppError } from "../../src/shared/errors.js";
@@ -197,7 +198,7 @@ function fakeStore(
   };
 }
 
-type AcquireAnswer = { token: string | null; refusal?: SteamRefusalReason };
+type AcquireAnswer = SteamTokenAcquisition;
 
 /** An acquisition that records whether it was reached at all. */
 function fakeAcquire(
@@ -209,7 +210,8 @@ function fakeAcquire(
   let calls = 0;
   const acquire = async (): Promise<AcquireAnswer> => {
     calls += 1;
-    return { token, ...(refusal ? { refusal } : {}) };
+    if (token) return { token };
+    return refusal ? { token: null, refusal } : { token: null };
   };
   return Object.defineProperty(acquire, "calls", {
     get: () => calls,


### PR DESCRIPTION
## Problem

Several renderer-facing states allowed combinations the application never produces. A Companion installation failure could appear to carry snapshot fields, Steam could appear to return both a token and a refusal, and client preparation could appear to have active-session facts. These loose shapes made consumers guess which fields were real.

## Solution

Companion publication, Steam token results, and client sessions are now exact unions. `ClientRuntime.session(appVersion)` is the sole owner of the correlated client snapshot, including the legitimate active fallback whose compatibility is unavailable. Live Enhancement tooling now narrows the real Companion status before reading snapshot fields instead of relying on the former open property bag.

Compile-negative tests make the impossible combinations fail type checking. Runtime tests cover preparing, active certified, active uncertified, and candidate-health sessions without changing the wire payload or persisted data.

## Verification

- `pnpm run check`
- `pnpm build`
- client-runtime Electron suite: 11/11 passed
- focused Steam, compatibility, capability, and exact-state tests: 68/68 passed
- `git diff --check`

Authored with Codex.
