### PR TITLE
refactor(settings): give complex panes explicit owners

### DIFF
--- a/src/renderer/settings-accounts.ts
+++ b/src/renderer/settings-accounts.ts
@@ -1,0 +1,66 @@
+/**
+ * Owns the Settings account-mode status and its explicit restart actions.
+ * It does not own profile documents or the Account Picker lifecycle.
+ */
+export function bindAccountSettings(elements: Readonly<{
+  enable: HTMLButtonElement;
+  status: HTMLElement;
+  modeStatus: HTMLElement;
+  singleSetup: HTMLElement;
+  multiActive: HTMLElement;
+  returnSingle: HTMLButtonElement;
+}>): void {
+  elements.enable.addEventListener('click', async () => {
+    if (!window.confirm(
+      'Enable Multiple Accounts and restart GWonMac? Your current Single Account data will stay untouched.',
+    )) return;
+    elements.enable.disabled = true;
+    elements.status.textContent = 'Creating the separate workspace…';
+    try {
+      const { exportEntries, templateFilesystem } = await import('./template-store.js');
+      const filesystem = templateFilesystem();
+      await window.gwNative.accounts.setup({
+        templateEntries: filesystem ? exportEntries(filesystem) : [],
+      });
+    } catch {
+      elements.enable.disabled = false;
+      elements.status.textContent =
+        'Multiple Accounts could not be enabled. Nothing changed.';
+    }
+  });
+
+  elements.returnSingle.addEventListener('click', async () => {
+    if (!window.confirm(
+      'Return to Single Account mode? GWonMac will restart. Multiple Accounts and Single Account data will both be preserved.',
+    )) return;
+    elements.returnSingle.disabled = true;
+    elements.modeStatus.textContent = 'Restarting in Single Account mode…';
+    try {
+      await window.gwNative.accounts.useSingle();
+    } catch {
+      elements.returnSingle.disabled = false;
+      elements.modeStatus.textContent =
+        'The mode change could not be saved. Nothing changed.';
+    }
+  });
+
+  void window.gwNative.accounts.get().then((state) => {
+    const singleMode = state.mode === 'single';
+    const activeProfiles = state.profiles.filter((profile) => !profile.archived);
+    const existingWorkspace = singleMode && activeProfiles.length > 0;
+    elements.modeStatus.textContent = existingWorkspace
+      ? `Single Account mode is active. Your ${activeProfiles.length} Multiple Accounts ${activeProfiles.length === 1 ? 'account is' : 'accounts are'} ready to restore.`
+      : singleMode
+        ? 'Single Account mode is active.'
+        : 'Multiple Accounts mode is active. Use the Account Picker to open and manage accounts.';
+    elements.singleSetup.hidden = !singleMode;
+    elements.multiActive.hidden = singleMode;
+    if (existingWorkspace) {
+      elements.enable.textContent = 'Restore Multiple Accounts and Restart…';
+    }
+  }).catch(() => {
+    elements.modeStatus.textContent = 'Account mode could not be read.';
+    elements.singleSetup.hidden = true;
+    elements.multiActive.hidden = true;
+  });
+}

