### PR TITLE
feat(trade): add searchable in-game trade discovery

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -45,7 +45,10 @@ Required template compatibility and Core cursor support run when their exact
 client proofs permit them. Optional **gwonmac Tools Beta** is off by default.
 
 Tools provides Build and Team authoring, party capture, team-code exchange,
-Target Distance, local Xunlai storage opening, and explicit Team Apply. Storage
+read-only Trade Chat discovery, Target Distance, local Xunlai storage opening,
+and explicit Team Apply. Trade Chat is an independent surface with public
+Kamadan and Pre-Searing feeds; players still publish listings in Guild Wars.
+Storage
 has its own opt-in and can be opened from Tools, with its customizable
 Command-Shift-C default shortcut, or by
 typing `/chest` or `/xunlai` in supported PvE outposts. Team Apply is a bounded
@@ -75,7 +78,9 @@ See [Release verification](docs/release-verification.md).
 - No Windows or Linux version.
 - No redistribution of ArenaNet game binaries.
 - No autonomous gameplay.
-- No bots, macros, input broadcasting, synchronized control, or trading tools.
+- No bots, macros, input broadcasting, synchronized control, automated trading,
+  listing publication, trade execution, pricing manipulation, inventory
+  automation, or chat automation.
 - No cloned application installations or duplicated ArenaNet game downloads
   for Multiple Accounts mode.
 - No generic memory, packet, command, or plugin API.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -48,6 +48,8 @@ Tools provides Build and Team authoring, party capture, team-code exchange,
 read-only Trade Chat discovery, Target Distance, local Xunlai storage opening,
 and explicit Team Apply. Trade Chat is an independent surface with public
 Kamadan and Pre-Searing feeds; players still publish listings in Guild Wars.
+Players may locally save an exact offer or follow a character to highlight
+their listings; this never sends or automates game chat.
 Storage
 has its own opt-in and can be opened from Tools, with its customizable
 Command-Shift-C default shortcut, or by

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -46,6 +46,13 @@ repository, the packaged application, or a release artifact.
 
 ## GWToolbox++ and GuildWarsMapBrowser
 
+Trade Chat interoperates with the public read-only Kamadan and Pre-Searing
+services operated for GWToolbox++ at `kamadan.gwtoolbox.com` and
+`ascalon.gwtoolbox.com`. GWonMac is not affiliated with those services. It uses
+their bounded public WebSocket protocol and links back to the selected source.
+Release remains conditional on confirming the service owner's permission or
+published compatibility expectations.
+
 `src/native/gw-dat/vendor/` is a source port from
 [GWToolbox++](https://github.com/gwdevhub/GWToolboxpp), which distributes it
 under the MIT License and identifies it as derived from
@@ -63,6 +70,12 @@ and cached there. The original Latin UI font is also read from that local game
 archive and converted to a browser font in memory. As with the game cursor
 described above, none of this game content is copied into this repository, the
 packaged application, or any release artifact.
+
+## ws
+
+The main process uses [`ws`](https://github.com/websockets/ws) for bounded
+WebSocket client connections. `ws` is copyright its contributors and is
+distributed under the MIT License.
 
 ## QT Friz Quad
 

--- a/apps/tools/DESIGN.md
+++ b/apps/tools/DESIGN.md
@@ -35,6 +35,11 @@ corner, or layer system.
 - Use `.ui-frame` for a framed panel.
 - Use `.ui-well` for a recessed content surface.
 - Use `.ui-raised` for a pressable raised surface.
+- Combine `.ui-panel-head` with `.ui-window-head` for floating windows that
+  carry a title and supporting line. The shared primitive owns normal and
+  constrained-viewport padding; feature styles must not retune it.
+- Use `.ui-scroll` for scrollable wells and lists so scrollbar material stays
+  consistent across Builds, Trade, and Travel.
 - Use the shared components for buttons, fields, checks, tabs, rows, skill
   slots, progress, empty states, banners, toasts, and resize grips.
 - Give each interactive control visible hover, focus, active, selected,
@@ -47,7 +52,7 @@ density, or behavior.
 
 ## Window and interaction rules
 
-- Settings and Tools use the same visible resize grip.
+- Settings, Builds and teams, and Trade Chat use the same visible resize grip.
 - Pointer resize uses capture and handles cancellation and lost capture.
 - Arrow keys resize the window. Shift increases the step.
 - Start a Tools drag only from title-bar furniture.
@@ -61,6 +66,21 @@ density, or behavior.
 - Keep version availability collapsed in Settings unless something is
   unavailable.
 - Keep a dragged window inside the viewport.
+- Let Builds and teams and Trade Chat remain open together. Pointer interaction
+  raises one explicit surface; do not add a generic tool registry.
+- Treat Trade Chat as a working ledger, not a chat transcript or a variation of
+  Builds and teams. Keep source, search, and intent controls above one semantic
+  ledger, with the selected offer in a bottom inspector.
+- At narrow widths, keep the Trade Chat list DOM and open the selected offer in
+  an in-window sheet. The sheet keeps the shared button and scroll primitives.
+- Anchor the new-message hint inside the Trade Chat ledger. Merge new messages
+  immediately when the player is near the top; otherwise queue them without
+  moving the current reading position, then merge and clear the queue at the
+  exact top.
+- Reveal local Trade Chat results 25 at a time as the player nears the bottom,
+  up to 200 results.
+- Scroll to revealed Trade Chat messages smoothly by default and instantly
+  when reduced motion is active.
 - Keep scrolling flex and grid children shrinkable.
 - Use container width to change panel layout.
 - Keep the skill bar usable with pointer, touch, and keyboard input.

--- a/apps/tools/DESIGN.md
+++ b/apps/tools/DESIGN.md
@@ -81,6 +81,9 @@ density, or behavior.
 - Search offer text and the upstream `user:` character index together, then
   merge results by message timestamp. Clearing the field returns immediately
   to the live ledger.
+- Collapse repeated search matches from one character to their newest matching
+  post and show the group count. Keep the live ledger chronological and
+  ungrouped.
 - Keep saved offers and followed players in one right-anchored Saved drawer.
   It is non-modal at wide widths and an in-window sheet when narrow. Its entry
   and exit share the right edge, focus returns to its trigger, and reduced

--- a/apps/tools/DESIGN.md
+++ b/apps/tools/DESIGN.md
@@ -82,6 +82,9 @@ density, or behavior.
   It is non-modal at wide widths and an in-window sheet when narrow. Its entry
   and exit share the right edge, focus returns to its trigger, and reduced
   motion replaces translation with a brief cross-fade.
+- Reveal compact save and follow actions on ledger-row hover or keyboard focus;
+  keep them visible for touch input. Keep the bottom inspector actions on one
+  compact, wrapping row so the message remains the visual focus.
 - Scroll to revealed Trade Chat messages smoothly by default and instantly
   when reduced motion is active.
 - Keep scrolling flex and grid children shrinkable.

--- a/apps/tools/DESIGN.md
+++ b/apps/tools/DESIGN.md
@@ -73,12 +73,15 @@ density, or behavior.
   ledger, with the selected offer in a bottom inspector.
 - At narrow widths, keep the Trade Chat list DOM and open the selected offer in
   an in-window sheet. The sheet keeps the shared button and scroll primitives.
-- Anchor the new-message hint inside the Trade Chat ledger. Merge new messages
-  immediately when the player is near the top; otherwise queue them without
-  moving the current reading position, then merge and clear the queue at the
-  exact top.
+- Merge Trade Chat messages immediately near the top. Away from the top, queue
+  them silently without moving the reading position or showing a repeating
+  arrival hint; merge the queue when the reader returns to the exact top.
 - Reveal local Trade Chat results 25 at a time as the player nears the bottom,
   up to 200 results.
+- Keep saved offers and followed players in one right-anchored Saved drawer.
+  It is non-modal at wide widths and an in-window sheet when narrow. Its entry
+  and exit share the right edge, focus returns to its trigger, and reduced
+  motion replaces translation with a brief cross-fade.
 - Scroll to revealed Trade Chat messages smoothly by default and instantly
   when reduced motion is active.
 - Keep scrolling flex and grid children shrinkable.

--- a/apps/tools/DESIGN.md
+++ b/apps/tools/DESIGN.md
@@ -78,6 +78,9 @@ density, or behavior.
   arrival hint; merge the queue when the reader returns to the exact top.
 - Reveal local Trade Chat results 25 at a time as the player nears the bottom,
   up to 200 results.
+- Search offer text and the upstream `user:` character index together, then
+  merge results by message timestamp. Clearing the field returns immediately
+  to the live ledger.
 - Keep saved offers and followed players in one right-anchored Saved drawer.
   It is non-modal at wide widths and an in-window sheet when narrow. Its entry
   and exit share the right edge, focus returns to its trigger, and reduced

--- a/apps/tools/src/ToolsApp.test-fixture.ts
+++ b/apps/tools/src/ToolsApp.test-fixture.ts
@@ -7,7 +7,7 @@ import { createDemoHost, type ToolsHost } from "./host";
 export async function workbench(host: ToolsHost = createDemoHost()) {
   const wrapper = mount(ToolsApp, {
     attachTo: document.body,
-    props: { host, mode: "standalone", visible: true },
+    props: { host, mode: "standalone", visible: true, active: true },
   });
   await flushPromises();
   return wrapper;

--- a/apps/tools/src/ToolsApp.vue
+++ b/apps/tools/src/ToolsApp.vue
@@ -6,6 +6,7 @@ import {
   onMounted,
   ref,
   shallowRef,
+  toRef,
   watch,
 } from "vue";
 import type { ToolsHost } from "./host";
@@ -28,12 +29,13 @@ import SkillBar from "./components/SkillBar.vue";
 import TeamDetail from "./components/TeamDetail.vue";
 import ModalDialog from "./components/ModalDialog.vue";
 import { navigateRows, navigateTabs } from "./tab-keyboard";
-import { installResizeGrip } from "../../../src/shared/ui/resize";
+import { useFloatingWindow } from "./use-floating-window";
 
 const props = defineProps<{
   host: ToolsHost;
   mode: "standalone" | "embedded";
   visible: boolean;
+  active: boolean;
 }>();
 const emit = defineEmits<{
   close: [];
@@ -41,12 +43,15 @@ const emit = defineEmits<{
 }>();
 
 const controller = useLibrary(props.host);
-const panel = ref<HTMLElement | null>(null);
-const resizeGrip = ref<HTMLButtonElement | null>(null);
 const search = ref<HTMLInputElement | null>(null);
 const mobileView = ref<"list" | "detail">("list");
-const position = ref({ left: 28, top: 42 });
-const size = ref<{ width: number; height: number } | null>(null);
+const { panel, resizeGrip, panelStyle, startDrag } = useFloatingWindow({
+  mode: props.mode,
+  visible: toRef(props, "visible"),
+  initialPosition: { left: 28, top: 42 },
+  minWidth: 320,
+  minHeight: 360,
+});
 const composer = ref<"build" | "team" | "import-team" | null>(null);
 const draftCode = ref("");
 const draftName = ref("");
@@ -78,35 +83,11 @@ const hasObservedParty = computed(() =>
   props.host.party.value.status === "ready"
   && (props.host.party.value.player !== null || props.host.party.value.heroes.length > 0)
 );
-const panelStyle = computed(() => {
-  if (props.mode !== "embedded") return undefined;
-  return {
-    left: `${position.value.left}px`,
-    top: `${position.value.top}px`,
-    ...(size.value
-      ? { width: `${size.value.width}px`, height: `${size.value.height}px` }
-      : {}),
-  };
-});
-
-const fitPanelToViewport = () => {
-  if (props.mode !== "embedded" || !panel.value) return;
-  const width = Math.min(panel.value.offsetWidth, window.innerWidth);
-  const height = Math.min(panel.value.offsetHeight, window.innerHeight);
-  if (width !== panel.value.offsetWidth || height !== panel.value.offsetHeight) {
-    size.value = { width, height };
-  }
-  position.value = {
-    left: Math.max(0, Math.min(window.innerWidth - width, position.value.left)),
-    top: Math.max(0, Math.min(window.innerHeight - height, position.value.top)),
-  };
-};
 watch(
   () => props.visible,
   (visible) => {
     if (visible) {
       requestAnimationFrame(() => {
-        fitPanelToViewport();
         // The embedded palette opens over a running game and must leave the
         // keyboard with it. Explicitly clicking into a field still focuses the
         // field; only the standalone window chooses a typing target on show.
@@ -233,41 +214,8 @@ const startBlankBuild = async () => {
   mobileView.value = "detail";
 };
 
-const startDrag = (event: PointerEvent) => {
-  if (props.mode !== "embedded" || !panel.value) return;
-  if ((event.target as Element).closest("button, input, select, textarea, a, summary, label")) return;
-  const element = panel.value;
-  const handle = event.currentTarget as HTMLElement;
-  const box = element.getBoundingClientRect();
-  const offsetX = event.clientX - box.left;
-  const offsetY = event.clientY - box.top;
-  handle.setPointerCapture(event.pointerId);
-  element.dataset.dragging = "";
-  const move = (next: PointerEvent) => {
-    const left = Math.max(
-      0,
-      Math.min(window.innerWidth - element.offsetWidth, next.clientX - offsetX),
-    );
-    const top = Math.max(
-      0,
-      Math.min(window.innerHeight - element.offsetHeight, next.clientY - offsetY),
-    );
-    position.value = { left, top };
-  };
-  const finish = () => {
-    delete element.dataset.dragging;
-    for (const name of ["pointermove", "pointerup", "pointercancel", "lostpointercapture"] as const) {
-      handle.removeEventListener(name, name === "pointermove" ? move : finish);
-    }
-  };
-  handle.addEventListener("pointermove", move);
-  handle.addEventListener("pointerup", finish);
-  handle.addEventListener("pointercancel", finish);
-  handle.addEventListener("lostpointercapture", finish);
-};
-
 const onKeydown = (event: KeyboardEvent) => {
-  if (!props.visible) return;
+  if (!props.visible || !props.active) return;
   const editable =
     event.target instanceof HTMLInputElement
     || event.target instanceof HTMLTextAreaElement
@@ -288,37 +236,11 @@ const onKeydown = (event: KeyboardEvent) => {
   }
 };
 
-let disposeResize: (() => void) | null = null;
-
 onMounted(() => {
   window.addEventListener("keydown", onKeydown);
-  window.addEventListener("resize", fitPanelToViewport);
-  requestAnimationFrame(fitPanelToViewport);
-  if (props.mode === "embedded" && panel.value && resizeGrip.value) {
-    disposeResize = installResizeGrip(resizeGrip.value, {
-      size: () => {
-        const box = panel.value!.getBoundingClientRect();
-        return { width: box.width, height: box.height };
-      },
-      limits: () => ({
-        minWidth: Math.min(320, window.innerWidth - position.value.left),
-        minHeight: Math.min(360, window.innerHeight - position.value.top),
-        maxWidth: window.innerWidth - position.value.left,
-        maxHeight: window.innerHeight - position.value.top,
-      }),
-      resize: (width, height) => { size.value = { width, height }; },
-      setActive: (active) => {
-        if (!panel.value) return;
-        if (active) panel.value.dataset.resizing = "";
-        else delete panel.value.dataset.resizing;
-      },
-    });
-  }
 });
 onBeforeUnmount(() => {
   window.removeEventListener("keydown", onKeydown);
-  window.removeEventListener("resize", fitPanelToViewport);
-  disposeResize?.();
 });
 </script>
 
@@ -336,7 +258,7 @@ onBeforeUnmount(() => {
       aria-label="GWonMac Tools"
       role="dialog"
     >
-      <header class="ui-panel-head window-bar" @pointerdown="startDrag">
+      <header class="ui-panel-head ui-window-head window-bar" @pointerdown="startDrag">
         <div class="window-brand" aria-hidden="true">GW</div>
         <div class="window-identity">
           <h1 class="ui-panel-title">GWonMac Tools</h1>

--- a/apps/tools/src/TradeChatApp.test.ts
+++ b/apps/tools/src/TradeChatApp.test.ts
@@ -56,6 +56,10 @@ describe("TradeChatApp", () => {
 
     expect(wrapper.text()).toContain("Tyria Cartographer");
     expect(wrapper.text()).not.toContain("Silver Wayfarer");
+    expect(wrapper.findAll(".trade-row")).toHaveLength(1);
+    expect(wrapper.get(".group-count").text()).toBe("2 posts");
+    expect(wrapper.get(".trade-row").text()).toContain("WTS arms 29e each");
+    expect(wrapper.get(".trade-row").text()).not.toContain("Earlier trade listing");
     wrapper.unmount();
   });
 
@@ -144,7 +148,7 @@ describe("TradeChatApp", () => {
     await wrapper.get(".saved-trigger").trigger("click");
     expect(wrapper.get(".trade-saved-drawer").text()).toContain("Tyria Cartographer");
     await wrapper.get(".saved-tabs button:last-child").trigger("click");
-    expect(wrapper.get(".trade-saved-drawer").text()).toContain("1 current offer");
+    expect(wrapper.get(".trade-saved-drawer").text()).toContain("2 current offers");
     wrapper.unmount();
   });
 

--- a/apps/tools/src/TradeChatApp.test.ts
+++ b/apps/tools/src/TradeChatApp.test.ts
@@ -42,8 +42,20 @@ describe("TradeChatApp", () => {
     await flushPromises();
     expect(wrapper.text()).toContain("Quiet Ember");
     expect(wrapper.text()).not.toContain("Silver Wayfarer");
-    await wrapper.get(".trade-search button:last-child").trigger("click");
+    await wrapper.get("input[type=search]").setValue("");
     expect(wrapper.text()).toContain("Silver Wayfarer");
+    expect(wrapper.text()).toContain("Latest messages");
+    wrapper.unmount();
+  });
+
+  it("searches player names through the upstream user query", async () => {
+    const wrapper = await ledger();
+    await wrapper.get("input[type=search]").setValue("Tyria Cartographer");
+    await wrapper.get(".trade-search").trigger("submit");
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("Tyria Cartographer");
+    expect(wrapper.text()).not.toContain("Silver Wayfarer");
     wrapper.unmount();
   });
 

--- a/apps/tools/src/TradeChatApp.test.ts
+++ b/apps/tools/src/TradeChatApp.test.ts
@@ -58,7 +58,7 @@ describe("TradeChatApp", () => {
     wrapper.unmount();
   });
 
-  it("reveals 25 more rows near the bottom and clears pending messages at the top", async () => {
+  it("reveals 25 more rows near the bottom and silently merges new messages at the top", async () => {
     const messages = Array.from({ length: 60 }, (_, index): TradeMessage => ({
       source: "kamadan",
       timestamp: Date.now() - index * 1_000,
@@ -79,6 +79,8 @@ describe("TradeChatApp", () => {
       },
       async copy() {},
       async openSource() {},
+      async getSaved() { return { offers: [], players: [] }; },
+      async setSaved(value) { return value; },
     };
     const wrapper = mount(TradeChatApp, {
       attachTo: document.body,
@@ -107,12 +109,30 @@ describe("TradeChatApp", () => {
       },
     });
     await flushPromises();
-    expect(wrapper.get(".pending-messages").text()).toContain("1 new message");
+    expect(wrapper.find(".pending-messages").exists()).toBe(false);
+    expect(wrapper.text()).not.toContain("new message");
 
     (list.element as HTMLElement).scrollTop = 0;
     await list.trigger("scroll");
     expect(wrapper.find(".pending-messages").exists()).toBe(false);
     expect(wrapper.get(".trade-row").text()).toContain("Newest Trader");
+    wrapper.unmount();
+  });
+
+  it("saves offers and players, highlights them, and exposes both drawer lists", async () => {
+    const wrapper = await ledger();
+    await wrapper.get(".inspector-actions button:first-child").trigger("click");
+    await flushPromises();
+    expect(wrapper.get(".trade-row").attributes("data-saved-offer")).toBe("");
+
+    await wrapper.get(".inspector-actions button:nth-child(2)").trigger("click");
+    await flushPromises();
+    expect(wrapper.get(".trade-row").attributes("data-saved-player")).toBe("");
+
+    await wrapper.get(".saved-trigger").trigger("click");
+    expect(wrapper.get(".trade-saved-drawer").text()).toContain("Tyria Cartographer");
+    await wrapper.get(".saved-tabs button:last-child").trigger("click");
+    expect(wrapper.get(".trade-saved-drawer").text()).toContain("1 current offer");
     wrapper.unmount();
   });
 });

--- a/apps/tools/src/TradeChatApp.test.ts
+++ b/apps/tools/src/TradeChatApp.test.ts
@@ -135,4 +135,24 @@ describe("TradeChatApp", () => {
     expect(wrapper.get(".trade-saved-drawer").text()).toContain("1 current offer");
     wrapper.unmount();
   });
+
+  it("explains when a restart is required for the saved-items bridge", async () => {
+    const demo = createDemoTradeHost();
+    const host: TradeHost = {
+      ...demo,
+      async setSaved() { throw new Error("trade_saved_restart_required"); },
+    };
+    const wrapper = mount(TradeChatApp, {
+      attachTo: document.body,
+      props: { host, mode: "standalone", visible: true, active: true },
+    });
+    await flushPromises();
+
+    await wrapper.get(".row-quick-action").trigger("click");
+    await flushPromises();
+
+    expect(wrapper.get(".trade-notice").text()).toBe("Restart GWonMac once to enable Saved items.");
+    expect(wrapper.get(".trade-row").attributes("data-saved-offer")).toBeUndefined();
+    wrapper.unmount();
+  });
 });

--- a/apps/tools/src/TradeChatApp.test.ts
+++ b/apps/tools/src/TradeChatApp.test.ts
@@ -1,0 +1,118 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import TradeChatApp from "./TradeChatApp.vue";
+import { createDemoTradeHost, type TradeHost } from "./trade-host";
+import type { TradeEvent, TradeMessage } from "../../../src/shared/trade-chat";
+
+async function ledger() {
+  const wrapper = mount(TradeChatApp, {
+    attachTo: document.body,
+    props: {
+      host: createDemoTradeHost(),
+      mode: "standalone",
+      visible: true,
+      active: true,
+    },
+  });
+  await flushPromises();
+  return wrapper;
+}
+
+describe("TradeChatApp", () => {
+  it("switches isolated sources and applies intent filters", async () => {
+    const wrapper = await ledger();
+    expect(wrapper.text()).toContain("Tyria Cartographer");
+    await wrapper.get(".source-segment button:last-child").trigger("click");
+    await flushPromises();
+    expect(wrapper.text()).toContain("Vanguard Althea");
+    expect(wrapper.text()).not.toContain("Tyria Cartographer");
+
+    await wrapper.get(".intent-segment button:nth-child(2)").trigger("click");
+    expect(wrapper.findAll(".trade-row").map((row) => row.text())).toEqual([
+      expect.stringContaining("Northlands Scout"),
+      expect.stringContaining("Ascalon Merchant"),
+    ]);
+    wrapper.unmount();
+  });
+
+  it("submits search and returns to the live feed", async () => {
+    const wrapper = await ledger();
+    await wrapper.get("input[type=search]").setValue("Polar Bear");
+    await wrapper.get(".trade-search").trigger("submit");
+    await flushPromises();
+    expect(wrapper.text()).toContain("Quiet Ember");
+    expect(wrapper.text()).not.toContain("Silver Wayfarer");
+    await wrapper.get(".trade-search button:last-child").trigger("click");
+    expect(wrapper.text()).toContain("Silver Wayfarer");
+    wrapper.unmount();
+  });
+
+  it("uses the active window ownership for the slash search shortcut", async () => {
+    const wrapper = await ledger();
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "/" }));
+    expect(document.activeElement).toBe(wrapper.get("input[type=search]").element);
+    await wrapper.setProps({ active: false });
+    (document.activeElement as HTMLElement).blur();
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "/" }));
+    expect(document.activeElement).not.toBe(wrapper.get("input[type=search]").element);
+    wrapper.unmount();
+  });
+
+  it("reveals 25 more rows near the bottom and clears pending messages at the top", async () => {
+    const messages = Array.from({ length: 60 }, (_, index): TradeMessage => ({
+      source: "kamadan",
+      timestamp: Date.now() - index * 1_000,
+      sender: `Trader ${index + 1}`,
+      message: index % 2 ? "WTB testing materials" : "WTS testing materials",
+    }));
+    const events: { publish: ((event: TradeEvent) => void) | null } = { publish: null };
+    const host: TradeHost = {
+      async subscribe(source) {
+        return { source, status: "live", messages };
+      },
+      async unsubscribe() {},
+      async search(request) { return { ...request, messages }; },
+      async retry() {},
+      onEvent(callback) {
+        events.publish = callback;
+        return () => { events.publish = null; };
+      },
+      async copy() {},
+      async openSource() {},
+    };
+    const wrapper = mount(TradeChatApp, {
+      attachTo: document.body,
+      props: { host, mode: "standalone", visible: true, active: true },
+    });
+    await flushPromises();
+    expect(wrapper.findAll(".trade-row")).toHaveLength(25);
+
+    const list = wrapper.get(".trade-list");
+    Object.defineProperties(list.element, {
+      clientHeight: { configurable: true, value: 400 },
+      scrollHeight: { configurable: true, value: 1_200 },
+      scrollTop: { configurable: true, writable: true, value: 720 },
+    });
+    await list.trigger("scroll");
+    expect(wrapper.findAll(".trade-row")).toHaveLength(50);
+
+    events.publish?.({
+      type: "message",
+      source: "kamadan",
+      message: {
+        source: "kamadan",
+        timestamp: Date.now() + 1_000,
+        sender: "Newest Trader",
+        message: "WTS a newly arrived offer",
+      },
+    });
+    await flushPromises();
+    expect(wrapper.get(".pending-messages").text()).toContain("1 new message");
+
+    (list.element as HTMLElement).scrollTop = 0;
+    await list.trigger("scroll");
+    expect(wrapper.find(".pending-messages").exists()).toBe(false);
+    expect(wrapper.get(".trade-row").text()).toContain("Newest Trader");
+    wrapper.unmount();
+  });
+});

--- a/apps/tools/src/TradeChatApp.test.ts
+++ b/apps/tools/src/TradeChatApp.test.ts
@@ -1,8 +1,12 @@
 import { flushPromises, mount } from "@vue/test-utils";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import TradeChatApp from "./TradeChatApp.vue";
 import { createDemoTradeHost, type TradeHost } from "./trade-host";
-import type { TradeEvent, TradeMessage } from "../../../src/shared/trade-chat";
+import type {
+  TradeEvent,
+  TradeMessage,
+  TradeSavedState,
+} from "../../../src/shared/trade-chat";
 
 async function ledger() {
   const wrapper = mount(TradeChatApp, {
@@ -87,7 +91,12 @@ describe("TradeChatApp", () => {
         return { source, status: "live", messages };
       },
       async unsubscribe() {},
-      async search(request) { return { ...request, messages }; },
+      async search(request) {
+        return {
+          ...request,
+          matches: messages.map((message) => ({ message, postCount: 1 })),
+        };
+      },
       async retry() {},
       onEvent(callback) {
         events.publish = callback;
@@ -114,16 +123,19 @@ describe("TradeChatApp", () => {
     await list.trigger("scroll");
     expect(wrapper.findAll(".trade-row")).toHaveLength(50);
 
-    events.publish?.({
-      type: "message",
-      source: "kamadan",
-      message: {
+    const arrivalBase = Date.now() + 1_000;
+    for (let index = 0; index < 150; index += 1) {
+      events.publish?.({
+        type: "message",
         source: "kamadan",
-        timestamp: Date.now() + 1_000,
-        sender: "Newest Trader",
-        message: "WTS a newly arrived offer",
-      },
-    });
+        message: {
+          source: "kamadan",
+          timestamp: arrivalBase + index,
+          sender: `Newest Trader ${index}`,
+          message: "WTS a newly arrived offer",
+        },
+      });
+    }
     await flushPromises();
     expect(wrapper.find(".pending-messages").exists()).toBe(false);
     expect(wrapper.text()).not.toContain("new message");
@@ -131,7 +143,8 @@ describe("TradeChatApp", () => {
     (list.element as HTMLElement).scrollTop = 0;
     await list.trigger("scroll");
     expect(wrapper.find(".pending-messages").exists()).toBe(false);
-    expect(wrapper.get(".trade-row").text()).toContain("Newest Trader");
+    expect(wrapper.get(".trade-row").text()).toContain("Newest Trader 149");
+    expect(wrapper.get(".trade-summary").text()).toContain("100 offers");
     wrapper.unmount();
   });
 
@@ -152,11 +165,11 @@ describe("TradeChatApp", () => {
     wrapper.unmount();
   });
 
-  it("explains when a restart is required for the saved-items bridge", async () => {
+  it("restores confirmed saved state when persistence fails", async () => {
     const demo = createDemoTradeHost();
     const host: TradeHost = {
       ...demo,
-      async setSaved() { throw new Error("trade_saved_restart_required"); },
+      async setSaved() { throw new Error("disk unavailable"); },
     };
     const wrapper = mount(TradeChatApp, {
       attachTo: document.body,
@@ -167,8 +180,84 @@ describe("TradeChatApp", () => {
     await wrapper.get(".row-quick-action").trigger("click");
     await flushPromises();
 
-    expect(wrapper.get(".trade-notice").text()).toBe("Restart GWonMac once to enable Saved items.");
+    expect(wrapper.get(".trade-notice").text()).toBe("Saved items could not be updated. Try again.");
     expect(wrapper.get(".trade-row").attributes("data-saved-offer")).toBeUndefined();
+    wrapper.unmount();
+  });
+
+  it("serializes rapid saved actions without losing either change", async () => {
+    const demo = createDemoTradeHost();
+    const writes: Array<{
+      value: TradeSavedState;
+      resolve: (value: TradeSavedState) => void;
+    }> = [];
+    const setSaved = vi.fn((value: TradeSavedState) => new Promise<TradeSavedState>((resolve) => {
+      writes.push({ value, resolve });
+    }));
+    const wrapper = mount(TradeChatApp, {
+      attachTo: document.body,
+      props: {
+        host: { ...demo, setSaved },
+        mode: "standalone",
+        visible: true,
+        active: true,
+      },
+    });
+    await flushPromises();
+
+    await wrapper.get(".inspector-actions button:first-child").trigger("click");
+    await wrapper.get(".inspector-actions button:nth-child(2)").trigger("click");
+    await flushPromises();
+    expect(setSaved).toHaveBeenCalledTimes(1);
+    writes[0]!.resolve(writes[0]!.value);
+    await flushPromises();
+    expect(setSaved).toHaveBeenCalledTimes(2);
+    expect(writes[1]!.value.offers).toHaveLength(1);
+    expect(writes[1]!.value.players).toHaveLength(1);
+    writes[1]!.resolve(writes[1]!.value);
+    await flushPromises();
+    expect(wrapper.get(".trade-row").attributes("data-saved-offer")).toBe("");
+    expect(wrapper.get(".trade-row").attributes("data-saved-player")).toBe("");
+    wrapper.unmount();
+  });
+
+  it("keeps the inspector aligned with the active intent filter", async () => {
+    const wrapper = await ledger();
+    expect(wrapper.get(".trade-inspector").text()).toContain("WTS arms");
+    await wrapper.get(".intent-segment button:last-child").trigger("click");
+    await flushPromises();
+    expect(wrapper.get(".trade-inspector").text()).toContain("WTB cupcakes");
+    expect(wrapper.get(".trade-inspector").text()).not.toContain("WTS arms");
+    wrapper.unmount();
+  });
+
+  it("keeps a saved offer selected while switching its source", async () => {
+    const demo = createDemoTradeHost();
+    const savedOffer = {
+      source: "pre-searing" as const,
+      timestamp: 99,
+      sender: "Archived Trader",
+      message: "WTS an archived Charr kit",
+      savedAt: Date.now(),
+    };
+    const wrapper = mount(TradeChatApp, {
+      attachTo: document.body,
+      props: {
+        host: {
+          ...demo,
+          async getSaved() { return { offers: [savedOffer], players: [] }; },
+        },
+        mode: "standalone",
+        visible: true,
+        active: true,
+      },
+    });
+    await flushPromises();
+    await wrapper.get(".saved-trigger").trigger("click");
+    await wrapper.get(".saved-card-main").trigger("click");
+    await flushPromises();
+    expect(wrapper.get(".ui-panel-title").text()).toBe("Pre-Searing Trade");
+    expect(wrapper.get(".trade-inspector").text()).toContain("archived Charr kit");
     wrapper.unmount();
   });
 });

--- a/apps/tools/src/TradeChatApp.vue
+++ b/apps/tools/src/TradeChatApp.vue
@@ -141,9 +141,20 @@ async function runSearch(existingRevision?: number): Promise<void> {
   const requestedSource = source.value;
   searching.value = true;
   try {
-    const result = await props.host.search({ source: requestedSource, query: trimmed });
+    const requests = [props.host.search({ source: requestedSource, query: trimmed })];
+    const playerQuery = `user:${trimmed}`;
+    if (
+      !trimmed.toLocaleLowerCase().startsWith("user:")
+      && [...playerQuery].length <= TRADE_LIMITS.queryCharacters
+    ) {
+      requests.push(props.host.search({ source: requestedSource, query: playerQuery }));
+    }
+    const results = await Promise.all(requests);
     if (revision !== requestRevision || source.value !== requestedSource) return;
-    current.value.search = [...result.messages];
+    current.value.search = sortNewest([...new Map(
+      results.flatMap((result) => result.messages)
+        .map((message) => [message.timestamp, message] as const),
+    ).values()]).slice(0, TRADE_LIMITS.searchResults);
     ensureSelection(current.value, current.value.search);
   } catch {
     if (revision === requestRevision) {
@@ -153,6 +164,11 @@ async function runSearch(existingRevision?: number): Promise<void> {
   } finally {
     if (revision === requestRevision) searching.value = false;
   }
+}
+
+function onQueryInput(event: Event): void {
+  const value = (event.target as HTMLInputElement).value;
+  if (!value.trim() && submittedQuery.value) clearSearch();
 }
 
 function clearSearch(): void {
@@ -456,6 +472,7 @@ function exactTime(timestamp: number): string {
             <input
               ref="searchInput"
               v-model="query"
+              @input="onQueryInput"
               type="search"
               maxlength="128"
               placeholder="Search offers or character names"

--- a/apps/tools/src/TradeChatApp.vue
+++ b/apps/tools/src/TradeChatApp.vue
@@ -1,0 +1,489 @@
+<script setup lang="ts">
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  reactive,
+  ref,
+  toRef,
+  watch,
+} from "vue";
+import type { TradeHost } from "./trade-host";
+import {
+  TRADE_LIMITS,
+  type TradeConnectionState,
+  type TradeEvent,
+  type TradeMessage,
+  type TradeSource,
+} from "../../../src/shared/trade-chat";
+import { useFloatingWindow } from "./use-floating-window";
+
+const props = defineProps<{
+  host: TradeHost;
+  mode: "standalone" | "embedded";
+  visible: boolean;
+  active: boolean;
+}>();
+const emit = defineEmits<{ close: []; ready: [] }>();
+
+type Intent = "all" | "selling" | "buying";
+type SourceState = {
+  status: TradeConnectionState;
+  live: TradeMessage[];
+  pending: TradeMessage[];
+  search: TradeMessage[];
+  selection: number | null;
+};
+
+const source = ref<TradeSource>("kamadan");
+const intent = ref<Intent>("all");
+const query = ref("");
+const submittedQuery = ref("");
+const searching = ref(false);
+const searchProblem = ref("");
+const notice = ref("");
+const detailOpen = ref(false);
+const visibleLimit = ref(25);
+const searchInput = ref<HTMLInputElement | null>(null);
+const list = ref<HTMLElement | null>(null);
+const states = reactive<Record<TradeSource, SourceState>>({
+  kamadan: state(),
+  "pre-searing": state(),
+});
+const { panel, resizeGrip, panelStyle, startDrag } = useFloatingWindow({
+  mode: props.mode,
+  visible: toRef(props, "visible"),
+  initialPosition: { left: 64, top: 54 },
+  minWidth: 520,
+  minHeight: 400,
+});
+
+const current = computed(() => states[source.value]);
+const sourceLabel = computed(() => source.value === "kamadan" ? "Kamadan" : "Pre-Searing");
+const statusLabel = computed(() => ({
+  connecting: "Connecting",
+  live: "Live",
+  reconnecting: "Reconnecting",
+  unavailable: "Unavailable",
+})[current.value.status]);
+const baseMessages = computed(() => submittedQuery.value
+  ? current.value.search
+  : current.value.live);
+const filtered = computed(() => baseMessages.value.filter((message) => {
+  const tags = messageIntents(message.message);
+  return intent.value === "all" || tags.includes(intent.value);
+}));
+const visibleMessages = computed(() => filtered.value.slice(0, visibleLimit.value));
+const selected = computed(() => {
+  const timestamp = current.value.selection;
+  return timestamp === null
+    ? null
+    : [...current.value.live, ...current.value.search, ...current.value.pending]
+      .find((message) => message.timestamp === timestamp) ?? null;
+});
+const emptyHeading = computed(() => {
+  if (searching.value) return "Searching the trade ledger…";
+  if (searchProblem.value) return "Search could not finish";
+  if (submittedQuery.value) return "No matching offers";
+  if (current.value.status === "unavailable") return "Trade feed unavailable";
+  return "Waiting for trade messages";
+});
+
+let requestRevision = 0;
+let stopEvents: (() => void) | null = null;
+let clock: ReturnType<typeof setInterval> | null = null;
+const now = ref(Date.now());
+
+async function subscribe(next: TradeSource): Promise<void> {
+  const revision = ++requestRevision;
+  searchProblem.value = "";
+  const target = states[next];
+  target.status = target.live.length ? "reconnecting" : "connecting";
+  try {
+    const snapshot = await props.host.subscribe(next);
+    if (revision !== requestRevision || source.value !== next || !props.visible) return;
+    target.status = snapshot.status;
+    target.live = [...snapshot.messages];
+    ensureSelection(target, target.live);
+    emit("ready");
+    if (submittedQuery.value) await runSearch(revision);
+  } catch {
+    if (revision === requestRevision) target.status = "unavailable";
+  }
+}
+
+async function runSearch(existingRevision?: number): Promise<void> {
+  const trimmed = query.value.trim();
+  submittedQuery.value = trimmed;
+  visibleLimit.value = 25;
+  searchProblem.value = "";
+  if (!trimmed) {
+    searching.value = false;
+    ensureSelection(current.value, current.value.live);
+    return;
+  }
+  const revision = existingRevision ?? ++requestRevision;
+  const requestedSource = source.value;
+  searching.value = true;
+  try {
+    const result = await props.host.search({ source: requestedSource, query: trimmed });
+    if (revision !== requestRevision || source.value !== requestedSource) return;
+    current.value.search = [...result.messages];
+    ensureSelection(current.value, current.value.search);
+  } catch {
+    if (revision === requestRevision) {
+      current.value.search = [];
+      searchProblem.value = "The feed did not answer. Check the connection and try again.";
+    }
+  } finally {
+    if (revision === requestRevision) searching.value = false;
+  }
+}
+
+function clearSearch(): void {
+  query.value = "";
+  submittedQuery.value = "";
+  searchProblem.value = "";
+  searching.value = false;
+  visibleLimit.value = 25;
+  requestRevision += 1;
+  ensureSelection(current.value, current.value.live);
+}
+
+function onTradeEvent(event: TradeEvent): void {
+  const target = states[event.source];
+  if (event.type === "status") {
+    target.status = event.status;
+    return;
+  }
+  removeReplacement(target, event.message.replacementTimestamp);
+  if ([...target.live, ...target.pending].some(
+    (candidate) => candidate.timestamp === event.message.timestamp,
+  )) return;
+  const nearTop = event.source !== source.value || !list.value || list.value.scrollTop < 36;
+  if (nearTop) {
+    target.live = sortNewest([event.message, ...target.live]).slice(0, TRADE_LIMITS.liveMessages);
+  } else {
+    target.pending = sortNewest([event.message, ...target.pending]);
+  }
+  ensureSelection(target, target.live);
+}
+
+function revealPending(): void {
+  commitPending();
+  const reducedMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
+  nextTick(() => list.value?.scrollTo({
+    top: 0,
+    behavior: reducedMotion ? "auto" : "smooth",
+  }));
+}
+
+function commitPending(): void {
+  if (!current.value.pending.length) return;
+  current.value.live = sortNewest([
+    ...current.value.pending,
+    ...current.value.live,
+  ]).slice(0, TRADE_LIMITS.liveMessages);
+  current.value.pending = [];
+}
+
+function onListScroll(event: Event): void {
+  const target = event.currentTarget;
+  if (!(target instanceof HTMLElement)) return;
+  if (target.scrollTop <= 2) commitPending();
+  const remaining = target.scrollHeight - target.clientHeight - target.scrollTop;
+  if (remaining <= 96 && visibleLimit.value < filtered.value.length) {
+    visibleLimit.value = Math.min(visibleLimit.value + 25, TRADE_LIMITS.searchResults);
+  }
+}
+
+function selectMessage(message: TradeMessage): void {
+  current.value.selection = message.timestamp;
+  detailOpen.value = true;
+}
+
+async function copy(value: string, label: string): Promise<void> {
+  try {
+    await props.host.copy(value);
+    notice.value = `${label} copied`;
+  } catch {
+    notice.value = "Clipboard access was refused. Select the text and copy it manually.";
+  }
+  window.setTimeout(() => {
+    if (notice.value.startsWith(label) || notice.value.startsWith("Clipboard")) notice.value = "";
+  }, 3_000);
+}
+
+function onListKeydown(event: KeyboardEvent): void {
+  if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+  const rows = visibleMessages.value;
+  if (!rows.length) return;
+  event.preventDefault();
+  const index = rows.findIndex((message) => message.timestamp === current.value.selection);
+  const next = event.key === "ArrowDown"
+    ? Math.min(rows.length - 1, index + 1)
+    : Math.max(0, index < 0 ? 0 : index - 1);
+  selectMessage(rows[next]!);
+  nextTick(() => {
+    list.value?.querySelector<HTMLElement>(`[data-timestamp="${rows[next]!.timestamp}"]`)
+      ?.focus({ preventScroll: false });
+  });
+}
+
+function onWindowKeydown(event: KeyboardEvent): void {
+  if (!props.visible || !props.active) return;
+  if (
+    event.key === "/"
+    && !(event.target instanceof HTMLInputElement)
+    && !(event.target instanceof HTMLTextAreaElement)
+  ) {
+    event.preventDefault();
+    searchInput.value?.focus();
+  }
+}
+
+watch(source, (next) => {
+  detailOpen.value = false;
+  visibleLimit.value = 25;
+  if (props.visible) void subscribe(next);
+});
+watch(() => props.visible, (visible) => {
+  if (visible) void subscribe(source.value);
+  else {
+    requestRevision += 1;
+    void props.host.unsubscribe();
+  }
+});
+
+onMounted(() => {
+  stopEvents = props.host.onEvent(onTradeEvent);
+  window.addEventListener("keydown", onWindowKeydown);
+  clock = setInterval(() => { now.value = Date.now(); }, 30_000);
+  if (props.visible) void subscribe(source.value);
+});
+onBeforeUnmount(() => {
+  requestRevision += 1;
+  stopEvents?.();
+  window.removeEventListener("keydown", onWindowKeydown);
+  if (clock) clearInterval(clock);
+  void props.host.unsubscribe();
+});
+
+function state(): SourceState {
+  return { status: "unavailable", live: [], pending: [], search: [], selection: null };
+}
+function sortNewest(messages: TradeMessage[]): TradeMessage[] {
+  return messages.sort((left, right) => right.timestamp - left.timestamp);
+}
+function ensureSelection(target: SourceState, messages: readonly TradeMessage[]): void {
+  if (!messages.some((message) => message.timestamp === target.selection)) {
+    target.selection = messages[0]?.timestamp ?? null;
+  }
+}
+function removeReplacement(target: SourceState, timestamp: number | undefined): void {
+  if (timestamp === undefined) return;
+  target.live = target.live.filter((message) => message.timestamp !== timestamp);
+  target.pending = target.pending.filter((message) => message.timestamp !== timestamp);
+  target.search = target.search.filter((message) => message.timestamp !== timestamp);
+}
+function messageIntents(message: string): Intent[] {
+  const selling = /(?:^|[^a-z0-9])wts(?:$|[^a-z0-9])/iu.test(message);
+  const buying = /(?:^|[^a-z0-9])wtb(?:$|[^a-z0-9])/iu.test(message);
+  return [selling ? "selling" : null, buying ? "buying" : null]
+    .filter((value): value is Intent => value !== null);
+}
+function age(timestamp: number): string {
+  const seconds = Math.max(0, Math.floor((now.value - timestamp) / 1000));
+  if (seconds < 60) return "now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m`;
+  const hours = Math.floor(minutes / 60);
+  return hours < 24 ? `${hours}h` : `${Math.floor(hours / 24)}d`;
+}
+function exactTime(timestamp: number): string {
+  return new Intl.DateTimeFormat(undefined, { dateStyle: "medium", timeStyle: "medium" })
+    .format(timestamp);
+}
+</script>
+
+<template>
+  <!--
+    THESIS: trade discovery is a working ledger, not a chat transcript or build tab.
+    OWN-WORLD: GWonMac ivory metal, recessed black wells, blue-black selection, quiet gilt.
+    STORY: choose a market, scan intent and age, inspect one offer, copy what is useful.
+    FIRST VIEWPORT: source and search above a full-width ledger; exact detail docks below.
+    FORM: approved concept 5, production seed trade-ledger-v1.
+    FINISH: unreviewed and undocumented is unfinished; this build ends with the finish review, the verdict, and DESIGN.md.
+  -->
+  <div
+    v-show="visible"
+    class="tools-stage trade-stage"
+    :data-mode="mode"
+    :data-detail-open="detailOpen ? '' : undefined"
+  >
+    <section
+      ref="panel"
+      class="ui-frame ui-panel tools-window trade-window"
+      :style="panelStyle"
+      role="dialog"
+      aria-label="Trade Chat"
+      data-design-contract="trade-ledger-v1"
+    >
+      <header class="ui-panel-head ui-window-head window-bar" @pointerdown="startDrag">
+        <div class="window-brand trade-brand" aria-hidden="true">T</div>
+        <div class="window-identity">
+          <h1 class="ui-panel-title">{{ sourceLabel }} Trade</h1>
+          <p class="ui-field-hint">Public trade feed · listings are posted in Guild Wars</p>
+        </div>
+        <span class="trade-status" :data-state="current.status" role="status">
+          <i aria-hidden="true" />{{ statusLabel }}
+        </span>
+        <button
+          v-if="mode === 'embedded'"
+          class="ui-button window-close"
+          data-icon
+          aria-label="Close Trade Chat"
+          @click="emit('close')"
+        >×</button>
+      </header>
+
+      <div class="trade-toolbar">
+        <div class="ui-segment source-segment" data-fill aria-label="Trade source">
+          <button :aria-pressed="source === 'kamadan'" @click="source = 'kamadan'">Kamadan</button>
+          <button :aria-pressed="source === 'pre-searing'" @click="source = 'pre-searing'">Pre-Searing</button>
+        </div>
+        <form class="trade-search" role="search" @submit.prevent="runSearch()">
+          <label class="ui-input-group">
+            <span class="ui-sr-only">Search offers or character names</span>
+            <input
+              ref="searchInput"
+              v-model="query"
+              type="search"
+              maxlength="128"
+              placeholder="Search offers or character names"
+              spellcheck="false"
+            >
+            <kbd class="ui-kbd">/</kbd>
+          </label>
+          <button class="ui-button" data-variant="primary" :disabled="searching || !query.trim()">
+            {{ searching ? "Searching…" : "Search" }}
+          </button>
+          <button v-if="submittedQuery" type="button" class="ui-button" @click="clearSearch">Live feed</button>
+        </form>
+        <div class="ui-segment intent-segment" data-fill aria-label="Offer intent">
+          <button :aria-pressed="intent === 'all'" @click="intent = 'all'">All</button>
+          <button :aria-pressed="intent === 'selling'" @click="intent = 'selling'">Selling</button>
+          <button :aria-pressed="intent === 'buying'" @click="intent = 'buying'">Buying</button>
+        </div>
+      </div>
+
+      <div class="trade-summary" aria-live="polite">
+        <span>
+          {{ submittedQuery ? `Results for “${submittedQuery}”` : "Latest messages" }}
+        </span>
+        <span>{{ filtered.length }} {{ filtered.length === 1 ? "offer" : "offers" }}</span>
+      </div>
+
+      <div class="trade-ledger ui-well">
+        <div class="trade-columns" aria-hidden="true">
+          <span>Intent</span><span>Character</span><span>Message</span><span>Age</span>
+        </div>
+        <button
+          v-if="current.pending.length"
+          class="ui-button pending-messages"
+          data-variant="primary"
+          @click="revealPending"
+        >{{ current.pending.length }} new {{ current.pending.length === 1 ? "message" : "messages" }}</button>
+        <div
+          v-if="searching || (!visibleMessages.length && (current.status === 'connecting' || current.status === 'reconnecting'))"
+          class="trade-state"
+          role="status"
+        >
+          <div class="trade-skeleton" /><div class="trade-skeleton" /><div class="trade-skeleton" />
+          <p>{{ current.status === "reconnecting" ? "Reconnecting — showing saved session messages when available." : emptyHeading }}</p>
+        </div>
+        <div v-else-if="!visibleMessages.length" class="trade-state">
+          <strong>{{ emptyHeading }}</strong>
+          <p v-if="searchProblem">{{ searchProblem }}</p>
+          <p v-else-if="submittedQuery">Try a shorter item name, character name, or another intent.</p>
+          <p v-else>Messages will appear here as soon as the public feed answers.</p>
+          <button
+            v-if="current.status === 'unavailable' || searchProblem"
+            class="ui-button"
+            @click="props.host.retry(source); subscribe(source)"
+          >Try again</button>
+        </div>
+        <div
+          v-else
+          ref="list"
+          class="trade-list ui-scroll"
+          role="listbox"
+          aria-label="Trade offers"
+          @scroll="onListScroll"
+          @keydown="onListKeydown"
+        >
+          <button
+            v-for="message in visibleMessages"
+            :key="message.timestamp"
+            class="trade-row"
+            role="option"
+            :data-timestamp="message.timestamp"
+            :aria-selected="current.selection === message.timestamp"
+            @click="selectMessage(message)"
+          >
+            <span class="intent-cell">
+              <span v-for="tag in messageIntents(message.message)" :key="tag" class="ui-chip" :data-intent="tag">
+                {{ tag === "selling" ? "WTS" : "WTB" }}
+              </span>
+              <span v-if="!messageIntents(message.message).length" class="ui-chip">Other</span>
+            </span>
+            <bdi class="character-cell">{{ message.sender }}</bdi>
+            <bdi class="message-cell">{{ message.message }}</bdi>
+            <time class="age-cell" :datetime="new Date(message.timestamp).toISOString()">{{ age(message.timestamp) }}</time>
+          </button>
+          <button
+            v-if="visibleLimit < filtered.length"
+            class="ui-button load-more"
+            @click="visibleLimit = Math.min(visibleLimit + 25, 200)"
+          >Load 25 more</button>
+        </div>
+      </div>
+
+      <section class="trade-inspector ui-raised ui-scroll" :aria-label="selected ? `Offer from ${selected.sender}` : 'Offer detail'">
+        <button class="ui-button mobile-back" @click="detailOpen = false">Back to offers</button>
+        <template v-if="selected">
+          <div class="inspector-copy">
+            <div class="inspector-meta">
+              <bdi>{{ selected.sender }}</bdi>
+              <time :datetime="new Date(selected.timestamp).toISOString()">{{ exactTime(selected.timestamp) }}</time>
+            </div>
+            <p><bdi>{{ selected.message }}</bdi></p>
+          </div>
+          <div class="inspector-actions">
+            <button class="ui-button" data-variant="primary" @click="copy(selected.sender, 'Character name')">
+              Copy character
+            </button>
+            <button class="ui-button" @click="copy(selected.message, 'Message')">Copy message</button>
+            <button class="ui-link" @click="props.host.openSource(source)">Open {{ sourceLabel }} feed</button>
+          </div>
+        </template>
+        <div v-else class="ui-empty">
+          <strong>Choose an offer</strong>
+          <p>The complete message and copy actions will appear here.</p>
+        </div>
+      </section>
+
+      <Transition name="notice">
+        <div v-if="notice" class="ui-toast trade-notice" role="status">{{ notice }}</div>
+      </Transition>
+      <button
+        v-if="mode === 'embedded'"
+        ref="resizeGrip"
+        type="button"
+        class="ui-resize-grip"
+        aria-label="Resize Trade Chat"
+      />
+    </section>
+  </div>
+</template>

--- a/apps/tools/src/TradeChatApp.vue
+++ b/apps/tools/src/TradeChatApp.vue
@@ -15,11 +15,20 @@ import {
   type TradeConnectionState,
   type TradeEvent,
   type TradeMessage,
+  type TradeSearchMatch,
   type TradeSavedOffer,
   type TradeSavedState,
   type TradeSource,
 } from "../../../src/shared/trade-chat";
+import {
+  insertTradeMessage,
+  liveLedgerRows,
+  searchLedgerRows,
+  tradeMessageIntents,
+  type TradeIntent,
+} from "./trade-ledger";
 import { useFloatingWindow } from "./use-floating-window";
+import TradeIcon from "./TradeIcon.vue";
 
 const props = defineProps<{
   host: TradeHost;
@@ -29,17 +38,17 @@ const props = defineProps<{
 }>();
 const emit = defineEmits<{ close: []; ready: [] }>();
 
-type Intent = "all" | "selling" | "buying";
 type SourceState = {
   status: TradeConnectionState;
   live: TradeMessage[];
   pending: TradeMessage[];
-  search: TradeMessage[];
+  search: TradeSearchMatch[];
   selection: number | null;
+  savedSelection: number | null;
 };
 
 const source = ref<TradeSource>("kamadan");
-const intent = ref<Intent>("all");
+const intent = ref<TradeIntent>("all");
 const query = ref("");
 const submittedQuery = ref("");
 const searching = ref(false);
@@ -49,6 +58,7 @@ const detailOpen = ref(false);
 const savedOpen = ref(false);
 const savedTab = ref<"offers" | "players">("offers");
 const saved = ref<TradeSavedState>({ offers: [], players: [] });
+const savedReady = ref(false);
 const savedButton = ref<HTMLButtonElement | null>(null);
 const savedClose = ref<HTMLButtonElement | null>(null);
 const visibleLimit = ref(25);
@@ -64,6 +74,7 @@ const { panel, resizeGrip, panelStyle, startDrag } = useFloatingWindow({
   initialPosition: { left: 64, top: 54 },
   minWidth: 520,
   minHeight: 400,
+  viewportMargin: 32,
 });
 
 const current = computed(() => states[source.value]);
@@ -74,39 +85,20 @@ const statusLabel = computed(() => ({
   reconnecting: "Reconnecting",
   unavailable: "Unavailable",
 })[current.value.status]);
-const baseMessages = computed(() => submittedQuery.value
-  ? current.value.search
-  : current.value.live);
-const intentMatches = computed(() => baseMessages.value.filter((message) => {
-  const tags = messageIntents(message.message);
-  return intent.value === "all" || tags.includes(intent.value);
-}));
-const displayedRows = computed(() => {
-  if (!submittedQuery.value) {
-    return intentMatches.value.map((message) => ({ message, count: 1 }));
-  }
-  const groups = new Map<string, { message: TradeMessage; count: number }>();
-  for (const message of sortNewest([...intentMatches.value])) {
-    const key = message.sender.toLocaleLowerCase();
-    const existing = groups.get(key);
-    if (existing) existing.count += 1;
-    else groups.set(key, { message, count: 1 });
-  }
-  return [...groups.values()];
-});
+const displayedRows = computed(() => submittedQuery.value
+  ? searchLedgerRows(current.value.search, intent.value)
+  : liveLedgerRows(current.value.live, intent.value));
 const filtered = computed(() => displayedRows.value.map((row) => row.message));
 const visibleMessages = computed(() => filtered.value.slice(0, visibleLimit.value));
 const selected = computed(() => {
   const timestamp = current.value.selection;
   return timestamp === null
     ? null
-    : [
-      ...current.value.live,
-      ...current.value.search,
-      ...current.value.pending,
-      ...saved.value.offers.filter((offer) => offer.source === source.value),
-    ]
-      .find((message) => message.timestamp === timestamp) ?? null;
+    : current.value.savedSelection === timestamp
+      ? saved.value.offers.find((offer) =>
+          offer.source === source.value && offer.timestamp === timestamp
+        ) ?? null
+      : displayedRows.value.find((row) => row.message.timestamp === timestamp)?.message ?? null;
 });
 const savedCount = computed(() => saved.value.offers.length + saved.value.players.length);
 const emptyHeading = computed(() => {
@@ -118,13 +110,16 @@ const emptyHeading = computed(() => {
 });
 
 function groupedPostCount(message: TradeMessage): number {
-  return displayedRows.value.find((row) => row.message.timestamp === message.timestamp)?.count ?? 1;
+  return displayedRows.value.find((row) => row.message.timestamp === message.timestamp)?.postCount ?? 1;
 }
 
 let requestRevision = 0;
 let stopEvents: (() => void) | null = null;
 let clock: ReturnType<typeof setInterval> | null = null;
 let noticeTimer: number | null = null;
+let savedRevision = 0;
+let confirmedSaved: TradeSavedState = { offers: [], players: [] };
+let savedWrites = Promise.resolve();
 const now = ref(Date.now());
 
 async function subscribe(next: TradeSource): Promise<void> {
@@ -137,7 +132,7 @@ async function subscribe(next: TradeSource): Promise<void> {
     if (revision !== requestRevision || source.value !== next || !props.visible) return;
     target.status = snapshot.status;
     target.live = [...snapshot.messages];
-    ensureSelection(target, target.live);
+    ensureSelection(target, displayedRows.value.map((row) => row.message), next);
     emit("ready");
     if (submittedQuery.value) await runSearch(revision);
   } catch {
@@ -152,28 +147,21 @@ async function runSearch(existingRevision?: number): Promise<void> {
   searchProblem.value = "";
   if (!trimmed) {
     searching.value = false;
-    ensureSelection(current.value, current.value.live);
+    ensureSelection(current.value, current.value.live, source.value);
     return;
   }
   const revision = existingRevision ?? ++requestRevision;
   const requestedSource = source.value;
   searching.value = true;
   try {
-    const requests = [props.host.search({ source: requestedSource, query: trimmed })];
-    const playerQuery = `user:${trimmed}`;
-    if (
-      !trimmed.toLocaleLowerCase().startsWith("user:")
-      && [...playerQuery].length <= TRADE_LIMITS.queryCharacters
-    ) {
-      requests.push(props.host.search({ source: requestedSource, query: playerQuery }));
-    }
-    const results = await Promise.all(requests);
+    const result = await props.host.search({ source: requestedSource, query: trimmed });
     if (revision !== requestRevision || source.value !== requestedSource) return;
-    current.value.search = sortNewest([...new Map(
-      results.flatMap((result) => result.messages)
-        .map((message) => [message.timestamp, message] as const),
-    ).values()]).slice(0, TRADE_LIMITS.searchResults);
-    ensureSelection(current.value, current.value.search);
+    current.value.search = [...result.matches];
+    ensureSelection(
+      current.value,
+      current.value.search.map((match) => match.message),
+      source.value,
+    );
   } catch {
     if (revision === requestRevision) {
       current.value.search = [];
@@ -196,7 +184,7 @@ function clearSearch(): void {
   searching.value = false;
   visibleLimit.value = 25;
   requestRevision += 1;
-  ensureSelection(current.value, current.value.live);
+  ensureSelection(current.value, current.value.live, source.value);
 }
 
 function onTradeEvent(event: TradeEvent): void {
@@ -211,19 +199,19 @@ function onTradeEvent(event: TradeEvent): void {
   )) return;
   const nearTop = event.source !== source.value || !list.value || list.value.scrollTop < 36;
   if (nearTop) {
-    target.live = sortNewest([event.message, ...target.live]).slice(0, TRADE_LIMITS.liveMessages);
+    target.live = insertTradeMessage(target.live, event.message);
   } else {
-    target.pending = sortNewest([event.message, ...target.pending]);
+    target.pending = insertTradeMessage(target.pending, event.message);
   }
-  ensureSelection(target, target.live);
+  ensureSelection(target, target.live, event.source);
 }
 
 function commitPending(): void {
   if (!current.value.pending.length) return;
-  current.value.live = sortNewest([
-    ...current.value.pending,
-    ...current.value.live,
-  ]).slice(0, TRADE_LIMITS.liveMessages);
+  current.value.live = current.value.pending.reduce(
+    (messages, message) => insertTradeMessage(messages, message),
+    current.value.live,
+  );
   current.value.pending = [];
 }
 
@@ -239,6 +227,7 @@ function onListScroll(event: Event): void {
 
 function selectMessage(message: TradeMessage): void {
   current.value.selection = message.timestamp;
+  current.value.savedSelection = null;
   detailOpen.value = true;
 }
 
@@ -268,21 +257,23 @@ function playerSaved(sender: string): boolean {
   return saved.value.players.some((player) => player.sender.toLocaleLowerCase() === key);
 }
 
-async function save(next: TradeSavedState, success: string): Promise<void> {
-  const previous = saved.value;
+function save(next: TradeSavedState, success: string): void {
+  const revision = ++savedRevision;
   saved.value = next;
-  try {
-    saved.value = await props.host.setSaved(next);
-    showNotice(success);
-  } catch (cause) {
-    saved.value = previous;
-    showNotice(cause instanceof Error && cause.message === "trade_saved_restart_required"
-      ? "Restart GWonMac once to enable Saved items."
-      : "Saved items could not be updated.");
-  }
+  savedWrites = savedWrites.then(async () => {
+    try {
+      confirmedSaved = await props.host.setSaved(next);
+      if (revision === savedRevision) saved.value = confirmedSaved;
+      showNotice(success);
+    } catch {
+      if (revision === savedRevision) saved.value = confirmedSaved;
+      showNotice("Saved items could not be updated. Try again.");
+    }
+  });
 }
 
 function toggleOffer(message: TradeMessage): void {
+  if (!savedReady.value) return;
   const exists = offerSaved(message);
   const offers = exists
     ? saved.value.offers.filter((offer) =>
@@ -290,17 +281,18 @@ function toggleOffer(message: TradeMessage): void {
     )
     : [{ ...message, savedAt: Date.now() }, ...saved.value.offers]
       .slice(0, TRADE_LIMITS.savedOffers);
-  void save({ ...saved.value, offers }, exists ? "Offer removed" : "Offer saved");
+  save({ ...saved.value, offers }, exists ? "Offer removed" : "Offer saved");
 }
 
 function togglePlayer(sender: string): void {
+  if (!savedReady.value) return;
   const key = sender.toLocaleLowerCase();
   const exists = playerSaved(sender);
   const players = exists
     ? saved.value.players.filter((player) => player.sender.toLocaleLowerCase() !== key)
     : [{ sender, savedAt: Date.now() }, ...saved.value.players]
       .slice(0, TRADE_LIMITS.savedPlayers);
-  void save({ ...saved.value, players }, exists ? "Player unfollowed" : "Player followed");
+  save({ ...saved.value, players }, exists ? "Player unfollowed" : "Player followed");
 }
 
 function openSaved(): void {
@@ -314,11 +306,12 @@ function closeSaved(): void {
 }
 
 async function inspectSavedOffer(offer: TradeSavedOffer): Promise<void> {
+  states[offer.source].selection = offer.timestamp;
+  states[offer.source].savedSelection = offer.timestamp;
   if (source.value !== offer.source) {
     source.value = offer.source;
     await nextTick();
   }
-  states[offer.source].selection = offer.timestamp;
   detailOpen.value = true;
   savedOpen.value = false;
 }
@@ -373,6 +366,9 @@ watch(source, (next) => {
   visibleLimit.value = 25;
   if (props.visible) void subscribe(next);
 });
+watch(displayedRows, (rows) => {
+  ensureSelection(current.value, rows.map((row) => row.message), source.value);
+});
 watch(() => props.visible, (visible) => {
   if (visible) void subscribe(source.value);
   else {
@@ -386,10 +382,12 @@ onMounted(() => {
   window.addEventListener("keydown", onWindowKeydown);
   clock = setInterval(() => { now.value = Date.now(); }, 30_000);
   if (props.visible) void subscribe(source.value);
-  void props.host.getSaved().then((value) => { saved.value = value; }).catch((cause: unknown) => {
-    showNotice(cause instanceof Error && cause.message === "trade_saved_restart_required"
-      ? "Restart GWonMac once to enable Saved items."
-      : "Saved items are unavailable for this session.");
+  void props.host.getSaved().then((value) => {
+    confirmedSaved = value;
+    saved.value = value;
+    savedReady.value = true;
+  }).catch(() => {
+    showNotice("Saved items are unavailable for this session.");
   });
 });
 onBeforeUnmount(() => {
@@ -402,12 +400,24 @@ onBeforeUnmount(() => {
 });
 
 function state(): SourceState {
-  return { status: "unavailable", live: [], pending: [], search: [], selection: null };
+  return {
+    status: "unavailable",
+    live: [],
+    pending: [],
+    search: [],
+    selection: null,
+    savedSelection: null,
+  };
 }
-function sortNewest(messages: TradeMessage[]): TradeMessage[] {
-  return messages.sort((left, right) => right.timestamp - left.timestamp);
-}
-function ensureSelection(target: SourceState, messages: readonly TradeMessage[]): void {
+function ensureSelection(
+  target: SourceState,
+  messages: readonly TradeMessage[],
+  targetSource: TradeSource,
+): void {
+  if (target.savedSelection !== null && saved.value.offers.some((offer) =>
+    offer.source === targetSource && offer.timestamp === target.savedSelection
+  )) return;
+  target.savedSelection = null;
   if (!messages.some((message) => message.timestamp === target.selection)) {
     target.selection = messages[0]?.timestamp ?? null;
   }
@@ -416,13 +426,7 @@ function removeReplacement(target: SourceState, timestamp: number | undefined): 
   if (timestamp === undefined) return;
   target.live = target.live.filter((message) => message.timestamp !== timestamp);
   target.pending = target.pending.filter((message) => message.timestamp !== timestamp);
-  target.search = target.search.filter((message) => message.timestamp !== timestamp);
-}
-function messageIntents(message: string): Intent[] {
-  const selling = /(?:^|[^a-z0-9])wts(?:$|[^a-z0-9])/iu.test(message);
-  const buying = /(?:^|[^a-z0-9])wtb(?:$|[^a-z0-9])/iu.test(message);
-  return [selling ? "selling" : null, buying ? "buying" : null]
-    .filter((value): value is Intent => value !== null);
+  target.search = target.search.filter(({ message }) => message.timestamp !== timestamp);
 }
 function age(timestamp: number): string {
   const seconds = Math.max(0, Math.floor((now.value - timestamp) / 1000));
@@ -514,8 +518,9 @@ function exactTime(timestamp: number): string {
             class="ui-button saved-trigger"
             :aria-expanded="savedOpen"
             aria-controls="trade-saved-drawer"
+            :disabled="!savedReady"
             @click="savedOpen ? closeSaved() : openSaved()"
-          ><span aria-hidden="true">★</span> Saved <span class="saved-count">{{ savedCount }}</span></button>
+          ><TradeIcon name="star" :filled="savedCount > 0" /> Saved <span class="saved-count">{{ savedCount }}</span></button>
         </div>
       </div>
 
@@ -556,7 +561,7 @@ function exactTime(timestamp: number): string {
           v-else
           ref="list"
           class="trade-list ui-scroll"
-          role="listbox"
+          role="list"
           aria-label="Trade offers"
           @scroll="onListScroll"
           @keydown="onListKeydown"
@@ -565,26 +570,25 @@ function exactTime(timestamp: number): string {
             v-for="message in visibleMessages"
             :key="message.timestamp"
             class="trade-row-shell"
-            role="presentation"
+            role="listitem"
           >
             <button
               class="trade-row"
-              role="option"
               :data-timestamp="message.timestamp"
               :data-saved-offer="offerSaved(message) ? '' : undefined"
               :data-saved-player="playerSaved(message.sender) ? '' : undefined"
-              :aria-selected="current.selection === message.timestamp"
+              :aria-current="current.selection === message.timestamp ? 'true' : undefined"
               @click="selectMessage(message)"
             >
               <span class="intent-cell">
-                <span v-if="offerSaved(message)" class="saved-mark" aria-label="Saved offer">★</span>
-                <span v-for="tag in messageIntents(message.message)" :key="tag" class="ui-chip" :data-intent="tag">
+                <span v-if="offerSaved(message)" class="saved-mark" aria-label="Saved offer"><TradeIcon name="star" filled /></span>
+                <span v-for="tag in tradeMessageIntents(message.message)" :key="tag" class="ui-chip" :data-intent="tag">
                   {{ tag === "selling" ? "WTS" : "WTB" }}
                 </span>
-                <span v-if="!messageIntents(message.message).length" class="ui-chip">Other</span>
+                <span v-if="!tradeMessageIntents(message.message).length" class="ui-chip">Other</span>
               </span>
               <span class="character-cell">
-                <span v-if="playerSaved(message.sender)" class="followed-mark" aria-label="Followed player">★</span>
+                <span v-if="playerSaved(message.sender)" class="followed-mark" aria-label="Followed player"><TradeIcon name="player" filled /></span>
                 <bdi>{{ message.sender }}</bdi>
                 <span
                   v-if="groupedPostCount(message) > 1"
@@ -600,16 +604,18 @@ function exactTime(timestamp: number): string {
                 class="row-quick-action"
                 :aria-label="`${offerSaved(message) ? 'Remove saved' : 'Save'} offer from ${message.sender}`"
                 :aria-pressed="offerSaved(message)"
+                :disabled="!savedReady"
                 :title="offerSaved(message) ? 'Remove saved offer' : 'Save offer'"
                 @click="toggleOffer(message)"
-              >{{ offerSaved(message) ? "★" : "☆" }}</button>
+              ><TradeIcon name="star" :filled="offerSaved(message)" /></button>
               <button
                 class="row-quick-action"
                 :aria-label="`${playerSaved(message.sender) ? 'Unfollow' : 'Follow'} ${message.sender}`"
                 :aria-pressed="playerSaved(message.sender)"
+                :disabled="!savedReady"
                 :title="playerSaved(message.sender) ? 'Unfollow player' : 'Follow player'"
                 @click="togglePlayer(message.sender)"
-              ><span aria-hidden="true">{{ playerSaved(message.sender) ? "♟" : "♙" }}</span></button>
+              ><TradeIcon name="player" :filled="playerSaved(message.sender)" /></button>
             </div>
           </div>
           <button
@@ -639,13 +645,15 @@ function exactTime(timestamp: number): string {
             <button
               class="ui-button"
               :aria-pressed="offerSaved(selected)"
+              :disabled="!savedReady"
               @click="toggleOffer(selected)"
-            >{{ offerSaved(selected) ? "★ Saved" : "☆ Save" }}</button>
+            ><TradeIcon name="star" :filled="offerSaved(selected)" />{{ offerSaved(selected) ? "Saved" : "Save" }}</button>
             <button
               class="ui-button"
               :aria-pressed="playerSaved(selected.sender)"
+              :disabled="!savedReady"
               @click="togglePlayer(selected.sender)"
-            >{{ playerSaved(selected.sender) ? "★ Following" : "☆ Follow" }}</button>
+            ><TradeIcon name="player" :filled="playerSaved(selected.sender)" />{{ playerSaved(selected.sender) ? "Following" : "Follow" }}</button>
             <button class="ui-button" data-variant="primary" @click="copy(selected.sender, 'Character name')">
               Copy name
             </button>
@@ -690,7 +698,7 @@ function exactTime(timestamp: number): string {
                   <span><bdi>{{ offer.sender }}</bdi><small>{{ offer.source === "kamadan" ? "Kamadan" : "Pre-Searing" }} · saved {{ age(offer.savedAt) }}</small></span>
                   <bdi>{{ offer.message }}</bdi>
                 </button>
-                <button class="saved-remove" aria-label="Remove saved offer" @click="toggleOffer(offer)">★</button>
+                <button class="saved-remove" aria-label="Remove saved offer" @click="toggleOffer(offer)"><TradeIcon name="star" filled /></button>
               </article>
             </template>
             <template v-else>
@@ -700,9 +708,9 @@ function exactTime(timestamp: number): string {
               </div>
               <article v-for="player in saved.players" :key="player.sender.toLocaleLowerCase()" class="saved-card saved-player-card">
                 <button class="saved-card-main" @click="findPlayer(player.sender)">
-                  <span><bdi>★ {{ player.sender }}</bdi><small>{{ currentOffersFor(player.sender) }} current {{ currentOffersFor(player.sender) === 1 ? "offer" : "offers" }} in {{ sourceLabel }}</small></span>
+                  <span><bdi><TradeIcon name="player" filled />{{ player.sender }}</bdi><small>{{ currentOffersFor(player.sender) }} current {{ currentOffersFor(player.sender) === 1 ? "offer" : "offers" }} in {{ sourceLabel }}</small></span>
                 </button>
-                <button class="saved-remove" :aria-label="`Unfollow ${player.sender}`" @click="togglePlayer(player.sender)">★</button>
+                <button class="saved-remove" :aria-label="`Unfollow ${player.sender}`" @click="togglePlayer(player.sender)"><TradeIcon name="player" filled /></button>
               </article>
             </template>
           </div>

--- a/apps/tools/src/TradeChatApp.vue
+++ b/apps/tools/src/TradeChatApp.vue
@@ -240,9 +240,11 @@ async function save(next: TradeSavedState, success: string): Promise<void> {
   try {
     saved.value = await props.host.setSaved(next);
     showNotice(success);
-  } catch {
+  } catch (cause) {
     saved.value = previous;
-    showNotice("Saved items could not be updated.");
+    showNotice(cause instanceof Error && cause.message === "trade_saved_restart_required"
+      ? "Restart GWonMac once to enable Saved items."
+      : "Saved items could not be updated.");
   }
 }
 
@@ -350,8 +352,10 @@ onMounted(() => {
   window.addEventListener("keydown", onWindowKeydown);
   clock = setInterval(() => { now.value = Date.now(); }, 30_000);
   if (props.visible) void subscribe(source.value);
-  void props.host.getSaved().then((value) => { saved.value = value; }).catch(() => {
-    showNotice("Saved items are unavailable for this session.");
+  void props.host.getSaved().then((value) => { saved.value = value; }).catch((cause: unknown) => {
+    showNotice(cause instanceof Error && cause.message === "trade_saved_restart_required"
+      ? "Restart GWonMac once to enable Saved items."
+      : "Saved items are unavailable for this session.");
   });
 });
 onBeforeUnmount(() => {
@@ -519,28 +523,49 @@ function exactTime(timestamp: number): string {
           @scroll="onListScroll"
           @keydown="onListKeydown"
         >
-          <button
+          <div
             v-for="message in visibleMessages"
             :key="message.timestamp"
-            class="trade-row"
-            role="option"
-            :data-timestamp="message.timestamp"
-            :data-saved-offer="offerSaved(message) ? '' : undefined"
-            :data-saved-player="playerSaved(message.sender) ? '' : undefined"
-            :aria-selected="current.selection === message.timestamp"
-            @click="selectMessage(message)"
+            class="trade-row-shell"
+            role="presentation"
           >
-            <span class="intent-cell">
-              <span v-if="offerSaved(message)" class="saved-mark" aria-label="Saved offer">★</span>
-              <span v-for="tag in messageIntents(message.message)" :key="tag" class="ui-chip" :data-intent="tag">
-                {{ tag === "selling" ? "WTS" : "WTB" }}
+            <button
+              class="trade-row"
+              role="option"
+              :data-timestamp="message.timestamp"
+              :data-saved-offer="offerSaved(message) ? '' : undefined"
+              :data-saved-player="playerSaved(message.sender) ? '' : undefined"
+              :aria-selected="current.selection === message.timestamp"
+              @click="selectMessage(message)"
+            >
+              <span class="intent-cell">
+                <span v-if="offerSaved(message)" class="saved-mark" aria-label="Saved offer">★</span>
+                <span v-for="tag in messageIntents(message.message)" :key="tag" class="ui-chip" :data-intent="tag">
+                  {{ tag === "selling" ? "WTS" : "WTB" }}
+                </span>
+                <span v-if="!messageIntents(message.message).length" class="ui-chip">Other</span>
               </span>
-              <span v-if="!messageIntents(message.message).length" class="ui-chip">Other</span>
-            </span>
-            <bdi class="character-cell"><span v-if="playerSaved(message.sender)" class="followed-mark" aria-label="Followed player">★</span>{{ message.sender }}</bdi>
-            <bdi class="message-cell">{{ message.message }}</bdi>
-            <time class="age-cell" :datetime="new Date(message.timestamp).toISOString()">{{ age(message.timestamp) }}</time>
-          </button>
+              <bdi class="character-cell"><span v-if="playerSaved(message.sender)" class="followed-mark" aria-label="Followed player">★</span>{{ message.sender }}</bdi>
+              <bdi class="message-cell">{{ message.message }}</bdi>
+              <time class="age-cell" :datetime="new Date(message.timestamp).toISOString()">{{ age(message.timestamp) }}</time>
+            </button>
+            <div class="row-quick-actions">
+              <button
+                class="row-quick-action"
+                :aria-label="`${offerSaved(message) ? 'Remove saved' : 'Save'} offer from ${message.sender}`"
+                :aria-pressed="offerSaved(message)"
+                :title="offerSaved(message) ? 'Remove saved offer' : 'Save offer'"
+                @click="toggleOffer(message)"
+              >{{ offerSaved(message) ? "★" : "☆" }}</button>
+              <button
+                class="row-quick-action"
+                :aria-label="`${playerSaved(message.sender) ? 'Unfollow' : 'Follow'} ${message.sender}`"
+                :aria-pressed="playerSaved(message.sender)"
+                :title="playerSaved(message.sender) ? 'Unfollow player' : 'Follow player'"
+                @click="togglePlayer(message.sender)"
+              ><span aria-hidden="true">{{ playerSaved(message.sender) ? "♟" : "♙" }}</span></button>
+            </div>
+          </div>
           <button
             v-if="visibleLimit < filtered.length"
             class="ui-button load-more"
@@ -564,17 +589,17 @@ function exactTime(timestamp: number): string {
               class="ui-button"
               :aria-pressed="offerSaved(selected)"
               @click="toggleOffer(selected)"
-            >{{ offerSaved(selected) ? "★ Saved offer" : "☆ Save offer" }}</button>
+            >{{ offerSaved(selected) ? "★ Saved" : "☆ Save" }}</button>
             <button
               class="ui-button"
               :aria-pressed="playerSaved(selected.sender)"
               @click="togglePlayer(selected.sender)"
-            >{{ playerSaved(selected.sender) ? "★ Following player" : "☆ Follow player" }}</button>
+            >{{ playerSaved(selected.sender) ? "★ Following" : "☆ Follow" }}</button>
             <button class="ui-button" data-variant="primary" @click="copy(selected.sender, 'Character name')">
-              Copy character
+              Copy name
             </button>
-            <button class="ui-button" @click="copy(selected.message, 'Message')">Copy message</button>
-            <button class="ui-link" @click="props.host.openSource(source)">Open {{ sourceLabel }} feed</button>
+            <button class="ui-button" @click="copy(selected.message, 'Message')">Copy text</button>
+            <button class="ui-link" @click="props.host.openSource(source)">{{ sourceLabel }} feed ↗</button>
           </div>
         </template>
         <div v-else class="ui-empty">

--- a/apps/tools/src/TradeChatApp.vue
+++ b/apps/tools/src/TradeChatApp.vue
@@ -77,10 +77,24 @@ const statusLabel = computed(() => ({
 const baseMessages = computed(() => submittedQuery.value
   ? current.value.search
   : current.value.live);
-const filtered = computed(() => baseMessages.value.filter((message) => {
+const intentMatches = computed(() => baseMessages.value.filter((message) => {
   const tags = messageIntents(message.message);
   return intent.value === "all" || tags.includes(intent.value);
 }));
+const displayedRows = computed(() => {
+  if (!submittedQuery.value) {
+    return intentMatches.value.map((message) => ({ message, count: 1 }));
+  }
+  const groups = new Map<string, { message: TradeMessage; count: number }>();
+  for (const message of sortNewest([...intentMatches.value])) {
+    const key = message.sender.toLocaleLowerCase();
+    const existing = groups.get(key);
+    if (existing) existing.count += 1;
+    else groups.set(key, { message, count: 1 });
+  }
+  return [...groups.values()];
+});
+const filtered = computed(() => displayedRows.value.map((row) => row.message));
 const visibleMessages = computed(() => filtered.value.slice(0, visibleLimit.value));
 const selected = computed(() => {
   const timestamp = current.value.selection;
@@ -102,6 +116,10 @@ const emptyHeading = computed(() => {
   if (current.value.status === "unavailable") return "Trade feed unavailable";
   return "Waiting for trade messages";
 });
+
+function groupedPostCount(message: TradeMessage): number {
+  return displayedRows.value.find((row) => row.message.timestamp === message.timestamp)?.count ?? 1;
+}
 
 let requestRevision = 0;
 let stopEvents: (() => void) | null = null;
@@ -505,7 +523,10 @@ function exactTime(timestamp: number): string {
         <span>
           {{ submittedQuery ? `Results for “${submittedQuery}”` : "Latest messages" }}
         </span>
-        <span>{{ filtered.length }} {{ filtered.length === 1 ? "offer" : "offers" }}</span>
+        <span>
+          {{ filtered.length }}
+          {{ submittedQuery ? (filtered.length === 1 ? "trader" : "traders") : (filtered.length === 1 ? "offer" : "offers") }}
+        </span>
       </div>
 
       <div class="trade-ledger ui-well">
@@ -562,7 +583,15 @@ function exactTime(timestamp: number): string {
                 </span>
                 <span v-if="!messageIntents(message.message).length" class="ui-chip">Other</span>
               </span>
-              <bdi class="character-cell"><span v-if="playerSaved(message.sender)" class="followed-mark" aria-label="Followed player">★</span>{{ message.sender }}</bdi>
+              <span class="character-cell">
+                <span v-if="playerSaved(message.sender)" class="followed-mark" aria-label="Followed player">★</span>
+                <bdi>{{ message.sender }}</bdi>
+                <span
+                  v-if="groupedPostCount(message) > 1"
+                  class="group-count"
+                  :aria-label="`Latest of ${groupedPostCount(message)} matching posts`"
+                >{{ groupedPostCount(message) }} posts</span>
+              </span>
               <bdi class="message-cell">{{ message.message }}</bdi>
               <time class="age-cell" :datetime="new Date(message.timestamp).toISOString()">{{ age(message.timestamp) }}</time>
             </button>
@@ -597,7 +626,12 @@ function exactTime(timestamp: number): string {
           <div class="inspector-copy">
             <div class="inspector-meta">
               <bdi>{{ selected.sender }}</bdi>
-              <time :datetime="new Date(selected.timestamp).toISOString()">{{ exactTime(selected.timestamp) }}</time>
+              <span>
+                <small v-if="groupedPostCount(selected) > 1">
+                  Latest of {{ groupedPostCount(selected) }} matching posts
+                </small>
+                <time :datetime="new Date(selected.timestamp).toISOString()">{{ exactTime(selected.timestamp) }}</time>
+              </span>
             </div>
             <p><bdi>{{ selected.message }}</bdi></p>
           </div>

--- a/apps/tools/src/TradeChatApp.vue
+++ b/apps/tools/src/TradeChatApp.vue
@@ -15,6 +15,8 @@ import {
   type TradeConnectionState,
   type TradeEvent,
   type TradeMessage,
+  type TradeSavedOffer,
+  type TradeSavedState,
   type TradeSource,
 } from "../../../src/shared/trade-chat";
 import { useFloatingWindow } from "./use-floating-window";
@@ -44,6 +46,11 @@ const searching = ref(false);
 const searchProblem = ref("");
 const notice = ref("");
 const detailOpen = ref(false);
+const savedOpen = ref(false);
+const savedTab = ref<"offers" | "players">("offers");
+const saved = ref<TradeSavedState>({ offers: [], players: [] });
+const savedButton = ref<HTMLButtonElement | null>(null);
+const savedClose = ref<HTMLButtonElement | null>(null);
 const visibleLimit = ref(25);
 const searchInput = ref<HTMLInputElement | null>(null);
 const list = ref<HTMLElement | null>(null);
@@ -79,9 +86,15 @@ const selected = computed(() => {
   const timestamp = current.value.selection;
   return timestamp === null
     ? null
-    : [...current.value.live, ...current.value.search, ...current.value.pending]
+    : [
+      ...current.value.live,
+      ...current.value.search,
+      ...current.value.pending,
+      ...saved.value.offers.filter((offer) => offer.source === source.value),
+    ]
       .find((message) => message.timestamp === timestamp) ?? null;
 });
+const savedCount = computed(() => saved.value.offers.length + saved.value.players.length);
 const emptyHeading = computed(() => {
   if (searching.value) return "Searching the trade ledger…";
   if (searchProblem.value) return "Search could not finish";
@@ -93,6 +106,7 @@ const emptyHeading = computed(() => {
 let requestRevision = 0;
 let stopEvents: (() => void) | null = null;
 let clock: ReturnType<typeof setInterval> | null = null;
+let noticeTimer: number | null = null;
 const now = ref(Date.now());
 
 async function subscribe(next: TradeSource): Promise<void> {
@@ -170,15 +184,6 @@ function onTradeEvent(event: TradeEvent): void {
   ensureSelection(target, target.live);
 }
 
-function revealPending(): void {
-  commitPending();
-  const reducedMotion = window.matchMedia?.("(prefers-reduced-motion: reduce)").matches ?? false;
-  nextTick(() => list.value?.scrollTo({
-    top: 0,
-    behavior: reducedMotion ? "auto" : "smooth",
-  }));
-}
-
 function commitPending(): void {
   if (!current.value.pending.length) return;
   current.value.live = sortNewest([
@@ -206,13 +211,91 @@ function selectMessage(message: TradeMessage): void {
 async function copy(value: string, label: string): Promise<void> {
   try {
     await props.host.copy(value);
-    notice.value = `${label} copied`;
+    showNotice(`${label} copied`);
   } catch {
-    notice.value = "Clipboard access was refused. Select the text and copy it manually.";
+    showNotice("Clipboard access was refused. Select the text and copy it manually.");
   }
-  window.setTimeout(() => {
-    if (notice.value.startsWith(label) || notice.value.startsWith("Clipboard")) notice.value = "";
-  }, 3_000);
+}
+
+function showNotice(message: string): void {
+  if (noticeTimer) clearTimeout(noticeTimer);
+  notice.value = message;
+  noticeTimer = window.setTimeout(() => { notice.value = ""; }, 3_000);
+}
+
+function offerSaved(message: TradeMessage): boolean {
+  return saved.value.offers.some((offer) =>
+    offer.source === message.source && offer.timestamp === message.timestamp
+  );
+}
+
+function playerSaved(sender: string): boolean {
+  const key = sender.toLocaleLowerCase();
+  return saved.value.players.some((player) => player.sender.toLocaleLowerCase() === key);
+}
+
+async function save(next: TradeSavedState, success: string): Promise<void> {
+  const previous = saved.value;
+  saved.value = next;
+  try {
+    saved.value = await props.host.setSaved(next);
+    showNotice(success);
+  } catch {
+    saved.value = previous;
+    showNotice("Saved items could not be updated.");
+  }
+}
+
+function toggleOffer(message: TradeMessage): void {
+  const exists = offerSaved(message);
+  const offers = exists
+    ? saved.value.offers.filter((offer) =>
+      offer.source !== message.source || offer.timestamp !== message.timestamp
+    )
+    : [{ ...message, savedAt: Date.now() }, ...saved.value.offers]
+      .slice(0, TRADE_LIMITS.savedOffers);
+  void save({ ...saved.value, offers }, exists ? "Offer removed" : "Offer saved");
+}
+
+function togglePlayer(sender: string): void {
+  const key = sender.toLocaleLowerCase();
+  const exists = playerSaved(sender);
+  const players = exists
+    ? saved.value.players.filter((player) => player.sender.toLocaleLowerCase() !== key)
+    : [{ sender, savedAt: Date.now() }, ...saved.value.players]
+      .slice(0, TRADE_LIMITS.savedPlayers);
+  void save({ ...saved.value, players }, exists ? "Player unfollowed" : "Player followed");
+}
+
+function openSaved(): void {
+  savedOpen.value = true;
+  nextTick(() => savedClose.value?.focus());
+}
+
+function closeSaved(): void {
+  savedOpen.value = false;
+  nextTick(() => savedButton.value?.focus());
+}
+
+async function inspectSavedOffer(offer: TradeSavedOffer): Promise<void> {
+  if (source.value !== offer.source) {
+    source.value = offer.source;
+    await nextTick();
+  }
+  states[offer.source].selection = offer.timestamp;
+  detailOpen.value = true;
+  savedOpen.value = false;
+}
+
+function findPlayer(sender: string): void {
+  query.value = sender;
+  savedOpen.value = false;
+  void runSearch();
+}
+
+function currentOffersFor(sender: string): number {
+  const key = sender.toLocaleLowerCase();
+  return current.value.live.filter((message) => message.sender.toLocaleLowerCase() === key).length;
 }
 
 function onListKeydown(event: KeyboardEvent): void {
@@ -233,6 +316,12 @@ function onListKeydown(event: KeyboardEvent): void {
 
 function onWindowKeydown(event: KeyboardEvent): void {
   if (!props.visible || !props.active) return;
+  if (event.key === "Escape" && savedOpen.value) {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    closeSaved();
+    return;
+  }
   if (
     event.key === "/"
     && !(event.target instanceof HTMLInputElement)
@@ -261,12 +350,16 @@ onMounted(() => {
   window.addEventListener("keydown", onWindowKeydown);
   clock = setInterval(() => { now.value = Date.now(); }, 30_000);
   if (props.visible) void subscribe(source.value);
+  void props.host.getSaved().then((value) => { saved.value = value; }).catch(() => {
+    showNotice("Saved items are unavailable for this session.");
+  });
 });
 onBeforeUnmount(() => {
   requestRevision += 1;
   stopEvents?.();
   window.removeEventListener("keydown", onWindowKeydown);
   if (clock) clearInterval(clock);
+  if (noticeTimer) clearTimeout(noticeTimer);
   void props.host.unsubscribe();
 });
 
@@ -371,10 +464,19 @@ function exactTime(timestamp: number): string {
           </button>
           <button v-if="submittedQuery" type="button" class="ui-button" @click="clearSearch">Live feed</button>
         </form>
-        <div class="ui-segment intent-segment" data-fill aria-label="Offer intent">
-          <button :aria-pressed="intent === 'all'" @click="intent = 'all'">All</button>
-          <button :aria-pressed="intent === 'selling'" @click="intent = 'selling'">Selling</button>
-          <button :aria-pressed="intent === 'buying'" @click="intent = 'buying'">Buying</button>
+        <div class="trade-toolbar-actions">
+          <div class="ui-segment intent-segment" data-fill aria-label="Offer intent">
+            <button :aria-pressed="intent === 'all'" @click="intent = 'all'">All</button>
+            <button :aria-pressed="intent === 'selling'" @click="intent = 'selling'">Selling</button>
+            <button :aria-pressed="intent === 'buying'" @click="intent = 'buying'">Buying</button>
+          </div>
+          <button
+            ref="savedButton"
+            class="ui-button saved-trigger"
+            :aria-expanded="savedOpen"
+            aria-controls="trade-saved-drawer"
+            @click="savedOpen ? closeSaved() : openSaved()"
+          ><span aria-hidden="true">★</span> Saved <span class="saved-count">{{ savedCount }}</span></button>
         </div>
       </div>
 
@@ -389,12 +491,6 @@ function exactTime(timestamp: number): string {
         <div class="trade-columns" aria-hidden="true">
           <span>Intent</span><span>Character</span><span>Message</span><span>Age</span>
         </div>
-        <button
-          v-if="current.pending.length"
-          class="ui-button pending-messages"
-          data-variant="primary"
-          @click="revealPending"
-        >{{ current.pending.length }} new {{ current.pending.length === 1 ? "message" : "messages" }}</button>
         <div
           v-if="searching || (!visibleMessages.length && (current.status === 'connecting' || current.status === 'reconnecting'))"
           class="trade-state"
@@ -429,16 +525,19 @@ function exactTime(timestamp: number): string {
             class="trade-row"
             role="option"
             :data-timestamp="message.timestamp"
+            :data-saved-offer="offerSaved(message) ? '' : undefined"
+            :data-saved-player="playerSaved(message.sender) ? '' : undefined"
             :aria-selected="current.selection === message.timestamp"
             @click="selectMessage(message)"
           >
             <span class="intent-cell">
+              <span v-if="offerSaved(message)" class="saved-mark" aria-label="Saved offer">★</span>
               <span v-for="tag in messageIntents(message.message)" :key="tag" class="ui-chip" :data-intent="tag">
                 {{ tag === "selling" ? "WTS" : "WTB" }}
               </span>
               <span v-if="!messageIntents(message.message).length" class="ui-chip">Other</span>
             </span>
-            <bdi class="character-cell">{{ message.sender }}</bdi>
+            <bdi class="character-cell"><span v-if="playerSaved(message.sender)" class="followed-mark" aria-label="Followed player">★</span>{{ message.sender }}</bdi>
             <bdi class="message-cell">{{ message.message }}</bdi>
             <time class="age-cell" :datetime="new Date(message.timestamp).toISOString()">{{ age(message.timestamp) }}</time>
           </button>
@@ -461,6 +560,16 @@ function exactTime(timestamp: number): string {
             <p><bdi>{{ selected.message }}</bdi></p>
           </div>
           <div class="inspector-actions">
+            <button
+              class="ui-button"
+              :aria-pressed="offerSaved(selected)"
+              @click="toggleOffer(selected)"
+            >{{ offerSaved(selected) ? "★ Saved offer" : "☆ Save offer" }}</button>
+            <button
+              class="ui-button"
+              :aria-pressed="playerSaved(selected.sender)"
+              @click="togglePlayer(selected.sender)"
+            >{{ playerSaved(selected.sender) ? "★ Following player" : "☆ Follow player" }}</button>
             <button class="ui-button" data-variant="primary" @click="copy(selected.sender, 'Character name')">
               Copy character
             </button>
@@ -473,6 +582,56 @@ function exactTime(timestamp: number): string {
           <p>The complete message and copy actions will appear here.</p>
         </div>
       </section>
+
+      <Transition name="saved-drawer">
+        <aside
+          v-if="savedOpen"
+          id="trade-saved-drawer"
+          class="trade-saved-drawer ui-drawer ui-raised"
+          role="complementary"
+          aria-label="Saved trade items"
+          @keydown.esc.stop.prevent="closeSaved"
+        >
+          <header class="saved-drawer-head ui-drawer-head">
+            <div>
+              <strong>Saved</strong>
+              <span>{{ savedCount }} {{ savedCount === 1 ? "item" : "items" }}</span>
+            </div>
+            <button ref="savedClose" class="ui-button" data-icon aria-label="Close Saved" @click="closeSaved">×</button>
+          </header>
+          <div class="ui-segment saved-tabs" data-fill aria-label="Saved item type">
+            <button :aria-pressed="savedTab === 'offers'" @click="savedTab = 'offers'">Offers {{ saved.offers.length }}</button>
+            <button :aria-pressed="savedTab === 'players'" @click="savedTab = 'players'">Players {{ saved.players.length }}</button>
+          </div>
+          <div class="saved-drawer-body ui-scroll">
+            <template v-if="savedTab === 'offers'">
+              <div v-if="!saved.offers.length" class="ui-empty">
+                <strong>No saved offers</strong>
+                <p>Save an offer from its detail panel to keep a local copy.</p>
+              </div>
+              <article v-for="offer in saved.offers" :key="`${offer.source}:${offer.timestamp}`" class="saved-card">
+                <button class="saved-card-main" @click="inspectSavedOffer(offer)">
+                  <span><bdi>{{ offer.sender }}</bdi><small>{{ offer.source === "kamadan" ? "Kamadan" : "Pre-Searing" }} · saved {{ age(offer.savedAt) }}</small></span>
+                  <bdi>{{ offer.message }}</bdi>
+                </button>
+                <button class="saved-remove" aria-label="Remove saved offer" @click="toggleOffer(offer)">★</button>
+              </article>
+            </template>
+            <template v-else>
+              <div v-if="!saved.players.length" class="ui-empty">
+                <strong>No followed players</strong>
+                <p>Follow a player to highlight every offer they post.</p>
+              </div>
+              <article v-for="player in saved.players" :key="player.sender.toLocaleLowerCase()" class="saved-card saved-player-card">
+                <button class="saved-card-main" @click="findPlayer(player.sender)">
+                  <span><bdi>★ {{ player.sender }}</bdi><small>{{ currentOffersFor(player.sender) }} current {{ currentOffersFor(player.sender) === 1 ? "offer" : "offers" }} in {{ sourceLabel }}</small></span>
+                </button>
+                <button class="saved-remove" :aria-label="`Unfollow ${player.sender}`" @click="togglePlayer(player.sender)">★</button>
+              </article>
+            </template>
+          </div>
+        </aside>
+      </Transition>
 
       <Transition name="notice">
         <div v-if="notice" class="ui-toast trade-notice" role="status">{{ notice }}</div>

--- a/apps/tools/src/TradeIcon.vue
+++ b/apps/tools/src/TradeIcon.vue
@@ -1,0 +1,25 @@
+<script setup lang="ts">
+defineProps<{ name: "star" | "player"; filled?: boolean }>();
+</script>
+
+<template>
+  <svg
+    v-if="name === 'star'"
+    class="trade-icon"
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+    :fill="filled ? 'currentColor' : 'none'"
+  >
+    <path d="m12 3.4 2.65 5.37 5.93.86-4.29 4.18 1.01 5.9L12 16.92 6.7 19.7l1.01-5.9-4.29-4.18 5.93-.86L12 3.4Z" />
+  </svg>
+  <svg
+    v-else
+    class="trade-icon"
+    viewBox="0 0 24 24"
+    aria-hidden="true"
+    :fill="filled ? 'currentColor' : 'none'"
+  >
+    <circle cx="12" cy="8" r="3.5" />
+    <path d="M5.5 20c.45-4.1 2.62-6.2 6.5-6.2s6.05 2.1 6.5 6.2" />
+  </svg>
+</template>

--- a/apps/tools/src/embedded.ts
+++ b/apps/tools/src/embedded.ts
@@ -2,6 +2,8 @@ import { createNativeHost } from "./host";
 import { mountToolsApp as mount } from "./mount";
 import { createNativeTravelHost } from "./travel-host";
 import { mountTravelPalette as mountTravel } from "./travel-mount";
+import { createNativeTradeHost } from "./trade-host";
+import { mountTradeChat as mountTrade } from "./trade-mount";
 import type {
   EmbeddedToolsBundle,
 } from "../../../src/shared/tools-bundle-contracts";
@@ -28,6 +30,10 @@ const embedded: EmbeddedToolsBundle<HTMLElement> = Object.freeze({
       options.development,
     ),
   }),
+  mountTradeChat: (target, options) => mountTrade(target, {
+    ...options,
+    host: createNativeTradeHost(window.gwNative),
+  }),
 });
 
-export const { mountToolsApp, mountTravelPalette } = embedded;
+export const { mountToolsApp, mountTravelPalette, mountTradeChat } = embedded;

--- a/apps/tools/src/mount.ts
+++ b/apps/tools/src/mount.ts
@@ -23,6 +23,7 @@ export function mountToolsApp(
   let lastPartyTrace = "";
   const development = options.development === true;
   const visible = ref(options.initiallyVisible ?? options.mode === "standalone");
+  const active = ref(options.mode === "standalone");
   const tools = ref<InstanceType<typeof ToolsApp> | null>(null);
   const setVisible = (next: boolean) => {
     if (visible.value === next) return;
@@ -39,6 +40,7 @@ export function mountToolsApp(
           host: options.host,
           mode: options.mode,
           visible: visible.value,
+          active: active.value,
           onClose: () => setVisible(false),
           onReady: () => {
             target.dataset.ready = "true";
@@ -56,6 +58,7 @@ export function mountToolsApp(
     show: () => setVisible(true),
     hide: () => setVisible(false),
     toggle: () => setVisible(!visible.value),
+    setActive: (next: boolean) => { active.value = next; },
     requestClose: () => tools.value?.requestClose(),
     update: (observation: ToolboxObservation) => {
       options.host.party.value = liveParty(observation);

--- a/apps/tools/src/standalone.ts
+++ b/apps/tools/src/standalone.ts
@@ -8,11 +8,20 @@ import { createDemoHost } from "./host";
 import { mountToolsApp } from "./mount";
 import { createDemoTravelHost } from "./travel-host";
 import { mountTravelPalette } from "./travel-mount";
+import { createDemoTradeHost } from "./trade-host";
+import { mountTradeChat } from "./trade-mount";
 
 const target = document.getElementById("app");
 if (!target) throw new Error("Tools workbench mount is missing");
 
-if (new URLSearchParams(window.location.search).has("travel")) {
+const params = new URLSearchParams(window.location.search);
+if (params.has("trade")) {
+  mountTradeChat(target, {
+    host: createDemoTradeHost(),
+    mode: "standalone",
+    initiallyVisible: true,
+  });
+} else if (params.has("travel")) {
   mountTravelPalette(target, {
     host: createDemoTravelHost(),
     initiallyVisible: true,

--- a/apps/tools/src/styles.css
+++ b/apps/tools/src/styles.css
@@ -3,6 +3,7 @@
 @import "./styles/build.css";
 @import "./styles/catalogue.css";
 @import "./styles/team.css";
+@import "./styles/trade.css";
 
 /* Cmd+T is one focused command surface. Travel is immediate; persistent setup
  * remains available in the same frame without becoming the default view. */

--- a/apps/tools/src/styles/trade.css
+++ b/apps/tools/src/styles/trade.css
@@ -117,6 +117,8 @@
   overflow: auto;
 }
 
+.trade-row-shell { position: relative; }
+
 .trade-row {
   width: 100%;
   min-height: 52px;
@@ -130,6 +132,47 @@
   text-shadow: var(--ui-text-shadow);
   cursor: pointer;
 }
+
+.trade-row-shell:hover .trade-row,
+.trade-row-shell:focus-within .trade-row { padding-right: 132px; }
+
+.row-quick-actions {
+  position: absolute;
+  top: 50%;
+  right: 60px;
+  display: flex;
+  gap: var(--ui-space-1);
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-50%) translateX(5px);
+  transition: opacity 120ms var(--ui-ease-out), transform 160ms var(--ui-ease-out);
+}
+
+.trade-row-shell:hover .row-quick-actions,
+.trade-row-shell:focus-within .row-quick-actions {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(-50%);
+}
+
+.row-quick-action {
+  display: inline-grid;
+  width: 30px;
+  height: 30px;
+  place-items: center;
+  padding: 0;
+  border: 1px solid var(--ui-edge);
+  border-radius: var(--ui-radius-sm);
+  background: var(--ui-raised-fill);
+  box-shadow: var(--ui-shadow-raised-soft);
+  color: var(--ui-text-muted);
+  font: var(--ui-font-size-lg) / 1 var(--ui-font);
+  cursor: pointer;
+}
+.row-quick-action:hover,
+.row-quick-action[aria-pressed="true"] { color: var(--ui-accent); filter: brightness(1.15); }
+.row-quick-action:active { transform: scale(0.94); }
+.row-quick-action:focus-visible { outline: 2px solid var(--ui-focus); outline-offset: 1px; }
 
 .trade-row:hover { background: var(--ui-hover); }
 .trade-row[aria-selected="true"] {
@@ -208,20 +251,20 @@
 
 .trade-inspector {
   display: grid;
-  min-height: 144px;
-  max-height: 190px;
+  min-height: 112px;
+  max-height: 148px;
   flex: 0 0 auto;
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: var(--ui-space-4);
+  gap: var(--ui-space-3);
   margin-top: var(--ui-gap);
-  padding: var(--ui-space-4);
+  padding: var(--ui-space-3) var(--ui-space-4);
   overflow: auto;
 }
 
 .inspector-copy { min-width: 0; }
 .inspector-copy p {
   max-width: 75ch;
-  margin: var(--ui-space-3) 0 0;
+  margin: var(--ui-space-2) 0 0;
   color: var(--ui-text-bright);
   font-family: var(--ui-font-readable);
   line-height: 1.55;
@@ -241,13 +284,14 @@
 
 .inspector-actions {
   display: flex;
-  min-width: 162px;
-  flex-direction: column;
-  align-items: stretch;
+  max-width: 520px;
+  flex-flow: row wrap;
+  align-items: center;
   justify-content: center;
   gap: var(--ui-space-2);
 }
-.inspector-actions .ui-link { align-self: center; }
+.inspector-actions .ui-button { min-height: 34px; padding-inline: var(--ui-space-2); }
+.inspector-actions .ui-link { padding-inline: var(--ui-space-1); white-space: nowrap; }
 .trade-inspector .mobile-back { display: none; }
 
 .trade-saved-drawer {
@@ -345,6 +389,15 @@
     gap: var(--ui-space-1) var(--ui-space-3);
     padding-block: var(--ui-space-3);
   }
+  .trade-row-shell:hover .trade-row,
+  .trade-row-shell:focus-within .trade-row { padding-right: var(--ui-space-3); }
+  .row-quick-actions {
+    top: var(--ui-space-2);
+    right: 48px;
+    opacity: 1;
+    pointer-events: auto;
+    transform: none;
+  }
   .intent-cell { grid-column: 1; grid-row: 1; }
   .age-cell { grid-column: 2; grid-row: 1; }
   .character-cell { grid-column: 1 / -1; grid-row: 2; }
@@ -397,4 +450,10 @@
   .saved-drawer-leave-active { transition: opacity 120ms linear; }
   .saved-drawer-enter-from,
   .saved-drawer-leave-to { transform: none; }
+  .row-quick-actions { transition: none; }
+}
+
+@media (hover: none) {
+  .trade-row { padding-right: 132px; }
+  .row-quick-actions { opacity: 1; pointer-events: auto; }
 }

--- a/apps/tools/src/styles/trade.css
+++ b/apps/tools/src/styles/trade.css
@@ -46,6 +46,16 @@
 .source-segment,
 .intent-segment { width: auto; }
 
+.trade-toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--ui-space-2);
+}
+
+.saved-trigger { white-space: nowrap; }
+.saved-trigger > span:first-child,
+.saved-count { color: var(--ui-accent); }
+
 .trade-search {
   display: grid;
   min-width: 0;
@@ -71,14 +81,6 @@
   color: var(--ui-text);
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.pending-messages {
-  position: absolute;
-  z-index: var(--ui-z-status);
-  top: calc(32px + var(--ui-space-2));
-  left: 50%;
-  transform: translateX(-50%);
 }
 
 .trade-ledger {
@@ -134,6 +136,12 @@
   background: var(--ui-selected);
   box-shadow: var(--ui-shadow-row-selected);
 }
+.trade-row[data-saved-offer] {
+  box-shadow: inset 3px 0 0 var(--ui-accent);
+}
+.trade-row[data-saved-offer][aria-selected="true"] {
+  box-shadow: inset 3px 0 0 var(--ui-accent), var(--ui-shadow-row-selected);
+}
 .trade-row:focus-visible {
   position: relative;
   z-index: 1;
@@ -148,6 +156,11 @@
   gap: var(--ui-space-1);
 }
 .intent-cell .ui-chip { min-height: 22px; padding-inline: 7px; }
+.saved-mark,
+.followed-mark { color: var(--ui-accent); }
+.saved-mark { align-self: center; }
+.followed-mark { margin-right: var(--ui-space-1); }
+.trade-row[data-saved-player] .character-cell { color: var(--ui-accent); }
 .ui-chip[data-intent="selling"] { color: var(--ui-info); }
 .ui-chip[data-intent="buying"] { color: var(--ui-success); }
 
@@ -237,6 +250,76 @@
 .inspector-actions .ui-link { align-self: center; }
 .trade-inspector .mobile-back { display: none; }
 
+.trade-saved-drawer {
+  position: absolute;
+  z-index: var(--ui-z-status);
+  top: 76px;
+  right: 10px;
+  bottom: 11px;
+  width: min(360px, calc(100% - 32px));
+  transform-origin: top right;
+}
+
+.saved-drawer-head > div { display: grid; min-width: 0; }
+.saved-drawer-head strong { color: var(--ui-text-bright); font-size: var(--ui-font-size-lg); }
+.saved-drawer-head span { color: var(--ui-text-muted); font-size: var(--ui-font-size-sm); }
+.saved-tabs { width: auto; margin: 0 var(--ui-space-3) var(--ui-space-3); }
+.saved-drawer-body { min-height: 0; flex: 1; overflow: auto; padding: 0 var(--ui-space-3) var(--ui-space-3); }
+
+.saved-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 36px;
+  margin-bottom: var(--ui-space-2);
+  overflow: hidden;
+  border-radius: var(--ui-radius-sm);
+  background: var(--ui-row-fill);
+  box-shadow: var(--ui-shadow-inset), 0 0 0 1px var(--ui-edge);
+}
+.saved-card-main,
+.saved-remove {
+  border: 0;
+  background: transparent;
+  color: var(--ui-text);
+  font: inherit;
+  cursor: pointer;
+}
+.saved-card-main {
+  display: grid;
+  min-width: 0;
+  gap: var(--ui-space-2);
+  padding: var(--ui-space-3);
+  text-align: left;
+}
+.saved-card-main > span { display: grid; min-width: 0; gap: var(--ui-space-1); }
+.saved-card-main bdi { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.saved-card-main > bdi { color: var(--ui-text-muted); }
+.saved-card-main small { color: var(--ui-text-faint); font-size: var(--ui-font-size-sm); }
+.saved-remove { color: var(--ui-accent); font-size: var(--ui-font-size-lg); }
+.saved-card-main:hover,
+.saved-remove:hover { background: var(--ui-hover); }
+.saved-card-main:active,
+.saved-remove:active,
+.saved-trigger:active { transform: scale(0.97); }
+.saved-card-main:focus-visible,
+.saved-remove:focus-visible {
+  position: relative;
+  z-index: 1;
+  outline: 2px solid var(--ui-focus);
+  outline-offset: -2px;
+}
+.saved-player-card .saved-card-main bdi { color: var(--ui-accent); }
+.saved-drawer-body .ui-empty { min-height: 180px; }
+
+.saved-drawer-enter-active,
+.saved-drawer-leave-active {
+  transition:
+    transform 280ms cubic-bezier(0.22, 1, 0.36, 1),
+    opacity 180ms var(--ui-ease-out);
+}
+.saved-drawer-enter-from,
+.saved-drawer-leave-to { opacity: 0; transform: translateX(24px) scale(0.98); }
+
 .trade-notice { right: var(--ui-space-4); bottom: var(--ui-space-4); }
 
 @keyframes trade-skeleton {
@@ -252,6 +335,8 @@
   }
   .source-segment,
   .intent-segment { width: 100%; }
+  .trade-toolbar-actions { align-items: stretch; }
+  .intent-segment { flex: 1; }
   .trade-search { grid-template-columns: minmax(0, 1fr) auto; }
   .trade-search .ui-button:last-child { grid-column: 1 / -1; }
   .trade-columns { display: none; }
@@ -288,7 +373,12 @@
     align-self: flex-start;
   }
   .inspector-actions { min-width: 0; flex-direction: row; flex-wrap: wrap; }
-  .pending-messages { top: var(--ui-space-2); }
+  .trade-saved-drawer {
+    top: 68px;
+    right: 10px;
+    bottom: 11px;
+    width: calc(100% - 20px);
+  }
 }
 
 @media (max-width: 600px) {
@@ -303,5 +393,8 @@
 
 @media (prefers-reduced-motion: reduce) {
   .trade-skeleton { animation: none; }
-  .pending-messages { transform: translateX(-50%); }
+  .saved-drawer-enter-active,
+  .saved-drawer-leave-active { transition: opacity 120ms linear; }
+  .saved-drawer-enter-from,
+  .saved-drawer-leave-to { transform: none; }
 }

--- a/apps/tools/src/styles/trade.css
+++ b/apps/tools/src/styles/trade.css
@@ -53,8 +53,19 @@
 }
 
 .saved-trigger { white-space: nowrap; }
-.saved-trigger > span:first-child,
+.saved-trigger > .trade-icon,
 .saved-count { color: var(--ui-accent); }
+
+.trade-icon {
+  width: 1.05em;
+  height: 1.05em;
+  flex: none;
+  stroke: currentColor;
+  stroke-width: 1.7;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  vertical-align: -0.15em;
+}
 
 .trade-search {
   display: grid;
@@ -175,15 +186,15 @@
 .row-quick-action:focus-visible { outline: 2px solid var(--ui-focus); outline-offset: 1px; }
 
 .trade-row:hover { background: var(--ui-hover); }
-.trade-row[aria-selected="true"] {
+.trade-row[aria-current="true"] {
   background: var(--ui-selected);
   box-shadow: var(--ui-shadow-row-selected);
 }
 .trade-row[data-saved-offer] {
-  box-shadow: inset 3px 0 0 var(--ui-accent);
+  box-shadow: inset 1px 0 0 var(--ui-accent);
 }
-.trade-row[data-saved-offer][aria-selected="true"] {
-  box-shadow: inset 3px 0 0 var(--ui-accent), var(--ui-shadow-row-selected);
+.trade-row[data-saved-offer][aria-current="true"] {
+  box-shadow: inset 1px 0 0 var(--ui-accent), var(--ui-shadow-row-selected);
 }
 .trade-row:focus-visible {
   position: relative;
@@ -307,7 +318,7 @@
   justify-content: center;
   gap: var(--ui-space-2);
 }
-.inspector-actions .ui-button { min-height: 34px; padding-inline: var(--ui-space-2); }
+.inspector-actions .ui-button { min-height: 34px; gap: var(--ui-space-1); padding-inline: var(--ui-space-2); }
 .inspector-actions .ui-link { padding-inline: var(--ui-space-1); white-space: nowrap; }
 .trade-inspector .mobile-back { display: none; }
 
@@ -354,9 +365,10 @@
 }
 .saved-card-main > span { display: grid; min-width: 0; gap: var(--ui-space-1); }
 .saved-card-main bdi { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.saved-card-main bdi .trade-icon { margin-right: var(--ui-space-1); }
 .saved-card-main > bdi { color: var(--ui-text-muted); }
 .saved-card-main small { color: var(--ui-text-faint); font-size: var(--ui-font-size-sm); }
-.saved-remove { color: var(--ui-accent); font-size: var(--ui-font-size-lg); }
+.saved-remove { display: grid; place-items: center; color: var(--ui-accent); font-size: var(--ui-font-size-lg); }
 .saved-card-main:hover,
 .saved-remove:hover { background: var(--ui-hover); }
 .saved-card-main:active,

--- a/apps/tools/src/styles/trade.css
+++ b/apps/tools/src/styles/trade.css
@@ -1,0 +1,307 @@
+/* Trade Chat composes the shared Guild Wars materials into a dense ledger. */
+.trade-window {
+  width: min(1040px, calc(100vw - 64px));
+  height: min(680px, calc(100vh - 64px));
+  min-width: 520px;
+  min-height: 400px;
+}
+
+.tools-stage[data-mode="standalone"] .trade-window {
+  width: min(1040px, calc(100vw - 64px));
+  height: min(680px, calc(100vh - 64px));
+}
+
+.trade-brand { font-size: var(--ui-font-size-lg); }
+
+.trade-status {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ui-space-2);
+  color: var(--ui-text-muted);
+  font-size: var(--ui-font-size-sm);
+  white-space: nowrap;
+}
+
+.trade-status i {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--ui-radius-pill);
+  background: var(--ui-text-faint);
+  box-shadow: 0 1px 3px var(--ui-outline);
+}
+
+.trade-status[data-state="live"] i { background: var(--ui-success); }
+.trade-status[data-state="connecting"] i,
+.trade-status[data-state="reconnecting"] i { background: var(--ui-warning); }
+.trade-status[data-state="unavailable"] i { background: var(--ui-danger); }
+
+.trade-toolbar {
+  display: grid;
+  grid-template-columns: auto minmax(280px, 1fr) auto;
+  align-items: center;
+  gap: var(--ui-gap);
+  padding-top: var(--ui-gap);
+}
+
+.source-segment,
+.intent-segment { width: auto; }
+
+.trade-search {
+  display: grid;
+  min-width: 0;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: var(--ui-space-2);
+}
+
+.trade-search .ui-input-group { min-width: 0; }
+
+.trade-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ui-space-3);
+  padding: var(--ui-space-2) var(--ui-space-1);
+  color: var(--ui-text-muted);
+  font-size: var(--ui-font-size-sm);
+  font-variant-numeric: tabular-nums;
+}
+
+.trade-summary span:first-child {
+  overflow: hidden;
+  color: var(--ui-text);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.pending-messages {
+  position: absolute;
+  z-index: var(--ui-z-status);
+  top: calc(32px + var(--ui-space-2));
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.trade-ledger {
+  position: relative;
+  display: flex;
+  min-height: 150px;
+  flex: 1 1 auto;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.trade-columns,
+.trade-row {
+  display: grid;
+  grid-template-columns: 104px minmax(150px, 0.8fr) minmax(280px, 2.3fr) 58px;
+  align-items: center;
+  gap: var(--ui-space-3);
+}
+
+.trade-columns {
+  flex: none;
+  min-height: 32px;
+  padding: 0 var(--ui-space-3);
+  border-bottom: 1px solid var(--ui-line-soft);
+  color: var(--ui-text-faint);
+  font-size: var(--ui-font-size-sm);
+}
+
+.trade-columns span:last-child { text-align: right; }
+
+.trade-list {
+  min-height: 0;
+  flex: 1;
+  overflow: auto;
+}
+
+.trade-row {
+  width: 100%;
+  min-height: 52px;
+  padding: var(--ui-space-2) var(--ui-space-3);
+  border: 0;
+  border-bottom: 1px solid var(--ui-line-soft);
+  background: var(--ui-row-fill);
+  color: var(--ui-text);
+  font: inherit;
+  text-align: left;
+  text-shadow: var(--ui-text-shadow);
+  cursor: pointer;
+}
+
+.trade-row:hover { background: var(--ui-hover); }
+.trade-row[aria-selected="true"] {
+  background: var(--ui-selected);
+  box-shadow: var(--ui-shadow-row-selected);
+}
+.trade-row:focus-visible {
+  position: relative;
+  z-index: 1;
+  outline: 2px solid var(--ui-focus);
+  outline-offset: -2px;
+}
+
+.intent-cell {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  gap: var(--ui-space-1);
+}
+.intent-cell .ui-chip { min-height: 22px; padding-inline: 7px; }
+.ui-chip[data-intent="selling"] { color: var(--ui-info); }
+.ui-chip[data-intent="buying"] { color: var(--ui-success); }
+
+.character-cell,
+.message-cell {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.character-cell { color: var(--ui-text-bright); }
+.message-cell { color: var(--ui-text-muted); }
+.age-cell {
+  color: var(--ui-text-faint);
+  font-size: var(--ui-font-size-sm);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.load-more { margin: var(--ui-space-3) auto; }
+
+.trade-state {
+  display: grid;
+  min-height: 150px;
+  flex: 1;
+  align-content: center;
+  justify-items: center;
+  gap: var(--ui-space-2);
+  padding: var(--ui-space-4);
+  color: var(--ui-text-muted);
+  text-align: center;
+}
+.trade-state p { max-width: 62ch; margin: 0; }
+.trade-state strong { color: var(--ui-text-bright); font-size: var(--ui-font-size-lg); }
+
+.trade-skeleton {
+  width: min(560px, 82%);
+  height: 22px;
+  border-radius: var(--ui-radius-sm);
+  background: var(--ui-hover);
+  animation: trade-skeleton 1.2s ease-in-out infinite alternate;
+}
+.trade-skeleton:nth-child(2) { width: min(470px, 70%); }
+.trade-skeleton:nth-child(3) { width: min(520px, 76%); }
+
+.trade-inspector {
+  display: grid;
+  min-height: 144px;
+  max-height: 190px;
+  flex: 0 0 auto;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--ui-space-4);
+  margin-top: var(--ui-gap);
+  padding: var(--ui-space-4);
+  overflow: auto;
+}
+
+.inspector-copy { min-width: 0; }
+.inspector-copy p {
+  max-width: 75ch;
+  margin: var(--ui-space-3) 0 0;
+  color: var(--ui-text-bright);
+  font-family: var(--ui-font-readable);
+  line-height: 1.55;
+  text-shadow: none;
+  user-select: text;
+}
+.inspector-meta {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--ui-space-4);
+  color: var(--ui-text-muted);
+  font-size: var(--ui-font-size-sm);
+}
+.inspector-meta bdi { color: var(--ui-accent); font-size: var(--ui-font-size-lg); }
+.inspector-meta time { font-variant-numeric: tabular-nums; white-space: nowrap; }
+
+.inspector-actions {
+  display: flex;
+  min-width: 162px;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: center;
+  gap: var(--ui-space-2);
+}
+.inspector-actions .ui-link { align-self: center; }
+.trade-inspector .mobile-back { display: none; }
+
+.trade-notice { right: var(--ui-space-4); bottom: var(--ui-space-4); }
+
+@keyframes trade-skeleton {
+  from { opacity: 0.34; }
+  to { opacity: 0.78; }
+}
+
+@container (max-width: 760px) {
+  .trade-window { min-width: 0; }
+  .trade-toolbar {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+  }
+  .source-segment,
+  .intent-segment { width: 100%; }
+  .trade-search { grid-template-columns: minmax(0, 1fr) auto; }
+  .trade-search .ui-button:last-child { grid-column: 1 / -1; }
+  .trade-columns { display: none; }
+  .trade-row {
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: var(--ui-space-1) var(--ui-space-3);
+    padding-block: var(--ui-space-3);
+  }
+  .intent-cell { grid-column: 1; grid-row: 1; }
+  .age-cell { grid-column: 2; grid-row: 1; }
+  .character-cell { grid-column: 1 / -1; grid-row: 2; }
+  .message-cell {
+    display: -webkit-box;
+    grid-column: 1 / -1;
+    grid-row: 3;
+    white-space: normal;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+  .trade-inspector { display: none; }
+  .trade-stage[data-detail-open] .trade-toolbar,
+  .trade-stage[data-detail-open] .trade-summary,
+  .trade-stage[data-detail-open] .trade-ledger { display: none; }
+  .trade-stage[data-detail-open] .trade-inspector {
+    display: flex;
+    min-height: 0;
+    max-height: none;
+    flex: 1;
+    flex-direction: column;
+    margin-top: var(--ui-gap);
+  }
+  .trade-inspector .mobile-back {
+    display: inline-flex;
+    align-self: flex-start;
+  }
+  .inspector-actions { min-width: 0; flex-direction: row; flex-wrap: wrap; }
+  .pending-messages { top: var(--ui-space-2); }
+}
+
+@media (max-width: 600px) {
+  .trade-window {
+    width: calc(100vw - 2 * var(--ui-space-2));
+    height: calc(100vh - 2 * var(--ui-space-2));
+    min-width: 0;
+  }
+  .trade-status { font-size: 0; }
+  .trade-status i { margin-inline: var(--ui-space-1); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .trade-skeleton { animation: none; }
+  .pending-messages { transform: translateX(-50%); }
+}

--- a/apps/tools/src/styles/trade.css
+++ b/apps/tools/src/styles/trade.css
@@ -214,13 +214,28 @@
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.character-cell { color: var(--ui-text-bright); }
+.character-cell {
+  display: flex;
+  align-items: center;
+  gap: var(--ui-space-1);
+  color: var(--ui-text-bright);
+}
+.character-cell bdi { min-width: 0; overflow: hidden; text-overflow: ellipsis; }
 .message-cell { color: var(--ui-text-muted); }
 .age-cell {
   color: var(--ui-text-faint);
   font-size: var(--ui-font-size-sm);
   font-variant-numeric: tabular-nums;
   text-align: right;
+}
+.group-count {
+  padding: 2px 6px;
+  border: 1px solid var(--ui-line-soft);
+  border-radius: 999px;
+  color: var(--ui-text-muted);
+  font-size: var(--ui-font-size-xs);
+  line-height: 1.2;
+  white-space: nowrap;
 }
 
 .load-more { margin: var(--ui-space-3) auto; }
@@ -281,6 +296,8 @@
 }
 .inspector-meta bdi { color: var(--ui-accent); font-size: var(--ui-font-size-lg); }
 .inspector-meta time { font-variant-numeric: tabular-nums; white-space: nowrap; }
+.inspector-meta > span { display: grid; justify-items: end; gap: 2px; }
+.inspector-meta small { color: var(--ui-text-faint); font-size: var(--ui-font-size-xs); }
 
 .inspector-actions {
   display: flex;

--- a/apps/tools/src/trade-host.test.ts
+++ b/apps/tools/src/trade-host.test.ts
@@ -1,0 +1,44 @@
+import { isProxy, reactive } from "vue";
+import { describe, expect, it, vi } from "vitest";
+import type { GwNativeApi } from "../../../src/shared/contracts";
+import type { TradeSavedState } from "../../../src/shared/trade-chat";
+import { createNativeTradeHost } from "./trade-host";
+
+describe("native trade host", () => {
+  it("normalizes reactive saved state before crossing IPC", async () => {
+    const setSaved = vi.fn(async (value: TradeSavedState) => value);
+    const trade: GwNativeApi["trade"] = {
+      async subscribe(source) { return { source, status: "live", messages: [] }; },
+      async unsubscribe() {},
+      async search(request) { return { ...request, messages: [] }; },
+      async retry() {},
+      onEvent() { return () => undefined; },
+      async getSaved() { return { offers: [], players: [] }; },
+      setSaved,
+    };
+    const api = {
+      trade,
+      clipboard: { async writeText() {} },
+      app: { async openExternal() {} },
+    };
+    const value = reactive<TradeSavedState>({
+      offers: [{
+        source: "kamadan",
+        timestamp: 10,
+        sender: "Test Trader",
+        message: "WTS test item",
+        savedAt: 20,
+      }],
+      players: [],
+    });
+    expect(isProxy(value)).toBe(true);
+
+    await createNativeTradeHost(api).setSaved(value);
+
+    const sent = setSaved.mock.calls[0]?.[0];
+    expect(sent).toEqual(value);
+    expect(isProxy(sent)).toBe(false);
+    expect(isProxy(sent?.offers)).toBe(false);
+    expect(isProxy(sent?.offers[0])).toBe(false);
+  });
+});

--- a/apps/tools/src/trade-host.test.ts
+++ b/apps/tools/src/trade-host.test.ts
@@ -10,7 +10,7 @@ describe("native trade host", () => {
     const trade: GwNativeApi["trade"] = {
       async subscribe(source) { return { source, status: "live", messages: [] }; },
       async unsubscribe() {},
-      async search(request) { return { ...request, messages: [] }; },
+      async search(request) { return { ...request, matches: [] }; },
       async retry() {},
       onEvent() { return () => undefined; },
       async getSaved() { return { offers: [], players: [] }; },

--- a/apps/tools/src/trade-host.ts
+++ b/apps/tools/src/trade-host.ts
@@ -24,6 +24,8 @@ export type TradeHost = Readonly<{
 
 export function createNativeTradeHost(api: GwNativeApi): TradeHost {
   const savedApi = api.trade as Partial<GwNativeApi["trade"]>;
+  const getSaved = savedApi.getSaved;
+  const setSaved = savedApi.setSaved;
   return Object.freeze({
     subscribe: (source) => api.trade.subscribe(source),
     unsubscribe: () => api.trade.unsubscribe(),
@@ -34,13 +36,56 @@ export function createNativeTradeHost(api: GwNativeApi): TradeHost {
     openSource: (source) => api.app.openExternal(
       source === "kamadan" ? "kamadanTrade" : "preSearingTrade",
     ),
-    getSaved: () => savedApi.getSaved
-      ? savedApi.getSaved()
-      : Promise.reject(new Error("trade_saved_restart_required")),
-    setSaved: (value) => savedApi.setSaved
-      ? savedApi.setSaved(value)
-      : Promise.reject(new Error("trade_saved_restart_required")),
+    getSaved: () => invokeSaved("get", undefined, getSaved),
+    setSaved: (value) => invokeSaved(
+      "set",
+      { offers: value.offers.length, players: value.players.length },
+      setSaved ? () => setSaved(value) : undefined,
+    ),
   });
+}
+
+async function invokeSaved(
+  operation: "get" | "set",
+  counts: Readonly<{ offers: number; players: number }> | undefined,
+  invoke: (() => Promise<TradeSavedState>) | undefined,
+): Promise<TradeSavedState> {
+  if (!invoke) {
+    console.error("[trade:saved] renderer bridge unavailable", { operation, counts });
+    throw new Error("trade_saved_restart_required");
+  }
+  console.info("[trade:saved] renderer invoke", { operation, counts });
+  try {
+    const saved = await invoke();
+    console.info("[trade:saved] renderer completed", {
+      operation,
+      offers: saved.offers.length,
+      players: saved.players.length,
+    });
+    return saved;
+  } catch (error) {
+    console.error("[trade:saved] renderer failed", {
+      operation,
+      counts,
+      error: rendererError(error),
+    });
+    throw error;
+  }
+}
+
+/** Never let saved player names, offer text, or open-ended errors enter the console. */
+function rendererError(error: unknown): Readonly<{ name: string; reason: string }> {
+  if (!(error instanceof Error)) return { name: typeof error, reason: "non-error" };
+  const reason = error.message.includes("duplicate saved trade entry")
+    ? "duplicate-entry"
+    : error.message.includes("invalid saved trade state")
+      ? "invalid-state"
+      : error.message.includes("No handler registered")
+        ? "missing-ipc-handler"
+        : error.message.includes("trade_saved_restart_required")
+          ? "bridge-unavailable"
+          : "ipc-failed";
+  return { name: error.name, reason };
 }
 
 const DEMO_MESSAGES: readonly TradeMessage[] = [

--- a/apps/tools/src/trade-host.ts
+++ b/apps/tools/src/trade-host.ts
@@ -163,11 +163,14 @@ export function createDemoTradeHost(): TradeHost {
     async unsubscribe() {},
     async search(request) {
       const query = request.query.toLocaleLowerCase();
+      const player = query.startsWith("user:") ? query.slice(5).trim() : null;
       return {
         ...request,
         messages: DEMO_MESSAGES.filter((message) =>
           message.source === request.source
-          && `${message.sender} ${message.message}`.toLocaleLowerCase().includes(query)
+          && (player === null
+            ? message.message.toLocaleLowerCase().includes(query)
+            : message.sender.toLocaleLowerCase().includes(player))
         ),
       };
     },

--- a/apps/tools/src/trade-host.ts
+++ b/apps/tools/src/trade-host.ts
@@ -4,6 +4,7 @@ import type {
   TradeMessage,
   TradeSearchRequest,
   TradeSearchResult,
+  TradeSavedState,
   TradeSnapshot,
   TradeSource,
 } from "../../../src/shared/trade-chat";
@@ -17,6 +18,8 @@ export type TradeHost = Readonly<{
   onEvent(callback: (event: TradeEvent) => void): () => void;
   copy(text: string): Promise<void>;
   openSource(source: TradeSource): Promise<void>;
+  getSaved(): Promise<TradeSavedState>;
+  setSaved(value: TradeSavedState): Promise<TradeSavedState>;
 }>;
 
 export function createNativeTradeHost(api: GwNativeApi): TradeHost {
@@ -30,6 +33,8 @@ export function createNativeTradeHost(api: GwNativeApi): TradeHost {
     openSource: (source) => api.app.openExternal(
       source === "kamadan" ? "kamadanTrade" : "preSearingTrade",
     ),
+    getSaved: () => api.trade.getSaved(),
+    setSaved: (value) => api.trade.setSaved(value),
   });
 }
 
@@ -50,6 +55,7 @@ export function createDemoTradeHost(): TradeHost {
   let source: TradeSource = "kamadan";
   const listeners = new Set<(event: TradeEvent) => void>();
   let timer: ReturnType<typeof setInterval> | null = null;
+  let saved: TradeSavedState = { offers: [], players: [] };
   const start = () => {
     if (timer) return;
     timer = setInterval(() => {
@@ -104,6 +110,11 @@ export function createDemoTradeHost(): TradeHost {
       await navigator.clipboard?.writeText(text);
     },
     async openSource() {},
+    async getSaved() { return saved; },
+    async setSaved(value) {
+      saved = value;
+      return saved;
+    },
   });
 }
 

--- a/apps/tools/src/trade-host.ts
+++ b/apps/tools/src/trade-host.ts
@@ -23,6 +23,7 @@ export type TradeHost = Readonly<{
 }>;
 
 export function createNativeTradeHost(api: GwNativeApi): TradeHost {
+  const savedApi = api.trade as Partial<GwNativeApi["trade"]>;
   return Object.freeze({
     subscribe: (source) => api.trade.subscribe(source),
     unsubscribe: () => api.trade.unsubscribe(),
@@ -33,8 +34,12 @@ export function createNativeTradeHost(api: GwNativeApi): TradeHost {
     openSource: (source) => api.app.openExternal(
       source === "kamadan" ? "kamadanTrade" : "preSearingTrade",
     ),
-    getSaved: () => api.trade.getSaved(),
-    setSaved: (value) => api.trade.setSaved(value),
+    getSaved: () => savedApi.getSaved
+      ? savedApi.getSaved()
+      : Promise.reject(new Error("trade_saved_restart_required")),
+    setSaved: (value) => savedApi.setSaved
+      ? savedApi.setSaved(value)
+      : Promise.reject(new Error("trade_saved_restart_required")),
   });
 }
 

--- a/apps/tools/src/trade-host.ts
+++ b/apps/tools/src/trade-host.ts
@@ -1,12 +1,13 @@
 /** The narrow host boundary used by the Trade Chat Vue surface. */
-import type {
-  TradeEvent,
-  TradeMessage,
-  TradeSearchRequest,
-  TradeSearchResult,
-  TradeSavedState,
-  TradeSnapshot,
-  TradeSource,
+import {
+  parseTradeSavedState,
+  type TradeEvent,
+  type TradeMessage,
+  type TradeSearchRequest,
+  type TradeSearchResult,
+  type TradeSavedState,
+  type TradeSnapshot,
+  type TradeSource,
 } from "../../../src/shared/trade-chat";
 import type { GwNativeApi } from "../../../src/shared/contracts";
 
@@ -22,7 +23,13 @@ export type TradeHost = Readonly<{
   setSaved(value: TradeSavedState): Promise<TradeSavedState>;
 }>;
 
-export function createNativeTradeHost(api: GwNativeApi): TradeHost {
+type NativeTradeHostApi = Readonly<{
+  trade: GwNativeApi["trade"];
+  clipboard: Pick<GwNativeApi["clipboard"], "writeText">;
+  app: Pick<GwNativeApi["app"], "openExternal">;
+}>;
+
+export function createNativeTradeHost(api: NativeTradeHostApi): TradeHost {
   const savedApi = api.trade as Partial<GwNativeApi["trade"]>;
   const getSaved = savedApi.getSaved;
   const setSaved = savedApi.setSaved;
@@ -37,12 +44,33 @@ export function createNativeTradeHost(api: GwNativeApi): TradeHost {
       source === "kamadan" ? "kamadanTrade" : "preSearingTrade",
     ),
     getSaved: () => invokeSaved("get", undefined, getSaved),
-    setSaved: (value) => invokeSaved(
-      "set",
-      { offers: value.offers.length, players: value.players.length },
-      setSaved ? () => setSaved(value) : undefined,
-    ),
+    setSaved: (value) => setSavedState(value, setSaved),
   });
+}
+
+async function setSavedState(
+  value: TradeSavedState,
+  setSaved: GwNativeApi["trade"]["setSaved"] | undefined,
+): Promise<TradeSavedState> {
+  const counts = { offers: value.offers.length, players: value.players.length };
+  let normalized: TradeSavedState;
+  try {
+    // Vue may hand us reactive proxies. Rebuild the bounded shared contract so
+    // Electron receives a plain structured-cloneable object.
+    normalized = parseTradeSavedState(value);
+    console.info("[trade:saved] renderer payload normalized", counts);
+  } catch (error) {
+    console.error("[trade:saved] renderer payload rejected", {
+      counts,
+      error: rendererError(error),
+    });
+    throw error;
+  }
+  return invokeSaved(
+    "set",
+    counts,
+    setSaved ? () => setSaved(normalized) : undefined,
+  );
 }
 
 async function invokeSaved(

--- a/apps/tools/src/trade-host.ts
+++ b/apps/tools/src/trade-host.ts
@@ -30,9 +30,6 @@ type NativeTradeHostApi = Readonly<{
 }>;
 
 export function createNativeTradeHost(api: NativeTradeHostApi): TradeHost {
-  const savedApi = api.trade as Partial<GwNativeApi["trade"]>;
-  const getSaved = savedApi.getSaved;
-  const setSaved = savedApi.setSaved;
   return Object.freeze({
     subscribe: (source) => api.trade.subscribe(source),
     unsubscribe: () => api.trade.unsubscribe(),
@@ -43,79 +40,10 @@ export function createNativeTradeHost(api: NativeTradeHostApi): TradeHost {
     openSource: (source) => api.app.openExternal(
       source === "kamadan" ? "kamadanTrade" : "preSearingTrade",
     ),
-    getSaved: () => invokeSaved("get", undefined, getSaved),
-    setSaved: (value) => setSavedState(value, setSaved),
+    getSaved: () => api.trade.getSaved(),
+    // Vue state can contain proxies, which Electron cannot structured-clone.
+    setSaved: (value) => api.trade.setSaved(parseTradeSavedState(value)),
   });
-}
-
-async function setSavedState(
-  value: TradeSavedState,
-  setSaved: GwNativeApi["trade"]["setSaved"] | undefined,
-): Promise<TradeSavedState> {
-  const counts = { offers: value.offers.length, players: value.players.length };
-  let normalized: TradeSavedState;
-  try {
-    // Vue may hand us reactive proxies. Rebuild the bounded shared contract so
-    // Electron receives a plain structured-cloneable object.
-    normalized = parseTradeSavedState(value);
-    console.info("[trade:saved] renderer payload normalized", counts);
-  } catch (error) {
-    console.error("[trade:saved] renderer payload rejected", {
-      counts,
-      error: rendererError(error),
-    });
-    throw error;
-  }
-  return invokeSaved(
-    "set",
-    counts,
-    setSaved ? () => setSaved(normalized) : undefined,
-  );
-}
-
-async function invokeSaved(
-  operation: "get" | "set",
-  counts: Readonly<{ offers: number; players: number }> | undefined,
-  invoke: (() => Promise<TradeSavedState>) | undefined,
-): Promise<TradeSavedState> {
-  if (!invoke) {
-    console.error("[trade:saved] renderer bridge unavailable", { operation, counts });
-    throw new Error("trade_saved_restart_required");
-  }
-  console.info("[trade:saved] renderer invoke", { operation, counts });
-  try {
-    const saved = await invoke();
-    console.info("[trade:saved] renderer completed", {
-      operation,
-      offers: saved.offers.length,
-      players: saved.players.length,
-    });
-    return saved;
-  } catch (error) {
-    console.error("[trade:saved] renderer failed", {
-      operation,
-      counts,
-      error: rendererError(error),
-    });
-    throw error;
-  }
-}
-
-/** Never let saved player names, offer text, or open-ended errors enter the console. */
-function rendererError(error: unknown): Readonly<{ name: string; reason: string }> {
-  if (!(error instanceof Error)) return { name: typeof error, reason: "non-error" };
-  const forwarded = /trade_saved_(?:get|set)_failed:([a-z0-9_-]+)/u.exec(error.message)?.[1];
-  const reason = forwarded
-    ?? (error.message.includes("duplicate saved trade entry")
-    ? "duplicate-entry"
-    : error.message.includes("invalid saved trade state")
-      ? "invalid-state"
-      : error.message.includes("No handler registered")
-        ? "missing-ipc-handler"
-        : error.message.includes("trade_saved_restart_required")
-          ? "bridge-unavailable"
-          : "ipc-failed");
-  return { name: error.name, reason };
 }
 
 const DEMO_MESSAGES: readonly TradeMessage[] = [
@@ -164,15 +92,20 @@ export function createDemoTradeHost(): TradeHost {
     async unsubscribe() {},
     async search(request) {
       const query = request.query.toLocaleLowerCase();
-      const player = query.startsWith("user:") ? query.slice(5).trim() : null;
+      const groups = new Map<string, { message: TradeMessage; postCount: number }>();
+      for (const message of DEMO_MESSAGES.filter((candidate) =>
+        candidate.source === request.source
+        && (candidate.message.toLocaleLowerCase().includes(query)
+          || candidate.sender.toLocaleLowerCase().includes(query))
+      ).sort((left, right) => right.timestamp - left.timestamp)) {
+        const key = message.sender.toLocaleLowerCase();
+        const group = groups.get(key);
+        if (group) group.postCount += 1;
+        else groups.set(key, { message, postCount: 1 });
+      }
       return {
         ...request,
-        messages: DEMO_MESSAGES.filter((message) =>
-          message.source === request.source
-          && (player === null
-            ? message.message.toLocaleLowerCase().includes(query)
-            : message.sender.toLocaleLowerCase().includes(player))
-        ),
+        matches: [...groups.values()],
       };
     },
     async retry(next) {

--- a/apps/tools/src/trade-host.ts
+++ b/apps/tools/src/trade-host.ts
@@ -76,7 +76,9 @@ async function invokeSaved(
 /** Never let saved player names, offer text, or open-ended errors enter the console. */
 function rendererError(error: unknown): Readonly<{ name: string; reason: string }> {
   if (!(error instanceof Error)) return { name: typeof error, reason: "non-error" };
-  const reason = error.message.includes("duplicate saved trade entry")
+  const forwarded = /trade_saved_(?:get|set)_failed:([a-z0-9_-]+)/u.exec(error.message)?.[1];
+  const reason = forwarded
+    ?? (error.message.includes("duplicate saved trade entry")
     ? "duplicate-entry"
     : error.message.includes("invalid saved trade state")
       ? "invalid-state"
@@ -84,7 +86,7 @@ function rendererError(error: unknown): Readonly<{ name: string; reason: string 
         ? "missing-ipc-handler"
         : error.message.includes("trade_saved_restart_required")
           ? "bridge-unavailable"
-          : "ipc-failed";
+          : "ipc-failed");
   return { name: error.name, reason };
 }
 

--- a/apps/tools/src/trade-host.ts
+++ b/apps/tools/src/trade-host.ts
@@ -1,0 +1,122 @@
+/** The narrow host boundary used by the Trade Chat Vue surface. */
+import type {
+  TradeEvent,
+  TradeMessage,
+  TradeSearchRequest,
+  TradeSearchResult,
+  TradeSnapshot,
+  TradeSource,
+} from "../../../src/shared/trade-chat";
+import type { GwNativeApi } from "../../../src/shared/contracts";
+
+export type TradeHost = Readonly<{
+  subscribe(source: TradeSource): Promise<TradeSnapshot>;
+  unsubscribe(): Promise<void>;
+  search(request: TradeSearchRequest): Promise<TradeSearchResult>;
+  retry(source: TradeSource): Promise<void>;
+  onEvent(callback: (event: TradeEvent) => void): () => void;
+  copy(text: string): Promise<void>;
+  openSource(source: TradeSource): Promise<void>;
+}>;
+
+export function createNativeTradeHost(api: GwNativeApi): TradeHost {
+  return Object.freeze({
+    subscribe: (source) => api.trade.subscribe(source),
+    unsubscribe: () => api.trade.unsubscribe(),
+    search: (request) => api.trade.search(request),
+    retry: (source) => api.trade.retry(source),
+    onEvent: (callback) => api.trade.onEvent(callback),
+    copy: (text) => api.clipboard.writeText(text),
+    openSource: (source) => api.app.openExternal(
+      source === "kamadan" ? "kamadanTrade" : "preSearingTrade",
+    ),
+  });
+}
+
+const DEMO_MESSAGES: readonly TradeMessage[] = [
+  fixture("kamadan", 1, "Tyria Cartographer", "WTS arms 29e each — trade me in Kamadan"),
+  fixture("kamadan", 2, "Rin of the Isles", "WTB cupcakes, need several stacks"),
+  fixture("kamadan", 3, "Silver Wayfarer", "WTS 105 consets — 1e each"),
+  fixture("kamadan", 4, "Acolyte Mira", "WTS chocolate bunnies 4e per stack"),
+  fixture("kamadan", 5, "Artic Voyager", "WTB +5 energy spear, message your offer"),
+  fixture("kamadan", 6, "Quiet Ember", "WTS unded Polar Bear 100a | Envoy Axe 20a | q12 Eblade 6a"),
+  fixture("pre-searing", 1, "Vanguard Althea", "WTB Charr carvings and red iris flowers"),
+  fixture("pre-searing", 2, "Northlands Scout", "WTS purple Charr bag, offer"),
+  fixture("pre-searing", 3, "Ascalon Merchant", "WTS dyes, iron ingots and wood planks"),
+  fixture("pre-searing", 4, "The Legendary Defender", "WTB max purple sword q8"),
+];
+
+export function createDemoTradeHost(): TradeHost {
+  let source: TradeSource = "kamadan";
+  const listeners = new Set<(event: TradeEvent) => void>();
+  let timer: ReturnType<typeof setInterval> | null = null;
+  const start = () => {
+    if (timer) return;
+    timer = setInterval(() => {
+      const message = fixture(
+        source,
+        Math.floor(Date.now() / 1000),
+        source === "kamadan" ? "Demo Trader" : "Ascalon Collector",
+        source === "kamadan" ? "WTS ectos 7e each" : "WTB black dyes, pm offer",
+      );
+      for (const listener of listeners) {
+        listener({ type: "message", source, message });
+      }
+    }, 18_000);
+  };
+  return Object.freeze({
+    async subscribe(next) {
+      source = next;
+      start();
+      return {
+        source,
+        status: "live",
+        messages: DEMO_MESSAGES.filter((message) => message.source === source),
+      };
+    },
+    async unsubscribe() {},
+    async search(request) {
+      const query = request.query.toLocaleLowerCase();
+      return {
+        ...request,
+        messages: DEMO_MESSAGES.filter((message) =>
+          message.source === request.source
+          && `${message.sender} ${message.message}`.toLocaleLowerCase().includes(query)
+        ),
+      };
+    },
+    async retry(next) {
+      for (const listener of listeners) {
+        listener({ type: "status", source: next, status: "live" });
+      }
+    },
+    onEvent(callback) {
+      listeners.add(callback);
+      return () => {
+        listeners.delete(callback);
+        if (listeners.size === 0 && timer) {
+          clearInterval(timer);
+          timer = null;
+        }
+      };
+    },
+    async copy(text) {
+      await navigator.clipboard?.writeText(text);
+    },
+    async openSource() {},
+  });
+}
+
+function fixture(
+  source: TradeSource,
+  offset: number,
+  sender: string,
+  message: string,
+): TradeMessage {
+  return Object.freeze({
+    source,
+    timestamp: Date.now() - offset * 60_000,
+    sender,
+    message,
+  });
+}

--- a/apps/tools/src/trade-host.ts
+++ b/apps/tools/src/trade-host.ts
@@ -125,6 +125,7 @@ const DEMO_MESSAGES: readonly TradeMessage[] = [
   fixture("kamadan", 4, "Acolyte Mira", "WTS chocolate bunnies 4e per stack"),
   fixture("kamadan", 5, "Artic Voyager", "WTB +5 energy spear, message your offer"),
   fixture("kamadan", 6, "Quiet Ember", "WTS unded Polar Bear 100a | Envoy Axe 20a | q12 Eblade 6a"),
+  fixture("kamadan", 7, "Tyria Cartographer", "Earlier trade listing, now superseded"),
   fixture("pre-searing", 1, "Vanguard Althea", "WTB Charr carvings and red iris flowers"),
   fixture("pre-searing", 2, "Northlands Scout", "WTS purple Charr bag, offer"),
   fixture("pre-searing", 3, "Ascalon Merchant", "WTS dyes, iron ingots and wood planks"),

--- a/apps/tools/src/trade-ledger.ts
+++ b/apps/tools/src/trade-ledger.ts
@@ -1,0 +1,51 @@
+import {
+  TRADE_LIMITS,
+  type TradeMessage,
+  type TradeSearchMatch,
+} from "../../../src/shared/trade-chat";
+
+export type TradeIntent = "all" | "selling" | "buying";
+export type TradeLedgerRow = Readonly<{ message: TradeMessage; postCount: number }>;
+
+export function tradeMessageIntents(message: string): Exclude<TradeIntent, "all">[] {
+  const selling = /(?:^|[^a-z0-9])wts(?:$|[^a-z0-9])/iu.test(message);
+  const buying = /(?:^|[^a-z0-9])wtb(?:$|[^a-z0-9])/iu.test(message);
+  return [selling ? "selling" : null, buying ? "buying" : null]
+    .filter((value): value is Exclude<TradeIntent, "all"> => value !== null);
+}
+
+export function liveLedgerRows(
+  messages: readonly TradeMessage[],
+  intent: TradeIntent,
+): TradeLedgerRow[] {
+  return messages
+    .filter((message) => matchesIntent(message, intent))
+    .map((message) => ({ message, postCount: 1 }));
+}
+
+export function searchLedgerRows(
+  matches: readonly TradeSearchMatch[],
+  intent: TradeIntent,
+): TradeLedgerRow[] {
+  return matches.filter(({ message }) => matchesIntent(message, intent));
+}
+
+export function insertTradeMessage(
+  messages: readonly TradeMessage[],
+  message: TradeMessage,
+  limit = TRADE_LIMITS.liveMessages,
+): TradeMessage[] {
+  const withoutReplacement = message.replacementTimestamp === undefined
+    ? messages
+    : messages.filter((candidate) => candidate.timestamp !== message.replacementTimestamp);
+  if (withoutReplacement.some((candidate) => candidate.timestamp === message.timestamp)) {
+    return [...withoutReplacement];
+  }
+  return [message, ...withoutReplacement]
+    .sort((left, right) => right.timestamp - left.timestamp)
+    .slice(0, limit);
+}
+
+function matchesIntent(message: TradeMessage, intent: TradeIntent): boolean {
+  return intent === "all" || tradeMessageIntents(message.message).includes(intent);
+}

--- a/apps/tools/src/trade-mount.ts
+++ b/apps/tools/src/trade-mount.ts
@@ -1,0 +1,41 @@
+/** Vue mount and lifetime for the independent Trade Chat surface. */
+import { createApp, h, ref } from "vue";
+import TradeChatApp from "./TradeChatApp.vue";
+import type { TradeHost } from "./trade-host";
+import type { TradeChatHandle } from "../../../src/shared/tools-bundle-contracts";
+
+export function mountTradeChat(
+  target: HTMLElement,
+  options: {
+    host: TradeHost;
+    mode: "standalone" | "embedded";
+    initiallyVisible?: boolean;
+    onVisibilityChange?: (visible: boolean) => void;
+  },
+): TradeChatHandle {
+  const visible = ref(options.initiallyVisible ?? options.mode === "standalone");
+  const active = ref(options.mode === "standalone");
+  const setVisible = (next: boolean) => {
+    if (visible.value === next) return;
+    visible.value = next;
+    options.onVisibilityChange?.(next);
+  };
+  const app = createApp({
+    setup: () => () => h(TradeChatApp, {
+      host: options.host,
+      mode: options.mode,
+      visible: visible.value,
+      active: active.value,
+      onClose: () => setVisible(false),
+      onReady: () => { target.dataset.ready = "true"; },
+    }),
+  });
+  app.mount(target);
+  return Object.freeze({
+    show: () => setVisible(true),
+    hide: () => setVisible(false),
+    toggle: () => setVisible(!visible.value),
+    setActive: (next: boolean) => { active.value = next; },
+    dispose: () => app.unmount(),
+  });
+}

--- a/apps/tools/src/use-floating-window.ts
+++ b/apps/tools/src/use-floating-window.ts
@@ -15,11 +15,13 @@ export function useFloatingWindow(options: {
   initialPosition: { left: number; top: number };
   minWidth: number;
   minHeight: number;
+  viewportMargin?: number;
 }) {
   const panel = ref<HTMLElement | null>(null);
   const resizeGrip = ref<HTMLButtonElement | null>(null);
   const position = ref({ ...options.initialPosition });
   const size = ref<{ width: number; height: number } | null>(null);
+  const margin = options.viewportMargin ?? 0;
   const panelStyle = computed(() => options.mode === "embedded"
     ? {
         left: `${position.value.left}px`,
@@ -32,14 +34,16 @@ export function useFloatingWindow(options: {
 
   const fitToViewport = () => {
     if (options.mode !== "embedded" || !panel.value) return;
-    const width = Math.min(panel.value.offsetWidth, window.innerWidth);
-    const height = Math.min(panel.value.offsetHeight, window.innerHeight);
+    const availableWidth = Math.max(0, window.innerWidth - margin * 2);
+    const availableHeight = Math.max(0, window.innerHeight - margin * 2);
+    const width = Math.min(panel.value.offsetWidth, availableWidth);
+    const height = Math.min(panel.value.offsetHeight, availableHeight);
     if (width !== panel.value.offsetWidth || height !== panel.value.offsetHeight) {
       size.value = { width, height };
     }
     position.value = {
-      left: Math.max(0, Math.min(window.innerWidth - width, position.value.left)),
-      top: Math.max(0, Math.min(window.innerHeight - height, position.value.top)),
+      left: Math.max(margin, Math.min(window.innerWidth - width - margin, position.value.left)),
+      top: Math.max(margin, Math.min(window.innerHeight - height - margin, position.value.top)),
     };
   };
 
@@ -55,12 +59,12 @@ export function useFloatingWindow(options: {
     element.dataset.dragging = "";
     const move = (next: PointerEvent) => {
       position.value = {
-        left: Math.max(0, Math.min(
-          window.innerWidth - element.offsetWidth,
+        left: Math.max(margin, Math.min(
+          window.innerWidth - element.offsetWidth - margin,
           next.clientX - offsetX,
         )),
-        top: Math.max(0, Math.min(
-          window.innerHeight - element.offsetHeight,
+        top: Math.max(margin, Math.min(
+          window.innerHeight - element.offsetHeight - margin,
           next.clientY - offsetY,
         )),
       };
@@ -89,10 +93,10 @@ export function useFloatingWindow(options: {
         return { width: box.width, height: box.height };
       },
       limits: () => ({
-        minWidth: Math.min(options.minWidth, window.innerWidth - position.value.left),
-        minHeight: Math.min(options.minHeight, window.innerHeight - position.value.top),
-        maxWidth: window.innerWidth - position.value.left,
-        maxHeight: window.innerHeight - position.value.top,
+        minWidth: Math.min(options.minWidth, window.innerWidth - position.value.left - margin),
+        minHeight: Math.min(options.minHeight, window.innerHeight - position.value.top - margin),
+        maxWidth: window.innerWidth - position.value.left - margin,
+        maxHeight: window.innerHeight - position.value.top - margin,
       }),
       resize: (width, height) => { size.value = { width, height }; },
       setActive: (active) => {

--- a/apps/tools/src/use-floating-window.ts
+++ b/apps/tools/src/use-floating-window.ts
@@ -1,0 +1,114 @@
+/** Shared drag, resize, and viewport fitting for independent in-game windows. */
+import {
+  computed,
+  onBeforeUnmount,
+  onMounted,
+  ref,
+  watch,
+  type Ref,
+} from "vue";
+import { installResizeGrip } from "../../../src/shared/ui/resize";
+
+export function useFloatingWindow(options: {
+  mode: "standalone" | "embedded";
+  visible: Ref<boolean>;
+  initialPosition: { left: number; top: number };
+  minWidth: number;
+  minHeight: number;
+}) {
+  const panel = ref<HTMLElement | null>(null);
+  const resizeGrip = ref<HTMLButtonElement | null>(null);
+  const position = ref({ ...options.initialPosition });
+  const size = ref<{ width: number; height: number } | null>(null);
+  const panelStyle = computed(() => options.mode === "embedded"
+    ? {
+        left: `${position.value.left}px`,
+        top: `${position.value.top}px`,
+        ...(size.value
+          ? { width: `${size.value.width}px`, height: `${size.value.height}px` }
+          : {}),
+      }
+    : undefined);
+
+  const fitToViewport = () => {
+    if (options.mode !== "embedded" || !panel.value) return;
+    const width = Math.min(panel.value.offsetWidth, window.innerWidth);
+    const height = Math.min(panel.value.offsetHeight, window.innerHeight);
+    if (width !== panel.value.offsetWidth || height !== panel.value.offsetHeight) {
+      size.value = { width, height };
+    }
+    position.value = {
+      left: Math.max(0, Math.min(window.innerWidth - width, position.value.left)),
+      top: Math.max(0, Math.min(window.innerHeight - height, position.value.top)),
+    };
+  };
+
+  const startDrag = (event: PointerEvent) => {
+    if (options.mode !== "embedded" || !panel.value) return;
+    if ((event.target as Element).closest("button, input, select, textarea, a, summary, label")) return;
+    const element = panel.value;
+    const handle = event.currentTarget as HTMLElement;
+    const box = element.getBoundingClientRect();
+    const offsetX = event.clientX - box.left;
+    const offsetY = event.clientY - box.top;
+    handle.setPointerCapture(event.pointerId);
+    element.dataset.dragging = "";
+    const move = (next: PointerEvent) => {
+      position.value = {
+        left: Math.max(0, Math.min(
+          window.innerWidth - element.offsetWidth,
+          next.clientX - offsetX,
+        )),
+        top: Math.max(0, Math.min(
+          window.innerHeight - element.offsetHeight,
+          next.clientY - offsetY,
+        )),
+      };
+    };
+    const finish = () => {
+      delete element.dataset.dragging;
+      handle.removeEventListener("pointermove", move);
+      handle.removeEventListener("pointerup", finish);
+      handle.removeEventListener("pointercancel", finish);
+      handle.removeEventListener("lostpointercapture", finish);
+    };
+    handle.addEventListener("pointermove", move);
+    handle.addEventListener("pointerup", finish);
+    handle.addEventListener("pointercancel", finish);
+    handle.addEventListener("lostpointercapture", finish);
+  };
+
+  let disposeResize: (() => void) | null = null;
+  onMounted(() => {
+    window.addEventListener("resize", fitToViewport);
+    requestAnimationFrame(fitToViewport);
+    if (options.mode !== "embedded" || !panel.value || !resizeGrip.value) return;
+    disposeResize = installResizeGrip(resizeGrip.value, {
+      size: () => {
+        const box = panel.value!.getBoundingClientRect();
+        return { width: box.width, height: box.height };
+      },
+      limits: () => ({
+        minWidth: Math.min(options.minWidth, window.innerWidth - position.value.left),
+        minHeight: Math.min(options.minHeight, window.innerHeight - position.value.top),
+        maxWidth: window.innerWidth - position.value.left,
+        maxHeight: window.innerHeight - position.value.top,
+      }),
+      resize: (width, height) => { size.value = { width, height }; },
+      setActive: (active) => {
+        if (!panel.value) return;
+        if (active) panel.value.dataset.resizing = "";
+        else delete panel.value.dataset.resizing;
+      },
+    });
+  });
+  onBeforeUnmount(() => {
+    window.removeEventListener("resize", fitToViewport);
+    disposeResize?.();
+  });
+  watch(options.visible, (visible) => {
+    if (visible) requestAnimationFrame(fitToViewport);
+  });
+
+  return { panel, resizeGrip, panelStyle, startDrag, fitToViewport };
+}

--- a/apps/tools/tests/trade.spec.ts
+++ b/apps/tools/tests/trade.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from "@playwright/test";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/?trade=1");
+  await expect(page.locator("#app[data-ready=true]")).toBeAttached();
+});
+
+test("searches and inspects the Kamadan ledger", async ({ page }) => {
+  const dialog = page.getByRole("dialog", { name: "Trade Chat" });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByRole("option")).toHaveCount(6);
+  await dialog.getByRole("searchbox").fill("Polar Bear");
+  await dialog.getByRole("button", { name: "Search", exact: true }).click();
+  await expect(dialog.getByRole("option")).toHaveCount(1);
+  await dialog.getByRole("option").click();
+  await expect(dialog.getByText("Quiet Ember")).toHaveCount(2);
+  await dialog.getByRole("button", { name: "Live feed" }).click();
+  await expect(dialog.getByRole("option")).toHaveCount(6);
+});
+
+test("keeps Pre-Searing separate and adapts to a narrow window", async ({ page }) => {
+  await page.setViewportSize({ width: 600, height: 720 });
+  const dialog = page.getByRole("dialog", { name: "Trade Chat" });
+  await dialog.getByRole("button", { name: "Pre-Searing" }).click();
+  await expect(dialog.getByRole("option").first()).toContainText("Vanguard Althea");
+  await expect(dialog.getByText("Tyria Cartographer")).toHaveCount(0);
+  await dialog.getByRole("option").first().click();
+  await expect(dialog.getByRole("button", { name: "Back to offers" })).toBeVisible();
+  await dialog.getByRole("button", { name: "Back to offers" }).click();
+  await expect(dialog.getByRole("option").first()).toBeVisible();
+});
+
+test("filters selling and buying without relying on chip colour", async ({ page }) => {
+  const dialog = page.getByRole("dialog", { name: "Trade Chat" });
+  await dialog.getByRole("button", { name: "Buying" }).click();
+  await expect(dialog.getByRole("option")).toHaveCount(2);
+  await expect(dialog.getByText("WTB", { exact: true })).toHaveCount(2);
+  await dialog.getByRole("button", { name: "Selling" }).click();
+  await expect(dialog.getByRole("option")).toHaveCount(4);
+  await expect(dialog.getByText("WTS", { exact: true })).toHaveCount(4);
+});

--- a/apps/tools/tests/trade.spec.ts
+++ b/apps/tools/tests/trade.spec.ts
@@ -42,8 +42,10 @@ test("filters selling and buying without relying on chip colour", async ({ page 
 
 test("saves offers and players in an anchored drawer", async ({ page }) => {
   const dialog = page.getByRole("dialog", { name: "Trade Chat" });
-  await dialog.getByRole("button", { name: "☆ Save offer" }).click();
-  await dialog.getByRole("button", { name: "☆ Follow player" }).click();
+  const firstOffer = dialog.getByRole("option").first();
+  await firstOffer.hover();
+  await dialog.getByRole("button", { name: "Save offer from Tyria Cartographer" }).click();
+  await dialog.getByRole("button", { name: "Follow Tyria Cartographer" }).click();
   await dialog.getByRole("button", { name: /Saved 2/ }).click();
   const drawer = dialog.getByRole("complementary", { name: "Saved trade items" });
   await expect(drawer).toContainText("Tyria Cartographer");

--- a/apps/tools/tests/trade.spec.ts
+++ b/apps/tools/tests/trade.spec.ts
@@ -8,14 +8,14 @@ test.beforeEach(async ({ page }) => {
 test("searches and inspects the Kamadan ledger", async ({ page }) => {
   const dialog = page.getByRole("dialog", { name: "Trade Chat" });
   await expect(dialog).toBeVisible();
-  await expect(dialog.getByRole("option")).toHaveCount(7);
+  await expect(dialog.locator(".trade-row")).toHaveCount(7);
   await dialog.getByRole("searchbox").fill("Polar Bear");
   await dialog.getByRole("button", { name: "Search", exact: true }).click();
-  await expect(dialog.getByRole("option")).toHaveCount(1);
-  await dialog.getByRole("option").click();
+  await expect(dialog.locator(".trade-row")).toHaveCount(1);
+  await dialog.locator(".trade-row").click();
   await expect(dialog.getByText("Quiet Ember")).toHaveCount(2);
   await dialog.getByRole("button", { name: "Live feed" }).click();
-  await expect(dialog.getByRole("option")).toHaveCount(7);
+  await expect(dialog.locator(".trade-row")).toHaveCount(7);
 });
 
 test("searches character names and returns to live when cleared", async ({ page }) => {
@@ -23,42 +23,42 @@ test("searches character names and returns to live when cleared", async ({ page 
   const search = dialog.getByRole("searchbox", { name: "Search offers or character names" });
   await search.fill("Tyria Cartographer");
   await dialog.getByRole("button", { name: "Search", exact: true }).click();
-  await expect(dialog.getByRole("option")).toHaveCount(1);
-  await expect(dialog.getByRole("option")).toContainText("Tyria Cartographer");
+  await expect(dialog.locator(".trade-row")).toHaveCount(1);
+  await expect(dialog.locator(".trade-row")).toContainText("Tyria Cartographer");
   await expect(dialog.getByText("2 posts", { exact: true })).toBeVisible();
-  await expect(dialog.getByRole("option")).toContainText("WTS arms 29e each");
-  await expect(dialog.getByRole("option")).not.toContainText("Earlier trade listing");
+  await expect(dialog.locator(".trade-row")).toContainText("WTS arms 29e each");
+  await expect(dialog.locator(".trade-row")).not.toContainText("Earlier trade listing");
 
   await search.fill("");
   await expect(dialog.getByText("Latest messages", { exact: true })).toBeVisible();
-  await expect(dialog.getByRole("option").first()).toContainText("Tyria Cartographer");
+  await expect(dialog.locator(".trade-row").first()).toContainText("Tyria Cartographer");
 });
 
 test("keeps Pre-Searing separate and adapts to a narrow window", async ({ page }) => {
   await page.setViewportSize({ width: 600, height: 720 });
   const dialog = page.getByRole("dialog", { name: "Trade Chat" });
   await dialog.getByRole("button", { name: "Pre-Searing" }).click();
-  await expect(dialog.getByRole("option").first()).toContainText("Vanguard Althea");
+  await expect(dialog.locator(".trade-row").first()).toContainText("Vanguard Althea");
   await expect(dialog.getByText("Tyria Cartographer")).toHaveCount(0);
-  await dialog.getByRole("option").first().click();
+  await dialog.locator(".trade-row").first().click();
   await expect(dialog.getByRole("button", { name: "Back to offers" })).toBeVisible();
   await dialog.getByRole("button", { name: "Back to offers" }).click();
-  await expect(dialog.getByRole("option").first()).toBeVisible();
+  await expect(dialog.locator(".trade-row").first()).toBeVisible();
 });
 
 test("filters selling and buying without relying on chip colour", async ({ page }) => {
   const dialog = page.getByRole("dialog", { name: "Trade Chat" });
   await dialog.getByRole("button", { name: "Buying" }).click();
-  await expect(dialog.getByRole("option")).toHaveCount(2);
+  await expect(dialog.locator(".trade-row")).toHaveCount(2);
   await expect(dialog.getByText("WTB", { exact: true })).toHaveCount(2);
   await dialog.getByRole("button", { name: "Selling" }).click();
-  await expect(dialog.getByRole("option")).toHaveCount(4);
+  await expect(dialog.locator(".trade-row")).toHaveCount(4);
   await expect(dialog.getByText("WTS", { exact: true })).toHaveCount(4);
 });
 
 test("saves offers and players in an anchored drawer", async ({ page }) => {
   const dialog = page.getByRole("dialog", { name: "Trade Chat" });
-  const firstOffer = dialog.getByRole("option").first();
+  const firstOffer = dialog.locator(".trade-row").first();
   const firstRow = firstOffer.locator("..");
   await firstOffer.hover();
   await firstRow.getByRole("button", { name: "Save offer from Tyria Cartographer" }).click();

--- a/apps/tools/tests/trade.spec.ts
+++ b/apps/tools/tests/trade.spec.ts
@@ -18,6 +18,19 @@ test("searches and inspects the Kamadan ledger", async ({ page }) => {
   await expect(dialog.getByRole("option")).toHaveCount(6);
 });
 
+test("searches character names and returns to live when cleared", async ({ page }) => {
+  const dialog = page.getByRole("dialog", { name: "Trade Chat" });
+  const search = dialog.getByRole("searchbox", { name: "Search offers or character names" });
+  await search.fill("Tyria Cartographer");
+  await dialog.getByRole("button", { name: "Search", exact: true }).click();
+  await expect(dialog.getByRole("option")).toHaveCount(1);
+  await expect(dialog.getByRole("option")).toContainText("Tyria Cartographer");
+
+  await search.fill("");
+  await expect(dialog.getByText("Latest messages", { exact: true })).toBeVisible();
+  await expect(dialog.getByRole("option").first()).toContainText("Tyria Cartographer");
+});
+
 test("keeps Pre-Searing separate and adapts to a narrow window", async ({ page }) => {
   await page.setViewportSize({ width: 600, height: 720 });
   const dialog = page.getByRole("dialog", { name: "Trade Chat" });

--- a/apps/tools/tests/trade.spec.ts
+++ b/apps/tools/tests/trade.spec.ts
@@ -8,14 +8,14 @@ test.beforeEach(async ({ page }) => {
 test("searches and inspects the Kamadan ledger", async ({ page }) => {
   const dialog = page.getByRole("dialog", { name: "Trade Chat" });
   await expect(dialog).toBeVisible();
-  await expect(dialog.getByRole("option")).toHaveCount(6);
+  await expect(dialog.getByRole("option")).toHaveCount(7);
   await dialog.getByRole("searchbox").fill("Polar Bear");
   await dialog.getByRole("button", { name: "Search", exact: true }).click();
   await expect(dialog.getByRole("option")).toHaveCount(1);
   await dialog.getByRole("option").click();
   await expect(dialog.getByText("Quiet Ember")).toHaveCount(2);
   await dialog.getByRole("button", { name: "Live feed" }).click();
-  await expect(dialog.getByRole("option")).toHaveCount(6);
+  await expect(dialog.getByRole("option")).toHaveCount(7);
 });
 
 test("searches character names and returns to live when cleared", async ({ page }) => {
@@ -25,6 +25,9 @@ test("searches character names and returns to live when cleared", async ({ page 
   await dialog.getByRole("button", { name: "Search", exact: true }).click();
   await expect(dialog.getByRole("option")).toHaveCount(1);
   await expect(dialog.getByRole("option")).toContainText("Tyria Cartographer");
+  await expect(dialog.getByText("2 posts", { exact: true })).toBeVisible();
+  await expect(dialog.getByRole("option")).toContainText("WTS arms 29e each");
+  await expect(dialog.getByRole("option")).not.toContainText("Earlier trade listing");
 
   await search.fill("");
   await expect(dialog.getByText("Latest messages", { exact: true })).toBeVisible();
@@ -56,14 +59,15 @@ test("filters selling and buying without relying on chip colour", async ({ page 
 test("saves offers and players in an anchored drawer", async ({ page }) => {
   const dialog = page.getByRole("dialog", { name: "Trade Chat" });
   const firstOffer = dialog.getByRole("option").first();
+  const firstRow = firstOffer.locator("..");
   await firstOffer.hover();
-  await dialog.getByRole("button", { name: "Save offer from Tyria Cartographer" }).click();
-  await dialog.getByRole("button", { name: "Follow Tyria Cartographer" }).click();
+  await firstRow.getByRole("button", { name: "Save offer from Tyria Cartographer" }).click();
+  await firstRow.getByRole("button", { name: "Follow Tyria Cartographer" }).click();
   await dialog.getByRole("button", { name: /Saved 2/ }).click();
   const drawer = dialog.getByRole("complementary", { name: "Saved trade items" });
   await expect(drawer).toContainText("Tyria Cartographer");
   await drawer.getByRole("button", { name: /Players 1/ }).click();
-  await expect(drawer).toContainText("1 current offer");
+  await expect(drawer).toContainText("2 current offers");
   await drawer.getByRole("button", { name: "Close Saved" }).click();
   await expect(drawer).toHaveCount(0);
 });

--- a/apps/tools/tests/trade.spec.ts
+++ b/apps/tools/tests/trade.spec.ts
@@ -39,3 +39,16 @@ test("filters selling and buying without relying on chip colour", async ({ page 
   await expect(dialog.getByRole("option")).toHaveCount(4);
   await expect(dialog.getByText("WTS", { exact: true })).toHaveCount(4);
 });
+
+test("saves offers and players in an anchored drawer", async ({ page }) => {
+  const dialog = page.getByRole("dialog", { name: "Trade Chat" });
+  await dialog.getByRole("button", { name: "☆ Save offer" }).click();
+  await dialog.getByRole("button", { name: "☆ Follow player" }).click();
+  await dialog.getByRole("button", { name: /Saved 2/ }).click();
+  const drawer = dialog.getByRole("complementary", { name: "Saved trade items" });
+  await expect(drawer).toContainText("Tyria Cartographer");
+  await drawer.getByRole("button", { name: /Players 1/ }).click();
+  await expect(drawer).toContainText("1 current offer");
+  await drawer.getByRole("button", { name: "Close Saved" }).click();
+  await expect(drawer).toHaveCount(0);
+});

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ its rules.
 | How do ArenaNet client files and game data update? | [Content pipeline](content-pipeline.md) |
 | How does the official client host and certification work? | [WASM host](wasm-host.md) |
 | How do client features remain safe across ArenaNet updates? | [ArenaNet compatibility](arenanet-compatibility.md) |
+| How does Trade Chat discovery work? | [Trade Chat discovery](trade-discovery.md) |
 | What can diagnostics record and export? | [Diagnostics](diagnostics.md) |
 | How do I change or recertify an Enhancement? | [Enhancement development](enhancement-development.md) |
 | How do application releases, Stable, and Beta work? | [Release verification](release-verification.md) |

--- a/docs/trade-discovery.md
+++ b/docs/trade-discovery.md
@@ -44,7 +44,7 @@ The first release does not include:
 - automatic whispers or trade actions;
 - a GWonMac marketplace, account, database, or backend;
 - price estimation, price history, item recognition, or inventory integration;
-- saved searches, watches, notifications, bookmarks, or ignored players;
+- saved searches, notifications, alerts, notes, tags, or ignored players;
 - regular expressions or a query language;
 - importing remote messages into the Guild Wars chat panel.
 
@@ -101,6 +101,7 @@ Do not copy these Toolbox++ implementation choices:
 | P0 | keep useful results during a connection failure | continue my current search and recover clearly |
 | P0 | use Trade at narrow and wide window sizes | keep it useful beside the game |
 | P0 | use the complete flow with a keyboard | avoid switching repeatedly between input methods |
+| P0 | save an offer or follow a player | keep useful leads and recognize their new listings |
 | Later | prepare an empty whisper to the selected character | shorten contact after the client action is certified |
 | Later | save a useful search | repeat a proven search when actual use justifies persistence |
 
@@ -184,8 +185,8 @@ reorder the row.
 
 Live results are newest first. When the player is at the top, new messages may
 appear immediately. When the player has scrolled away from the top, the list
-must not jump. A compact **New messages** action returns to the latest results.
-Scrolling fully back to the top performs the same merge and clears the action.
+must not jump or show a repeating arrival notice. New messages merge silently
+when the player scrolls fully back to the top.
 
 ## Trade intent filter
 
@@ -210,6 +211,7 @@ The detail pane is calm and sparse. It shows:
 - the character name;
 - the relative time and an exact local timestamp;
 - **Copy character name** as the primary first-release action;
+- **Save offer** and **Follow player** as explicit local actions;
 - **Copy message** as a secondary action; and
 - source attribution with **Open Kamadan** or **Open Ascalon** as a secondary
   link.
@@ -263,8 +265,7 @@ The core Trade feature must not depend on this enhancement.
 
 1. The player clears the query.
 2. The preserved live feed returns at its previous position.
-3. If newer messages accumulated, **New messages** offers a deliberate return
-   to the top.
+3. Newer messages merge silently when the player returns fully to the top.
 
 ## States and recovery
 
@@ -307,7 +308,8 @@ keeps normal pointer and keyboard input everywhere else.
 ## Data and architecture
 
 The public Kamadan and Ascalon services remain the only sources of truth for
-trade messages. GWonMac does not persist a copy of their history.
+trade messages. GWonMac does not persist their history. It stores only offers
+the player explicitly saves and player names the player explicitly follows.
 
 Main owns one `TradeChatService` for the app process:
 
@@ -345,6 +347,11 @@ network request while scrolling.
 Multiple game accounts share the same public network connection and in-memory
 feeds. Selection, query, filter, source, and scroll state stay with each Trade
 Chat window. No account identity or profile data is sent to either source.
+
+Saved offers and followed players live in one bounded, owner-only local JSON
+document. The Saved drawer separates Offers and Players. A saved offer keeps
+its exact source, timestamp, sender, message, and saved time. Following a player
+highlights matching current and future rows without sending anything upstream.
 
 ## Privacy, safety, and external dependency
 

--- a/docs/trade-discovery.md
+++ b/docs/trade-discovery.md
@@ -1,0 +1,412 @@
+# Trade chat discovery
+
+Status: Accepted
+
+This document owns the product and interaction specification for the separate
+Trade Chat window in GWonMac.
+
+## Product decision
+
+Trade helps a player find a recent, relevant Kamadan or Pre-Searing Ascalon
+Trade message and contact its author without leaving Guild Wars.
+
+It is a read-only discovery tool. It is not a marketplace, listing manager, or
+chat client. A player creates a listing by posting to Trade chat in Guild Wars,
+exactly as they do today.
+
+The feature has two primary outcomes:
+
+1. Find a player who is selling an item that you want to buy.
+2. Find a player who wants to buy an item that you want to sell.
+
+Success means the player can move from an item name to a useful character name
+and message with little effort. Message volume, engagement, and time spent in
+the Trade window are not success measures.
+
+## Product boundary
+
+The first release includes:
+
+- the latest public Kamadan and Pre-Searing Ascalon Trade messages;
+- a visible **Kamadan** and **Pre-Searing** source switch;
+- text search over the selected source's public history;
+- simple **All**, **Selling**, and **Buying** filters;
+- a readable message detail view;
+- relative and exact message times;
+- an explicit action to copy the character name;
+- connection, stale-data, empty, and failure states; and
+- a link and attribution to the selected public source.
+
+The first release does not include:
+
+- creating, editing, saving, scheduling, or posting listings;
+- sending, repeating, or automating chat messages;
+- automatic whispers or trade actions;
+- a GWonMac marketplace, account, database, or backend;
+- price estimation, price history, item recognition, or inventory integration;
+- saved searches, watches, notifications, bookmarks, or ignored players;
+- regular expressions or a query language;
+- importing remote messages into the Guild Wars chat panel.
+
+These exclusions are deliberate. They keep the first release focused on the
+observed problem: finding the other side of a trade.
+
+`PRODUCT.md` uses the narrower boundary established here: no automated trading,
+trade execution, listing publication, price manipulation, inventory automation,
+or chat automation.
+
+## What to learn from Toolbox++
+
+Keep these parts of the Toolbox++ model:
+
+- use the public Kamadan and Ascalon feeds instead of building another data
+  source;
+- show recent messages immediately;
+- let one search cover message text and sender names when the upstream service
+  supports it;
+- keep the full original message visible; and
+- make contacting the sender the end of the flow.
+
+Improve these parts:
+
+- use the existing GWonMac interface system and master-detail layout;
+- distinguish players who sell from players who buy;
+- preserve the reader's position when new messages arrive;
+- show clear connection and stale-data states;
+- handle upstream replacement messages instead of showing obsolete copies;
+- share source connections across Trade Chat windows;
+- keep the renderer isolated from network and game-client capabilities; and
+- use normal TLS certificate validation and bounded network input.
+
+Do not copy these Toolbox++ implementation choices:
+
+- one WebSocket connection per window;
+- disabled TLS certificate validation;
+- polling global worker state from the interface;
+- unbounded fragment or message accumulation; or
+- direct game-memory actions from the trade view.
+
+## Core user stories
+
+| Priority | As a player, I want to... | So that I can... |
+| --- | --- | --- |
+| P0 | see recent messages from either supported source | notice current offers without visiting a website |
+| P0 | switch between Kamadan and Pre-Searing | browse each economy without mixing their messages |
+| P0 | search for an item or player name | reduce a fast feed to relevant messages |
+| P0 | show only `WTS` messages | find someone selling an item I want |
+| P0 | show only `WTB` messages | find someone buying an item I own |
+| P0 | compare the full message and its age | judge whether contacting the player is worthwhile |
+| P0 | copy the exact character name | contact the correct player in Guild Wars |
+| P0 | keep reading while new messages arrive | avoid losing my position in the feed |
+| P0 | keep useful results during a connection failure | continue my current search and recover clearly |
+| P0 | use Trade at narrow and wide window sizes | keep it useful beside the game |
+| P0 | use the complete flow with a keyboard | avoid switching repeatedly between input methods |
+| Later | prepare an empty whisper to the selected character | shorten contact after the client action is certified |
+| Later | save a useful search | repeat a proven search when actual use justifies persistence |
+
+## Window and entry point
+
+Trade Chat is a separate non-modal window. It does not share a window,
+workspace switch, navigation, or content area with Builds and teams. The player
+opens it directly from the GWonMac tool entry point.
+
+The window title is **Kamadan Trade** or **Pre-Searing Trade**, matching the
+selected source. Closing it does not close Builds and teams or Guild Wars.
+Opening Builds and teams does not open or embed Trade.
+
+The accepted ledger uses the existing component language without copying the
+Builds window structure:
+
+| Area | Purpose |
+| --- | --- |
+| Title bar | Active source title, window controls, status, and drag behavior |
+| Toolbar | Source, search, intent filter, status, and result count |
+| Ledger | One semantic list of recent or matching messages |
+| Bottom inspector | Full selected message, time, and contact actions |
+
+```text
+┌─ Kamadan Trade ─────────────────────────────────────────────┐
+│ [Kamadan][Pre-Searing] [ Search messages… ] [All][WTS][WTB]│
+├─────────┬──────────────────┬───────────────────────────┬─────┤
+│ Intent  │ Character        │ Message                   │ Age │
+│ WTS     │ Character A      │ WTS q9 ...                │ 2m  │
+│ WTB     │ Character B      │ WTB ...                   │ 5m  │
+├─────────┴──────────────────┴───────────────────────────┴─────┤
+│ Character A · exact time                                    │
+│ WTS q9 ...                                                  │
+│ [Copy character] [Copy message]               [Open source] │
+└──────────────────────────────────────────────────────────────┘
+```
+
+At wide widths, the ledger and bottom inspector remain visible together. At
+narrow widths, the same list DOM becomes stacked cards and selecting a result
+opens an in-window detail sheet.
+**Back to results** returns without losing the query or scroll position.
+
+## Toolbar and ledger
+
+The rail contains, in order:
+
+1. A **Kamadan** and **Pre-Searing** source switch.
+2. The selected source and a compact connection status.
+3. One search field with a clear button.
+4. An **All**, **Selling**, and **Buying** segmented filter.
+5. The current result count or live-feed label.
+6. The bounded result list.
+
+The two source choices are distinct feeds and economies. **Pre-Searing** maps
+to the public Ascalon service, which archives Pre-Searing Ascalon City,
+America English district 1. There is no separate post-Searing Ascalon source.
+The first release does not merge the sources into a **Both** view.
+
+Switching source replaces the live feed, history results, status, and source
+link as one operation. It may preserve the entered query and intent filter so
+the player can compare the same item, but messages from the two sources never
+appear in one result set.
+
+An empty search field shows the live feed. Submitting non-empty text shows
+history results. Clearing the field returns to the preserved live feed. Search
+runs on explicit submit, not on every keystroke.
+
+Each result row shows:
+
+- the character name;
+- a compact relative time such as `2m` or `1h`;
+- enough original message text to identify the trade; and
+- restrained **WTS** and **WTB** markers when the message contains those terms.
+
+The original wording is canonical. GWonMac does not rewrite a message into a
+structured listing.
+
+Matching search text is highlighted visually without changing copyable text.
+Sender names use bidirectional text isolation so mixed writing systems do not
+reorder the row.
+
+Live results are newest first. When the player is at the top, new messages may
+appear immediately. When the player has scrolled away from the top, the list
+must not jump. A compact **New messages** action returns to the latest results.
+Scrolling fully back to the top performs the same merge and clears the action.
+
+## Trade intent filter
+
+The intent filter is a local convenience, not a claim that GWonMac understands
+the item or offer.
+
+- **Selling** includes messages with a case-insensitive, whole-word `WTS`.
+- **Buying** includes messages with a case-insensitive, whole-word `WTB`.
+- **All** includes every result.
+- A message that contains both terms appears in both filtered views.
+- `WTT` and messages without either term remain available in **All**.
+
+The initial filter is **All**. The chosen filter stays active while the player
+moves between live and search results during the window session. It is not
+persisted to disk.
+
+## Message detail
+
+The detail pane is calm and sparse. It shows:
+
+- the complete original message with selectable text;
+- the character name;
+- the relative time and an exact local timestamp;
+- **Copy character name** as the primary first-release action;
+- **Copy message** as a secondary action; and
+- source attribution with **Open Kamadan** or **Open Ascalon** as a secondary
+  link.
+
+Copy feedback appears beside the action and does not hide the copied value.
+Selecting another row replaces the detail in place.
+
+The detail view does not show guessed item fields, prices, availability, or
+online status. A recent message is evidence that the character posted recently;
+it is not evidence that the trade remains available.
+
+### Optional certified whisper action
+
+Toolbox++ can prepare a whisper to the selected character. GWonMac may add
+**Whisper** later only when the official client host provides a separately
+certified, explicit capability for the active game window.
+
+That action may focus or prepare an empty whisper to the selected character. It
+must never insert an offer, send a message, repeat input, or choose a different
+game window. **Copy character name** remains the fallback when the capability
+is unavailable or uncertified.
+
+The core Trade feature must not depend on this enhancement.
+
+## Primary user flows
+
+### Browse current offers
+
+1. The player opens the **Trade Chat** window.
+2. Cached messages appear immediately when available.
+3. The source connects and adds newer messages.
+4. The player selects a message and reads the complete text.
+5. The player copies the character name and contacts that character in game.
+
+### Find an item to buy
+
+1. The player enters an item name and submits the search.
+2. Search results appear newest first.
+3. The player chooses **Selling** to focus on `WTS` messages.
+4. The player selects a useful result and checks its exact age.
+5. The player copies the seller's character name.
+
+### Find a buyer for an item
+
+1. The player enters an item name and submits the search.
+2. The player chooses **Buying** to focus on `WTB` messages.
+3. The player compares recent messages without losing the result list.
+4. The player copies the buyer's character name.
+
+### Return to current activity
+
+1. The player clears the query.
+2. The preserved live feed returns at its previous position.
+3. If newer messages accumulated, **New messages** offers a deliberate return
+   to the top.
+
+## States and recovery
+
+| State | Required behavior |
+| --- | --- |
+| Initial connection | Show a small progress state without replacing the window |
+| Live | Show the latest bounded feed and connection status |
+| Searching | Keep the submitted query visible and show progress in the result area |
+| No results | State that no recent messages matched; keep query and filters editable |
+| Reconnecting | Keep existing rows visible, mark them as possibly stale, and retry |
+| Offline | Keep existing rows visible with their real times and offer **Retry** |
+| Source failure | Explain which source is unavailable; other GWonMac windows remain usable |
+| Invalid response | Ignore the unsafe response, preserve valid rows, and retry safely |
+| No selection | Prompt the player to select a message; do not fill the pane with help text |
+| Narrow detail | Show **Back to results** and preserve list state |
+
+The feed does not use an empty-state illustration. The interface should feel
+like a compact working tool, consistent with Hero/Build management.
+
+## Keyboard and accessibility
+
+- Tab enters the active Trade Chat window and follows visual reading order.
+- The search field, intent filter, results, and actions have visible focus.
+- Up and Down move through results when the result list has focus.
+- Enter selects the focused result.
+- `/` focuses Trade search when focus is not in an input.
+- Escape closes the topmost GWonMac surface. Trade must not override it to
+  clear search.
+- Live arrivals are not announced one by one to assistive technology.
+- Connection changes and submitted-search result counts use one polite status
+  announcement.
+- Message and sender text remains selectable and uses bidirectional isolation.
+- Reduced-motion mode removes nonessential arrival and selection motion.
+- Both interface styles and all supported opacity values meet the contrast
+  rules in `apps/tools/DESIGN.md`.
+
+The Trade Chat window must receive input only inside its controls. Guild Wars
+keeps normal pointer and keyboard input everywhere else.
+
+## Data and architecture
+
+The public Kamadan and Ascalon services remain the only sources of truth for
+trade messages. GWonMac does not persist a copy of their history.
+
+Main owns one `TradeChatService` for the app process:
+
+- it lazily owns at most one shared connection per source;
+- a source connection exists only while at least one Trade Chat window
+  subscribes to that source;
+- a bounded in-memory ring per source keeps at most 100 valid live messages;
+- the renderer receives typed snapshots, result pages, status, and live events
+  through narrow IPC;
+- the renderer never opens the WebSocket or chooses an arbitrary network host;
+- Kamadan uses the exact `kamadan.gwtoolbox.com` host;
+- Pre-Searing uses the exact `ascalon.gwtoolbox.com` host;
+- live messages, history, pending arrivals, replacements, and searches remain
+  separate by source;
+- the canonical message key contains the source and upstream timestamp;
+- TLS certificate validation remains enabled;
+- response size, message size, fragment count, queue length, and timeouts are
+  bounded;
+- reconnect uses exponential backoff with jitter;
+- a replacement reference removes the referenced older message before the new
+  message is inserted; and
+- duplicate message timestamps do not create duplicate rows.
+
+Each source connection may stop after its final subscriber leaves that source.
+The service does not run as a permanent background service and does not notify
+the player while every Trade Chat window is closed.
+
+Search responses belong to the submitted request that produced them. A late
+response from an older query cannot replace newer results. The renderer reveals
+the bounded response 25 messages at a time and reveals the next 25 when the
+reader reaches the bottom, up to 200. This is local progressive reveal: the
+upstream WebSocket protocol has no cursor pagination and GWonMac makes no extra
+network request while scrolling.
+
+Multiple game accounts share the same public network connection and in-memory
+feeds. Selection, query, filter, source, and scroll state stay with each Trade
+Chat window. No account identity or profile data is sent to either source.
+
+## Privacy, safety, and external dependency
+
+Trade messages are public but can still contain player identifiers and free
+text. Diagnostics must not record:
+
+- message text;
+- character names;
+- search queries;
+- copied values; or
+- WebSocket payloads.
+
+Diagnostics may record bounded technical outcomes such as connected,
+reconnecting, response rejected, duration, and result count.
+
+Before release, maintainers must confirm that the public Kamadan and Ascalon
+operator permits this client use and document required attribution, rate
+limits, and protocol expectations. GWonMac must identify itself honestly where
+the protocol permits it. The app must degrade safely when either unofficial
+service changes or becomes unavailable.
+
+Automated tests use recorded, anonymous fixtures. They must not depend on the
+live public service.
+
+## First-release acceptance criteria
+
+The feature is ready when all of these statements are true:
+
+- Opening the separate Trade Chat window shows recent valid messages without
+  opening or changing Builds and teams.
+- Switching between Kamadan and Pre-Searing replaces the complete source view
+  and never mixes their messages.
+- A player can submit a plain-text search and return to the live feed.
+- **Selling** and **Buying** apply the defined `WTS` and `WTB` rules.
+- Results remain readable and stable while new live messages arrive.
+- Selecting a result shows the complete original message and exact age.
+- Copying a character name and message gives persistent, accessible feedback.
+- Replacement and duplicate messages do not leave obsolete duplicate rows.
+- Two Trade Chat windows on the same source share one upstream live connection.
+- Two windows on different sources use one lazy connection per active source.
+- Disconnection preserves existing rows, marks them stale, and reconnects with
+  bounded backoff.
+- A malformed or oversized response cannot grow memory without a bound or
+  crash the renderer.
+- Search queries, character names, and message text never enter diagnostics.
+- The interface works at narrow, wide, short, transparent, and opaque sizes in
+  both visual styles.
+- The complete flow works with keyboard only, without stealing Guild Wars input
+  outside the Trade window.
+- The core feature works without game-memory access or the optional whisper
+  capability.
+
+## Deliberate follow-ups
+
+Do not add these until first-release use shows a concrete need:
+
+1. A certified **Whisper** action can shorten the final contact step without
+   sending text.
+2. Saved searches and foreground-only alerts can help repeated item hunts, but
+   they add persistence, notification rules, and noise.
+3. Sender-focused history can be added if the upstream search contract supports
+   it reliably.
+
+Each follow-up needs its own acceptance criterion. None should delay the core
+find-and-contact experience.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -133,6 +133,19 @@ After that restart, these choices update immediately:
   whether the current character can travel there. Travel keeps the current
   Guild Wars region and language and uses district Any.
 
+Open **Trade Chat** from the View menu, with Command-Shift-B, or by typing the
+exact lowercase `/trade` command on a certified client. The Trade window is
+independent from Builds and teams, so both can stay open. `/trade` passes
+through to Guild Wars when Tools is disabled or the current parser is not
+certified; the menu and shortcut do not depend on client certification.
+
+Trade Chat shows the public Kamadan and Pre-Searing Ascalon feeds. Choose one
+source, search for an item or character, and use **Selling** or **Buying** to
+filter whole-word `WTS` and `WTB` messages. Select a row to read the complete
+message and exact time, then copy the character name or message. The feature is
+read-only: publish listings and contact players through normal Guild Wars chat.
+Nothing from the feed, searches, or copied character names is saved.
+
 Tools and Travel stay open when you click Guild Wars behind them. Press Tab to
 move the keyboard into the topmost GWonMac window. Press Escape to close that
 window and return the keyboard to Guild Wars. If a confirmation dialog is open,
@@ -144,9 +157,10 @@ The same pane lists **Keyboard shortcuts**. Choose **Change**, then press a
 Command shortcut to replace the default. Letter and number shortcuts use their
 physical keyboard positions, so they stay stable when Option or the active
 keyboard layout changes. Control remains available to Guild Wars. Delete clears a shortcut, Escape
-cancels recording. **Show or hide GWonMac Tools** uses Command-B by default.
-**Restore default shortcuts** also restores Command-Shift-C for Xunlai storage
-and Command-T for Travel. Shortcuts work only while the
+cancels recording. **Show or hide GWonMac Tools** uses Command-B by default,
+and **Show or hide Trade Chat** uses Command-Shift-B. **Restore default
+shortcuts** also restores Command-Shift-C for Xunlai storage, Command-T for
+Travel, and Command-Shift-B for Trade Chat. Shortcuts work only while the
 Guild Wars window is active. GWonMac keeps normal editing and application
 shortcuts such as Command-C and Command-Q, plus Travel's Command-1 through
 Command-9 assignments, reserved.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -144,7 +144,11 @@ source, search for an item or character, and use **Selling** or **Buying** to
 filter whole-word `WTS` and `WTB` messages. Select a row to read the complete
 message and exact time, then copy the character name or message. The feature is
 read-only: publish listings and contact players through normal Guild Wars chat.
-Nothing from the feed, searches, or copied character names is saved.
+Feed history, searches, and copied character names are not saved automatically.
+Use **Save offer** to keep an exact local copy of a useful listing. Use
+**Follow player** to highlight that character's current and future listings.
+Open **Saved** to review Offers and Players in a right-side drawer. These saved
+items stay on this Mac; GWonMac does not send them to either public feed.
 
 Tools and Travel stay open when you click Guild Wars behind them. Press Tab to
 move the keyboard into the topmost GWonMac window. Press Escape to close that

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -97,7 +97,7 @@ export default tseslint.config(
       "**/node_modules/**",
       ".claude/**",
       ".pnpm-store/**",
-      "dist/**",
+      "**/dist/**",
       "dist-release/**",
       ".vite/**",
       "**/.nuxt/**",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.55.0",
     "@types/node": "^24.13.3",
+    "@types/ws": "^8.18.1",
     "electron": "^43.4.1",
     "eslint": "^10.7.0",
     "eslint-plugin-vue": "^10.10.0",
@@ -84,5 +85,8 @@
     "typescript": "^5.9.2",
     "typescript-eslint": "^8.43.0",
     "vue-eslint-parser": "^10.4.1"
+  },
+  "dependencies": {
+    "ws": "^8.21.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,10 @@ packageExtensionsChecksum: sha256-7i6J8iSXKD3HFZ5RPpJbxs/OrOx5iH++yjNIaIHzQ/Y=
 importers:
 
   .:
+    dependencies:
+      ws:
+        specifier: ^8.21.3
+        version: 8.21.3
     devDependencies:
       '@electron-forge/cli':
         specifier: ^7.11.2
@@ -53,6 +57,9 @@ importers:
       '@types/node':
         specifier: ^24.13.3
         version: 24.13.3
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       electron:
         specifier: ^43.4.1
         version: 43.4.1
@@ -8169,6 +8176,18 @@ packages:
 
   ws@8.21.1:
     resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.21.3:
+    resolution: {integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -17533,6 +17552,8 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@8.21.1: {}
+
+  ws@8.21.3: {}
 
   wsl-utils@0.3.1:
     dependencies:

--- a/src/main/certification/enhancement-command-transform.ts
+++ b/src/main/certification/enhancement-command-transform.ts
@@ -102,6 +102,9 @@ export function localActionSlashParser(
   enabledGlobalIndex: number,
   travelEnabledGlobalIndex: number,
   travelToggleGlobalIndex: number,
+  tradeEnabledGlobalIndex: number,
+  tradeToggleGlobalIndex: number,
+  tradeAliases: boolean,
   travelAliases: boolean,
   xunlaiAliases: boolean,
 ): Uint8Array {
@@ -112,6 +115,16 @@ export function localActionSlashParser(
   );
   return concat(
     uleb(0),
+    ...(tradeAliases ? [concat(
+      Uint8Array.of(0x02, 0x40),
+      exactSlashCommand(1, "/trade"),
+      Uint8Array.of(0x45, 0x0d), uleb(0),
+      Uint8Array.of(0x23), uleb(tradeEnabledGlobalIndex),
+      Uint8Array.of(0x45, 0x0d), uleb(0),
+      Uint8Array.of(0x41), sleb(1),
+      Uint8Array.of(0x24), uleb(tradeToggleGlobalIndex),
+      Uint8Array.of(0x41), sleb(1), Uint8Array.of(0x0f, 0x0b),
+    )] : []),
     ...(travelAliases ? [concat(
       // Travel has its own setting and does not borrow the storage mailbox or
       // payload. The renderer takes this bounded signal.
@@ -141,6 +154,32 @@ export function localActionSlashParser(
       Uint8Array.of(0x24), uleb(pendingGlobalIndex),
       Uint8Array.of(0x41), sleb(1),
     )] : [original()]),
+    Uint8Array.of(0x0b),
+  );
+}
+
+/** Enables the exact host-only `/trade` alias and clears stale signals when off. */
+export function tradeToggleConfigure(
+  enabledGlobalIndex: number,
+  toggleGlobalIndex: number,
+): Uint8Array {
+  return concat(
+    uleb(0),
+    Uint8Array.of(0x20), uleb(0), Uint8Array.of(0x45, 0x45),
+    Uint8Array.of(0x24), uleb(enabledGlobalIndex),
+    Uint8Array.of(0x23), uleb(enabledGlobalIndex), Uint8Array.of(0x45, 0x04, 0x40),
+    Uint8Array.of(0x41), sleb(0), Uint8Array.of(0x24), uleb(toggleGlobalIndex),
+    Uint8Array.of(0x0b),
+    Uint8Array.of(0x41), sleb(1), Uint8Array.of(0x0b),
+  );
+}
+
+/** Reads and clears the single pending Trade Chat toggle. */
+export function tradeToggleTake(toggleGlobalIndex: number): Uint8Array {
+  return concat(
+    uleb(0),
+    Uint8Array.of(0x23), uleb(toggleGlobalIndex),
+    Uint8Array.of(0x41), sleb(0), Uint8Array.of(0x24), uleb(toggleGlobalIndex),
     Uint8Array.of(0x0b),
   );
 }

--- a/src/main/certification/enhancement-transform-features.ts
+++ b/src/main/certification/enhancement-transform-features.ts
@@ -16,6 +16,8 @@ import {
   localActionSlashParser,
   storageConfigure,
   storageEnqueue,
+  tradeToggleConfigure,
+  tradeToggleTake,
 } from "./enhancement-command-transform.js";
 import {
   travelConfigure,
@@ -45,6 +47,8 @@ export type TransformTypeIndices = Readonly<{
   travelEnqueue: number | null;
   travelConfigure: number | null;
   travelToggle: number | null;
+  tradeConfigure: number | null;
+  tradeToggle: number | null;
 }>;
 
 export type TransformGlobalIndices = Readonly<{
@@ -55,6 +59,8 @@ export type TransformGlobalIndices = Readonly<{
   travelPayload: number;
   travelEnabled: number;
   travelToggle: number;
+  tradeEnabled: number;
+  tradeToggle: number;
 }>;
 
 export type TransformRewriteWorkspace = Readonly<{
@@ -105,8 +111,30 @@ export function applyFeatureContributions(
       globalIndices.storageEnabled,
       globalIndices.travelEnabled,
       globalIndices.travelToggle,
+      globalIndices.tradeEnabled,
+      globalIndices.tradeToggle,
+      capabilities.chatAliases,
       capabilities.travelAction,
       capabilities.xunlaiAction,
+    );
+  };
+  const addTradeExports = (): void => {
+    if (!capabilities.chatAliases) return;
+    addedFunctionExports.push(
+      {
+        name: "enhancement_configure_trade_toggle",
+        index: appendFunction(
+          required(typeIndices.tradeConfigure, "trade configure function type"),
+          tradeToggleConfigure(globalIndices.tradeEnabled, globalIndices.tradeToggle),
+        ),
+      },
+      {
+        name: "enhancement_take_trade_toggle",
+        index: appendFunction(
+          required(typeIndices.tradeToggle, "trade toggle function type"),
+          tradeToggleTake(globalIndices.tradeToggle),
+        ),
+      },
     );
   };
   if (!commandDrainBoundary) {
@@ -117,6 +145,7 @@ export function applyFeatureContributions(
         bodies[parser.localIndex]!,
       ));
     }
+    addTradeExports();
     return;
   }
 
@@ -221,6 +250,7 @@ export function applyFeatureContributions(
   if (capabilities.chatAliases) {
     rewriteAliases(required(parserOriginalIndex, "original storage slash parser"));
   }
+  addTradeExports();
 
   if (capabilities.xunlaiAction) {
     addedFunctionExports.push(

--- a/src/main/certification/enhancement-transform.ts
+++ b/src/main/certification/enhancement-transform.ts
@@ -676,6 +676,9 @@ function assembleEnhancementTransform(
             : []),
         ]
       : []),
+    ...(capabilities.chatAliases
+      ? ["enhancement_configure_trade_toggle", "enhancement_take_trade_toggle"]
+      : []),
   ];
   for (const name of addedExportNames) {
     if (existingExports.some((entry) => entry.name === name)) {
@@ -698,6 +701,8 @@ function assembleEnhancementTransform(
   const travelPayloadGlobalIndex = capabilities.travelAction ? allocateGlobals(1) : 0;
   const travelEnabledGlobalIndex = capabilities.travelAction ? allocateGlobals(1) : 0;
   const travelToggleGlobalIndex = capabilities.travelAction ? allocateGlobals(1) : 0;
+  const tradeEnabledGlobalIndex = capabilities.chatAliases ? allocateGlobals(1) : 0;
+  const tradeToggleGlobalIndex = capabilities.chatAliases ? allocateGlobals(1) : 0;
   const traceGlobalBase = capabilities.teamApply
     ? allocateGlobals(PROFESSION_TRACE_WORDS)
     : 0;
@@ -736,6 +741,12 @@ function assembleEnhancementTransform(
     ? appendType({ params: [0x7f, 0x7f], results: [0x7f] })
     : null;
   const travelToggleTypeIndex = capabilities.travelAction
+    ? appendType({ params: [], results: [0x7f] })
+    : null;
+  const tradeConfigureTypeIndex = capabilities.chatAliases
+    ? appendType({ params: [0x7f], results: [0x7f] })
+    : null;
+  const tradeToggleTypeIndex = capabilities.chatAliases
     ? appendType({ params: [], results: [0x7f] })
     : null;
 
@@ -778,6 +789,8 @@ function assembleEnhancementTransform(
       travelEnqueue: travelEnqueueTypeIndex,
       travelConfigure: travelConfigureTypeIndex,
       travelToggle: travelToggleTypeIndex,
+      tradeConfigure: tradeConfigureTypeIndex,
+      tradeToggle: tradeToggleTypeIndex,
     },
     globalIndices: {
       commandPending: commandPendingGlobalIndex,
@@ -787,6 +800,8 @@ function assembleEnhancementTransform(
       travelPayload: travelPayloadGlobalIndex,
       travelEnabled: travelEnabledGlobalIndex,
       travelToggle: travelToggleGlobalIndex,
+      tradeEnabled: tradeEnabledGlobalIndex,
+      tradeToggle: tradeToggleGlobalIndex,
     },
     traceGlobals,
     uiOriginalIndex,

--- a/src/main/core/paths.ts
+++ b/src/main/core/paths.ts
@@ -20,6 +20,7 @@ export interface GamePaths {
   userData: string;
   settings: string;
   travelPreferences: string;
+  tradeSaved: string;
   buildLibrary: string;
   windowState: string;
   launcherMode: string;
@@ -52,6 +53,7 @@ export function gamePaths(userData: string): GamePaths {
     userData,
     settings: path.join(userData, "settings.json"),
     travelPreferences: path.join(userData, "travel-preferences.json"),
+    tradeSaved: path.join(userData, "trade-saved.json"),
     buildLibrary: path.join(userData, "build-library.json"),
     windowState: path.join(userData, "window-state.json"),
     launcherMode: path.join(userData, "launcher-mode.json"),

--- a/src/main/core/trade-chat-service.ts
+++ b/src/main/core/trade-chat-service.ts
@@ -5,7 +5,7 @@
  * URLs and reconnect mechanics stop here; subscribers receive only the bounded
  * shared contract and no message text is ever written to diagnostics.
  */
-import WebSocket, { type RawData } from "ws";
+import WebSocket, { type ClientOptions, type RawData } from "ws";
 import {
   TRADE_LIMITS,
   TRADE_SOURCES,
@@ -14,6 +14,7 @@ import {
   type TradeConnectionState,
   type TradeEvent,
   type TradeMessage,
+  type TradeSearchMatch,
   type TradeSearchResult,
   type TradeSnapshot,
   type TradeSource,
@@ -25,11 +26,24 @@ const PING_INTERVAL_MS = 30_000;
 const PONG_TIMEOUT_MS = 10_000;
 const RECONNECT_DELAYS_MS = [1_000, 2_000, 4_000, 8_000, 16_000, 30_000] as const;
 
+type TradeServiceTiming = Readonly<{
+  searchTimeoutMs: number;
+  pingIntervalMs: number;
+  pongTimeoutMs: number;
+  reconnectDelaysMs: readonly number[];
+}>;
+
+export type TradeChatServiceOptions = Readonly<{
+  createSocket?: (url: string, options: ClientOptions) => WebSocket;
+  random?: () => number;
+  timing?: Partial<TradeServiceTiming>;
+}>;
+
 type Listener = (event: TradeEvent) => void;
 
 type PendingSearch = {
-  readonly promise: Promise<TradeSearchResult>;
-  readonly resolve: (result: TradeSearchResult) => void;
+  readonly promise: Promise<readonly TradeMessage[]>;
+  readonly resolve: (result: readonly TradeMessage[]) => void;
   readonly reject: (reason: Error) => void;
   readonly timer: ReturnType<typeof setTimeout>;
 };
@@ -53,6 +67,21 @@ export class TradeChatService {
     TRADE_SOURCES.map((source) => [source, createFeed(source)]),
   );
   readonly #subscriptions = new Map<number, TradeSource>();
+  readonly #createSocket: (url: string, options: ClientOptions) => WebSocket;
+  readonly #random: () => number;
+  readonly #timing: TradeServiceTiming;
+
+  constructor(options: TradeChatServiceOptions = {}) {
+    this.#createSocket = options.createSocket ?? ((url, socketOptions) =>
+      new WebSocket(url, socketOptions));
+    this.#random = options.random ?? Math.random;
+    this.#timing = {
+      searchTimeoutMs: options.timing?.searchTimeoutMs ?? SEARCH_TIMEOUT_MS,
+      pingIntervalMs: options.timing?.pingIntervalMs ?? PING_INTERVAL_MS,
+      pongTimeoutMs: options.timing?.pongTimeoutMs ?? PONG_TIMEOUT_MS,
+      reconnectDelaysMs: options.timing?.reconnectDelaysMs ?? RECONNECT_DELAYS_MS,
+    };
+  }
 
   subscribe(id: number, source: TradeSource, listener: Listener): TradeSnapshot {
     this.unsubscribe(id);
@@ -80,6 +109,22 @@ export class TradeChatService {
     if (this.#subscriptions.get(id) !== source) {
       return Promise.reject(new Error("trade source is not subscribed"));
     }
+    const playerQuery = `user:${query}`;
+    const queries = [query];
+    if ([...playerQuery].length <= TRADE_LIMITS.queryCharacters) queries.push(playerQuery);
+    return Promise.allSettled(queries.map((candidate) => this.#query(source, candidate)))
+      .then((results) => {
+        const messages = results.flatMap((result) => result.status === "fulfilled"
+          ? result.value
+          : []);
+        if (messages.length === 0 && results.every((result) => result.status === "rejected")) {
+          throw new Error("trade search failed");
+        }
+        return Object.freeze({ source, query, matches: groupSearchMatches(messages) });
+      });
+  }
+
+  #query(source: TradeSource, query: string): Promise<readonly TradeMessage[]> {
     const feed = this.#feed(source);
     if (feed.socket?.readyState !== WebSocket.OPEN) {
       return Promise.reject(new Error("trade feed is not connected"));
@@ -87,9 +132,9 @@ export class TradeChatService {
     const existing = feed.pendingSearches.get(query);
     if (existing) return existing.promise;
 
-    let resolve!: (result: TradeSearchResult) => void;
+    let resolve!: (result: readonly TradeMessage[]) => void;
     let reject!: (reason: Error) => void;
-    const promise = new Promise<TradeSearchResult>((accept, refuse) => {
+    const promise = new Promise<readonly TradeMessage[]>((accept, refuse) => {
       resolve = accept;
       reject = refuse;
     });
@@ -98,7 +143,7 @@ export class TradeChatService {
       if (!pending) return;
       feed.pendingSearches.delete(query);
       pending.reject(new Error("trade search timed out"));
-    }, SEARCH_TIMEOUT_MS);
+    }, this.#timing.searchTimeoutMs);
     feed.pendingSearches.set(query, { promise, resolve, reject, timer });
     feed.socket.send(JSON.stringify({ query }), (error) => {
       if (!error) return;
@@ -133,7 +178,7 @@ export class TradeChatService {
     if (feed.socket || feed.subscribers.size === 0) return;
     feed.closing = false;
     this.#setStatus(feed, feed.reconnectAttempt === 0 ? "connecting" : "reconnecting");
-    const socket = new WebSocket(TRADE_SOURCE_URLS[feed.source].websocket, {
+    const socket = this.#createSocket(TRADE_SOURCE_URLS[feed.source].websocket, {
       followRedirects: false,
       handshakeTimeout: CONNECT_TIMEOUT_MS,
       maxPayload: TRADE_LIMITS.payloadBytes,
@@ -191,11 +236,7 @@ export class TradeChatService {
       if (!pending) return;
       feed.pendingSearches.delete(payload.query);
       clearTimeout(pending.timer);
-      pending.resolve(Object.freeze({
-        source: feed.source,
-        query: payload.query,
-        messages: payload.messages,
-      }));
+      pending.resolve(payload.messages);
       return;
     }
     this.#insertMessage(feed, payload.message);
@@ -224,16 +265,16 @@ export class TradeChatService {
       if (feed.socket !== socket || socket.readyState !== WebSocket.OPEN) return;
       socket.ping();
       if (feed.pongTimer) clearTimeout(feed.pongTimer);
-      feed.pongTimer = setTimeout(() => socket.terminate(), PONG_TIMEOUT_MS);
-    }, PING_INTERVAL_MS);
+      feed.pongTimer = setTimeout(() => socket.terminate(), this.#timing.pongTimeoutMs);
+    }, this.#timing.pingIntervalMs);
   }
 
   #scheduleReconnect(feed: Feed): void {
     this.#setStatus(feed, "reconnecting");
-    const index = Math.min(feed.reconnectAttempt, RECONNECT_DELAYS_MS.length - 1);
-    const base = RECONNECT_DELAYS_MS[index]!;
+    const index = Math.min(feed.reconnectAttempt, this.#timing.reconnectDelaysMs.length - 1);
+    const base = this.#timing.reconnectDelaysMs[index]!;
     feed.reconnectAttempt += 1;
-    const delay = Math.round(base * (0.8 + Math.random() * 0.4));
+    const delay = Math.round(base * (0.8 + this.#random() * 0.4));
     feed.reconnectTimer = setTimeout(() => {
       feed.reconnectTimer = null;
       this.#connect(feed);
@@ -293,6 +334,21 @@ export class TradeChatService {
   #feed(source: TradeSource): Feed {
     return this.#feeds.get(source)!;
   }
+}
+
+function groupSearchMatches(messages: readonly TradeMessage[]): readonly TradeSearchMatch[] {
+  const unique = new Map<number, TradeMessage>();
+  for (const message of messages) unique.set(message.timestamp, message);
+  const groups = new Map<string, { message: TradeMessage; postCount: number }>();
+  for (const message of [...unique.values()].sort((a, b) => b.timestamp - a.timestamp)) {
+    const key = message.sender.toLocaleLowerCase();
+    const group = groups.get(key);
+    if (group) group.postCount += 1;
+    else groups.set(key, { message, postCount: 1 });
+  }
+  return Object.freeze([...groups.values()]
+    .slice(0, TRADE_LIMITS.searchResults)
+    .map((match) => Object.freeze(match)));
 }
 
 function createFeed(source: TradeSource): Feed {

--- a/src/main/core/trade-chat-service.ts
+++ b/src/main/core/trade-chat-service.ts
@@ -1,0 +1,318 @@
+/**
+ * Process-wide ownership of the public GWToolbox trade feeds.
+ *
+ * One connection per named source is shared by every game window. Raw frames,
+ * URLs and reconnect mechanics stop here; subscribers receive only the bounded
+ * shared contract and no message text is ever written to diagnostics.
+ */
+import WebSocket, { type RawData } from "ws";
+import {
+  TRADE_LIMITS,
+  TRADE_SOURCES,
+  TRADE_SOURCE_URLS,
+  parseTradePayload,
+  type TradeConnectionState,
+  type TradeEvent,
+  type TradeMessage,
+  type TradeSearchResult,
+  type TradeSnapshot,
+  type TradeSource,
+} from "../../shared/trade-chat.js";
+
+const CONNECT_TIMEOUT_MS = 10_000;
+const SEARCH_TIMEOUT_MS = 8_000;
+const PING_INTERVAL_MS = 30_000;
+const PONG_TIMEOUT_MS = 10_000;
+const RECONNECT_DELAYS_MS = [1_000, 2_000, 4_000, 8_000, 16_000, 30_000] as const;
+
+type Listener = (event: TradeEvent) => void;
+
+type PendingSearch = {
+  readonly promise: Promise<TradeSearchResult>;
+  readonly resolve: (result: TradeSearchResult) => void;
+  readonly reject: (reason: Error) => void;
+  readonly timer: ReturnType<typeof setTimeout>;
+};
+
+type Feed = {
+  readonly source: TradeSource;
+  readonly subscribers: Map<number, Listener>;
+  readonly pendingSearches: Map<string, PendingSearch>;
+  messages: TradeMessage[];
+  status: TradeConnectionState;
+  socket: WebSocket | null;
+  reconnectAttempt: number;
+  reconnectTimer: ReturnType<typeof setTimeout> | null;
+  pingTimer: ReturnType<typeof setInterval> | null;
+  pongTimer: ReturnType<typeof setTimeout> | null;
+  closing: boolean;
+};
+
+export class TradeChatService {
+  readonly #feeds = new Map<TradeSource, Feed>(
+    TRADE_SOURCES.map((source) => [source, createFeed(source)]),
+  );
+  readonly #subscriptions = new Map<number, TradeSource>();
+
+  subscribe(id: number, source: TradeSource, listener: Listener): TradeSnapshot {
+    this.unsubscribe(id);
+    const feed = this.#feed(source);
+    this.#subscriptions.set(id, source);
+    feed.subscribers.set(id, listener);
+    if (!feed.socket && !feed.reconnectTimer) this.#connect(feed);
+    return Object.freeze({
+      source,
+      status: feed.status,
+      messages: Object.freeze([...feed.messages]),
+    });
+  }
+
+  unsubscribe(id: number): void {
+    const source = this.#subscriptions.get(id);
+    if (!source) return;
+    this.#subscriptions.delete(id);
+    const feed = this.#feed(source);
+    feed.subscribers.delete(id);
+    if (feed.subscribers.size === 0) this.#stop(feed);
+  }
+
+  search(id: number, source: TradeSource, query: string): Promise<TradeSearchResult> {
+    if (this.#subscriptions.get(id) !== source) {
+      return Promise.reject(new Error("trade source is not subscribed"));
+    }
+    const feed = this.#feed(source);
+    if (feed.socket?.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new Error("trade feed is not connected"));
+    }
+    const existing = feed.pendingSearches.get(query);
+    if (existing) return existing.promise;
+
+    let resolve!: (result: TradeSearchResult) => void;
+    let reject!: (reason: Error) => void;
+    const promise = new Promise<TradeSearchResult>((accept, refuse) => {
+      resolve = accept;
+      reject = refuse;
+    });
+    const timer = setTimeout(() => {
+      const pending = feed.pendingSearches.get(query);
+      if (!pending) return;
+      feed.pendingSearches.delete(query);
+      pending.reject(new Error("trade search timed out"));
+    }, SEARCH_TIMEOUT_MS);
+    feed.pendingSearches.set(query, { promise, resolve, reject, timer });
+    feed.socket.send(JSON.stringify({ query }), (error) => {
+      if (!error) return;
+      this.#rejectSearch(feed, query, new Error("trade search could not be sent"));
+    });
+    return promise;
+  }
+
+  retry(id: number, source: TradeSource): void {
+    if (this.#subscriptions.get(id) !== source) return;
+    const feed = this.#feed(source);
+    if (feed.subscribers.size === 0) return;
+    this.#clearReconnect(feed);
+    if (feed.socket) {
+      feed.closing = true;
+      feed.socket.terminate();
+      feed.socket = null;
+    }
+    feed.reconnectAttempt = 0;
+    this.#connect(feed);
+  }
+
+  dispose(): void {
+    this.#subscriptions.clear();
+    for (const feed of this.#feeds.values()) {
+      feed.subscribers.clear();
+      this.#stop(feed);
+    }
+  }
+
+  #connect(feed: Feed): void {
+    if (feed.socket || feed.subscribers.size === 0) return;
+    feed.closing = false;
+    this.#setStatus(feed, feed.reconnectAttempt === 0 ? "connecting" : "reconnecting");
+    const socket = new WebSocket(TRADE_SOURCE_URLS[feed.source].websocket, {
+      followRedirects: false,
+      handshakeTimeout: CONNECT_TIMEOUT_MS,
+      maxPayload: TRADE_LIMITS.payloadBytes,
+      perMessageDeflate: false,
+      headers: { "User-Agent": "GWonMac Trade Chat" },
+    });
+    feed.socket = socket;
+
+    socket.on("open", () => {
+      if (feed.socket !== socket) return;
+      feed.reconnectAttempt = 0;
+      this.#setStatus(feed, "live");
+      socket.send(JSON.stringify({ query: " " }));
+      this.#startHeartbeat(feed, socket);
+    });
+    socket.on("pong", () => {
+      if (feed.socket !== socket) return;
+      if (feed.pongTimer) clearTimeout(feed.pongTimer);
+      feed.pongTimer = null;
+    });
+    socket.on("message", (data) => this.#onMessage(feed, data));
+    socket.on("error", () => {
+      // `close` owns the state transition and bounded reconnect. Error text may
+      // contain network details and is deliberately not logged.
+    });
+    socket.on("close", () => {
+      if (feed.socket !== socket) return;
+      feed.socket = null;
+      this.#clearHeartbeat(feed);
+      this.#rejectAllSearches(feed, new Error("trade feed disconnected"));
+      if (feed.closing || feed.subscribers.size === 0) return;
+      this.#scheduleReconnect(feed);
+    });
+  }
+
+  #onMessage(feed: Feed, data: RawData): void {
+    const bytes = rawBytes(data);
+    if (bytes.byteLength > TRADE_LIMITS.payloadBytes) return;
+    let value: unknown;
+    try {
+      value = JSON.parse(bytes.toString("utf8"));
+    } catch {
+      return;
+    }
+    const payload = parseTradePayload(feed.source, value);
+    if (!payload) return;
+    if (payload.kind === "search") {
+      if (payload.query === " ") {
+        for (const message of [...payload.messages].reverse()) {
+          this.#insertMessage(feed, message);
+        }
+        return;
+      }
+      const pending = feed.pendingSearches.get(payload.query);
+      if (!pending) return;
+      feed.pendingSearches.delete(payload.query);
+      clearTimeout(pending.timer);
+      pending.resolve(Object.freeze({
+        source: feed.source,
+        query: payload.query,
+        messages: payload.messages,
+      }));
+      return;
+    }
+    this.#insertMessage(feed, payload.message);
+  }
+
+  #insertMessage(feed: Feed, message: TradeMessage): void {
+    if (message.replacementTimestamp !== undefined) {
+      feed.messages = feed.messages.filter(
+        (candidate) => candidate.timestamp !== message.replacementTimestamp,
+      );
+    }
+    if (feed.messages.some((candidate) => candidate.timestamp === message.timestamp)) return;
+    feed.messages = [message, ...feed.messages]
+      .sort((left, right) => right.timestamp - left.timestamp)
+      .slice(0, TRADE_LIMITS.liveMessages);
+    this.#emit(feed, Object.freeze({
+      type: "message",
+      source: feed.source,
+      message,
+    }));
+  }
+
+  #startHeartbeat(feed: Feed, socket: WebSocket): void {
+    this.#clearHeartbeat(feed);
+    feed.pingTimer = setInterval(() => {
+      if (feed.socket !== socket || socket.readyState !== WebSocket.OPEN) return;
+      socket.ping();
+      if (feed.pongTimer) clearTimeout(feed.pongTimer);
+      feed.pongTimer = setTimeout(() => socket.terminate(), PONG_TIMEOUT_MS);
+    }, PING_INTERVAL_MS);
+  }
+
+  #scheduleReconnect(feed: Feed): void {
+    this.#setStatus(feed, "reconnecting");
+    const index = Math.min(feed.reconnectAttempt, RECONNECT_DELAYS_MS.length - 1);
+    const base = RECONNECT_DELAYS_MS[index]!;
+    feed.reconnectAttempt += 1;
+    const delay = Math.round(base * (0.8 + Math.random() * 0.4));
+    feed.reconnectTimer = setTimeout(() => {
+      feed.reconnectTimer = null;
+      this.#connect(feed);
+    }, delay);
+  }
+
+  #setStatus(feed: Feed, status: TradeConnectionState): void {
+    if (feed.status === status) return;
+    feed.status = status;
+    this.#emit(feed, Object.freeze({ type: "status", source: feed.source, status }));
+  }
+
+  #emit(feed: Feed, event: TradeEvent): void {
+    for (const listener of feed.subscribers.values()) listener(event);
+  }
+
+  #stop(feed: Feed): void {
+    feed.closing = true;
+    this.#clearReconnect(feed);
+    this.#clearHeartbeat(feed);
+    this.#rejectAllSearches(feed, new Error("trade feed closed"));
+    if (feed.socket) {
+      const socket = feed.socket;
+      feed.socket = null;
+      socket.close();
+    }
+    feed.status = "unavailable";
+    feed.reconnectAttempt = 0;
+  }
+
+  #clearReconnect(feed: Feed): void {
+    if (feed.reconnectTimer) clearTimeout(feed.reconnectTimer);
+    feed.reconnectTimer = null;
+  }
+
+  #clearHeartbeat(feed: Feed): void {
+    if (feed.pingTimer) clearInterval(feed.pingTimer);
+    if (feed.pongTimer) clearTimeout(feed.pongTimer);
+    feed.pingTimer = null;
+    feed.pongTimer = null;
+  }
+
+  #rejectSearch(feed: Feed, query: string, error: Error): void {
+    const pending = feed.pendingSearches.get(query);
+    if (!pending) return;
+    feed.pendingSearches.delete(query);
+    clearTimeout(pending.timer);
+    pending.reject(error);
+  }
+
+  #rejectAllSearches(feed: Feed, error: Error): void {
+    for (const query of [...feed.pendingSearches.keys()]) {
+      this.#rejectSearch(feed, query, error);
+    }
+  }
+
+  #feed(source: TradeSource): Feed {
+    return this.#feeds.get(source)!;
+  }
+}
+
+function createFeed(source: TradeSource): Feed {
+  return {
+    source,
+    subscribers: new Map(),
+    pendingSearches: new Map(),
+    messages: [],
+    status: "unavailable",
+    socket: null,
+    reconnectAttempt: 0,
+    reconnectTimer: null,
+    pingTimer: null,
+    pongTimer: null,
+    closing: false,
+  };
+}
+
+function rawBytes(data: RawData): Buffer {
+  if (Array.isArray(data)) return Buffer.concat(data);
+  if (data instanceof ArrayBuffer) return Buffer.from(data);
+  return data;
+}

--- a/src/main/core/trade-saved-store.ts
+++ b/src/main/core/trade-saved-store.ts
@@ -1,0 +1,50 @@
+/**
+ * Owns the one durable, bounded document of starred offers and players.
+ * Feed history remains transient; only explicit player choices reach disk.
+ */
+import { readFile } from "node:fs/promises";
+import {
+  EMPTY_TRADE_SAVED_STATE,
+  parseTradeSavedState,
+  type TradeSavedState,
+} from "../../shared/trade-chat.js";
+import { writeAtomicJson } from "./atomic-file.js";
+import { quarantineCorruptDocument } from "./corrupt-document.js";
+import { Mutex } from "./mutex.js";
+
+export class TradeSavedStore {
+  private readonly mutex = new Mutex();
+  private readonly path: string;
+
+  constructor(path: string) {
+    this.path = path;
+  }
+
+  get(): Promise<TradeSavedState> {
+    return this.mutex.run(() => load(this.path));
+  }
+
+  set(value: TradeSavedState): Promise<TradeSavedState> {
+    return this.mutex.run(async () => {
+      const saved = parseTradeSavedState(value);
+      await writeAtomicJson(this.path, saved, 0o600);
+      return saved;
+    });
+  }
+}
+
+async function load(path: string): Promise<TradeSavedState> {
+  let text: string;
+  try {
+    text = await readFile(path, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return EMPTY_TRADE_SAVED_STATE;
+    throw error;
+  }
+  try {
+    return parseTradeSavedState(JSON.parse(text) as unknown);
+  } catch {
+    await quarantineCorruptDocument(path);
+    return EMPTY_TRADE_SAVED_STATE;
+  }
+}

--- a/src/main/core/trade-saved-store.ts
+++ b/src/main/core/trade-saved-store.ts
@@ -21,45 +21,16 @@ export class TradeSavedStore {
   }
 
   get(): Promise<TradeSavedState> {
-    return this.mutex.run(async () => {
-      console.info("[trade:saved] store read started");
-      try {
-        const saved = await load(this.path);
-        console.info("[trade:saved] store read completed", counts(saved));
-        return saved;
-      } catch (error) {
-        console.error("[trade:saved] store read failed", storeError(error));
-        throw error;
-      }
-    });
+    return this.mutex.run(() => load(this.path));
   }
 
   set(value: TradeSavedState): Promise<TradeSavedState> {
     return this.mutex.run(async () => {
-      console.info("[trade:saved] store write started", counts(value));
-      try {
-        const saved = parseTradeSavedState(value);
-        console.info("[trade:saved] store write validated", counts(saved));
-        await writeAtomicJson(this.path, saved, 0o600);
-        console.info("[trade:saved] store write completed", counts(saved));
-        return saved;
-      } catch (error) {
-        console.error("[trade:saved] store write failed", storeError(error));
-        throw error;
-      }
+      const saved = parseTradeSavedState(value);
+      await writeAtomicJson(this.path, saved, 0o600);
+      return saved;
     });
   }
-}
-
-function counts(value: TradeSavedState): Readonly<{ offers: number; players: number }> {
-  return { offers: value.offers.length, players: value.players.length };
-}
-
-/** Keep paths, player names, and offer text out of logs. */
-function storeError(error: unknown): Readonly<{ name: string; code?: string }> {
-  if (!(error instanceof Error)) return { name: typeof error };
-  const code = "code" in error && typeof error.code === "string" ? error.code : undefined;
-  return code ? { name: error.name, code } : { name: error.name };
 }
 
 async function load(path: string): Promise<TradeSavedState> {

--- a/src/main/core/trade-saved-store.ts
+++ b/src/main/core/trade-saved-store.ts
@@ -21,16 +21,45 @@ export class TradeSavedStore {
   }
 
   get(): Promise<TradeSavedState> {
-    return this.mutex.run(() => load(this.path));
+    return this.mutex.run(async () => {
+      console.info("[trade:saved] store read started");
+      try {
+        const saved = await load(this.path);
+        console.info("[trade:saved] store read completed", counts(saved));
+        return saved;
+      } catch (error) {
+        console.error("[trade:saved] store read failed", storeError(error));
+        throw error;
+      }
+    });
   }
 
   set(value: TradeSavedState): Promise<TradeSavedState> {
     return this.mutex.run(async () => {
-      const saved = parseTradeSavedState(value);
-      await writeAtomicJson(this.path, saved, 0o600);
-      return saved;
+      console.info("[trade:saved] store write started", counts(value));
+      try {
+        const saved = parseTradeSavedState(value);
+        console.info("[trade:saved] store write validated", counts(saved));
+        await writeAtomicJson(this.path, saved, 0o600);
+        console.info("[trade:saved] store write completed", counts(saved));
+        return saved;
+      } catch (error) {
+        console.error("[trade:saved] store write failed", storeError(error));
+        throw error;
+      }
     });
   }
+}
+
+function counts(value: TradeSavedState): Readonly<{ offers: number; players: number }> {
+  return { offers: value.offers.length, players: value.players.length };
+}
+
+/** Keep paths, player names, and offer text out of logs. */
+function storeError(error: unknown): Readonly<{ name: string; code?: string }> {
+  if (!(error instanceof Error)) return { name: typeof error };
+  const code = "code" in error && typeof error.code === "string" ? error.code : undefined;
+  return code ? { name: error.name, code } : { name: error.name };
 }
 
 async function load(path: string): Promise<TradeSavedState> {

--- a/src/main/ipc-channel-registry.ts
+++ b/src/main/ipc-channel-registry.ts
@@ -1,0 +1,98 @@
+/**
+ * Owns typed, authorized registration for every renderer-to-main invoke.
+ * Channel handlers provide validation and behavior; this boundary proves the sender.
+ */
+import { ipcMain, type BrowserWindow } from "electron";
+import { IPC, type InvokeChannel } from "../shared/contracts.js";
+import { AllowlistError, errorCode } from "../shared/errors.js";
+import { logEvent } from "./diagnostics.js";
+import {
+  isAccountsRendererUrl,
+  isCanonicalRendererUrl,
+} from "./core/renderer-trust.js";
+import type { WindowRegistry } from "./window-registry.js";
+
+export type Parser<In> = (args: readonly unknown[]) => In;
+type Run<In, Out> = (win: BrowserWindow, input: In) => Out | Promise<Out>;
+
+interface ChannelDef<In, Out> {
+  readonly parse: Parser<In>;
+  readonly run: Run<In, Out>;
+  readonly role: "game" | "hub" | "any";
+}
+
+/** Erases the invariant input type only after `channel()` checked the pair. */
+export interface AnyChannelDef {
+  readonly parse: Parser<unknown>;
+  readonly run: Run<never, unknown>;
+  readonly role: "game" | "hub" | "any";
+}
+
+export function channel<In, Out>(
+  parse: Parser<In>,
+  run: Run<In, Out>,
+  role: "game" | "hub" | "any" = "game",
+): ChannelDef<In, Out> {
+  return { parse, run, role };
+}
+
+export function registerChannelDefinitions(
+  windows: WindowRegistry,
+  handlers: Partial<Record<InvokeChannel, AnyChannelDef>>,
+): void {
+  for (const [key, definition] of Object.entries(handlers)) {
+    const def = definition as ChannelDef<unknown, unknown>;
+    const name = key as InvokeChannel;
+    ipcMain.handle(IPC[name], async (event, ...args: unknown[]) => {
+      const win = assertSender(windows, event, def.role);
+      let input: unknown;
+      try {
+        input = def.parse(args);
+      } catch (error) {
+        const context = windows.contextForWebContents(win.webContents.id);
+        if (context?.role === "game") {
+          logEvent(
+            { k: "ipc.rejected", channel: name, code: errorCode(error) },
+            windows.requireDiagnosticOwnerForWindow(win),
+          );
+        }
+        throw error;
+      }
+      return def.run(win, input);
+    });
+  }
+}
+
+export function sendIfLive(
+  win: BrowserWindow,
+  channelName: string,
+  value: unknown,
+): boolean {
+  if (win.isDestroyed() || win.webContents.isDestroyed()) return false;
+  try {
+    win.webContents.send(channelName, value);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function assertSender(
+  registry: WindowRegistry,
+  event: Electron.IpcMainInvokeEvent,
+  role: "game" | "hub" | "any",
+): BrowserWindow {
+  const win = registry.windowForWebContents(event.sender.id);
+  const context = registry.contextForWebContents(event.sender.id);
+  if (!win || !context || (role !== "any" && context.role !== role)) {
+    throw new AllowlistError("unowned ipc sender");
+  }
+  if (!event.senderFrame || event.senderFrame !== event.sender.mainFrame) {
+    throw new AllowlistError("ipc sender is not the main frame");
+  }
+  const trusted = context.role === "hub"
+    ? isAccountsRendererUrl(event.senderFrame.url)
+    : isCanonicalRendererUrl(event.senderFrame.url);
+  if (!trusted) throw new AllowlistError("invalid ipc origin");
+  return win;
+}

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -13,7 +13,7 @@
  * arguments and either forwards one owner-local capability directly or calls
  * the workflow owner; it returns codes rather than inventing prose.
  */
-import { clipboard, ipcMain, shell, type BrowserWindow } from "electron";
+import { clipboard, shell, type BrowserWindow } from "electron";
 import type {
   AppSettings,
   AppSettingsPatch,
@@ -64,7 +64,6 @@ import { ENHANCEMENT_RUNTIME_FEATURES } from "../shared/contracts.js";
 import { isDigest } from "../shared/digest.js";
 import {
   AllowlistError,
-  AppError,
   errorCode,
   ValidationError,
 } from "../shared/errors.js";
@@ -110,10 +109,6 @@ import {
   startDnsResolveSpan,
 } from "./diagnostics.js";
 import { gamePaths } from "./paths.js";
-import {
-  isAccountsRendererUrl,
-  isCanonicalRendererUrl,
-} from "./core/renderer-trust.js";
 import { MAX_QUEUED_BYTES_PER_SOCKET } from "./core/sockets.js";
 import { isQuitting } from "./lifecycle.js";
 import { windowRegistry, type WindowRegistry } from "./window-registry.js";
@@ -128,6 +123,13 @@ import {
   requestGameStorageReset,
 } from "./settings-actions.js";
 import { editGameText } from './game-text-editing.js';
+import {
+  channel,
+  registerChannelDefinitions,
+  sendIfLive,
+  type AnyChannelDef,
+  type Parser,
+} from "./ipc-channel-registry.js";
 import {
   parseTradeSearchRequest,
   parseTradeSavedState,
@@ -198,76 +200,6 @@ export interface IpcContext {
 }
 
 type SteamInvokeChannel = "steamToken" | "steamStore" | "steamClear";
-
-function assertSender(
-  registry: WindowRegistry,
-  event: Electron.IpcMainInvokeEvent,
-  role: "game" | "hub" | "any",
-): BrowserWindow {
-  const win = registry.windowForWebContents(event.sender.id);
-  const context = registry.contextForWebContents(event.sender.id);
-  if (!win || !context || (role !== "any" && context.role !== role)) {
-    throw new AllowlistError("unowned ipc sender");
-  }
-  if (!event.senderFrame || event.senderFrame !== event.sender.mainFrame) {
-    throw new AllowlistError("ipc sender is not the main frame");
-  }
-  const trusted = context.role === "hub"
-    ? isAccountsRendererUrl(event.senderFrame.url)
-    : isCanonicalRendererUrl(event.senderFrame.url);
-  if (!trusted) {
-    throw new AllowlistError("invalid ipc origin");
-  }
-  return win;
-}
-
-function sendIfLive(win: BrowserWindow, channel: string, value: unknown): boolean {
-  if (win.isDestroyed() || win.webContents.isDestroyed()) return false;
-  try {
-    win.webContents.send(channel, value);
-    return true;
-  } catch {
-    // Renderer destruction can race the checks above. Socket callbacks are
-    // native and synchronous, so that ordinary teardown must not escape into
-    // the process-wide fatal-error handler.
-    return false;
-  }
-}
-
-/**
- * Turns the raw `invoke` arguments into the handler's input, or throws. One per
- * channel, and no channel can be registered without one.
- */
-type Parser<In> = (args: readonly unknown[]) => In;
-type Run<In, Out> = (win: BrowserWindow, input: In) => Out | Promise<Out>;
-
-interface ChannelDef<In, Out> {
-  readonly parse: Parser<In>;
-  readonly run: Run<In, Out>;
-  readonly role: "game" | "hub" | "any";
-}
-
-/**
- * A definition with its input type erased, for the `satisfies` constraint.
- * `ChannelDef` is invariant in `In` — `In` is the return of `parse` and a
- * parameter of `run` — so the erasure has to widen each side in its own
- * direction: `parse` to `unknown`, `run` to `never`. That accepts every
- * `channel()` result without an `any` anywhere.
- */
-interface AnyChannelDef {
-  readonly parse: Parser<unknown>;
-  readonly run: Run<never, unknown>;
-  readonly role: "game" | "hub" | "any";
-}
-
-/** You cannot construct a channel without a parser. That is the point. */
-function channel<In, Out>(
-  parse: Parser<In>,
-  run: Run<In, Out>,
-  role: "game" | "hub" | "any" = "game",
-): ChannelDef<In, Out> {
-  return { parse, run, role };
-}
 
 /** For the channels that carry nothing. Still a parser, still explicit. */
 const exact = (args: readonly unknown[], count: number): void => {
@@ -625,20 +557,12 @@ export function registerIpcHandlers(ctx: IpcContext): {
 
     tradeSavedGet: channel(nothing, async () => {
       await requireTradeEnabled();
-      try {
-        return await ctx.getTradeSaved();
-      } catch (error) {
-        throw tradeSavedOperationError("get", error);
-      }
+      return ctx.getTradeSaved();
     }),
 
     tradeSavedSet: channel(one(parseTradeSavedState), async (_win, value) => {
       await requireTradeEnabled();
-      try {
-        return await ctx.setTradeSaved(value);
-      } catch (error) {
-        throw tradeSavedOperationError("set", error);
-      }
+      return ctx.setTradeSaved(value);
     }),
 
     tradeSearch: channel(asTradeSearchRequest, async (win, request) => {
@@ -907,128 +831,6 @@ export function registerIpcHandlers(ctx: IpcContext): {
       }
     },
   };
-}
-
-function registerChannelDefinitions(
-  windows: WindowRegistry,
-  handlers: Partial<Record<InvokeChannel, AnyChannelDef>>,
-): void {
-  // One registration, uniform and total: `assertSender` first, then the
-  // channel's own parser, then its run. The cast is the erasure `satisfies`
-  // left behind — `parse` produced exactly what `run` takes when `channel()`
-  // typechecked the pair.
-  //
-  // A refused payload is recorded here rather than by the handler, because the
-  // handler is never entered. Two channels used to parse inside their own
-  // `try` and log `credentials.saveFailed` / `settings.saveFailed`; one event
-  // in the loop keeps that evidence for a bug report and extends it to all
-  // thirty, so a "saved login stopped working" export shows the rejection
-  // instead of nothing.
-  for (const [key, definition] of Object.entries(handlers)) {
-    const def = definition as ChannelDef<unknown, unknown>;
-    const name = key as InvokeChannel;
-    ipcMain.handle(IPC[name], async (event, ...args: unknown[]) => {
-      const win = assertSender(windows, event, def.role);
-      const traceSaved = name === "tradeSavedGet" || name === "tradeSavedSet";
-      if (traceSaved) {
-        console.info("[trade:saved] ipc received", {
-          operation: name === "tradeSavedSet" ? "set" : "get",
-          ...tradeSavedArgumentCounts(args),
-        });
-      }
-      let input: unknown;
-      try {
-        input = def.parse(args);
-      } catch (error) {
-        const context = windows.contextForWebContents(win.webContents.id);
-        // Hub input has no account owner and must never become global evidence
-        // in every account's export. Game input always has its exact owner.
-        if (context?.role === "game") {
-          logEvent(
-            { k: "ipc.rejected", channel: name, code: errorCode(error) },
-            windows.requireDiagnosticOwnerForWindow(win),
-          );
-        }
-        if (traceSaved) {
-          console.error("[trade:saved] ipc payload rejected", {
-            operation: name === "tradeSavedSet" ? "set" : "get",
-            code: errorCode(error),
-            name: error instanceof Error ? error.name : typeof error,
-            reason: tradeSavedErrorReason(error),
-          });
-        }
-        throw error;
-      }
-      try {
-        const output = await def.run(win, input);
-        if (traceSaved) {
-          console.info("[trade:saved] ipc completed", {
-            operation: name === "tradeSavedSet" ? "set" : "get",
-          });
-        }
-        return output;
-      } catch (error) {
-        if (traceSaved) {
-          console.error("[trade:saved] ipc failed", {
-            operation: name === "tradeSavedSet" ? "set" : "get",
-            code: errorCode(error),
-            name: error instanceof Error ? error.name : typeof error,
-            reason: tradeSavedErrorReason(error),
-          });
-        }
-        throw error;
-      }
-    });
-  }
-}
-
-/** Inspect only collection sizes. Saved feed text and player names stay private. */
-function tradeSavedArgumentCounts(args: readonly unknown[]): Readonly<{
-  offers?: number;
-  players?: number;
-}> {
-  const value = args[0];
-  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
-  const record = value as Record<string, unknown>;
-  return {
-    ...(Array.isArray(record.offers) ? { offers: record.offers.length } : {}),
-    ...(Array.isArray(record.players) ? { players: record.players.length } : {}),
-  };
-}
-
-function tradeSavedErrorReason(error: unknown): string {
-  if (!(error instanceof Error)) return "non-error";
-  if (error.message === "duplicate saved trade entry") return "duplicate-entry";
-  if (error.message === "invalid saved trade state") return "invalid-state";
-  if (error.message === "trade chat is disabled") return "tools-disabled";
-  return "operation-failed";
-}
-
-/** Send only a bounded technical reason across Electron's otherwise opaque rejection. */
-function tradeSavedOperationError(
-  operation: "get" | "set",
-  error: unknown,
-): AppError {
-  const code = errorCode(error);
-  const reason = code !== "unknown"
-    ? code
-    : technicalErrorReason(error);
-  return new AppError(
-    code,
-    `trade_saved_${operation}_failed:${reason}`,
-    { cause: error },
-  );
-}
-
-function technicalErrorReason(error: unknown): string {
-  if (!(error instanceof Error)) return "non-error";
-  const rawCode = "code" in error && typeof error.code === "string"
-    ? error.code
-    : "";
-  if (/^[A-Z][A-Z0-9_]{1,31}$/u.test(rawCode)) return rawCode.toLocaleLowerCase();
-  return /^[A-Za-z][A-Za-z0-9]{0,31}Error$/u.test(error.name)
-    ? error.name.toLocaleLowerCase()
-    : "unclassified";
 }
 
 export function registerSteamIpcHandlers(

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -129,9 +129,11 @@ import {
 import { editGameText } from './game-text-editing.js';
 import {
   parseTradeSearchRequest,
+  parseTradeSavedState,
   parseTradeSource,
   type TradeSearchRequest,
   type TradeSource,
+  type TradeSavedState,
 } from "../shared/trade-chat.js";
 import type { TradeChatService } from "./core/trade-chat-service.js";
 
@@ -156,6 +158,8 @@ export interface IpcContext {
   /** Whether this process started with every certified Tools capability prepared. */
   toolsEnabledAtLaunch: boolean;
   tradeChat: TradeChatService;
+  getTradeSaved: () => Promise<TradeSavedState>;
+  setTradeSaved: (value: TradeSavedState) => Promise<TradeSavedState>;
   downloadFullGame: () => Promise<FullDownloadOutcome>;
   stopFullDownload: () => void;
   confirmClientHealthy: (token: ClientHealthToken) => Promise<void>;
@@ -616,6 +620,16 @@ export function registerIpcHandlers(ctx: IpcContext): {
 
     tradeUnsubscribe: channel(nothing, (win) => {
       ctx.tradeChat.unsubscribe(win.webContents.id);
+    }),
+
+    tradeSavedGet: channel(nothing, async () => {
+      await requireTradeEnabled();
+      return ctx.getTradeSaved();
+    }),
+
+    tradeSavedSet: channel(one(parseTradeSavedState), async (_win, value) => {
+      await requireTradeEnabled();
+      return ctx.setTradeSaved(value);
     }),
 
     tradeSearch: channel(asTradeSearchRequest, async (win, request) => {

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -127,6 +127,13 @@ import {
   requestGameStorageReset,
 } from "./settings-actions.js";
 import { editGameText } from './game-text-editing.js';
+import {
+  parseTradeSearchRequest,
+  parseTradeSource,
+  type TradeSearchRequest,
+  type TradeSource,
+} from "../shared/trade-chat.js";
+import type { TradeChatService } from "./core/trade-chat-service.js";
 
 export interface IpcContext {
   sockets: SocketManager;
@@ -148,6 +155,7 @@ export interface IpcContext {
   setTravelPreferences: (update: TravelUserPreferencesUpdate) => Promise<TravelUserPreferences>;
   /** Whether this process started with every certified Tools capability prepared. */
   toolsEnabledAtLaunch: boolean;
+  tradeChat: TradeChatService;
   downloadFullGame: () => Promise<FullDownloadOutcome>;
   stopFullDownload: () => void;
   confirmClientHealthy: (token: ClientHealthToken) => Promise<void>;
@@ -464,11 +472,29 @@ const asExternalLinkKind = one((value: unknown): ExternalLinkKind => {
     value !== "discord" &&
     value !== "donate" &&
     value !== "releases" &&
-    value !== "store"
+    value !== "store" &&
+    value !== "kamadanTrade" &&
+    value !== "preSearingTrade"
   ) {
     throw new ValidationError("invalid external link kind");
   }
   return value;
+});
+
+const asTradeSource = one((value: unknown): TradeSource => {
+  try {
+    return parseTradeSource(value);
+  } catch {
+    throw new ValidationError("invalid trade source");
+  }
+});
+
+const asTradeSearchRequest = one((value: unknown): TradeSearchRequest => {
+  try {
+    return parseTradeSearchRequest(value);
+  } catch {
+    throw new ValidationError("invalid trade search request");
+  }
 });
 
 const asAccountsSetup = one(parseAccountsSetup);
@@ -483,6 +509,12 @@ export function registerIpcHandlers(ctx: IpcContext): {
 } {
   const paths = gamePaths();
   const secretOperations = new Set<Promise<unknown>>();
+  const tradeCleanupInstalled = new Set<number>();
+  const requireTradeEnabled = async (): Promise<void> => {
+    if (!(await ctx.getSettings()).gwonmacTools) {
+      throw new AllowlistError("trade chat is disabled");
+    }
+  };
   const secretOperation = <T>(operation: () => Promise<T>): Promise<T> => {
     if (isQuitting()) {
       return Promise.reject(new ValidationError("application is quitting"));
@@ -565,6 +597,39 @@ export function registerIpcHandlers(ctx: IpcContext): {
     settingsReset: channel(nothing, async (win) => {
       const outcome = await confirmSettingsReset(win, ctx.resetSettings);
       return outcome;
+    }),
+
+    tradeSubscribe: channel(asTradeSource, async (win, source) => {
+      await requireTradeEnabled();
+      const id = win.webContents.id;
+      if (!tradeCleanupInstalled.has(id)) {
+        tradeCleanupInstalled.add(id);
+        win.webContents.once("destroyed", () => {
+          tradeCleanupInstalled.delete(id);
+          ctx.tradeChat.unsubscribe(id);
+        });
+      }
+      return ctx.tradeChat.subscribe(id, source, (event) => {
+        sendIfLive(win, IPC.tradeEvent, event);
+      });
+    }),
+
+    tradeUnsubscribe: channel(nothing, (win) => {
+      ctx.tradeChat.unsubscribe(win.webContents.id);
+    }),
+
+    tradeSearch: channel(asTradeSearchRequest, async (win, request) => {
+      await requireTradeEnabled();
+      return ctx.tradeChat.search(
+        win.webContents.id,
+        request.source,
+        request.query,
+      );
+    }),
+
+    tradeRetry: channel(asTradeSource, async (win, source) => {
+      await requireTradeEnabled();
+      ctx.tradeChat.retry(win.webContents.id, source);
     }),
 
     travelPreferencesGet: channel(nothing, () => ctx.getTravelPreferences()),

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -64,6 +64,7 @@ import { ENHANCEMENT_RUNTIME_FEATURES } from "../shared/contracts.js";
 import { isDigest } from "../shared/digest.js";
 import {
   AllowlistError,
+  AppError,
   errorCode,
   ValidationError,
 } from "../shared/errors.js";
@@ -624,12 +625,20 @@ export function registerIpcHandlers(ctx: IpcContext): {
 
     tradeSavedGet: channel(nothing, async () => {
       await requireTradeEnabled();
-      return ctx.getTradeSaved();
+      try {
+        return await ctx.getTradeSaved();
+      } catch (error) {
+        throw tradeSavedOperationError("get", error);
+      }
     }),
 
     tradeSavedSet: channel(one(parseTradeSavedState), async (_win, value) => {
       await requireTradeEnabled();
-      return ctx.setTradeSaved(value);
+      try {
+        return await ctx.setTradeSaved(value);
+      } catch (error) {
+        throw tradeSavedOperationError("set", error);
+      }
     }),
 
     tradeSearch: channel(asTradeSearchRequest, async (win, request) => {
@@ -993,6 +1002,33 @@ function tradeSavedErrorReason(error: unknown): string {
   if (error.message === "invalid saved trade state") return "invalid-state";
   if (error.message === "trade chat is disabled") return "tools-disabled";
   return "operation-failed";
+}
+
+/** Send only a bounded technical reason across Electron's otherwise opaque rejection. */
+function tradeSavedOperationError(
+  operation: "get" | "set",
+  error: unknown,
+): AppError {
+  const code = errorCode(error);
+  const reason = code !== "unknown"
+    ? code
+    : technicalErrorReason(error);
+  return new AppError(
+    code,
+    `trade_saved_${operation}_failed:${reason}`,
+    { cause: error },
+  );
+}
+
+function technicalErrorReason(error: unknown): string {
+  if (!(error instanceof Error)) return "non-error";
+  const rawCode = "code" in error && typeof error.code === "string"
+    ? error.code
+    : "";
+  if (/^[A-Z][A-Z0-9_]{1,31}$/u.test(rawCode)) return rawCode.toLocaleLowerCase();
+  return /^[A-Za-z][A-Za-z0-9]{0,31}Error$/u.test(error.name)
+    ? error.name.toLocaleLowerCase()
+    : "unclassified";
 }
 
 export function registerSteamIpcHandlers(

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -920,6 +920,13 @@ function registerChannelDefinitions(
     const name = key as InvokeChannel;
     ipcMain.handle(IPC[name], async (event, ...args: unknown[]) => {
       const win = assertSender(windows, event, def.role);
+      const traceSaved = name === "tradeSavedGet" || name === "tradeSavedSet";
+      if (traceSaved) {
+        console.info("[trade:saved] ipc received", {
+          operation: name === "tradeSavedSet" ? "set" : "get",
+          ...tradeSavedArgumentCounts(args),
+        });
+      }
       let input: unknown;
       try {
         input = def.parse(args);
@@ -933,11 +940,59 @@ function registerChannelDefinitions(
             windows.requireDiagnosticOwnerForWindow(win),
           );
         }
+        if (traceSaved) {
+          console.error("[trade:saved] ipc payload rejected", {
+            operation: name === "tradeSavedSet" ? "set" : "get",
+            code: errorCode(error),
+            name: error instanceof Error ? error.name : typeof error,
+            reason: tradeSavedErrorReason(error),
+          });
+        }
         throw error;
       }
-      return def.run(win, input);
+      try {
+        const output = await def.run(win, input);
+        if (traceSaved) {
+          console.info("[trade:saved] ipc completed", {
+            operation: name === "tradeSavedSet" ? "set" : "get",
+          });
+        }
+        return output;
+      } catch (error) {
+        if (traceSaved) {
+          console.error("[trade:saved] ipc failed", {
+            operation: name === "tradeSavedSet" ? "set" : "get",
+            code: errorCode(error),
+            name: error instanceof Error ? error.name : typeof error,
+            reason: tradeSavedErrorReason(error),
+          });
+        }
+        throw error;
+      }
     });
   }
+}
+
+/** Inspect only collection sizes. Saved feed text and player names stay private. */
+function tradeSavedArgumentCounts(args: readonly unknown[]): Readonly<{
+  offers?: number;
+  players?: number;
+}> {
+  const value = args[0];
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const record = value as Record<string, unknown>;
+  return {
+    ...(Array.isArray(record.offers) ? { offers: record.offers.length } : {}),
+    ...(Array.isArray(record.players) ? { players: record.players.length } : {}),
+  };
+}
+
+function tradeSavedErrorReason(error: unknown): string {
+  if (!(error instanceof Error)) return "non-error";
+  if (error.message === "duplicate saved trade entry") return "duplicate-entry";
+  if (error.message === "invalid saved trade state") return "invalid-state";
+  if (error.message === "trade chat is disabled") return "tools-disabled";
+  return "operation-failed";
 }
 
 export function registerSteamIpcHandlers(

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -40,6 +40,7 @@ import { loadSettings } from "./core/settings.js";
 import { PreferencesCoordinator } from "./core/preferences-coordinator.js";
 import { SocketManager } from "./core/sockets.js";
 import { TradeChatService } from "./core/trade-chat-service.js";
+import { TradeSavedStore } from "./core/trade-saved-store.js";
 import {
   count,
   exportDiagnosticsForWindow,
@@ -584,6 +585,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
   });
   const sockets = buildSocketManager();
   const tradeChat = new TradeChatService();
+  const tradeSaved = new TradeSavedStore(paths.tradeSaved);
   appUpdaterController = new AppUpdater({
     currentVersion: HOST_VERSION,
     capable: distribution.automaticUpdates,
@@ -680,6 +682,8 @@ if (primaryInstance) void app.whenReady().then(async () => {
     setTravelPreferences: (update) => preferences.updateTravelPreferences(update),
     toolsEnabledAtLaunch: settings.gwonmacTools,
     tradeChat,
+    getTradeSaved: () => tradeSaved.get(),
+    setTradeSaved: (value) => tradeSaved.set(value),
     downloadFullGame: () => clientRuntime.downloadAll(),
     stopFullDownload: () => clientRuntime.stopDownload(),
     confirmClientHealthy: (token) =>

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -39,6 +39,7 @@ import { RendererClientSessions } from "./renderer-client-sessions.js";
 import { loadSettings } from "./core/settings.js";
 import { PreferencesCoordinator } from "./core/preferences-coordinator.js";
 import { SocketManager } from "./core/sockets.js";
+import { TradeChatService } from "./core/trade-chat-service.js";
 import {
   count,
   exportDiagnosticsForWindow,
@@ -582,6 +583,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
     onProgress: setProgress,
   });
   const sockets = buildSocketManager();
+  const tradeChat = new TradeChatService();
   appUpdaterController = new AppUpdater({
     currentVersion: HOST_VERSION,
     capable: distribution.automaticUpdates,
@@ -677,6 +679,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
     getTravelPreferences: () => preferences.getTravelPreferences(),
     setTravelPreferences: (update) => preferences.updateTravelPreferences(update),
     toolsEnabledAtLaunch: settings.gwonmacTools,
+    tradeChat,
     downloadFullGame: () => clientRuntime.downloadAll(),
     stopFullDownload: () => clientRuntime.stopDownload(),
     confirmClientHealthy: (token) =>
@@ -783,6 +786,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
       await Promise.all(gameWindows.map((win) => flushWindowState(win)));
     }
     sockets.closeAll();
+    tradeChat.dispose();
     updateLongRunningTaskFeedback(INITIAL_PROGRESS, null);
     await clientRuntime.shutdown();
     if (activeAccountMode === "single") await clearBrowserCookies("quit");

--- a/src/main/renderer-commands.ts
+++ b/src/main/renderer-commands.ts
@@ -162,6 +162,11 @@ export async function toggleTools(win: BrowserWindow): Promise<void> {
   }
 }
 
+/** Show or hide the independent read-only Trade Chat surface. */
+export async function toggleTrade(win: BrowserWindow): Promise<void> {
+  await sendRendererCommand(win, { type: "trade.toggle" });
+}
+
 /**
  * Ask the certified game-thread command queue to open Xunlai storage.
  *

--- a/src/main/window-menu.ts
+++ b/src/main/window-menu.ts
@@ -28,6 +28,7 @@ import {
   resetGameInput,
   sendRendererCommand,
   toggleTravel,
+  toggleTrade,
   toggleTools,
 } from "./renderer-commands.js";
 import { isDevBuild } from "./protocol.js";
@@ -166,6 +167,11 @@ export function installApplicationMenu({
           id: "toggle-tools",
           label: "Show or hide GWonMac Tools",
           click: withGameOwner((win) => toggleTools(win)),
+        },
+        {
+          id: "toggle-trade",
+          label: "Show or hide Trade Chat",
+          click: withGameOwner((win) => toggleTrade(win)),
         },
         {
           id: "open-xunlai-storage",

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -44,6 +44,7 @@ import {
   editWindowText,
   openStorage,
   sendRendererCommand,
+  toggleTrade,
   toggleTools,
   toggleTravel,
 } from "./renderer-commands.js";
@@ -526,6 +527,7 @@ export function createMainWindow(
   installWindowShortcuts(win, {
     run(action) {
       if (action === "tools.toggle") void toggleTools(win);
+      else if (action === "trade.toggle") void toggleTrade(win);
       else if (action === "storage.open") void openStorage(win);
       else void toggleTravel(win);
     },

--- a/src/preload/preload.body.cjs
+++ b/src/preload/preload.body.cjs
@@ -181,6 +181,8 @@ const api = {
     unsubscribe: () => ipcRenderer.invoke(IPC.tradeUnsubscribe),
     search: (request) => ipcRenderer.invoke(IPC.tradeSearch, request),
     retry: (source) => ipcRenderer.invoke(IPC.tradeRetry, source),
+    getSaved: () => ipcRenderer.invoke(IPC.tradeSavedGet),
+    setSaved: (value) => ipcRenderer.invoke(IPC.tradeSavedSet, value),
     onEvent: (callback) => listen(IPC.tradeEvent, callback),
   },
   travelPreferences: {

--- a/src/preload/preload.body.cjs
+++ b/src/preload/preload.body.cjs
@@ -176,6 +176,13 @@ const api = {
     reset: () => ipcRenderer.invoke(IPC.settingsReset),
     onChange: (callback) => listen(IPC.settingsEvent, callback),
   },
+  trade: {
+    subscribe: (source) => ipcRenderer.invoke(IPC.tradeSubscribe, source),
+    unsubscribe: () => ipcRenderer.invoke(IPC.tradeUnsubscribe),
+    search: (request) => ipcRenderer.invoke(IPC.tradeSearch, request),
+    retry: (source) => ipcRenderer.invoke(IPC.tradeRetry, source),
+    onEvent: (callback) => listen(IPC.tradeEvent, callback),
+  },
   travelPreferences: {
     get: () => ipcRenderer.invoke(IPC.travelPreferencesGet),
     set: (value) => ipcRenderer.invoke(IPC.travelPreferencesSet, value),

--- a/src/renderer/certified-companion-installation.ts
+++ b/src/renderer/certified-companion-installation.ts
@@ -193,6 +193,19 @@ export async function installCertifiedCompanion(
     ? (await import("./enhancement-travel-installation.js"))
         .createTravelInstallation(exports, true)
     : null;
+  const configureTradeToggle = capabilities.chatAliases
+    ? (typeof exports.enhancement_configure_trade_toggle === "function"
+        ? exports.enhancement_configure_trade_toggle as (enabled: number) => number
+        : null)
+    : null;
+  const takeTradeToggle = capabilities.chatAliases
+    ? (typeof exports.enhancement_take_trade_toggle === "function"
+        ? exports.enhancement_take_trade_toggle as () => number
+        : null)
+    : null;
+  if (capabilities.chatAliases && (!configureTradeToggle || !takeTradeToggle)) {
+    throw new Error("the aliases profile derived a module with no Trade Chat toggle");
+  }
   // The guard above proves `free` is callable, but WebAssembly exports are typed
   // as the bare `Function`, so the kernel's ABI has to be named here or the five
   // call sites below stop checking what they pass.
@@ -271,6 +284,7 @@ export async function installCertifiedCompanion(
       attempt("Toolbox disposal", disposeToolbox);
     }
     attempt("Tools settings listener disposal", disposeToolSettings);
+    attempt("Trade alias disable", () => { configureTradeToggle?.(0); });
     if (observerStopped) {
       attempt("profession trace disposal", () => professionTrace?.dispose());
     }
@@ -638,6 +652,14 @@ export async function installCertifiedCompanion(
       window.gwCursorState = installedCursorState;
     }
     let optionalSettings = window.gwToolsSettings();
+    const configureTradeAlias = () => {
+      configureTradeToggle?.(optionalSettings.enabled ? 1 : 0);
+    };
+    const pollTradeAlias = () => {
+      if (takeTradeToggle?.() === 1 && optionalSettings.enabled) {
+        window.dispatchEvent(new CustomEvent("gw:trade-toggle"));
+      }
+    };
     let snapshotPlayRegion: RuntimePlayRegion | null = observeState
       ? "unknown"
       : null;
@@ -760,6 +782,10 @@ export async function installCertifiedCompanion(
             import("./tools-host.js").then(({ mountToolsInto }) =>
               mountToolsInto(host, onVisibilityChange, commands, storage, true),
             ),
+          mountTrade: (host, onVisibilityChange) =>
+            import("./tools-host.js").then(({ mountTradeInto }) =>
+              mountTradeInto(host, onVisibilityChange),
+            ),
         })
       : null;
     if (professionTracePointer !== 0 && professionTraceReader !== null) {
@@ -783,6 +809,7 @@ export async function installCertifiedCompanion(
       syncActiveObservers();
       syncStoragePolicy();
       syncTravelPolicy();
+      configureTradeAlias();
     };
     window.addEventListener("gw:tools-settings", onToolSettings);
     disposeToolSettings = () =>
@@ -795,6 +822,7 @@ export async function installCertifiedCompanion(
     syncActiveObservers();
     syncStoragePolicy();
     syncTravelPolicy();
+    configureTradeAlias();
     table.set(manifest.tableSlot, kernelDispatch);
     installedCallback = kernelDispatch;
     const observerRuntime = {
@@ -911,6 +939,7 @@ export async function installCertifiedCompanion(
             readout?.update(state);
             syncStoragePolicy();
             syncTravelPolicy();
+            pollTradeAlias();
           } }
         : null,
       foundation
@@ -933,6 +962,7 @@ export async function installCertifiedCompanion(
               syncActiveObservers();
             }
             syncTravelPolicy();
+            pollTradeAlias();
             toolbox?.update(state);
           } }
         : null,

--- a/src/renderer/commands.ts
+++ b/src/renderer/commands.ts
@@ -82,6 +82,11 @@
           );
         }
         break;
+      case 'trade.toggle':
+        if (!dispatch('gw:trade-toggle')) {
+          throw new Error('Trade Chat is not available in this launch.');
+        }
+        break;
       case 'storage.open': {
         const result: { error?: unknown } = {};
         if (!dispatch('gw:storage-open', result)) {

--- a/src/renderer/gw-native.d.ts
+++ b/src/renderer/gw-native.d.ts
@@ -54,6 +54,7 @@ declare global {
 
   interface GwonmacSurfaceHandle {
     setOpen(open: boolean): void;
+    raise(): void;
     dispose(): void;
   }
 

--- a/src/renderer/harness.css
+++ b/src/renderer/harness.css
@@ -540,6 +540,8 @@ html,body { width:100%; height:100%; margin:0; overflow:hidden;
   #settings-form .settings-rtab[aria-selected="true"] { border-left: 0; border-bottom-color: var(--ui-accent); }
   .settings-panes { padding: var(--ui-space-3); }
   #settings-tool-features { grid-template-columns: minmax(0, 1fr); }
+  .settings-shortcut-row { grid-template-columns: minmax(0, 1fr) auto; }
+  .settings-shortcut-name { grid-column: 1 / -1; }
   .settings-quality-seg { flex-direction: column; }
   .settings-quality-seg label { width: 100%; }
 }

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -465,6 +465,13 @@
                 <p class="settings-shortcut-message" role="status" aria-live="polite" hidden></p>
                 <button type="button" class="ui-link settings-shortcut-replace" hidden>Replace existing shortcut</button>
               </div>
+              <div class="settings-shortcut-row" data-shortcut-action="trade.toggle">
+                <span class="settings-shortcut-name">Show or hide Trade Chat</span>
+                <kbd class="settings-shortcut-value">—</kbd>
+                <button type="button" class="ui-button settings-shortcut-change">Change</button>
+                <p class="settings-shortcut-message" role="status" aria-live="polite" hidden></p>
+                <button type="button" class="ui-link settings-shortcut-replace" hidden>Replace existing shortcut</button>
+              </div>
               <div class="settings-shortcut-row" data-shortcut-action="storage.open">
                 <span class="settings-shortcut-name">Open Xunlai storage</span>
                 <kbd class="settings-shortcut-value">—</kbd>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -457,7 +457,7 @@
             </fieldset>
             <fieldset class="settings-shortcuts" aria-describedby="settings-shortcuts-help">
               <legend>Keyboard shortcuts</legend>
-              <p id="settings-shortcuts-help" class="settings-note">Shortcuts work while the Guild Wars window is active.</p>
+              <p id="settings-shortcuts-help" class="settings-note">Change or clear any shortcut. Shortcuts work while the Guild Wars window is active.</p>
               <div class="settings-shortcut-row" data-shortcut-action="tools.toggle">
                 <span class="settings-shortcut-name">Show or hide GWonMac Tools</span>
                 <kbd class="settings-shortcut-value">—</kbd>

--- a/src/renderer/settings-shortcuts.ts
+++ b/src/renderer/settings-shortcuts.ts
@@ -8,6 +8,7 @@ import {
   shortcutConflict,
   shortcutDisplay,
   shortcutReserved,
+  SHORTCUT_ACTIONS,
   SHORTCUT_LABELS,
   withShortcutOverride,
   type ShortcutAction,
@@ -33,10 +34,15 @@ export function bindShortcutSettings(options: Readonly<{
   let pendingReplacement:
     | { action: ShortcutAction; conflict: ShortcutAction; binding: ShortcutBinding }
     | null = null;
-  const rows = new Map<ShortcutAction, HTMLElement>(
+  const discoveredRows = new Map<ShortcutAction, HTMLElement>(
     [...options.form.querySelectorAll<HTMLElement>('[data-shortcut-action]')]
       .map((row) => [row.dataset.shortcutAction as ShortcutAction, row]),
   );
+  const rows = new Map<ShortcutAction, HTMLElement>(SHORTCUT_ACTIONS.map((action) => {
+    const row = discoveredRows.get(action);
+    if (!row) throw new Error(`missing shortcut row: ${action}`);
+    return [action, row];
+  }));
 
   function parts(action: ShortcutAction) {
     const row = rows.get(action);
@@ -82,6 +88,12 @@ export function bindShortcutSettings(options: Readonly<{
       );
       const current = options.settings();
       if (current) await render(current);
+    } finally {
+      // A captured Command chord can lose its key-up to AppKit. Once the
+      // setting transaction settles, release the capture claim so the newly
+      // assigned shortcut is usable immediately. Auto-repeat is still ignored
+      // by the main-process shortcut controller.
+      await window.gwNative.shortcuts.cancelCapture();
     }
   }
 
@@ -174,12 +186,19 @@ export function bindShortcutSettings(options: Readonly<{
   }
 
   options.restore.addEventListener('click', () => {
-    pendingReplacement = null;
-    clearMessages();
-    void save({});
+    void (async () => {
+      if (recording) await window.gwNative.shortcuts.cancelCapture();
+      recording = null;
+      pendingReplacement = null;
+      clearMessages();
+      await save({});
+    })();
   });
   options.dialog.addEventListener('close', () => {
-    if (recording) void window.gwNative.shortcuts.cancelCapture();
+    // AppKit can consume the matching key-up while Command is held. Always
+    // clear capture-owned key claims when Settings closes, even after capture
+    // already returned a binding, so the new shortcut works on its first use.
+    void window.gwNative.shortcuts.cancelCapture();
     recording = null;
     pendingReplacement = null;
     clearMessages();

--- a/src/renderer/surface-controller.ts
+++ b/src/renderer/surface-controller.ts
@@ -125,6 +125,11 @@ export function installSurfaceController(
           if (next) surfaces.set(id, { ...surface, order: order++ });
           else surfaces.delete(id);
         },
+        raise() {
+          const current = surfaces.get(id);
+          if (!current) return;
+          surfaces.set(id, { ...current, order: order++ });
+        },
         dispose() {
           open = false;
           surfaces.delete(id);

--- a/src/renderer/toolbox-foundation.ts
+++ b/src/renderer/toolbox-foundation.ts
@@ -1,39 +1,15 @@
 /**
- * The Tools overlay: the layer a tool draws on above the game canvas.
+ * The shared in-game boundary for the two independent Tools windows.
  *
- * The overlay owns the boundary and nothing else — the toggle commands, the
- * event stops, pointer-lock release, the cursor mirror, focus transfer and
- * teardown.
- * It draws no panel of its own. It used to: three rows of companion state, with
- * their own titlebar, drag and placement, kept beside the mounted tool and
- * permanently hidden whenever one was mounted. Two panels arguing over one
- * corner of the screen is not an interface, and the one nobody could see was
- * still being written to on every companion poll.
- *
- * There is deliberately no widget registry, plugin surface or layout engine
- * here. One tool mounts, it brings its own window, and a second tool can
- * introduce a layout when it exists and needs one.
- *
- * The overlay is chrome, so it owns only its own pixels: every click that is
- * not on Tools chrome still belongs to the game.
+ * Builds & Teams and Trade Chat mount lazily into explicit hosts. They may be
+ * open together; the last interacted host owns visual stacking, Escape and
+ * Tab. There is intentionally no registry or general layout system.
  */
 import { createNonActivatingSurface } from "./non-activating-surface.js";
 import type { ToolboxObservation } from "../shared/builds/live-party.js";
 
-/**
- * The companion's toolbox projection, as `window.gwCompanionRuntime.toolbox`
- * publishes it. The overlay draws none of it — it holds the latest one and
- * hands it to the mounted tool, which is the only thing here that draws.
- *
- * The shared domain owns this projection. This overlay is only its courier.
- */
 type ToolboxState = ToolboxObservation;
 
-/**
- * Non-modal palette styling. The overlay root never intercepts the pointer;
- * only what the tool draws is interactive, so the game keeps owning every
- * click that is not on Tools chrome.
- */
 const OVERLAY_CSS = `
 #toolbox-foundation {
   position: fixed;
@@ -44,50 +20,48 @@ const OVERLAY_CSS = `
   color: #e8e4d8;
   font: 12px/1.45 -apple-system, "SF Pro Text", "Segoe UI", sans-serif;
 }
+#toolbox-foundation > [data-role] {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
 `;
 
 const TOGGLE_CODE = "Space";
 
-/**
- * A tool mounted into the overlay. It draws its own window; the overlay tells
- * it when it is meant to be on screen and tears it down at the end.
- */
 export interface MountedTool {
   setVisible(visible: boolean): void;
-  /** Ask the tool to close so it can protect any unsaved authoring work. */
+  setActive?(active: boolean): void;
   requestClose(): void;
-  /**
-   * The companion's latest projection of the running game.
-   *
-   * Push, not pull: the overlay is already on the observer's update path, and a
-   * tool that polled instead would be a second reader of the same region on a
-   * cadence nobody chose. Called on mount with whatever has arrived so far, so
-   * a tool loaded after the game was already running does not start blank.
-   */
   update(state: ToolboxState): void;
   dispose(): void;
 }
 
+type MountTool = (
+  host: HTMLElement,
+  onVisibilityChange: (visible: boolean) => void,
+) => Promise<MountedTool | null>;
+
+type FoundationOptions = {
+  /** Existing Builds & Teams mount. The name stays compatible with fixtures. */
+  mountTool: MountTool;
+  /** The separate host-only Trade Chat mount. */
+  mountTrade?: MountTool;
+};
+
+type Slot = {
+  readonly name: "builds" | "trade";
+  readonly host: HTMLElement;
+  readonly mount: MountTool;
+  readonly surface: GwonmacSurfaceHandle;
+  tool: MountedTool | null;
+  requested: boolean;
+  visible: boolean;
+};
+
 export function createToolboxFoundation(
   parent: HTMLElement,
-  options: {
-    /**
-     * Loads the tool into the overlay, on the first open rather than at
-     * install: a player who never opens Tools never pays for the bundle.
-     *
-     * Required. The overlay has nothing to show without it, and an overlay
-     * that could be built without a tool is a configuration nothing ships and
-     * every test would then be free to certify.
-     *
-     * `onVisibilityChange` is how a tool that hides itself — its own close
-     * control — says so. Without it the overlay goes on believing it is open
-     * and the next toggle closes an already-hidden tool instead of reopening it.
-     */
-    mountTool: (
-      host: HTMLElement,
-      onVisibilityChange: (visible: boolean) => void,
-    ) => Promise<MountedTool | null>;
-  },
+  options: FoundationOptions,
 ) {
   const document = parent.ownerDocument;
   const canvas = document.getElementById("canvas");
@@ -98,223 +72,189 @@ export function createToolboxFoundation(
   const style = document.createElement("style");
   style.id = "toolbox-foundation-style";
   style.textContent = OVERLAY_CSS;
-
   const root = document.createElement("section");
   root.id = "toolbox-foundation";
   root.setAttribute("aria-label", "Tools");
-
-  // Where the tool draws: a full-bleed layer inside the overlay root. A tool
-  // brings its own window and positions it against the viewport, so it is given
-  // the viewport rather than a box to escape from. Being inside the root is
-  // what matters — that is where the event stops and the cursor mirror live, so
-  // a tool needs no second boundary of its own.
-  const toolHost = document.createElement("div");
-  toolHost.id = "toolbox-tool";
-  toolHost.dataset.role = "tool";
-  root.append(toolHost);
+  const buildsHost = makeHost(document, "toolbox-builds", "builds");
+  const tradeHost = makeHost(document, "toolbox-trade", "trade");
+  root.append(buildsHost, tradeHost);
   parent.append(style, root);
 
-  // Everything the tool draws is non-activating. Clicking it operates the
-  // control without taking the keyboard, so the game keeps receiving keys
-  // until the player clicks into something they can actually type in.
-  const surface = createNonActivatingSurface(root, () => canvas);
-
-  let tool: MountedTool | null = null;
-  let toolRequested = false;
+  const nonActivating = createNonActivatingSurface(root, () => canvas);
+  let state: ToolboxState = Object.freeze({ status: "waiting" });
   let disposed = false;
-  const ensureTool = () => {
-    if (toolRequested) return;
-    toolRequested = true;
-    // The tool reports its own visibility back, which is how its close control
-    // reaches the overlay. Echoes of the overlay's own `setVisible` come back
-    // through here too and stop at `setOpen`'s no-change guard.
-    void options.mountTool(toolHost, (visible) => setOpen(visible))
+  let stackOrder = 0;
+  let active: Slot | null = null;
+
+  const requestClose = (slot: Slot): void => {
+    if (!slot.visible) return;
+    if (slot.tool) slot.tool.requestClose();
+    else setOpen(slot, false);
+  };
+  const makeSlot = (
+    name: Slot["name"],
+    element: HTMLElement,
+    mount: MountTool,
+  ): Slot => {
+    const slot: Slot = {
+      name,
+      host: element,
+      mount,
+      tool: null,
+      requested: false,
+      visible: false,
+      surface: window.gwSurfaces.register({
+        root: element,
+        priority: 4,
+        dismiss: () => requestClose(slot),
+      }),
+    };
+    return slot;
+  };
+  const builds = makeSlot("builds", buildsHost, options.mountTool);
+  const trade = options.mountTrade
+    ? makeSlot("trade", tradeHost, options.mountTrade)
+    : null;
+  const slots = (): Slot[] => trade ? [builds, trade] : [builds];
+
+  const activate = (slot: Slot) => {
+    active = slot;
+    slot.host.style.zIndex = String(++stackOrder);
+    slot.surface.raise();
+    for (const candidate of slots()) {
+      candidate.tool?.setActive?.(candidate === slot);
+    }
+  };
+
+  const ensure = (slot: Slot) => {
+    if (slot.requested) return;
+    slot.requested = true;
+    void slot.mount(slot.host, (visible) => setOpen(slot, visible))
       .then((mounted) => {
         if (disposed) {
           mounted?.dispose();
           return;
         }
-        tool = mounted;
-        // The overlay may have been closed again while the bundle loaded, and
-        // the companion has almost certainly published since — the tool loads
-        // on first open, which is minutes into a session. Both are caught up
-        // here rather than waiting for the next toggle and the next publish.
-        tool?.setVisible(overlayOpen);
-        tool?.update(state);
+        slot.tool = mounted;
+        mounted?.setVisible(slot.visible);
+        mounted?.setActive?.(active === slot);
+        if (slot.name === "builds") mounted?.update(state);
       });
   };
 
-  let state: ToolboxState = Object.freeze({ status: "waiting" });
-  let overlayOpen = false;
-
-  const requestClose = () => {
-    if (!overlayOpen) return;
-    if (tool) tool.requestClose();
-    else setOpen(false);
-  };
-  const dismissable = window.gwSurfaces.register({
-    root,
-    priority: 4,
-    dismiss: requestClose,
-  });
-
-  const releaseGameInput = () => {
-    window.dispatchEvent(new CustomEvent("gw:input-reset"));
-  };
-
-  const setOpen = (next: boolean) => {
-    if (next === overlayOpen) return;
-    overlayOpen = next;
-    if (next) ensureTool();
-    tool?.setVisible(next);
-    root.dataset.open = String(next);
-    dismissable.setOpen(next);
-    // Pointer lock still has to go: the tool is unreachable by a captured
-    // cursor. The keyboard, though, stays with the game — opening Tools is not
-    // a statement that you have stopped playing.
+  const setOpen = (slot: Slot, next: boolean) => {
+    if (slot.visible === next) return;
+    slot.visible = next;
+    if (next) {
+      ensure(slot);
+      activate(slot);
+    }
+    slot.tool?.setVisible(next);
+    slot.host.dataset.open = String(next);
+    slot.surface.setOpen(next);
+    root.dataset.open = String(slots().some((candidate) => candidate.visible));
     if (next && document.pointerLockElement !== null) document.exitPointerLock();
-    // A menu command can arrive while another renderer-owned control has focus.
-    // Say where the keyboard goes rather than assuming it stayed.
-    surface.releaseKeyboard();
+    if (!next && active === slot) {
+      active = slots().filter((candidate) => candidate.visible)
+        .sort((left, right) => Number(right.host.style.zIndex) - Number(left.host.style.zIndex))[0] ?? null;
+      active?.surface.raise();
+      for (const candidate of slots()) candidate.tool?.setActive?.(candidate === active);
+    }
+    nonActivating.releaseKeyboard();
   };
 
-  const toggleOpen = () => {
-    if (overlayOpen) requestClose();
-    else setOpen(true);
-  };
-
-  // The global chord toggles Tools. The shared surface controller separately
-  // owns Escape and keyboard entry for whichever GWonMac surface is topmost.
-  const onToggleChord = (event: KeyboardEvent) => {
-    const toggles =
-      event.code === TOGGLE_CODE &&
-      event.ctrlKey &&
-      event.shiftKey &&
-      !event.altKey &&
-      !event.metaKey;
-    if (!toggles) return;
-    event.preventDefault();
-    event.stopImmediatePropagation();
-    toggleOpen();
-  };
-
-  // Events from Tools chrome stop at this renderer-owned boundary. The game's
-  // window/document listeners continue to own every event outside it, and
-  // pointer capture during a drag keeps even fast drags inside the boundary.
-  const stopAtOverlay = (event: Event) => event.stopPropagation();
-  for (const name of [
-    "keydown",
-    "keyup",
-    "pointerdown",
-    "pointerup",
-    "pointermove",
-    "mousedown",
-    "mouseup",
-    "mousemove",
-    "click",
-    "wheel",
-    "contextmenu",
-  ]) {
-    root.addEventListener(name, stopAtOverlay);
+  const toggle = (slot: Slot) => slot.visible ? requestClose(slot) : setOpen(slot, true);
+  for (const slot of slots()) {
+    slot.host.addEventListener("pointerdown", () => {
+      if (slot.visible) activate(slot);
+    }, true);
   }
 
-  // The native Guild Wars cursor is published as the canvas's style cursor.
-  // Mirror it so the game cursor stays the cursor over Tools chrome too;
-  // with the native cursor off the mirrored value is empty and the system
-  // arrow shows.
-  const mirrorCursor = () => {
-    root.style.cursor = canvas.style.cursor;
-  };
-  const cursorMirror = new MutationObserver(mirrorCursor);
-  cursorMirror.observe(canvas, {
-    attributes: true,
-    attributeFilter: ["style"],
-  });
-  mirrorCursor();
-
-  // The menu's accelerator arrives here as a command, already taken by the main
-  // process before the renderer -- and so before the game -- could see the key
-  // at all. Answering it is what tells `commands.ts` the capability is
-  // installed: the event is cancelable, and cancelling it is this overlay
-  // saying "handled". The chord below stays as the keyboard-only route for a
-  // build with no menu.
-  const onCommand = (event: Event) => {
+  const onToggleChord = (event: KeyboardEvent) => {
+    if (
+      event.code !== TOGGLE_CODE
+      || !event.ctrlKey
+      || !event.shiftKey
+      || event.altKey
+      || event.metaKey
+    ) return;
     event.preventDefault();
-    toggleOpen();
+    event.stopImmediatePropagation();
+    toggle(builds);
   };
-  window.addEventListener("gw:tools-toggle", onCommand);
+  const onBuildsCommand = (event: Event) => {
+    event.preventDefault();
+    toggle(builds);
+  };
+  const onTradeCommand = (event: Event) => {
+    if (!trade) return;
+    event.preventDefault();
+    toggle(trade);
+  };
+
+  const stopAtOverlay = (event: Event) => event.stopPropagation();
+  for (const name of [
+    "keydown", "keyup", "pointerdown", "pointerup", "pointermove",
+    "mousedown", "mouseup", "mousemove", "click", "wheel", "contextmenu",
+  ]) root.addEventListener(name, stopAtOverlay);
+
+  const mirrorCursor = () => { root.style.cursor = canvas.style.cursor; };
+  const cursorMirror = new MutationObserver(mirrorCursor);
+  cursorMirror.observe(canvas, { attributes: true, attributeFilter: ["style"] });
+  mirrorCursor();
+  window.addEventListener("gw:tools-toggle", onBuildsCommand);
+  window.addEventListener("gw:trade-toggle", onTradeCommand);
   window.addEventListener("keydown", onToggleChord, true);
 
   return {
-    /**
-     * The companion's latest toolbox projection, from the observer.
-     *
-     * Held as well as forwarded: the tool mounts on first open, long after the
-     * game starts publishing, and `ensureTool` replays this into it. Without
-     * that the panel would show nothing until the party next changed.
-     */
     update(next: ToolboxState) {
       state = next;
-      tool?.update(next);
+      builds.tool?.update(next);
     },
-    get state() {
-      return state;
-    },
+    get state() { return state; },
     dispose() {
       disposed = true;
-      tool?.dispose();
-      tool = null;
-      dismissable.dispose();
-      surface.dispose();
-      cursorMirror.disconnect();
-      window.removeEventListener("gw:tools-toggle", onCommand);
-      window.removeEventListener("keydown", onToggleChord, true);
-      releaseGameInput();
-      if (root.contains(document.activeElement)) {
-        canvas.focus({ preventScroll: true });
+      for (const slot of slots()) {
+        slot.tool?.dispose();
+        slot.surface.dispose();
       }
+      nonActivating.dispose();
+      cursorMirror.disconnect();
+      window.removeEventListener("gw:tools-toggle", onBuildsCommand);
+      window.removeEventListener("gw:trade-toggle", onTradeCommand);
+      window.removeEventListener("keydown", onToggleChord, true);
+      window.dispatchEvent(new CustomEvent("gw:input-reset"));
+      if (root.contains(document.activeElement)) canvas.focus({ preventScroll: true });
       style.remove();
       root.remove();
     },
   };
 }
 
-/**
- * Owns the optional lifetime around one toolbox foundation.
- *
- * Both certified and host-only sessions can change their Tools setting while
- * the renderer stays alive. Keeping that transition here makes disabling mean
- * the same thing in both paths: the DOM, command listener, chord, and mounted
- * tool all disappear together. The latest observation is retained so a later
- * re-enable starts current rather than waiting for the next game poll.
- */
 export function createToolboxLifecycle(
   parent: HTMLElement,
-  options: Parameters<typeof createToolboxFoundation>[1],
+  options: FoundationOptions,
 ) {
   let foundation: ReturnType<typeof createToolboxFoundation> | null = null;
   let state: ToolboxState = Object.freeze({ status: "waiting" });
   let disposed = false;
-
   return {
     setEnabled(enabled: boolean) {
       if (disposed) return;
       if (enabled) {
-        if (foundation !== null) return;
+        if (foundation) return;
         foundation = createToolboxFoundation(parent, options);
         foundation.update(state);
-        return;
+      } else {
+        foundation?.dispose();
+        foundation = null;
       }
-      foundation?.dispose();
-      foundation = null;
     },
     update(next: ToolboxState) {
       state = next;
       foundation?.update(next);
     },
-    get state() {
-      return foundation?.state ?? null;
-    },
+    get state() { return foundation?.state ?? null; },
     dispose() {
       if (disposed) return;
       disposed = true;
@@ -322,4 +262,11 @@ export function createToolboxLifecycle(
       foundation = null;
     },
   };
+}
+
+function makeHost(document: Document, id: string, role: string): HTMLElement {
+  const element = document.createElement("div");
+  element.id = id;
+  element.dataset.role = role;
+  return element;
 }

--- a/src/renderer/tools-host.ts
+++ b/src/renderer/tools-host.ts
@@ -152,6 +152,7 @@ export function mountToolsInto(
           if (visible) app.show();
           else app.hide();
         },
+        setActive: app.setActive,
         requestClose: app.requestClose,
         update: app.update,
         dispose: app.dispose,
@@ -160,6 +161,35 @@ export function mountToolsInto(
     .catch((cause: unknown) => {
       console.error("[tools] the Tools application failed to load", cause);
       host.textContent = "Tools could not be loaded — see the console.";
+      return null;
+    });
+}
+
+/** Loads the independent read-only Trade Chat window into its own host. */
+export function mountTradeInto(
+  host: HTMLElement,
+  onVisibilityChange: (visible: boolean) => void,
+): Promise<MountedTool | null> {
+  const specifier = "./tools/tools-app.js";
+  return import(specifier)
+    .then((bundle: EmbeddedToolsBundle<HTMLElement>) => {
+      const app = bundle.mountTradeChat(host, {
+        initiallyVisible: false,
+        onVisibilityChange,
+        mode: "embedded",
+        development: window.gwNative.init.development,
+      });
+      return {
+        setVisible: (visible: boolean) => visible ? app.show() : app.hide(),
+        setActive: app.setActive,
+        requestClose: app.hide,
+        update: () => {},
+        dispose: app.dispose,
+      };
+    })
+    .catch((cause: unknown) => {
+      console.error("[tools] Trade Chat failed to load", cause);
+      host.textContent = "Trade Chat could not be loaded — see the console.";
       return null;
     });
 }
@@ -183,6 +213,7 @@ export function mountHostOnlyTools(
         null,
         templatePublishingAvailable,
       ),
+    mountTrade: mountTradeInto,
   });
   const syncEnabled = () => {
     const settings = window.gwToolsSettings();

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -360,7 +360,7 @@ export interface AppSettings {
   travelShortcuts: StoredTravelShortcuts;
   /** Experimental live target distance/range readout. */
   targetReadout: boolean;
-  /** Player changes to the three app-owned shortcuts; missing entries use defaults. */
+  /** Player changes to the app-owned shortcuts; missing entries use defaults. */
   shortcutOverrides: ShortcutOverrides;
   /** Request the certified 4 GB client module on the next Guild Wars launch. */
   extendedMemoryEnabled: boolean;

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -62,6 +62,7 @@ import type {
   TradeEvent,
   TradeSearchRequest,
   TradeSearchResult,
+  TradeSavedState,
   TradeSnapshot,
   TradeSource,
 } from "./trade-chat.js";
@@ -811,6 +812,8 @@ export const IPC = {
   tradeSearch: "gw:trade:search",
   tradeRetry: "gw:trade:retry",
   tradeEvent: "gw:trade:event",
+  tradeSavedGet: "gw:trade:saved:get",
+  tradeSavedSet: "gw:trade:saved:set",
   travelPreferencesGet: "gw:travelPreferences:get",
   travelPreferencesSet: "gw:travelPreferences:set",
   shortcutCapture: "gw:shortcuts:capture",
@@ -960,6 +963,8 @@ export interface GwNativeApi {
     unsubscribe(): Promise<void>;
     search(request: TradeSearchRequest): Promise<TradeSearchResult>;
     retry(source: TradeSource): Promise<void>;
+    getSaved(): Promise<TradeSavedState>;
+    setSaved(value: TradeSavedState): Promise<TradeSavedState>;
     onEvent(callback: (event: TradeEvent) => void): () => void;
   };
   travelPreferences: {

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -58,6 +58,13 @@ import {
   UPDATE_TRACKS,
   type UpdateTrack,
 } from "./release.js";
+import type {
+  TradeEvent,
+  TradeSearchRequest,
+  TradeSearchResult,
+  TradeSnapshot,
+  TradeSource,
+} from "./trade-chat.js";
 
 export { RELEASE_REPO } from "./project-identity.js";
 export { DEFAULT_UPDATE_TRACK, UPDATE_TRACKS };
@@ -470,7 +477,9 @@ export type ExternalLinkKind =
   | "discord"
   | "donate"
   | "releases"
-  | "store";
+  | "store"
+  | "kamadanTrade"
+  | "preSearingTrade";
 
 /**
  * Directories the renderer may ask to reveal in Finder. A closed enum, never
@@ -489,6 +498,8 @@ export const EXTERNAL_URLS: Record<ExternalLinkKind, string> = {
   releases: `https://github.com/${RELEASE_REPO}/releases`,
   // Official ArenaNet store, for players who do not own the game yet.
   store: "https://store.guildwars.com/en-us",
+  kamadanTrade: "https://kamadan.gwtoolbox.com",
+  preSearingTrade: "https://ascalon.gwtoolbox.com",
 };
 
 /**
@@ -720,6 +731,7 @@ export type RendererCommand =
   | { type: "text.edit"; command: GameTextEditCommand }
   | { type: "accounts.settings.open" }
   | { type: "tools.toggle" }
+  | { type: "trade.toggle" }
   | { type: "storage.open" }
   | { type: "travel.toggle" }
   | {
@@ -794,6 +806,11 @@ export const IPC = {
   settingsSet: "gw:settings:set",
   settingsReset: "gw:settings:reset",
   settingsEvent: "gw:settings:event",
+  tradeSubscribe: "gw:trade:subscribe",
+  tradeUnsubscribe: "gw:trade:unsubscribe",
+  tradeSearch: "gw:trade:search",
+  tradeRetry: "gw:trade:retry",
+  tradeEvent: "gw:trade:event",
   travelPreferencesGet: "gw:travelPreferences:get",
   travelPreferencesSet: "gw:travelPreferences:set",
   shortcutCapture: "gw:shortcuts:capture",
@@ -868,6 +885,7 @@ export const EVENT_CHANNELS = [
   "progressEvent",
   "socketEvent",
   "settingsEvent",
+  "tradeEvent",
   "rendererCommand",
   "rendererCommandDone",
   "inputTraceEvent",
@@ -936,6 +954,13 @@ export interface GwNativeApi {
     set(value: RendererSettingsPatch): Promise<AppSettings>;
     reset(): Promise<SettingsResetOutcome | null>;
     onChange(callback: (settings: AppSettings) => void): () => void;
+  };
+  trade: {
+    subscribe(source: TradeSource): Promise<TradeSnapshot>;
+    unsubscribe(): Promise<void>;
+    search(request: TradeSearchRequest): Promise<TradeSearchResult>;
+    retry(source: TradeSource): Promise<void>;
+    onEvent(callback: (event: TradeEvent) => void): () => void;
   };
   travelPreferences: {
     get(): Promise<TravelUserPreferences>;

--- a/src/shared/enhancement-contracts.ts
+++ b/src/shared/enhancement-contracts.ts
@@ -168,7 +168,7 @@ export {
   ENHANCEMENT_LAYOUT_WORD_COUNT,
   ENHANCEMENT_PARTY_DIRTY_MESSAGE_COUNT,
 } from "./enhancement-config.js";
-export const ENHANCEMENT_TRANSFORM_ABI = 38;
+export const ENHANCEMENT_TRANSFORM_ABI = 39;
 
 export function enhancementConfigWordActive(
   capabilities: EnhancementCapabilities,

--- a/src/shared/keyboard-shortcuts.ts
+++ b/src/shared/keyboard-shortcuts.ts
@@ -2,7 +2,12 @@
  * Canonical app-shortcut actions, defaults, persistence shapes, and pure operations.
  * Main and renderer consume this one model so interception and presentation agree.
  */
-export const SHORTCUT_ACTIONS = ["tools.toggle", "storage.open", "travel.open"] as const;
+export const SHORTCUT_ACTIONS = [
+  "tools.toggle",
+  "trade.toggle",
+  "storage.open",
+  "travel.open",
+] as const;
 export type ShortcutAction = (typeof SHORTCUT_ACTIONS)[number];
 
 export interface ShortcutBinding {
@@ -25,6 +30,7 @@ export type ShortcutCaptureResult =
 export const DEFAULT_SHORTCUTS: Readonly<Record<ShortcutAction, ShortcutBinding>> =
   Object.freeze({
     "tools.toggle": Object.freeze({ key: "b", shift: false, option: false }),
+    "trade.toggle": Object.freeze({ key: "b", shift: true, option: false }),
     "storage.open": Object.freeze({ key: "c", shift: true, option: false }),
     "travel.open": Object.freeze({ key: "t", shift: false, option: false }),
   });
@@ -32,6 +38,7 @@ export const DEFAULT_SHORTCUTS: Readonly<Record<ShortcutAction, ShortcutBinding>
 export const SHORTCUT_LABELS: Readonly<Record<ShortcutAction, string>> =
   Object.freeze({
     "tools.toggle": "Show or hide GWonMac Tools",
+    "trade.toggle": "Show or hide Trade Chat",
     "storage.open": "Open Xunlai storage",
     "travel.open": "Open Travel",
   });
@@ -76,6 +83,9 @@ export function resolveShortcuts(
     "tools.toggle": overrides["tools.toggle"] === undefined
       ? DEFAULT_SHORTCUTS["tools.toggle"]
       : overrides["tools.toggle"],
+    "trade.toggle": overrides["trade.toggle"] === undefined
+      ? DEFAULT_SHORTCUTS["trade.toggle"]
+      : overrides["trade.toggle"],
     "storage.open": overrides["storage.open"] === undefined
       ? DEFAULT_SHORTCUTS["storage.open"]
       : overrides["storage.open"],

--- a/src/shared/tools-bundle-contracts.ts
+++ b/src/shared/tools-bundle-contracts.ts
@@ -20,6 +20,7 @@ export type ToolsAppHandle = Readonly<{
   show: () => void;
   hide: () => void;
   toggle: () => void;
+  setActive: (active: boolean) => void;
   requestClose: () => void;
   /** The companion's latest game projection; the Tools domain interprets it. */
   update: (observation: ToolboxObservation) => void;
@@ -54,6 +55,21 @@ export type TravelPaletteMountOptions = Readonly<{
   onVisibilityChange?: (visible: boolean) => void;
 }>;
 
+export type TradeChatHandle = Readonly<{
+  show: () => void;
+  hide: () => void;
+  toggle: () => void;
+  setActive: (active: boolean) => void;
+  dispose: () => void;
+}>;
+
+export type TradeChatMountOptions = Readonly<{
+  initiallyVisible?: boolean;
+  onVisibilityChange?: (visible: boolean) => void;
+  mode: "standalone" | "embedded";
+  development: boolean;
+}>;
+
 /** The exact named exports of the generated Tools module. */
 export type EmbeddedToolsBundle<Target> = Readonly<{
   mountToolsApp: (
@@ -64,4 +80,8 @@ export type EmbeddedToolsBundle<Target> = Readonly<{
     target: Target,
     options: TravelPaletteMountOptions,
   ) => TravelPaletteHandle;
+  mountTradeChat: (
+    target: Target,
+    options: TradeChatMountOptions,
+  ) => TradeChatHandle;
 }>;

--- a/src/shared/trade-chat.ts
+++ b/src/shared/trade-chat.ts
@@ -58,10 +58,15 @@ export type TradeSearchRequest = Readonly<{
   query: string;
 }>;
 
+export type TradeSearchMatch = Readonly<{
+  message: TradeMessage;
+  postCount: number;
+}>;
+
 export type TradeSearchResult = Readonly<{
   source: TradeSource;
   query: string;
-  messages: readonly TradeMessage[];
+  matches: readonly TradeSearchMatch[];
 }>;
 
 export type TradeSavedOffer = TradeMessage & Readonly<{ savedAt: number }>;

--- a/src/shared/trade-chat.ts
+++ b/src/shared/trade-chat.ts
@@ -15,6 +15,8 @@ export const TRADE_LIMITS = Object.freeze({
   messageCharacters: 1_024,
   liveMessages: 100,
   searchResults: 200,
+  savedOffers: 100,
+  savedPlayers: 100,
   payloadBytes: 1024 * 1024,
 });
 
@@ -62,6 +64,18 @@ export type TradeSearchResult = Readonly<{
   messages: readonly TradeMessage[];
 }>;
 
+export type TradeSavedOffer = TradeMessage & Readonly<{ savedAt: number }>;
+export type TradeSavedPlayer = Readonly<{ sender: string; savedAt: number }>;
+export type TradeSavedState = Readonly<{
+  offers: readonly TradeSavedOffer[];
+  players: readonly TradeSavedPlayer[];
+}>;
+
+export const EMPTY_TRADE_SAVED_STATE: TradeSavedState = Object.freeze({
+  offers: Object.freeze([]),
+  players: Object.freeze([]),
+});
+
 export type TradeEvent =
   | Readonly<{
       type: "status";
@@ -94,6 +108,35 @@ export function parseTradeSearchRequest(value: unknown): TradeSearchRequest {
     throw new TypeError("invalid trade query");
   }
   return Object.freeze({ source, query });
+}
+
+export function parseTradeSavedState(value: unknown): TradeSavedState {
+  if (
+    !isRecord(value)
+    || !hasOnlyKeys(value, ["offers", "players"])
+    || !Array.isArray(value.offers)
+    || !Array.isArray(value.players)
+    || value.offers.length > TRADE_LIMITS.savedOffers
+    || value.players.length > TRADE_LIMITS.savedPlayers
+  ) throw new TypeError("invalid saved trade state");
+
+  const offers = value.offers.map((candidate) => parseSavedOffer(candidate));
+  const players = value.players.map((candidate) => parseSavedPlayer(candidate));
+  if (offers.some((offer) => offer === null) || players.some((player) => player === null)) {
+    throw new TypeError("invalid saved trade state");
+  }
+  const typedOffers = offers as TradeSavedOffer[];
+  const typedPlayers = players as TradeSavedPlayer[];
+  if (
+    new Set(typedOffers.map((offer) => `${offer.source}:${offer.timestamp}`)).size
+      !== typedOffers.length
+    || new Set(typedPlayers.map((player) => player.sender.toLocaleLowerCase())).size
+      !== typedPlayers.length
+  ) throw new TypeError("duplicate saved trade entry");
+  return Object.freeze({
+    offers: Object.freeze(typedOffers),
+    players: Object.freeze(typedPlayers),
+  });
 }
 
 export type ParsedTradePayload =
@@ -164,6 +207,33 @@ function parseTimestamp(value: unknown): number | null {
       ? Number(value)
       : Number.NaN;
   return Number.isSafeInteger(numeric) && numeric > 0 ? numeric : null;
+}
+
+function parseSavedOffer(value: unknown): TradeSavedOffer | null {
+  if (!isRecord(value) || !hasOnlyKeys(value, [
+    "source", "timestamp", "sender", "message", "replacementTimestamp", "savedAt",
+  ])) return null;
+  if (!isTradeSource(value.source)) return null;
+  const message = parseTradeMessage(value.source, {
+    t: value.timestamp,
+    s: value.sender,
+    m: value.message,
+    ...(value.replacementTimestamp === undefined ? {} : { r: value.replacementTimestamp }),
+  });
+  const savedAt = parseTimestamp(value.savedAt);
+  return message && savedAt !== null ? Object.freeze({ ...message, savedAt }) : null;
+}
+
+function parseSavedPlayer(value: unknown): TradeSavedPlayer | null {
+  if (
+    !isRecord(value)
+    || !hasOnlyKeys(value, ["sender", "savedAt"])
+    || typeof value.sender !== "string"
+    || value.sender.length === 0
+    || countCharacters(value.sender) > TRADE_LIMITS.senderCharacters
+  ) return null;
+  const savedAt = parseTimestamp(value.savedAt);
+  return savedAt === null ? null : Object.freeze({ sender: value.sender, savedAt });
 }
 
 function deduplicate(messages: readonly TradeMessage[]): TradeMessage[] {

--- a/src/shared/trade-chat.ts
+++ b/src/shared/trade-chat.ts
@@ -1,0 +1,195 @@
+/**
+ * The complete, bounded contract for the two public GWToolbox trade feeds.
+ *
+ * Network payloads are deliberately converted here before either process may
+ * use them. The renderer receives only these values; it never receives raw
+ * WebSocket frames or a URL it could change.
+ */
+
+export const TRADE_SOURCES = ["kamadan", "pre-searing"] as const;
+export type TradeSource = (typeof TRADE_SOURCES)[number];
+
+export const TRADE_LIMITS = Object.freeze({
+  queryCharacters: 128,
+  senderCharacters: 128,
+  messageCharacters: 1_024,
+  liveMessages: 100,
+  searchResults: 200,
+  payloadBytes: 1024 * 1024,
+});
+
+export const TRADE_SOURCE_URLS: Readonly<
+  Record<TradeSource, { readonly websocket: string; readonly website: string }>
+> = Object.freeze({
+  kamadan: Object.freeze({
+    websocket: "wss://kamadan.gwtoolbox.com",
+    website: "https://kamadan.gwtoolbox.com",
+  }),
+  "pre-searing": Object.freeze({
+    websocket: "wss://ascalon.gwtoolbox.com",
+    website: "https://ascalon.gwtoolbox.com",
+  }),
+});
+
+export type TradeConnectionState =
+  | "connecting"
+  | "live"
+  | "reconnecting"
+  | "unavailable";
+
+export type TradeMessage = Readonly<{
+  source: TradeSource;
+  timestamp: number;
+  sender: string;
+  message: string;
+  replacementTimestamp?: number;
+}>;
+
+export type TradeSnapshot = Readonly<{
+  source: TradeSource;
+  status: TradeConnectionState;
+  messages: readonly TradeMessage[];
+}>;
+
+export type TradeSearchRequest = Readonly<{
+  source: TradeSource;
+  query: string;
+}>;
+
+export type TradeSearchResult = Readonly<{
+  source: TradeSource;
+  query: string;
+  messages: readonly TradeMessage[];
+}>;
+
+export type TradeEvent =
+  | Readonly<{
+      type: "status";
+      source: TradeSource;
+      status: TradeConnectionState;
+    }>
+  | Readonly<{
+      type: "message";
+      source: TradeSource;
+      message: TradeMessage;
+    }>;
+
+export function isTradeSource(value: unknown): value is TradeSource {
+  return TRADE_SOURCES.includes(value as TradeSource);
+}
+
+export function parseTradeSource(value: unknown): TradeSource {
+  if (!isTradeSource(value)) throw new TypeError("invalid trade source");
+  return value;
+}
+
+export function parseTradeSearchRequest(value: unknown): TradeSearchRequest {
+  if (!isRecord(value) || !hasOnlyKeys(value, ["source", "query"])) {
+    throw new TypeError("invalid trade search request");
+  }
+  const source = parseTradeSource(value.source);
+  if (typeof value.query !== "string") throw new TypeError("invalid trade query");
+  const query = value.query.trim();
+  if (query.length === 0 || countCharacters(query) > TRADE_LIMITS.queryCharacters) {
+    throw new TypeError("invalid trade query");
+  }
+  return Object.freeze({ source, query });
+}
+
+export type ParsedTradePayload =
+  | Readonly<{ kind: "message"; message: TradeMessage }>
+  | Readonly<{
+      kind: "search";
+      query: string;
+      messages: readonly TradeMessage[];
+    }>;
+
+export function parseTradePayload(
+  source: TradeSource,
+  value: unknown,
+): ParsedTradePayload | null {
+  if (!isRecord(value)) return null;
+  if (typeof value.query === "string" && Array.isArray(value.results)) {
+    const query = value.query;
+    if (countCharacters(query) > TRADE_LIMITS.queryCharacters) return null;
+    const messages: TradeMessage[] = [];
+    for (const candidate of value.results.slice(0, TRADE_LIMITS.searchResults)) {
+      const message = parseTradeMessage(source, candidate);
+      if (message) messages.push(message);
+    }
+    return Object.freeze({
+      kind: "search",
+      query,
+      messages: Object.freeze(sortNewest(deduplicate(messages))),
+    });
+  }
+  const message = parseTradeMessage(source, value);
+  return message ? Object.freeze({ kind: "message", message }) : null;
+}
+
+export function parseTradeMessage(
+  source: TradeSource,
+  value: unknown,
+): TradeMessage | null {
+  if (!isRecord(value)) return null;
+  const timestamp = parseTimestamp(value.t);
+  const replacementTimestamp = value.r === undefined
+    ? undefined
+    : parseTimestamp(value.r);
+  if (
+    timestamp === null
+    || (value.r !== undefined && replacementTimestamp === null)
+    || typeof value.s !== "string"
+    || typeof value.m !== "string"
+    || value.s.length === 0
+    || value.m.length === 0
+    || countCharacters(value.s) > TRADE_LIMITS.senderCharacters
+    || countCharacters(value.m) > TRADE_LIMITS.messageCharacters
+  ) return null;
+  const message = {
+    source,
+    timestamp,
+    sender: value.s,
+    message: value.m,
+  };
+  return replacementTimestamp === undefined || replacementTimestamp === null
+    ? Object.freeze(message)
+    : Object.freeze({ ...message, replacementTimestamp });
+}
+
+function parseTimestamp(value: unknown): number | null {
+  const numeric = typeof value === "number"
+    ? value
+    : typeof value === "string" && /^[0-9]+$/u.test(value)
+      ? Number(value)
+      : Number.NaN;
+  return Number.isSafeInteger(numeric) && numeric > 0 ? numeric : null;
+}
+
+function deduplicate(messages: readonly TradeMessage[]): TradeMessage[] {
+  const seen = new Set<number>();
+  return messages.filter((message) => {
+    if (seen.has(message.timestamp)) return false;
+    seen.add(message.timestamp);
+    return true;
+  });
+}
+
+function sortNewest(messages: TradeMessage[]): TradeMessage[] {
+  return messages.sort((left, right) => right.timestamp - left.timestamp);
+}
+
+function countCharacters(value: string): number {
+  return [...value].length;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hasOnlyKeys(
+  value: Record<string, unknown>,
+  keys: readonly string[],
+): boolean {
+  return Object.keys(value).every((key) => keys.includes(key));
+}

--- a/src/shared/ui/components.css
+++ b/src/shared/ui/components.css
@@ -302,6 +302,41 @@
   font-weight: var(--ui-font-weight-semibold);
 }
 
+/* Persistent button state is explicit in text and tone. This is shared by
+ * starred Trade items and any future binary action; colour is never its only
+ * signal because the button label changes with aria-pressed. */
+.ui-button[aria-pressed="true"] {
+  background: var(--ui-accent-fill) padding-box, var(--ui-ring-gold) border-box;
+  box-shadow: var(--ui-shadow-selected);
+  color: var(--ui-accent-ink);
+}
+
+/* A non-modal parallel surface anchored to the control that opened it. The
+ * feature owner decides its edge and dimensions; this primitive owns material,
+ * internal flow, and the shared heading rhythm. */
+.ui-drawer {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--ui-panel-fill) padding-box, var(--ui-ring-gilt) border-box;
+  box-shadow: var(--ui-shadow-raised), var(--ui-shadow);
+  backdrop-filter: blur(18px) saturate(1.15);
+}
+
+.ui-drawer-head {
+  display: flex;
+  min-height: 58px;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ui-space-3);
+  padding: var(--ui-space-3) var(--ui-space-3) var(--ui-space-2);
+}
+
+@media (prefers-reduced-transparency: reduce) {
+  .ui-drawer { backdrop-filter: none; }
+}
+
 .ui-button[data-variant="primary"]:hover:not(:disabled):not([aria-disabled="true"]) {
   filter: brightness(1.2);
 }

--- a/src/shared/ui/components.css
+++ b/src/shared/ui/components.css
@@ -178,6 +178,30 @@
   box-shadow: var(--ui-title-shadow);
 }
 
+/* Floating work windows carry a title and supporting line, unlike compact
+ * panel headers. Keep their breathing room in one primitive so every tool
+ * window uses the same chrome instead of tuning title padding per feature. */
+.ui-window-head {
+  min-height: 54px;
+  gap: var(--ui-space-3);
+  padding: var(--ui-space-2) var(--ui-space-3);
+}
+
+@container (max-width: 480px) {
+  .ui-window-head {
+    min-height: 42px;
+    gap: var(--ui-space-2);
+    padding: var(--ui-space-1) var(--ui-space-2);
+  }
+}
+
+@media (max-height: 520px) {
+  .ui-window-head {
+    min-height: 42px;
+    padding-block: var(--ui-space-1);
+  }
+}
+
 .ui-panel-title {
   flex: 1;
   min-width: 0;

--- a/tests/electron/input-clipboard.spec.ts
+++ b/tests/electron/input-clipboard.spec.ts
@@ -65,10 +65,12 @@ test.describe("renderer text editing", () => {
           })),
           appAccelerators: [
             "toggle-tools",
+            "toggle-trade",
             "open-xunlai-storage",
             "open-travel",
           ].map((id) => menu?.getMenuItemById(id)?.accelerator),
           toolsLabel: menu?.getMenuItemById("toggle-tools")?.label,
+          tradeLabel: menu?.getMenuItemById("toggle-trade")?.label,
         };
       })).toEqual({
         edit: [
@@ -77,8 +79,9 @@ test.describe("renderer text editing", () => {
           { id: "edit-paste", label: "Paste", role: null, accelerator: "CmdOrCtrl+V", hasClick: true },
           { id: "edit-select-all", label: "Select All", role: null, accelerator: "CmdOrCtrl+A", hasClick: true },
         ],
-        appAccelerators: [null, null, null],
+        appAccelerators: [null, null, null, null],
         toolsLabel: "Show or hide GWonMac Tools",
+        tradeLabel: "Show or hide Trade Chat",
       });
     } finally {
       await closeOffline(fixture);

--- a/tests/electron/input-toolbox.spec.ts
+++ b/tests/electron/input-toolbox.spec.ts
@@ -67,6 +67,17 @@ test.describe("renderer Tools input", () => {
                 onVisibilityChange: (visible: boolean) => void,
               ): Promise<{
                 setVisible(visible: boolean): void;
+                setActive?(active: boolean): void;
+                requestClose(): void;
+                update(state: object): void;
+                dispose(): void;
+              } | null>;
+              mountTrade?(
+                host: HTMLElement,
+                onVisibilityChange: (visible: boolean) => void,
+              ): Promise<{
+                setVisible(visible: boolean): void;
+                setActive?(active: boolean): void;
                 requestClose(): void;
                 update(state: object): void;
                 dispose(): void;
@@ -120,6 +131,9 @@ test.describe("renderer Tools input", () => {
               setVisible: (visible: boolean) => {
                 panel.style.display = visible ? "block" : "none";
               },
+              setActive: (active: boolean) => {
+                panel.dataset.active = String(active);
+              },
               requestClose: () => {
                 panel.style.display = "none";
                 onVisibilityChange(false);
@@ -134,6 +148,43 @@ test.describe("renderer Tools input", () => {
                   (state as { firstHeroId?: number }).firstHeroId ?? "",
                 );
               },
+              dispose: () => panel.remove(),
+            });
+          },
+          mountTrade: (
+            host: HTMLElement,
+            onVisibilityChange: (visible: boolean) => void,
+          ) => {
+            const panel = document.createElement("div");
+            panel.dataset.testid = "stub-trade";
+            panel.style.cssText =
+              "position:fixed;left:340px;top:24px;width:280px;height:160px;"
+              + "padding:12px;background:#141414;pointer-events:auto;display:none";
+            const action = document.createElement("button");
+            action.type = "button";
+            action.textContent = "Trade action";
+            const field = document.createElement("input");
+            field.type = "search";
+            field.setAttribute("aria-label", "Trade field");
+            const close = document.createElement("button");
+            close.type = "button";
+            close.textContent = "Close trade";
+            const hide = () => {
+              panel.style.display = "none";
+              onVisibilityChange(false);
+            };
+            close.addEventListener("click", hide);
+            panel.append(action, field, close);
+            host.append(panel);
+            return Promise.resolve({
+              setVisible: (visible: boolean) => {
+                panel.style.display = visible ? "block" : "none";
+              },
+              setActive: (active: boolean) => {
+                panel.dataset.active = String(active);
+              },
+              requestClose: hide,
+              update: () => undefined,
               dispose: () => panel.remove(),
             });
           },
@@ -184,6 +235,7 @@ test.describe("renderer Tools input", () => {
       const body = page.locator("body");
       const root = page.locator("#toolbox-foundation");
       const tool = page.getByTestId("stub-tool");
+      const trade = page.getByTestId("stub-trade");
       await expect(root).not.toHaveAttribute("data-open");
       await expect(tool).toBeHidden();
 
@@ -221,6 +273,20 @@ test.describe("renderer Tools input", () => {
       });
       await expect(tool).toHaveAttribute("data-observations", "2");
       await expect(tool).toHaveAttribute("data-hero-id", "24");
+
+      // Trade is an independent surface. Opening it keeps Builds visible, and
+      // Escape dismisses only the last raised surface.
+      await page.evaluate(() => {
+        window.dispatchEvent(new CustomEvent("gw:trade-toggle", { cancelable: true }));
+      });
+      await expect(trade).toBeVisible();
+      await expect(tool).toBeVisible();
+      await page.getByRole("button", { name: "Trade action" }).click();
+      await expect(trade).toHaveAttribute("data-active", "true");
+      await expect(tool).toHaveAttribute("data-active", "false");
+      await page.keyboard.press("Escape");
+      await expect(trade).toBeHidden();
+      await expect(tool).toBeVisible();
 
       await expect.poll(() => isDomActiveElement(page.locator("#canvas")))
         .toBe(true);
@@ -328,7 +394,7 @@ test.describe("renderer Tools input", () => {
       await expect(body).toHaveAttribute("data-toolbox-input-resets", "0");
 
       // The stable host remains even though the retired HUD trigger does not.
-      await expect(page.locator("#toolbox-tool")).toHaveCount(1);
+      await expect(page.locator("#toolbox-builds")).toHaveCount(1);
       await expect(root.locator('[data-role="hud"]')).toHaveCount(0);
 
       // The native game cursor published on the canvas is mirrored over
@@ -445,7 +511,7 @@ test.describe("renderer Tools input", () => {
       };
       await page.keyboard.press("Control+Shift+Space");
       await expect(root).toHaveAttribute("data-open", "true");
-      await expect(page.locator("#toolbox-tool")).toHaveAttribute("data-ready", "true");
+      await expect(page.locator("#toolbox-builds")).toHaveAttribute("data-ready", "true");
       await expect(page.locator('.tools-stage[data-mode="embedded"]')).toBeVisible();
       await expect(page.getByRole("heading", { name: "GWonMac Tools" })).toBeVisible();
       await expect(page.getByText("Saved on this Mac")).toBeVisible();

--- a/tests/electron/sandbox.spec.ts
+++ b/tests/electron/sandbox.spec.ts
@@ -65,6 +65,7 @@ test.describe("sandbox boundary", () => {
           "sockets",
           "steam",
           "templates",
+          "trade",
           "travelPreferences",
           "wasmBridgeMarkers",
         ],

--- a/tests/electron/settings-tools-updates.spec.ts
+++ b/tests/electron/settings-tools-updates.spec.ts
@@ -1,8 +1,44 @@
-import { expect, test } from "@playwright/test";
+import {
+  expect,
+  test,
+  type ElectronApplication,
+  type Page,
+} from "@playwright/test";
 import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { closeOffline, launchOffline } from "./fixtures.mjs";
 import { packageVersion } from "./settings-test-fixture.mjs";
+
+type ShortcutModifier = "meta" | "control" | "shift" | "alt";
+
+function sendInput(
+  app: ElectronApplication,
+  keyCode: string,
+  modifiers: ShortcutModifier[] = [],
+) {
+  return app.evaluate(({ BrowserWindow }, input) => {
+    const contents = BrowserWindow.getAllWindows()[0]?.webContents;
+    contents?.sendInputEvent({
+      type: "keyDown",
+      keyCode: input.keyCode,
+      modifiers: input.modifiers,
+    });
+    contents?.sendInputEvent({
+      type: "keyUp",
+      keyCode: input.keyCode,
+      modifiers: input.modifiers,
+    });
+  }, { keyCode, modifiers });
+}
+
+async function openControls(app: ElectronApplication, page: Page) {
+  await app.evaluate(({ Menu }) => {
+    Menu.getApplicationMenu()
+      ?.items[0]?.submenu?.items.find((item) => item.label === "Settings…")
+      ?.click();
+  });
+  await page.locator("#settings-tab-controls").click();
+}
 
 test.describe("tools and update settings", () => {
   test("removes Travel Recent controls while accepting the released file", async () => {
@@ -97,35 +133,16 @@ test.describe("tools and update settings", () => {
   });
 
   test("records, replaces, clears, and restores app shortcuts without firing them", async () => {
-      const fixture = await launchOffline("gw-settings-shortcuts-e2e-");
+    const fixture = await launchOffline("gw-settings-shortcuts-e2e-");
     try {
       const { app, page } = fixture;
-      const sendInput = (
-        keyCode: string,
-        modifiers: Array<"meta" | "control" | "shift" | "alt"> = [],
-      ) => app.evaluate(({ BrowserWindow }, input) => {
-        const contents = BrowserWindow.getAllWindows()[0]?.webContents;
-        contents?.sendInputEvent({
-          type: "keyDown",
-          keyCode: input.keyCode,
-          modifiers: input.modifiers,
-        });
-        contents?.sendInputEvent({
-          type: "keyUp",
-          keyCode: input.keyCode,
-          modifiers: input.modifiers,
-        });
-      }, { keyCode, modifiers });
-      await app.evaluate(({ Menu }) => {
-        Menu.getApplicationMenu()
-          ?.items[0]?.submenu?.items.find((item) => item.label === "Settings…")
-          ?.click();
-      });
-      await page.locator("#settings-tab-controls").click();
+      await openControls(app, page);
 
       const toolsRow = page.locator('[data-shortcut-action="tools.toggle"]');
+      const tradeRow = page.locator('[data-shortcut-action="trade.toggle"]');
       const storageRow = page.locator('[data-shortcut-action="storage.open"]');
       await expect(toolsRow.locator("kbd")).toHaveText("⌘B");
+      await expect(tradeRow.locator("kbd")).toHaveText("⌘⇧B");
       await expect(storageRow.locator("kbd")).toHaveText("⌘⇧C");
 
       await page.evaluate(() => {
@@ -150,7 +167,7 @@ test.describe("tools and update settings", () => {
       await expect(toolsRow.locator("kbd")).toHaveText("Listening…");
       await expect(toolsRow.locator(".settings-shortcut-message"))
         .toContainText("Delete clears · Escape cancels");
-      await sendInput("B", ["meta"]);
+      await sendInput(app, "B", ["meta"]);
       await expect.poll(() => page.evaluate(() => window.gwNative.settings.get()))
         .toMatchObject({
           shortcutOverrides: {},
@@ -159,7 +176,7 @@ test.describe("tools and update settings", () => {
 
       await toolsRow.locator(".settings-shortcut-change").click();
       await expect(toolsRow.locator("kbd")).toHaveText("Listening…");
-      await sendInput("K", ["meta", "shift"]);
+      await sendInput(app, "K", ["meta", "shift"]);
       await expect.poll(async () => ({
         key: await toolsRow.locator("kbd").textContent(),
         message: await toolsRow.locator(".settings-shortcut-message").textContent(),
@@ -177,7 +194,7 @@ test.describe("tools and update settings", () => {
         ?.getMenuItemById("toggle-tools")?.accelerator)).toBeNull();
 
       await storageRow.locator(".settings-shortcut-change").click();
-      await sendInput("K", ["meta", "shift"]);
+      await sendInput(app, "K", ["meta", "shift"]);
       await expect(storageRow.locator(".settings-shortcut-message"))
         .toContainText("used by Show or hide GWonMac Tools");
       await storageRow.locator(".settings-shortcut-replace").click();
@@ -191,19 +208,113 @@ test.describe("tools and update settings", () => {
       await expect(toolsRow.locator("kbd")).toHaveText("Not set");
 
       await storageRow.locator(".settings-shortcut-change").click();
-      await sendInput("Backspace");
+      await sendInput(app, "Backspace");
       await expect(storageRow.locator("kbd")).toHaveText("Not set");
 
+      await tradeRow.locator(".settings-shortcut-change").click();
+      await expect(tradeRow.locator("kbd")).toHaveText("Listening…");
       await page.locator("#settings-shortcuts-restore").click();
       await expect.poll(() => page.evaluate(() => window.gwNative.settings.get()))
         .toMatchObject({ shortcutOverrides: {} });
       await expect(toolsRow.locator("kbd")).toHaveText("⌘B");
+      await expect(tradeRow.locator("kbd")).toHaveText("⌘⇧B");
+      await expect(tradeRow.locator(".settings-shortcut-change")).toHaveText("Change");
       await expect(storageRow.locator("kbd")).toHaveText("⌘⇧C");
       await page.locator("#settings-done").click();
-      await sendInput("B", ["control"]);
+      await sendInput(app, "B", ["control"]);
       await expect(page.locator("body")).toHaveAttribute("data-shortcut-actions", "0");
-      await sendInput("B", ["meta"]);
+      await sendInput(app, "B", ["meta"]);
       await expect(page.locator("body")).toHaveAttribute("data-shortcut-actions", "1");
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
+  test("changes, clears, and restores the Trade Chat shortcut", async () => {
+    const fixture = await launchOffline(
+      "gw-settings-trade-shortcut-e2e-",
+      {},
+      (userData) => writeFile(
+        path.join(userData, "settings.json"),
+        JSON.stringify({ gwonmacTools: true }),
+        { mode: 0o600 },
+      ),
+    );
+    try {
+      const { app, page } = fixture;
+
+      await page.evaluate(() => {
+        document.body.dataset.tradeShortcutActions = "0";
+        document.body.dataset.tradeShortcutLeaks = "0";
+        window.addEventListener("gw:trade-toggle", (event) => {
+          event.preventDefault();
+          document.body.dataset.tradeShortcutActions = String(
+            Number(document.body.dataset.tradeShortcutActions ?? "0") + 1,
+          );
+        });
+        window.addEventListener("keydown", (event) => {
+          if (event.code === "KeyK") {
+            document.body.dataset.tradeShortcutLeaks = String(
+              Number(document.body.dataset.tradeShortcutLeaks ?? "0") + 1,
+            );
+          }
+        }, true);
+      });
+      await sendInput(app, "B", ["meta", "shift"]);
+      await expect(page.locator("body")).toHaveAttribute(
+        "data-trade-shortcut-actions",
+        "1",
+      );
+
+      await openControls(app, page);
+      const tradeRow = page.locator('[data-shortcut-action="trade.toggle"]');
+      await expect(tradeRow.locator("kbd")).toHaveText("⌘⇧B");
+      await tradeRow.locator(".settings-shortcut-change").click();
+      await sendInput(app, "K", ["meta", "shift"]);
+      await expect.poll(() => page.evaluate(() => window.gwNative.settings.get()))
+        .toMatchObject({
+          shortcutOverrides: {
+            "trade.toggle": { key: "k", shift: true, option: false },
+          },
+        });
+      await expect(tradeRow.locator("kbd")).toHaveText("⌘⇧K");
+
+      await page.locator("#settings-done").click();
+      await sendInput(app, "B", ["meta", "shift"]);
+      await expect(page.locator("body")).toHaveAttribute(
+        "data-trade-shortcut-actions",
+        "1",
+      );
+      await sendInput(app, "K", ["meta", "shift"]);
+      await expect(page.locator("body")).toHaveAttribute(
+        "data-trade-shortcut-actions",
+        "2",
+      );
+      await expect(page.locator("body")).toHaveAttribute(
+        "data-trade-shortcut-leaks",
+        "0",
+      );
+
+      await openControls(app, page);
+      await tradeRow.locator(".settings-shortcut-change").click();
+      await sendInput(app, "Backspace");
+      await expect(tradeRow.locator("kbd")).toHaveText("Not set");
+      await page.locator("#settings-done").click();
+      await sendInput(app, "K", ["meta", "shift"]);
+      await expect(page.locator("body")).toHaveAttribute(
+        "data-trade-shortcut-actions",
+        "2",
+      );
+
+      await openControls(app, page);
+      await page.locator("#settings-shortcuts-restore").click();
+      await expect(tradeRow.locator("kbd")).toHaveText("⌘⇧B");
+      await page.locator("#settings-done").click();
+      await sendInput(app, "B", ["meta", "shift"]);
+      await expect(page.locator("body")).toHaveAttribute(
+        "data-trade-shortcut-actions",
+        "3",
+      );
     } finally {
       await closeOffline(fixture);
     }

--- a/tests/helpers/packaged-enhancement-fixture.ts
+++ b/tests/helpers/packaged-enhancement-fixture.ts
@@ -708,7 +708,7 @@ export async function assertPackagedHostOnlyToolsSession() {
         })));
       assert.equal(claimed, true, "the production Tools command was not claimed");
       await fixture.page.waitForSelector('#toolbox-foundation[data-open="true"]');
-      await fixture.page.waitForSelector('#toolbox-tool[data-ready="true"]', {
+      await fixture.page.waitForSelector('#toolbox-builds[data-ready="true"]', {
         state: "attached",
       });
       await fixture.page.waitForSelector('.tools-stage[data-mode="embedded"]', {
@@ -852,7 +852,7 @@ export async function assertPackagedHostOnlyToolsAfterSoftRefusal() {
       })));
     assert.equal(claimed, true, "soft refusal did not install host-only Tools");
     await fixture.page.waitForSelector('#toolbox-foundation[data-open="true"]');
-    await fixture.page.waitForSelector('#toolbox-tool[data-ready="true"]', {
+    await fixture.page.waitForSelector('#toolbox-builds[data-ready="true"]', {
       state: "attached",
     });
     await fixture.page.waitForSelector('.tools-stage[data-mode="embedded"]', {

--- a/tests/helpers/packaged-enhancement-scenarios.ts
+++ b/tests/helpers/packaged-enhancement-scenarios.ts
@@ -736,6 +736,8 @@ export async function assertToolboxFoundationLifecycle() {
               return 1;
             },
             enhancement_take_travel_toggle: () => 0,
+            enhancement_configure_trade_toggle: () => 1,
+            enhancement_take_trade_toggle: () => 0,
           },
         },
         module,

--- a/tests/policy/source-main-process-security-guards.test.ts
+++ b/tests/policy/source-main-process-security-guards.test.ts
@@ -33,7 +33,7 @@ test("IPC still refuses a sender that is not the main frame at the canonical URL
   // for real in tests/electron/sandbox.spec.ts — means the main frame cannot
   // leave the canonical URL. `isCanonicalRendererUrl` itself is executed in
   // tests/unit/renderer-trust.test.ts.
-  const ipc = read("src/main/ipc.ts");
+  const ipc = read("src/main/ipc-channel-registry.ts");
   assert.match(ipc, /event\.senderFrame !== event\.sender\.mainFrame/u);
   assert.match(ipc, /isCanonicalRendererUrl\(event\.senderFrame\.url\)/u);
 });
@@ -45,7 +45,7 @@ test("production resolves native windows only through the window registry", () =
     assert.doesNotMatch(source, /BrowserWindow\.(?:getAllWindows|getFocusedWindow|fromWebContents)\(/u, file);
   }
   assert.match(
-    read("src/main/ipc.ts"),
+    read("src/main/ipc-channel-registry.ts"),
     /registry\.windowForWebContents\(event\.sender\.id\)/u,
   );
 });

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -135,7 +135,9 @@ test("the host has one native automatic application replacement path", () => {
   assert.match(identity, /GITHUB_OWNER\.toLowerCase\(\).*github\.io/);
   assert.match(identity, /stable: `\$\{UPDATE_FEED_ROOT\}\/stable\/darwin\/arm64\/RELEASES\.json`/);
   assert.match(identity, /beta: `\$\{UPDATE_FEED_ROOT\}\/beta\/darwin\/arm64\/RELEASES\.json`/);
-  assert.deepEqual(json("package.json").dependencies ?? {}, {});
+  assert.deepEqual(json("package.json").dependencies, {
+    ws: "^8.21.3",
+  });
 });
 
 test("distribution channels use preflighted signing and a scoped marker", () => {
@@ -494,11 +496,16 @@ test("developer builds are exact, ad-hoc, bounded, and isolated from releases", 
   );
 });
 
-test("the root app and website add no runtime package entries and audit exceptions stay explicit", () => {
+test("runtime package entries and audit exceptions stay explicit", () => {
   const rootPackage = json("package.json");
   const workspace = read("pnpm-workspace.yaml");
   const lockfile = read("pnpm-lock.yaml");
-  assert.equal(rootPackage.dependencies, undefined);
+  assert.deepEqual(rootPackage.dependencies, {
+    // The main process owns the bounded public trade-feed connection. Keeping
+    // this exact allowlist makes any further runtime dependency an intentional
+    // policy change.
+    ws: "^8.21.3",
+  });
   assert.equal(
     rootPackage.devDependencies?.["@electron-forge/shared-types"],
     "^7.11.2",

--- a/tests/release/preload-behaviour.test.ts
+++ b/tests/release/preload-behaviour.test.ts
@@ -198,6 +198,20 @@ const INVOCATIONS: Invocation[] = [
     }],
     channel: IPC.travelPreferencesSet,
   },
+  { path: "trade.subscribe", args: ["kamadan"], channel: IPC.tradeSubscribe },
+  { path: "trade.unsubscribe", args: [], channel: IPC.tradeUnsubscribe },
+  {
+    path: "trade.search",
+    args: [{ source: "kamadan", query: "black dye" }],
+    channel: IPC.tradeSearch,
+  },
+  { path: "trade.retry", args: ["kamadan"], channel: IPC.tradeRetry },
+  { path: "trade.getSaved", args: [], channel: IPC.tradeSavedGet },
+  {
+    path: "trade.setSaved",
+    args: [{ offers: [], players: [] }],
+    channel: IPC.tradeSavedSet,
+  },
   { path: "accounts.get", args: [], channel: IPC.accountsGet },
   {
     path: "accounts.setup",
@@ -382,6 +396,11 @@ const SUBSCRIPTIONS: Subscription[] = [
     path: "appUpdates.onState",
     channel: IPC.appUpdatesState,
     subscribe: (api, listener) => api.appUpdates.onState(listener),
+  },
+  {
+    path: "trade.onEvent",
+    channel: IPC.tradeEvent,
+    subscribe: (api, listener) => api.trade.onEvent(listener),
   },
 ];
 

--- a/tests/release/source-agrees-with-the-shared-contracts.test.ts
+++ b/tests/release/source-agrees-with-the-shared-contracts.test.ts
@@ -76,7 +76,7 @@ test("every main→renderer event channel is named somewhere in main", async () 
     .filter((file) => file && existsSync(path.join(root, file)))
     .map(read)
     .join("\n");
-  assert.equal(EVENT_CHANNELS.length, 7);
+  assert.equal(EVENT_CHANNELS.length, 8);
   for (const key of EVENT_CHANNELS) {
     assert.match(main, new RegExp(`\\bIPC\\.${key}\\b`), `${key} is missing from main`);
   }

--- a/tests/unit/enhancement-command-transform.test.ts
+++ b/tests/unit/enhancement-command-transform.test.ts
@@ -350,7 +350,7 @@ describe("Enhancement command transform", () => {
     assert.deepEqual(dispatches, [[build.travelAction!.messageId, payload, 0]]);
   });
 
-  it("consumes /tp and the two exact storage commands at their named boundaries", () => {
+  it("consumes /trade, /tp and exact storage commands at their named boundaries", () => {
     const input = fixture();
     const build = manifest(input);
     const output = transformEnhancementWasm(input, build, CURSOR_TOOLBOX_COMMANDS);
@@ -378,6 +378,10 @@ describe("Enhancement command transform", () => {
       (payload: number, enabled: number) => number;
     const takeTravelToggle = instance.exports[build.travelAction!.toggleExport] as
       () => number;
+    const configureTrade = instance.exports.enhancement_configure_trade_toggle as
+      (enabled: number) => number;
+    const takeTradeToggle = instance.exports.enhancement_take_trade_toggle as
+      () => number;
     const payload = 64;
     const message = 256;
     words.set([0, 0, 3], payload / 4);
@@ -398,7 +402,17 @@ describe("Enhancement command transform", () => {
     assert.deepEqual(gameCalls, [11, 11]);
     assert.equal(takeTravelToggle(), 0);
 
+    writeMessage("/trade");
+    assert.equal(slash(11, message), 0, "disabled Trade Chat preserves Guild Wars parsing");
+    assert.equal(takeTradeToggle(), 0);
+    assert.equal(configureTrade(1), 1);
+    assert.equal(slash(11, message), 1, "the exact Trade Chat command is consumed");
+    assert.equal(takeTradeToggle(), 1, "the renderer receives one Trade Chat toggle");
+    assert.equal(takeTradeToggle(), 0, "taking the Trade Chat request clears it");
+    assert.equal(configureTrade(0), 1);
+
     assert.equal(configureTravel(128, 1), 1);
+    writeMessage("/tp");
     assert.equal(slash(11, message), 1, "the exact Travel command is consumed");
     assert.equal(takeTravelToggle(), 1, "the renderer receives one toggle request");
     assert.equal(takeTravelToggle(), 0, "taking the request clears it");
@@ -406,14 +420,14 @@ describe("Enhancement command transform", () => {
     assert.equal(configure(payload, 1), 1);
     writeMessage("/chest");
     assert.equal(slash(12, message), 1, "the exact command is consumed");
-    assert.deepEqual(gameCalls, [11, 11], "slash handling only queues the action");
+    assert.deepEqual(gameCalls, [11, 11, 11], "slash handling only queues the action");
     frame(70, 700);
-    assert.deepEqual(gameCalls, [11, 11, payload, 70]);
+    assert.deepEqual(gameCalls, [11, 11, 11, payload, 70]);
 
     writeMessage("/xunlai");
     assert.equal(slash(13, message), 1, "the alias uses the same mailbox");
     frame(80, 800);
-    assert.deepEqual(gameCalls, [11, 11, payload, 70, payload, 80]);
+    assert.deepEqual(gameCalls, [11, 11, 11, payload, 70, payload, 80]);
 
     assert.equal(command(31, 4242, 0, 0, 0), 1);
     writeMessage("/chest");
@@ -430,12 +444,13 @@ describe("Enhancement command transform", () => {
     );
 
     for (const nearMiss of [
-      "/TP", "/tpp", "/tp ", "/Chest", "/chests", "/chest extra", "/xunlaii", "/storage",
+      "/Trade", "/trade ", "/trade foo", "/TP", "/tpp", "/tp ",
+      "/Chest", "/chests", "/chest extra", "/xunlaii", "/storage",
     ]) {
       writeMessage(nearMiss);
       assert.equal(slash(99, message), 0, nearMiss);
     }
-    assert.deepEqual(gameCalls.slice(-8), [99, 99, 99, 99, 99, 99, 99, 99]);
+    assert.deepEqual(gameCalls.slice(-11), Array(11).fill(99));
   });
 
   it("dispatches queued commands only from the certified game-thread callback", () => {

--- a/tests/unit/keyboard-shortcuts.test.ts
+++ b/tests/unit/keyboard-shortcuts.test.ts
@@ -21,6 +21,7 @@ describe("keyboard shortcuts", () => {
       "storage.open": null,
     }), {
       "tools.toggle": { key: "k", shift: true, option: false },
+      "trade.toggle": DEFAULT_SHORTCUTS["trade.toggle"],
       "storage.open": null,
       "travel.open": DEFAULT_SHORTCUTS["travel.open"],
     });

--- a/tests/unit/memory-warning.test.ts
+++ b/tests/unit/memory-warning.test.ts
@@ -99,6 +99,7 @@ describe("memory warning presenter", () => {
         dismiss = surface.dismiss;
         return {
           setOpen(value) { open.push(value); },
+          raise() {},
           dispose() {},
         };
       },

--- a/tests/unit/paths.test.ts
+++ b/tests/unit/paths.test.ts
@@ -25,6 +25,7 @@ describe("resolved profile paths", () => {
       userData: root,
       settings: `${root}/settings.json`,
       travelPreferences: `${root}/travel-preferences.json`,
+      tradeSaved: `${root}/trade-saved.json`,
       buildLibrary: `${root}/build-library.json`,
       windowState: `${root}/window-state.json`,
       launcherMode: `${root}/launcher-mode.json`,

--- a/tests/unit/settings-binders-reconcile-failures.test.ts
+++ b/tests/unit/settings-binders-reconcile-failures.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { DEFAULT_SETTINGS } from "../../src/shared/contracts.ts";
 import { bindShortcutSettings } from "../../src/renderer/settings-shortcuts.ts";
+import { SHORTCUT_ACTIONS } from "../../src/shared/keyboard-shortcuts.ts";
 
 type Listener = () => void;
 
@@ -57,16 +58,18 @@ function installWindow(value: object): () => void {
 }
 
 test("a failed shortcut write reconciles through Settings and leaves capture mode", async () => {
-  const row = new FakeShortcutRow("tools.toggle");
+  const rows = SHORTCUT_ACTIONS.map((action) => new FakeShortcutRow(action));
+  const row = rows[0]!;
   const restore = new FakeElement();
   const dialog = new FakeElement();
   let current = { ...DEFAULT_SETTINGS };
+  let captureCancellations = 0;
   let recovered!: () => void;
   const recovery = new Promise<void>((resolve) => { recovered = resolve; });
   const uninstall = installWindow({
     gwNative: {
       shortcuts: {
-        cancelCapture: async () => {},
+        cancelCapture: async () => { captureCancellations += 1; },
         capture: async () => ({
           status: "captured",
           binding: { key: "k", shift: true, option: false },
@@ -77,7 +80,7 @@ test("a failed shortcut write reconciles through Settings and leaves capture mod
   try {
     bindShortcutSettings({
       form: {
-        querySelectorAll: () => [row],
+        querySelectorAll: () => rows,
       } as unknown as HTMLFormElement,
       dialog: dialog as unknown as HTMLDialogElement,
       restore: restore as unknown as HTMLElement,
@@ -96,6 +99,7 @@ test("a failed shortcut write reconciles through Settings and leaves capture mod
 
     assert.equal(row.valueElement.textContent, "⌘B");
     assert.equal(row.change.textContent, "Change");
+    assert.equal(captureCancellations, 1);
   } finally {
     uninstall();
   }

--- a/tests/unit/trade-chat.test.ts
+++ b/tests/unit/trade-chat.test.ts
@@ -1,7 +1,12 @@
 import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import { describe, it } from "node:test";
+import { TradeSavedStore } from "../../src/main/core/trade-saved-store.js";
 import {
   parseTradePayload,
+  parseTradeSavedState,
   parseTradeSearchRequest,
 } from "../../src/shared/trade-chat.js";
 
@@ -51,5 +56,51 @@ describe("trade chat contracts", () => {
       source: "kamadan",
       query: "x".repeat(129),
     }));
+  });
+
+  it("validates bounded saved offers and players without accepting duplicates", () => {
+    const saved = parseTradeSavedState({
+      offers: [{
+        source: "kamadan",
+        timestamp: 10,
+        sender: "Angel Trader",
+        message: "WTS Glacial Blade",
+        savedAt: 20,
+      }],
+      players: [{ sender: "Angel Trader", savedAt: 20 }],
+    });
+    assert.equal(saved.offers[0]?.message, "WTS Glacial Blade");
+    assert.equal(saved.players[0]?.sender, "Angel Trader");
+    assert.throws(() => parseTradeSavedState({
+      offers: [],
+      players: [
+        { sender: "Angel Trader", savedAt: 20 },
+        { sender: "angel trader", savedAt: 21 },
+      ],
+    }));
+  });
+
+  it("persists saved trade state in one private atomic document", async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), "gwonmac-trade-saved-"));
+    try {
+      const store = new TradeSavedStore(path.join(directory, "trade-saved.json"));
+      assert.deepEqual(await store.get(), { offers: [], players: [] });
+      const expected = {
+        offers: [{
+          source: "kamadan" as const,
+          timestamp: 10,
+          sender: "Angel Trader",
+          message: "WTS Glacial Blade",
+          savedAt: 20,
+        }],
+        players: [{ sender: "Angel Trader", savedAt: 20 }],
+      };
+      assert.deepEqual(await store.set(expected), expected);
+      assert.deepEqual(await new TradeSavedStore(
+        path.join(directory, "trade-saved.json"),
+      ).get(), expected);
+    } finally {
+      await rm(directory, { recursive: true });
+    }
   });
 });

--- a/tests/unit/trade-chat.test.ts
+++ b/tests/unit/trade-chat.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  parseTradePayload,
+  parseTradeSearchRequest,
+} from "../../src/shared/trade-chat.js";
+
+describe("trade chat contracts", () => {
+  it("accepts numeric and numeric-string timestamps plus replacements", () => {
+    assert.deepEqual(parseTradePayload("kamadan", {
+      t: "1787500323057",
+      s: "Vii Vua",
+      m: "wts 105 consets - 1e each",
+      r: "1787500281247",
+      ignored: "upstream metadata",
+    }), {
+      kind: "message",
+      message: {
+        source: "kamadan",
+        timestamp: 1787500323057,
+        sender: "Vii Vua",
+        message: "wts 105 consets - 1e each",
+        replacementTimestamp: 1787500281247,
+      },
+    });
+  });
+
+  it("bounds, validates, deduplicates and orders search results", () => {
+    const result = parseTradePayload("pre-searing", {
+      query: "dye",
+      num_results: 3,
+      results: [
+        { t: 2, s: "B", m: "WTB dye" },
+        { t: 1, s: "A", m: "WTS dye" },
+        { t: 2, s: "duplicate", m: "ignored" },
+        { t: "bad", s: "invalid", m: "ignored" },
+      ],
+    });
+    assert.equal(result?.kind, "search");
+    if (result?.kind !== "search") return;
+    assert.deepEqual(result.messages.map((message) => message.timestamp), [2, 1]);
+    assert.ok(result.messages.every((message) => message.source === "pre-searing"));
+  });
+
+  it("rejects malformed payloads and invalid searches", () => {
+    assert.equal(parseTradePayload("kamadan", { t: 1, s: "", m: "WTS" }), null);
+    assert.equal(parseTradePayload("kamadan", { t: -1, s: "A", m: "WTS" }), null);
+    assert.throws(() => parseTradeSearchRequest({ source: "both", query: "ecto" }));
+    assert.throws(() => parseTradeSearchRequest({ source: "kamadan", query: " " }));
+    assert.throws(() => parseTradeSearchRequest({
+      source: "kamadan",
+      query: "x".repeat(129),
+    }));
+  });
+});

--- a/tests/unit/trade-chat.test.ts
+++ b/tests/unit/trade-chat.test.ts
@@ -1,8 +1,11 @@
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { describe, it } from "node:test";
+import WebSocket from "ws";
+import { TradeChatService } from "../../src/main/core/trade-chat-service.js";
 import { TradeSavedStore } from "../../src/main/core/trade-saved-store.js";
 import {
   parseTradePayload,
@@ -104,3 +107,129 @@ describe("trade chat contracts", () => {
     }
   });
 });
+
+class FakeTradeSocket extends EventEmitter {
+  readyState: number = WebSocket.CONNECTING;
+  readonly sent: string[] = [];
+  pings = 0;
+  terminated = false;
+
+  open(): void {
+    this.readyState = WebSocket.OPEN;
+    this.emit("open");
+  }
+
+  message(value: unknown): void {
+    this.emit("message", Buffer.from(JSON.stringify(value)));
+  }
+
+  send(value: string, callback?: (error?: Error) => void): void {
+    this.sent.push(value);
+    callback?.();
+  }
+
+  ping(): void { this.pings += 1; }
+
+  close(): void {
+    this.readyState = WebSocket.CLOSED;
+    this.emit("close");
+  }
+
+  terminate(): void {
+    this.terminated = true;
+    this.close();
+  }
+}
+
+describe("trade chat service", () => {
+  it("shares one connection and coalesces semantic offer and player searches", async () => {
+    const socket = new FakeTradeSocket();
+    const service = serviceWith([socket]);
+    service.subscribe(1, "kamadan", () => undefined);
+    service.subscribe(2, "kamadan", () => undefined);
+    socket.open();
+    assert.equal(socket.sent.length, 1);
+
+    const first = service.search(1, "kamadan", "dye");
+    const second = service.search(2, "kamadan", "dye");
+    assert.deepEqual(socket.sent.slice(1).map(queryFrom), ["dye", "user:dye"]);
+    socket.message({
+      query: "dye",
+      results: [
+        { t: 3, s: "Spam Trader", m: "WTS dye" },
+        { t: 2, s: "Spam Trader", m: "WTS another dye" },
+      ],
+    });
+    socket.message({
+      query: "user:dye",
+      results: [{ t: 1, s: "Dye Collector", m: "WTB ectos" }],
+    });
+
+    const [a, b] = await Promise.all([first, second]);
+    assert.deepEqual(a, b);
+    assert.equal(a.matches.length, 2);
+    assert.equal(a.matches[0]?.message.sender, "Spam Trader");
+    assert.equal(a.matches[0]?.postCount, 2);
+    service.dispose();
+  });
+
+  it("bounds live history, applies replacements, and stops after the last subscriber", () => {
+    const socket = new FakeTradeSocket();
+    const service = serviceWith([socket]);
+    service.subscribe(1, "kamadan", () => undefined);
+    service.subscribe(2, "kamadan", () => undefined);
+    socket.open();
+    for (let timestamp = 1; timestamp <= 110; timestamp += 1) {
+      socket.message({ t: timestamp, s: `Trader ${timestamp}`, m: "WTS item" });
+    }
+    socket.message({ t: 111, s: "Replacement", m: "WTS replacement", r: 110 });
+    const snapshot = service.subscribe(3, "kamadan", () => undefined);
+    assert.equal(snapshot.messages.length, 100);
+    assert.equal(snapshot.messages[0]?.timestamp, 111);
+    assert.ok(!snapshot.messages.some((message) => message.timestamp === 110));
+    service.unsubscribe(1);
+    service.unsubscribe(2);
+    assert.equal(socket.readyState, WebSocket.OPEN);
+    service.unsubscribe(3);
+    assert.equal(socket.readyState, WebSocket.CLOSED);
+  });
+
+  it("times out unanswered searches and reconnects while subscribed", async () => {
+    const first = new FakeTradeSocket();
+    const second = new FakeTradeSocket();
+    const service = serviceWith([first, second], {
+      searchTimeoutMs: 5,
+      reconnectDelaysMs: [1],
+    });
+    service.subscribe(1, "kamadan", () => undefined);
+    first.open();
+    await assert.rejects(service.search(1, "kamadan", "ecto"), /trade search failed/);
+    first.close();
+    await delay(10);
+    assert.equal(second.listenerCount("open"), 1);
+    service.dispose();
+  });
+});
+
+function serviceWith(
+  sockets: FakeTradeSocket[],
+  timing: { searchTimeoutMs?: number; reconnectDelaysMs?: readonly number[] } = {},
+): TradeChatService {
+  return new TradeChatService({
+    createSocket: () => {
+      const socket = sockets.shift();
+      assert.ok(socket, "unexpected WebSocket connection");
+      return socket as unknown as WebSocket;
+    },
+    random: () => 0.5,
+    timing,
+  });
+}
+
+function queryFrom(value: string): string {
+  return (JSON.parse(value) as { query: string }).query;
+}
+
+function delay(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}


### PR DESCRIPTION
## Problem

Finding Guild Wars trade offers currently means leaving the game or relying on the raw public feed. Players need a fast, read-only way to search Kamadan and Pre-Searing offers without mixing Trade Chat into Builds & Teams or automating listings and trades.

## Solution

This adds an independent, draggable Trade Chat window that can stay open beside Builds & Teams. It provides:

- separate Kamadan and Pre-Searing feeds with bounded shared WebSocket connections;
- message and player-name search, WTS/WTB filters, repeated-post grouping, and live-feed restoration when search is cleared;
- saved offers and followed players with quick row actions and a focused saved-items drawer;
- a responsive Guild Wars/modern ledger UI with keyboard navigation and selectable message details;
- View menu, exact `/trade`, and configurable shortcut access with `⌘⇧B` as the default;
- immediate shortcut updates, clearing, conflict replacement, and default restoration in Settings.

The integration remains read-only. Listings are still created through Guild Wars trade chat. Feed text and searches are not persisted or written to diagnostics.

## Safety and compatibility

- Only the fixed Kamadan and Ascalon service hosts and source pages are allowed.
- Payloads, timestamps, searches, result counts, history, reconnects, and WebSocket frame sizes are bounded and validated.
- Automated tests use deterministic offline fixtures and never contact the public feeds.
- Shipping still requires confirming the public services' compatibility expectations or owner permission.

## Verification

- `pnpm check`
- `pnpm build`
- 49 integration tests
- 25 release tests
- 38 Tools browser tests
- 102 Tools component tests
- Trade Settings Electron flow: 9/9 passed
- Electron sweep: 150 passed, 1 skipped; one unrelated macOS pointer-lock timeout passed with its complete 7/7 file on rerun
- `pnpm package:built`
- `pnpm test:packaged`
- responsive UI visual sweep and manual wide/narrow inspection

Implemented and verified with Codex using the repository's local Electron, Playwright, Vitest, and Node test harnesses.
