### PR TITLE
chore(workspace): restore dependency isolation

### DIFF
--- a/internals/migrations.md
+++ b/internals/migrations.md
@@ -1,5 +1,41 @@
 # Active migrations
 
+## Unhead 3.x family pin
+
+- Why: a fresh Nuxt dependency resolution can mix Unhead 2.x and 3.x APIs,
+  which breaks the website build and server before a page can render.
+- Introduced: 2026-08-04 in commit `b93839ff`.
+- Depends on it: the Nuxt website build, server bundle, and generated head
+  metadata.
+- Remove when: delete both `unhead` overrides, regenerate the lockfile with
+  `pnpm install --lockfile-only`, then a clean `pnpm install --frozen-lockfile`
+  and `pnpm test:website` both pass without a mixed Unhead family.
+
+## Ginko sidebar padding override
+
+- Why: Ginko Docs 0.2.3 always gives the sidebar scroll viewport `pt-2`, even
+  when this site's group navigation renders no section switcher above it.
+- Introduced: 2026-08-02 in commit `b929e496`.
+- Depends on it: the top spacing of grouped desktop documentation navigation.
+- Remove when: with the CSS rule deleted, `pnpm test:website` passes and
+  `/docs/guides/install` at a 1280 x 900 viewport retains 32 px between the
+  sidebar scroll viewport and its first navigation row without consumer CSS.
+
+## Website package metadata repairs
+
+- Why: `@nuxt/scripts` 0.13.4 imports `estree-walker`, and `nuxt-define`
+  1.0.0 imports `@nuxt/kit`, but neither published manifest declares that
+  runtime dependency. Nuxt I18n 10.6.0 also asks Nuxt Kit to resolve its
+  declared Intlify runtime from outside the I18n package, which requires a
+  narrow public hoist under pnpm's isolated linker.
+- Introduced: 2026-08-21 with dependency isolation restoration.
+- Depends on it: fresh website preparation and certification without wildcard
+  package hoisting.
+- Remove when: the pinned packages declare or resolve these imports themselves;
+  delete both `packageExtensions` and the six-entry `publicHoistPattern`, regenerate
+  the lockfile, and require a clean `pnpm install --frozen-lockfile` plus
+  `pnpm test:website` and `pnpm package:built` to pass.
+
 ## Split Travel preference storage
 
 - Why: published Stable reads the district-bearing shortcut records in

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@electron-forge/cli": "^7.11.2",
     "@electron-forge/maker-dmg": "^7.11.2",
     "@electron-forge/maker-zip": "^7.11.2",
+    "@electron-forge/shared-types": "^7.11.2",
     "@electron/asar": "^3.4.1",
     "@electron/fuses": "^2.1.3",
     "@electron/osx-sign": "1.3.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,8 @@ overrides:
   unhead: 3.2.3
   '@unhead/vue': 3.2.3
 
+packageExtensionsChecksum: sha256-7i6J8iSXKD3HFZ5RPpJbxs/OrOx5iH++yjNIaIHzQ/Y=
+
 importers:
 
   .:
@@ -27,6 +29,9 @@ importers:
         specifier: ^7.11.2
         version: 7.11.2
       '@electron-forge/maker-zip':
+        specifier: ^7.11.2
+        version: 7.11.2
+      '@electron-forge/shared-types':
         specifier: ^7.11.2
         version: 7.11.2
       '@electron/asar':
@@ -119,16 +124,16 @@ importers:
         version: 1.2.121
       '@lupinum/ginko-content':
         specifier: 0.3.2
-        version: 0.3.2(8bc4c488b294eac47e7cc73f79c4e365)
+        version: 0.3.2(a229819565679b1be13a02e738322424)
       '@lupinum/ginko-docs':
         specifier: 0.2.3