--- a/src/renderer/settings-shortcuts.ts
+++ b/src/renderer/settings-shortcuts.ts
@@ -1,0 +1,187 @@
+/**
+ * Owns Settings shortcut capture, conflict replacement, rendering, and cleanup.
+ * Generic Settings persistence stays with the classic Settings entry point.
+ */
+import type { AppSettings } from '../shared/contracts.js';
+import {
+  resolveShortcuts,
+  shortcutConflict,
+  shortcutDisplay,
+  shortcutReserved,
+  SHORTCUT_LABELS,
+  withShortcutOverride,
+  type ShortcutAction,
+  type ShortcutBinding,
+} from '../shared/keyboard-shortcuts.js';
+
+type FeedbackTone = 'neutral' | 'progress' | 'success' | 'warning' | 'error';
+
+export type ShortcutSettingsBinder = Readonly<{
+  render: (settings: AppSettings) => Promise<void>;
+}>;
+
+export function bindShortcutSettings(options: Readonly<{
+  form: HTMLFormElement;
+  dialog: HTMLDialogElement;
+  restore: HTMLElement;
+  settings: () => AppSettings | null;
+  persist: (overrides: AppSettings['shortcutOverrides']) => Promise<unknown>;
+  feedback: (message: string, tone: FeedbackTone, resetAfter?: number) => void;
+}>): ShortcutSettingsBinder {
+  let recording: ShortcutAction | null = null;
+  let pendingReplacement:
+    | { action: ShortcutAction; conflict: ShortcutAction; binding: ShortcutBinding }
+    | null = null;
+  const rows = new Map<ShortcutAction, HTMLElement>(
+    [...options.form.querySelectorAll<HTMLElement>('[data-shortcut-action]')]
+      .map((row) => [row.dataset.shortcutAction as ShortcutAction, row]),
+  );
+
+  function parts(action: ShortcutAction) {
+    const row = rows.get(action);
+    if (!row) throw new Error(`missing shortcut row: ${action}`);
+    const value = row.querySelector<HTMLElement>('.settings-shortcut-value');
+    const change = row.querySelector<HTMLButtonElement>('.settings-shortcut-change');
+    const message = row.querySelector<HTMLElement>('.settings-shortcut-message');
+    const replace = row.querySelector<HTMLButtonElement>('.settings-shortcut-replace');
+    if (!value || !change || !message || !replace) {
+      throw new Error(`incomplete shortcut row: ${action}`);
+    }
+    return { value, change, message, replace };
+  }
+
+  function clearMessages(): void {
+    for (const action of rows.keys()) {
+      const { message, replace } = parts(action);
+      message.textContent = '';
+      message.hidden = true;
+      replace.hidden = true;
+    }
+  }
+
+  async function render(settings: AppSettings): Promise<void> {
+    const resolved = resolveShortcuts(settings.shortcutOverrides);
+    for (const action of rows.keys()) {
+      const { value, change } = parts(action);
+      value.textContent = recording === action
+        ? 'Listening…'
+        : shortcutDisplay(resolved[action]);
+      change.textContent = recording === action ? 'Cancel' : 'Change';
+    }
+  }
+
+  async function save(overrides: AppSettings['shortcutOverrides']): Promise<void> {
+    options.feedback('Saving…', 'progress');
+    try {
+      await options.persist(overrides);
+      options.feedback('Shortcut saved.', 'success', 2200);
+    } catch {
+      options.feedback(
+        'The shortcut could not be saved. Your previous shortcuts are still active; try again.',
+        'error',
+      );
+    }
+  }
+
+  async function record(action: ShortcutAction): Promise<void> {
+    const current = options.settings();
+    if (!current) return;
+    if (recording === action) {
+      await window.gwNative.shortcuts.cancelCapture();
+      return;
+    }
+    if (recording) await window.gwNative.shortcuts.cancelCapture();
+    recording = action;
+    pendingReplacement = null;
+    clearMessages();
+    await render(current);
+    const row = parts(action);
+    row.message.textContent =
+      'Press Command with a letter or number · Delete clears · Escape cancels.';
+    row.message.hidden = false;
+    const result = await window.gwNative.shortcuts.capture();
+    if (recording !== action) return;
+    recording = null;
+    const latest = options.settings();
+    if (!latest) return;
+    if (result.status === 'cancelled') {
+      clearMessages();
+      await render(latest);
+      row.change.focus();
+      return;
+    }
+    if (result.status === 'invalid') {
+      row.message.textContent = 'Use Command with one letter or number.';
+      row.message.hidden = false;
+      await render(latest);
+      row.change.focus();
+      return;
+    }
+    if (result.status === 'cleared') {
+      clearMessages();
+      await save(withShortcutOverride(latest.shortcutOverrides, action, null));
+      row.change.focus();
+      return;
+    }
+    if (shortcutReserved(result.binding)) {
+      row.message.textContent =
+        `${shortcutDisplay(result.binding)} is reserved by macOS or GWonMac.`;
+      row.message.hidden = false;
+      await render(latest);
+      row.change.focus();
+      return;
+    }
+    const conflict = shortcutConflict(
+      action,
+      result.binding,
+      resolveShortcuts(latest.shortcutOverrides),
+    );
+    if (conflict) {
+      pendingReplacement = { action, conflict, binding: result.binding };
+      row.message.textContent =
+        `${shortcutDisplay(result.binding)} is used by ${SHORTCUT_LABELS[conflict]}.`;
+      row.message.hidden = false;
+      row.replace.hidden = false;
+      await render(latest);
+      row.replace.focus();
+      return;
+    }
+    clearMessages();
+    await save(withShortcutOverride(latest.shortcutOverrides, action, result.binding));
+    row.change.focus();
+  }
+
+  for (const [action, row] of rows) {
+    row.querySelector<HTMLButtonElement>('.settings-shortcut-change')
+      ?.addEventListener('click', () => void record(action));
+    row.querySelector<HTMLButtonElement>('.settings-shortcut-replace')
+      ?.addEventListener('click', () => {
+        const replacement = pendingReplacement;
+        const settings = options.settings();
+        if (!replacement || replacement.action !== action || !settings) return;
+        let next = withShortcutOverride(
+          settings.shortcutOverrides,
+          replacement.conflict,
+          null,
+        );
+        next = withShortcutOverride(next, action, replacement.binding);
+        pendingReplacement = null;
+        clearMessages();
+        void save(next).then(() => parts(action).change.focus());
+      });
+  }
+
+  options.restore.addEventListener('click', () => {
+    pendingReplacement = null;
+    clearMessages();
+    void save({});
+  });
+  options.dialog.addEventListener('close', () => {
+    if (recording) void window.gwNative.shortcuts.cancelCapture();
+    recording = null;
+    pendingReplacement = null;
+    clearMessages();
+  });
+
+  return Object.freeze({ render });
+}

