### PR TITLE
chore(protocol): remove unused range helpers

### DIFF
--- a/src/main/core/ranges.ts
+++ b/src/main/core/ranges.ts
@@ -1,15 +1,7 @@
 /**
- * HTTP byte ranges for the virtual snapshot: parsing, clamping, and the one
- * refusal that matters.
- *
- * `Gw.snapshot` is assembled on demand from cached chunks and has no whole-file
- * representation to fall back to, so `requireSnapshotRange` treats a missing or
- * unsatisfiable Range as an error rather than serving the entire multi-gigabyte
- * resource. `assertSafeRead` bounds offset and length against the real size
- * before any read is attempted, so a malformed request cannot become an
- * out-of-bounds read.
+ * Parses one HTTP byte-range request.
+ * It returns inclusive bounds clamped to the supplied resource size.
  */
-import { AppError, ValidationError } from "../../shared/errors.js";
 
 const RANGE_RE = /^bytes=(\d*)-(\d*)$/;
 
@@ -17,8 +9,6 @@ export interface ByteRange {
   start: number;
   end: number; // inclusive
 }
-
-export type InclusiveRange = ByteRange;
 
 /** Inclusive start/end; null = no usable Range (caller may serve whole file). */
 export function parseRangeHeader(
@@ -42,39 +32,4 @@ export function parseRangeHeader(
   }
   if (start >= total || start > end) return "unsatisfiable";
   return { start, end: Math.min(end, total - 1) };
-}
-
-export function contentRangeHeader(start: number, end: number, total: number): string {
-  return `bytes ${start}-${end}/${total}`;
-}
-
-export function rangeLength(range: ByteRange): number {
-  return range.end - range.start + 1;
-}
-
-/** Virtual snapshot must never be served as a whole 4.2 GB response. */
-export function requireSnapshotRange(
-  header: string | null | undefined,
-  total: number,
-): ByteRange {
-  const rng = parseRangeHeader(header, total);
-  if (rng === "unsatisfiable" || rng === null) {
-    throw new AppError(
-      "range_required",
-      "Gw.snapshot is served from cached chunks; range requests only",
-    );
-  }
-  return rng;
-}
-
-export function assertSafeRead(offset: number, length: number, size: number): void {
-  if (!Number.isSafeInteger(offset) || offset < 0) {
-    throw new ValidationError("offset must be a non-negative safe integer");
-  }
-  if (!Number.isSafeInteger(length) || length <= 0) {
-    throw new ValidationError("length must be a positive safe integer");
-  }
-  if (offset + length > size) {
-    throw new ValidationError("read exceeds snapshot size");
-  }
 }

--- a/src/shared/errors.ts
+++ b/src/shared/errors.ts
@@ -71,7 +71,6 @@ export const ERROR_CODES = [
   "net_offline",
   "not_ready",
   "proxy_path",
-  "range_required",
   "response_limit",
   "response_too_large",
   "secure_storage",

--- a/tests/unit/ranges.test.ts
+++ b/tests/unit/ranges.test.ts
@@ -1,20 +1,12 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
-import {
-  parseRangeHeader,
-  contentRangeHeader,
-  rangeLength,
-  requireSnapshotRange,
-} from "../../src/main/core/ranges.js";
-import { AppError } from "../../src/shared/errors.js";
+import { parseRangeHeader } from "../../src/main/core/ranges.js";
 
 describe("ranges", () => {
   it("parses closed, open-ended, and suffix ranges", () => {
     assert.deepEqual(parseRangeHeader("bytes=10-19", 100), { start: 10, end: 19 });
     assert.deepEqual(parseRangeHeader("bytes=10-", 100), { start: 10, end: 99 });
     assert.deepEqual(parseRangeHeader("bytes=-8", 100), { start: 92, end: 99 });
-    assert.equal(rangeLength({ start: 10, end: 19 }), 10);
-    assert.equal(contentRangeHeader(10, 19, 100), "bytes 10-19/100");
   });
 
   it("returns null without a usable Range header", () => {
@@ -26,14 +18,5 @@ describe("ranges", () => {
   it("marks unsatisfiable ranges", () => {
     assert.equal(parseRangeHeader("bytes=999-1000", 100), "unsatisfiable");
     assert.equal(parseRangeHeader("bytes=50-40", 100), "unsatisfiable");
-  });
-
-  it("refuses whole-file snapshot reads", () => {
-    assert.throws(() => requireSnapshotRange(null, 100), (e: unknown) => {
-      assert.ok(e instanceof AppError);
-      assert.equal(e.code, "range_required");
-      return true;
-    });
-    assert.deepEqual(requireSnapshotRange("bytes=0-31", 100), { start: 0, end: 31 });
   });
 });


### PR DESCRIPTION
The protocol module still exposed range helpers that no production code used. Keeping them made the snapshot boundary look broader than it is and preserved an unreachable error code.

This removes the dead helpers, their tests, and the unused `range_required` catalogue entry. `parseRangeHeader` remains unchanged because the protocol still uses it.

## Verification

- `pnpm run check`
- focused range and error-catalogue tests
- repository-wide search for removed exports and imports
- `git diff --check`