-        version: 0.2.3(c32f00484a4ba5e3afd96922e188695e)
+        version: 0.2.3(b19dfea54ee5075f71ab883131c0502d)
       nuxt:
         specifier: 4.5.1
         version: 4.5.1(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(@types/node@24.13.3)(@vue/compiler-sfc@3.5.40)(cac@7.0.0)(db0@0.3.4)(encoding@0.1.13)(esbuild@0.28.1)(eslint@10.7.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.3)(optionator@0.9.4)(oxc-parser@0.140.0)(oxlint@1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.13.3)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(terser@5.49.0)(typescript@5.9.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(yaml@2.9.0)))(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.62.2))(rollup@4.62.2)(srvx@0.11.22)(terser@5.49.0)(typescript@5.9.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript@5.9.3))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23))(yaml@2.9.0)
       nuxt-site-config:
         specifier: 4.1.2
-        version: 4.1.2(38d876099acb84eabfe1153710d64b28)
+        version: 4.1.2(a8b674a789803630ffa5b5add28f0a91)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -3734,6 +3739,7 @@ packages:
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -9645,7 +9651,7 @@ snapshots:
       '@inquirer/prompts': 6.0.1
       '@inquirer/type': 1.5.5
 
-  '@lupinum/ginko-content@0.3.2(8bc4c488b294eac47e7cc73f79c4e365)':
+  '@lupinum/ginko-content@0.3.2(a229819565679b1be13a02e738322424)':
     dependencies:
       '@comark/vue': 0.4.0(shiki@4.4.1)(vue@3.5.40(typescript@5.9.3))
       '@nuxt/kit': 4.5.0(magic-string@1.1.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23)))
@@ -9727,12 +9733,12 @@ snapshots:
       - webpack
       - xml2js
 
-  '@lupinum/ginko-docs@0.2.3(c32f00484a4ba5e3afd96922e188695e)':
+  '@lupinum/ginko-docs@0.2.3(b19dfea54ee5075f71ab883131c0502d)':
     dependencies:
       '@iconify-json/circle-flags': 1.2.10
       '@iconify-json/logos': 1.2.11
       '@iconify-json/lucide': 1.2.121
-      '@lupinum/ginko-content': 0.3.2(8bc4c488b294eac47e7cc73f79c4e365)
+      '@lupinum/ginko-content': 0.3.2(a229819565679b1be13a02e738322424)
       '@nuxt/fonts': 0.14.0(db0@0.3.4)(esbuild@0.28.1)(ioredis@5.11.1)(magic-string@1.1.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23))
       '@nuxt/icon': 2.4.1(magic-string@1.1.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23)))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(vue@3.5.40(typescript@5.9.3))
       '@nuxt/image': 2.1.0(@types/node@24.13.3)(magic-string@1.1.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23)))(unstorage@1.17.5(db0@0.3.4)(ioredis@5.11.1))
@@ -9741,8 +9747,8 @@ snapshots:
       '@nuxtjs/color-mode': 4.0.1(magic-string@1.1.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23)))
       '@nuxtjs/i18n': 10.6.0(@vue/compiler-dom@3.5.40)(db0@0.3.4)(esbuild@0.28.1)(eslint@10.7.0(jiti@2.7.0))(ioredis@5.11.1)(magicast@0.5.3)(rolldown@1.2.0)(rollup@4.62.2)(typescript@5.9.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(vue@3.5.40(typescript@5.9.3))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23))
       '@nuxtjs/mcp-toolkit': 0.17.2(@vue/compiler-sfc@3.5.40)(h3@2.0.1-rc.22(crossws@0.4.10(srvx@0.11.22)))(magic-string@1.1.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(rollup@4.62.2)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23)))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(vue@3.5.40(typescript@5.9.3))(zod@4.4.3)
