### PR TITLE
refactor(enhancements): unify bounded companion regions

### DIFF
--- a/src/renderer/companion-region-installation.ts
+++ b/src/renderer/companion-region-installation.ts
@@ -1,0 +1,113 @@
+/**
+ * Owns one fixed-size, companion-written memory region and its accepted feed.
+ *
+ * Region allocation, activation withdrawal, freshness, and cleanup are the
+ * same safety problem for every bounded observation. Domain modules supply the
+ * wire size, states, and an explicit freshness policy; event-driven records can
+ * opt out of the timer instead of treating an unchanged value as dead.
+ */
+import {
+  createCompanionSequenceFeed,
+  type CompanionSequenceFeedOptions,
+} from "./companion-sequence-feed.js";
+
+type SequencedState = Readonly<{
+  status: string;
+  sequence?: number;
+}>;
+
+type Malloc = (bytes: number) => unknown;
+type Free = (pointer: number) => void;
+
+export type CompanionRegionDescriptor<State extends SequencedState> = Readonly<{
+  available: boolean;
+  name: string;
+  bytes: number;
+  align?: number;
+  waiting: State;
+  stale: State;
+  freshness: CompanionSequenceFeedOptions | null;
+}>;
+
+export function createCompanionRegionInstallation<State extends SequencedState>(
+  descriptor: CompanionRegionDescriptor<State>,
+) {
+  const {
+    available,
+    name,
+    bytes,
+    align = 4,
+    waiting,
+    stale,
+    freshness,
+  } = descriptor;
+  if (
+    name.length === 0
+    || !Number.isSafeInteger(bytes)
+    || bytes <= 0
+    || !Number.isSafeInteger(align)
+    || align <= 0
+    || waiting.status === "ready"
+    || stale.status === "ready"
+  ) {
+    throw new Error("Companion region descriptor is invalid");
+  }
+
+  const feed = createCompanionSequenceFeed(
+    waiting,
+    stale,
+    freshness ?? { staleAfterMs: null },
+  );
+  let pointer = 0;
+  let active = false;
+  let disposed = false;
+  const sink = Object.freeze({
+    update(state: State) {
+      if (!disposed && active) feed.update(state);
+    },
+  });
+
+  return Object.freeze({
+    available,
+    get pointer() { return pointer; },
+    get bytes() { return available ? bytes : 0; },
+    get allocated() { return !available || pointer !== 0; },
+    get active() { return active; },
+    get state() { return feed.state; },
+    get region() {
+      return available
+        ? Object.freeze({ name, pointer, size: bytes, align })
+        : null;
+    },
+    get sink() { return available ? sink : null; },
+    allocate(malloc: Malloc) {
+      if (disposed || !available || pointer !== 0) return;
+      const allocated = Number(malloc(bytes));
+      pointer = Number.isSafeInteger(allocated) && allocated > 0
+        ? allocated
+        : 0;
+    },
+    setActive(next: boolean) {
+      if (disposed || !available || active === next) return;
+      active = next;
+      if (!active) feed.withdraw();
+    },
+    subscribe(listener: (state: State) => void) {
+      return available ? feed.subscribe(listener) : () => false;
+    },
+    release(free: Free) {
+      active = false;
+      feed.withdraw();
+      if (pointer !== 0) free(pointer);
+      pointer = 0;
+      feed.reset();
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      active = false;
+      feed.withdraw();
+      feed.dispose();
+    },
+  });
+}

--- a/src/renderer/companion-sequence-feed.ts
+++ b/src/renderer/companion-sequence-feed.ts
@@ -15,10 +15,26 @@ export type CompanionSequenceFeedOptions = Readonly<{
   now?: () => number;
   schedule?: (callback: () => void, delay: number) => FreshnessTimer;
   cancel?: (timer: FreshnessTimer) => void;
-  staleAfterMs?: number;
+  staleAfterMs?: number | null;
 }>;
 
 const DEFAULT_STALE_AFTER_MS = 500;
