### PR TITLE
fix(native): contain decoder stdin failures

### DIFF
--- a/src/main/core/gw-dat-decoder.ts
+++ b/src/main/core/gw-dat-decoder.ts
@@ -27,40 +27,79 @@ export function runGwDatDecoder(
     const chunks: Buffer[] = [];
     let length = 0;
     let settled = false;
-    const fail = (error: Error) => {
-      if (settled) return;
-      settled = true;
-      child.kill();
-      reject(error);
-    };
     const timer = setTimeout(
-      () => fail(new Error("the archive decoder timed out")),
+      () => settle({ error: new Error("the archive decoder timed out") }),
       HELPER_TIMEOUT_MS,
     );
-    child.stdout.on("data", (chunk: Buffer) => {
+    function removeOperationalListeners(): void {
+      child.stdout.removeListener("data", onStdoutData);
+      child.removeListener("close", onChildClose);
+    }
+    function settle(
+      outcome: { readonly value: Buffer } | { readonly error: unknown },
+    ): void {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      removeOperationalListeners();
+      if ("error" in outcome) {
+        if (child.exitCode === null && child.signalCode === null) child.kill();
+        reject(outcome.error);
+      } else {
+        resolve(outcome.value);
+      }
+    }
+    function onStdoutData(chunk: Buffer): void {
       length += chunk.length;
       if (length > options.maxOutput) {
-        fail(new Error("the archive decoder exceeded its output bound"));
+        settle({
+          error: new Error("the archive decoder exceeded its output bound"),
+        });
       } else {
         chunks.push(chunk);
       }
-    });
-    child.on("error", fail);
-    child.on("close", (code) => {
-      clearTimeout(timer);
-      if (settled) return;
-      settled = true;
+    }
+    function onChildError(error: Error): void {
+      settle({ error });
+    }
+    function onChildResourceClose(): void {
+      // Like stdin below, the process error listener remains until close so a
+      // failed kill cannot turn cleanup into an uncaught EventEmitter error.
+      child.removeListener("error", onChildError);
+    }
+    function onChildClose(code: number | null): void {
       if (code !== 0) {
-        reject(new Error("the archive decoder refused the local asset"));
+        settle({ error: new Error("the archive decoder refused the local asset") });
         return;
       }
       try {
-        resolve(options.parse(Buffer.concat(chunks, length)));
+        settle({ value: options.parse(Buffer.concat(chunks, length)) });
       } catch (error) {
-        reject(error);
+        settle({ error });
       }
-    });
-    child.stdin.end(input);
+    }
+    function onStdinError(error: NodeJS.ErrnoException): void {
+      // A decoder that refuses an input may close its pipe while Node is still
+      // flushing that input. Its process result owns the refusal.
+      if (error.code !== "EPIPE") settle({ error });
+    }
+    function onStdinClose(): void {
+      // This listener intentionally outlives settlement: removing it while a
+      // buffered write can still report EPIPE would turn expected refusal into
+      // an uncaught process error. The stream's close owns its final cleanup.
+      child.stdin.removeListener("error", onStdinError);
+    }
+    child.stdout.on("data", onStdoutData);
+    child.on("error", onChildError);
+    child.on("close", onChildClose);
+    child.once("close", onChildResourceClose);
+    child.stdin.on("error", onStdinError);
+    child.stdin.once("close", onStdinClose);
+    try {
+      child.stdin.end(input);
+    } catch (error) {
+      settle({ error });
+    }
   });
 }
 

--- a/src/native/gw-dat/decoder-main.cpp
+++ b/src/native/gw-dat/decoder-main.cpp
@@ -1,7 +1,5 @@
 #include <cstdint>
-#include <cstdio>
 #include <iostream>
-#include <iterator>
 #include <string_view>
 #include <vector>
 
