### PR TITLE
feat(tools): show configurable skill cooldowns

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,8 @@ its rules.
 | How does Trade Chat discovery work? | [Trade Chat discovery](trade-discovery.md) |
 | What can diagnostics record and export? | [Diagnostics](diagnostics.md) |
 | How do I change or recertify an Enhancement? | [Enhancement development](enhancement-development.md) |
+| How are player skill cooldowns certified and displayed? | [Skill cooldowns](skill-cooldowns.md) |
+| What is the later research path for effects and debuffs? | [Future effect and debuff research](future-effect-durations.md) |
 | How do application releases, Stable, and Beta work? | [Release verification](release-verification.md) |
 | Which UI tokens and components must Tools use? | [Tools design](../apps/tools/DESIGN.md) |
 

--- a/docs/future-effect-durations.md
+++ b/docs/future-effect-durations.md
@@ -1,0 +1,48 @@
+# Future research: skill effects and debuffs
+
+This is not part of the cooldown feature. Recharge state answers when a skill
+can be used again. Effects, enchantments, conditions, and hexes describe state
+on agents and need separate certification, policy, data contracts, and UI.
+
+## Evidence and open questions
+
+Toolbox reads the player's effect collection in local
+`GWToolboxpp/GWToolboxdll/Widgets/SkillbarWidget.cpp:157-209`. It matches each
+effect's `skill_id` to a bar skill, derives time remaining, can keep the longest
+match, and has a special multiple-effect path at lines 231-257. It explicitly
+does not treat a skill typed as a hex as a friendly player effect. GWCA derives
+effect time from the same precise skill timer in local
+`GWCA/Source/Skill.cpp:27-33`.
+
+Those sources are leads only. Before implementation, exact JSPi proof must
+answer:
+
+1. Which bounded collection contains effects Guild Wars legitimately exposes
+   for the player and party?
+2. Which fields prove effect identity, source/target agent, duration, start
+   timestamp, and removal?
+3. Can one skill create multiple simultaneous records, and what stable identity
+   distinguishes them?
+4. Which condition, hex, and other debuff facts are actually exposed to the
+   local player, especially in PvP?
+5. Which reviewed functions update or consume each field in the exact client?
+
+## Recommended capability split
+
+- Start with friendly player enchantment/effect durations only if exact client
+  functions uniquely prove the bounded collection and timer relationship.
+- Represent multiple records explicitly; do not collapse them to one duration
+  in the observation layer. A presentation may later choose the longest only as
+  a documented derived view.
+- Treat party effects and hostile-agent debuffs as separate capabilities. Do
+  not infer them from skill-bar recharge or animation state.
+- Keep the present PvE-only Tools policy by default. Any PvP availability needs
+  a separate fairness review proving that the UI reveals only information the
+  stock client already gives that player.
+- Require exact hashes, exact function signatures and operands, unique matches,
+  bounded reads, sequence-protected publication, and feature-local fail-closed
+  behavior, as the cooldown observer does.
+
+The research output should first be a proof report and read-only diagnostics.
+Only after live evidence confirms semantics should a new UI or durable setting
+be proposed.

--- a/docs/skill-cooldowns.md
+++ b/docs/skill-cooldowns.md
@@ -70,9 +70,12 @@ publishes no cooldown data.
 The shared record is fixed at 60 bytes and uses an odd/even publication
 sequence. The renderer reads the sequence before and after the payload and
 withdraws torn or stale publications. Geometry and recharge data remain
-separate until
+separate until the presentation coordinator in
+[`skill-overlays-installation.ts`](../src/renderer/skill-overlays-installation.ts)
+joins their lifecycles. Both HUDs use the single coordinate conversion in
+[`skill-slot-projection.ts`](../src/renderer/skill-slot-projection.ts), and
 [`skill-cooldown-overlay-consumer.ts`](../src/renderer/skill-cooldown-overlay-consumer.ts)
-joins their two complete eight-slot projections.
+joins the two complete eight-slot records.
 
 Text updates are bounded by the formatter's visible output. Above three seconds
 the view changes only when the upward-rounded whole second changes. Below three

--- a/docs/skill-cooldowns.md
+++ b/docs/skill-cooldowns.md
@@ -1,0 +1,98 @@
+# Skill cooldown observation and display
+
+This feature is display-only. It reads Guild Wars' player skill recharge state,
+publishes one bounded eight-slot record, and draws text over the already
+certified skill-slot rectangles. It does not activate, intercept, remap, or send
+gameplay input.
+
+## Research leads
+
+The native projects explain the likely model, but they do not certify this
+client build:
+
+- Local `GWToolboxpp/GWToolboxdll/Widgets/SkillbarWidget.cpp:141-155` formats
+  recharge values, hides zero and values above 1,800,000 ms, uses a decimal
+  threshold, and optionally rounds whole seconds upward. Lines 212-258 read the
+  player's eight slots. Lines 261-307 center outlined text in each observed
+  skill frame.
+- Local `GWCA/Include/GWCA/GameEntities/Skill.h:80-105` documents an eight-slot
+  row: a 0xbc-byte `Skillbar`, 0x14-byte `SkillbarSkill` records, and the
+  recharge timestamp at slot offset 0x08.
+- Local `GWCA/Source/Skill.cpp:9-12` computes remaining recharge as
+  `recharge - MemoryMgr::GetSkillTimer()`.
+- Local `GWCA/Source/SkillbarMgr.cpp:636-649` chooses the row whose `agent_id`
+  equals the player agent ID.
+- Local `GWCA/Source/MemoryMgr.cpp:8-29` and
+  `GWCA/Include/GWCA/Managers/MemoryMgr.h:7-21` describe the precise native
+  skill timer. GWonMac does not copy that native pointer scan.
+- Local `GWCA/Include/GWCA/Packets/StoC.h:577-583` and `:1004-1009` document
+  recharge and recharged packet shapes. GWonMac does not add a packet hook.
+
+Toolbox effect monitoring is a separate data domain. See
+[Future effect and debuff research](future-effect-durations.md).
+
+## Exact JSPi proof
+
+The certified ArenaNet module is identified by SHA-256
+`b8cc509714b82b69fdfd79a26ba257aa4c9ef23d90bca9dfcbbd044e371cfb17`.
+The feature proof is owned by
+[`enhancement-skill-cooldown-proof.ts`](../src/main/certification/enhancement-skill-cooldown-proof.ts):
+
+- Function 8704 is the unique `(i32, i32, i32) -> i32` body with SHA-256
+  `de894c4032f9c9cf7a50a8f36ad1174446ead7246bf9ae830f43d8e45eb0d697`.
+- Function 249 is the unique `() -> i32` body with SHA-256
+  `f2b448b590efb575ca868617b0a41d544971b29ecec04a69247f3a2f7210e773`.
+- Exact operands in the reviewed reader prove the 0xbc row stride, eight-slot
+  bound, 0x14 slot stride, total recharge address, and direct call to the
+  precise timer. Combining that with the independently certified `skills`
+  offset proves recharge at slot offset 0x08.
+- The transformation rechecks both body hashes and the exact timer call site
+  before it can redirect the reviewed tick path. A mismatch refuses only the
+  cooldown capability.
+
+The exact build record is in
+[`enhancement-builds.ts`](../src/main/certification/enhancement-builds.ts), and
+the transformation checks are in
+[`enhancement-transform.ts`](../src/main/certification/enhancement-transform.ts).
+Mutation tests independently alter the reader bound and timer operand and prove
+that cooldown certification withdraws while the other Tools capabilities stay
+available.
+
+## Runtime boundary
+
+[`skill_cooldowns.rs`](../src/companion-kernel/skill_cooldowns.rs) owns native
+collection. It resolves the certified player, selects exactly one matching bar,
+caches stable player/bar identity, reads exactly eight timestamps on ordinary
+ticks, rejects duplicates and invalid layouts, and refuses recharge values over
+1,800,000 ms. Loading, PvP, missing, ambiguous, wrapped, or malformed state
+publishes no cooldown data.
+
+The shared record is fixed at 60 bytes and uses an odd/even publication
+sequence. The renderer reads the sequence before and after the payload and
+withdraws torn or stale publications. Geometry and recharge data remain
+separate until
+[`skill-cooldown-overlay-consumer.ts`](../src/renderer/skill-cooldown-overlay-consumer.ts)
+joins their two complete eight-slot projections.
+
+Text updates are bounded by the formatter's visible output. Above three seconds
+the view changes only when the upward-rounded whole second changes. Below three
+seconds it changes only when the upward-rounded tenth changes. Ready skills
+have no label. The complete overlay hides when either source is unavailable,
+stale, malformed, loading, or denied by the existing Tools/PvE policy.
+
+## Presentation and remaining acceptance
+
+The HUD and Settings preview share
+[`skill-cooldown-view.ts`](../src/renderer/skill-cooldown-view.ts), including
+the extracted `Guild Wars Original Display` font, outline, shadow, optical
+offset, scale, formatter, and color tokens. The one canonical setting accepts
+red, cream, gold, blue, or an exact six-digit custom RGB value.
+
+[`skill-cooldown-visual.ts`](../scripts/skill-cooldown-visual.ts) creates the
+required duration/color/size/key-coexistence matrix at 1x, 1.5x, and 2x. It can
+place the view over a real native skill crop and writes reference, rendered,
+and difference images. This remains a calibration aid, not live acceptance.
+
+The only unresolved acceptance item is live visual and lifecycle verification.
+It requires the current worktree build running with Guild Wars, followed by a
+review of the final screenshot. Synthetic output must not close that item.

