### PR TITLE
chore(runtime): update Electron to 43.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.55.0",
     "@types/node": "^24.13.3",
-    "electron": "^43.2.0",
+    "electron": "^43.4.1",
     "eslint": "^10.7.0",
     "eslint-plugin-vue": "^10.10.0",
     "node-api-headers": "1.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: ^24.13.3
         version: 24.13.3
       electron:
-        specifier: ^43.2.0
-        version: 43.2.0
+        specifier: ^43.4.1
+        version: 43.4.1
       eslint:
         specifier: ^10.7.0
         version: 10.7.0(jiti@2.7.0)
@@ -4613,8 +4613,8 @@ packages:
   electron-to-chromium@1.5.395:
     resolution: {integrity: sha512-7zt9Aw+SrmxLWLN0zhaTWZQiCdryLVrYTq5R7iZakLvi2UQPYMMsROYV/2qVCzMeCiSXHwKOU+sZ4zOVVlrtKA==}
 
-  electron@43.2.0:
-    resolution: {integrity: sha512-80zvrgG7ZRXD+tD0IyLvrnN9n+veSxadMRsMaC9wKKP3iUbtC7rGM8+dVuCmOb0Rrwwv8ESW4awnUZh9Hbp1fA==}
+  electron@43.4.1:
+    resolution: {integrity: sha512-5b+EuiwkgG5iRcsEL34rimgRpkYp15SsfZOa0pC5kXs0Tb82TH4n95rpQzTZa7yRCbA7tm0WoEbuBL6NaAhAcA==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -13184,7 +13184,7 @@ snapshots:
 
   electron-to-chromium@1.5.395: {}
 
-  electron@43.2.0:
+  electron@43.4.1:
     dependencies:
       '@electron-internal/extract-zip': 1.0.4
       '@electron/get': 5.0.0


### PR DESCRIPTION
GWonMac was still resolving Electron 43.2.0 even though the manifest allowed newer releases in the supported 43.x line. Electron 43.4.1 contains directly relevant BrowserWindow memory, idle CPU, tracing, shutdown, and GPU-context fixes.

This updates the declared minimum and lockfile resolution to Electron 43.4.1. No application code or transitive dependency versions change, and frozen installs remain deterministic.

## Verification

- `pnpm verify`
  - checks, build, native integration, release tests, Tools tests, and 150 Electron tests passed
  - one expected opt-in live-client Electron test skipped
  - packaged app smoke and packaged Enhancement runtime passed
- `pnpm audit --prod` — no known vulnerabilities
- `git diff --check`
- local Electron resolution: `43.4.1`

## Graphics A/B smoke

Ran an alternating 43.2.0 → 43.4.1 → 43.2.0 sequence from isolated worktrees using the merged graphics probe. All three accepted captures reached `game.outpost` with the same 4482×2468 WebGL2 drawing buffer and reported:

- 60 submitted FPS;
- no WebGL context loss;
- no presentation failures;
- no dropped diagnostic records;
- 25 ms visible-frame p95;
- 250 µs bitmap-output p95 and 100 µs bitmap-presentation p95;
- visually complete geometry and textures.

One earlier 43.4.1 capture taken during map loading is retained locally as contaminated evidence and excluded from the comparison. The A/B is a compatibility smoke test, not a performance claim, because scene activity and client memory growth varied between runs.

Harness: GWonMac `graphics:live` observation tier, official cached client build 38849, Apple M1 Pro, 2× render scale.
