### PR TITLE
fix(native): validate texture dimensions before decoding

### DIFF
--- a/src/native/gw-dat/decoder-main.cpp
+++ b/src/native/gw-dat/decoder-main.cpp
@@ -11,7 +11,6 @@
 namespace {
 constexpr std::size_t kMaxCompressedBytes = 1024 * 1024;
 constexpr std::uint32_t kMaxDecodedBytes = 1024 * 1024;
-constexpr int kMaxDimension = 256;
 
 void writeU16(std::uint16_t value) {
   std::cout.put(static_cast<char>(value & 0xff));
@@ -64,9 +63,9 @@ int main(int argc, char** argv) {
   delete[] unpacked;
   if (
       texture.width <= 0 || texture.height <= 0
-      || texture.width > kMaxDimension || texture.height > kMaxDimension
       || texture.rgba_data.size()
-          != static_cast<std::size_t>(texture.width * texture.height)
+          != static_cast<std::size_t>(texture.width)
+              * static_cast<std::size_t>(texture.height)
   ) {
     return 5;
   }

--- a/src/native/gw-dat/texture-layout.h
+++ b/src/native/gw-dat/texture-layout.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <optional>
+
+struct TextureLayout
+{
+    int width;
+    int height;
+    std::size_t pixel_count;
+    std::size_t rgba_bytes;
+    std::size_t block_count;
+};
+
+inline std::optional<TextureLayout> ReadTextureLayout(const unsigned char* data, std::size_t size)
+{
+    constexpr std::size_t header_size = 12;
+    constexpr std::uint16_t max_dimension = 256;
+    constexpr std::size_t pixels_per_block = 16;
+    constexpr std::size_t bytes_per_pixel = 4;
+
+    if (data == nullptr || size < header_size)
+    {
+        return std::nullopt;
+    }
+
+    std::uint16_t width = 0;
+    std::uint16_t height = 0;
+    std::memcpy(&width, data + 8, sizeof(width));
+    std::memcpy(&height, data + 10, sizeof(height));
+
+    if (width == 0 || height == 0 || width > max_dimension || height > max_dimension
+        || width % 4 != 0 || height % 4 != 0)
+    {
+        return std::nullopt;
+    }
+
+    const std::size_t wide_width = width;
+    const std::size_t wide_height = height;
+    if (wide_width > std::numeric_limits<std::size_t>::max() / wide_height)
+    {
+        return std::nullopt;
+    }
+    const std::size_t pixel_count = wide_width * wide_height;
+    if (pixel_count > std::numeric_limits<std::size_t>::max() / bytes_per_pixel)
+    {
+        return std::nullopt;
+    }
+
+    return TextureLayout{
+        static_cast<int>(width),
+        static_cast<int>(height),
+        pixel_count,
+        pixel_count * bytes_per_pixel,
+        pixel_count / pixels_per_block,
+    };
+}

--- a/src/native/gw-dat/vendor/README.md
+++ b/src/native/gw-dat/vendor/README.md
@@ -16,16 +16,18 @@ Keep both grants and the required upstream credit beside the source:
 texture after decompression. Skill icons use `DXTL`. This is the `'L'` case in
 `ProcessImageFile`.
 
-## Do not modify the vendored algorithm
+## Do not modify the vendored decoding algorithm
 
 > [!CAUTION]
-> Treat these files as a black box. Take an upstream change instead of cleaning
-> up or correcting the transcribed code.
+> Treat the transcribed decompression and pixel-decoding logic as a black box.
+> Take an upstream change instead of cleaning up or correcting that algorithm.
 
 The source was transcribed by hand from compiled x86 code. Some variables have
-register-based names such as `EBPminus8` and `ESIplus8`. Put project-owned
-validation and fixes in the wrapper in the parent directory. The wrapper must
-bound each input and output dimension before it calls the vendored code.
+register-based names such as `EBPminus8` and `ESIplus8`. Project-owned
+validation lives in the wrapper directory above this one. It must bound each
+dimension and derive checked pixel, byte, and block counts before the vendored
+reader allocates or decompresses. The reader may consume those validated
+counts; it must not derive them again with narrower arithmetic.
 
 `scripts/build.mjs` applies three required compiler adjustments:
 

--- a/src/native/gw-dat/vendor/gwdat/AtexDecompress.cpp
+++ b/src/native/gw-dat/vendor/gwdat/AtexDecompress.cpp
@@ -40,7 +40,7 @@ void AtexDecompress(unsigned int* InputBuffer, unsigned int BufferSize, unsigned
 
     int BlockSize = ColorDataSize + AlphaDataSize2 + AlphaDataSize;
 
-    int BlockCount = ImageDescriptor.xres * ImageDescriptor.yres / 16;
+    const unsigned int BlockCount = static_cast<unsigned int>(ImageDescriptor.block_count);
 
     if (! BlockCount)
     {

--- a/src/native/gw-dat/vendor/gwdat/AtexDecompress.h
+++ b/src/native/gw-dat/vendor/gwdat/AtexDecompress.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cstddef>
+
 struct SImageDescriptor
 {
     int xres, yres;
@@ -9,6 +11,7 @@ struct SImageDescriptor
     unsigned char* image;
     int imageformat;
     int c;
+    std::size_t block_count;
 };
 
 struct SImageData

--- a/src/native/gw-dat/vendor/gwdat/AtexReader.cpp
+++ b/src/native/gw-dat/vendor/gwdat/AtexReader.cpp
@@ -4,8 +4,11 @@
 
 #include "AtexReader.h"
 #include "AtexDecompress.h"
+#include "../../texture-layout.h"
 
 #pragma pack(1)
+
+static_assert(sizeof(RGBA) == 4);
 
 union DXT1Color
 {
@@ -25,25 +28,25 @@ struct DXT5Alpha
     __int64 table;
 };
 
-std::vector<RGBA> ProcessDXT1(unsigned char* data, int xr, int yr)
+std::vector<RGBA> ProcessDXT1(unsigned char* data, const TextureLayout& layout)
 {
-    DXT1Color* coltable = new DXT1Color[xr * yr / 16];
-    unsigned int* blocktable = new unsigned int[xr * yr / 16];
+    DXT1Color* coltable = new DXT1Color[layout.block_count];
+    unsigned int* blocktable = new unsigned int[layout.block_count];
 
     unsigned int* d = (unsigned int*)data;
 
-    for (int x = 0; x < xr * yr / 16; x++)
+    for (std::size_t x = 0; x < layout.block_count; x++)
     {
         coltable[x] = *(DXT1Color*)&d[x * 2];
         blocktable[x] = d[x * 2 + 1];
     }
 
-    std::vector<RGBA> image(xr * yr);
-    memset(image.data(), 0, xr * yr * 4);
+    std::vector<RGBA> image(layout.pixel_count);
+    memset(image.data(), 0, layout.rgba_bytes);
 
     int p = 0;
-    for (int y = 0; y < yr / 4; y++)
-        for (int x = 0; x < xr / 4; x++)
+    for (int y = 0; y < layout.height / 4; y++)
+        for (int x = 0; x < layout.width / 4; x++)
         {
             RGBA ctbl[4];
             memset(ctbl, 255, 16);
@@ -80,7 +83,7 @@ std::vector<RGBA> ProcessDXT1(unsigned char* data, int xr, int yr)
             for (int b = 0; b < 4; b++)
                 for (int a = 0; a < 4; a++)
                 {
-                    image[x * 4 + a + (y * 4 + b) * xr] = ctbl[t & 3];
+                    image[x * 4 + a + (y * 4 + b) * layout.width] = ctbl[t & 3];
                     t = t >> 2;
                 }
 
@@ -92,27 +95,27 @@ std::vector<RGBA> ProcessDXT1(unsigned char* data, int xr, int yr)
     return image;
 }
 
-std::vector<RGBA> ProcessDXT3(unsigned char* data, int xr, int yr)
+std::vector<RGBA> ProcessDXT3(unsigned char* data, const TextureLayout& layout)
 {
-    DXT1Color* coltable = new DXT1Color[xr * yr / 16];
-    __int64* alphatable = new __int64[xr * yr / 16];
-    unsigned int* blocktable = new unsigned int[xr * yr / 16];
+    DXT1Color* coltable = new DXT1Color[layout.block_count];
+    __int64* alphatable = new __int64[layout.block_count];
+    unsigned int* blocktable = new unsigned int[layout.block_count];
 
     unsigned int* d = (unsigned int*)data;
 
-    for (int x = 0; x < xr * yr / 16; x++)
+    for (std::size_t x = 0; x < layout.block_count; x++)
     {
         alphatable[x] = ((__int64*)d)[x * 2];
         coltable[x] = *(DXT1Color*)&d[x * 4 + 2];
         blocktable[x] = d[x * 4 + 3];
     }
 
-    std::vector<RGBA> image(xr * yr);
-    memset(image.data(), 0, xr * yr * 4);
+    std::vector<RGBA> image(layout.pixel_count);
+    memset(image.data(), 0, layout.rgba_bytes);
 
     int p = 0;
-    for (int y = 0; y < yr / 4; y++)
-        for (int x = 0; x < xr / 4; x++)
+    for (int y = 0; y < layout.height / 4; y++)
+        for (int x = 0; x < layout.width / 4; x++)
         {
             RGBA ctbl[4];
             memset(ctbl, 255, 16);
@@ -137,9 +140,9 @@ std::vector<RGBA> ProcessDXT3(unsigned char* data, int xr, int yr)
             for (int b = 0; b < 4; b++)
                 for (int a = 0; a < 4; a++)
                 {
-                    image[x * 4 + a + (y * 4 + b) * xr] = ctbl[t & 3];
+                    image[x * 4 + a + (y * 4 + b) * layout.width] = ctbl[t & 3];
                     t = t >> 2;
-                    image[x * 4 + a + (y * 4 + b) * xr].a = (unsigned char)((k & 15) * 17);
+                    image[x * 4 + a + (y * 4 + b) * layout.width].a = (unsigned char)((k & 15) * 17);
                     k = k >> 4;
                 }
 
@@ -152,27 +155,27 @@ std::vector<RGBA> ProcessDXT3(unsigned char* data, int xr, int yr)
     return image;
 }
 
-std::vector<RGBA> ProcessDXT5(unsigned char* data, int xr, int yr)
+std::vector<RGBA> ProcessDXT5(unsigned char* data, const TextureLayout& layout)
 {
-    DXT1Color* coltable = new DXT1Color[xr * yr / 16];
-    DXT5Alpha* alphatable = new DXT5Alpha[xr * yr / 16];
-    unsigned int* blocktable = new unsigned int[xr * yr / 16];
+    DXT1Color* coltable = new DXT1Color[layout.block_count];
+    DXT5Alpha* alphatable = new DXT5Alpha[layout.block_count];
+    unsigned int* blocktable = new unsigned int[layout.block_count];
 
     unsigned int* d = (unsigned int*)data;
 
-    for (int x = 0; x < xr * yr / 16; x++)
+    for (std::size_t x = 0; x < layout.block_count; x++)
     {
         alphatable[x] = *(DXT5Alpha*)&(((__int64*)d)[x * 2]);
         coltable[x] = *(DXT1Color*)&d[x * 4 + 2];
         blocktable[x] = d[x * 4 + 3];
     }
 
-    std::vector<RGBA> image(xr * yr);
-    memset(image.data(), 0, xr * yr * 4);
+    std::vector<RGBA> image(layout.pixel_count);
+    memset(image.data(), 0, layout.rgba_bytes);
 
     int p = 0;
-    for (int y = 0; y < yr / 4; y++)
-        for (int x = 0; x < xr / 4; x++)
+    for (int y = 0; y < layout.height / 4; y++)
+        for (int x = 0; x < layout.width / 4; x++)
         {
             RGBA ctbl[4];
             memset(ctbl, 255, 16);
@@ -216,9 +219,9 @@ std::vector<RGBA> ProcessDXT5(unsigned char* data, int xr, int yr)
             for (int b = 0; b < 4; b++)
                 for (int a = 0; a < 4; a++)
                 {
-                    image[x * 4 + a + (y * 4 + b) * xr] = ctbl[t & 3];
+                    image[x * 4 + a + (y * 4 + b) * layout.width] = ctbl[t & 3];
                     t = t >> 2;
-                    image[x * 4 + a + (y * 4 + b) * xr].a = atbl[k & 7];
+                    image[x * 4 + a + (y * 4 + b) * layout.width].a = atbl[k & 7];
                     k = k >> 3;
                 }
 
@@ -235,14 +238,14 @@ std::vector<RGBA> ProcessDXT5(unsigned char* data, int xr, int yr)
 
 // DXTA has no colour: it's a single channel of 8-byte interpolated-alpha blocks
 // (BC4/DXT5-alpha style). Present the channel as opaque greyscale.
-std::vector<RGBA> ProcessDXTA(unsigned char* data, int xr, int yr)
+std::vector<RGBA> ProcessDXTA(unsigned char* data, const TextureLayout& layout)
 {
-    std::vector<RGBA> image(xr * yr);
-    memset(image.data(), 0, xr * yr * 4);
+    std::vector<RGBA> image(layout.pixel_count);
+    memset(image.data(), 0, layout.rgba_bytes);
 
-    const int blocks_per_row = xr / 4;
-    for (int by = 0; by < yr / 4; by++)
-        for (int bx = 0; bx < xr / 4; bx++)
+    const int blocks_per_row = layout.width / 4;
+    for (int by = 0; by < layout.height / 4; by++)
+        for (int bx = 0; bx < layout.width / 4; bx++)
         {
             unsigned char* blk = data + ((by * blocks_per_row + bx) * 8);
             unsigned char a0 = blk[0], a1 = blk[1], atbl[8];
@@ -270,7 +273,7 @@ std::vector<RGBA> ProcessDXTA(unsigned char* data, int xr, int yr)
                 {
                     const unsigned char v = atbl[k & 7];
                     k = k >> 3;
-                    RGBA& p = image[bx * 4 + a + (by * 4 + b) * xr];
+                    RGBA& p = image[bx * 4 + a + (by * 4 + b) * layout.width];
                     p.r = p.g = p.b = v;
                     p.a = 255;
                 }
@@ -280,10 +283,21 @@ std::vector<RGBA> ProcessDXTA(unsigned char* data, int xr, int yr)
 
 DatTexture ProcessImageFile(unsigned char* img, int size)
 {
-    int id1, id2;
+    constexpr int minimum_texture_bytes = 24;
+    if (size < minimum_texture_bytes)
+    {
+        return DatTexture();
+    }
+    const std::optional<TextureLayout> layout = ReadTextureLayout(img, static_cast<std::size_t>(size));
+    if (!layout)
+    {
+        return DatTexture();
+    }
 
-    id1 = ((unsigned int*)img)[0];
-    id2 = ((unsigned int*)img)[1];
+    std::uint32_t id1 = 0;
+    std::uint32_t id2 = 0;
+    std::memcpy(&id1, img, sizeof(id1));
+    std::memcpy(&id2, img + 4, sizeof(id2));
 
     if (id1 != 'XTTA' && id1 != 'XETA')
     {
@@ -295,18 +309,19 @@ DatTexture ProcessImageFile(unsigned char* img, int size)
         return DatTexture();
     }
 
-    int cmptype = id2 >> 24;
+    int cmptype = static_cast<int>(id2 >> 24);
 
     SImageDescriptor r;
-    r.xres = *(unsigned short*)(img + 8);
-    r.yres = *(unsigned short*)(img + 10);
+    r.xres = layout->width;
+    r.yres = layout->height;
     r.Data = img;
     r.imageformat = 0xf;
     r.a = size;
     r.b = 6;
     r.c = 0;
+    r.block_count = layout->block_count;
 
-    std::vector<RGBA> output(r.xres * r.yres);
+    std::vector<RGBA> output(layout->pixel_count);
     r.image = (unsigned char*)output.data();
 
     std::vector<RGBA> image;
@@ -317,14 +332,14 @@ DatTexture ProcessImageFile(unsigned char* img, int size)
     {
     case '1':
         AtexDecompress((unsigned int*)img, size, 0xf, r, (unsigned int*)output.data());
-        image = ProcessDXT1((unsigned char*)output.data(), r.xres, r.yres);
+        image = ProcessDXT1((unsigned char*)output.data(), *layout);
         tex_type = TextureType::BC1;
         break;
     case '2':
     case '3':
     case 'N':
         AtexDecompress((unsigned int*)img, size, 0x11, r, (unsigned int*)output.data());
-        image = ProcessDXT3((unsigned char*)output.data(), r.xres, r.yres);
+        image = ProcessDXT3((unsigned char*)output.data(), *layout);
         if (cmptype == 'N')
         {
             tex_type = TextureType::NormalMap;
@@ -337,15 +352,15 @@ DatTexture ProcessImageFile(unsigned char* img, int size)
     case '4':
     case '5':
         AtexDecompress((unsigned int*)img, size, 0x13, r, (unsigned int*)output.data());
-        image = ProcessDXT5((unsigned char*)output.data(), r.xres, r.yres);
+        image = ProcessDXT5((unsigned char*)output.data(), *layout);
         tex_type = TextureType::BC5;
         break;
     case 'L':
         // DXTL's fourth channel is luminance, not transparency: premultiply the
         // colour by it and leave the texture opaque (skill icons etc. are DXTL).
         AtexDecompress((unsigned int*)img, size, 0x12, r, (unsigned int*)output.data());
-        image = ProcessDXT5((unsigned char*)output.data(), r.xres, r.yres);
-        for (int x = 0; x < r.xres * r.yres; x++)
+        image = ProcessDXT5((unsigned char*)output.data(), *layout);
+        for (std::size_t x = 0; x < layout->pixel_count; x++)
         {
             image[x].r = (image[x].r * image[x].a) / 255;
             image[x].g = (image[x].g * image[x].a) / 255;
@@ -356,7 +371,7 @@ DatTexture ProcessImageFile(unsigned char* img, int size)
         break;
     case 'A':
         AtexDecompress((unsigned int*)img, size, 0x14, r, (unsigned int*)output.data());
-        image = ProcessDXTA((unsigned char*)output.data(), r.xres, r.yres);
+        image = ProcessDXTA((unsigned char*)output.data(), *layout);
         tex_type = TextureType::BC5;
         break;
     default:

--- a/tests/integration/gw-dat-dimensions.test.ts
+++ b/tests/integration/gw-dat-dimensions.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+import { test } from "node:test";
+
+const run = promisify(execFile);
+const root = process.cwd();
+
+test(
+  "the texture decoder refuses unsafe dimensions before decompression",
+  { skip: process.platform !== "darwin" },
+  async () => {
+    const temporary = await mkdtemp(path.join(os.tmpdir(), "gwonmac-atex-test-"));
+    const executable = path.join(temporary, "gw-dat-dimensions");
+    try {
+      await run(
+        "xcrun",
+        [
+          "clang++",
+          "-std=c++20",
+          "-fsanitize=address,undefined",
+          "-fno-omit-frame-pointer",
+          "-D__int64=long long",
+          "-Wno-multichar",
+          "-Isrc/native/gw-dat",
+          "tests/native/gw-dat-dimensions.cpp",
+          "src/native/gw-dat/vendor/gwdat/AtexReader.cpp",
+          "-o",
+          executable,
+        ],
+        { cwd: root },
+      );
+      const result = await run(executable);
+      assert.equal(result.stderr, "");
+    } finally {
+      await rm(temporary, { recursive: true, force: true });
+    }
+  },
+);

--- a/tests/native/gw-dat-dimensions.cpp
+++ b/tests/native/gw-dat-dimensions.cpp
@@ -1,0 +1,79 @@
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <cstring>
+
+#include "texture-layout.h"
+#include "vendor/gwdat/AtexDecompress.h"
+#include "vendor/gwdat/AtexReader.h"
+
+namespace {
+int decompress_calls = 0;
+
+std::array<unsigned char, 24> textureHeader(std::uint16_t width, std::uint16_t height)
+{
+    std::array<unsigned char, 24> header{};
+    const std::uint32_t magic = 'XTTA';
+    const std::uint32_t format = 'TXD' | (static_cast<std::uint32_t>('1') << 24);
+    std::memcpy(header.data(), &magic, sizeof(magic));
+    std::memcpy(header.data() + 4, &format, sizeof(format));
+    std::memcpy(header.data() + 8, &width, sizeof(width));
+    std::memcpy(header.data() + 10, &height, sizeof(height));
+    const std::uint32_t data_size = 12;
+    std::memcpy(header.data() + 12, &data_size, sizeof(data_size));
+    return header;
+}
+
+void expectRefused(std::uint16_t width, std::uint16_t height)
+{
+    auto header = textureHeader(width, height);
+    const int calls_before = decompress_calls;
+    const DatTexture texture = ProcessImageFile(header.data(), static_cast<int>(header.size()));
+    assert(texture.rgba_data.empty());
+    assert(decompress_calls == calls_before);
+}
+
+void expectAccepted(std::uint16_t width, std::uint16_t height)
+{
+    auto header = textureHeader(width, height);
+    const int calls_before = decompress_calls;
+    const DatTexture texture = ProcessImageFile(header.data(), static_cast<int>(header.size()));
+    assert(texture.width == width);
+    assert(texture.height == height);
+    assert(texture.rgba_data.size()
+        == static_cast<std::size_t>(width) * static_cast<std::size_t>(height));
+    assert(decompress_calls == calls_before + 1);
+}
+}
+
+void AtexDecompress(
+    unsigned int*, unsigned int, unsigned int, const SImageDescriptor&, unsigned int*)
+{
+    ++decompress_calls;
+}
+
+int main()
+{
+    assert(!ReadTextureLayout(nullptr, 12));
+    auto short_header = textureHeader(4, 4);
+    const int calls_before = decompress_calls;
+    assert(ProcessImageFile(short_header.data(), 23).rgba_data.empty());
+    assert(ProcessImageFile(short_header.data(), -1).rgba_data.empty());
+    assert(decompress_calls == calls_before);
+
+    expectRefused(0, 4);
+    expectRefused(4, 0);
+    expectRefused(2, 4);
+    expectRefused(4, 6);
+    expectRefused(260, 4);
+    expectRefused(4, 260);
+    expectRefused(65535, 65535);
+
+    auto malformed = textureHeader(4, 4);
+    malformed[0] = 0;
+    assert(ProcessImageFile(malformed.data(), static_cast<int>(malformed.size())).rgba_data.empty());
+    assert(decompress_calls == calls_before);
+
+    expectAccepted(4, 4);
+    expectAccepted(256, 256);
+}


### PR DESCRIPTION
Guild Wars texture dimensions come from decoded file bytes, but the reader multiplied them as signed `int` values before allocating and decompressing. Values up to 65,535 could therefore overflow before the later 256×256 output check. CodeQL reported the nine unsafe allocation and byte-count sites as alerts #9–#17.

This moves the boundary to the start of texture reading. One project-owned layout validator now refuses null, truncated, zero, oversized, and non-4×4-aligned dimensions, performs checked `size_t` arithmetic once, and publishes the pixel, RGBA-byte, and block counts used by every decoder path. No decompression or image allocation happens before that validation.

The vendored decoding algorithm is unchanged. Only its unsafe derived-size expressions now consume the validated layout, including the decompressor's block count. The late wrapper multiplication was widened and remains only an output invariant.

The native regression harness stubs decompression so it can prove every malicious header is refused before that boundary. It also proves 4×4 and 256×256 inputs still pass, and runs under AddressSanitizer and UndefinedBehaviorSanitizer.

Verified:

- sanitizer-backed malicious-header and valid-boundary test
- `pnpm run check`
- `pnpm build`
- `pnpm verify`
- 143 Electron tests passed; one expected live-client test skipped
- packaged application and Enhancement runtime smoke tests passed
- no remaining raw dimension-product expressions in the native decoder

CodeQL should close alerts #9–#17 automatically after this reaches `main`.

Implemented and verified with Codex.