@@ -28,10 +26,18 @@ void writeU32(std::uint32_t value) {
 int main(int argc, char** argv) {
   const bool raw = argc == 2 && std::string_view(argv[1]) == "--raw";
   if (argc != (raw ? 2 : 1)) return 1;
-  std::vector<unsigned char> input{
-      std::istreambuf_iterator<char>(std::cin),
-      std::istreambuf_iterator<char>()};
-  if (input.size() < 8 || input.size() > kMaxCompressedBytes) return 2;
+  std::vector<unsigned char> input(kMaxCompressedBytes + 1);
+  std::cin.read(
+      reinterpret_cast<char*>(input.data()),
+      static_cast<std::streamsize>(input.size()));
+  const std::streamsize inputSize = std::cin.gcount();
+  if (
+      std::cin.bad() || inputSize < 8
+      || inputSize > static_cast<std::streamsize>(kMaxCompressedBytes)
+  ) {
+    return 2;
+  }
+  input.resize(static_cast<std::size_t>(inputSize));
 
   const std::size_t tail = input.size() - 4;
   const std::uint32_t declared =

--- a/tests/integration/gw-dat-dimensions.test.ts
+++ b/tests/integration/gw-dat-dimensions.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
-import { execFile } from "node:child_process";
+import { execFile, spawn } from "node:child_process";
+import { once } from "node:events";
 import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -8,6 +9,40 @@ import { test } from "node:test";
 
 const run = promisify(execFile);
 const root = process.cwd();
+const MAX_COMPRESSED_BYTES = 1024 * 1024;
+
+test(
+  "the archive decoder refuses oversized stdin without waiting for EOF",
+  { skip: process.platform !== "darwin" },
+  async () => {
+    const decoder = spawn(path.join(root, "build/native/gw-dat-decode"), [], {
+      stdio: ["pipe", "ignore", "ignore"],
+      windowsHide: true,
+    });
+    // The expected early exit can close the pipe while Node still has bytes
+    // buffered. The process exit below is the assertion this test owns.
+    decoder.stdin.on("error", () => undefined);
+    decoder.stdin.write(Buffer.alloc(MAX_COMPRESSED_BYTES + 1));
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const [code, signal] = await Promise.race([
+        once(decoder, "close"),
+        new Promise<never>((_resolve, reject) => {
+          timer = setTimeout(() => {
+            decoder.kill();
+            reject(new Error("the archive decoder waited for stdin EOF"));
+          }, 2_000);
+        }),
+      ]);
+      assert.equal(signal, null);
+      assert.equal(code, 2);
+    } finally {
+      clearTimeout(timer);
+      if (decoder.exitCode === null && decoder.signalCode === null) decoder.kill();
+    }
+  },
+);
 
 test(
   "the texture decoder refuses unsafe dimensions before decompression",

--- a/tests/unit/gw-dat-decoder.test.ts
+++ b/tests/unit/gw-dat-decoder.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { runGwDatDecoder } from "../../src/main/core/gw-dat-decoder.js";
+
+const OPTIONS = {
+  args: ["--eval", "process.exit(2)"],
+  maxOutput: 8,
+  parse: (output: Uint8Array) => Buffer.from(output),
+} as const;
+
+describe("Guild Wars archive decoder process boundary", () => {
+  it("settles and stops the child when writing stdin throws", async () => {
+    const input = new Uint8Array(8);
+    if (!(input.buffer instanceof ArrayBuffer)) throw new Error("expected ArrayBuffer");
+    structuredClone(input, { transfer: [input.buffer] });
+
+    await assert.rejects(
+      runGwDatDecoder(process.execPath, input, {
+        ...OPTIONS,
+        args: ["--eval", "setTimeout(() => undefined, 10_000)"],
+      }),
+      TypeError,
+    );
+  });
+
+  it("contains an early stdin close and reports the decoder refusal", async () => {
+    await assert.rejects(
+      runGwDatDecoder(process.execPath, Buffer.alloc(2 * 1024 * 1024), OPTIONS),
+      /archive decoder refused the local asset/u,
+    );
+  });
+
+  it("settles once when an output refusal closes stdin", async () => {
+    await assert.rejects(
+      runGwDatDecoder(process.execPath, Buffer.alloc(2 * 1024 * 1024), {
+        args: ["--eval", "process.stdout.write('too large')"],
+        maxOutput: 1,
+        parse: OPTIONS.parse,
+      }),
+      /archive decoder exceeded its output bound/u,
+    );
+  });
+});


### PR DESCRIPTION
The archive decoder could surface an uncaught stdin error when its native child rejected input early. Its native reader also waited for EOF before enforcing the compressed-input limit, so an oversized writer could keep the helper alive unnecessarily.

The process boundary now settles every exit path once, contains expected early pipe closure, catches synchronous writes, and cleans up its timer and listeners safely. The native helper reads at most 1 MiB plus one detection byte, so oversized input is refused without waiting for EOF.

## Verification

- `pnpm run check`
- `pnpm build`
- decoder unit tests, including synchronous write failure and early stdin close
- native integration tests, including an oversized writer that remains open
- `git diff --check`