--- a/src/renderer/settings-travel-preferences.ts
+++ b/src/renderer/settings-travel-preferences.ts
@@ -1,0 +1,77 @@
+/**
+ * Owns Travel's Recent limit and clear-history flows inside Settings.
+ * Travel remains the only persistence authority for these preferences.
+ */
+import type { TravelUserPreferences } from '../shared/travel.js';
+
+type FeedbackTone = 'neutral' | 'progress' | 'success' | 'warning' | 'error';
+
+export type TravelPreferenceSettingsBinder = Readonly<{
+  render: (toolsEnabled: boolean, preferences: TravelUserPreferences | null) => void;
+}>;
+
+export function bindTravelPreferenceSettings(options: Readonly<{
+  limit: HTMLSelectElement;
+  clear: HTMLButtonElement;
+  current: () => TravelUserPreferences | null;
+  accept: (preferences: TravelUserPreferences | null) => void;
+  renderSettings: () => void;
+  feedback: (message: string, tone: FeedbackTone, resetAfter?: number) => void;
+}>): TravelPreferenceSettingsBinder {
+  function render(
+    toolsEnabled: boolean,
+    preferences: TravelUserPreferences | null,
+  ): void {
+    options.limit.value = String(preferences?.recentLimit ?? 5);
+    options.limit.disabled = !toolsEnabled;
+    options.clear.disabled =
+      !toolsEnabled || (preferences?.recentMapIds.length ?? 0) === 0;
+  }
+
+  async function reconcileAfterFailure(message: string): Promise<void> {
+    const current = options.current();
+    const active = await window.gwNative.travelPreferences.get()
+      .catch(() => current);
+    options.accept(active);
+    options.renderSettings();
+    options.feedback(message, 'error');
+  }
+
+  options.limit.addEventListener('change', () => {
+    const value = Number(options.limit.value);
+    const expected = options.current();
+    if (expected === null || (value !== 0 && value !== 3 && value !== 5 && value !== 10)) {
+      return;
+    }
+    options.feedback('Saving…', 'progress');
+    void window.gwNative.travelPreferences
+      .set({ expected, patch: { recentLimit: value } })
+      .then((saved) => {
+        options.accept(saved);
+        options.renderSettings();
+        options.feedback('Saved.', 'success', 2200);
+      })
+      .catch(() => reconcileAfterFailure(
+        'Settings could not confirm which Recent limit is active. Review the current value, then try again.',
+      ));
+  });
+
+  options.clear.addEventListener('click', () => {
+    const expected = options.current();
+    if (options.clear.disabled || expected === null) return;
+    options.feedback('Clearing Recent…', 'progress');
+    options.clear.disabled = true;
+    void window.gwNative.travelPreferences
+      .set({ expected, patch: { recentMapIds: [] } })
+      .then((saved) => {
+        options.accept(saved);
+        options.renderSettings();
+        options.feedback('Recent destinations cleared.', 'success', 2200);
+      })
+      .catch(() => reconcileAfterFailure(
+        'GWonMac could not confirm whether Recent was cleared. Review the current list, then try again.',
+      ));
+  });
+
+  return Object.freeze({ render });
+}

