### PR TITLE
fix(test): keep Electron E2E windows hidden

### DIFF
--- a/src/main/accounts-window.ts
+++ b/src/main/accounts-window.ts
@@ -6,6 +6,7 @@
  * activation can reveal the same window again.
  */
 import { app, BrowserWindow, Menu, session } from "electron";
+import { BACKGROUND_LAUNCH } from "./background-launch.js";
 import type { ProtocolDeps } from "./protocol.js";
 import { installGwProtocolHandlerForSession } from "./protocol.js";
 import { preloadPath } from "./paths.js";
@@ -70,6 +71,7 @@ export function createAccountsWindow(deps: ProtocolDeps): BrowserWindow {
     return existing;
   }
   const owner = session.fromPartition("persist:gw-multi-hub", { cache: false });
+  if (BACKGROUND_LAUNCH) app.dock?.hide();
   if (!protocolInstalled) {
     installGwProtocolHandlerForSession(owner, deps);
     protocolInstalled = true;
@@ -104,7 +106,9 @@ export function createAccountsWindow(deps: ProtocolDeps): BrowserWindow {
     if (url !== HUB_URL) event.preventDefault();
   });
   win.webContents.on("will-attach-webview", (event) => event.preventDefault());
-  win.once("ready-to-show", () => win.show());
+  win.once("ready-to-show", () => {
+    if (!BACKGROUND_LAUNCH) win.show();
+  });
   win.on("focus", installAccountsMenu);
   installAccountsMenu();
   win.on("close", (event) => {

--- a/src/main/background-launch.ts
+++ b/src/main/background-launch.ts
@@ -1,0 +1,11 @@
+/**
+ * The development-only background launch policy shared by app windows.
+ *
+ * Electron E2E tests create many real macOS windows. The test fixture enables
+ * this policy so those windows keep rendering without appearing over the
+ * developer's work. Focus-dependent tests disable it explicitly.
+ */
+import { app } from "electron";
+
+export const BACKGROUND_LAUNCH =
+  !app.isPackaged && process.env.GW_BACKGROUND_LAUNCH === "1";

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -27,6 +27,7 @@ import type {
 import { errorCode } from "../shared/errors.js";
 import { longRunningTaskFeedback } from "../shared/progress.js";
 import type { SocketManager } from "./core/sockets.js";
+import { BACKGROUND_LAUNCH } from "./background-launch.js";
 import {
   defaultWindowState,
   cascadeWindowState,
@@ -53,11 +54,6 @@ import {
   updateWindowShortcuts,
 } from "./window-shortcuts.js";
 import { windowRegistry, type GameWindowContext } from "./window-registry.js";
-
-// Tests launch the app dozens of times; without this they steal keyboard focus
-// on every launch. Focus-dependent specs leave the flag unset.
-const BACKGROUND_LAUNCH =
-  !app.isPackaged && process.env.GW_BACKGROUND_LAUNCH === "1";
 
 export interface WindowHost {
   sockets: SocketManager;
@@ -447,7 +443,8 @@ export function createMainWindow(
 
   win.once("ready-to-show", () => {
     if (initialState?.mode === "maximized") win.maximize();
-    if (BACKGROUND_LAUNCH || options.showInactive) win.showInactive();
+    if (BACKGROUND_LAUNCH) return;
+    if (options.showInactive) win.showInactive();
     else win.show();
     if (initialState?.mode === "fullscreen") win.setFullScreen(true);
   });

--- a/tests/electron/app.spec.ts
+++ b/tests/electron/app.spec.ts
@@ -78,6 +78,8 @@ test.describe("Electron application", () => {
     const app = await launch(userData, env);
     try {
       await app.firstWindow({ timeout: 30_000 });
+      expect(await app.evaluate(({ BrowserWindow }) =>
+        BrowserWindow.getAllWindows()[0]?.isVisible())).toBe(false);
       await app.evaluate(({ BrowserWindow }) => {
         const win = BrowserWindow.getAllWindows()[0];
         win?.minimize();

--- a/tests/electron/fixtures.mts
+++ b/tests/electron/fixtures.mts
@@ -101,8 +101,9 @@ export async function launchOfflineAt(
     if (value !== undefined) env[key] = value;
   }
   Object.assign(env, {
-    // Launch without taking keyboard focus. Specs that assert on real OS focus
-    // (document.hasFocus, pointer lock, fullscreen) pass GW_BACKGROUND_LAUNCH: "0".
+    // Keep the real Electron windows hidden while they render. Specs that
+    // assert on native visibility, OS focus, pointer lock, or fullscreen pass
+    // GW_BACKGROUND_LAUNCH: "0".
     GW_BACKGROUND_LAUNCH: "1",
     ...environment,
     // Every default launch is offline by policy. With no seeded generation the

--- a/tests/electron/input-clipboard.spec.ts
+++ b/tests/electron/input-clipboard.spec.ts
@@ -86,7 +86,9 @@ test.describe("renderer text editing", () => {
   });
 
   test("copies, cuts, pastes Unicode, and selects through one game route", async () => {
-    const fixture = await launchCachedClient("gw-clipboard-e2e-");
+    const fixture = await launchCachedClient("gw-clipboard-e2e-", {
+      GW_BACKGROUND_LAUNCH: "0",
+    });
     try {
       const { app, page } = fixture;
       await startGameInput(page);


### PR DESCRIPTION
Local Electron E2E runs opened dozens of real macOS windows over the developer's work. The existing background flag avoided keyboard focus, but still showed every window.

This change keeps background-launched game and Multiple Accounts windows fully hidden while they continue rendering. Tests that depend on native visibility, focus, fullscreen, or clipboard behavior opt into normal window presentation explicitly. Packaged and ordinary development launches are unchanged.

## Verification

- `pnpm build`
- `pnpm run check`
- Focused Electron E2E coverage for hidden main-window launch, hidden Hub interaction, and the foreground clipboard exception: 3 passed

Built and verified with OpenAI Codex (GPT-5).
