### PR TITLE
fix(build): reject Electron archive symlink escapes

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   tmp: 0.2.7
   undici@7: 7.29.0
   undici@8: 8.9.0
+  extract-zip: npm:@electron-internal/extract-zip@1.0.4
   unhead: 3.2.3
   '@unhead/vue': 3.2.3
 
@@ -3267,9 +3268,6 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
-  '@types/yauzl@2.10.3':
-    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
-
   '@typescript-eslint/eslint-plugin@8.65.0':
     resolution: {integrity: sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -4039,9 +4037,6 @@ packages:
     resolution: {integrity: sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
-
-  buffer-crc32@0.2.13:
-    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
 
   buffer-crc32@1.0.0:
     resolution: {integrity: sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==}
@@ -4892,11 +4887,6 @@ packages:
     resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
     engines: {node: '>=4'}
 
-  extract-zip@2.0.1:
-    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
-    engines: {node: '>= 10.17.0'}
-    hasBin: true
-
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -4938,9 +4928,6 @@ packages:
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
-
-  fd-slicer@1.1.0:
-    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -6604,9 +6591,6 @@ packages:
     resolution: {integrity: sha512-nh39Mo1eGWmZS7y+mK/dQIqg7S1lp38DpRxkyoHf0ZcUs/HDc+yyTjuOtTvSMZHmfSLuSQaX945u05Y2Q6UWZg==}
     engines: {node: '>=14', npm: '>=7'}
 
-  pend@1.2.0:
-    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
-
   perfect-debounce@2.1.0:
     resolution: {integrity: sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g==}
 
@@ -8254,9 +8238,6 @@ packages:
     resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
 
-  yauzl@2.10.0:
-    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
-
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -8874,7 +8855,7 @@ snapshots:
       '@electron/windows-sign': 1.2.2
       '@malept/cross-spawn-promise': 2.0.0
       debug: 4.4.3
-      extract-zip: 2.0.1
+      extract-zip: '@electron-internal/extract-zip@1.0.4'
       filenamify: 4.3.0
       fs-extra: 11.3.6
       galactus: 1.0.0
@@ -11752,11 +11733,6 @@ snapshots:
     dependencies:
       '@types/node': 24.13.3
 
-  '@types/yauzl@2.10.3':
-    dependencies:
-      '@types/node': 24.13.3
-    optional: true
-
   '@typescript-eslint/eslint-plugin@8.65.0(@typescript-eslint/parser@8.65.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3))(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -12629,8 +12605,6 @@ snapshots:
       electron-to-chromium: 1.5.395
       node-releases: 2.0.51
       update-browserslist-db: 1.2.3(browserslist@4.28.7)
-
-  buffer-crc32@0.2.13: {}
 
   buffer-crc32@1.0.0: {}
 
@@ -13586,16 +13560,6 @@ snapshots:
       iconv-lite: 0.4.24
       tmp: 0.2.7
 
-  extract-zip@2.0.1:
-    dependencies:
-      debug: 4.4.3
-      get-stream: 5.2.0
-      yauzl: 2.10.0
-    optionalDependencies:
-      '@types/yauzl': 2.10.3
-    transitivePeerDependencies:
-      - supports-color
-
   fast-deep-equal@3.1.3: {}
 
   fast-fifo@1.3.2: {}
@@ -13645,10 +13609,6 @@ snapshots:
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
-
-  fd-slicer@1.1.0:
-    dependencies:
-      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -15828,8 +15788,6 @@ snapshots:
 
   pe-library@1.0.1: {}
 
-  pend@1.2.0: {}
-
   perfect-debounce@2.1.0: {}
 
   picocolors@1.1.1: {}
@@ -17627,11 +17585,6 @@ snapshots:
       string-width: 7.2.0
       y18n: 5.0.8
       yargs-parser: 22.0.0
-
-  yauzl@2.10.0:
-    dependencies:
-      buffer-crc32: 0.2.13
-      fd-slicer: 1.1.0
 
   yocto-queue@0.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,6 +21,9 @@ overrides:
   tmp: 0.2.7
   "undici@7": 7.29.0
   "undici@8": 8.9.0
+  # Forge's Packager 18 still names the retired extractor. Electron's hardened
+  # drop-in keeps that API while rejecting symlink escapes.
+  extract-zip: "npm:@electron-internal/extract-zip@1.0.4"
   # Fresh re-resolution rebinds part of the Nuxt graph to the unhead 2.x
   # family, which mismatches the 3.x API and breaks the website build/server.
   unhead: 3.2.3
@@ -45,10 +48,6 @@ allowBuilds:
 # repository-owned PNG background and copies the ICNS icon without parsing it.
 auditConfig:
   ignoreGhsas:
-    # Electron Forge reaches extract-zip only through its packaging toolchain.
-    # No patched extract-zip release exists yet; Electron archives come from
-    # the checksum-verified @electron/get path, not from player-controlled data.
-    - GHSA-jmr9-qjv8-65gv
     - GHSA-w3rx-r6r6-pgpr
     - GHSA-5p2g-fcmc-qvqq
     # The affected esbuild serve-directory path exists only on Windows. Owned

--- a/tests/integration/electron-extraction.test.ts
+++ b/tests/integration/electron-extraction.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { createRequire } from "node:module";
+import {
+  lstat,
+  mkdtemp,
+  mkdir,
+  readFile,
+  readlink,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { test } from "node:test";
+
+const run = promisify(execFile);
+const localRequire = createRequire(import.meta.url);
+const forgeRequire = createRequire(
+  localRequire.resolve("@electron-forge/cli/package.json"),
+);
+const packagerRequire = createRequire(
+  forgeRequire.resolve("@electron/packager/package.json"),
+);
+
+interface PackagerExtractor {
+  extractElectronZip(zipPath: string, targetDir: string): Promise<void>;
+}
+
+function isPackagerExtractor(value: unknown): value is PackagerExtractor {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "extractElectronZip" in value &&
+    typeof value.extractElectronZip === "function"
+  );
+}
+
+const extractor: unknown = packagerRequire("./dist/unzip.js");
+assert.ok(isPackagerExtractor(extractor));
+
+async function zipSymlink(target: string, archiveName: string): Promise<string> {
+  const root = await mkdtemp(path.join(os.tmpdir(), "gwonmac-extract-refusal-"));
+  const source = path.join(root, "source");
+  await mkdir(source);
+  await symlink(target, path.join(source, "link"));
+  const archive = path.join(root, archiveName);
+  await run("zip", ["-qy", archive, "link"], { cwd: source });
+  return archive;
+}
+
+test("Electron packaging refuses relative and absolute symlink escapes", async () => {
+  for (const [target, archiveName] of [
+    ["../../outside", "relative.zip"],
+    [path.join(os.tmpdir(), "outside"), "absolute.zip"],
+  ] as const) {
+    const archive = await zipSymlink(target, archiveName);
+    const output = await mkdtemp(path.join(os.tmpdir(), "gwonmac-extract-output-"));
+    await assert.rejects(
+      extractor.extractElectronZip(archive, output),
+      /symlink|outside|escape|path/iu,
+    );
+    await assert.rejects(lstat(path.join(output, "link")), { code: "ENOENT" });
+  }
+});
+
+test("Electron packaging preserves ordinary files and internal symlinks", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "gwonmac-extract-control-"));
+  const source = path.join(root, "source");
+  const output = path.join(root, "output");
+  await mkdir(source);
+  await writeFile(path.join(source, "ordinary-file"), "owned fixture\n");
+  await symlink("ordinary-file", path.join(source, "ordinary-link"));
+  const archive = path.join(root, "legitimate.zip");
+  await run("zip", ["-qy", archive, "ordinary-file", "ordinary-link"], {
+    cwd: source,
+  });
+
+  await extractor.extractElectronZip(archive, output);
+
+  assert.equal(await readFile(path.join(output, "ordinary-file"), "utf8"), "owned fixture\n");
+  assert.equal(await readlink(path.join(output, "ordinary-link")), "ordinary-file");
+});

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -698,6 +698,8 @@ test("developer builds are exact, ad-hoc, bounded, and isolated from releases", 
 
 test("the root app and website add no runtime package entries and audit exceptions stay explicit", () => {
   const rootPackage = json("package.json");
+  const workspace = read("pnpm-workspace.yaml");
+  const lockfile = read("pnpm-lock.yaml");
   assert.equal(rootPackage.dependencies, undefined);
   assert.equal(
     rootPackage.devDependencies?.["@electron-forge/shared-types"],
@@ -705,22 +707,26 @@ test("the root app and website add no runtime package entries and audit exceptio
   );
   assert.equal(json("apps/website/package.json").dependencies, undefined);
   assert.match(
-    read("pnpm-workspace.yaml"),
+    workspace,
     /publicHoistPattern:\n {2}- "@intlify\/core"\n {2}- "@intlify\/core-base"\n {2}- "@intlify\/message-compiler"\n {2}- "@intlify\/shared"\n {2}- "@intlify\/utils"\n {2}- "vue-i18n"/u,
   );
   assert.doesNotMatch(
-    read("pnpm-workspace.yaml"),
+    workspace,
     /publicHoistPattern:\s*\n\s*-\s*["']?\*["']?/u,
   );
   assert.deepEqual(
-    read("pnpm-workspace.yaml").match(/GHSA-[a-z0-9-]+/gu),
+    workspace.match(/GHSA-[a-z0-9-]+/gu),
     [
-      "GHSA-jmr9-qjv8-65gv",
       "GHSA-w3rx-r6r6-pgpr",
       "GHSA-5p2g-fcmc-qvqq",
       "GHSA-g7r4-m6w7-qqqr",
     ],
   );
+  assert.match(
+    workspace,
+    /extract-zip: "npm:@electron-internal\/extract-zip@1\.0\.4"/u,
+  );
+  assert.doesNotMatch(lockfile, /(?:^|\n) {2}extract-zip@2\.0\.1:/u);
 });
 
 test("packaging cleans its output first, and builds the renderer runtime", () => {


### PR DESCRIPTION
Electron Forge's packaging path still resolved `extract-zip@2.0.1`. That retired extractor accepts ZIP symlinks whose targets escape the extraction directory, so a compromised Electron archive could write through a link outside the package staging boundary.

This replaces only Forge Packager 18's legacy package name with Electron's hardened, API-compatible extractor, which the current Electron dependency already uses. The obsolete audit exception is removed, and the lockfile no longer contains the vulnerable extractor or its retired ZIP stack.

The regression test resolves the extractor through Forge and Packager's real runtime boundary. It proves relative and absolute escaping symlinks are refused while ordinary files and safe internal symlinks still extract normally.

Verified:

- clean frozen install
- `pnpm audit --json` returns no advisories
- focused malicious and legitimate archive tests
- `pnpm run check`
- `pnpm test:website`
- `pnpm verify`
- 143 Electron tests passed; one expected live-client test skipped
- packaged application and Enhancement runtime smoke tests passed

Implemented and verified with Codex.