-      '@nuxtjs/robots': 6.1.3(38d876099acb84eabfe1153710d64b28)
-      '@nuxtjs/sitemap': 8.3.2(38d876099acb84eabfe1153710d64b28)
+      '@nuxtjs/robots': 6.1.3(a8b674a789803630ffa5b5add28f0a91)
+      '@nuxtjs/sitemap': 8.3.2(a8b674a789803630ffa5b5add28f0a91)
       '@resvg/resvg-js': 2.6.2
       '@shikijs/transformers': 4.4.1
       '@tailwindcss/vite': 4.3.3(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
@@ -9752,7 +9758,7 @@ snapshots:
       motion-v: 2.3.0(@vueuse/core@14.4.0(vue@3.5.40(typescript@5.9.3)))(vue@3.5.40(typescript@5.9.3))
       nitropack: 2.13.4(encoding@0.1.13)(oxc-parser@0.140.0)(rolldown@1.2.0)(srvx@0.11.22)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23))
       nuxt: 4.5.1(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(@types/node@24.13.3)(@vue/compiler-sfc@3.5.40)(cac@7.0.0)(db0@0.3.4)(encoding@0.1.13)(esbuild@0.28.1)(eslint@10.7.0(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.3)(optionator@0.9.4)(oxc-parser@0.140.0)(oxlint@1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.13.3)(esbuild@0.28.1)(happy-dom@20.11.1)(jiti@2.7.0)(terser@5.49.0)(typescript@5.9.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(yaml@2.9.0)))(rollup-plugin-visualizer@7.0.1(rolldown@1.2.0)(rollup@4.62.2))(rollup@4.62.2)(srvx@0.11.22)(terser@5.49.0)(typescript@5.9.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(vue-tsc@3.3.8(typescript@5.9.3))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23))(yaml@2.9.0)
-      nuxt-og-image: 6.7.5(1c46bee8bda26cb8eba79069a422cbd3)
+      nuxt-og-image: 6.7.5(4ee77011926f20eea70fbfddfc10b5ba)
       reka-ui: 2.10.1(vue@3.5.40(typescript@5.9.3))
       satori: 0.19.3
       shiki: 4.4.1
@@ -10412,7 +10418,7 @@ snapshots:
       - rolldown
       - unplugin
 
-  '@nuxt/nitro-server@4.5.1(e530e32d3dfbf8e4d588175cfff4c916)':
+  '@nuxt/nitro-server@4.5.1(3aa818704c9829cb44318c013571e722)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23)))
@@ -10514,6 +10520,7 @@ snapshots:
       '@vueuse/core': 14.4.0(vue@3.5.40(typescript@5.9.3))
       consola: 3.4.2
       defu: 6.1.7
+      estree-walker: 3.0.3
       h3: 1.15.11
       magic-string: 0.30.21
       ofetch: 1.5.1
@@ -10561,7 +10568,7 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.2.0
 
-  '@nuxt/vite-builder@4.5.1(8fe0692fa2c9d19fe573883534671782)':
+  '@nuxt/vite-builder@4.5.1(2e6b0afae43d3ce1d1cd2c5d5b623d3b)':
     dependencies:
       '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23)))
       '@vitejs/plugin-vue': 6.0.8(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(vue@3.5.40(typescript@5.9.3))
@@ -10657,7 +10664,7 @@ snapshots:
       knitwork: 1.3.0
       magic-string: 0.30.21
       mlly: 1.8.2
-      nuxt-define: 1.0.0
+      nuxt-define: 1.0.0(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.141.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23)))
       oxc-parser: 0.141.0
       oxc-transform: 0.141.0
       oxc-walker: 0.7.0(oxc-parser@0.141.0)
@@ -10731,15 +10738,15 @@ snapshots:
       - supports-color
       - unplugin
 
-  '@nuxtjs/robots@6.1.3(38d876099acb84eabfe1153710d64b28)':
+  '@nuxtjs/robots@6.1.3(a8b674a789803630ffa5b5add28f0a91)':
     dependencies:
       '@fingerprintjs/botd': 2.0.0
       '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23)))
       consola: 3.4.2
       defu: 6.1.7
       h3: 1.15.11