+export const CONTINUOUS_COMPANION_FRESHNESS = Object.freeze({
+  staleAfterMs: DEFAULT_STALE_AFTER_MS,
+});
+const UINT32_HALF_RANGE = 0x8000_0000;
+
+function isSequence(value: unknown): value is number {
+  return typeof value === "number"
+    && Number.isInteger(value)
+    && value >= 0
+    && value <= 0xffff_ffff;
+}
+
+function isNewerSequence(candidate: number, previous: number): boolean {
+  const distance = (candidate - previous) >>> 0;
+  return distance !== 0 && distance < UINT32_HALF_RANGE;
+}
 
 export function createCompanionSequenceFeed<State extends SequencedState>(
   initial: State,
@@ -30,14 +46,24 @@ export function createCompanionSequenceFeed<State extends SequencedState>(
   const schedule = options.schedule ?? ((callback, delay) =>
     globalThis.setTimeout(callback, delay));
   const cancel = options.cancel ?? ((timer) => globalThis.clearTimeout(timer));
-  const staleAfterMs = options.staleAfterMs ?? DEFAULT_STALE_AFTER_MS;
+  const staleAfterMs = options.staleAfterMs === undefined
+    ? DEFAULT_STALE_AFTER_MS
+    : options.staleAfterMs;
+  if (
+    staleAfterMs !== null
+    && (!Number.isFinite(staleAfterMs) || staleAfterMs < 0)
+  ) {
+    throw new Error("Companion freshness duration is invalid");
+  }
   let current = initial;
   let acceptedSequence: number | null = null;
   let blockedSequence: number | null = null;
   let advancedAt = 0;
   let timer: FreshnessTimer | null = null;
+  let disposed = false;
 
   const publish = (state: State) => {
+    if (current === state) return;
     current = state;
     for (const listener of listeners) listener(state);
   };
@@ -47,6 +73,7 @@ export function createCompanionSequenceFeed<State extends SequencedState>(
   };
   const watch = () => {
     stopTimer();
+    if (disposed || staleAfterMs === null) return;
     const sequence = acceptedSequence;
     if (sequence === null) return;
     timer = schedule(() => {
@@ -61,43 +88,66 @@ export function createCompanionSequenceFeed<State extends SequencedState>(
       publish(stale);
     }, Math.max(0, staleAfterMs - (now() - advancedAt)));
   };
+  const invalidate = (next: State) => {
+    if (disposed) return;
+    if (acceptedSequence !== null) blockedSequence = acceptedSequence;
+    stopTimer();
+    publish(next);
+  };
+  const withdraw = () => invalidate(stale);
 
   return Object.freeze({
     get state() {
       return current;
     },
     update(next: State) {
-      if (next.status !== "ready" || !Number.isSafeInteger(next.sequence)) {
-        if (acceptedSequence !== null) blockedSequence = acceptedSequence;
-        stopTimer();
-        publish(next);
+      if (disposed) return;
+      if (next.status !== "ready") {
+        invalidate(next);
         return;
       }
-      const sequence = next.sequence!;
-      if (sequence === blockedSequence) {
+      if (!isSequence(next.sequence)) {
+        withdraw();
+        return;
+      }
+      const sequence = next.sequence;
+      if (
+        acceptedSequence !== null
+        && sequence !== acceptedSequence
+        && !isNewerSequence(sequence, acceptedSequence)
+      ) {
+        blockedSequence = acceptedSequence;
+        stopTimer();
         publish(stale);
         return;
       }
-      if (sequence !== acceptedSequence) {
-        acceptedSequence = sequence;
-        blockedSequence = null;
-        advancedAt = now();
-        watch();
+      if (sequence === acceptedSequence) {
+        if (sequence === blockedSequence) publish(stale);
+        return;
       }
+      acceptedSequence = sequence;
+      blockedSequence = null;
+      advancedAt = now();
+      watch();
       publish(next);
     },
+    withdraw,
     subscribe(listener: (state: State) => void) {
+      if (disposed) return () => false;
       listeners.add(listener);
       listener(current);
       return () => listeners.delete(listener);
     },
     reset() {
+      if (disposed) return;
       stopTimer();
       acceptedSequence = null;
       blockedSequence = null;
       publish(initial);
     },
     dispose() {
+      if (disposed) return;
+      disposed = true;
       stopTimer();
       listeners.clear();
     },

--- a/src/renderer/skill-cooldown-state-installation.ts
+++ b/src/renderer/skill-cooldown-state-installation.ts
@@ -7,63 +7,29 @@ import {
   type CompanionSkillCooldownState,
 } from "./companion-skill-snapshot.js";
 import {
-  createCompanionSequenceFeed,
+  createCompanionRegionInstallation,
+} from "./companion-region-installation.js";
+import {
+  CONTINUOUS_COMPANION_FRESHNESS,
   type CompanionSequenceFeedOptions,
 } from "./companion-sequence-feed.js";
-
-type Malloc = (bytes: number) => unknown;
-type Free = (pointer: number) => void;
 export type SkillCooldownObservationState = CompanionSkillCooldownState;
 
 export function createSkillCooldownObservationInstallation(
   available: boolean,
-  freshness: CompanionSequenceFeedOptions = {},
+  freshness: CompanionSequenceFeedOptions = CONTINUOUS_COMPANION_FRESHNESS,
 ) {
-  let pointer = 0;
   const waiting = Object.freeze({
     status: "waiting",
     reason: "memory",
   } as const);
   const stale = Object.freeze({ status: "waiting", reason: "stale" } as const);
-  const feed = createCompanionSequenceFeed<CompanionSkillCooldownState>(
+  return createCompanionRegionInstallation<CompanionSkillCooldownState>({
+    available,
+    name: "skill cooldowns",
+    bytes: COMPANION_SKILL_COOLDOWN_BYTES,
     waiting,
     stale,
     freshness,
-  );
-  return Object.freeze({
-    available,
-    get pointer() { return pointer; },
-    get bytes() { return available ? COMPANION_SKILL_COOLDOWN_BYTES : 0; },
-    get allocated() { return !available || pointer !== 0; },
-    get state() { return feed.state; },
-    get region() {
-      return available
-        ? Object.freeze({
-            name: "skill cooldowns",
-            pointer,
-            size: COMPANION_SKILL_COOLDOWN_BYTES,
-            align: 4,
-          })
-        : null;
-    },
-    get sink() {
-      return available ? feed : null;
-    },
-    subscribe(listener: (state: CompanionSkillCooldownState) => void) {
-      return available ? feed.subscribe(listener) : () => false;
-    },
-    allocate(malloc: Malloc) {
-      if (available && pointer === 0) {
-        pointer = Number(malloc(COMPANION_SKILL_COOLDOWN_BYTES));
-      }
-    },
-    release(free: Free) {
-      if (pointer !== 0) free(pointer);
-      pointer = 0;
-      feed.reset();
-    },
-    dispose() {
-      feed.dispose();
-    },
   });
 }

--- a/src/renderer/skill-overlays-installation.ts
+++ b/src/renderer/skill-overlays-installation.ts
@@ -55,6 +55,8 @@ export function createSkillOverlaysInstallation(
       );
     },
     sync(settings: SkillSettings, geometryEnabled: boolean, cooldownEnabled: boolean) {
+      geometry.setActive(geometryEnabled && (hasKeyBindings(settings) || cooldownEnabled));
+      cooldowns.setActive(cooldownEnabled);
       keyConsumer?.setBindings(settings.skillKeyBindings);
       keyConsumer?.setEnabled(geometryEnabled && hasKeyBindings(settings));
       cooldownOverlay.sync(settings.skillCooldownColor, cooldownEnabled);

--- a/src/renderer/skill-slot-geometry-installation.ts
+++ b/src/renderer/skill-slot-geometry-installation.ts
@@ -6,56 +6,18 @@ import {
   COMPANION_SKILL_SLOT_BYTES,
   type CompanionSkillSlotState,
 } from "./companion-skill-snapshot.js";
-import { createCompanionSequenceFeed } from "./companion-sequence-feed.js";
-
-type Malloc = (bytes: number) => unknown;
-type Free = (pointer: number) => void;
+import { createCompanionRegionInstallation } from "./companion-region-installation.js";
+import { CONTINUOUS_COMPANION_FRESHNESS } from "./companion-sequence-feed.js";
 
 export function createSkillSlotGeometryInstallation(available: boolean) {
-  let pointer = 0;
   const waiting = Object.freeze({ status: "waiting", reason: "memory" } as const);
   const stale = Object.freeze({ status: "waiting", reason: "stale" } as const);
-  const feed = createCompanionSequenceFeed<CompanionSkillSlotState>(waiting, stale);
-
-  return Object.freeze({
+  return createCompanionRegionInstallation<CompanionSkillSlotState>({
     available,
-    get pointer() {
-      return pointer;
-    },
-    get bytes() {
-      return available ? COMPANION_SKILL_SLOT_BYTES : 0;
-    },
-    get allocated() {
-      return !available || pointer !== 0;
-    },
-    get region() {
-      return available
-        ? Object.freeze({
-            name: "skill slots",
-            pointer,
-            size: COMPANION_SKILL_SLOT_BYTES,
-            align: 4,
-          })
-        : null;
-    },
-    get sink() {
-      return available ? feed : null;
-    },
-    allocate(malloc: Malloc) {
-      if (available && pointer === 0) {
-        pointer = Number(malloc(COMPANION_SKILL_SLOT_BYTES));
-      }
-    },
-    subscribe(listener: (state: CompanionSkillSlotState) => void) {
-      return available ? feed.subscribe(listener) : () => false;
-    },
-    release(free: Free) {
-      if (pointer !== 0) free(pointer);
-      pointer = 0;
-      feed.reset();
-    },
-    dispose() {
-      feed.dispose();
-    },
+    name: "skill slots",
+    bytes: COMPANION_SKILL_SLOT_BYTES,
+    waiting,
+    stale,
+    freshness: CONTINUOUS_COMPANION_FRESHNESS,
   });
 }

--- a/tests/unit/companion-region-installation.test.ts
+++ b/tests/unit/companion-region-installation.test.ts
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createCompanionRegionInstallation } from "../../src/renderer/companion-region-installation.ts";
+import { createCompanionSequenceFeed } from "../../src/renderer/companion-sequence-feed.ts";
+
+type State =
+  | Readonly<{ status: "waiting"; reason: "memory" | "stale" }>
+  | Readonly<{ status: "ready"; sequence: number; value: number }>;
+
+const waiting = Object.freeze({ status: "waiting", reason: "memory" } as const);
+const stale = Object.freeze({ status: "waiting", reason: "stale" } as const);
+const ready = (sequence: number, value = sequence): State => Object.freeze({
+  status: "ready",
+  sequence,
+  value,
+});
+
+test("a bounded region owns allocation and ignores observations while inactive", () => {
+  const region = createCompanionRegionInstallation<State>({
+    available: true,
+    name: "test facts",
+    bytes: 32,
+    waiting,
+    stale,
+    freshness: null,
+  });
+  const observed: State[] = [];
+  const unsubscribe = region.subscribe((state) => observed.push(state));
+
+  region.sink?.update(ready(2));
+  assert.deepEqual(observed, [waiting]);
+  region.allocate(() => 128);
+  assert.deepEqual(region.region, {
+    name: "test facts",
+    pointer: 128,
+    size: 32,
+    align: 4,
+  });
+
+  region.setActive(true);
+  region.sink?.update(ready(2));
+  assert.equal(region.state.status, "ready");
+  region.setActive(false);
+  assert.equal(region.state, stale);
+  region.setActive(true);
+  region.sink?.update(ready(2, 99));
+  assert.equal(region.state, stale, "reactivation requires a newer publication");
+  region.sink?.update(ready(4));
+  assert.deepEqual(region.state, ready(4));
+
+  let released = 0;
+  region.release((pointer) => { released = pointer; });
+  assert.equal(released, 128);
+  assert.equal(region.pointer, 0);
+  assert.equal(region.state, waiting);
+  unsubscribe();
+  region.dispose();
+});
+
+test("a withdrawn sequence accepts only a newer uint32 publication", () => {
+  const feed = createCompanionSequenceFeed<State>(waiting, stale);
+  feed.update(ready(10));
+  feed.withdraw();
+  feed.update(ready(10, 99));
+  feed.update(ready(8));
+  assert.equal(feed.state, stale);
+  feed.update(ready(12));
+  assert.deepEqual(feed.state, ready(12));
+});
+
+test("malformed ready sequences fail closed", () => {
+  const feed = createCompanionSequenceFeed<State>(waiting, stale);
+  feed.update(ready(2));
+  for (const sequence of [undefined, -2, 1.5, 0x1_0000_0000]) {
+    feed.update({ status: "ready", sequence, value: 99 } as unknown as State);
+    assert.equal(feed.state, stale);
+  }
+});
+
+test("an event-driven region keeps a stable accepted publication", () => {
+  let scheduled = false;
+  const region = createCompanionRegionInstallation<State>({
+    available: true,
+    name: "event facts",
+    bytes: 32,
+    waiting,
+    stale,
+    freshness: {
+      staleAfterMs: null,
+      schedule: () => {
+        scheduled = true;
+        return 1;
+      },
+    },
+  });
+  // The null policy must prevent the default liveness timer from existing.
+  region.setActive(true);
+  region.sink?.update(ready(2));
+  assert.equal(region.state.status, "ready");
+  assert.equal(scheduled, false);
+});
+
+test("region descriptors require non-ready withdrawal sentinels", () => {
+  assert.throws(() => createCompanionRegionInstallation<State>({
+    available: true,
+    name: "unsafe facts",
+    bytes: 32,
+    waiting,
+    stale: ready(2),
+    freshness: null,
+  }), /descriptor is invalid/u);
+  assert.throws(() => createCompanionRegionInstallation<State>({
+    available: true,
+    name: "unsafe facts",
+    bytes: 32,
+    waiting: ready(2),
+    stale,
+    freshness: null,
+  }), /descriptor is invalid/u);
+});
+
+test("teardown withdraws ready state even when freeing fails", () => {
+  const region = createCompanionRegionInstallation<State>({
+    available: true,
+    name: "test facts",
+    bytes: 32,
+    waiting,
+    stale,
+    freshness: null,
+  });
+  region.allocate(() => 128);
+  region.setActive(true);
+  region.sink?.update(ready(2));
+  assert.throws(() => region.release(() => { throw new Error("free failed"); }));
+  assert.equal(region.state, stale);
+  assert.equal(region.pointer, 128, "ownership remains until free succeeds");
+
+  region.release(() => undefined);
+  assert.equal(region.state, waiting);
+  region.allocate(() => 256);
+  region.setActive(true);
+  region.sink?.update(ready(4));
+  region.dispose();
+  assert.equal(region.state, stale);
+  region.sink?.update(ready(6));
+  assert.equal(region.state, stale, "disposal is terminal");
+  region.release(() => undefined);
+});
+
+test("freshness duration rejects non-finite and negative values", () => {
+  for (const staleAfterMs of [Number.NaN, Number.POSITIVE_INFINITY, -1]) {
+    assert.throws(
+      () => createCompanionSequenceFeed<State>(waiting, stale, { staleAfterMs }),
+      /freshness duration/u,
+    );
+  }
+});
+
+test("sequence ordering accepts uint32 wrap and suppresses duplicate publications", () => {
+  const feed = createCompanionSequenceFeed<State>(waiting, stale);
+  const observed: State[] = [];
+  feed.subscribe((state) => observed.push(state));
+  feed.update(ready(0xffff_fffe));
+  feed.update(ready(0xffff_fffe, 99));
+  feed.update(ready(0));
+
+  assert.deepEqual(observed, [waiting, ready(0xffff_fffe), ready(0)]);
+});

--- a/tests/unit/skill-cooldown-state-installation.test.ts
+++ b/tests/unit/skill-cooldown-state-installation.test.ts
@@ -14,6 +14,7 @@ it("withdraws a cooldown publication whose sequence stops advancing", () => {
     cancel: () => { scheduled = null; },
     staleAfterMs: 500,
   });
+  installation.setActive(true);
   installation.sink?.update(Object.freeze({
     status: "ready",
     sequence: 2,

--- a/tests/unit/skill-overlays-installation.test.ts
+++ b/tests/unit/skill-overlays-installation.test.ts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { DEFAULT_SETTINGS } from "../../src/shared/contracts.ts";
+import { createSkillOverlaysInstallation } from "../../src/renderer/skill-overlays-installation.ts";
+
+const binding = Object.freeze({
+  input: Object.freeze({ kind: "keyboard" as const, code: "KeyC" }),
+  modifiers: Object.freeze({
+    control: false,
+    option: false,
+    shift: false,
+    command: false,
+  }),
+});
+const withBinding = Object.freeze({
+  ...DEFAULT_SETTINGS,
+  skillKeyBindings: Object.freeze([
+    binding,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+  ] as const),
+});
+
+test("skill policy activates and withdraws only the observation regions it needs", () => {
+  const skills = createSkillOverlaysInstallation({
+    skillSlotGeometry: true,
+    skillCooldownObservation: true,
+  });
+  skills.sync(DEFAULT_SETTINGS, false, false);
+  assert.equal(skills.geometry.active, false);
+  assert.equal(skills.cooldowns.active, false);
+
+  skills.sync(withBinding, true, false);
+  assert.equal(skills.geometry.active, true, "a key badge needs geometry");
+  assert.equal(skills.cooldowns.active, false);
+  skills.geometry.sink?.update({
+    status: "ready",
+    sequence: 2,
+    frameId: 1,
+    viewportWidth: 800,
+    viewportHeight: 600,
+    slots: Object.freeze(Array.from({ length: 8 }, (_, index) => Object.freeze({
+      left: index * 50,
+      bottom: 20,
+      right: index * 50 + 48,
+      top: 68,
+    }))),
+  });
+  assert.equal(skills.geometry.state.status, "ready");
+
+  skills.sync(DEFAULT_SETTINGS, false, false);
+  assert.deepEqual(skills.geometry.state, { status: "waiting", reason: "stale" });
+  skills.sync(withBinding, true, false);
+  skills.geometry.sink?.update({
+    status: "ready",
+    sequence: 2,
+    frameId: 2,
+    viewportWidth: 800,
+    viewportHeight: 600,
+    slots: Object.freeze(Array.from({ length: 8 }, (_, index) => Object.freeze({
+      left: index * 50,
+      bottom: 20,
+      right: index * 50 + 48,
+      top: 68,
+    }))),
+  });
+  assert.deepEqual(
+    skills.geometry.state,
+    { status: "waiting", reason: "stale" },
+    "re-enabling cannot revive the withdrawn publication",
+  );
+  skills.geometry.sink?.update({
+    status: "ready",
+    sequence: 4,
+    frameId: 2,
+    viewportWidth: 800,
+    viewportHeight: 600,
+    slots: Object.freeze(Array.from({ length: 8 }, (_, index) => Object.freeze({
+      left: index * 50,
+      bottom: 20,
+      right: index * 50 + 48,
+      top: 68,
+    }))),
+  });
+  assert.equal(skills.geometry.state.status, "ready");
+
+  skills.sync(DEFAULT_SETTINGS, true, true);
+  assert.equal(skills.geometry.active, true, "cooldowns also need geometry");
+  assert.equal(skills.cooldowns.active, true);
+  skills.disposePresentation();
+  skills.geometry.dispose();
+  skills.cooldowns.dispose();
+});


### PR DESCRIPTION
Skill geometry and cooldown state each implemented the same allocation, freshness, withdrawal, and cleanup lifecycle. That duplication made every new certified observation another place for stale data or teardown behavior to drift.

This PR introduces one internal bounded-region owner for companion-written observations. Domain modules still define their wire size and state types, but share allocation ownership, explicit freshness policy, monotonic uint32 sequence acceptance, immediate policy withdrawal, and terminal cleanup. Event-driven records can explicitly opt out of heartbeat freshness.

The skill overlay coordinator now activates only the regions its current policy needs. Disabling a feature withdraws accepted state immediately, and re-enabling requires a newer native publication before presentation can return.

Review hardening included:

- malformed ready sequences fail closed;
- stale and waiting sentinels must be non-ready;
- duplicate and rolled-back sequences are ignored, including uint32 wrap handling;
- release and dispose withdraw before ownership teardown;
- free failures retain ownership without retaining ready state;
- invalid freshness durations are rejected;
- disposed regions cannot restart timers or accept new observations.

Verification:

- `pnpm typecheck`
- `pnpm lint`
- `pnpm test:unit` — 1,210 passed
- `pnpm test:policy` — 174 passed
- `pnpm tools:test` — 102 passed
- `pnpm build`
- `node scripts/verify-companion-kernel.mjs`
- `pnpm test:integration` — 55 passed (with loopback permission)

Local Electron/E2E tests were intentionally not run at Matthias's request. The normal GitHub CI remains authoritative for that layer.

Stack dependency: #264