--- a/src/renderer/settings.ts
+++ b/src/renderer/settings.ts
@@ -15,8 +15,6 @@
   type RendererMilestone =
     import('../shared/diagnostics.js').RendererMilestone;
   type UpdateAction = import('./update-action.js').UpdateAction;
-  type ShortcutAction = import('../shared/keyboard-shortcuts.js').ShortcutAction;
-  type ShortcutBinding = import('../shared/keyboard-shortcuts.js').ShortcutBinding;
 
   const byId = (id: string) => {
     const element = document.getElementById(id);
@@ -91,174 +89,6 @@
   const idleFeedback = 'Changes save automatically.';
   let feedbackTimer: number | null = null;
   let activeSettingsPane = 'data';
-  let recordingShortcut: ShortcutAction | null = null;
-  let pendingShortcutReplacement:
-    | { action: ShortcutAction; conflict: ShortcutAction; binding: ShortcutBinding }
-    | null = null;
-
-  const shortcutModule = import('../shared/keyboard-shortcuts.js');
-  const shortcutRows = new Map<ShortcutAction, HTMLElement>(
-    [...form.querySelectorAll<HTMLElement>('[data-shortcut-action]')].map((row) => [
-      row.dataset.shortcutAction as ShortcutAction,
-      row,
-    ]),
-  );
-
-  function shortcutRowParts(action: ShortcutAction) {
-    const row = shortcutRows.get(action);
-    if (!row) throw new Error(`missing shortcut row: ${action}`);
-    const value = row.querySelector<HTMLElement>('.settings-shortcut-value');
-    const change = row.querySelector<HTMLButtonElement>('.settings-shortcut-change');
-    const message = row.querySelector<HTMLElement>('.settings-shortcut-message');
-    const replace = row.querySelector<HTMLButtonElement>('.settings-shortcut-replace');
-    if (!value || !change || !message || !replace) {
-      throw new Error(`incomplete shortcut row: ${action}`);
-    }
-    return { value, change, message, replace };
-  }
-
-  function clearShortcutMessages(): void {
-    for (const action of shortcutRows.keys()) {
-      const { message, replace } = shortcutRowParts(action);
-      message.textContent = '';
-      message.hidden = true;
-      replace.hidden = true;
-    }
-  }
-
-  async function renderShortcuts(settings: AppSettings): Promise<void> {
-    const { resolveShortcuts, shortcutDisplay } = await shortcutModule;
-    const resolved = resolveShortcuts(settings.shortcutOverrides);
-    for (const action of shortcutRows.keys()) {
-      const { value, change } = shortcutRowParts(action);
-      value.textContent = recordingShortcut === action
-        ? 'Listening…'
-        : shortcutDisplay(resolved[action]);
-      change.textContent = recordingShortcut === action ? 'Cancel' : 'Change';
-    }
-  }
-
-  async function saveShortcutOverrides(
-    overrides: AppSettings['shortcutOverrides'],
-  ): Promise<void> {
-    setFeedback('Saving…', 'progress');
-    try {
-      await persistSettings({ shortcutOverrides: overrides });
-      setFeedback('Shortcut saved.', 'success', 2200);
-    } catch {
-      setFeedback('The shortcut could not be saved. Your previous shortcuts are still active; try again.', 'error');
-    }
-  }
-
-  async function recordShortcut(action: ShortcutAction): Promise<void> {
-    if (!currentSettings) return;
-    if (recordingShortcut === action) {
-      await window.gwNative.shortcuts.cancelCapture();
-      return;
-    }
-    if (recordingShortcut) await window.gwNative.shortcuts.cancelCapture();
-    recordingShortcut = action;
-    pendingShortcutReplacement = null;
-    clearShortcutMessages();
-    await renderShortcuts(currentSettings);
-    const parts = shortcutRowParts(action);
-    parts.message.textContent =
-      'Press Command with a letter or number · Delete clears · Escape cancels.';
-    parts.message.hidden = false;
-    const result = await window.gwNative.shortcuts.capture();
-    if (recordingShortcut !== action) return;
-    recordingShortcut = null;
-    if (result.status === 'cancelled') {
-      clearShortcutMessages();
-      await renderShortcuts(currentSettings);
-      parts.change.focus();
-      return;
-    }
-    if (result.status === 'invalid') {
-      parts.message.textContent = 'Use Command with one letter or number.';
-      parts.message.hidden = false;
-      await renderShortcuts(currentSettings);
-      parts.change.focus();
-      return;
-    }
-    let next = { ...currentSettings.shortcutOverrides };
-    if (result.status === 'cleared') {
-      clearShortcutMessages();
-      const { withShortcutOverride } = await shortcutModule;
-      next = withShortcutOverride(next, action, null);
-      await saveShortcutOverrides(next);
-      parts.change.focus();
-      return;
-    }
-    const {
-      resolveShortcuts,
-      shortcutConflict,
-      shortcutDisplay,
-      shortcutReserved,
-      SHORTCUT_LABELS,
-      withShortcutOverride,
-    } = await shortcutModule;
-    if (shortcutReserved(result.binding)) {
-      parts.message.textContent = `${shortcutDisplay(result.binding)} is reserved by macOS or GWonMac.`;
-      parts.message.hidden = false;
-      await renderShortcuts(currentSettings);
-      parts.change.focus();
-      return;
-    }
-    const conflict = shortcutConflict(
-      action,
-      result.binding,
-      resolveShortcuts(currentSettings.shortcutOverrides),
-    );
-    if (conflict) {
-      pendingShortcutReplacement = { action, conflict, binding: result.binding };
-      parts.message.textContent = `${shortcutDisplay(result.binding)} is used by ${SHORTCUT_LABELS[conflict]}.`;
-      parts.message.hidden = false;
-      parts.replace.hidden = false;
-      await renderShortcuts(currentSettings);
-      parts.replace.focus();
-      return;
-    }
-    next = withShortcutOverride(next, action, result.binding);
-    clearShortcutMessages();
-    await saveShortcutOverrides(next);
-    parts.change.focus();
-  }
-
-  for (const [action, row] of shortcutRows) {
-    row.querySelector<HTMLButtonElement>('.settings-shortcut-change')
-      ?.addEventListener('click', () => void recordShortcut(action));
-    row.querySelector<HTMLButtonElement>('.settings-shortcut-replace')
-      ?.addEventListener('click', () => {
-        const replacement = pendingShortcutReplacement;
-        if (!replacement || replacement.action !== action || !currentSettings) return;
-        const settings = currentSettings;
-        void shortcutModule.then(({ withShortcutOverride }) => {
-          let next = withShortcutOverride(
-            settings.shortcutOverrides,
-            replacement.conflict,
-            null,
-          );
-          next = withShortcutOverride(next, action, replacement.binding);
-          pendingShortcutReplacement = null;
-          clearShortcutMessages();
-          void saveShortcutOverrides(next)
-            .then(() => shortcutRowParts(action).change.focus());
-        });
-      });
-  }
-
-  byId('settings-shortcuts-restore').addEventListener('click', () => {
-    pendingShortcutReplacement = null;
-    clearShortcutMessages();
-    void saveShortcutOverrides({});
-  });
-  dialog.addEventListener('close', () => {
-    if (recordingShortcut) void window.gwNative.shortcuts.cancelCapture();
-    recordingShortcut = null;
-    pendingShortcutReplacement = null;
-    clearShortcutMessages();
-  });
   // Settings is renderer UI, not game input. Keep its keys inside the modal;
   // Escape still reaches the dialog's native cancel behavior because stopping
   // propagation does not cancel the event.
@@ -449,6 +279,38 @@
       'error',
     );
   }
