### PR TITLE
fix(diagnostics): export complete owner sessions

### DIFF
--- a/src/main/diagnostics-export.ts
+++ b/src/main/diagnostics-export.ts
@@ -13,9 +13,20 @@ export async function exportDiagnosticsReport(
   win: BrowserWindow,
   exportDiagnostics: () => Promise<string>,
 ): Promise<void> {
-  if (diagnosticsExportInFlight) return;
+  const ownerId = windowRegistry.diagnosticOwnerForWindow(win);
+  if (ownerId === null) {
+    throw new Error("diagnostics export requires an account owner");
+  }
+  if (diagnosticsExportInFlight) {
+    await dialog.showMessageBox(win, {
+      type: "info",
+      buttons: ["OK"],
+      message: "Another diagnostics export is in progress",
+      detail: "Wait for it to finish, then try again.",
+    }).catch(() => undefined);
+    return;
+  }
   diagnosticsExportInFlight = true;
-  const ownerId = windowRegistry.diagnosticOwnerForWindow(win) ?? undefined;
   try {
     const saved = await exportDiagnostics();
     if (!saved) return;

--- a/src/main/diagnostics/export.ts
+++ b/src/main/diagnostics/export.ts
@@ -100,13 +100,12 @@ export async function exportDiagnosticsZip(
   try {
     const capture = recorder.captureResult(extras.diagnosticOwnerId);
     const captureLevel = exportedCaptureLevel(extras.diagnosticOwnerId);
-    const summary = capture?.summary
-      ?? (extras.diagnosticOwnerId === undefined
-        ? recorder.summary(captureLevel)
-        : recorder.summaryForOwner(
-            extras.diagnosticOwnerId,
-            captureLevel,
-          ));
+    // The main report keeps the complete safe session around a capture. The
+    // capture's narrower measurements remain in capture-summary.json, while its
+    // metadata, frames, and trace retain their own exact lifetime below.
+    const summary = extras.diagnosticOwnerId === undefined
+      ? recorder.summary(captureLevel)
+      : recorder.summaryForOwner(extras.diagnosticOwnerId, captureLevel);
     const exportedEvents = await recorder.exportedEvents(
       extras.diagnosticOwnerId,
     );

--- a/src/main/diagnostics/flight-recorder.ts
+++ b/src/main/diagnostics/flight-recorder.ts
@@ -168,7 +168,6 @@ export class FlightRecorder {
   private captureCounters: Map<string, number> | null = null;
   private captureHistograms: Map<string, Histogram> | null = null;
   private captureLatest: DiagnosticFields | null = null;
-  private captureEventSequences: Set<number> | null = null;
   private captureGraphics: GraphicsDiagnostics | null = null;
   /**
    * The renderer whose window-local evidence this capture accepts. App-global
@@ -177,13 +176,13 @@ export class FlightRecorder {
   private captureOwnerId: number | null = null;
   private captureStartedUs = 0;
   private captureFirstSequenceNumber = 0;
+  private captureLastSequenceNumber = 0;
   private captureStartedDroppedEvents = 0;
   private completedCapture: {
     ownerId: number;
     graphics: GraphicsDiagnostics | null;
     metadata: CaptureMetadata;
     summary: DiagnosticSummary;
-    eventSequences: ReadonlySet<number>;
   } | null = null;
   private seq = 0;
   private droppedEvents = 0;
@@ -229,8 +228,11 @@ export class FlightRecorder {
       this.count("diagnostics.evictedEvents");
     }
     this.events.push(record);
-    if (this.captureEventSequences && this.includesInCapture(ownerId)) {
-      this.captureEventSequences.add(record.seq);
+    if (this.captureOwnerId !== null && this.includesInCapture(ownerId)) {
+      if (this.captureLastSequenceNumber === 0) {
+        this.captureFirstSequenceNumber = record.seq;
+      }
+      this.captureLastSequenceNumber = record.seq;
     }
     this.writes = this.writes
       .then(() => this.append(record))
@@ -357,11 +359,11 @@ export class FlightRecorder {
     this.captureCounters = new Map();
     this.captureHistograms = new Map();
     this.captureLatest = {};
-    this.captureEventSequences = new Set();
     this.captureGraphics = this.ownerGraphics.get(ownerId) ?? null;
     this.captureOwnerId = ownerId;
     this.captureStartedUs = this.timestampUs();
     this.captureFirstSequenceNumber = this.seq + 1;
+    this.captureLastSequenceNumber = 0;
     this.captureStartedDroppedEvents = this.droppedEvents;
     this.completedCapture = null;
   }
@@ -375,12 +377,10 @@ export class FlightRecorder {
       return;
     }
     const endedUs = this.timestampUs();
-    const eventSequences = this.captureEventSequences ?? new Set<number>();
     const ownerId = this.captureOwnerId;
     if (ownerId === null) return;
-    const firstSequenceNumber = eventSequences.values().next().value
-      ?? this.captureFirstSequenceNumber;
-    const lastSequenceNumber = [...eventSequences].at(-1) ?? this.seq;
+    const firstSequenceNumber = this.captureFirstSequenceNumber;
+    const lastSequenceNumber = this.captureLastSequenceNumber || this.seq;
     this.completedCapture = {
       ownerId,
       graphics: this.captureGraphics,
@@ -399,16 +399,15 @@ export class FlightRecorder {
         this.captureLatest,
         this.droppedEvents - this.captureStartedDroppedEvents,
       ),
-      eventSequences,
     };
     this.captureCounters = null;
     this.captureHistograms = null;
     this.captureLatest = null;
-    this.captureEventSequences = null;
     this.captureGraphics = null;
     this.captureOwnerId = null;
     this.captureStartedUs = 0;
     this.captureFirstSequenceNumber = 0;
+    this.captureLastSequenceNumber = 0;
     this.captureStartedDroppedEvents = 0;
   }
 
@@ -430,11 +429,11 @@ export class FlightRecorder {
     this.captureCounters = null;
     this.captureHistograms = null;
     this.captureLatest = null;
-    this.captureEventSequences = null;
     this.captureGraphics = null;
     this.captureOwnerId = null;
     this.captureStartedUs = 0;
     this.captureFirstSequenceNumber = 0;
+    this.captureLastSequenceNumber = 0;
     this.captureStartedDroppedEvents = 0;
   }
 
@@ -554,12 +553,7 @@ export class FlightRecorder {
       records.push(...parseLogRecords(await readFile(file, "utf8")));
     }
     records.sort((left, right) => left.seq - right.seq);
-    const captured = this.captureResult(ownerId)
-      ? this.completedCapture?.eventSequences
-      : undefined;
-    if (captured) {
-      records = records.filter((record) => captured.has(record.seq));
-    } else if (ownerId !== undefined) {
+    if (ownerId !== undefined) {
       records = records.filter(
         (record) => record.ownerId === undefined || record.ownerId === ownerId,
       );

--- a/tests/electron/diagnostics-ownership.spec.ts
+++ b/tests/electron/diagnostics-ownership.spec.ts
@@ -36,6 +36,8 @@ test("keeps renderer capture evidence with its owning window", async () => {
         samples: 4,
       });
 
+      recorder.record({ k: "window.shown" }, {}, ownerId);
+      recorder.record({ k: "window.hidden" }, {}, peerId);
       await recorder.beginCapture(ownerId);
       renderer.recordGraphics(ownerId, graphics("owner-gpu", 1280));
       renderer.recordGraphics(peerId, graphics("peer-gpu", 1920));
@@ -57,6 +59,8 @@ test("keeps renderer capture evidence with its owning window", async () => {
         ownerId,
       );
       recorder.endCapture(1, "manual");
+      recorder.record({ k: "window.resized" }, {}, ownerId);
+      recorder.record({ k: "window.moved" }, {}, peerId);
       const capture = recorder.captureResult();
       renderer.recordGraphics(ownerId, graphics("replacement-gpu", 1440));
       const captureGraphicsAfterReplacement =
@@ -77,6 +81,9 @@ test("keeps renderer capture evidence with its owning window", async () => {
       const peerEvents = JSON.parse(
         `[${(await recorder.exportedEvents(peerId)).text.replaceAll("\n", ",")}]`,
       ).map((event: { name: string }) => event.name);
+      const ownerEvents = JSON.parse(
+        `[${(await recorder.exportedEvents(ownerId)).text.replaceAll("\n", ",")}]`,
+      ).map((event: { name: string }) => event.name);
       return {
         counters: capture?.summary.counters,
         latest: capture?.summary.latest,
@@ -86,6 +93,7 @@ test("keeps renderer capture evidence with its owning window", async () => {
         peerCapture: recorder.captureResult(peerId),
         peerFrames: recorder.framePath(peerId),
         peerEvents,
+        ownerEvents,
         captureGraphicsAfterReplacement,
         liveGraphicsAfterReplacement,
         milestoneBefore,
@@ -116,7 +124,18 @@ test("keeps renderer capture evidence with its owning window", async () => {
     expect(result.counters?.["test.peer"]).toBeUndefined();
     expect(result.peerEvents).toContain("electron.ready");
     expect(result.peerEvents).toContain("window.blurred");
+    expect(result.peerEvents).toContain("window.hidden");
+    expect(result.peerEvents).toContain("window.moved");
     expect(result.peerEvents).not.toContain("window.focused");
+    expect(result.peerEvents).not.toContain("window.shown");
+    expect(result.peerEvents).not.toContain("window.resized");
+    expect(result.ownerEvents).toContain("electron.ready");
+    expect(result.ownerEvents).toContain("window.focused");
+    expect(result.ownerEvents).toContain("window.shown");
+    expect(result.ownerEvents).toContain("window.resized");
+    expect(result.ownerEvents).not.toContain("window.blurred");
+    expect(result.ownerEvents).not.toContain("window.hidden");
+    expect(result.ownerEvents).not.toContain("window.moved");
     expect(result.replacementMilestone).toBeGreaterThanOrEqual(
       result.milestoneBefore,
     );
@@ -233,6 +252,149 @@ test("only the owner observes a capture and Level 2 refuses shared tracing", asy
     expect(result.captureChromiumPids).not.toContain(result.ownerPid);
     expect(result.ownerChromiumPids).toContain(result.ownerPid);
     expect(result.ownerChromiumPids).not.toContain(result.peerPid);
+  } finally {
+    await closeOffline(fixture);
+  }
+});
+
+test("keeps exports globally serialized and reports contention to its owner", async () => {
+  const fixture = await launchOffline("gw-diagnostics-export-contention-e2e-");
+  try {
+    const result = await fixture.app.evaluate(
+      async ({ BrowserWindow, dialog }, modulePath) => {
+        const load = process
+          .getBuiltinModule("node:module")
+          .createRequire(modulePath);
+        const { exportDiagnosticsReport } = load(modulePath);
+        const { recorder } = load(
+          modulePath.replace(/diagnostics-export\.js$/u, "diagnostics/recorder.js"),
+        );
+        const { windowRegistry } = load(
+          modulePath.replace(/diagnostics-export\.js$/u, "window-registry.js"),
+        );
+        const first = new BrowserWindow({ show: false, title: "First owner" });
+        const peer = new BrowserWindow({ show: false, title: "Peer owner" });
+        windowRegistry.register(first, {
+          mode: "multi",
+          role: "game",
+          profileId: "export-first",
+        }, 301);
+        windowRegistry.register(peer, {
+          mode: "multi",
+          role: "game",
+          profileId: "export-peer",
+        }, 302);
+
+        const originalShowMessageBox = dialog.showMessageBox;
+        const messages: Array<{
+          parent: string | null;
+          message: string;
+          detail: string | undefined;
+        }> = [];
+        Object.defineProperty(dialog, "showMessageBox", {
+          configurable: true,
+          value: async (parent: unknown, options: {
+            message: string;
+            detail?: string;
+          }) => {
+            messages.push({
+              parent: parent instanceof BrowserWindow ? parent.getTitle() : null,
+              message: options.message,
+              detail: options.detail,
+            });
+            return { response: 0, checkboxChecked: false };
+          },
+        });
+
+        let releaseFirst: () => void = () => undefined;
+        let markFirstEntered: () => void = () => undefined;
+        const firstEntered = new Promise<void>((resolve) => {
+          markFirstEntered = resolve;
+        });
+        const firstReleased = new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
+        let firstCalls = 0;
+        let peerCalls = 0;
+        try {
+          const exportingFirst = exportDiagnosticsReport(first, async () => {
+            firstCalls += 1;
+            markFirstEntered();
+            await firstReleased;
+            return "first.zip";
+          });
+          await firstEntered;
+          // Ownership is captured before the work starts. Its completion remains
+          // attributable even when the initiating window closes in the meantime.
+          windowRegistry.unregister(first);
+          first.destroy();
+          await exportDiagnosticsReport(peer, async () => {
+            peerCalls += 1;
+            return "must-not-run.zip";
+          });
+          releaseFirst();
+          await exportingFirst;
+          await exportDiagnosticsReport(peer, async () => {
+            peerCalls += 1;
+            return "peer.zip";
+          });
+          await exportDiagnosticsReport(peer, async () => {
+            peerCalls += 1;
+            throw new Error("owned export failure");
+          });
+
+          const eventOwners = async (ownerId: number, name: string) =>
+            (await recorder.exportedEvents(ownerId)).text
+              .split("\n")
+              .filter(Boolean)
+              .map((line: string) => JSON.parse(line) as {
+                name: string;
+                ownerId?: number;
+              })
+              .filter((event: { name: string }) => event.name === name)
+              .map((event: { ownerId?: number }) => event.ownerId);
+          return {
+            firstCalls,
+            peerCalls,
+            messages,
+            firstExportOwners: await eventOwners(301, "diagnostics.exported"),
+            peerExportOwners: await eventOwners(302, "diagnostics.exported"),
+            peerFailureOwners: await eventOwners(302, "diagnostics.exportFailed"),
+          };
+        } finally {
+          releaseFirst();
+          Object.defineProperty(dialog, "showMessageBox", {
+            configurable: true,
+            value: originalShowMessageBox,
+          });
+          windowRegistry.unregister(first);
+          windowRegistry.unregister(peer);
+          if (!first.isDestroyed()) first.destroy();
+          if (!peer.isDestroyed()) peer.destroy();
+        }
+      },
+      path.join(root, "build/main/diagnostics-export.js"),
+    );
+
+    expect(result).toEqual({
+      firstCalls: 1,
+      peerCalls: 2,
+      messages: [
+        {
+          parent: "Peer owner",
+          message: "Another diagnostics export is in progress",
+          detail: "Wait for it to finish, then try again.",
+        },
+        {
+          parent: "Peer owner",
+          message: "Diagnostics export failed",
+          detail: "owned export failure",
+        },
+      ],
+      firstExportOwners: [301],
+      peerExportOwners: [302],
+      peerFailureOwners: [302],
+    });
   } finally {
     await closeOffline(fixture);
   }

--- a/tests/electron/diagnostics.spec.ts
+++ b/tests/electron/diagnostics.spec.ts
@@ -737,8 +737,31 @@ test.describe("diagnostics", () => {
           checkboxChecked: false,
         });
       });
+      const diagnosticOwnerId = await app.evaluate(({ BrowserWindow }, modulePath) => {
+        const load = process.getBuiltinModule("node:module").createRequire(modulePath);
+        const { recorder } = load(
+          modulePath.replace(/diagnostics\.js$/u, "diagnostics/recorder.js"),
+        );
+        const { windowRegistry } = load(
+          modulePath.replace(/diagnostics\.js$/u, "window-registry.js"),
+        );
+        const win = BrowserWindow.getAllWindows()[0];
+        if (!win) throw new Error("diagnostics owner is unavailable");
+        const ownerId = windowRegistry.diagnosticOwnerForWindow(win);
+        if (ownerId === null) throw new Error("diagnostics owner id is unavailable");
+        recorder.record({ k: "window.shown" }, {}, ownerId);
+        recorder.count("test.session.before", 1, ownerId);
+        return ownerId;
+      }, path.join(root, "build/main/diagnostics.js"));
       await clickMenu(app, "start-performance-capture");
       await expect(page.locator("#capture-status")).toBeVisible();
+      await app.evaluate((_, args) => {
+        const load = process.getBuiltinModule("node:module").createRequire(args.modulePath);
+        const { recorder } = load(
+          args.modulePath.replace(/diagnostics\.js$/u, "diagnostics/recorder.js"),
+        );
+        recorder.count("test.capture", 1, args.ownerId);
+      }, { modulePath: path.join(root, "build/main/diagnostics.js"), ownerId: diagnosticOwnerId });
       await page.evaluate(async () => {
         window.gwDiagnostics.swap(200, 50, 25);
         await window.gwDiagnostics.flush();
@@ -750,6 +773,14 @@ test.describe("diagnostics", () => {
       });
       await clickMenu(app, "stop-capture");
       await expect(page.locator("#capture-status")).toBeHidden();
+      await app.evaluate((_, args) => {
+        const load = process.getBuiltinModule("node:module").createRequire(args.modulePath);
+        const { recorder } = load(
+          args.modulePath.replace(/diagnostics\.js$/u, "diagnostics/recorder.js"),
+        );
+        recorder.record({ k: "window.resized" }, {}, args.ownerId);
+        recorder.count("test.session.after", 1, args.ownerId);
+      }, { modulePath: path.join(root, "build/main/diagnostics.js"), ownerId: diagnosticOwnerId });
 
       const target = path.join(diagnosticRoot, "capture.zip");
       const modulePath = path.join(root, "build/main/diagnostics.js");
@@ -761,6 +792,7 @@ test.describe("diagnostics", () => {
           const diagnostics = require(args.modulePath);
           await diagnostics.exportDiagnosticsZip(args.target, {
             appVersion: electronApp.getVersion(),
+            diagnosticOwnerId: args.ownerId,
             // OS/Chromium summary documents are pattern-scanned rather than
             // certified. Plant the adversarial values there; app-authored
             // events have no free-text recording API anymore.
@@ -779,7 +811,7 @@ test.describe("diagnostics", () => {
             },
           });
         },
-        { modulePath, target },
+        { modulePath, target, ownerId: diagnosticOwnerId },
       );
 
       const extracted = path.join(diagnosticRoot, "extracted");
@@ -850,6 +882,30 @@ test.describe("diagnostics", () => {
       expect(exportedText).toContain("[redacted-path]");
       expect(exportedText).toContain("[redacted-email]");
       expect(events).toContain("performance.problemmarked");
+      expect(events).toContain("window.shown");
+      expect(events).toContain("window.resized");
+      const eventRecords = events
+        .split("\n")
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as { name: string; seq: number });
+      expect(eventRecords.find((event) => event.name === "window.shown")?.seq)
+        .toBeLessThan(manifest.capture.firstSequenceNumber);
+      expect(eventRecords.find((event) => event.name === "window.resized")?.seq)
+        .toBeGreaterThan(manifest.capture.lastSequenceNumber);
+      const summary = JSON.parse(
+        await readFile(path.join(extracted, "summary.json"), "utf8"),
+      );
+      const captureSummary = JSON.parse(
+        await readFile(path.join(extracted, "capture-summary.json"), "utf8"),
+      );
+      expect(summary.counters).toMatchObject({
+        "test.session.before": 1,
+        "test.capture": 1,
+        "test.session.after": 1,
+      });
+      expect(captureSummary.counters).toMatchObject({ "test.capture": 1 });
+      expect(captureSummary.counters["test.session.before"]).toBeUndefined();
+      expect(captureSummary.counters["test.session.after"]).toBeUndefined();
 
       const environment = JSON.parse(
         await readFile(path.join(extracted, "environment.json"), "utf8"),


### PR DESCRIPTION
A completed capture currently narrows `events.jsonl` to capture markers, which can hide useful safe context from before and after the problem. A second export request is also ignored silently, and export outcomes can lose their initiating account.

Exports remain deliberately serialized, but contention now gets a dialog on the requesting account window. The report includes the full safe session for its exact owner while capture metadata, frames, trace, and capture summary remain capture-specific. Peer-account evidence stays excluded, and success or failure remains attributed to the initiating owner even if that window closes.

## Verification

- `pnpm run check`
- `pnpm build`
- focused diagnostics Electron tests: 14 passed
- completed-capture, focus-change, owner-close, peer-isolation, and simultaneous-export coverage
- `git diff --check`