--- a/scripts/skill-cooldown-visual.ts
+++ b/scripts/skill-cooldown-visual.ts
@@ -1,0 +1,187 @@
+/**
+ * Deterministic, headless visual matrix for the shared cooldown view.
+ * This is not a live-game acceptance test; pass a native crop as --reference
+ * to compare the real background at 1x, 1.5x, and 2x.
+ */
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { chromium } from "playwright";
+import ts from "typescript";
+
+const root = path.resolve(import.meta.dirname, "..");
+const outputDir = path.join(root, "test-results", "skill-cooldown-visual");
+const referencePath = process.argv.find((value) => value.startsWith("--reference="))?.slice(12);
+const fontPath = process.argv.find((value) => value.startsWith("--font="))?.slice(7)
+  ?? path.join(root, "src", "renderer", "fonts", "QTFrizQuad.otf");
+const reference = referencePath ? (await readFile(referencePath)).toString("base64") : null;
+const font = (await readFile(fontPath)).toString("base64");
+await mkdir(outputDir, { recursive: true });
+
+const compile = async (relative: string) => ts.transpileModule(
+  await readFile(path.join(root, "src", relative), "utf8"),
+  {
+    fileName: relative,
+    compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ESNext },
+  },
+).outputText;
+const moduleUrl = (source: string) =>
+  `data:text/javascript;base64,${Buffer.from(source).toString("base64")}`;
+const appearanceUrl = moduleUrl(await compile("renderer/appearance.ts"));
+const cooldownModelUrl = moduleUrl(await compile("shared/skill-cooldowns.ts"));
+const bindingModelUrl = moduleUrl(await compile("shared/skill-key-bindings.ts"));
+const cooldownView = (await compile("renderer/skill-cooldown-view.ts"))
+  .replace("../shared/skill-cooldowns.js", cooldownModelUrl)
+  .replace("./appearance.js", appearanceUrl);
+const bindingView = (await compile("renderer/skill-key-binding-view.ts"))
+  .replace("../shared/skill-key-bindings.js", bindingModelUrl)
+  .replace("./appearance.js", appearanceUrl);
+
+const browser = await chromium.launch();
+try {
+  for (const scale of [1, 1.5, 2]) {
+    const page = await browser.newPage({
+      viewport: { width: 1040, height: 920 },
+      deviceScaleFactor: scale,
+    });
+    await page.setContent(`<!doctype html><html><head><style>
+      @font-face { font-family: "Guild Wars Original Display"; src: url("data:font/ttf;base64,${font}"); }
+      * { box-sizing: border-box; }
+      html, body { margin: 0; min-height: 100%; background: #17332f; color: #f3ead6; font: 13px/1.3 system-ui; }
+      body { padding: 24px; }
+      h1 { margin: 0 0 18px; font-size: 18px; }
+      .matrix { display: grid; grid-template-columns: 86px repeat(7, 96px); gap: 12px; align-items: center; }
+      .row-label { color: #d2c5a5; }
+      .fixture { display: grid; justify-items: center; gap: 4px; }
+      .slot { position: relative; width: 82px; height: 82px; overflow: hidden; border: 2px solid #aeb1a8; border-radius: 7px;
+        background: ${reference === null
+          ? "radial-gradient(circle at 54% 43%, #e15acb 0 6%, #654395 31%, #14243a 72%)"
+          : `center / cover no-repeat url("data:image/png;base64,${reference}")`};
+        box-shadow: inset 0 0 14px rgb(0 0 0 / 64%), 0 1px 2px #000; }
+      .fixture small { color: #b8b3a5; font-variant-numeric: tabular-nums; }
+      .slot.small { width: 40px; height: 40px; }
+      .slot.large { width: 140px; height: 140px; }
+      .settings-skill-cooldown-preview-key { --skill-key-edge: 23px; position: absolute; right: 2px; bottom: 2px; max-width: calc(100% - 4px); }
+      #sizes { display: flex; align-items: end; gap: 18px; margin-top: 26px; }
+    </style></head><body><h1>Skill cooldown visual matrix · ${scale}×</h1><div id="matrix" class="matrix"></div><div id="sizes"></div></body></html>`);
+    const referenceOutput = path.join(outputDir, `skill-cooldowns-${scale}x-reference.png`);
+    await page.screenshot({ path: referenceOutput });
+    await page.addScriptTag({
+      type: "module",
+      content: `${cooldownView}\nglobalThis.__cooldownView = createSkillCooldownView;`,
+    });
+    await page.addScriptTag({
+      type: "module",
+      content: `${bindingView}\nglobalThis.__bindingView = createSkillKeyBindingView;`,
+    });
+    const measurements = await page.evaluate(() => {
+      const createCooldown = (globalThis as unknown as {
+        __cooldownView(parent: HTMLElement): { element: HTMLElement; update(ms: number, color: unknown): void };
+      }).__cooldownView;
+      const createBinding = (globalThis as unknown as {
+        __bindingView(parent: HTMLElement): { element: HTMLElement; update(binding: unknown): void };
+      }).__bindingView;
+      const matrix = document.getElementById("matrix")!;
+      const values = [32_000, 14_000, 9_000, 3_000, 2_900, 400, 0];
+      const colors = [
+        ["Red", { kind: "preset", preset: "red" }],
+        ["Cream", { kind: "preset", preset: "cream" }],
+        ["Gold", { kind: "preset", preset: "gold" }],
+        ["Blue", { kind: "preset", preset: "blue" }],
+        ["Custom", { kind: "custom", value: "#c884ff" }],
+      ] as const;
+      const measured: Array<Record<string, number | string | null>> = [];
+      for (const [name, color] of colors) {
+        const label = document.createElement("span");
+        label.className = "row-label";
+        label.textContent = name;
+        matrix.append(label);
+        values.forEach((remainingMs, index) => {
+          const fixture = document.createElement("span");
+          fixture.className = "fixture";
+          const slot = document.createElement("span");
+          slot.className = "slot";
+          const caption = document.createElement("small");
+          caption.textContent = remainingMs === 0 ? "ready" : `${remainingMs} ms`;
+          fixture.append(slot, caption);
+          matrix.append(fixture);
+          const view = createCooldown(slot);
+          view.element.style.setProperty("--skill-cooldown-slot-height", "82px");
+          view.update(remainingMs, color);
+          if (name === "Red" && index === 4) {
+            const key = createBinding(slot);
+            key.element.classList.add("settings-skill-cooldown-preview-key");
+            key.update({
+              input: { kind: "keyboard", code: "F12" },
+              modifiers: { control: true, option: true, shift: true, command: true },
+            });
+          }
+          const rect = view.element.getBoundingClientRect();
+          const glyph = view.element.firstElementChild?.getBoundingClientRect();
+          measured.push({
+            name,
+            remainingMs,
+            slot: rect.height,
+            glyphWidth: glyph?.width ?? null,
+            glyphHeight: glyph?.height ?? null,
+          });
+        });
+      }
+      const sizes = document.getElementById("sizes")!;
+      for (const [className, edge] of [["small", 40], ["large", 140]] as const) {
+        const slot = document.createElement("span");
+        slot.className = `slot ${className}`;
+        sizes.append(slot);
+        const view = createCooldown(slot);
+        view.element.style.setProperty("--skill-cooldown-slot-height", `${edge}px`);
+        view.update(2_900, { kind: "preset", preset: "red" });
+      }
+      return measured;
+    });
+    await page.evaluate(() => document.fonts.ready);
+    const renderedOutput = path.join(outputDir, `skill-cooldowns-${scale}x-rendered.png`);
+    const rendered = await page.screenshot({ path: renderedOutput });
+    const referencePng = await readFile(referenceOutput);
+    const differenceDataUrl = await page.evaluate(async ({ before, after }) => {
+      const load = (data: string) => new Promise<HTMLImageElement>((resolve, reject) => {
+        const image = new Image();
+        image.onload = () => resolve(image);
+        image.onerror = reject;
+        image.src = `data:image/png;base64,${data}`;
+      });
+      const [left, right] = await Promise.all([load(before), load(after)]);
+      const canvas = document.createElement("canvas");
+      canvas.width = right.naturalWidth;
+      canvas.height = right.naturalHeight;
+      const context = canvas.getContext("2d")!;
+      context.drawImage(left, 0, 0);
+      const a = context.getImageData(0, 0, canvas.width, canvas.height);
+      context.clearRect(0, 0, canvas.width, canvas.height);
+      context.drawImage(right, 0, 0);
+      const b = context.getImageData(0, 0, canvas.width, canvas.height);
+      const out = context.createImageData(canvas.width, canvas.height);
+      for (let at = 0; at < out.data.length; at += 4) {
+        out.data[at] = Math.abs(a.data[at]! - b.data[at]!);
+        out.data[at + 1] = Math.abs(a.data[at + 1]! - b.data[at + 1]!);
+        out.data[at + 2] = Math.abs(a.data[at + 2]! - b.data[at + 2]!);
+        out.data[at + 3] = 255;
+      }
+      context.putImageData(out, 0, 0);
+      return canvas.toDataURL("image/png");
+    }, {
+      before: referencePng.toString("base64"),
+      after: rendered.toString("base64"),
+    });
+    const differenceOutput = path.join(outputDir, `skill-cooldowns-${scale}x-difference.png`);
+    await writeFile(differenceOutput, Buffer.from(differenceDataUrl.split(",")[1]!, "base64"));
+    console.log(JSON.stringify({
+      scale,
+      reference: referenceOutput,
+      rendered: renderedOutput,
+      difference: differenceOutput,
+      measurements,
+    }));
+    await page.close();
+  }
+} finally {
+  await browser.close();
+}

--- a/scripts/verify-stable-beta-roundtrip.ts
+++ b/scripts/verify-stable-beta-roundtrip.ts
@@ -188,6 +188,8 @@ const candidateSettingsDomains = Array.from(
       targetReadout: cycle(booleanValues, index),
       shortcutOverrides: {},
       skillKeyBindings: [null, null, null, null, null, null, null, null],
+      skillCooldownOverlayEnabled: cycle(booleanValues, index),
+      skillCooldownColor: { kind: "preset", preset: "red" },
       extendedMemoryEnabled: cycle(booleanValues, index + 1),
       showDiagnostics: cycle(booleanValues, index),
       dataStrategy: "full",

--- a/src/main/core/settings.ts
+++ b/src/main/core/settings.ts
@@ -35,6 +35,10 @@ import {
   cloneSkillKeyBindings,
   isSkillKeyBindings,
 } from "../../shared/skill-key-bindings.js";
+import {
+  cloneSkillCooldownColor,
+  isSkillCooldownColor,
+} from "../../shared/skill-cooldowns.js";
 import { isStoredTravelShortcuts } from "../../shared/travel.js";
 import { writeAtomicJson } from "./atomic-file.js";
 import { quarantineCorruptDocument } from "./corrupt-document.js";
@@ -142,6 +146,12 @@ export function parseSettings(raw: unknown): AppSettings {
     }
     out.skillKeyBindings = cloneSkillKeyBindings(src.skillKeyBindings);
   }
