### PR TITLE
fix(persistence): preserve corrupt player documents consistently

### DIFF
--- a/src/main/core/build-library.ts
+++ b/src/main/core/build-library.ts
@@ -34,18 +34,17 @@
  * and `onRecovered` fires — the caller is expected to tell somebody, not to
  * treat the empty result as normal.
  */
-import { readdir, readFile, rename, unlink } from "node:fs/promises";
-import { basename, dirname, join } from "node:path";
+import { readFile } from "node:fs/promises";
 import type { BuildId, BuildLibrary } from "../../shared/builds/library.js";
 import {
   EMPTY_LIBRARY,
   parseBuildLibrary,
 } from "../../shared/builds/parse-library.js";
 import { writeAtomicJson, writeAtomicJsonExclusive } from "./atomic-file.js";
+import { quarantineCorruptDocument } from "./corrupt-document.js";
 
 /** Owner-only: a build library is a player's own work, not shared state. */
 const LIBRARY_MODE = 0o600;
-const CORRUPT_BACKUPS_KEPT = 3;
 
 export async function loadBuildLibrary(
   path: string,
@@ -81,38 +80,9 @@ async function recoverCorruptLibrary(
   path: string,
   onRecovered: ((backupPath: string) => void | Promise<void>) | undefined,
 ): Promise<BuildLibrary> {
-  const backupPath = `${path}.corrupt-${Date.now()}`;
-  try {
-    await rename(path, backupPath);
-  } catch (e) {
-    const err = e as NodeJS.ErrnoException;
-    if (err.code !== "ENOENT") throw e;
-    return EMPTY_LIBRARY;
-  }
-  await pruneCorruptBackups(path);
-  await onRecovered?.(backupPath);
+  const backupPath = await quarantineCorruptDocument(path);
+  if (backupPath) await onRecovered?.(backupPath);
   return EMPTY_LIBRARY;
-}
-
-/** Keep the three newest backups, as `settings.ts` does, and for the same reason. */
-async function pruneCorruptBackups(libraryPath: string): Promise<void> {
-  const directory = dirname(libraryPath);
-  const prefix = `${basename(libraryPath)}.corrupt-`;
-  let names: string[];
-  try {
-    names = await readdir(directory);
-  } catch {
-    return;
-  }
-  const stale = names
-    .filter((name) => name.startsWith(prefix))
-    .map((name) => ({ name, at: Number(name.slice(prefix.length)) }))
-    .filter(({ at }) => Number.isSafeInteger(at))
-    .sort((left, right) => right.at - left.at)
-    .slice(CORRUPT_BACKUPS_KEPT);
-  await Promise.all(
-    stale.map(({ name }) => unlink(join(directory, name)).catch(() => undefined)),
-  );
 }
 
 /**

--- a/src/main/core/corrupt-document.ts
+++ b/src/main/core/corrupt-document.ts
@@ -1,0 +1,69 @@
+/**
+ * Preserve one unreadable player document and bound only the backups this
+ * helper owns. Domain loaders still decide their defaults and notifications.
+ */
+import { randomUUID } from "node:crypto";
+import { readdir, rename, unlink } from "node:fs/promises";
+import { basename, dirname, join } from "node:path";
+
+const CORRUPT_BACKUPS_KEPT = 3;
+
+function backupTimestamp(name: string, prefix: string): number | null {
+  const suffix = name.slice(prefix.length);
+  const match = /^(\d+)(?:-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})?$/u
+    .exec(suffix);
+  if (!match) return null;
+  const timestamp = Number(match[1]);
+  return Number.isSafeInteger(timestamp) ? timestamp : null;
+}
+
+async function pruneCorruptBackups(
+  documentPath: string,
+  preservedBackup: string,
+): Promise<void> {
+  const directory = dirname(documentPath);
+  const prefix = `${basename(documentPath)}.corrupt-`;
+  let names: string[];
+  try {
+    names = await readdir(directory);
+  } catch {
+    return;
+  }
+  const preservedName = basename(preservedBackup);
+  const backups = names
+    .filter((name) => name.startsWith(prefix))
+    .map((name) => ({ name, timestamp: backupTimestamp(name, prefix) }))
+    .filter(
+      (entry): entry is { name: string; timestamp: number } =>
+        entry.timestamp !== null,
+    )
+    .sort((left, right) =>
+      right.timestamp - left.timestamp || right.name.localeCompare(left.name));
+  const keep = new Set([
+    preservedName,
+    ...backups
+      .filter(({ name }) => name !== preservedName)
+      .slice(0, CORRUPT_BACKUPS_KEPT - 1)
+      .map(({ name }) => name),
+  ]);
+  await Promise.all(
+    backups
+      .filter(({ name }) => !keep.has(name))
+      .map(({ name }) => unlink(join(directory, name)).catch(() => undefined)),
+  );
+}
+
+/** Move an existing document aside without replacing earlier recovery data. */
+export async function quarantineCorruptDocument(
+  documentPath: string,
+): Promise<string | null> {
+  const backupPath = `${documentPath}.corrupt-${Date.now()}-${randomUUID()}`;
+  try {
+    await rename(documentPath, backupPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+  await pruneCorruptBackups(documentPath, backupPath);
+  return backupPath;
+}

--- a/src/main/core/preferences-coordinator.ts
+++ b/src/main/core/preferences-coordinator.ts
@@ -81,9 +81,16 @@ async function saveSettingsAndReconcile(
 export class PreferencesCoordinator {
   readonly #lock = new Mutex();
   readonly #paths: () => PreferencesPaths;
+  readonly #onTravelRecovered:
+    | ((backupPath: string) => void | Promise<void>)
+    | undefined;
 
-  constructor(paths: () => PreferencesPaths) {
+  constructor(
+    paths: () => PreferencesPaths,
+    onTravelRecovered?: (backupPath: string) => void | Promise<void>,
+  ) {
     this.#paths = paths;
+    this.#onTravelRecovered = onTravelRecovered;
   }
 
   getSettings(): Promise<AppSettings> {
@@ -107,7 +114,10 @@ export class PreferencesCoordinator {
       );
       let currentTravel: TravelPreferencesDocument;
       try {
-        currentTravel = await loadTravelPreferences(paths.travelPreferences);
+        currentTravel = await loadTravelPreferences(
+          paths.travelPreferences,
+          this.#onTravelRecovered,
+        );
       } catch {
         return Object.freeze({
           status: "partial",
@@ -125,15 +135,22 @@ export class PreferencesCoordinator {
       }
       let travel: TravelPreferencesDocument;
       try {
-        travel = await updateTravelPreferences(paths.travelPreferences, {
-          synonyms: DEFAULT_TRAVEL_PREFERENCES.synonyms,
-          recentLimit: DEFAULT_TRAVEL_PREFERENCES.recentLimit,
-          recentMapIds: DEFAULT_TRAVEL_PREFERENCES.recentMapIds,
-        });
+        travel = await updateTravelPreferences(
+          paths.travelPreferences,
+          {
+            synonyms: DEFAULT_TRAVEL_PREFERENCES.synonyms,
+            recentLimit: DEFAULT_TRAVEL_PREFERENCES.recentLimit,
+            recentMapIds: DEFAULT_TRAVEL_PREFERENCES.recentMapIds,
+          },
+          this.#onTravelRecovered,
+        );
       } catch (error) {
         if (error instanceof AtomicPublicationUnconfirmedError) {
           try {
-            travel = await loadTravelPreferences(paths.travelPreferences);
+            travel = await loadTravelPreferences(
+              paths.travelPreferences,
+              this.#onTravelRecovered,
+            );
           } catch {
             return Object.freeze({
               status: "partial",
@@ -172,7 +189,10 @@ export class PreferencesCoordinator {
       const paths = this.#paths();
       return composeTravelPreferences(
         await loadSettings(paths.settings),
-        await loadTravelPreferences(paths.travelPreferences),
+        await loadTravelPreferences(
+          paths.travelPreferences,
+          this.#onTravelRecovered,
+        ),
       );
     });
   }
@@ -183,7 +203,10 @@ export class PreferencesCoordinator {
     return this.#lock.run(async () => {
       const paths = this.#paths();
       const settings = await loadSettings(paths.settings);
-      const travel = await loadTravelPreferences(paths.travelPreferences);
+      const travel = await loadTravelPreferences(
+        paths.travelPreferences,
+        this.#onTravelRecovered,
+      );
       const current = composeTravelPreferences(settings, travel);
       if (!sameTravelUserPreferences(current, update.expected)) {
         throw new AppError(
@@ -202,7 +225,11 @@ export class PreferencesCoordinator {
           });
           return composeTravelPreferences(saved, travel);
         }
-        const saved = await updateTravelPreferences(paths.travelPreferences, update.patch);
+        const saved = await updateTravelPreferences(
+          paths.travelPreferences,
+          update.patch,
+          this.#onTravelRecovered,
+        );
         return composeTravelPreferences(settings, saved);
       } catch (error) {
         if (error instanceof AtomicPublicationUnconfirmedError) {
@@ -220,7 +247,11 @@ export class PreferencesCoordinator {
       try {
         return composeTravelPreferences(
           settings,
-          await recordConfirmedTravel(paths.travelPreferences, mapId),
+          await recordConfirmedTravel(
+            paths.travelPreferences,
+            mapId,
+            this.#onTravelRecovered,
+          ),
         );
       } catch (error) {
         if (error instanceof AtomicPublicationUnconfirmedError) {

--- a/src/main/core/settings.ts
+++ b/src/main/core/settings.ts
@@ -14,8 +14,7 @@
  * because a silently ignored key is indistinguishable to the renderer from a
  * setting that did not stick.
  */
-import { readdir, readFile, rename, unlink } from "node:fs/promises";
-import { basename, dirname, join } from "node:path";
+import { readFile } from "node:fs/promises";
 import {
   DATA_STRATEGIES,
   DEFAULT_SETTINGS,
@@ -35,6 +34,7 @@ import { AppError } from "../../shared/errors.js";
 import { isShortcutOverrides } from "../../shared/keyboard-shortcuts.js";
 import { isStoredTravelShortcuts } from "../../shared/travel.js";
 import { writeAtomicJson } from "./atomic-file.js";
+import { quarantineCorruptDocument } from "./corrupt-document.js";
 
 const RENDER_SCALE_VALUES = new Set<AppSettings["renderScale"]>(RENDER_SCALES);
 const DATA_STRATEGY_VALUES = new Set<AppSettings["dataStrategy"]>(DATA_STRATEGIES);
@@ -71,7 +71,6 @@ function asBoundedInteger(
 }
 const SETTINGS_KEYS = new Set(Object.keys(DEFAULT_SETTINGS));
 const SETTINGS_FORMAT = 1;
-const CORRUPT_BACKUPS_KEPT = 3;
 
 function asBool(v: unknown, field: string): boolean {
   if (typeof v !== "boolean") {
@@ -274,46 +273,9 @@ async function recoverCorruptSettings(
   path: string,
   onRecovered: ((backupPath: string) => void | Promise<void>) | undefined,
 ): Promise<AppSettings> {
-  const backupPath = `${path}.corrupt-${Date.now()}`;
-  try {
-    await rename(path, backupPath);
-  } catch (e) {
-    const err = e as NodeJS.ErrnoException;
-    if (err.code !== "ENOENT") throw e;
-    return { ...DEFAULT_SETTINGS };
-  }
-  await pruneCorruptBackups(path);
-  await onRecovered?.(backupPath);
+  const backupPath = await quarantineCorruptDocument(path);
+  if (backupPath) await onRecovered?.(backupPath);
   return { ...DEFAULT_SETTINGS };
-}
-
-/**
- * Keep the three newest `settings.json.corrupt-<epoch>` files and drop the
- * rest. A backup exists so a player can get a lost setting back; nothing reads
- * the fourth-oldest one, and they accumulated for the life of the profile.
- * The epoch is in the name, so ordering needs no stat, and only names this
- * module writes are ever removed.
- */
-async function pruneCorruptBackups(settingsPath: string): Promise<void> {
-  const directory = dirname(settingsPath);
-  const prefix = `${basename(settingsPath)}.corrupt-`;
-  let names: string[];
-  try {
-    names = await readdir(directory);
-  } catch {
-    return;
-  }
-  const stale = names
-    .filter((name) => name.startsWith(prefix))
-    .map((name) => ({ name, at: Number(name.slice(prefix.length)) }))
-    .filter(({ at }) => Number.isSafeInteger(at))
-    .sort((left, right) => right.at - left.at)
-    .slice(CORRUPT_BACKUPS_KEPT);
-  await Promise.all(
-    stale.map(({ name }) =>
-      unlink(join(directory, name)).catch(() => undefined),
-    ),
-  );
 }
 
 export async function saveSettings(path: string, value: AppSettings): Promise<AppSettings> {

--- a/src/main/core/travel-preferences.ts
+++ b/src/main/core/travel-preferences.ts
@@ -2,7 +2,7 @@
  * Owns durable Travel preferences.
  * Keeps them outside Stable-owned settings.json for rollback safety.
  */
-import { readFile, rename } from "node:fs/promises";
+import { readFile } from "node:fs/promises";
 import {
   DEFAULT_TRAVEL_PREFERENCES,
   applyTravelPreferencesPatch,
@@ -12,8 +12,12 @@ import {
   type TravelPreferencesPatch,
 } from "../../shared/travel-preferences.js";
 import { writeAtomicJson } from "./atomic-file.js";
+import { quarantineCorruptDocument } from "./corrupt-document.js";
 
-export async function loadTravelPreferences(path: string): Promise<TravelPreferencesDocument> {
+export async function loadTravelPreferences(
+  path: string,
+  onRecovered?: (backupPath: string) => void | Promise<void>,
+): Promise<TravelPreferencesDocument> {
   let text: string;
   try {
     text = await readFile(path, "utf8");
@@ -24,7 +28,8 @@ export async function loadTravelPreferences(path: string): Promise<TravelPrefere
   try {
     return parseTravelPreferences(JSON.parse(text));
   } catch {
-    await rename(path, `${path}.corrupt`);
+    const backupPath = await quarantineCorruptDocument(path);
+    if (backupPath) await onRecovered?.(backupPath);
     return DEFAULT_TRAVEL_PREFERENCES;
   }
 }
@@ -32,8 +37,12 @@ export async function loadTravelPreferences(path: string): Promise<TravelPrefere
 export async function updateTravelPreferences(
   path: string,
   patch: TravelPreferencesPatch,
+  onRecovered?: (backupPath: string) => void | Promise<void>,
 ): Promise<TravelPreferencesDocument> {
-  const next = applyTravelPreferencesPatch(await loadTravelPreferences(path), patch);
+  const next = applyTravelPreferencesPatch(
+    await loadTravelPreferences(path, onRecovered),
+    patch,
+  );
   await writeAtomicJson(path, next);
   return next;
 }
@@ -41,8 +50,9 @@ export async function updateTravelPreferences(
 export async function recordConfirmedTravel(
   path: string,
   mapId: number,
+  onRecovered?: (backupPath: string) => void | Promise<void>,
 ): Promise<TravelPreferencesDocument> {
-  const current = await loadTravelPreferences(path);
+  const current = await loadTravelPreferences(path, onRecovered);
   if (current.recentLimit === 0) return current;
   const next = applyTravelPreferencesPatch(current, {
     recentMapIds: recordRecentTravel(current.recentMapIds, mapId),

--- a/src/main/diagnostics/schema-app-update.ts
+++ b/src/main/diagnostics/schema-app-update.ts
@@ -370,6 +370,11 @@ export const APP_AND_UPDATE_EVENT_SCHEMA = {
     level: "error",
     fields: none,
   },
+  "travelPreferences.corruptRecovered": {
+    subsystem: "settings",
+    level: "error",
+    fields: none,
+  },
   "settings.loadFailed": {
     subsystem: "settings",
     level: "error",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -160,7 +160,10 @@ const HOST_VERSION = (() => {
   return app.getVersion();
 })();
 
-const preferences = new PreferencesCoordinator(() => gamePaths());
+const preferences = new PreferencesCoordinator(
+  () => gamePaths(),
+  () => logEvent({ k: "travelPreferences.corruptRecovered" }),
+);
 let appUpdaterController: AppUpdater | null = null;
 let updateRestartInFlight: Promise<void> | null = null;
 let secondInstanceRequested = false;

--- a/tests/unit/corrupt-document.test.ts
+++ b/tests/unit/corrupt-document.test.ts
@@ -1,0 +1,56 @@
+/** Corrupt player documents are preserved without accumulating forever. */
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, readdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { basename, join } from "node:path";
+import { describe, it } from "node:test";
+import { quarantineCorruptDocument } from "../../src/main/core/corrupt-document.js";
+
+describe("corrupt document quarantine", () => {
+  it("preserves the new bytes, retains three backups, and touches no neighbour", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "gw-corrupt-document-"));
+    const documentPath = join(directory, "player.json");
+    for (const timestamp of [1000, 2000, 3000, 4000]) {
+      await writeFile(`${documentPath}.corrupt-${timestamp}`, String(timestamp));
+    }
+    await writeFile(`${documentPath}.corrupt-manual`, "keep manual evidence");
+    await writeFile(join(directory, "other.json"), "keep neighbour");
+    await writeFile(documentPath, "current corrupt bytes");
+
+    const backupPath = await quarantineCorruptDocument(documentPath);
+    assert.ok(backupPath);
+    assert.match(
+      backupPath,
+      /player\.json\.corrupt-\d+-[0-9a-f-]{36}$/u,
+    );
+    assert.equal(await readFile(backupPath, "utf8"), "current corrupt bytes");
+    assert.equal(await readFile(`${documentPath}.corrupt-4000`, "utf8"), "4000");
+    assert.equal(await readFile(`${documentPath}.corrupt-3000`, "utf8"), "3000");
+    assert.equal(
+      await readFile(`${documentPath}.corrupt-manual`, "utf8"),
+      "keep manual evidence",
+    );
+    assert.equal(
+      await readFile(join(directory, "other.json"), "utf8"),
+      "keep neighbour",
+    );
+    assert.deepEqual(
+      (await readdir(directory)).filter((name) =>
+        /^player\.json\.corrupt-\d/u.test(name)).sort(),
+      [
+        "player.json.corrupt-3000",
+        "player.json.corrupt-4000",
+        basename(backupPath),
+      ].sort(),
+    );
+  });
+
+  it("returns null when another owner already moved the document", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "gw-corrupt-document-"));
+    assert.equal(
+      await quarantineCorruptDocument(join(directory, "missing.json")),
+      null,
+    );
+    assert.deepEqual(await readdir(directory), []);
+  });
+});

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -254,7 +254,7 @@ describe("settings", () => {
     });
     assert.deepEqual(corrupt, DEFAULT_SETTINGS);
     assert.equal(corrupt.renderScale, 2);
-    assert.match(backup, /settings\.json\.corrupt-\d+$/);
+    assert.match(backup, /settings\.json\.corrupt-\d+-[0-9a-f-]{36}$/u);
     assert.equal(await readFile(backup, "utf8"), "{not json");
     assert.deepEqual(await readdir(dir), [backup.split("/").at(-1)]);
   });

--- a/tests/unit/travel-preferences.test.ts
+++ b/tests/unit/travel-preferences.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { mkdtemp, readFile } from "node:fs/promises";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { Mutex } from "../../src/main/core/mutex.js";
@@ -12,6 +12,29 @@ import {
 import { parseTravelPreferences } from "../../src/shared/travel-preferences.js";
 
 describe("Travel preferences", () => {
+  it("preserves corrupt bytes before returning defaults and reports the backup", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "gw-travel-preferences-"));
+    const path = join(dir, "travel-preferences.json");
+    await writeFile(path, "{not travel json");
+    let recovered = "";
+
+    const loaded = await loadTravelPreferences(path, (backupPath) => {
+      recovered = backupPath;
+    });
+
+    assert.deepEqual(loaded, {
+      formatVersion: 1,
+      synonyms: [],
+      recentLimit: 5,
+      recentMapIds: [],
+    });
+    assert.match(
+      recovered,
+      /travel-preferences\.json\.corrupt-\d+-[0-9a-f-]{36}$/u,
+    );
+    assert.equal(await readFile(recovered, "utf8"), "{not travel json");
+  });
+
   it("stores the Travel-only document without adding Stable-owned settings keys", async () => {
     const dir = await mkdtemp(join(tmpdir(), "gw-travel-preferences-"));
     const path = join(dir, "travel-preferences.json");


### PR DESCRIPTION
Settings and build libraries preserved corrupt player files, but Travel could overwrite one fixed `.corrupt` file. That made recovery inconsistent and could destroy earlier evidence.

This adds one narrow quarantine helper for player documents. It moves corrupt bytes to a unique timestamped backup, retains the three newest recognized backups, ignores unrelated files, and handles a concurrent `ENOENT` without inventing a failure. Settings, build libraries, and Travel now share that behavior; Travel also reports the recovery path through the existing diagnostics callback.

The player-approved Multiple Accounts quarantine remains separate because it intentionally retains all evidence.

## Verification

- `pnpm run check`
- `pnpm build`
- focused persistence tests (52 passed)
- `git diff --check`
