### PR TITLE
fix(accounts): prevent silent loss on profile close

### DIFF
--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -95,8 +95,7 @@ interface WindowStateOwner {
 const preparedWindowStates = new Map<string, WindowState | null>();
 const windowStateOwners = new Map<BrowserWindow, WindowStateOwner>();
 const ownedWindowTitles = new WeakMap<BrowserWindow, string>();
-const profileCloses = new WeakSet<BrowserWindow>();
-const PROFILE_CLOSE_DEADLINE_MS = 6_000;
+const profileCloses = new WeakMap<BrowserWindow, Promise<void>>();
 let downloadPowerBlockerId: number | null = null;
 
 export function updateLongRunningTaskFeedback(
@@ -290,26 +289,54 @@ export function setOwnedWindowTitle(win: BrowserWindow, title: string): void {
   win.setTitle(title);
 }
 
-/** Flush and destroy exactly one Multi game window without quitting the app. */
-export async function closeProfileWindow(win: BrowserWindow): Promise<void> {
-  if (win.isDestroyed() || profileCloses.has(win)) return;
-  profileCloses.add(win);
-  try {
-    await Promise.race([
-      (async () => {
-        await sendRendererCommand(win, { type: "filesystem.sync" });
-        await flushWindowState(win);
-      })(),
-      new Promise<void>((resolve) => {
-        setTimeout(resolve, PROFILE_CLOSE_DEADLINE_MS);
-      }),
-    ]);
-  } catch (error) {
-    logEvent({ k: "window.stateSaveFailed" });
-    console.error("profile close persistence failed", error);
-  } finally {
-    if (!win.isDestroyed()) win.destroy();
+async function closeProfileWindowOnce(win: BrowserWindow): Promise<void> {
+  while (!win.isDestroyed()) {
+    const outcome = await sendRendererCommand(win, { type: "filesystem.sync" });
+    if (outcome === "completed") break;
+
+    let response: number;
+    try {
+      response = (await dialog.showMessageBox(win, {
+        type: "warning",
+        buttons: ["Retry", "Close Without Saving", "Cancel"],
+        defaultId: 2,
+        cancelId: 2,
+        noLink: true,
+        message: "This account could not finish saving",
+        detail:
+          "Keep the account open and retry, or close it knowing that recent game files may be lost.",
+      })).response;
+    } catch (error) {
+      console.error("profile close confirmation failed", error);
+      return;
+    }
+    if (response === 0) continue;
+    if (response !== 1) return;
+    break;
   }
+  if (win.isDestroyed()) return;
+  try {
+    await flushWindowState(win);
+  } catch (error) {
+    logEvent(
+      { k: "window.stateSaveFailed" },
+      windowRegistry.diagnosticOwnerForWindow(win) ?? undefined,
+    );
+    console.error("profile window state save failed", error);
+  }
+  if (!win.isDestroyed()) win.destroy();
+}
+
+/** Flush and destroy exactly one Multi game window without quitting the app. */
+export function closeProfileWindow(win: BrowserWindow): Promise<void> {
+  if (win.isDestroyed()) return Promise.resolve();
+  const active = profileCloses.get(win);
+  if (active) return active;
+  const operation = closeProfileWindowOnce(win).finally(() => {
+    profileCloses.delete(win);
+  });
+  profileCloses.set(win, operation);
+  return operation;
 }
 
 /** The only renderer URL, and it carries no configuration. */

--- a/tests/electron/multiple-accounts.spec.ts
+++ b/tests/electron/multiple-accounts.spec.ts
@@ -15,6 +15,10 @@ declare global {
     originalRelaunch: Electron.App["relaunch"];
   };
   var __runtimeDialogParent: string | null | undefined;
+  var __profileCloseDialogs: {
+    parents: string[];
+    responses: number[];
+  } | undefined;
   var __forcedCandidateHealthToken: object | null;
   var __healthTokenDescriptor: PropertyDescriptor | undefined;
   interface Window {
@@ -840,6 +844,126 @@ test("Multi starts at the Hub and isolates two profile windows from Single", asy
       username: "second@example.test",
       password: "two",
     });
+    expect(await fixture.page.evaluate(() => document.visibilityState)).toBe("visible");
+  } finally {
+    await closeOffline(fixture);
+  }
+});
+
+test("keeps an account open until an incomplete save is resolved explicitly", async () => {
+  const fixture = await launchOffline("gw-multi-close-save-e2e-", {}, async (userData) => {
+    await mkdir(path.join(userData, "multi"), { recursive: true });
+    await writeFile(
+      path.join(userData, "launcher-mode.json"),
+      JSON.stringify({ formatVersion: 1, mode: "multi" }),
+    );
+    await writeFile(path.join(userData, "multi", "workspace.json"), JSON.stringify({
+      formatVersion: 1,
+      deletingProfileIds: [],
+      profiles: [
+        { id: FIRST, name: "Primary", archived: false, templates: "shared", builds: "shared" },
+        { id: SECOND, name: "Alt", archived: false, templates: "shared", builds: "shared" },
+      ],
+    }));
+  });
+  try {
+    await fixture.page.evaluate(
+      ([first, second]) => window.gwNative.accounts.open(
+        [first, second] as ProfileId[],
+      ),
+      [FIRST, SECOND] as const,
+    );
+    await expect.poll(() => fixture.app.windows().length).toBe(3);
+    await fixture.app.evaluate(({ BrowserWindow, dialog }) => {
+      globalThis.__profileCloseDialogs = {
+        parents: [],
+        responses: [0, 2, 1],
+      };
+      Object.defineProperty(dialog, "showMessageBox", {
+        configurable: true,
+        value: async (first: unknown) => {
+          const state = globalThis.__profileCloseDialogs;
+          if (!state) throw new Error("profile close dialog state is missing");
+          state.parents.push(first instanceof BrowserWindow ? first.getTitle() : "unowned");
+          return {
+            response: state.responses.shift() ?? 2,
+            checkboxChecked: false,
+          };
+        },
+      });
+      const win = BrowserWindow.getAllWindows().find((candidate) =>
+        candidate.getTitle().endsWith("Primary"));
+      if (!win) throw new Error("Primary window not found");
+      const send = win.webContents.send.bind(win.webContents);
+      let swallowed = false;
+      Object.defineProperty(win.webContents, "send", {
+        configurable: true,
+        value: (channel: string, ...args: unknown[]) => {
+          const command = args[1] as { type?: string } | undefined;
+          if (!swallowed && command?.type === "filesystem.sync") {
+            swallowed = true;
+            return;
+          }
+          send(channel, ...args);
+        },
+      });
+      win.close();
+    });
+    await expect.poll(() => fixture.app.evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getAllWindows().some((win) =>
+        win.getTitle().endsWith("Primary")),
+    ), { timeout: 12_000 }).toBe(false);
+    expect(await fixture.app.evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getAllWindows().some((win) => win.getTitle().endsWith("Alt")),
+    )).toBe(true);
+
+    await fixture.app.evaluate(({ BrowserWindow, ipcMain }) => {
+      const win = BrowserWindow.getAllWindows().find((candidate) =>
+        candidate.getTitle().endsWith("Alt"));
+      if (!win) throw new Error("Alt window not found");
+      const send = win.webContents.send.bind(win.webContents);
+      Object.defineProperty(win.webContents, "send", {
+        configurable: true,
+        value: (channel: string, ...args: unknown[]) => {
+          const [id, command] = args as [number, { type?: string }];
+          if (command?.type === "filesystem.sync") {
+            queueMicrotask(() => ipcMain.emit(
+              "gw:renderer:commandDone",
+              { sender: win.webContents },
+              id,
+              "failed",
+            ));
+            return;
+          }
+          send(channel, ...args);
+        },
+      });
+      win.close();
+    });
+    await expect.poll(() => fixture.app.evaluate(() =>
+      globalThis.__profileCloseDialogs?.parents.length)).toBe(2);
+    expect(await fixture.app.evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getAllWindows().some((win) => win.getTitle().endsWith("Alt")),
+    )).toBe(true);
+
+    await fixture.app.evaluate(({ BrowserWindow }) => {
+      const win = BrowserWindow.getAllWindows().find((candidate) =>
+        candidate.getTitle().endsWith("Alt"));
+      if (!win) throw new Error("Alt window not found");
+      win.close();
+    });
+    await expect.poll(() => fixture.app.evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getAllWindows().some((win) => win.getTitle().endsWith("Alt")),
+    )).toBe(false);
+    expect(await fixture.app.evaluate(() => globalThis.__profileCloseDialogs))
+      .toEqual({
+        parents: [
+          "Guild Wars Reforged — Primary",
+          "Guild Wars Reforged — Alt",
+          "Guild Wars Reforged — Alt",
+        ],
+        responses: [],
+      });
     expect(await fixture.page.evaluate(() => document.visibilityState)).toBe("visible");
   } finally {
     await closeOffline(fixture);


### PR DESCRIPTION
Closing one Multiple Accounts game window could destroy it after six seconds even when its renderer had failed to save recent game files. That made an ordinary window close capable of silently losing the latest account-local changes.

Profile close now waits for the renderer's bounded save result. A failed or timed-out save keeps the exact account window open and offers Retry, Close Without Saving, or Cancel in a dialog parented to that window. Repeated close requests join the same operation, while Cancel releases the guard so a later retry works normally. Global application shutdown keeps its existing bounded lifecycle path.

## Verification

- `pnpm run check`
- `pnpm build`
- focused Multiple Accounts close test: timeout, Retry, failed save, Cancel, explicit unsafe close, and owner-bound dialogs
- existing two-profile isolation scenario
- `git diff --check`

Model / harness: OpenAI Codex desktop (GPT-5)