+
+  const shortcutSettings = import('./settings-shortcuts.js').then((module) =>
+    module.bindShortcutSettings({
+      form,
+      dialog,
+      restore: byId('settings-shortcuts-restore'),
+      settings: () => currentSettings,
+      persist: (shortcutOverrides) => persistSettings({ shortcutOverrides }),
+      feedback: setFeedback,
+    }));
+  const travelPreferenceSettings = import('./settings-travel-preferences.js')
+    .then((module) => module.bindTravelPreferenceSettings({
+      limit: travelRecentLimit,
+      clear: travelRecentsClear,
+      current: () => currentTravelPreferences,
+      accept: (preferences) => {
+        currentTravelPreferences = preferences;
+      },
+      renderSettings: () => {
+        if (currentSettings) fillForm(currentSettings);
+      },
+      feedback: setFeedback,
+    }));
+  void import('./settings-accounts.js').then((module) =>
+    module.bindAccountSettings({
+      enable: accountsEnable,
+      status: accountsStatus,
+      modeStatus: accountsModeStatus,
+      singleSetup: accountsSingleSetup,
+      multiActive: accountsMultiActive,
+      returnSingle: accountsReturnSingle,
+    }));
 
   const extendedMemorySetting = import('./extended-memory-setting.js')
     .then((module) => module.bindExtendedMemorySetting(document));
