### PR TITLE
fix(diagnostics): isolate account-owned evidence

### DIFF
--- a/src/main/diagnostics-export.ts
+++ b/src/main/diagnostics-export.ts
@@ -5,6 +5,7 @@
 import { dialog, type BrowserWindow } from "electron";
 import { errorCode } from "../shared/errors.js";
 import { logEvent } from "./diagnostics.js";
+import { windowRegistry } from "./window-registry.js";
 
 let diagnosticsExportInFlight = false;
 
@@ -14,12 +15,13 @@ export async function exportDiagnosticsReport(
 ): Promise<void> {
   if (diagnosticsExportInFlight) return;
   diagnosticsExportInFlight = true;
+  const ownerId = windowRegistry.diagnosticOwnerForWindow(win) ?? undefined;
   try {
     const saved = await exportDiagnostics();
     if (!saved) return;
-    logEvent({ k: "diagnostics.exported" });
+    logEvent({ k: "diagnostics.exported" }, ownerId);
   } catch (error) {
-    logEvent({ k: "diagnostics.exportFailed", code: errorCode(error) });
+    logEvent({ k: "diagnostics.exportFailed", code: errorCode(error) }, ownerId);
     await dialog.showMessageBox(win, {
       type: "error",
       buttons: ["OK"],

--- a/src/main/diagnostics/samplers.ts
+++ b/src/main/diagnostics/samplers.ts
@@ -14,6 +14,7 @@ import { app, powerMonitor, screen } from "electron";
 import { runtimeVersions } from "./flight-recorder.js";
 import { logEvent, recorder } from "./recorder.js";
 import { asAppVersion } from "./schema-fields.js";
+import { windowRegistry } from "../window-registry.js";
 
 const SAMPLE_INTERVAL_MS = 1_000;
 const PROCESS_SAMPLE_INTERVAL = 5;
@@ -27,7 +28,7 @@ const eventLoop = monitorEventLoopDelay({ resolution: 5 });
 let previousEventLoopUtilization = performance.eventLoopUtilization();
 let eventLoopWindowStartedUs = 0;
 
-function sampleProcesses(): void {
+export function sampleProcesses(): void {
   sampleNumber += 1;
   const detailedSample =
     sampleNumber % PROCESS_SAMPLE_INTERVAL === 0;
@@ -66,14 +67,28 @@ function sampleProcesses(): void {
   }
 
   if (!detailedSample) return;
-  const aggregates = new Map<string, { cpuPercent: number; rssBytes: number }>();
+  const aggregates = new Map<
+    string,
+    { cpuPercent: number; rssBytes: number; ownerId?: number }
+  >();
   for (const metric of app.getAppMetrics()) {
     const prefix = `process.${metric.type.toLowerCase()}`;
+    const ownerId = metric.type === "Tab"
+      ? windowRegistry.diagnosticOwnerForProcessId(metric.pid) ?? undefined
+      : undefined;
+    // An unregistered renderer must not become global evidence in every
+    // account's report.
+    if (metric.type === "Tab" && ownerId === undefined) continue;
     recorder.setLatest(
       `${prefix}.cpuPercentElectron`,
       metric.cpu.percentCPUUsage,
+      ownerId,
     );
-    recorder.setLatest(`${prefix}.rssBytes`, metric.memory.workingSetSize * 1_024);
+    recorder.setLatest(
+      `${prefix}.rssBytes`,
+      metric.memory.workingSetSize * 1_024,
+      ownerId,
+    );
     logEvent({ k: "process.chromium",
       pid: metric.pid,
       cpuPercentElectron: metric.cpu.percentCPUUsage,
@@ -81,18 +96,32 @@ function sampleProcesses(): void {
       rssBytes: metric.memory.workingSetSize * 1_024,
       privateBytes: (metric.memory.privateBytes ?? 0) * 1_024,
       sandboxed: metric.sandboxed ?? false,
-    });
-    const aggregate = aggregates.get(prefix) ?? { cpuPercent: 0, rssBytes: 0 };
+    }, ownerId);
+    const aggregateKey = `${prefix}:${ownerId ?? "global"}`;
+    const aggregate = aggregates.get(aggregateKey) ?? {
+      cpuPercent: 0,
+      rssBytes: 0,
+      ...(ownerId === undefined ? {} : { ownerId }),
+    };
     aggregate.cpuPercent += metric.cpu.percentCPUUsage;
     aggregate.rssBytes += metric.memory.workingSetSize * 1_024;
-    aggregates.set(prefix, aggregate);
+    aggregates.set(aggregateKey, aggregate);
   }
-  for (const [prefix, aggregate] of aggregates) {
-    recorder.count(`${prefix}.cpuPercentElectronSum`, aggregate.cpuPercent);
-    recorder.count(`${prefix}.cpuSamples`);
-    recorder.setLatest(`${prefix}.cpuPercentElectron`, aggregate.cpuPercent);
-    recorder.setLatest(`${prefix}.rssBytes`, aggregate.rssBytes);
-    recorder.setPeak(`${prefix}.peakRssBytes`, aggregate.rssBytes);
+  for (const [key, aggregate] of aggregates) {
+    const prefix = key.slice(0, key.lastIndexOf(":"));
+    recorder.count(
+      `${prefix}.cpuPercentElectronSum`,
+      aggregate.cpuPercent,
+      aggregate.ownerId,
+    );
+    recorder.count(`${prefix}.cpuSamples`, 1, aggregate.ownerId);
+    recorder.setLatest(
+      `${prefix}.cpuPercentElectron`,
+      aggregate.cpuPercent,
+      aggregate.ownerId,
+    );
+    recorder.setLatest(`${prefix}.rssBytes`, aggregate.rssBytes, aggregate.ownerId);
+    recorder.setPeak(`${prefix}.peakRssBytes`, aggregate.rssBytes, aggregate.ownerId);
   }
 }
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -581,10 +581,14 @@ export function registerIpcHandlers(ctx: IpcContext): {
     }),
 
     credentialsLoad: channel(nothing, async (win) => {
+      const ownerId = diagnosticOwner(win);
       try {
         return await secretOperation(() => ctx.credentialsStoreFor(win).load());
       } catch (error) {
-        logEvent({ k: "credentials.loadFailed", code: errorCode(error) });
+        logEvent(
+          { k: "credentials.loadFailed", code: errorCode(error) },
+          ownerId,
+        );
         throw error;
       }
     }),
@@ -594,20 +598,28 @@ export function registerIpcHandlers(ctx: IpcContext): {
     credentialsSave: channel(
       one(parseCredentials),
       async (win, value: StoredCredentials) => {
+        const ownerId = diagnosticOwner(win);
         try {
           await secretOperation(() => ctx.credentialsStoreFor(win).save(value));
         } catch (error) {
-          logEvent({ k: "credentials.saveFailed", code: errorCode(error) });
+          logEvent(
+            { k: "credentials.saveFailed", code: errorCode(error) },
+            ownerId,
+          );
           throw error;
         }
       },
     ),
 
     credentialsClear: channel(nothing, async (win) => {
+      const ownerId = diagnosticOwner(win);
       try {
         await secretOperation(() => ctx.credentialsStoreFor(win).clear());
       } catch (error) {
-        logEvent({ k: "credentials.clearFailed", code: errorCode(error) });
+        logEvent(
+          { k: "credentials.clearFailed", code: errorCode(error) },
+          ownerId,
+        );
         throw error;
       }
     }),
@@ -706,11 +718,18 @@ export function registerIpcHandlers(ctx: IpcContext): {
     ),
 
     templatesExport: channel(one(parseExportEntries), async (win, entries) => {
+      const ownerId = diagnosticOwner(win);
       const result = await exportTemplates(win, entries);
       if (result.status === "written") {
-        logEvent({ k: "templates.exported", count: result.count });
+        logEvent(
+          { k: "templates.exported", count: result.count },
+          ownerId,
+        );
       } else if (result.status === "failed") {
-        logEvent({ k: "templates.exportFailed", code: result.errorCode });
+        logEvent(
+          { k: "templates.exportFailed", code: result.errorCode },
+          ownerId,
+        );
       }
       return result;
     }),
@@ -827,7 +846,10 @@ function registerChannelDefinitions(
       try {
         input = def.parse(args);
       } catch (error) {
-        logEvent({ k: "ipc.rejected", channel: name, code: errorCode(error) });
+        logEvent(
+          { k: "ipc.rejected", channel: name, code: errorCode(error) },
+          windows.diagnosticOwnerForWindow(win) ?? undefined,
+        );
         throw error;
       }
       return def.run(win, input);
@@ -853,17 +875,33 @@ export function registerSteamIpcHandlers(
     }
     return coordinator;
   };
+  const diagnosticOwner = (win: BrowserWindow): number => {
+    const ownerId = (windows ?? windowRegistry).diagnosticOwnerForWindow(win);
+    if (ownerId === null) {
+      throw new ValidationError("game window has no diagnostics owner");
+    }
+    return ownerId;
+  };
 
   const runSteamSignIn = async (
     win: BrowserWindow,
+    ownerId: number,
   ): Promise<SteamTokenAcquisition> => {
     const result = await acquireSteamToken(win, (event) => {
-      if (event.k === "opened") logEvent({ k: "steam.signInOpened" });
+      if (event.k === "opened") {
+        logEvent({ k: "steam.signInOpened" }, ownerId);
+      }
       if (event.k === "blocked") {
-        logEvent({ k: "steam.signInBlocked", what: event.what });
+        logEvent(
+          { k: "steam.signInBlocked", what: event.what },
+          ownerId,
+        );
       }
       if (event.k === "settled") {
-        logEvent({ k: "steam.signInResult", outcome: event.outcome });
+        logEvent(
+          { k: "steam.signInResult", outcome: event.outcome },
+          ownerId,
+        );
       }
     });
     // The reason survives to the renderer: a player whose sign-in failed used
@@ -880,27 +918,39 @@ export function registerSteamIpcHandlers(
     // here would only turn "no token" into a launch failure.
     steamToken: channel(asSilentFlag, async (win, silent) => {
       const steam = coordinatorFor(win);
+      const ownerId = diagnosticOwner(win);
       if (isQuitting()) throw new ValidationError("application is quitting");
       const resolution = await steam.resolve({
         silent,
-        acquire: () => runSteamSignIn(win),
+        acquire: () => runSteamSignIn(win, ownerId),
       });
       for (const note of resolution.notes) {
         if (note.note === "loadFailed") {
-          logEvent({ k: "steam.tokenLoadFailed", code: note.code });
+          logEvent(
+            { k: "steam.tokenLoadFailed", code: note.code },
+            ownerId,
+          );
         }
-        if (note.note === "expired") logEvent({ k: "steam.tokenExpired" });
+        if (note.note === "expired") {
+          logEvent({ k: "steam.tokenExpired" }, ownerId);
+        }
         if (note.note === "storeFailed") {
-          logEvent({ k: "steam.tokenStoreFailed", code: note.code });
+          logEvent(
+            { k: "steam.tokenStoreFailed", code: note.code },
+            ownerId,
+          );
         }
         if (note.note === "acquireFailed") {
-          logEvent({ k: "steam.signInResult", outcome: "failed" });
+          logEvent(
+            { k: "steam.signInResult", outcome: "failed" },
+            ownerId,
+          );
         }
       }
       logEvent({ k: "steam.tokenRequested",
         outcome: steamTokenOutcome(resolution),
         silent,
-      });
+      }, ownerId);
       if (resolution.token) {
         return { token: resolution.token } satisfies SteamTokenResult;
       }
@@ -916,18 +966,23 @@ export function registerSteamIpcHandlers(
     steamStore: channel(asSteamStoreback, async (win, { token, expiry }) => {
       if (isQuitting()) throw new ValidationError("application is quitting");
       const steam = coordinatorFor(win);
+      const ownerId = diagnosticOwner(win);
       const outcome = await steam.refresh(token, expiry);
-      logEvent({ k: "steam.storeback", outcome });
+      logEvent({ k: "steam.storeback", outcome }, ownerId);
     }),
 
     steamClear: channel(nothing, async (win) => {
       if (isQuitting()) throw new ValidationError("application is quitting");
       const steam = coordinatorFor(win);
+      const ownerId = diagnosticOwner(win);
       try {
         await steam.clear();
-        logEvent({ k: "steam.tokenCleared" });
+        logEvent({ k: "steam.tokenCleared" }, ownerId);
       } catch (error) {
-        logEvent({ k: "steam.tokenClearFailed", code: errorCode(error) });
+        logEvent(
+          { k: "steam.tokenClearFailed", code: errorCode(error) },
+          ownerId,
+        );
         throw error;
       }
     }),

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -516,7 +516,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
   }
   await applyPendingCacheClear(paths);
   if (activeAccountMode === "single") {
-    await applyPendingGameStorageReset(paths);
+    await applyPendingGameStorageReset(paths, SINGLE_DIAGNOSTIC_OWNER_ID);
   }
   await ensureDirs(activeAccountMode);
   await startDiagnostics();
@@ -565,7 +565,9 @@ if (primaryInstance) void app.whenReady().then(async () => {
     settings,
     enhancementProgram,
   );
-  if (activeAccountMode === "single") await prepareWindowState();
+  if (activeAccountMode === "single") {
+    await prepareWindowState(undefined, undefined, SINGLE_DIAGNOSTIC_OWNER_ID);
+  }
   const keychain: NativeKeychain = persistentSecrets
     ? nativeHost
     : new VolatileNativeKeychain();
@@ -842,7 +844,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
           logEvent({
             k: "capture.automationStartFailed",
             code: errorCode(error),
-          });
+          }, windowRegistry.diagnosticOwnerForWindow(win) ?? undefined);
         });
       } else if (message === AUTOMATION_COMMAND.stopCapture) {
         void stopDiagnosticCapture();
@@ -867,7 +869,6 @@ if (primaryInstance) void app.whenReady().then(async () => {
       }
     });
   }
-  logEvent({ k: "window.created" });
   if (profileMatches) {
     void clientRuntime.requestUpdate();
   } else {

--- a/src/main/multiple-accounts-controller.ts
+++ b/src/main/multiple-accounts-controller.ts
@@ -490,12 +490,17 @@ export class MultipleAccountsController {
       const reset = await applyPendingSessionStorageReset(
         owner,
         profilePaths.gameStorageClearRequest,
+        this.diagnosticOwnerFor(profileId),
       );
       if (reset && profile.templates === "private") {
         await rm(profilePaths.templates, { force: true });
       }
       await mkdir(profilePaths.root, { recursive: true });
-      await prepareWindowState(profilePaths.windowState, newWindowOrdinal);
+      await prepareWindowState(
+        profilePaths.windowState,
+        newWindowOrdinal,
+        this.diagnosticOwnerFor(profileId),
+      );
       failureStage = "starting";
       let hubWasVisibleBeforeRecovery = false;
       const win = createMainWindow(this.options.windowHost, {

--- a/src/main/renderer-commands.ts
+++ b/src/main/renderer-commands.ts
@@ -17,6 +17,7 @@ import {
   type RendererCommandOutcome,
 } from "../shared/contracts.js";
 import { logEvent } from "./diagnostics/recorder.js";
+import { windowRegistry } from "./window-registry.js";
 
 interface Pending {
   webContentsId: number;
@@ -150,11 +151,15 @@ export async function editWindowText(
  * the Toolbox capability it stopped them for a refusal that only reached a log.
  */
 export async function toggleTools(win: BrowserWindow): Promise<void> {
+  const ownerId = windowRegistry.diagnosticOwnerForWindow(win) ?? undefined;
   const outcome = await sendRendererCommand(win, { type: "tools.toggle" });
   // The renderer refuses outright when the Toolbox capability is not
   // installed, which is the ordinary case on a launch that did not ask for it.
   if (outcome !== "completed") {
-    logEvent({ k: "tools.toggleRefused", outcome });
+    logEvent(
+      { k: "tools.toggleRefused", outcome },
+      ownerId,
+    );
   }
 }
 

--- a/src/main/settings-actions.ts
+++ b/src/main/settings-actions.ts
@@ -21,8 +21,13 @@ import { logEvent } from "./diagnostics.js";
 import type { GamePaths } from "./paths.js";
 import { resetGameInput } from "./renderer-commands.js";
 import { resetWindowState } from "./window.js";
+import { windowRegistry } from "./window-registry.js";
 
 type RelaunchAction = "capabilityEnable" | "cacheClear" | "gameStorageReset";
+
+function diagnosticOwner(win: BrowserWindow): number | undefined {
+  return windowRegistry.diagnosticOwnerForWindow(win) ?? undefined;
+}
 
 async function confirmAction(
   win: BrowserWindow,
@@ -113,6 +118,7 @@ export async function confirmSettingsReset(
   win: BrowserWindow,
   reset: () => Promise<SettingsResetOutcome>,
 ): Promise<SettingsResetOutcome | null> {
+  const ownerId = diagnosticOwner(win);
   if (
     !(await confirmAction(win, {
       confirmLabel: "Reset GWonMac Settings",
@@ -130,7 +136,7 @@ export async function confirmSettingsReset(
     } catch {
       // The settings document is already durable. Window geometry is a
       // separate document and cannot roll that result back.
-      logEvent({ k: "window.stateResetFailed" });
+      logEvent({ k: "window.stateResetFailed" }, ownerId);
     }
     if (outcome.status === "complete") logEvent({ k: "settings.reset" });
     return outcome;
@@ -169,6 +175,7 @@ export async function requestGameStorageReset(
   win: BrowserWindow,
   markerPath: string,
 ): Promise<boolean> {
+  const ownerId = diagnosticOwner(win);
   if (
     !(await confirmAction(win, {
       confirmLabel: "Reset and Restart",
@@ -182,10 +189,13 @@ export async function requestGameStorageReset(
   try {
     await writeFile(markerPath, "", { mode: 0o600 });
   } catch (error) {
-    logEvent({ k: "filesystem.resetFailed", code: errorCode(error) });
+    logEvent(
+      { k: "filesystem.resetFailed", code: errorCode(error) },
+      ownerId,
+    );
     throw error;
   }
-  logEvent({ k: "filesystem.resetRequested" });
+  logEvent({ k: "filesystem.resetRequested" }, ownerId);
   requestRelaunch(win, "gameStorageReset");
   return true;
 }
@@ -210,16 +220,19 @@ export async function applyPendingCacheClear(paths: GamePaths): Promise<void> {
 
 export async function applyPendingGameStorageReset(
   paths: GamePaths,
+  diagnosticOwnerId?: number,
 ): Promise<void> {
   await applyPendingSessionStorageReset(
     session.defaultSession,
     paths.gameStorageClearRequest,
+    diagnosticOwnerId,
   );
 }
 
 export async function applyPendingSessionStorageReset(
   owner: Session,
   markerPath: string,
+  diagnosticOwnerId?: number,
 ): Promise<boolean> {
   if (!(await pendingMarkerExists(markerPath))) return false;
   // This runs before a renderer can mount IDBFS. Clearing it later would race
@@ -229,6 +242,6 @@ export async function applyPendingSessionStorageReset(
     storages: ["indexdb"],
   });
   await rm(markerPath, { force: true });
-  logEvent({ k: "filesystem.resetCompleted" });
+  logEvent({ k: "filesystem.resetCompleted" }, diagnosticOwnerId);
   return true;
 }

--- a/src/main/window-menu.ts
+++ b/src/main/window-menu.ts
@@ -151,9 +151,14 @@ export function installApplicationMenu({
           id: "reset-window-state",
           label: "Reset Window Size and Position",
           click: withGameOwner(async (win) => {
+            const ownerId =
+              windowRegistry.diagnosticOwnerForWindow(win) ?? undefined;
             await resetGameInput(win);
             void resetWindowState(win).catch(() => {
-              logEvent({ k: "window.stateResetFailed" });
+              logEvent(
+                { k: "window.stateResetFailed" },
+                ownerId,
+              );
             });
           }),
         },

--- a/src/main/window-registry.ts
+++ b/src/main/window-registry.ts
@@ -15,7 +15,10 @@ export type WindowContext =
   | Readonly<{ mode: "multi"; role: "game"; profileId: ProfileId }>;
 
 interface RegisteredWindow {
-  readonly webContents: { readonly id: number };
+  readonly webContents: {
+    readonly id: number;
+    getOSProcessId?(): number;
+  };
   isDestroyed(): boolean;
   isFocused(): boolean;
 }
@@ -105,6 +108,27 @@ export class WindowRegistry<Window extends RegisteredWindow = BrowserWindow> {
     return entry && !entry.win.isDestroyed()
       ? entry.diagnosticOwnerId
       : null;
+  }
+
+  /** Resolve a live renderer process without treating an ambiguous PID as owned. */
+  diagnosticOwnerForProcessId(processId: number): number | null {
+    let ownerId: number | null = null;
+    for (const { win, diagnosticOwnerId } of this.#byWebContents.values()) {
+      let rendererProcessId: number | undefined;
+      try {
+        rendererProcessId = win.webContents.getOSProcessId?.();
+      } catch {
+        continue;
+      }
+      if (
+        win.isDestroyed()
+        || diagnosticOwnerId === null
+        || rendererProcessId !== processId
+      ) continue;
+      if (ownerId !== null && ownerId !== diagnosticOwnerId) return null;
+      ownerId = diagnosticOwnerId;
+    }
+    return ownerId;
   }
 
   singleGameWindow(): Window | null {

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -85,6 +85,7 @@ export function resetRendererRecovery(statePath: string): void {
 }
 interface WindowStateOwner {
   readonly path: string;
+  readonly diagnosticOwnerId: number;
   restored: WindowState | null;
   lastNormalBounds: WindowBounds | null;
   timer: ReturnType<typeof setTimeout> | null;
@@ -131,9 +132,10 @@ function primaryWorkArea(): WindowBounds {
 export async function prepareWindowState(
   statePath = gamePaths().windowState,
   newWindowOrdinal?: number,
+  diagnosticOwnerId?: number,
 ): Promise<boolean> {
   const loaded = await loadWindowState(statePath, () => {
-    logEvent({ k: "window.stateCorruptCleared" });
+    logEvent({ k: "window.stateCorruptCleared" }, diagnosticOwnerId);
   });
   const restored = loaded
     ? fitWindowStateToDisplays(loaded, workAreas(), primaryWorkArea())
@@ -153,7 +155,7 @@ export async function prepareWindowState(
       mode: restored.mode,
       width: restored.bounds.width,
       height: restored.bounds.height,
-    });
+    }, diagnosticOwnerId);
   }
   return restored !== null;
 }
@@ -202,7 +204,10 @@ function scheduleWindowStateSave(win: BrowserWindow): void {
   owner.timer = setTimeout(() => {
     owner.timer = null;
     void persistWindowState(win).catch(() => {
-      logEvent({ k: "window.stateSaveFailed" });
+      logEvent(
+        { k: "window.stateSaveFailed" },
+        owner.diagnosticOwnerId,
+      );
     });
   }, 300);
 }
@@ -275,7 +280,7 @@ export function resetWindowState(win: BrowserWindow): Promise<void> {
       logEvent({ k: "window.stateReset",
         width: settled.bounds.width,
         height: settled.bounds.height,
-      });
+      }, owner.diagnosticOwnerId);
     } finally {
       owner.resetDepth -= 1;
     }
@@ -415,6 +420,7 @@ export function createMainWindow(
 
   const stateOwner: WindowStateOwner = {
     path: statePath,
+    diagnosticOwnerId: options.diagnosticOwnerId,
     restored: initialState,
     lastNormalBounds: initialState?.bounds ?? null,
     timer: null,
@@ -425,6 +431,7 @@ export function createMainWindow(
   windowStateOwners.set(win, stateOwner);
   windowRegistry.register(win, context, options.diagnosticOwnerId);
   resetRendererDiagnostics(options.diagnosticOwnerId);
+  logEvent({ k: "window.created" }, options.diagnosticOwnerId);
   if (options.title) {
     ownedWindowTitles.set(win, options.title);
     win.webContents.on("page-title-updated", (event) => {
@@ -457,7 +464,7 @@ export function createMainWindow(
   const persistMode = (): void => {
     if (stateOwner.resetDepth > 0) return;
     void persistWindowState(win).catch(() => {
-      logEvent({ k: "window.stateSaveFailed" });
+      logEvent({ k: "window.stateSaveFailed" }, diagnosticOwnerId);
     });
   };
   win.on("maximize", persistMode);

--- a/tests/electron/diagnostics-ownership.spec.ts
+++ b/tests/electron/diagnostics-ownership.spec.ts
@@ -152,7 +152,18 @@ test("only the owner observes a capture and Level 2 refuses shared tracing", asy
           profileId: "diagnostics-peer",
         }, 202);
         try {
+          await peer.loadURL("data:text/html,peer");
           await diagnostics.startDiagnosticCapture(peer, 1);
+          const { exportDiagnosticsReport } = load(
+            modulePath.replace(/diagnostics\.js$/u, "diagnostics-export.js"),
+          );
+          await exportDiagnosticsReport(peer, async () => "saved");
+          const samplers = load(
+            modulePath.replace(/diagnostics\.js$/u, "diagnostics/samplers.js"),
+          );
+          for (let index = 0; index < 5; index += 1) {
+            samplers.sampleProcesses();
+          }
           const ownerLevel = diagnostics.diagnosticSummary(owner).captureLevel;
           const peerLevel = diagnostics.diagnosticSummary(peer).captureLevel;
           const span = diagnostics.startSnapshotReadSpan(
@@ -164,9 +175,14 @@ test("only the owner observes a capture and Level 2 refuses shared tracing", asy
           const { recorder } = load(
             modulePath.replace(/diagnostics\.js$/u, "diagnostics/recorder.js"),
           );
-          const captureEvents = JSON.parse(
+          const captureRecords = JSON.parse(
             `[${(await recorder.exportedEvents(202)).text.replaceAll("\n", ",")}]`,
-          ).map((event: { name: string }) => event.name);
+          ) as Array<{ name: string; fields: { pid?: number } }>;
+          const ownerId = windowRegistry.diagnosticOwnerForWindow(owner);
+          if (ownerId === null) throw new Error("owner diagnostics unavailable");
+          const ownerRecords = JSON.parse(
+            `[${(await recorder.exportedEvents(ownerId)).text.replaceAll("\n", ",")}]`,
+          ) as Array<{ name: string; fields: { pid?: number } }>;
           let levelTwoError = "";
           try {
             await diagnostics.startDiagnosticCapture(owner, 2);
@@ -178,7 +194,16 @@ test("only the owner observes a capture and Level 2 refuses shared tracing", asy
             ownerLevel,
             peerLevel,
             ownerIdDiffersFromWebContents: peer.webContents.id !== 202,
-            captureEvents,
+            captureEvents: captureRecords.map((event) => event.name),
+            ownerEvents: ownerRecords.map((event) => event.name),
+            captureChromiumPids: captureRecords
+              .filter((event) => event.name === "process.chromium")
+              .map((event) => event.fields.pid),
+            ownerChromiumPids: ownerRecords
+              .filter((event) => event.name === "process.chromium")
+              .map((event) => event.fields.pid),
+            ownerPid: owner.webContents.getOSProcessId(),
+            peerPid: peer.webContents.getOSProcessId(),
             levelTwoError,
           };
         } finally {
@@ -190,16 +215,24 @@ test("only the owner observes a capture and Level 2 refuses shared tracing", asy
       path.join(root, "build/main/diagnostics.js"),
     );
 
-    expect(result).toEqual({
+    expect(result).toMatchObject({
       ownerLevel: 0,
       peerLevel: 1,
       ownerIdDiffersFromWebContents: true,
       captureEvents: expect.arrayContaining([
+        "diagnostics.exported",
         "snapshot.read.begin",
         "snapshot.read.end",
       ]),
+      ownerEvents: expect.not.arrayContaining(["diagnostics.exported"]),
       levelTwoError: "Chromium tracing requires exactly one open game window",
     });
+    expect(result.captureEvents).toContain("process.main");
+    expect(result.ownerEvents).toContain("process.main");
+    expect(result.captureChromiumPids).toContain(result.peerPid);
+    expect(result.captureChromiumPids).not.toContain(result.ownerPid);
+    expect(result.ownerChromiumPids).toContain(result.ownerPid);
+    expect(result.ownerChromiumPids).not.toContain(result.peerPid);
   } finally {
     await closeOffline(fixture);
   }

--- a/tests/unit/window-registry.test.ts
+++ b/tests/unit/window-registry.test.ts
@@ -5,10 +5,15 @@ import { WindowRegistry } from "../../src/main/window-registry.js";
 import { parseProfileId } from "../../src/shared/multiple-accounts.js";
 import { AppError } from "../../src/shared/errors.js";
 
-function fake(id: number) {
+function fake(id: number, processId?: number) {
   let destroyed = false;
   return {
-    webContents: { id },
+    webContents: {
+      id,
+      ...(processId === undefined
+        ? {}
+        : { getOSProcessId: () => processId }),
+    },
     isDestroyed: () => destroyed,
     isFocused: () => false,
     destroy: () => { destroyed = true; },
@@ -43,6 +48,32 @@ describe("window registry", () => {
       42,
     );
     assert.equal(registry.diagnosticOwnerForWindow(replacement), 42);
+  });
+
+  it("attributes a renderer process only to its exact account owner", () => {
+    const registry = new WindowRegistry<ReturnType<typeof fake>>();
+    const first = fake(7, 700);
+    const second = fake(8, 800);
+    registry.register(first, { mode: "single", role: "game" }, 101);
+    registry.register(second, {
+      mode: "multi",
+      role: "game",
+      profileId: parseProfileId("b2521fbf-50a8-424c-823a-bd5be4b58ace"),
+    }, 202);
+    assert.equal(registry.diagnosticOwnerForProcessId(700), 101);
+    assert.equal(registry.diagnosticOwnerForProcessId(800), 202);
+    assert.equal(registry.diagnosticOwnerForProcessId(900), null);
+  });
+
+  it("refuses to assign a renderer process shared by different owners", () => {
+    const registry = new WindowRegistry<ReturnType<typeof fake>>();
+    registry.register(fake(7, 700), { mode: "single", role: "game" }, 101);
+    registry.register(fake(8, 700), {
+      mode: "multi",
+      role: "game",
+      profileId: parseProfileId("b2521fbf-50a8-424c-823a-bd5be4b58ace"),
+    }, 202);
+    assert.equal(registry.diagnosticOwnerForProcessId(700), null);
   });
 
   it("enforces one live game window for a profile", () => {


### PR DESCRIPTION
Multiple Accounts diagnostics still treated several account-local actions and renderer process samples as application-global evidence. That could put one profile's credential, Steam, Tools, IPC, template, window, or renderer-health history into another profile's report.

These events now use the existing diagnostic owner identity, captured before asynchronous work begins. Real renderer process IDs resolve through the authoritative window registry; unknown or ambiguous renderers are omitted instead of becoming global. Truly shared updater, cache, download, settings, and lifecycle evidence remains global.

## Verification

- `pnpm run check`
- `pnpm build`
- focused WindowRegistry tests: 11 passed
- focused Steam and diagnostics Electron tests: 14 passed
- two-profile tests for owner isolation and shared global evidence
- `git diff --check`
