### PR TITLE
refactor(enhancements): define feature contracts

### DIFF
--- a/src/renderer/certified-companion-installation.ts
+++ b/src/renderer/certified-companion-installation.ts
@@ -653,10 +653,10 @@ export async function installCertifiedCompanion(
     let optionalSettings = window.gwToolsSettings();
     skills.mount(document.body, optionalSettings);
     const configureTradeAlias = () => {
-      configureTradeToggle?.(optionalSettings.enabled ? 1 : 0);
+      configureTradeToggle?.(optionalSettings.gwonmacTools ? 1 : 0);
     };
     const pollTradeAlias = () => {
-      if (takeTradeToggle?.() === 1 && optionalSettings.enabled) {
+      if (takeTradeToggle?.() === 1 && optionalSettings.gwonmacTools) {
         window.dispatchEvent(new CustomEvent("gw:trade-toggle"));
       }
     };

--- a/src/renderer/enhancement-runtime-policy.ts
+++ b/src/renderer/enhancement-runtime-policy.ts
@@ -3,15 +3,13 @@
  * Saved product settings and explicit developer programs meet only here.
  */
 import type { EnhancementProgram } from "../shared/enhancement-contracts.js";
+import {
+  featureActivationRequested,
+  featureRegionAllowsRequest,
+  type FeatureActivationSettings,
+} from "../shared/feature-contracts.js";
 
-export type OptionalToolSettings = Readonly<{
-  enabled: boolean;
-  targetReadout: boolean;
-  teamManagement: boolean;
-  xunlaiStorage: boolean;
-  travelPalette?: boolean;
-  skillCooldownOverlayEnabled?: boolean;
-}>;
+export type OptionalToolSettings = FeatureActivationSettings;
 
 export type RuntimePlayRegion = "pve" | "pvp" | "unknown";
 
@@ -34,7 +32,9 @@ export function enhancementRuntimePolicy(
   settings: OptionalToolSettings,
   playRegion: RuntimePlayRegion,
 ) {
-  const pve = playRegion === "pve";
+  const requested = (id: Parameters<typeof featureActivationRequested>[0]) =>
+    featureActivationRequested(id, settings)
+      && featureRegionAllowsRequest(id, playRegion);
   const developerToolbox = program === "toolbox-foundation"
     || program === "toolbox-commands"
     || program === "xunlai-storage";
@@ -44,21 +44,19 @@ export function enhancementRuntimePolicy(
   return Object.freeze({
     // The saved Build/Team library is local UI. It remains reachable at the
     // login screen, in PvP, and while live game observations are unavailable.
-    tools: developerToolbox || settings.enabled,
+    tools: developerToolbox || requested("tools"),
     targetReadout: program === "target-observer"
-      || (settings.enabled && settings.targetReadout && pve),
-    teamManagement: pve && (
-      developerTeam || (settings.enabled && settings.teamManagement)
-    ),
+      || requested("targetReadout"),
+    teamManagement: featureRegionAllowsRequest("teamApply", playRegion)
+      && (developerTeam || requested("teamApply")),
     // The storage controller owns live access refusal and its user-facing
     // reason. This value means requested, not currently available.
     xunlaiStorage:
-      developerStorage || (settings.enabled && settings.xunlaiStorage),
-    travelPalette: pve && (
-      developerStorage || (settings.enabled && settings.travelPalette === true)
-    ),
-    skillSlotGeometry: settings.enabled && pve,
-    skillCooldownOverlay:
-      settings.enabled && settings.skillCooldownOverlayEnabled === true && pve,
+      developerStorage || requested("xunlaiStorage"),
+    travelPalette: featureRegionAllowsRequest("travel", playRegion)
+      && (developerStorage || requested("travel")),
+    skillSlotGeometry:
+      requested("skillKeyLabels") || requested("skillCooldowns"),
+    skillCooldownOverlay: requested("skillCooldowns"),
   });
 }

--- a/src/renderer/gw-native.d.ts
+++ b/src/renderer/gw-native.d.ts
@@ -195,7 +195,7 @@ declare global {
     gwApplySettings?(settings: AppSettings): void;
     gwSurfaces: GwonmacSurfaceController;
     gwToolsSettings(): Readonly<{
-      enabled: boolean;
+      gwonmacTools: boolean;
       teamManagement: boolean;
       xunlaiStorage: boolean;
       travelPalette: boolean;

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -488,7 +488,7 @@ const emptySkillKeyBindings:
   import('../shared/contracts.js').AppSettings['skillKeyBindings'] =
     [null, null, null, null, null, null, null, null];
 window.gwToolsSettings = () => Object.freeze({
-  enabled: appSettings?.gwonmacTools ?? false,
+  gwonmacTools: appSettings?.gwonmacTools ?? false,
   teamManagement: appSettings?.teamManagement ?? true,
   xunlaiStorage: appSettings?.xunlaiStorage ?? false,
   travelPalette: appSettings?.travelPalette ?? false,

--- a/src/renderer/tools-host.ts
+++ b/src/renderer/tools-host.ts
@@ -220,7 +220,7 @@ export function mountHostOnlyTools(
     // The saved Build/Team library is the Tools surface. Apply team is only
     // one live-game action inside it, so turning Apply off must not remove the
     // library or its keyboard shortcut.
-    lifecycle.setEnabled(settings.enabled);
+    lifecycle.setEnabled(settings.gwonmacTools);
   };
   window.addEventListener("gw:tools-settings", syncEnabled);
   syncEnabled();

--- a/src/shared/enhancement-contracts.ts
+++ b/src/shared/enhancement-contracts.ts
@@ -3,6 +3,12 @@
  * preload and renderer. Keeping this separate prevents the general IPC
  * contract from becoming the accidental home of the transform ABI.
  */
+import {
+  ENHANCEMENT_CONFIG_FIELDS,
+  ENHANCEMENT_CONFIG_WORD_COUNT,
+  type EnhancementConfigOwner,
+} from "./enhancement-config.js";
+
 export const ENHANCEMENTS = ["nativeCursor", "tools"] as const;
 
 export type Enhancement = (typeof ENHANCEMENTS)[number];
@@ -19,29 +25,106 @@ export const ENHANCEMENT_PROGRAMS = [
 
 export type EnhancementProgram = (typeof ENHANCEMENT_PROGRAMS)[number];
 
-/**
- * Profile-mask bit order. Reordering or inserting fields changes every profile
- * identity and requires an Enhancement transform ABI change.
- */
-export const ENHANCEMENT_CAPABILITY_FIELDS = Object.freeze([
-  "nativeCursor",
-  "targetObservation",
-  "partyObservation",
-  "teamApply",
-  "travelAction",
-  "xunlaiAction",
-  "chatAliases",
-  "skillSlotGeometry",
-  "skillCooldownObservation",
-] as const);
+type EnhancementHook = "cursor" | "ui";
 
-export type EnhancementCapability = (typeof ENHANCEMENT_CAPABILITY_FIELDS)[number];
+/**
+ * Compile-time capability registry and profile-mask bit order. Reordering or
+ * inserting entries changes every profile identity and requires an Enhancement
+ * transform ABI change. Dependencies describe proof/runtime requirements; they
+ * never select addresses or dynamically install code.
+ */
+const CAPABILITY_DEFINITIONS = Object.freeze([
+  {
+    id: "nativeCursor",
+    requiresAll: [],
+    requiresAny: [],
+    configOwners: ["cursor"],
+    hooks: ["cursor"],
+  },
+  {
+    id: "targetObservation",
+    requiresAll: [],
+    requiresAny: [],
+    configOwners: ["observation", "target"],
+    hooks: [],
+  },
+  {
+    id: "partyObservation",
+    requiresAll: [],
+    requiresAny: [],
+    configOwners: ["observation", "party"],
+    hooks: ["ui"],
+  },
+  {
+    id: "teamApply",
+    requiresAll: ["partyObservation"],
+    requiresAny: [],
+    configOwners: [],
+    hooks: [],
+  },
+  {
+    id: "travelAction",
+    requiresAll: [],
+    requiresAny: [],
+    configOwners: [],
+    hooks: [],
+  },
+  {
+    id: "xunlaiAction",
+    requiresAll: [],
+    requiresAny: [],
+    configOwners: ["observation", "storage"],
+    hooks: [],
+  },
+  {
+    id: "chatAliases",
+    requiresAll: [],
+    requiresAny: ["travelAction", "xunlaiAction"],
+    configOwners: [],
+    hooks: [],
+  },
+  {
+    id: "skillSlotGeometry",
+    requiresAll: ["partyObservation"],
+    requiresAny: [],
+    configOwners: ["skill-slots"],
+    hooks: [],
+  },
+  {
+    id: "skillCooldownObservation",
+    requiresAll: ["partyObservation"],
+    requiresAny: [],
+    configOwners: ["skill-cooldown"],
+    hooks: [],
+  },
+] as const);
+for (const contract of CAPABILITY_DEFINITIONS) {
+  Object.freeze(contract.requiresAll);
+  Object.freeze(contract.requiresAny);
+  Object.freeze(contract.configOwners);
+  Object.freeze(contract.hooks);
+  Object.freeze(contract);
+}
+
+export type EnhancementCapability = (typeof CAPABILITY_DEFINITIONS)[number]["id"];
+export type EnhancementCapabilityContract = Readonly<{
+  id: EnhancementCapability;
+  requiresAll: readonly EnhancementCapability[];
+  requiresAny: readonly EnhancementCapability[];
+  configOwners: readonly EnhancementConfigOwner[];
+  hooks: readonly EnhancementHook[];
+}>;
+export const ENHANCEMENT_CAPABILITY_CONTRACTS:
+readonly EnhancementCapabilityContract[] = CAPABILITY_DEFINITIONS;
+export const ENHANCEMENT_CAPABILITY_FIELDS = Object.freeze(
+  CAPABILITY_DEFINITIONS.map(({ id }) => id),
+);
 export type EnhancementCapabilities = Readonly<Record<EnhancementCapability, boolean>>;
 
 const MAX_CAPABILITY_MASK = (1 << ENHANCEMENT_CAPABILITY_FIELDS.length) - 1;
 const CAPABILITY_PROFILE = /^features-([0-9a-f]{2,3})$/;
 
-/** A compact transform identity; the two hex digits are the eight capability bits. */
+/** A compact transform identity whose hex mask follows the registry order. */
 export type EnhancementCapabilityProfile = `features-${string}`;
 
 function capabilitiesFromMask(mask: number): EnhancementCapabilities {
@@ -165,10 +248,6 @@ export const ENHANCEMENT_CAPABILITY_PRESETS = Object.freeze({
   all: capabilitiesFromMask(0x1ff),
 });
 
-import {
-  ENHANCEMENT_CONFIG_FIELDS,
-  ENHANCEMENT_CONFIG_WORD_COUNT,
-} from "./enhancement-config.js";
 export {
   ENHANCEMENT_CONFIG_WORD_COUNT,
   ENHANCEMENT_LAYOUT_WORD_COUNT,
@@ -184,26 +263,15 @@ export function enhancementConfigWordActive(
     return false;
   }
   const owner = ENHANCEMENT_CONFIG_FIELDS[index]?.owner;
-  if (owner === "target") {
-    return capabilities.targetObservation;
-  }
-  if (owner === "observation") {
-    return capabilities.targetObservation
-      || capabilities.partyObservation
-      || capabilities.xunlaiAction;
-  }
-  if (owner === "cursor") return capabilities.nativeCursor;
-  if (owner === "party") return capabilities.partyObservation;
-  if (owner === "skill-slots") return capabilities.skillSlotGeometry;
-  if (owner === "skill-cooldown") return capabilities.skillCooldownObservation;
-  return owner === "storage" && capabilities.xunlaiAction;
+  return owner !== undefined && ENHANCEMENT_CAPABILITY_CONTRACTS.some(
+    (contract) => capabilities[contract.id]
+      && contract.configOwners.includes(owner),
+  );
 }
 
-export type EnhancementHooks = Readonly<{
-  tick: boolean;
-  cursor: boolean;
-  ui: boolean;
-}>;
+export type EnhancementHooks = Readonly<
+  { tick: boolean } & Record<EnhancementHook, boolean>
+>;
 
 export function enhancementCapabilitiesFor(
   selection: EnhancementSelection,
@@ -229,8 +297,12 @@ export function enhancementHooksFor(
 ): EnhancementHooks {
   return Object.freeze({
     tick: enhancementCapabilitiesRequested(capabilities),
-    cursor: capabilities.nativeCursor,
-    ui: capabilities.partyObservation,
+    cursor: ENHANCEMENT_CAPABILITY_CONTRACTS.some(
+      (contract) => capabilities[contract.id] && contract.hooks.includes("cursor"),
+    ),
+    ui: ENHANCEMENT_CAPABILITY_CONTRACTS.some(
+      (contract) => capabilities[contract.id] && contract.hooks.includes("ui"),
+    ),
   });
 }
 
@@ -240,16 +312,25 @@ export function enhancementCapabilitiesRequested(
   return ENHANCEMENT_CAPABILITY_FIELDS.some((field) => capabilities[field]);
 }
 
-/** Team Apply alone requires the party observer; local actions do not. */
+function capabilityDependenciesSatisfied(
+  contract: EnhancementCapabilityContract,
+  capabilities: EnhancementCapabilities,
+): boolean {
+  return contract.requiresAll.every((dependency) => capabilities[dependency])
+    && (
+      contract.requiresAny.length === 0
+      || contract.requiresAny.some((dependency) => capabilities[dependency])
+    );
+}
+
+/** Every enabled capability must carry the dependencies in its contract. */
 export function validEnhancementCapabilities(
   capabilities: EnhancementCapabilities,
 ): boolean {
-  return (!capabilities.teamApply || capabilities.partyObservation)
-    && (!capabilities.skillSlotGeometry || capabilities.partyObservation)
-    && (!capabilities.skillCooldownObservation || capabilities.partyObservation)
-    && (!capabilities.chatAliases
-      || capabilities.travelAction
-      || capabilities.xunlaiAction);
+  return ENHANCEMENT_CAPABILITY_CONTRACTS.every(
+    (contract) => !capabilities[contract.id]
+      || capabilityDependenciesSatisfied(contract, capabilities),
+  );
 }
 
 /** The exact requested subset that one build's optional certificate groups support. */
@@ -257,22 +338,18 @@ export function intersectEnhancementCapabilities(
   requested: EnhancementCapabilities,
   supported: EnhancementCapabilities,
 ): EnhancementCapabilities {
-  const partyObservation = requested.partyObservation && supported.partyObservation;
-  const travelAction = requested.travelAction && supported.travelAction;
-  const xunlaiAction = requested.xunlaiAction && supported.xunlaiAction;
-  return Object.freeze({
-    nativeCursor: requested.nativeCursor && supported.nativeCursor,
-    targetObservation:
-      requested.targetObservation && supported.targetObservation,
-    partyObservation,
-    teamApply: requested.teamApply && supported.teamApply && partyObservation,
-    travelAction,
-    xunlaiAction,
-    chatAliases: requested.chatAliases && supported.chatAliases
-      && (travelAction || xunlaiAction),
-    skillSlotGeometry: requested.skillSlotGeometry && supported.skillSlotGeometry
-      && partyObservation,
-    skillCooldownObservation: requested.skillCooldownObservation
-      && supported.skillCooldownObservation && partyObservation,
-  });
+  const enabled = Object.fromEntries(ENHANCEMENT_CAPABILITY_FIELDS.map(
+    (field) => [field, requested[field] && supported[field]],
+  )) as Record<EnhancementCapability, boolean>;
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const contract of ENHANCEMENT_CAPABILITY_CONTRACTS) {
+      if (enabled[contract.id] && !capabilityDependenciesSatisfied(contract, enabled)) {
+        enabled[contract.id] = false;
+        changed = true;
+      }
+    }
+  }
+  return Object.freeze(enabled);
 }

--- a/src/shared/feature-contracts.ts
+++ b/src/shared/feature-contracts.ts
@@ -1,0 +1,135 @@
+/**
+ * Static product-feature selection policy.
+ *
+ * This registry centralizes only policy that it actively enforces. Native
+ * capabilities and lifecycle behavior stay in their owning modules until a
+ * coordinator can consume those contracts directly.
+ */
+import type { AppSettings } from "./contracts.js";
+
+type BooleanSetting = {
+  [Key in keyof AppSettings]: AppSettings[Key] extends boolean ? Key : never
+}[keyof AppSettings];
+type FeatureBooleanSetting = BooleanSetting & (
+  | "gwonmacTools"
+  | "targetReadout"
+  | "teamManagement"
+  | "xunlaiStorage"
+  | "travelPalette"
+  | "skillCooldownOverlayEnabled"
+);
+type ContentSetting = "skillKeyBindings";
+type FeatureActivation =
+  | Readonly<{ kind: "master"; setting: FeatureBooleanSetting }>
+  | Readonly<{
+      kind: "setting";
+      setting: FeatureBooleanSetting;
+      master: FeatureBooleanSetting;
+    }>
+  | Readonly<{
+      kind: "configured-content";
+      setting: ContentSetting;
+      master: FeatureBooleanSetting;
+    }>;
+
+type FeatureSelectionPolicy = Readonly<{
+  activation: FeatureActivation;
+  region: "any" | "pve";
+}>;
+
+function defineFeatureSelectionPolicies<
+  const Registry extends Record<string, FeatureSelectionPolicy>,
+>(registry: Registry): Readonly<{
+  readonly [Id in keyof Registry]: FeatureSelectionPolicy;
+}> {
+  for (const policy of Object.values(registry)) {
+    Object.freeze(policy.activation);
+    Object.freeze(policy);
+  }
+  return Object.freeze(registry);
+}
+
+export const FEATURE_SELECTION_POLICIES = defineFeatureSelectionPolicies({
+  tools: {
+    activation: { kind: "master", setting: "gwonmacTools" },
+    region: "any",
+  },
+  targetReadout: {
+    activation: {
+      kind: "setting",
+      setting: "targetReadout",
+      master: "gwonmacTools",
+    },
+    region: "pve",
+  },
+  teamApply: {
+    activation: {
+      kind: "setting",
+      setting: "teamManagement",
+      master: "gwonmacTools",
+    },
+    region: "pve",
+  },
+  xunlaiStorage: {
+    activation: {
+      kind: "setting",
+      setting: "xunlaiStorage",
+      master: "gwonmacTools",
+    },
+    // The storage controller owns the stronger, fresh access gate; this
+    // selector therefore makes no region claim of its own.
+    region: "any",
+  },
+  travel: {
+    activation: {
+      kind: "setting",
+      setting: "travelPalette",
+      master: "gwonmacTools",
+    },
+    region: "pve",
+  },
+  skillKeyLabels: {
+    activation: {
+      kind: "configured-content",
+      setting: "skillKeyBindings",
+      master: "gwonmacTools",
+    },
+    region: "pve",
+  },
+  skillCooldowns: {
+    activation: {
+      kind: "setting",
+      setting: "skillCooldownOverlayEnabled",
+      master: "gwonmacTools",
+    },
+    region: "pve",
+  },
+});
+
+export type FeatureId = keyof typeof FEATURE_SELECTION_POLICIES;
+export type FeatureActivationSettings = Pick<
+  AppSettings,
+  FeatureBooleanSetting | ContentSetting
+>;
+
+export function featureActivationRequested(
+  id: FeatureId,
+  settings: FeatureActivationSettings,
+): boolean {
+  const activation = FEATURE_SELECTION_POLICIES[id].activation;
+  if (activation.kind === "master") return settings[activation.setting];
+  if (!settings[activation.master]) return false;
+  if (activation.kind === "setting") return settings[activation.setting];
+  return settings[activation.setting].some((value) => value !== null);
+}
+
+/**
+ * Answers only the coarse region part of feature selection. Feature-owned
+ * live-state gates remain authoritative for stronger access checks.
+ */
+export function featureRegionAllowsRequest(
+  id: FeatureId,
+  region: "pve" | "pvp" | "unknown",
+): boolean {
+  return FEATURE_SELECTION_POLICIES[id].region !== "pve" || region === "pve";
+}

--- a/tests/helpers/packaged-enhancement-scenarios.ts
+++ b/tests/helpers/packaged-enhancement-scenarios.ts
@@ -363,7 +363,7 @@ export async function assertCleanupSafetyGates() {
               await import(surfaceSpecifier);
           window.gwSurfaces = installSurfaceController(document);
           window.gwToolsSettings = () => Object.freeze({
-            enabled: true,
+            gwonmacTools: true,
             teamManagement: true,
             xunlaiStorage: true,
             travelPalette: true,
@@ -706,7 +706,7 @@ export async function assertToolboxFoundationLifecycle() {
           await import(snapshotSpecifier);
       globalThis.dispatchEvent(new Event("pagehide"));
       window.gwToolsSettings = () => Object.freeze({
-        enabled: true,
+        gwonmacTools: true,
         teamManagement: true,
       xunlaiStorage: true,
       travelPalette: true,
@@ -1151,7 +1151,7 @@ export async function assertRollbackAfterTablePublication() {
       try {
         globalThis.dispatchEvent(new Event("pagehide"));
         window.gwToolsSettings = () => Object.freeze({
-          enabled: true,
+          gwonmacTools: true,
           teamManagement: true,
       xunlaiStorage: true,
       travelPalette: true,

--- a/tests/unit/enhancement-runtime-policy.test.ts
+++ b/tests/unit/enhancement-runtime-policy.test.ts
@@ -6,11 +6,13 @@ import {
 } from "../../src/renderer/enhancement-runtime-policy.js";
 
 const off = Object.freeze({
-  enabled: false,
+  gwonmacTools: false,
   targetReadout: false,
   teamManagement: false,
   xunlaiStorage: false,
   travelPalette: false,
+  skillKeyBindings: [null, null, null, null, null, null, null, null] as const,
+  skillCooldownOverlayEnabled: false,
 });
 
 test("developer programs replace saved optional-tool selection in PvE", () => {
@@ -54,11 +56,13 @@ test("developer programs replace saved optional-tool selection in PvE", () => {
 
 test("runtime-gated commands fail closed while storage keeps its refusal reason", () => {
   const on = Object.freeze({
-    enabled: true,
+    gwonmacTools: true,
     targetReadout: true,
     teamManagement: true,
     xunlaiStorage: true,
     travelPalette: true,
+    skillKeyBindings: off.skillKeyBindings,
+    skillCooldownOverlayEnabled: false,
   });
   for (const region of ["unknown", "pvp"] as const) {
     assert.equal(enhancementRuntimePolicy("toolbox-commands", on, region).teamManagement, false);
@@ -79,11 +83,12 @@ test("a snapshot remains authoritative when party evidence disagrees", () => {
 
 test("product tool settings remain live once the capability is present", () => {
   assert.deepEqual(enhancementRuntimePolicy("none", {
-    enabled: true,
+    gwonmacTools: true,
     targetReadout: false,
     teamManagement: true,
     xunlaiStorage: false,
     travelPalette: true,
+    skillKeyBindings: off.skillKeyBindings,
     skillCooldownOverlayEnabled: true,
   }, "pve"), {
     tools: true,
@@ -94,6 +99,36 @@ test("product tool settings remain live once the capability is present", () => {
     skillSlotGeometry: true,
     skillCooldownOverlay: true,
   });
+});
+
+test("skill geometry runs only for configured labels or enabled cooldowns", () => {
+  const empty = enhancementRuntimePolicy("none", {
+    ...off,
+    gwonmacTools: true,
+    skillKeyBindings: [null, null, null, null, null, null, null, null],
+    skillCooldownOverlayEnabled: false,
+  }, "pve");
+  assert.equal(empty.skillSlotGeometry, false);
+  const labels = enhancementRuntimePolicy("none", {
+    ...off,
+    gwonmacTools: true,
+    skillKeyBindings: [
+      {
+        input: { kind: "keyboard", code: "KeyC" },
+        modifiers: { control: false, option: false, shift: false, command: false },
+      },
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+    ],
+    skillCooldownOverlayEnabled: false,
+  }, "pve");
+  assert.equal(labels.skillSlotGeometry, true);
+  assert.equal(labels.skillCooldownOverlay, false);
 });
 
 test("local Tools availability never depends on a live-game safety gate", () => {
@@ -113,7 +148,8 @@ test("local Tools availability never depends on a live-game safety gate", () => 
           for (const targetReadout of [false, true]) {
             for (const xunlaiStorage of [false, true]) {
               const policy = enhancementRuntimePolicy(program, {
-                enabled,
+                ...off,
+                gwonmacTools: enabled,
                 teamManagement,
                 xunlaiStorage,
                 targetReadout,

--- a/tests/unit/feature-contracts.test.ts
+++ b/tests/unit/feature-contracts.test.ts
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { DEFAULT_SETTINGS } from "../../src/shared/contracts.ts";
+import {
+  ENHANCEMENT_CAPABILITY_CONTRACTS,
+  ENHANCEMENT_CAPABILITY_FIELDS,
+  NO_ENHANCEMENT_CAPABILITIES,
+  enhancementHooksFor,
+  intersectEnhancementCapabilities,
+  validEnhancementCapabilities,
+  type EnhancementCapability,
+} from "../../src/shared/enhancement-contracts.ts";
+import {
+  FEATURE_SELECTION_POLICIES,
+  featureActivationRequested,
+  featureRegionAllowsRequest,
+} from "../../src/shared/feature-contracts.ts";
+
+test("the capability registry is the ordered wire vocabulary", () => {
+  assert.deepEqual(ENHANCEMENT_CAPABILITY_CONTRACTS, [
+    {
+      id: "nativeCursor",
+      requiresAll: [],
+      requiresAny: [],
+      configOwners: ["cursor"],
+      hooks: ["cursor"],
+    },
+    {
+      id: "targetObservation",
+      requiresAll: [],
+      requiresAny: [],
+      configOwners: ["observation", "target"],
+      hooks: [],
+    },
+    {
+      id: "partyObservation",
+      requiresAll: [],
+      requiresAny: [],
+      configOwners: ["observation", "party"],
+      hooks: ["ui"],
+    },
+    {
+      id: "teamApply",
+      requiresAll: ["partyObservation"],
+      requiresAny: [],
+      configOwners: [],
+      hooks: [],
+    },
+    {
+      id: "travelAction",
+      requiresAll: [],
+      requiresAny: [],
+      configOwners: [],
+      hooks: [],
+    },
+    {
+      id: "xunlaiAction",
+      requiresAll: [],
+      requiresAny: [],
+      configOwners: ["observation", "storage"],
+      hooks: [],
+    },
+    {
+      id: "chatAliases",
+      requiresAll: [],
+      requiresAny: ["travelAction", "xunlaiAction"],
+      configOwners: [],
+      hooks: [],
+    },
+    {
+      id: "skillSlotGeometry",
+      requiresAll: ["partyObservation"],
+      requiresAny: [],
+      configOwners: ["skill-slots"],
+      hooks: [],
+    },
+    {
+      id: "skillCooldownObservation",
+      requiresAll: ["partyObservation"],
+      requiresAny: [],
+      configOwners: ["skill-cooldown"],
+      hooks: [],
+    },
+  ]);
+  assert.deepEqual(
+    ENHANCEMENT_CAPABILITY_CONTRACTS.map(({ id }) => id),
+    ENHANCEMENT_CAPABILITY_FIELDS,
+  );
+  assert.equal(new Set(ENHANCEMENT_CAPABILITY_FIELDS).size, 9);
+  for (const contract of ENHANCEMENT_CAPABILITY_CONTRACTS) {
+    assert.equal(Object.isFrozen(contract), true, contract.id);
+    assert.equal(Object.isFrozen(contract.requiresAll), true, contract.id);
+    assert.equal(Object.isFrozen(contract.requiresAny), true, contract.id);
+    assert.equal(Object.isFrozen(contract.configOwners), true, contract.id);
+    assert.equal(Object.isFrozen(contract.hooks), true, contract.id);
+  }
+
+  const visiting = new Set<string>();
+  const visited = new Set<string>();
+  const byId = new Map(ENHANCEMENT_CAPABILITY_CONTRACTS.map(
+    (contract) => [contract.id, contract],
+  ));
+  const visit = (id: EnhancementCapability): void => {
+    assert.equal(visiting.has(id), false, `capability dependency cycle at ${id}`);
+    if (visited.has(id)) return;
+    visiting.add(id);
+    const contract = byId.get(id);
+    assert.ok(contract);
+    for (const dependency of [...contract.requiresAll, ...contract.requiresAny]) {
+      assert.ok(byId.has(dependency), `${id} names unknown dependency ${dependency}`);
+      visit(dependency);
+    }
+    visiting.delete(id);
+    visited.add(id);
+  };
+  for (const id of ENHANCEMENT_CAPABILITY_FIELDS) visit(id);
+});
+
+test("dependency pruning is derived from capability contracts", () => {
+  for (const contract of ENHANCEMENT_CAPABILITY_CONTRACTS) {
+    const isolated = {
+      ...NO_ENHANCEMENT_CAPABILITIES,
+      [contract.id]: true,
+    };
+    const hasDependencies = contract.requiresAll.length > 0
+      || contract.requiresAny.length > 0;
+    assert.equal(validEnhancementCapabilities(isolated), !hasDependencies, contract.id);
+    assert.equal(
+      intersectEnhancementCapabilities(isolated, isolated)[contract.id],
+      !hasDependencies,
+      contract.id,
+    );
+    assert.deepEqual(enhancementHooksFor(isolated), {
+      tick: true,
+      cursor: contract.id === "nativeCursor",
+      ui: contract.id === "partyObservation",
+    }, contract.id);
+  }
+});
+
+test("feature selection policies are deeply immutable", () => {
+  assert.equal(Object.isFrozen(FEATURE_SELECTION_POLICIES), true);
+  for (const [id, policy] of Object.entries(FEATURE_SELECTION_POLICIES)) {
+    assert.equal(Object.isFrozen(policy), true, id);
+    assert.equal(Object.isFrozen(policy.activation), true, id);
+  }
+});
+
+test("shared activation and area policy cover required, setting, and content features", () => {
+  assert.equal(featureActivationRequested("tools", DEFAULT_SETTINGS), false);
+  assert.equal(featureActivationRequested("skillCooldowns", DEFAULT_SETTINGS), false);
+  const enabled = { ...DEFAULT_SETTINGS, gwonmacTools: true };
+  assert.equal(featureActivationRequested("tools", enabled), true);
+  assert.equal(featureActivationRequested("skillCooldowns", enabled), true);
+  assert.equal(featureActivationRequested("skillKeyLabels", enabled), false);
+  assert.equal(featureActivationRequested("skillKeyLabels", {
+    ...enabled,
+    skillKeyBindings: [
+      {
+        input: { kind: "keyboard", code: "KeyC" },
+        modifiers: { control: false, option: false, shift: false, command: false },
+      },
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+    ],
+  }), true);
+  assert.equal(featureRegionAllowsRequest("travel", "pve"), true);
+  assert.equal(featureRegionAllowsRequest("travel", "unknown"), false);
+  assert.equal(featureRegionAllowsRequest("tools", "pvp"), true);
+  assert.equal(featureRegionAllowsRequest("xunlaiStorage", "unknown"), true);
+});


### PR DESCRIPTION
Tools feature selection and native capability behavior were spread across manual condition matrices. This creates one executable contract for each concern without introducing a dynamic plugin system or speculative lifecycle metadata.

The native capability registry now owns mask order, dependencies, config ownership, and hook selection. A separate product selection registry owns only settings activation and coarse region policy that the runtime actively consumes. The internal Tools settings projection also uses canonical AppSettings names end to end.

This keeps future features plugin-shaped at compile time while preserving explicit certified implementations and fail-closed capability pruning. Skill geometry now stays inactive when neither key labels nor cooldowns are configured.

Verification:
- pnpm typecheck
- pnpm lint
- pnpm test:unit (1216 passed)
- pnpm test:policy (174 passed)
- pnpm tools:test (102 passed)
- pnpm build
- pnpm test:integration (55 passed; non-E2E)

Not run: Electron, Playwright, packaged, or other E2E tests, per the requested parallel-work constraint.