@@ -672,17 +534,15 @@
     teamManagement.checked = settings.teamManagement;
     xunlaiStorage.checked = settings.xunlaiStorage;
     travelPalette.checked = settings.travelPalette;
-    travelRecentLimit.value = String(travelPreferences?.recentLimit ?? 5);
     targetReadout.checked = settings.targetReadout;
-    void renderShortcuts(settings);
+    void shortcutSettings.then((binder) => binder.render(settings));
     toolFeatures.hidden = !settings.gwonmacTools;
     toolsOff.hidden = settings.gwonmacTools;
     teamManagement.disabled = !settings.gwonmacTools;
     xunlaiStorage.disabled = !settings.gwonmacTools;
     travelPalette.disabled = !settings.gwonmacTools;
-    travelRecentLimit.disabled = !settings.gwonmacTools;
-    travelRecentsClear.disabled =
-      !settings.gwonmacTools || (travelPreferences?.recentMapIds.length ?? 0) === 0;
+    void travelPreferenceSettings.then((binder) =>
+      binder.render(settings.gwonmacTools, travelPreferences));
     targetReadout.disabled = !settings.gwonmacTools;
     autoCheckUpdates.checked = settings.autoCheckUpdates;
     updateTrack.value = settings.updateTrack;
@@ -769,25 +629,7 @@
       void dataStrategy.then((controller) => controller.saveSelectedStrategy());
       return;
     }
-    if (control.name === 'travelRecentLimit') {
-      const value = Number(control.value);
-      const expected = currentTravelPreferences;
-      if (expected === null || (value !== 0 && value !== 3 && value !== 5 && value !== 10)) return;
-      setFeedback('Saving…', 'progress');
-      void window.gwNative.travelPreferences.set({ expected, patch: { recentLimit: value } })
-        .then((saved) => {
-          currentTravelPreferences = saved;
-          if (currentSettings) fillForm(currentSettings, saved);
-          setFeedback('Saved.', 'success', 2200);
-        })
-        .catch(async () => {
-          currentTravelPreferences = await window.gwNative.travelPreferences.get()
-            .catch(() => currentTravelPreferences);
-          if (currentSettings) fillForm(currentSettings, currentTravelPreferences);
-          setFeedback('Settings could not confirm which Recent limit is active. Review the current value, then try again.', 'error');
-        });
-      return;
-    }
+    if (control.name === 'travelRecentLimit') return;
     const patch = patchForControl(control);
     if (!patch) return;
     setFeedback('Saving…', 'progress');
@@ -809,25 +651,6 @@
       .catch(() => recoverSettingsAfterFailedWrite(
         'Close and reopen Settings to confirm which value is active before retrying.',
       ));