+  if ("skillCooldownColor" in src) {
+    if (!isSkillCooldownColor(src.skillCooldownColor)) {
+      throw new AppError("bad_settings", "settings.skillCooldownColor has an invalid color");
+    }
+    out.skillCooldownColor = cloneSkillCooldownColor(src.skillCooldownColor);
+  }
   if ("travelShortcuts" in src) {
     if (!isStoredTravelShortcuts(src.travelShortcuts)) {
       throw new AppError("bad_settings", "settings.travelShortcuts has invalid destinations");
@@ -156,6 +166,7 @@ export function parseSettings(raw: unknown): AppSettings {
     "xunlaiStorage",
     "travelPalette",
     "targetReadout",
+    "skillCooldownOverlayEnabled",
     "extendedMemoryEnabled",
   ] as const) {
     if (setting in src) out[setting] = asBool(src[setting], setting);

--- a/src/renderer/certified-companion-installation.ts
+++ b/src/renderer/certified-companion-installation.ts
@@ -39,6 +39,7 @@ import {
 import { createSkillSlotGeometryInstallation } from "./skill-slot-geometry-installation.js";
 import { createSkillKeyOverlayConsumer } from "./skill-key-overlay-consumer.js";
 import { createSkillCooldownObservationInstallation } from "./skill-cooldown-state-installation.js";
+import { createSkillCooldownOverlayInstallation } from "./skill-cooldown-overlay-installation.js";
 import { validateCompanionOwnedRegions } from "./companion-owned-regions.js";
 import {
   observeCompanion,
@@ -143,6 +144,9 @@ export async function installCertifiedCompanion(
   const skillSlotGeometry = createSkillSlotGeometryInstallation(hasSkillSlotGeometry);
   const skillCooldowns = createSkillCooldownObservationInstallation(
     capabilities.skillCooldownObservation,
+  );
+  const skillCooldownOverlay = createSkillCooldownOverlayInstallation(
+    capabilities.skillCooldownObservation && hasSkillSlotGeometry,
   );
   const observeState = capabilities.targetObservation || capabilities.xunlaiAction;
   const publishObserverState = program === "target-observer";
@@ -303,6 +307,7 @@ export async function installCertifiedCompanion(
       attempt("skill key overlay disposal", disposeSkillKeyOverlay);
       attempt("skill-slot feed disposal", skillSlotGeometry.dispose);
       attempt("skill cooldown feed disposal", skillCooldowns.dispose);
+      attempt("skill cooldown overlay disposal", skillCooldownOverlay.dispose);
     }
     attempt("Tools settings listener disposal", disposeToolSettings);
     attempt("Trade alias disable", () => { configureTradeToggle?.(0); });
@@ -732,8 +737,20 @@ export async function installCertifiedCompanion(
         policy().skillSlotGeometry && hasSkillKeyBindings(),
       );
     };
+    const syncSkillCooldowns = () => skillCooldownOverlay.sync(
+      optionalSettings.skillCooldownColor,
+      policy().skillCooldownOverlay,
+    );
+    skillCooldownOverlay.mount(
+      document.body,
+      optionalSettings.skillCooldownColor,
+      false,
+      skillSlotGeometry.subscribe,
+      skillCooldowns.subscribe,
+    );
     setTargetEnabled();
     syncSkillKeys();
+    syncSkillCooldowns();
     disposeReadout = () => {
       readout?.dispose();
       readout = null;
@@ -754,10 +771,10 @@ export async function installCertifiedCompanion(
         | (targetEnabled() ? COMPANION_FEATURE_BITS.targetObservation : 0)
         | (hasSkillSlotGeometry
             && policy().skillSlotGeometry
-            && hasSkillKeyBindings()
+            && (hasSkillKeyBindings() || policy().skillCooldownOverlay)
           ? COMPANION_FEATURE_BITS.skillSlotGeometry
           : 0)
-        | (capabilities.skillCooldownObservation
+        | (capabilities.skillCooldownObservation && policy().skillCooldownOverlay
           ? COMPANION_FEATURE_BITS.skillCooldownObservation
           : 0);
       kernelDispatch(
@@ -845,6 +862,7 @@ export async function installCertifiedCompanion(
       syncToolboxAvailability();
       setTargetEnabled();
       syncSkillKeys();
+      syncSkillCooldowns();
       syncActiveObservers();
       syncStoragePolicy();
       syncTravelPolicy();
@@ -979,6 +997,7 @@ export async function installCertifiedCompanion(
               tracePolicy("region");
               setTargetEnabled();
               syncSkillKeys();
+              syncSkillCooldowns();
               syncActiveObservers();
             }
             readout?.update(state);
@@ -1005,6 +1024,7 @@ export async function installCertifiedCompanion(
               tracePolicy("region");
               setTargetEnabled();
               syncSkillKeys();
+              syncSkillCooldowns();
               syncActiveObservers();
             }
             syncTravelPolicy();

--- a/src/renderer/certified-companion-installation.ts
+++ b/src/renderer/certified-companion-installation.ts
@@ -36,10 +36,7 @@ import {
   COMPANION_SKILL_COOLDOWN_BYTES,
   COMPANION_SKILL_SLOT_BYTES,
 } from "./companion-skill-snapshot.js";
-import { createSkillSlotGeometryInstallation } from "./skill-slot-geometry-installation.js";
-import { createSkillKeyOverlayConsumer } from "./skill-key-overlay-consumer.js";
-import { createSkillCooldownObservationInstallation } from "./skill-cooldown-state-installation.js";
-import { createSkillCooldownOverlayInstallation } from "./skill-cooldown-overlay-installation.js";
+import { createSkillOverlaysInstallation } from "./skill-overlays-installation.js";
 import { validateCompanionOwnedRegions } from "./companion-owned-regions.js";
 import {
   observeCompanion,
@@ -140,14 +137,9 @@ export async function installCertifiedCompanion(
   // launches always receive `none`; developer observers request their scalar
   // projection explicitly without implicitly mounting the Toolbox overlay.
   const foundation = capabilities.partyObservation;
-  const hasSkillSlotGeometry = capabilities.skillSlotGeometry;
-  const skillSlotGeometry = createSkillSlotGeometryInstallation(hasSkillSlotGeometry);
-  const skillCooldowns = createSkillCooldownObservationInstallation(
-    capabilities.skillCooldownObservation,
-  );
-  const skillCooldownOverlay = createSkillCooldownOverlayInstallation(
-    capabilities.skillCooldownObservation && hasSkillSlotGeometry,
-  );
+  const skills = createSkillOverlaysInstallation(capabilities);
+  const skillSlotGeometry = skills.geometry;
+  const skillCooldowns = skills.cooldowns;
   const observeState = capabilities.targetObservation || capabilities.xunlaiAction;
   const publishObserverState = program === "target-observer";
   const featureFlags =
@@ -155,10 +147,7 @@ export async function installCertifiedCompanion(
     | (observeState ? COMPANION_FEATURE_BITS.gameSnapshot : 0)
     | (foundation ? COMPANION_FEATURE_BITS.toolboxFoundation : 0)
     | (capabilities.targetObservation ? COMPANION_FEATURE_BITS.targetObservation : 0)
-    | (hasSkillSlotGeometry ? COMPANION_FEATURE_BITS.skillSlotGeometry : 0)
-    | (capabilities.skillCooldownObservation
-      ? COMPANION_FEATURE_BITS.skillCooldownObservation
-      : 0);
+    | skills.certifiedFeatureFlags;
   if (featureFlags === 0) return null;
 
   const manifest = decodeEnhancementManifest(module, capabilities);
@@ -262,7 +251,6 @@ export async function installCertifiedCompanion(
   let disposeReadout = () => {};
   let disposeToolbox = () => {};
   let disposeToolSettings = () => {};
-  let disposeSkillKeyOverlay = () => {};
   let disposeCursorRefresh = () => {};
   let professionTrace: ReturnType<typeof createProfessionCommandTrace> | null = null;
   let installedCallback: CallableFunction | null = null;
@@ -304,10 +292,9 @@ export async function installCertifiedCompanion(
       attempt("cursor disposal", disposeCursor);
       attempt("target readout disposal", disposeReadout);
       attempt("Toolbox disposal", disposeToolbox);
-      attempt("skill key overlay disposal", disposeSkillKeyOverlay);
+      attempt("skill overlay disposal", skills.disposePresentation);
       attempt("skill-slot feed disposal", skillSlotGeometry.dispose);
       attempt("skill cooldown feed disposal", skillCooldowns.dispose);
-      attempt("skill cooldown overlay disposal", skillCooldownOverlay.dispose);
     }
     attempt("Tools settings listener disposal", disposeToolSettings);
     attempt("Trade alias disable", () => { configureTradeToggle?.(0); });
@@ -664,20 +651,7 @@ export async function installCertifiedCompanion(
       window.gwCursorState = installedCursorState;
     }
     let optionalSettings = window.gwToolsSettings();
-    let skillKeyConsumer: ReturnType<typeof createSkillKeyOverlayConsumer> | null = null;
-    if (hasSkillSlotGeometry) {
-      const canvas = document.getElementById("canvas");
-      if (!(canvas instanceof HTMLCanvasElement)) {
-        throw new Error("Enhancement skill key target is missing");
-      }
-      skillKeyConsumer = createSkillKeyOverlayConsumer(document.body, canvas);
-      const unsubscribe = skillSlotGeometry.subscribe(skillKeyConsumer.update);
-      disposeSkillKeyOverlay = () => {
-        unsubscribe();
-        skillKeyConsumer?.dispose();
-        skillKeyConsumer = null;
-      };
-    }
+    skills.mount(document.body, optionalSettings);
     const configureTradeAlias = () => {
       configureTradeToggle?.(optionalSettings.enabled ? 1 : 0);
     };
@@ -729,28 +703,13 @@ export async function installCertifiedCompanion(
         readout = null;
       }
     };
-    const hasSkillKeyBindings = () =>
-      optionalSettings.skillKeyBindings.some((binding) => binding !== null);
-    const syncSkillKeys = () => {
-      skillKeyConsumer?.setBindings(optionalSettings.skillKeyBindings);
-      skillKeyConsumer?.setEnabled(
-        policy().skillSlotGeometry && hasSkillKeyBindings(),
-      );
-    };
-    const syncSkillCooldowns = () => skillCooldownOverlay.sync(
-      optionalSettings.skillCooldownColor,
+    const syncSkillOverlays = () => skills.sync(
+      optionalSettings,
+      policy().skillSlotGeometry,
       policy().skillCooldownOverlay,
     );
-    skillCooldownOverlay.mount(
-      document.body,
-      optionalSettings.skillCooldownColor,
-      false,
-      skillSlotGeometry.subscribe,
-      skillCooldowns.subscribe,
-    );
     setTargetEnabled();
-    syncSkillKeys();
-    syncSkillCooldowns();
+    syncSkillOverlays();
     disposeReadout = () => {
       readout?.dispose();
       readout = null;
@@ -769,14 +728,11 @@ export async function installCertifiedCompanion(
         // prove that it became PvE without restarting.
         | (foundation ? COMPANION_FEATURE_BITS.toolboxFoundation : 0)
         | (targetEnabled() ? COMPANION_FEATURE_BITS.targetObservation : 0)
-        | (hasSkillSlotGeometry
-            && policy().skillSlotGeometry
-            && (hasSkillKeyBindings() || policy().skillCooldownOverlay)
-          ? COMPANION_FEATURE_BITS.skillSlotGeometry
-          : 0)
-        | (capabilities.skillCooldownObservation && policy().skillCooldownOverlay
-          ? COMPANION_FEATURE_BITS.skillCooldownObservation
-          : 0);
+        | skills.activeFeatureFlags(
+          optionalSettings,
+          policy().skillSlotGeometry,
+          policy().skillCooldownOverlay,
+        );
       kernelDispatch(
         COMPANION_DISPATCH_KINDS.activeFeatures,
         active,
@@ -861,8 +817,7 @@ export async function installCertifiedCompanion(
       tracePolicy("settings");
       syncToolboxAvailability();
       setTargetEnabled();
-      syncSkillKeys();
-      syncSkillCooldowns();
+      syncSkillOverlays();
       syncActiveObservers();
       syncStoragePolicy();
       syncTravelPolicy();
@@ -996,8 +951,7 @@ export async function installCertifiedCompanion(
               snapshotPlayRegion = next;
               tracePolicy("region");
               setTargetEnabled();
-              syncSkillKeys();
-              syncSkillCooldowns();
+              syncSkillOverlays();
               syncActiveObservers();
             }
             readout?.update(state);
@@ -1023,8 +977,7 @@ export async function installCertifiedCompanion(
             if (playRegion() !== previousRegion) {
               tracePolicy("region");
               setTargetEnabled();
-              syncSkillKeys();
-              syncSkillCooldowns();
+              syncSkillOverlays();
               syncActiveObservers();
             }
             syncTravelPolicy();

--- a/src/renderer/client-compatibility-notice.ts
+++ b/src/renderer/client-compatibility-notice.ts
@@ -175,6 +175,19 @@ function featureStatusLabel(status: ClientCompatibility['features'][Feature]): s
   }
 }
 
+function cooldownPresentationStatus(
+  features: ClientCompatibility['features'],
+): ClientCompatibility['features'][Feature] {
+  const cooldown = features.skillCooldownObservation;
+  const geometry = features.skillSlotGeometry;
+  if (cooldown.status === 'unavailable') return cooldown;
+  if (geometry.status === 'unavailable') return geometry;
+  if (cooldown.status === 'off' || geometry.status === 'off') return offFeatureStatus;
+  return cooldown;
+}
+
+const offFeatureStatus = Object.freeze({ status: 'off' } as const);
+
 /**
  * Render the session into both fixed compatibility surfaces.
  */
@@ -210,8 +223,11 @@ export function renderClientCompatibility(
   const report = compatibilityReport(session.compatibility);
   settingsAvailability.open = report.degraded;
   for (const feature of Object.keys(session.compatibility.features) as Feature[]) {
+    const status = feature === 'skillCooldownObservation'
+      ? cooldownPresentationStatus(session.compatibility.features)
+      : session.compatibility.features[feature];
     requiredElement(root, `settings-feature-${feature}`).textContent =
-      featureStatusLabel(session.compatibility.features[feature]);
+      featureStatusLabel(status);
   }
   const detail = report.details.join(' ');
   settingsStatus.hidden = false;

--- a/src/renderer/enhancement-runtime-policy.ts
+++ b/src/renderer/enhancement-runtime-policy.ts
@@ -10,6 +10,7 @@ export type OptionalToolSettings = Readonly<{
   teamManagement: boolean;
   xunlaiStorage: boolean;
   travelPalette?: boolean;
+  skillCooldownOverlayEnabled?: boolean;
 }>;
 
 export type RuntimePlayRegion = "pve" | "pvp" | "unknown";
@@ -57,5 +58,7 @@ export function enhancementRuntimePolicy(
       developerStorage || (settings.enabled && settings.travelPalette === true)
     ),
     skillSlotGeometry: settings.enabled && pve,
+    skillCooldownOverlay:
+      settings.enabled && settings.skillCooldownOverlayEnabled === true && pve,
   });
 }

--- a/src/renderer/gw-native.d.ts
+++ b/src/renderer/gw-native.d.ts
@@ -201,6 +201,8 @@ declare global {
       travelPalette: boolean;
       targetReadout: boolean;
       skillKeyBindings: AppSettings['skillKeyBindings'];
+      skillCooldownOverlayEnabled: boolean;
+      skillCooldownColor: AppSettings['skillCooldownColor'];
     }>;
     gwLoading: LoadingController;
     gwDiagnostics: RendererDiagnostics;

--- a/src/renderer/harness.css
+++ b/src/renderer/harness.css
@@ -402,6 +402,62 @@ html,body { width:100%; height:100%; margin:0; overflow:hidden;
 }
 .settings-skill-key-clear:disabled { visibility: hidden; }
 #settings-skill-keys-clear { justify-self: start; }
+.settings-skill-cooldowns { display: grid; gap: var(--ui-space-2); }
+.settings-skill-cooldowns > .settings-note { margin: 0; }
+.settings-skill-cooldown-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 112px;
+  align-items: center;
+  gap: var(--ui-space-4);
+}
+.settings-skill-cooldown-colors { display: grid; gap: var(--ui-space-1); }
+.settings-skill-cooldown-colors > label {
+  display: grid;
+  grid-template-columns: auto 18px minmax(0, 1fr);
+  align-items: center;
+  gap: var(--ui-space-2);
+}
+.settings-skill-cooldown-colors > label > [data-cooldown-swatch],
+.settings-skill-cooldown-colors > label > .settings-skill-cooldown-custom-swatch {
+  width: 14px;
+  height: 14px;
+  border: 1px solid rgb(255 255 255 / 45%);
+  border-radius: 50%;
+  background: var(--cooldown-swatch, currentColor);
+  box-shadow: 0 0 0 1px rgb(0 0 0 / 70%);
+}
+.settings-skill-cooldown-custom {
+  display: flex;
+  align-items: center;
+  gap: var(--ui-space-2);
+  margin: var(--ui-space-1) 0 0 28px;
+}
+.settings-skill-cooldown-custom input[type="color"] { width: 38px; height: 30px; padding: 2px; }
+.settings-skill-cooldown-custom .ui-input { width: 7.5rem; }
+.settings-skill-cooldown-preview {
+  display: grid;
+  place-items: center;
+}
+.settings-skill-cooldown-preview-slot {
+  display: block;
+  position: relative;
+  width: 72px;
+  height: 72px;
+  overflow: hidden;
+  border: 1px solid rgb(170 177 168 / 82%);
+  border-radius: 7px;
+  background:
+    radial-gradient(circle at 45% 38%, rgb(70 156 188 / 90%), transparent 38%),
+    linear-gradient(145deg, #173840, #7860a2 58%, #172120);
+  box-shadow: inset 0 0 16px rgb(0 0 0 / 72%);
+}
+.settings-skill-cooldown-preview-key {
+  --skill-key-edge: 21px;
+  position: absolute;
+  right: 2px;
+  bottom: 2px;
+  max-width: calc(100% - 4px);
+}
 .settings-shortcut-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto auto;

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -494,6 +494,9 @@ window.gwToolsSettings = () => Object.freeze({
   travelPalette: appSettings?.travelPalette ?? false,
   targetReadout: appSettings?.targetReadout ?? false,
   skillKeyBindings: appSettings?.skillKeyBindings ?? emptySkillKeyBindings,
+  skillCooldownOverlayEnabled: appSettings?.skillCooldownOverlayEnabled ?? true,
+  skillCooldownColor: appSettings?.skillCooldownColor
+    ?? Object.freeze({ kind: 'preset', preset: 'red' }),
 });
 window.gwApplySettings = (next) => {
   const previousScale = appSettings?.renderScale;

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -566,7 +566,7 @@
                            aria-label="Custom cooldown hexadecimal color">
                   </div>
                 </div>
-                <div class="settings-skill-cooldown-preview" aria-label="Cooldown and key label preview">
+                <div class="settings-skill-cooldown-preview" role="img" aria-label="Cooldown and key label preview">
                   <span class="settings-skill-cooldown-preview-slot"></span>
                 </div>
               </div>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -544,6 +544,33 @@
               </div>
               <button type="button" id="settings-skill-keys-clear" class="ui-link" data-skill-key-capture-control>Clear all labels</button>
             </fieldset>
+            <fieldset id="settings-skill-cooldowns" class="settings-skill-cooldowns" hidden
+                      aria-describedby="settings-skill-cooldowns-help">
+              <legend>Skill cooldowns</legend>
+              <label class="settings-check ui-check">
+                <input type="checkbox" name="skillCooldownOverlayEnabled">
+                <span>Show cooldown numbers</span>
+              </label>
+              <p id="settings-skill-cooldowns-help" class="settings-note">Displays Guild Wars’ existing recharge state only. It never changes or sends game controls.</p>
+              <div class="settings-skill-cooldown-layout">
+                <div class="settings-skill-cooldown-colors" role="radiogroup" aria-label="Cooldown number color">
+                  <label><input type="radio" name="skillCooldownColorChoice" value="red"><span data-cooldown-swatch="red"></span><span>Guild Wars red <small>Recommended</small></span></label>
+                  <label><input type="radio" name="skillCooldownColorChoice" value="cream"><span data-cooldown-swatch="cream"></span><span>Native cream</span></label>
+                  <label><input type="radio" name="skillCooldownColorChoice" value="gold"><span data-cooldown-swatch="gold"></span><span>Warm gold</span></label>
+                  <label><input type="radio" name="skillCooldownColorChoice" value="blue"><span data-cooldown-swatch="blue"></span><span>Icy blue</span></label>
+                  <label><input type="radio" name="skillCooldownColorChoice" value="custom"><span class="settings-skill-cooldown-custom-swatch"></span><span>Custom color</span></label>
+                  <div class="settings-skill-cooldown-custom">
+                    <input type="color" name="skillCooldownCustomPicker" aria-label="Choose custom cooldown color">
+                    <input type="text" name="skillCooldownCustomHex" class="ui-input" inputmode="text"
+                           pattern="#[0-9a-fA-F]{6}" maxlength="7" spellcheck="false"
+                           aria-label="Custom cooldown hexadecimal color">
+                  </div>
+                </div>
+                <div class="settings-skill-cooldown-preview" aria-label="Cooldown and key label preview">
+                  <span class="settings-skill-cooldown-preview-slot"></span>
+                </div>
+              </div>
+            </fieldset>
           </div>
           <details id="settings-availability" class="settings-availability">
             <summary>Availability for this Guild Wars version</summary>

--- a/src/renderer/settings-skill-cooldowns.ts
+++ b/src/renderer/settings-skill-cooldowns.ts
@@ -5,6 +5,7 @@
 import type { AppSettings } from "../shared/contracts.js";
 import {
   isSkillCooldownColor,
+  isSkillCooldownCustomHex,
   SKILL_COOLDOWN_PRESET_COLORS,
   type SkillCooldownColor,
   type SkillCooldownPreset,
@@ -12,13 +13,14 @@ import {
 import { createSkillCooldownView } from "./skill-cooldown-view.js";
 import { createSkillKeyBindingView } from "./skill-key-binding-view.js";
 
-const HEX = /^#[0-9a-fA-F]{6}$/u;
+type FeedbackTone = "neutral" | "progress" | "success" | "warning" | "error";
 
 export function bindSkillCooldownSettings(options: Readonly<{
   fieldset: HTMLFieldSetElement;
   settings: () => AppSettings | null;
   persist: (patch: Pick<AppSettings, "skillCooldownColor">) => Promise<unknown>;
   recoverAfterPersistFailure: (message: string) => Promise<void>;
+  feedback: (message: string, tone: FeedbackTone, resetAfter?: number) => void;
 }>) {
   const choices = [...options.fieldset.querySelectorAll<HTMLInputElement>(
     'input[name="skillCooldownColorChoice"]',
@@ -43,8 +45,8 @@ export function bindSkillCooldownSettings(options: Readonly<{
   const selected = (): SkillCooldownColor | null => {
     const value = choices.find((choice) => choice.checked)?.value;
     if (value === "custom") {
-      return HEX.test(text.value)
-        ? { kind: "custom", value: text.value as `#${string}` }
+      return isSkillCooldownCustomHex(text.value)
+        ? { kind: "custom", value: text.value }
         : null;
     }
     return value === "red" || value === "cream" || value === "gold" || value === "blue"
@@ -62,12 +64,14 @@ export function bindSkillCooldownSettings(options: Readonly<{
     }
   };
   const validateText = () => {
-    text.setCustomValidity(HEX.test(text.value) ? "" : "Enter a six-digit color such as #e35a4f.");
+    text.setCustomValidity(isSkillCooldownCustomHex(text.value) ? "" : "Enter a six-digit color such as #e35a4f.");
   };
   const save = async (color: SkillCooldownColor) => {
     if (!isSkillCooldownColor(color)) return;
+    options.feedback("Saving…", "progress");
     try {
       await options.persist({ skillCooldownColor: color });
+      options.feedback("Cooldown color saved.", "success", 2200);
     } catch {
       await options.recoverAfterPersistFailure(
         "Review the active cooldown color before trying again.",
@@ -77,7 +81,7 @@ export function bindSkillCooldownSettings(options: Readonly<{
 
   choices.forEach((choice) => choice.addEventListener("change", () => {
     const color = selected();
-    picker.disabled = choice.value !== "custom" && !choices.some((item) => item.value === "custom" && item.checked);
+    picker.disabled = !choices.some((item) => item.value === "custom" && item.checked);
     text.disabled = picker.disabled;
     drawPreview();
     if (color) void save(color);
@@ -94,7 +98,7 @@ export function bindSkillCooldownSettings(options: Readonly<{
   });
   text.addEventListener("input", () => {
     validateText();
-    if (!HEX.test(text.value)) return;
+    if (!isSkillCooldownCustomHex(text.value)) return;
     customValue = text.value;
     picker.value = customValue;
     drawPreview();

--- a/src/renderer/settings-skill-cooldowns.ts
+++ b/src/renderer/settings-skill-cooldowns.ts
@@ -1,0 +1,128 @@
+/** Settings binder for the single canonical cooldown presentation choice. */
+import type { AppSettings } from "../shared/contracts.js";
+import {
+  isSkillCooldownColor,
+  SKILL_COOLDOWN_PRESET_COLORS,
+  type SkillCooldownColor,
+  type SkillCooldownPreset,
+} from "../shared/skill-cooldowns.js";
+import { createSkillCooldownView } from "./skill-cooldown-view.js";
+import { createSkillKeyBindingView } from "./skill-key-binding-view.js";
+
+const HEX = /^#[0-9a-fA-F]{6}$/u;
+
+export function bindSkillCooldownSettings(options: Readonly<{
+  fieldset: HTMLFieldSetElement;
+  settings: () => AppSettings | null;
+  persist: (patch: Pick<AppSettings, "skillCooldownColor">) => Promise<unknown>;
+  recoverAfterPersistFailure: (message: string) => Promise<void>;
+}>) {
+  const choices = [...options.fieldset.querySelectorAll<HTMLInputElement>(
+    'input[name="skillCooldownColorChoice"]',
+  )];
+  const enabled = options.fieldset.querySelector<HTMLInputElement>(
+    '[name="skillCooldownOverlayEnabled"]',
+  );
+  const picker = options.fieldset.querySelector<HTMLInputElement>('[name="skillCooldownCustomPicker"]');
+  const text = options.fieldset.querySelector<HTMLInputElement>('[name="skillCooldownCustomHex"]');
+  const preview = options.fieldset.querySelector<HTMLElement>('.settings-skill-cooldown-preview-slot');
+  if (!enabled || !picker || !text || !preview) throw new Error("incomplete skill cooldown settings");
+  const countdown = createSkillCooldownView(preview);
+  countdown.element.style.setProperty("--skill-cooldown-slot-height", "72px");
+  const key = createSkillKeyBindingView(preview);
+  key.element.classList.add("settings-skill-cooldown-preview-key");
+  key.update({
+    input: { kind: "keyboard", code: "KeyC" },
+    modifiers: { control: true, option: true, shift: true, command: true },
+  });
+  let customValue = "#e35a4f";
+
+  const selected = (): SkillCooldownColor | null => {
+    const value = choices.find((choice) => choice.checked)?.value;
+    if (value === "custom") {
+      return HEX.test(text.value)
+        ? { kind: "custom", value: text.value as `#${string}` }
+        : null;
+    }
+    return value === "red" || value === "cream" || value === "gold" || value === "blue"
+      ? { kind: "preset", preset: value }
+      : null;
+  };
+  const drawPreview = () => {
+    const color = selected();
+    if (color) {
+      countdown.update(2_900, color);
+      if (color.kind === "custom") {
+        options.fieldset.querySelector<HTMLElement>(".settings-skill-cooldown-custom-swatch")
+          ?.style.setProperty("--cooldown-swatch", color.value);
+      }
+    }
+  };
+  const validateText = () => {
+    text.setCustomValidity(HEX.test(text.value) ? "" : "Enter a six-digit color such as #e35a4f.");
+  };
+  const save = async (color: SkillCooldownColor) => {
+    if (!isSkillCooldownColor(color)) return;
+    try {
+      await options.persist({ skillCooldownColor: color });
+    } catch {
+      await options.recoverAfterPersistFailure(
+        "Review the active cooldown color before trying again.",
+      );
+    }
+  };
+
+  choices.forEach((choice) => choice.addEventListener("change", () => {
+    const color = selected();
+    picker.disabled = choice.value !== "custom" && !choices.some((item) => item.value === "custom" && item.checked);
+    text.disabled = picker.disabled;
+    drawPreview();
+    if (color) void save(color);
+  }));
+  picker.addEventListener("input", () => {
+    customValue = picker.value;
+    text.value = customValue;
+    validateText();
+    drawPreview();
+  });
+  picker.addEventListener("change", () => {
+    const color = selected();
+    if (color) void save(color);
+  });
+  text.addEventListener("input", () => {
+    validateText();
+    if (!HEX.test(text.value)) return;
+    customValue = text.value;
+    picker.value = customValue;
+    drawPreview();
+  });
+  text.addEventListener("change", () => {
+    const color = selected();
+    if (color) void save(color);
+  });
+
+  return Object.freeze({
+    render(settings: AppSettings) {
+      options.fieldset.hidden = !settings.gwonmacTools;
+      enabled.checked = settings.skillCooldownOverlayEnabled;
+      enabled.disabled = !settings.gwonmacTools;
+      const color = settings.skillCooldownColor;
+      if (color.kind === "custom") customValue = color.value;
+      const value = color.kind === "custom" ? "custom" : color.preset;
+      choices.forEach((choice) => { choice.checked = choice.value === value; });
+      picker.value = customValue;
+      text.value = customValue;
+      options.fieldset.querySelector<HTMLElement>(".settings-skill-cooldown-custom-swatch")
+        ?.style.setProperty("--cooldown-swatch", customValue);
+      const custom = value === "custom";
+      picker.disabled = !custom;
+      text.disabled = !custom;
+      validateText();
+      countdown.update(2_900, color);
+      for (const [preset, cssColor] of Object.entries(SKILL_COOLDOWN_PRESET_COLORS)) {
+        const swatch = options.fieldset.querySelector<HTMLElement>(`[data-cooldown-swatch="${preset as SkillCooldownPreset}"]`);
+        swatch?.style.setProperty("--cooldown-swatch", cssColor);
+      }
+    },
+  });
+}

--- a/src/renderer/settings-skill-cooldowns.ts
+++ b/src/renderer/settings-skill-cooldowns.ts
@@ -1,4 +1,7 @@
-/** Settings binder for the single canonical cooldown presentation choice. */
+/**
+ * Settings binder for the single canonical cooldown presentation choice.
+ * The shared view remains the only owner of how that choice is drawn.
+ */
 import type { AppSettings } from "../shared/contracts.js";
 import {
   isSkillCooldownColor,

--- a/src/renderer/settings.ts
+++ b/src/renderer/settings.ts
@@ -282,6 +282,13 @@
       recoverAfterPersistFailure: recoverSettingsAfterFailedWrite,
       feedback: setFeedback,
     }));
+  const skillCooldownSettings = import('./settings-skill-cooldowns.js').then((module) =>
+    module.bindSkillCooldownSettings({
+      fieldset: byId('settings-skill-cooldowns') as HTMLFieldSetElement,
+      settings: () => currentSettings,
+      persist: (patch) => persistSettings(patch),
+      recoverAfterPersistFailure: recoverSettingsAfterFailedWrite,
+    }));
   void import('./settings-accounts.js').then((module) =>
     module.bindAccountSettings({
       enable: accountsEnable,
@@ -474,6 +481,7 @@
       case 'xunlaiStorage':
       case 'travelPalette':
       case 'targetReadout':
+      case 'skillCooldownOverlayEnabled':
         return control instanceof globalThis.HTMLInputElement
           ? { [control.name]: control.checked }
           : null;
@@ -516,6 +524,7 @@
     targetReadout.checked = settings.targetReadout;
     void shortcutSettings.then((binder) => binder.render(settings));
     void skillKeySettings.then((binder) => binder.render(settings));
+    void skillCooldownSettings.then((binder) => binder.render(settings));
     toolFeatures.hidden = !settings.gwonmacTools;
     toolsOff.hidden = settings.gwonmacTools;
     teamManagement.disabled = !settings.gwonmacTools;

--- a/src/renderer/settings.ts
+++ b/src/renderer/settings.ts
@@ -288,6 +288,7 @@
       settings: () => currentSettings,
       persist: (patch) => persistSettings(patch),
       recoverAfterPersistFailure: recoverSettingsAfterFailedWrite,
+      feedback: setFeedback,
     }));
   void import('./settings-accounts.js').then((module) =>
     module.bindAccountSettings({

--- a/src/renderer/skill-cooldown-overlay-consumer.ts
+++ b/src/renderer/skill-cooldown-overlay-consumer.ts
@@ -8,6 +8,7 @@ import type {
   CompanionSkillSlotState,
 } from "./companion-skill-snapshot.js";
 import { createSkillCooldownOverlay, type SkillCooldownSlot } from "./skill-cooldown-overlay.js";
+import { projectSkillSlots } from "./skill-slot-projection.js";
 
 export function createSkillCooldownOverlayConsumer(
   parent: HTMLElement,
@@ -27,19 +28,15 @@ export function createSkillCooldownOverlayConsumer(
       || geometry.slots.length !== 8
       || cooldowns.rechargeTimestamps.length !== 8
     ) return null;
-    const canvasRect = canvas.getBoundingClientRect();
-    const scaleX = canvasRect.width / geometry.viewportWidth;
-    const scaleY = canvasRect.height / geometry.viewportHeight;
+    const projected = projectSkillSlots(geometry, canvas);
+    if (projected === null) return null;
     const slots: SkillCooldownSlot[] = [];
     for (let index = 0; index < 8; index += 1) {
-      const rect = geometry.slots[index]!;
+      const rect = projected[index]!;
       const timestamp = cooldowns.rechargeTimestamps[index]!;
       const remainingMs = timestamp === 0 ? 0 : (timestamp - cooldowns.gameTimer) >>> 0;
       slots.push(Object.freeze({
-        x: canvasRect.left + rect.left * scaleX,
-        y: canvasRect.top + (geometry.viewportHeight - rect.top) * scaleY,
-        width: (rect.right - rect.left) * scaleX,
-        height: (rect.top - rect.bottom) * scaleY,
+        ...rect,
         remainingMs,
       }));
     }

--- a/src/renderer/skill-cooldown-overlay-consumer.ts
+++ b/src/renderer/skill-cooldown-overlay-consumer.ts
@@ -1,0 +1,65 @@
+/** Joins certified slot geometry and recharge state at the presentation edge. */
+import type { SkillCooldownColor } from "../shared/skill-cooldowns.js";
+import type {
+  CompanionSkillCooldownState,
+  CompanionSkillSlotState,
+} from "./companion-skill-snapshot.js";
+import { createSkillCooldownOverlay, type SkillCooldownSlot } from "./skill-cooldown-overlay.js";
+
+export function createSkillCooldownOverlayConsumer(
+  parent: HTMLElement,
+  canvas: HTMLCanvasElement,
+) {
+  const overlay = createSkillCooldownOverlay(parent);
+  let geometry: CompanionSkillSlotState = Object.freeze({ status: "waiting", reason: "memory" });
+  let cooldowns: CompanionSkillCooldownState = Object.freeze({ status: "waiting", reason: "memory" });
+  let color: SkillCooldownColor = Object.freeze({ kind: "preset", preset: "red" });
+  let enabled = false;
+
+  function projection(): readonly SkillCooldownSlot[] | null {
+    if (
+      !enabled
+      || geometry.status !== "ready"
+      || cooldowns.status !== "ready"
+      || geometry.slots.length !== 8
+      || cooldowns.rechargeTimestamps.length !== 8
+    ) return null;
+    const canvasRect = canvas.getBoundingClientRect();
+    const scaleX = canvasRect.width / geometry.viewportWidth;
+    const scaleY = canvasRect.height / geometry.viewportHeight;
+    const slots: SkillCooldownSlot[] = [];
+    for (let index = 0; index < 8; index += 1) {
+      const rect = geometry.slots[index]!;
+      const timestamp = cooldowns.rechargeTimestamps[index]!;
+      const remainingMs = timestamp === 0 ? 0 : (timestamp - cooldowns.gameTimer) >>> 0;
+      slots.push(Object.freeze({
+        x: canvasRect.left + rect.left * scaleX,
+        y: canvasRect.top + (geometry.viewportHeight - rect.top) * scaleY,
+        width: (rect.right - rect.left) * scaleX,
+        height: (rect.top - rect.bottom) * scaleY,
+        remainingMs,
+      }));
+    }
+    return Object.freeze(slots);
+  }
+  function render() { overlay.update(projection(), color); }
+
+  return Object.freeze({
+    update(next: CompanionSkillSlotState) {
+      geometry = next;
+      render();
+    },
+    setCooldownState(next: CompanionSkillCooldownState) {
+      cooldowns = next;
+      render();
+    },
+    sync(nextColor: SkillCooldownColor, nextEnabled: boolean) {
+      color = nextColor;
+      enabled = nextEnabled;
+      render();
+    },
+    dispose() {
+      overlay.dispose();
+    },
+  });
+}

--- a/src/renderer/skill-cooldown-overlay-consumer.ts
+++ b/src/renderer/skill-cooldown-overlay-consumer.ts
@@ -1,4 +1,7 @@
-/** Joins certified slot geometry and recharge state at the presentation edge. */
+/**
+ * Joins certified slot geometry and recharge state at the presentation edge.
+ * Neither source is reinterpreted or retained as gameplay state here.
+ */
 import type { SkillCooldownColor } from "../shared/skill-cooldowns.js";
 import type {
   CompanionSkillCooldownState,

--- a/src/renderer/skill-cooldown-overlay-installation.ts
+++ b/src/renderer/skill-cooldown-overlay-installation.ts
@@ -1,0 +1,45 @@
+/** Owns the cooldown HUD and its subscriptions to accepted native state. */
+import type { SkillCooldownColor } from "../shared/skill-cooldowns.js";
+import type {
+  CompanionSkillCooldownState,
+  CompanionSkillSlotState,
+} from "./companion-skill-snapshot.js";
+import { createSkillCooldownOverlayConsumer } from "./skill-cooldown-overlay-consumer.js";
+
+export function createSkillCooldownOverlayInstallation(available: boolean) {
+  let consumer: ReturnType<typeof createSkillCooldownOverlayConsumer> | null = null;
+  let unsubscribeGeometry: (() => void) | null = null;
+  let unsubscribeCooldowns: (() => void) | null = null;
+  return Object.freeze({
+    mount(
+      parent: HTMLElement,
+      color: SkillCooldownColor,
+      enabled: boolean,
+      subscribeGeometry: (listener: (state: CompanionSkillSlotState) => void) => () => void,
+      subscribeCooldowns: (
+        listener: (state: CompanionSkillCooldownState) => void,
+      ) => () => void,
+    ) {
+      if (!available || consumer !== null) return;
+      const canvas = parent.ownerDocument.getElementById("canvas");
+      if (!(canvas instanceof HTMLCanvasElement)) {
+        throw new Error("Enhancement skill cooldown target is missing");
+      }
+      consumer = createSkillCooldownOverlayConsumer(parent, canvas);
+      unsubscribeGeometry = subscribeGeometry(consumer.update);
+      unsubscribeCooldowns = subscribeCooldowns(consumer.setCooldownState);
+      consumer.sync(color, enabled);
+    },
+    sync(color: SkillCooldownColor, enabled: boolean) {
+      consumer?.sync(color, enabled);
+    },
+    dispose() {
+      unsubscribeGeometry?.();
+      unsubscribeCooldowns?.();
+      unsubscribeGeometry = null;
+      unsubscribeCooldowns = null;
+      consumer?.dispose();
+      consumer = null;
+    },
+  });
+}

--- a/src/renderer/skill-cooldown-overlay-installation.ts
+++ b/src/renderer/skill-cooldown-overlay-installation.ts
@@ -1,4 +1,7 @@
-/** Owns the cooldown HUD and its subscriptions to accepted native state. */
+/**
+ * Owns the cooldown HUD and subscriptions to accepted native state. Certified
+ * memory allocation remains in the observation installation.
+ */
 import type { SkillCooldownColor } from "../shared/skill-cooldowns.js";
 import type {
   CompanionSkillCooldownState,

--- a/src/renderer/skill-cooldown-overlay.ts
+++ b/src/renderer/skill-cooldown-overlay.ts
@@ -1,0 +1,72 @@
+/** Pointer-transparent eight-slot cooldown presentation. */
+import type { SkillCooldownColor } from "../shared/skill-cooldowns.js";
+import { formatSkillCooldown } from "../shared/skill-cooldowns.js";
+import { createSkillCooldownView } from "./skill-cooldown-view.js";
+
+export type SkillCooldownSlot = Readonly<{
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  remainingMs: number;
+}>;
+
+const ROOT_STYLE = "position:fixed;inset:0;z-index:2;display:none;overflow:hidden;pointer-events:none;user-select:none";
+const SLOT_STYLE = "position:absolute;pointer-events:none;overflow:hidden";
+
+function validSlot(value: SkillCooldownSlot): boolean {
+  return [value.x, value.y, value.width, value.height, value.remainingMs].every(Number.isFinite)
+    && Math.abs(value.x) <= 32_768
+    && Math.abs(value.y) <= 32_768
+    && value.width > 0
+    && value.width <= 2_048
+    && value.height > 0
+    && value.height <= 2_048
+    && Number.isSafeInteger(value.remainingMs)
+    && value.remainingMs >= 0;
+}
+
+export function createSkillCooldownOverlay(parent: HTMLElement) {
+  const document = parent.ownerDocument;
+  const root = document.createElement("div");
+  root.id = "skill-cooldown-overlay";
+  root.setAttribute("aria-hidden", "true");
+  root.style.cssText = ROOT_STYLE;
+  const views = Array.from({ length: 8 }, () => {
+    const slot = document.createElement("span");
+    slot.style.cssText = SLOT_STYLE;
+    root.append(slot);
+    return { slot, countdown: createSkillCooldownView(slot) };
+  });
+  parent.append(root);
+  let signature = "";
+  return Object.freeze({
+    update(slots: readonly SkillCooldownSlot[] | null, color: SkillCooldownColor) {
+      if (slots !== null && (slots.length !== 8 || slots.some((slot) => !validSlot(slot)))) {
+        slots = null;
+      }
+      const next = slots === null ? "" : `${slots.map((slot) =>
+        `${slot.x},${slot.y},${slot.width},${slot.height},${formatSkillCooldown(slot.remainingMs) ?? ""}`
+      ).join(";")}|${JSON.stringify(color)}`;
+      if (next === signature) return;
+      signature = next;
+      if (slots === null) {
+        root.style.display = "none";
+        return;
+      }
+      slots.forEach((value, index) => {
+        const view = views[index]!;
+        view.slot.style.cssText = `${SLOT_STYLE};left:${value.x}px;top:${value.y}px;width:${value.width}px;height:${value.height}px`;
+        view.countdown.element.style.setProperty("--skill-cooldown-slot-height", `${value.height}px`);
+        view.countdown.update(value.remainingMs, color);
+      });
+      root.style.display = slots.some((slot) => formatSkillCooldown(slot.remainingMs) !== null)
+        ? "block"
+        : "none";
+    },
+    get state() {
+      return Object.freeze({ visible: root.style.display === "block", signature });
+    },
+    dispose() { root.remove(); },
+  });
+}

--- a/src/renderer/skill-cooldown-overlay.ts
+++ b/src/renderer/skill-cooldown-overlay.ts
@@ -1,4 +1,7 @@
-/** Pointer-transparent eight-slot cooldown presentation. */
+/**
+ * Pointer-transparent eight-slot cooldown presentation.
+ * This owner writes the DOM only when visible labels or slot geometry change.
+ */
 import type { SkillCooldownColor } from "../shared/skill-cooldowns.js";
 import { formatSkillCooldown } from "../shared/skill-cooldowns.js";
 import { createSkillCooldownView } from "./skill-cooldown-view.js";

--- a/src/renderer/skill-cooldown-state-installation.ts
+++ b/src/renderer/skill-cooldown-state-installation.ts
@@ -49,6 +49,9 @@ export function createSkillCooldownObservationInstallation(
     get sink() {
       return available ? feed : null;
     },
+    subscribe(listener: (state: CompanionSkillCooldownState) => void) {
+      return available ? feed.subscribe(listener) : () => false;
+    },
     allocate(malloc: Malloc) {
       if (available && pointer === 0) {
         pointer = Number(malloc(COMPANION_SKILL_COOLDOWN_BYTES));

--- a/src/renderer/skill-cooldown-view.ts
+++ b/src/renderer/skill-cooldown-view.ts
@@ -1,4 +1,7 @@
-/** Shared native-style cooldown text used by the HUD and Settings preview. */
+/**
+ * Shared native-style cooldown text used by the HUD and Settings preview.
+ * Font, outline, optical position, scaling, and color stay identical in both.
+ */
 import {
   formatSkillCooldown,
   skillCooldownCssColor,

--- a/src/renderer/skill-cooldown-view.ts
+++ b/src/renderer/skill-cooldown-view.ts
@@ -1,0 +1,89 @@
+/** Shared native-style cooldown text used by the HUD and Settings preview. */
+import {
+  formatSkillCooldown,
+  skillCooldownCssColor,
+  type SkillCooldownColor,
+} from "../shared/skill-cooldowns.js";
+import { ensureGuildWarsFont } from "./appearance.js";
+
+const STYLE_ID = "skill-cooldown-styles";
+const STYLE = `
+.skill-cooldown-label {
+  --skill-cooldown-slot-height: 64px;
+  --skill-cooldown-optical-x: -2%;
+  --skill-cooldown-optical-y: -4%;
+  --skill-cooldown-outline: #120d0a;
+  --skill-cooldown-shadow: rgb(0 0 0 / 88%);
+  display: flex;
+  position: absolute;
+  inset: 0;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+  color: var(--skill-cooldown-color);
+  font-family: "Guild Wars Original Display", "Guild Wars Original", "QTFrizQuad", Palatino, Georgia, serif;
+  font-size: calc(var(--skill-cooldown-slot-height) * .56);
+  font-weight: 400;
+  font-variant-numeric: tabular-nums;
+  line-height: .9;
+  letter-spacing: -.025em;
+  pointer-events: none;
+  user-select: none;
+  -webkit-font-smoothing: antialiased;
+}
+.skill-cooldown-label[hidden] { display: none; }
+.skill-cooldown-glyph {
+  display: block;
+  max-width: 82%;
+  overflow: hidden;
+  transform: translate(var(--skill-cooldown-optical-x), var(--skill-cooldown-optical-y));
+  -webkit-text-stroke: max(1px, calc(var(--skill-cooldown-slot-height) * .028)) var(--skill-cooldown-outline);
+  paint-order: stroke fill;
+  text-shadow:
+    0 2px 2px var(--skill-cooldown-shadow),
+    1px 0 1px var(--skill-cooldown-shadow),
+    -1px 0 1px var(--skill-cooldown-shadow),
+    0 -1px 1px var(--skill-cooldown-shadow);
+  white-space: nowrap;
+}
+.skill-cooldown-label[data-decimal="true"] { font-size: calc(var(--skill-cooldown-slot-height) * .48); }
+.skill-cooldown-label[data-long="true"] { font-size: calc(var(--skill-cooldown-slot-height) * .40); }
+`;
+
+function ensureStyles(document: Document): void {
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = STYLE;
+  document.head.append(style);
+}
+
+export function createSkillCooldownView(parent: HTMLElement) {
+  const document = parent.ownerDocument;
+  ensureStyles(document);
+  void ensureGuildWarsFont();
+  const element = document.createElement("span");
+  element.className = "skill-cooldown-label";
+  element.setAttribute("aria-hidden", "true");
+  const glyph = document.createElement("span");
+  glyph.className = "skill-cooldown-glyph";
+  element.append(glyph);
+  parent.append(element);
+  let signature = "";
+  return Object.freeze({
+    element,
+    update(remainingMs: number, color: SkillCooldownColor) {
+      const label = formatSkillCooldown(remainingMs);
+      const cssColor = skillCooldownCssColor(color);
+      const next = label === null ? "" : `${label}|${cssColor}`;
+      if (signature === next) return;
+      signature = next;
+      element.hidden = label === null;
+      if (label === null) return;
+      glyph.textContent = label;
+      element.style.setProperty("--skill-cooldown-color", cssColor);
+      element.dataset.decimal = String(label.includes("."));
+      element.dataset.long = String(label.length >= 4);
+    },
+  });
+}

--- a/src/renderer/skill-key-overlay-consumer.ts
+++ b/src/renderer/skill-key-overlay-consumer.ts
@@ -10,6 +10,7 @@ import {
   cloneSkillKeyBindings,
   type SkillKeyBindings,
 } from "../shared/skill-key-bindings.js";
+import { projectSkillSlots } from "./skill-slot-projection.js";
 
 export function createSkillKeyOverlayConsumer(
   parent: HTMLElement,
@@ -32,20 +33,18 @@ export function createSkillKeyOverlayConsumer(
       overlay.update({ status: "waiting" });
       return;
     }
-    const ready = state;
-    const canvasRect = canvas.getBoundingClientRect();
-    const scaleX = canvasRect.width / ready.viewportWidth;
-    const scaleY = canvasRect.height / ready.viewportHeight;
+    const projected = projectSkillSlots(state, canvas);
+    if (projected === null) {
+      overlay.update({ status: "waiting" });
+      return;
+    }
     overlay.update({
       status: "ready",
       slots: bindings.flatMap((binding, index) => {
         if (binding === null) return [];
-        const slot = ready.slots[index]!;
+        const slot = projected[index]!;
         return [{
-          x: canvasRect.left + slot.left * scaleX,
-          y: canvasRect.top + (ready.viewportHeight - slot.top) * scaleY,
-          width: (slot.right - slot.left) * scaleX,
-          height: (slot.top - slot.bottom) * scaleY,
+          ...slot,
           binding,
         }];
       }),

--- a/src/renderer/skill-overlays-installation.ts
+++ b/src/renderer/skill-overlays-installation.ts
@@ -1,0 +1,91 @@
+/**
+ * Coordinates the two presentation-only skill HUDs over their independent
+ * certified geometry and recharge feeds. Native ownership stays in the feed
+ * installations; this module owns only their shared settings/policy lifecycle.
+ */
+import { COMPANION_FEATURE_BITS } from "../shared/companion-abi.js";
+import type { AppSettings } from "../shared/contracts.js";
+import type { EnhancementCapabilities } from "../shared/enhancement-contracts.js";
+import { createSkillCooldownOverlayInstallation } from "./skill-cooldown-overlay-installation.js";
+import { createSkillCooldownObservationInstallation } from "./skill-cooldown-state-installation.js";
+import { createSkillKeyOverlayConsumer } from "./skill-key-overlay-consumer.js";
+import { createSkillSlotGeometryInstallation } from "./skill-slot-geometry-installation.js";
+
+type SkillSettings = Pick<AppSettings, "skillKeyBindings" | "skillCooldownColor">;
+
+export function createSkillOverlaysInstallation(
+  capabilities: Pick<EnhancementCapabilities, "skillSlotGeometry" | "skillCooldownObservation">,
+) {
+  const geometry = createSkillSlotGeometryInstallation(capabilities.skillSlotGeometry);
+  const cooldowns = createSkillCooldownObservationInstallation(
+    capabilities.skillCooldownObservation,
+  );
+  const cooldownOverlay = createSkillCooldownOverlayInstallation(
+    capabilities.skillCooldownObservation && capabilities.skillSlotGeometry,
+  );
+  let keyConsumer: ReturnType<typeof createSkillKeyOverlayConsumer> | null = null;
+  let unsubscribeKeyGeometry: (() => void) | null = null;
+
+  const hasKeyBindings = (settings: SkillSettings) =>
+    settings.skillKeyBindings.some((binding) => binding !== null);
+
+  return Object.freeze({
+    geometry,
+    cooldowns,
+    certifiedFeatureFlags:
+      (capabilities.skillSlotGeometry ? COMPANION_FEATURE_BITS.skillSlotGeometry : 0)
+      | (capabilities.skillCooldownObservation
+        ? COMPANION_FEATURE_BITS.skillCooldownObservation
+        : 0),
+    mount(parent: HTMLElement, settings: SkillSettings) {
+      if (capabilities.skillSlotGeometry) {
+        const canvas = parent.ownerDocument.getElementById("canvas");
+        if (!(canvas instanceof HTMLCanvasElement)) {
+          throw new Error("Enhancement skill overlay target is missing");
+        }
+        keyConsumer = createSkillKeyOverlayConsumer(parent, canvas);
+        unsubscribeKeyGeometry = geometry.subscribe(keyConsumer.update);
+      }
+      cooldownOverlay.mount(
+        parent,
+        settings.skillCooldownColor,
+        false,
+        geometry.subscribe,
+        cooldowns.subscribe,
+      );
+    },
+    sync(settings: SkillSettings, geometryEnabled: boolean, cooldownEnabled: boolean) {
+      keyConsumer?.setBindings(settings.skillKeyBindings);
+      keyConsumer?.setEnabled(geometryEnabled && hasKeyBindings(settings));
+      cooldownOverlay.sync(settings.skillCooldownColor, cooldownEnabled);
+    },
+    activeFeatureFlags(
+      settings: SkillSettings,
+      geometryEnabled: boolean,
+      cooldownEnabled: boolean,
+    ) {
+      return (
+        capabilities.skillSlotGeometry
+          && geometryEnabled
+          && (hasKeyBindings(settings) || cooldownEnabled)
+          ? COMPANION_FEATURE_BITS.skillSlotGeometry
+          : 0
+      ) | (
+        capabilities.skillCooldownObservation && cooldownEnabled
+          ? COMPANION_FEATURE_BITS.skillCooldownObservation
+          : 0
+      );
+    },
+    disposePresentation() {
+      const failures: unknown[] = [];
+      try { unsubscribeKeyGeometry?.(); } catch (cause) { failures.push(cause); }
+      unsubscribeKeyGeometry = null;
+      try { keyConsumer?.dispose(); } catch (cause) { failures.push(cause); }
+      keyConsumer = null;
+      try { cooldownOverlay.dispose(); } catch (cause) { failures.push(cause); }
+      if (failures.length > 0) {
+        throw new AggregateError(failures, "Skill overlay cleanup failed");
+      }
+    },
+  });
+}

--- a/src/renderer/skill-slot-projection.ts
+++ b/src/renderer/skill-slot-projection.ts
@@ -1,0 +1,44 @@
+/** The one conversion from certified game coordinates to viewport CSS pixels. */
+import type { CompanionSkillSlotState } from "./companion-skill-snapshot.js";
+
+export type SkillSlotProjection = Readonly<{
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}>;
+
+export function projectSkillSlots(
+  state: CompanionSkillSlotState,
+  canvas: HTMLCanvasElement,
+): readonly SkillSlotProjection[] | null {
+  if (state.status !== "ready" || state.slots.length !== 8) return null;
+  const canvasRect = canvas.getBoundingClientRect();
+  if (
+    !Number.isFinite(canvasRect.left)
+    || !Number.isFinite(canvasRect.top)
+    || !Number.isFinite(canvasRect.width)
+    || !Number.isFinite(canvasRect.height)
+    || canvasRect.width <= 0
+    || canvasRect.height <= 0
+    || state.viewportWidth <= 0
+    || state.viewportHeight <= 0
+  ) return null;
+  const scaleX = canvasRect.width / state.viewportWidth;
+  const scaleY = canvasRect.height / state.viewportHeight;
+  const projected = state.slots.map((slot) => Object.freeze({
+    x: canvasRect.left + slot.left * scaleX,
+    y: canvasRect.top + (state.viewportHeight - slot.top) * scaleY,
+    width: (slot.right - slot.left) * scaleX,
+    height: (slot.top - slot.bottom) * scaleY,
+  }));
+  return projected.every((slot) =>
+    Number.isFinite(slot.x)
+    && Number.isFinite(slot.y)
+    && Number.isFinite(slot.width)
+    && Number.isFinite(slot.height)
+    && slot.width > 0
+    && slot.height > 0)
+    ? Object.freeze(projected)
+    : null;
+}

--- a/src/renderer/skill-slot-projection.ts
+++ b/src/renderer/skill-slot-projection.ts
@@ -1,4 +1,7 @@
-/** The one conversion from certified game coordinates to viewport CSS pixels. */
+/**
+ * The one conversion from certified game coordinates to viewport CSS pixels.
+ * Invalid geometry and hidden canvases withdraw the complete projection.
+ */
 import type { CompanionSkillSlotState } from "./companion-skill-snapshot.js";
 
 export type SkillSlotProjection = Readonly<{

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -48,6 +48,10 @@ import type {
   SkillKeyCaptureResult,
 } from "./skill-key-bindings.js";
 import {
+  DEFAULT_SKILL_COOLDOWN_COLOR,
+  type SkillCooldownColor,
+} from "./skill-cooldowns.js";
+import {
   DEFAULT_STORED_TRAVEL_SHORTCUTS,
   type StoredTravelShortcuts,
   type TravelUserPreferences,
@@ -369,6 +373,10 @@ export interface AppSettings {
   shortcutOverrides: ShortcutOverrides;
   /** Display-only labels that mirror the player's eight Guild Wars bindings. */
   skillKeyBindings: SkillKeyBindings;
+  /** Show Guild Wars' observed recharge state as display-only countdowns. */
+  skillCooldownOverlayEnabled: boolean;
+  /** One curated or exact RGB color shared by all eight cooldown labels. */
+  skillCooldownColor: SkillCooldownColor;
   /** Request the certified 4 GB client module on the next Guild Wars launch. */
   extendedMemoryEnabled: boolean;
   showDiagnostics: boolean;
@@ -442,6 +450,8 @@ export const DEFAULT_SETTINGS: AppSettings = {
   targetReadout: false,
   shortcutOverrides: {},
   skillKeyBindings: [null, null, null, null, null, null, null, null],
+  skillCooldownOverlayEnabled: true,
+  skillCooldownColor: DEFAULT_SKILL_COOLDOWN_COLOR,
   extendedMemoryEnabled: false,
   showDiagnostics: false,
   dataStrategy: "full",

--- a/src/shared/skill-cooldowns.ts
+++ b/src/shared/skill-cooldowns.ts
@@ -1,4 +1,7 @@
-/** Canonical settings and display rules for the presentation-only skill timer. */
+/**
+ * Canonical settings and display rules for the presentation-only skill timer.
+ * This module owns no game observation, DOM, persistence, or input behavior.
+ */
 export const SKILL_COOLDOWN_PRESETS = ["red", "cream", "gold", "blue"] as const;
 export type SkillCooldownPreset = (typeof SKILL_COOLDOWN_PRESETS)[number];
 

--- a/src/shared/skill-cooldowns.ts
+++ b/src/shared/skill-cooldowns.ts
@@ -20,6 +20,10 @@ export const MAX_SKILL_COOLDOWN_MS = 1_800_000;
 const CUSTOM_COLOR = /^#[0-9a-fA-F]{6}$/u;
 const PRESETS = new Set<unknown>(SKILL_COOLDOWN_PRESETS);
 
+export function isSkillCooldownCustomHex(value: unknown): value is `#${string}` {
+  return typeof value === "string" && CUSTOM_COLOR.test(value);
+}
+
 export function isSkillCooldownColor(value: unknown): value is SkillCooldownColor {
   if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
   const color = value as Record<string, unknown>;
@@ -28,8 +32,7 @@ export function isSkillCooldownColor(value: unknown): value is SkillCooldownColo
   }
   return color.kind === "custom"
     && Object.keys(color).length === 2
-    && typeof color.value === "string"
-    && CUSTOM_COLOR.test(color.value);
+    && isSkillCooldownCustomHex(color.value);
 }
 
 export function cloneSkillCooldownColor(color: SkillCooldownColor): SkillCooldownColor {

--- a/src/shared/skill-cooldowns.ts
+++ b/src/shared/skill-cooldowns.ts
@@ -1,0 +1,65 @@
+/** Canonical settings and display rules for the presentation-only skill timer. */
+export const SKILL_COOLDOWN_PRESETS = ["red", "cream", "gold", "blue"] as const;
+export type SkillCooldownPreset = (typeof SKILL_COOLDOWN_PRESETS)[number];
+
+export type SkillCooldownColor =
+  | Readonly<{ kind: "preset"; preset: SkillCooldownPreset }>
+  | Readonly<{ kind: "custom"; value: `#${string}` }>;
+
+export const DEFAULT_SKILL_COOLDOWN_COLOR: SkillCooldownColor = Object.freeze({
+  kind: "preset",
+  preset: "red",
+});
+
+export const SKILL_COOLDOWN_DECIMAL_THRESHOLD_MS = 3_000;
+export const MAX_SKILL_COOLDOWN_MS = 1_800_000;
+
+const CUSTOM_COLOR = /^#[0-9a-fA-F]{6}$/u;
+const PRESETS = new Set<unknown>(SKILL_COOLDOWN_PRESETS);
+
+export function isSkillCooldownColor(value: unknown): value is SkillCooldownColor {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return false;
+  const color = value as Record<string, unknown>;
+  if (color.kind === "preset") {
+    return Object.keys(color).length === 2 && PRESETS.has(color.preset);
+  }
+  return color.kind === "custom"
+    && Object.keys(color).length === 2
+    && typeof color.value === "string"
+    && CUSTOM_COLOR.test(color.value);
+}
+
+export function cloneSkillCooldownColor(color: SkillCooldownColor): SkillCooldownColor {
+  return color.kind === "preset"
+    ? Object.freeze({ kind: "preset", preset: color.preset })
+    : Object.freeze({ kind: "custom", value: color.value });
+}
+
+/**
+ * Format a certified remaining duration. Active values below three seconds use
+ * tenths rounded upward, so an unavailable skill never flashes `0.0`.
+ */
+export function formatSkillCooldown(remainingMs: unknown): string | null {
+  if (
+    typeof remainingMs !== "number"
+    || !Number.isSafeInteger(remainingMs)
+    || remainingMs <= 0
+    || remainingMs > MAX_SKILL_COOLDOWN_MS
+  ) return null;
+  if (remainingMs < SKILL_COOLDOWN_DECIMAL_THRESHOLD_MS) {
+    return (Math.ceil(remainingMs / 100) / 10).toFixed(1);
+  }
+  return String(Math.ceil(remainingMs / 1_000));
+}
+
+export const SKILL_COOLDOWN_PRESET_COLORS: Readonly<Record<SkillCooldownPreset, string>> =
+  Object.freeze({
+    red: "#e35a4f",
+    cream: "#f3e8c8",
+    gold: "#e4b957",
+    blue: "#85cbea",
+  });
+
+export function skillCooldownCssColor(color: SkillCooldownColor): string {
+  return color.kind === "custom" ? color.value : SKILL_COOLDOWN_PRESET_COLORS[color.preset];
+}

--- a/tests/helpers/packaged-enhancement-scenarios.ts
+++ b/tests/helpers/packaged-enhancement-scenarios.ts
@@ -369,6 +369,8 @@ export async function assertCleanupSafetyGates() {
             travelPalette: true,
             targetReadout: false,
             skillKeyBindings: [null, null, null, null, null, null, null, null] as const,
+            skillCooldownOverlayEnabled: true,
+            skillCooldownColor: { kind: "preset", preset: "red" } as const,
           });
         });
       }
@@ -710,6 +712,8 @@ export async function assertToolboxFoundationLifecycle() {
       travelPalette: true,
         targetReadout: false,
         skillKeyBindings: [null, null, null, null, null, null, null, null] as const,
+        skillCooldownOverlayEnabled: true,
+        skillCooldownColor: { kind: "preset", preset: "red" } as const,
       });
       const runtime = await installCertifiedCompanion(
         {
@@ -1153,6 +1157,8 @@ export async function assertRollbackAfterTablePublication() {
       travelPalette: true,
           targetReadout: false,
           skillKeyBindings: [null, null, null, null, null, null, null, null] as const,
+          skillCooldownOverlayEnabled: true,
+          skillCooldownColor: { kind: "preset", preset: "red" } as const,
         });
         globalThis.requestAnimationFrame = () => {
           installedCursorStatePublished = typeof window.gwCursorState === "function";

--- a/tests/policy/skill-cooldowns-are-display-only.test.ts
+++ b/tests/policy/skill-cooldowns-are-display-only.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const rendererSources = [
+  "src/renderer/skill-cooldown-view.ts",
+  "src/renderer/skill-cooldown-overlay.ts",
+  "src/renderer/skill-cooldown-overlay-consumer.ts",
+  "src/renderer/skill-cooldown-observation-installation.ts",
+  "src/renderer/settings-skill-cooldowns.ts",
+] as const;
+
+test("cooldown presentation has no gameplay input or command dependency", async () => {
+  const source = (await Promise.all(rendererSources.map((path) => readFile(path, "utf8"))))
+    .join("\n");
+  assert.doesNotMatch(source, /(?:\.\/|\.\.\/)input(?:\.js)?["']/u);
+  assert.doesNotMatch(source, /commandEnqueue|sendInput|postMessage|dispatchKey|useSkill/u);
+  assert.doesNotMatch(source, /gwNative\.(?:input|skillKeys)/u);
+});

--- a/tests/policy/skill-cooldowns-are-display-only.test.ts
+++ b/tests/policy/skill-cooldowns-are-display-only.test.ts
@@ -7,6 +7,8 @@ const rendererSources = [
   "src/renderer/skill-cooldown-overlay.ts",
   "src/renderer/skill-cooldown-overlay-consumer.ts",
   "src/renderer/skill-cooldown-state-installation.ts",
+  "src/renderer/skill-overlays-installation.ts",
+  "src/renderer/skill-slot-projection.ts",
   "src/renderer/settings-skill-cooldowns.ts",
 ] as const;
 

--- a/tests/policy/skill-cooldowns-are-display-only.test.ts
+++ b/tests/policy/skill-cooldowns-are-display-only.test.ts
@@ -6,7 +6,7 @@ const rendererSources = [
   "src/renderer/skill-cooldown-view.ts",
   "src/renderer/skill-cooldown-overlay.ts",
   "src/renderer/skill-cooldown-overlay-consumer.ts",
-  "src/renderer/skill-cooldown-observation-installation.ts",
+  "src/renderer/skill-cooldown-state-installation.ts",
   "src/renderer/settings-skill-cooldowns.ts",
 ] as const;
 

--- a/tests/unit/client-compatibility-notice.test.ts
+++ b/tests/unit/client-compatibility-notice.test.ts
@@ -263,6 +263,23 @@ describe("client compatibility notice", () => {
     assert.equal(dom.element("settings-availability").open, true);
   });
 
+  it("reports cooldown presentation unavailable when slot geometry is unavailable", () => {
+    const dom = compatibilityDom();
+    renderClientCompatibility(dom.root, {
+      appVersion: "2026.7.0",
+      extendedMemory: STANDARD_MEMORY,
+      healthToken: null,
+      compatibility: compatibility({
+        skillSlotGeometry: unavailable("game-update"),
+        skillCooldownObservation: available,
+      }),
+    });
+    assert.equal(
+      dom.element("settings-feature-skillCooldownObservation").textContent,
+      "Unavailable",
+    );
+  });
+
   it("dismisses the launcher even when acknowledgement cannot persist", async () => {
     const dom = compatibilityDom();
     let acknowledgements = 0;

--- a/tests/unit/enhancement-runtime-policy.test.ts
+++ b/tests/unit/enhancement-runtime-policy.test.ts
@@ -21,6 +21,7 @@ test("developer programs replace saved optional-tool selection in PvE", () => {
     xunlaiStorage: false,
     travelPalette: false,
     skillSlotGeometry: false,
+    skillCooldownOverlay: false,
   });
   assert.deepEqual(enhancementRuntimePolicy("toolbox-commands", off, "pve"), {
     tools: true,
@@ -29,6 +30,7 @@ test("developer programs replace saved optional-tool selection in PvE", () => {
     xunlaiStorage: true,
     travelPalette: true,
     skillSlotGeometry: false,
+    skillCooldownOverlay: false,
   });
   assert.deepEqual(enhancementRuntimePolicy("xunlai-storage", off, "pve"), {
     tools: true,
@@ -37,6 +39,7 @@ test("developer programs replace saved optional-tool selection in PvE", () => {
     xunlaiStorage: true,
     travelPalette: true,
     skillSlotGeometry: false,
+    skillCooldownOverlay: false,
   });
   assert.deepEqual(enhancementRuntimePolicy("target-observer", off, "pve"), {
     tools: false,
@@ -45,6 +48,7 @@ test("developer programs replace saved optional-tool selection in PvE", () => {
     xunlaiStorage: false,
     travelPalette: false,
     skillSlotGeometry: false,
+    skillCooldownOverlay: false,
   });
 });
 
@@ -87,6 +91,7 @@ test("product tool settings remain live once the capability is present", () => {
     xunlaiStorage: false,
     travelPalette: true,
     skillSlotGeometry: true,
+    skillCooldownOverlay: true,
   });
 });
 

--- a/tests/unit/enhancement-runtime-policy.test.ts
+++ b/tests/unit/enhancement-runtime-policy.test.ts
@@ -84,6 +84,7 @@ test("product tool settings remain live once the capability is present", () => {
     teamManagement: true,
     xunlaiStorage: false,
     travelPalette: true,
+    skillCooldownOverlayEnabled: true,
   }, "pve"), {
     tools: true,
     targetReadout: false,

--- a/tests/unit/settings-skill-cooldowns.test.ts
+++ b/tests/unit/settings-skill-cooldowns.test.ts
@@ -1,0 +1,159 @@
+/** Headless behavior coverage for the canonical cooldown color setting. */
+import assert from "node:assert/strict";
+import test from "node:test";
+import { bindSkillCooldownSettings } from "../../src/renderer/settings-skill-cooldowns.ts";
+import { DEFAULT_SETTINGS, type AppSettings } from "../../src/shared/contracts.ts";
+import type { SkillCooldownColor } from "../../src/shared/skill-cooldowns.ts";
+
+type Listener = () => void;
+
+class FakeStyle {
+  readonly values = new Map<string, string>();
+  setProperty(name: string, value: string): void { this.values.set(name, value); }
+}
+
+class FakeDocument {
+  readonly head = new FakeElement(this);
+  createElement(): FakeElement { return new FakeElement(this); }
+  createElementNS(): FakeElement { return new FakeElement(this); }
+  getElementById(id: string): FakeElement | null {
+    return this.head.children.find((child) => child.id === id) ?? null;
+  }
+}
+
+class FakeElement {
+  readonly children: FakeElement[] = [];
+  readonly listeners = new Map<string, Listener[]>();
+  readonly style = new FakeStyle();
+  readonly dataset: Record<string, string> = {};
+  readonly classList = { add: (...names: string[]) => { this.className += ` ${names.join(" ")}`; } };
+  id = "";
+  className = "";
+  textContent = "";
+  hidden = false;
+  disabled = false;
+  checked = false;
+  value = "";
+  validationMessage = "";
+  readonly ownerDocument: FakeDocument;
+
+  constructor(ownerDocument: FakeDocument) { this.ownerDocument = ownerDocument; }
+  append(...children: FakeElement[]): void { this.children.push(...children); }
+  replaceChildren(...children: FakeElement[]): void {
+    this.children.splice(0, this.children.length, ...children);
+  }
+  setAttribute(): void {}
+  addEventListener(type: string, listener: Listener): void {
+    this.listeners.set(type, [...(this.listeners.get(type) ?? []), listener]);
+  }
+  dispatch(type: string): void {
+    for (const listener of this.listeners.get(type) ?? []) listener();
+  }
+  setCustomValidity(message: string): void { this.validationMessage = message; }
+}
+
+class FakeFieldset extends FakeElement {
+  readonly enabled = new FakeElement(this.ownerDocument);
+  readonly picker = new FakeElement(this.ownerDocument);
+  readonly text = new FakeElement(this.ownerDocument);
+  readonly preview = new FakeElement(this.ownerDocument);
+  readonly customSwatch = new FakeElement(this.ownerDocument);
+  readonly presetSwatches = new Map<string, FakeElement>();
+  readonly choices = ["red", "cream", "gold", "blue", "custom"].map((value) => {
+    const choice = new FakeElement(this.ownerDocument);
+    choice.value = value;
+    return choice;
+  });
+
+  constructor(document: FakeDocument) {
+    super(document);
+    for (const preset of ["red", "cream", "gold", "blue"]) {
+      this.presetSwatches.set(preset, new FakeElement(document));
+    }
+  }
+
+  querySelectorAll(): FakeElement[] { return this.choices; }
+  querySelector(selector: string): FakeElement | null {
+    if (selector === '[name="skillCooldownOverlayEnabled"]') return this.enabled;
+    if (selector === '[name="skillCooldownCustomPicker"]') return this.picker;
+    if (selector === '[name="skillCooldownCustomHex"]') return this.text;
+    if (selector === ".settings-skill-cooldown-preview-slot") return this.preview;
+    if (selector === ".settings-skill-cooldown-custom-swatch") return this.customSwatch;
+    const preset = selector.match(/^\[data-cooldown-swatch="(.+)"\]$/u)?.[1];
+    return preset ? this.presetSwatches.get(preset) ?? null : null;
+  }
+}
+
+function fixture(settings: AppSettings, fail = false) {
+  const document = new FakeDocument();
+  const fieldset = new FakeFieldset(document);
+  const saved: SkillCooldownColor[] = [];
+  const feedback: string[] = [];
+  let recoveries = 0;
+  const binder = bindSkillCooldownSettings({
+    fieldset: fieldset as unknown as HTMLFieldSetElement,
+    settings: () => settings,
+    persist: async ({ skillCooldownColor }) => {
+      if (fail) throw new Error("disk full");
+      saved.push(skillCooldownColor);
+    },
+    recoverAfterPersistFailure: async () => { recoveries += 1; },
+    feedback: (message) => { feedback.push(message); },
+  });
+  return { binder, fieldset, saved, feedback, recoveries: () => recoveries };
+}
+
+const flush = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+test("cooldown settings render the canonical choice and shared preview", () => {
+  const settings = { ...DEFAULT_SETTINGS, gwonmacTools: true };
+  const view = fixture(settings);
+  view.binder.render(settings);
+  assert.equal(view.fieldset.hidden, false);
+  assert.equal(view.fieldset.enabled.checked, settings.skillCooldownOverlayEnabled);
+  assert.equal(view.fieldset.choices[0]!.checked, true);
+  assert.equal(view.fieldset.picker.disabled, true);
+  assert.equal(view.fieldset.preview.children.length, 2);
+});
+
+test("cooldown settings reject malformed custom colors and persist valid colors", async () => {
+  const settings = { ...DEFAULT_SETTINGS, gwonmacTools: true };
+  const view = fixture(settings);
+  view.binder.render(settings);
+  view.fieldset.choices.forEach((choice) => { choice.checked = choice.value === "custom"; });
+  view.fieldset.choices[4]!.dispatch("change");
+  await flush();
+  assert.equal(view.fieldset.picker.disabled, false);
+  assert.deepEqual(view.saved, [{ kind: "custom", value: "#e35a4f" }]);
+
+  view.fieldset.text.value = "#bad";
+  view.fieldset.text.dispatch("input");
+  view.fieldset.text.dispatch("change");
+  await flush();
+  assert.match(view.fieldset.text.validationMessage, /six-digit/u);
+  assert.equal(view.saved.length, 1);
+
+  view.fieldset.text.value = "#12aBcF";
+  view.fieldset.text.dispatch("input");
+  view.fieldset.text.dispatch("change");
+  await flush();
+  assert.deepEqual(view.saved, [
+    { kind: "custom", value: "#e35a4f" },
+    { kind: "custom", value: "#12aBcF" },
+  ]);
+  assert.deepEqual(view.feedback, [
+    "Saving…", "Cooldown color saved.",
+    "Saving…", "Cooldown color saved.",
+  ]);
+});
+
+test("cooldown settings recover the active state after a failed write", async () => {
+  const settings = { ...DEFAULT_SETTINGS, gwonmacTools: true };
+  const view = fixture(settings, true);
+  view.binder.render(settings);
+  view.fieldset.choices.forEach((choice) => { choice.checked = choice.value === "gold"; });
+  view.fieldset.choices[2]!.dispatch("change");
+  await flush();
+  assert.equal(view.recoveries(), 1);
+  assert.deepEqual(view.feedback, ["Saving…"]);
+});

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -31,6 +31,8 @@ describe("settings", () => {
       targetReadout: false,
       shortcutOverrides: {},
       skillKeyBindings: [null, null, null, null, null, null, null, null],
+      skillCooldownOverlayEnabled: true,
+      skillCooldownColor: { kind: "preset", preset: "red" },
       extendedMemoryEnabled: false,
       showDiagnostics: false,
       dataStrategy: "full",
@@ -74,6 +76,8 @@ describe("settings", () => {
       targetReadout: false,
       shortcutOverrides: {},
       skillKeyBindings: [null, null, null, null, null, null, null, null],
+      skillCooldownOverlayEnabled: true,
+      skillCooldownColor: { kind: "preset", preset: "red" },
       extendedMemoryEnabled: false,
       showDiagnostics: true,
       dataStrategy: "full",
@@ -221,6 +225,19 @@ describe("settings", () => {
     );
   });
 
+  it("accepts one canonical cooldown switch and color", () => {
+    assert.equal(parseSettings({ skillCooldownOverlayEnabled: false }).skillCooldownOverlayEnabled, false);
+    assert.deepEqual(parseSettingsPatch({
+      skillCooldownColor: { kind: "custom", value: "#12aBcF" },
+    }), { skillCooldownColor: { kind: "custom", value: "#12aBcF" } });
+    for (const value of [
+      { kind: "custom", value: "#fff" },
+      { kind: "custom", value: "#12345g" },
+      { kind: "preset", preset: "green" },
+      { kind: "preset", preset: "red", extra: true },
+    ]) assert.throws(() => parseSettings({ skillCooldownColor: value }), AppError);
+  });
+
   it("validates patches without filling fields from defaults", () => {
     assert.throws(() => parseSettingsPatch({ nativeCursor: true }), AppError);
     assert.deepEqual(parseSettingsPatch({ lastUpdateCheckAt: 1_000 }), {
@@ -304,6 +321,8 @@ describe("settings", () => {
       "renderScale",
       "shortcutOverrides",
       "showDiagnostics",
+      "skillCooldownColor",
+      "skillCooldownOverlayEnabled",
       "skillKeyBindings",
       "targetReadout",
       "teamManagement",
@@ -354,6 +373,8 @@ describe("settings", () => {
       targetReadout: false,
       shortcutOverrides: {},
       skillKeyBindings: [null, null, null, null, null, null, null, null],
+      skillCooldownOverlayEnabled: true,
+      skillCooldownColor: { kind: "preset", preset: "red" },
       extendedMemoryEnabled: false,
       showDiagnostics: true,
       dataStrategy: "full",

--- a/tests/unit/skill-cooldown-overlay.test.ts
+++ b/tests/unit/skill-cooldown-overlay.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createSkillCooldownOverlayConsumer } from "../../src/renderer/skill-cooldown-overlay-consumer.js";
+import { createSkillCooldownOverlay } from "../../src/renderer/skill-cooldown-overlay.js";
+
+class FakeStyle {
+  cssText = "";
+  display = "";
+  values = new Map<string, string>();
+  setProperty(name: string, value: string) { this.values.set(name, value); }
+}
+class FakeElement {
+  id = "";
+  className = "";
+  hidden = false;
+  textContent = "";
+  style = new FakeStyle();
+  dataset: Record<string, string> = {};
+  children: FakeElement[] = [];
+  parent: FakeElement | null = null;
+  attributes = new Map<string, string>();
+  ownerDocument: FakeDocument;
+  classList = { add: (...names: string[]) => { this.className += ` ${names.join(" ")}`; } };
+  constructor(ownerDocument: FakeDocument) { this.ownerDocument = ownerDocument; }
+  setAttribute(name: string, value: string) { this.attributes.set(name, value); }
+  append(...children: FakeElement[]) {
+    for (const child of children) { child.parent = this; this.children.push(child); }
+  }
+  remove() {
+    if (this.parent) this.parent.children.splice(this.parent.children.indexOf(this), 1);
+  }
+}
+class FakeDocument {
+  head = new FakeElement(this);
+  createElement() { return new FakeElement(this); }
+  getElementById(id: string) { return this.head.children.find((child) => child.id === id) ?? null; }
+}
+
+const textOf = (element: FakeElement): string =>
+  element.textContent + element.children.map(textOf).join("");
+
+const geometry = (sequence = 2) => ({
+  status: "ready" as const,
+  sequence,
+  frameId: 4,
+  viewportWidth: 800,
+  viewportHeight: 600,
+  slots: Array.from({ length: 8 }, (_, index) => ({
+    left: 100 + index * 50,
+    bottom: 20,
+    right: 148 + index * 50,
+    top: 68,
+  })),
+});
+
+test("the presentation joins complete geometry and cooldown state without touching keys", () => {
+  const document = new FakeDocument();
+  const body = document.createElement();
+  const canvas = {
+    getBoundingClientRect: () => ({ left: 10, top: 20, width: 800, height: 600 }),
+  } as HTMLCanvasElement;
+  const consumer = createSkillCooldownOverlayConsumer(body as unknown as HTMLElement, canvas);
+  consumer.sync({ kind: "preset", preset: "red" }, true);
+  consumer.update(geometry());
+  consumer.setCooldownState({
+    status: "ready",
+    sequence: 2,
+    generation: 1,
+    gameTimer: 10_000,
+    playerAgentId: 7,
+    rechargeTimestamps: [12_899, 24_001, 0, 0, 0, 0, 0, 10_400],
+  });
+  const root = body.children[0]!;
+  assert.equal(root.id, "skill-cooldown-overlay");
+  assert.equal(root.style.display, "block");
+  assert.equal(root.attributes.get("aria-hidden"), "true");
+  assert.match(root.style.cssText, /pointer-events:none/u);
+  assert.deepEqual(root.children.map(textOf), ["2.9", "15", "", "", "", "", "", "0.4"]);
+  assert.match(root.children[0]!.style.cssText, /left:110px;top:552px;width:48px;height:48px/u);
+  assert.equal(root.children[0]!.children[0]!.style.values.get("--skill-cooldown-slot-height"), "48px");
+});
+
+test("ready skills, stale state, disabled Tools, and incomplete publications hide everything", () => {
+  const document = new FakeDocument();
+  const body = document.createElement();
+  const consumer = createSkillCooldownOverlayConsumer(
+    body as unknown as HTMLElement,
+    { getBoundingClientRect: () => ({ left: 0, top: 0, width: 800, height: 600 }) } as HTMLCanvasElement,
+  );
+  consumer.sync({ kind: "custom", value: "#abcdef" }, true);
+  consumer.update(geometry());
+  consumer.setCooldownState({
+    status: "ready",
+    sequence: 2,
+    generation: 1,
+    gameTimer: 10_000,
+    playerAgentId: 7,
+    rechargeTimestamps: [0, 0, 0, 0, 0, 0, 0, 0],
+  });
+  const root = body.children[0]!;
+  assert.equal(root.style.display, "none");
+  consumer.setCooldownState({ status: "waiting", reason: "loading" });
+  assert.equal(root.style.display, "none");
+  consumer.sync({ kind: "custom", value: "#abcdef" }, false);
+  consumer.setCooldownState({
+    status: "ready",
+    sequence: 4,
+    generation: 1,
+    gameTimer: 10_000,
+    playerAgentId: 7,
+    rechargeTimestamps: [11_000, 0, 0, 0, 0, 0, 0, 0],
+  });
+  assert.equal(root.style.display, "none");
+});
+
+test("sub-frame timer changes that keep the same label cause no presentation update", () => {
+  const document = new FakeDocument();
+  const body = document.createElement();
+  const overlay = createSkillCooldownOverlay(body as unknown as HTMLElement);
+  const slots = Array.from({ length: 8 }, (_, index) => ({
+    x: index * 50,
+    y: 0,
+    width: 48,
+    height: 48,
+    remainingMs: index === 0 ? 2_899 : 0,
+  }));
+  overlay.update(slots, { kind: "preset", preset: "red" });
+  const signature = overlay.state.signature;
+  overlay.update(
+    slots.map((slot, index) => ({ ...slot, remainingMs: index === 0 ? 2_850 : 0 })),
+    { kind: "preset", preset: "red" },
+  );
+  assert.equal(overlay.state.signature, signature);
+});
+
+test("either accepted feed withdrawing hides the complete cooldown HUD", () => {
+  const document = new FakeDocument();
+  const body = document.createElement();
+  const consumer = createSkillCooldownOverlayConsumer(
+    body as unknown as HTMLElement,
+    { getBoundingClientRect: () => ({ left: 0, top: 0, width: 800, height: 600 }) } as HTMLCanvasElement,
+  );
+  const cooldowns = {
+    status: "ready" as const,
+    sequence: 2,
+    generation: 1,
+    gameTimer: 10_000,
+    playerAgentId: 7,
+    rechargeTimestamps: [11_000, 0, 0, 0, 0, 0, 0, 0],
+  };
+  consumer.sync({ kind: "preset", preset: "red" }, true);
+  consumer.update(geometry());
+  consumer.setCooldownState(cooldowns);
+  const root = body.children[0]!;
+  assert.equal(root.style.display, "block");
+  consumer.setCooldownState({ status: "waiting", reason: "stale" });
+  assert.equal(root.style.display, "none");
+  consumer.update(geometry(4));
+  assert.equal(root.style.display, "none", "fresh geometry cannot mask withdrawn recharge state");
+  consumer.setCooldownState({ ...cooldowns, sequence: 4, gameTimer: 10_100 });
+  assert.equal(root.style.display, "block");
+});

--- a/tests/unit/skill-cooldowns.test.ts
+++ b/tests/unit/skill-cooldowns.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  formatSkillCooldown,
+  isSkillCooldownColor,
+  skillCooldownCssColor,
+} from "../../src/shared/skill-cooldowns.js";
+
+test("cooldown formatting rounds active values upward without showing zero", () => {
+  assert.equal(formatSkillCooldown(0), null);
+  assert.equal(formatSkillCooldown(1), "0.1");
+  assert.equal(formatSkillCooldown(99), "0.1");
+  assert.equal(formatSkillCooldown(100), "0.1");
+  assert.equal(formatSkillCooldown(101), "0.2");
+  assert.equal(formatSkillCooldown(400), "0.4");
+  assert.equal(formatSkillCooldown(2_899), "2.9");
+  assert.equal(formatSkillCooldown(2_999), "3.0");
+  assert.equal(formatSkillCooldown(3_000), "3");
+  assert.equal(formatSkillCooldown(3_001), "4");
+  assert.equal(formatSkillCooldown(14_001), "15");
+  assert.equal(formatSkillCooldown(1_800_000), "1800");
+  assert.equal(formatSkillCooldown(1_800_001), null);
+  assert.equal(formatSkillCooldown(-1), null);
+  assert.equal(formatSkillCooldown(1.5), null);
+  assert.equal(formatSkillCooldown(Number.NaN), null);
+});
+
+test("cooldown colors accept only the closed presets or exact six-digit RGB", () => {
+  for (const preset of ["red", "cream", "gold", "blue"] as const) {
+    const color = { kind: "preset", preset } as const;
+    assert.equal(isSkillCooldownColor(color), true);
+    assert.match(skillCooldownCssColor(color), /^#[0-9a-f]{6}$/u);
+  }
+  assert.equal(isSkillCooldownColor({ kind: "custom", value: "#12aBcF" }), true);
+  assert.equal(skillCooldownCssColor({ kind: "custom", value: "#12aBcF" }), "#12aBcF");
+  for (const value of ["#fff", "#1234567", "123456", "#gg0000", "#12345 "]) {
+    assert.equal(isSkillCooldownColor({ kind: "custom", value }), false);
+  }
+  assert.equal(isSkillCooldownColor({ kind: "preset", preset: "green" }), false);
+  assert.equal(isSkillCooldownColor({ kind: "preset", preset: "red", extra: true }), false);
+});

--- a/tests/unit/skill-cooldowns.test.ts
+++ b/tests/unit/skill-cooldowns.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   formatSkillCooldown,
   isSkillCooldownColor,
+  isSkillCooldownCustomHex,
   skillCooldownCssColor,
 } from "../../src/shared/skill-cooldowns.js";
 
@@ -34,8 +35,10 @@ test("cooldown colors accept only the closed presets or exact six-digit RGB", ()
   assert.equal(isSkillCooldownColor({ kind: "custom", value: "#12aBcF" }), true);
   assert.equal(skillCooldownCssColor({ kind: "custom", value: "#12aBcF" }), "#12aBcF");
   for (const value of ["#fff", "#1234567", "123456", "#gg0000", "#12345 "]) {
+    assert.equal(isSkillCooldownCustomHex(value), false);
     assert.equal(isSkillCooldownColor({ kind: "custom", value }), false);
   }
+  assert.equal(isSkillCooldownCustomHex("#12aBcF"), true);
   assert.equal(isSkillCooldownColor({ kind: "preset", preset: "green" }), false);
   assert.equal(isSkillCooldownColor({ kind: "preset", preset: "red", extra: true }), false);
 });


### PR DESCRIPTION
Players need the certified recharge state to be readable at a glance without obscuring their custom key labels or changing how Guild Wars plays.

This PR adds the centered cooldown HUD and its complete Settings UI: enable/disable, four curated presets, exact six-digit custom RGB, and a live preview shared with the HUD renderer. Whole seconds round upward, the final three seconds use tenths, ready skills show nothing, and long values shrink instead of clipping.

The final review centralizes slot projection and skill-overlay lifecycle, removes duplicate freshness/timer paths, keeps geometry and recharge as independent accepted feeds, gates native observation on actual settings and policy, derives cooldown availability from both required capabilities, and adds headless Settings persistence/recovery/accessibility coverage. The HUD uses the extracted Guild Wars display font and one shared set of outline, shadow, color, and optical-centering tokens.

Verification:

- TypeScript type checks and ESLint
- 1,201 headless unit tests, including formatter, Settings, overlay coexistence, stale withdrawal, and runtime policy
- 174 security/policy tests and 102 Tools UI tests
- 55 integration tests
- Production build, 25 release tests, and reproducible companion-kernel verification
- All three exact-client artifact tests against the current local `Gw.jspi.wasm`

Electron/E2E tests were intentionally not run because they disrupt an active parallel game session. Deterministic visual fixtures are included; the final live-game screenshot remains the explicit manual acceptance step.

Implemented and reviewed with Codex using a thermo-nuclear multi-agent maintainability review.
