### PR TITLE
fix(window): keep the app menu with its focused account

### DIFF
--- a/src/main/window-menu.ts
+++ b/src/main/window-menu.ts
@@ -35,20 +35,29 @@ import {
   resolveShortcuts,
   shortcutAccelerator,
 } from "../shared/keyboard-shortcuts.js";
+import { windowRegistry } from "./window-registry.js";
 
 const USER_GUIDE_URL = `${EXTERNAL_URLS.github}/blob/main/docs/user-guide.md`;
 
 export interface ApplicationMenuActions {
   host: WindowHost;
-  win: BrowserWindow;
   shortcuts?: ReturnType<typeof resolveShortcuts>;
   /** Window state stays window.ts's; the menu only asks for the reset. */
-  resetWindowState: () => Promise<void>;
+  resetWindowState: (win: BrowserWindow) => Promise<void>;
+}
+
+function withGameOwner(
+  run: (win: BrowserWindow) => void | Promise<void>,
+): () => void | Promise<void> {
+  return () => {
+    const win = windowRegistry.focusedOrSoleGameWindow();
+    if (!win) return;
+    return run(win);
+  };
 }
 
 export function installApplicationMenu({
   host,
-  win,
   shortcuts = resolveShortcuts({}),
   resetWindowState,
 }: ApplicationMenuActions): void {
@@ -68,22 +77,22 @@ export function installApplicationMenu({
               { type: "separator" as const },
               {
                 label: "Check for Updates…",
-                click: async () => {
+                click: withGameOwner(async (win) => {
                   await resetGameInput(win);
                   await sendRendererCommand(win, {
                     type: "settings.open",
                     pane: "updates",
                     checkForUpdates: true,
                   });
-                },
+                }),
               },
               {
                 label: "Settings…",
                 accelerator: "CmdOrCtrl+,",
-                click: async () => {
+                click: withGameOwner(async (win) => {
                   await resetGameInput(win);
                   await sendRendererCommand(win, { type: "settings.open" });
-                },
+                }),
               },
               { type: "separator" as const },
               { role: "hide" as const },
@@ -114,12 +123,12 @@ export function installApplicationMenu({
         {
           id: "reset-window-state",
           label: "Reset Window Size and Position",
-          click: async () => {
+          click: withGameOwner(async (win) => {
             await resetGameInput(win);
-            void resetWindowState().catch(() => {
+            void resetWindowState(win).catch(() => {
               logEvent({ k: "window.stateResetFailed" });
             });
-          },
+          }),
         },
         { type: "separator" },
         {
@@ -134,36 +143,36 @@ export function installApplicationMenu({
           // without binding it a second time and firing twice.
           ...(toolsAccelerator ? { accelerator: toolsAccelerator } : {}),
           registerAccelerator: false,
-          click: () => toggleTools(win),
+          click: withGameOwner((win) => toggleTools(win)),
         },
         {
           id: "open-xunlai-storage",
           label: "Open Xunlai Storage",
           ...(storageAccelerator ? { accelerator: storageAccelerator } : {}),
           registerAccelerator: false,
-          click: () => openStorage(win),
+          click: withGameOwner((win) => openStorage(win)),
         },
         {
           id: "open-travel",
           label: "Open Travel",
           ...(travelAccelerator ? { accelerator: travelAccelerator } : {}),
           registerAccelerator: false,
-          click: () => toggleTravel(win),
+          click: withGameOwner((win) => toggleTravel(win)),
         },
         {
           label: "Toggle Diagnostics",
-          click: async () => {
+          click: withGameOwner(async (win) => {
             await resetGameInput(win);
             const cur = await host.getSettings();
             await host.updateSettings({ showDiagnostics: !cur.showDiagnostics });
             await sendRendererCommand(win, { type: "diagnostics.toggle" });
-          },
+          }),
         },
         {
           id: "reload-game",
           label: "Reload Game",
           accelerator: "CmdOrCtrl+R",
-          click: async () => {
+          click: withGameOwner(async (win) => {
             await resetGameInput(win);
             if (host.sockets.size(win.webContents.id) > 0) {
               const { response } = await dialog.showMessageBox(win, {
@@ -177,7 +186,7 @@ export function installApplicationMenu({
               if (response !== 0) return;
             }
             host.reloadGame(win);
-          },
+          }),
         },
         ...(dev
           ? [
@@ -205,18 +214,18 @@ export function installApplicationMenu({
         {
           id: "report-bug",
           label: "Report a Bug…",
-          click: async () => {
+          click: withGameOwner(async (win) => {
             await resetGameInput(win);
             await shell.openExternal(EXTERNAL_URLS.bugReport);
-          },
+          }),
         },
         {
           id: "request-feature",
           label: "Request a Feature…",
-          click: async () => {
+          click: withGameOwner(async (win) => {
             await resetGameInput(win);
             await shell.openExternal(EXTERNAL_URLS.featureRequest);
-          },
+          }),
         },
         // Diagnostics are optional support tools, never a gate before filing
         // an issue. ⌘⇧M stays global for an active performance capture.
@@ -226,16 +235,16 @@ export function installApplicationMenu({
             {
               id: "export-diagnostics",
               label: "Export Recent Diagnostics…",
-              click: async () => {
+              click: withGameOwner(async (win) => {
                 await resetGameInput(win);
                 await exportDiagnosticsReport(win, () => host.exportDiagnostics(win));
-              },
+              }),
             },
             { type: "separator" },
             {
               id: "start-performance-capture",
               label: "Start Performance Capture",
-              click: async () => {
+              click: withGameOwner(async (win) => {
                 await resetGameInput(win);
                 void host.startCapture(win, 1).catch((error) => {
                   void dialog.showMessageBox(win, {
@@ -245,21 +254,21 @@ export function installApplicationMenu({
                     detail: error instanceof Error ? error.message : String(error),
                   }).catch(() => undefined);
                 });
-              },
+              }),
             },
             {
               id: "mark-performance-problem",
               label: "Mark Performance Problem",
               accelerator: "CmdOrCtrl+Shift+M",
-              click: async () => {
+              click: withGameOwner(async (win) => {
                 await resetGameInput(win);
                 host.markPerformanceProblem(win);
-              },
+              }),
             },
             {
               id: "start-chromium-trace",
               label: "Start Chromium Trace",
-              click: async () => {
+              click: withGameOwner(async (win) => {
                 await resetGameInput(win);
                 void host.startCapture(win, 2).catch((error) => {
                   void dialog.showMessageBox(win, {
@@ -269,7 +278,7 @@ export function installApplicationMenu({
                     detail: error instanceof Error ? error.message : String(error),
                   }).catch(() => undefined);
                 });
-              },
+              }),
             },
             // The trace answers a different question from a capture — what the
             // input host decided, not what the frame cost — so it is its own
@@ -278,18 +287,18 @@ export function installApplicationMenu({
             {
               id: "toggle-input-trace",
               label: "Show Input Trace",
-              click: async () => {
+              click: withGameOwner(async (win) => {
                 const enabled = !inputTraceEnabled(win);
                 await setInputTraceVisibility(win, enabled, sendRendererCommand);
-              },
+              }),
             },
             {
               id: "stop-capture",
               label: "Stop Capture",
-              click: async () => {
+              click: withGameOwner(async (win) => {
                 await resetGameInput(win);
                 void host.stopCapture(win).catch(() => undefined);
-              },
+              }),
             },
           ],
         },

--- a/src/main/window-registry.ts
+++ b/src/main/window-registry.ts
@@ -117,6 +117,10 @@ export class WindowRegistry<Window extends RegisteredWindow = BrowserWindow> {
     return this.windows((context) => context.role === "game");
   }
 
+  focusedWindow(): Window | null {
+    return this.windows().find((win) => win.isFocused()) ?? null;
+  }
+
   focusedGameWindow(): Window | null {
     return this.gameWindows().find((win) => win.isFocused()) ?? null;
   }

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -472,6 +472,19 @@ export function createMainWindow(
   // The View menu item carries the same accelerator with
   // `registerAccelerator: false`, so the shortcut is still shown and
   // discoverable without also being bound and fired twice.
+  let menuShortcuts: Parameters<typeof installApplicationMenu>[0]["shortcuts"];
+  const installMenu = () => {
+    // The application menu is global. Settings can finish loading in any game
+    // window, so an unfocused window must never replace the focused owner's
+    // menu with callbacks that close over itself.
+    if (BrowserWindow.getFocusedWindow() !== win) return;
+    installApplicationMenu({
+      host,
+      win,
+      ...(menuShortcuts ? { shortcuts: menuShortcuts } : {}),
+      resetWindowState: () => resetWindowState(win),
+    });
+  };
   installWindowShortcuts(win, {
     run(action) {
       if (action === "tools.toggle") void toggleTools(win);
@@ -479,12 +492,8 @@ export function createMainWindow(
       else void toggleTravel(win);
     },
     changed(shortcuts) {
-      installApplicationMenu({
-        host,
-        win,
-        shortcuts,
-        resetWindowState: () => resetWindowState(win),
-      });
+      menuShortcuts = shortcuts;
+      installMenu();
     },
   });
   void host.getSettings().then((settings) => {
@@ -610,11 +619,6 @@ export function createMainWindow(
     ) host.gameWindowClosed?.();
   });
 
-  const installMenu = () => installApplicationMenu({
-    host,
-    win,
-    resetWindowState: () => resetWindowState(win),
-  });
   win.on("focus", installMenu);
   installMenu();
   void win.loadURL(RENDERER_URL);

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -477,12 +477,14 @@ export function createMainWindow(
     // The application menu is global. Settings can finish loading in any game
     // window, so an unfocused window must never replace the focused owner's
     // menu with callbacks that close over itself.
-    if (BrowserWindow.getFocusedWindow() !== win) return;
+    const focused = windowRegistry.focusedWindow();
+    if (focused ? focused !== win : windowRegistry.gameWindows().length !== 1) {
+      return;
+    }
     installApplicationMenu({
       host,
-      win,
       ...(menuShortcuts ? { shortcuts: menuShortcuts } : {}),
-      resetWindowState: () => resetWindowState(win),
+      resetWindowState,
     });
   };
   installWindowShortcuts(win, {

--- a/tests/electron/fixtures.mts
+++ b/tests/electron/fixtures.mts
@@ -40,6 +40,14 @@ export async function isDomActiveElement(target: Locator): Promise<boolean> {
   );
 }
 
+const removeUserData = (userData: string): Promise<void> =>
+  rm(userData, {
+    recursive: true,
+    force: true,
+    maxRetries: 5,
+    retryDelay: 100,
+  });
+
 export async function launchOffline(
   prefix: string,
   environment: Record<string, string> = {},
@@ -50,7 +58,7 @@ export async function launchOffline(
     await prepare(userData);
     return await launchOfflineAt(userData, environment);
   } catch (error) {
-    await rm(userData, { recursive: true, force: true });
+    await removeUserData(userData);
     throw error;
   }
 }
@@ -178,5 +186,5 @@ async function stopElectron(app: ElectronApplication): Promise<void> {
 
 export async function closeOffline(fixture: OfflineFixture): Promise<void> {
   await stopElectron(fixture.app);
-  await rm(fixture.userData, { recursive: true, force: true });
+  await removeUserData(fixture.userData);
 }

--- a/tests/unit/window-registry.test.ts
+++ b/tests/unit/window-registry.test.ts
@@ -114,9 +114,11 @@ describe("window registry", () => {
     registry.register(win, { mode: "single", role: "game" });
     assert.equal(registry.windowForWebContents(7), win);
     assert.equal(registry.windowForWebContents(8), null);
+    assert.equal(registry.focusedWindow(), null);
     assert.equal(registry.focusedGameWindow(), null);
     assert.equal(registry.focusedOrSoleGameWindow(), win);
     focused = true;
+    assert.equal(registry.focusedWindow(), win);
     assert.equal(registry.focusedGameWindow(), win);
   });
 


### PR DESCRIPTION
## Problem

The app menu is global, but each game window installed callbacks that closed over itself. In Multiple Accounts mode, an unfocused window could finish loading Settings after focus changed and silently replace the focused account's menu. A diagnostic command could then target the wrong profile. The hosted gate exposed this as a flaky owner-isolation test.

## Solution

- Install a window's application menu only while that exact registered window is focused.
- Resolve focus through `WindowRegistry`, keeping it as the sole native-window authority.
- Retain each window's latest shortcut presentation until it next owns focus.
- Retry recursive removal of temporary Electron profiles when Chromium finishes a late partition write during teardown.

## Verification

- `pnpm run check` — 1,162 unit, 172 policy, and 96 Tools tests passed.
- `pnpm build` passed.
- The focused Multiple Accounts ownership journey passed, including account-local memory and diagnostics targeting.
- The owner-targeting tail passed on every local run that reached it; two stress repeats stopped earlier on the existing macOS foreground-focus limitation, not the owner assertions.
- `git diff --check` passed.

Authored with Codex.