-  });
-
-  travelRecentsClear.addEventListener('click', () => {
-    const expected = currentTravelPreferences;
-    if (travelRecentsClear.disabled || expected === null) return;
-    setFeedback('Clearing Recent…', 'progress');
-    travelRecentsClear.disabled = true;
-    void window.gwNative.travelPreferences.set({ expected, patch: { recentMapIds: [] } })
-      .then((saved) => {
-        currentTravelPreferences = saved;
-        if (currentSettings) fillForm(currentSettings, saved);
-        setFeedback('Recent destinations cleared.', 'success', 2200);
-      })
-      .catch(async () => {
-        currentTravelPreferences = await window.gwNative.travelPreferences.get()
-          .catch(() => currentTravelPreferences);
-        if (currentSettings) fillForm(currentSettings, currentTravelPreferences);
-        setFeedback('GWonMac could not confirm whether Recent was cleared. Review the current list, then try again.', 'error');
-      });
   });
 
   byId('settings-reveal-data')?.addEventListener('click', () => {
@@ -878,54 +701,6 @@
       settingsPanes.inert = true;
       setFeedback('GWonMac could not confirm whether settings were reset. Close and reopen Settings to review the active values.', 'error');
     }
-  });
-
-  accountsEnable.addEventListener('click', async () => {
-    if (!window.confirm('Enable Multiple Accounts and restart GWonMac? Your current Single Account data will stay untouched.')) return;
-    accountsEnable.disabled = true;
-    accountsStatus.textContent = 'Creating the separate workspace…';
-    try {
-      const { exportEntries, templateFilesystem } = await import('./template-store.js');
-      const filesystem = templateFilesystem();
-      await window.gwNative.accounts.setup({
-        templateEntries: filesystem ? exportEntries(filesystem) : [],
-      });
-    } catch {
-      accountsEnable.disabled = false;
-      accountsStatus.textContent = 'Multiple Accounts could not be enabled. Nothing changed.';
-    }
-  });
-
-  accountsReturnSingle.addEventListener('click', async () => {
-    if (!window.confirm('Return to Single Account mode? GWonMac will restart. Multiple Accounts and Single Account data will both be preserved.')) return;
-    accountsReturnSingle.disabled = true;
-    accountsModeStatus.textContent = 'Restarting in Single Account mode…';
-    try {
-      await window.gwNative.accounts.useSingle();
-    } catch {
-      accountsReturnSingle.disabled = false;
-      accountsModeStatus.textContent = 'The mode change could not be saved. Nothing changed.';
-    }
-  });
-
-  void window.gwNative.accounts.get().then((state) => {
-    const singleMode = state.mode === 'single';
-    const activeProfiles = state.profiles.filter((profile) => !profile.archived);
-    const existingWorkspace = singleMode && activeProfiles.length > 0;
-    accountsModeStatus.textContent = existingWorkspace
-      ? `Single Account mode is active. Your ${activeProfiles.length} Multiple Accounts ${activeProfiles.length === 1 ? 'account is' : 'accounts are'} ready to restore.`
-      : singleMode
-        ? 'Single Account mode is active.'
-      : 'Multiple Accounts mode is active. Use the Account Picker to open and manage accounts.';
-    accountsSingleSetup.hidden = !singleMode;
-    accountsMultiActive.hidden = singleMode;
-    if (existingWorkspace) {
-      accountsEnable.textContent = 'Restore Multiple Accounts and Restart…';
-    }
-  }).catch(() => {
-    accountsModeStatus.textContent = 'Account mode could not be read.';
-    accountsSingleSetup.hidden = true;
-    accountsMultiActive.hidden = true;
   });
 
   window.addEventListener('resize', updateRenderScaleDimensions);


### PR DESCRIPTION
The Settings entry point owned routing and feedback correctly, but it also carried three cohesive interaction systems: shortcut capture, account-mode actions, and Travel-history preferences. That made those panes harder to audit without creating a reason to change their persistence ownership.

This extracts those three systems into narrow binders. `settings.ts` remains the pane router, feedback owner, and sole serialized generic-settings writer. The binders receive explicit callbacks and do not introduce another persistence path.

## Verification

- `pnpm run check`
- `pnpm build`
- focused Settings Electron journeys (17 passed)
- `git diff --check`