-      nuxt-site-config: 4.1.2(38d876099acb84eabfe1153710d64b28)
-      nuxtseo-shared: 5.3.6(35be52a7ad830cbebc594cc944929b99)
+      nuxt-site-config: 4.1.2(a8b674a789803630ffa5b5add28f0a91)
+      nuxtseo-shared: 5.3.6(b240dd929e60fc80feaa95d0b7e0102e)
       pathe: 2.0.3
       pkg-types: 2.3.1
       ufo: 1.6.4
@@ -10756,13 +10763,13 @@ snapshots:
       - vite
       - vue
 
-  '@nuxtjs/sitemap@8.3.2(38d876099acb84eabfe1153710d64b28)':
+  '@nuxtjs/sitemap@8.3.2(a8b674a789803630ffa5b5add28f0a91)':
     dependencies:
       '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23)))
       consola: 3.4.2
       defu: 6.1.7
-      nuxt-site-config: 4.1.2(38d876099acb84eabfe1153710d64b28)
-      nuxtseo-shared: 5.3.6(35be52a7ad830cbebc594cc944929b99)
+      nuxt-site-config: 4.1.2(a8b674a789803630ffa5b5add28f0a91)
+      nuxtseo-shared: 5.3.6(b240dd929e60fc80feaa95d0b7e0102e)
       ofetch: 1.5.1
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -11934,7 +11941,7 @@ snapshots:
       local-pkg: 1.2.1
       mlly: 1.8.2
       nostics: 1.2.0
-      nypm: 0.6.8
+      nypm: 0.6.9
       vite: 8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -15102,9 +15109,17 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt-define@1.0.0: {}
+  nuxt-define@1.0.0(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.141.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23))):
+    dependencies:
+      '@nuxt/kit': 4.5.1(magic-string@0.30.21)(magicast@0.5.3)(oxc-parser@0.141.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23)))
+    transitivePeerDependencies:
+      - magic-string
+      - magicast
+      - oxc-parser
+      - rolldown
+      - unplugin
 
-  nuxt-og-image@6.7.5(1c46bee8bda26cb8eba79069a422cbd3):
+  nuxt-og-image@6.7.5(4ee77011926f20eea70fbfddfc10b5ba):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.3)(oxc-parser@0.142.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23)))
@@ -15122,8 +15137,8 @@ snapshots:
       magic-string: 1.1.0
       magicast: 0.5.3
       mocked-exports: 0.1.1
-      nuxt-site-config: 4.1.2(88376787ff6107a7321153710d64b28)
-      nuxtseo-shared: 5.3.6(1fd0e6a4e4feb9932d3d96e9236ca210)
+      nuxt-site-config: 4.1.2(e417c080d0378ac1f94309f50205150e)
+      nuxtseo-shared: 5.3.6(9195e3ae5c0136d7be3afe23066add4a)
       nypm: 0.6.8
       object-identity: 0.2.3
       ofetch: 1.5.1
@@ -15192,13 +15207,13 @@ snapshots:
       - unplugin
       - vue
 
-  nuxt-site-config@4.1.2(38d876099acb84eabfe1153710d64b28):
+  nuxt-site-config@4.1.2(a8b674a789803630ffa5b5add28f0a91):
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23)))
       h3: 1.15.11
       nuxt-site-config-kit: 4.1.2(magic-string@1.1.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23)))(vue@3.5.40(typescript@5.9.3))
-      nuxtseo-shared: 5.3.6(35be52a7ad830cbebc594cc944929b99)
+      nuxtseo-shared: 5.3.6(b240dd929e60fc80feaa95d0b7e0102e)
       pathe: 2.0.3
       pkg-types: 2.3.1
       site-config-stack: 4.1.2(vue@3.5.40(typescript@5.9.3))
@@ -15215,13 +15230,13 @@ snapshots:
       - vue
       - zod
 
-  nuxt-site-config@4.1.2(88376787ff6107a7321153710d64b28):
+  nuxt-site-config@4.1.2(e417c080d0378ac1f94309f50205150e):
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.3)(oxc-parser@0.142.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23)))
       h3: 1.15.11
       nuxt-site-config-kit: 4.1.2(magic-string@1.1.0)(magicast@0.5.3)(oxc-parser@0.142.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23)))(vue@3.5.40(typescript@5.9.3))
-      nuxtseo-shared: 5.3.6(1fd0e6a4e4feb9932d3d96e9236ca210)
+      nuxtseo-shared: 5.3.6(9195e3ae5c0136d7be3afe23066add4a)
       pathe: 2.0.3
       pkg-types: 2.3.1
       site-config-stack: 4.1.2(vue@3.5.40(typescript@5.9.3))
@@ -15244,10 +15259,10 @@ snapshots:
       '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.1)(cac@7.0.0)(magicast@0.5.3)
       '@nuxt/devtools': 3.4.1(db0@0.3.4)(ioredis@5.11.1)(magic-string@1.1.0)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23)))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(vue@3.5.40(typescript@5.9.3))
       '@nuxt/kit': 4.5.1(magic-string@1.1.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23)))
-      '@nuxt/nitro-server': 4.5.1(e530e32d3dfbf8e4d588175cfff4c916)
+      '@nuxt/nitro-server': 4.5.1(3aa818704c9829cb44318c013571e722)
       '@nuxt/schema': 4.5.1
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.1(magic-string@1.1.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23))))
-      '@nuxt/vite-builder': 4.5.1(8fe0692fa2c9d19fe573883534671782)
+      '@nuxt/vite-builder': 4.5.1(2e6b0afae43d3ce1d1cd2c5d5b623d3b)
       '@unhead/vue': 3.2.3(@modelcontextprotocol/sdk@1.30.0(zod@4.4.3))(cac@7.0.0)(esbuild@0.28.1)(lightningcss@1.33.0)(rolldown@1.2.0)(rollup@4.62.2)(srvx@0.11.22)(typescript@5.9.3)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(vue@3.5.40(typescript@5.9.3))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23))
       '@vue/shared': 3.5.40
       chokidar: 5.0.0
@@ -15377,7 +15392,7 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxtseo-shared@5.3.6(1fd0e6a4e4feb9932d3d96e9236ca210):
+  nuxtseo-shared@5.3.6(9195e3ae5c0136d7be3afe23066add4a):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/devtools-kit': 4.0.0-alpha.7(magic-string@1.1.0)(magicast@0.5.3)(oxc-parser@0.142.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23)))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
@@ -15397,7 +15412,7 @@ snapshots:
       ufo: 1.6.4
       vue: 3.5.40(typescript@5.9.3)
     optionalDependencies:
-      nuxt-site-config: 4.1.2(88376787ff6107a7321153710d64b28)
+      nuxt-site-config: 4.1.2(a8b674a789803630ffa5b5add28f0a91)
       zod: 4.4.3
     transitivePeerDependencies:
       - magic-string
@@ -15407,7 +15422,7 @@ snapshots:
       - unplugin
       - vite
 
-  nuxtseo-shared@5.3.6(35be52a7ad830cbebc594cc944929b99):
+  nuxtseo-shared@5.3.6(b240dd929e60fc80feaa95d0b7e0102e):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/devtools-kit': 4.0.0-alpha.7(magic-string@1.1.0)(magicast@0.5.3)(oxc-parser@0.140.0)(rolldown@1.2.0)(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.2.0)(rollup@4.62.2)(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4(esbuild@0.28.1)(lightningcss@1.33.0)(postcss@8.5.23)))(vite@8.1.5(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
@@ -15427,7 +15442,7 @@ snapshots:
       ufo: 1.6.4
       vue: 3.5.40(typescript@5.9.3)
     optionalDependencies:
-      nuxt-site-config: 4.1.2(88376787ff6107a7321153710d64b28)
+      nuxt-site-config: 4.1.2(a8b674a789803630ffa5b5add28f0a91)
       zod: 4.4.3
     transitivePeerDependencies:
       - magic-string

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,8 +1,15 @@
 packages:
   - "apps/*"
-# Default isolated linker keeps .bin links. publicHoistPattern satisfies Electron Forge.
+# Nuxt I18n resolves these declared dependencies from Nuxt Kit rather than from
+# its own package. Keep that compatibility surface exact; Forge also accepts
+# this narrow pattern as proof that pnpm packaging was configured intentionally.
 publicHoistPattern:
-  - "*"
+  - "@intlify/core"
+  - "@intlify/core-base"
+  - "@intlify/message-compiler"
+  - "@intlify/shared"
+  - "@intlify/utils"
+  - "vue-i18n"
 confirmModulesPurge: false
 blockExoticSubdeps: false
 overrides:
@@ -18,6 +25,13 @@ overrides:
   # family, which mismatches the 3.x API and breaks the website build/server.
   unhead: 3.2.3
   "@unhead/vue": 3.2.3
+packageExtensions:
+  "@nuxt/scripts@0.13.4":
+    dependencies:
+      estree-walker: 3.0.3
+  "nuxt-define@1.0.0":
+    dependencies:
+      "@nuxt/kit": 4.5.1
 allowBuilds:
   electron: true
   esbuild: true

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -34,6 +34,7 @@ type Manifest = {
   repository?: { url?: string };
   bugs?: { url?: string };
   dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
   scripts?: Record<string, string>;
 };
 type VercelConfig = {
@@ -711,8 +712,21 @@ test("developer builds are exact, ad-hoc, bounded, and isolated from releases", 
 });
 
 test("the root app and website add no runtime package entries and audit exceptions stay explicit", () => {
-  assert.equal(json("package.json").dependencies, undefined);
+  const rootPackage = json("package.json");
+  assert.equal(rootPackage.dependencies, undefined);
+  assert.equal(
+    rootPackage.devDependencies?.["@electron-forge/shared-types"],
+    "^7.11.2",
+  );
   assert.equal(json("apps/website/package.json").dependencies, undefined);
+  assert.match(
+    read("pnpm-workspace.yaml"),
+    /publicHoistPattern:\n {2}- "@intlify\/core"\n {2}- "@intlify\/core-base"\n {2}- "@intlify\/message-compiler"\n {2}- "@intlify\/shared"\n {2}- "@intlify\/utils"\n {2}- "vue-i18n"/u,
+  );
+  assert.doesNotMatch(
+    read("pnpm-workspace.yaml"),
+    /publicHoistPattern:\s*\n\s*-\s*["']?\*["']?/u,
+  );
   assert.deepEqual(
     read("pnpm-workspace.yaml").match(/GHSA-[a-z0-9-]+/gu),
     [


### PR DESCRIPTION
The workspace used wildcard public hoisting, so packages could import undeclared dependencies and still appear healthy. That obscured real ownership and made clean installs less trustworthy.

This removes wildcard hoisting, gives the root direct ownership of `@electron-forge/shared-types`, and repairs three verified upstream metadata/resolution gaps with exact package extensions and a six-package Nuxt I18n public hoist. Policy tests forbid the wildcard and pin the narrow compatibility surface. Active Unhead, Ginko, and package-metadata workarounds now have introduction evidence and exact removal gates in `internals/migrations.md`.

## Verification

- `pnpm install --frozen-lockfile`
- `pnpm run check`
- `pnpm package:built && pnpm test:packaged`
- `pnpm test:website`
- full Electron matrix before final rebase (137 passed, one expected live skip; one unrelated trackpad timeout passed on focused retry)
- `git diff --check`
