### PR TITLE
refactor(tools): certify play-region policy independently

### DIFF
--- a/certificates/certified-client.json
+++ b/certificates/certified-client.json
@@ -1,4 +1,4 @@
 {
   "formatVersion": 1,
-  "codeGeneration": "06bff323bf52656a578da1c82452d5fceda648f6b88005a2f3289cb8b2406b1d"
+  "codeGeneration": "e017ae15a4b46743a8a1a57bcd7c28a14894dbeeaf7a1c1775473f32c8df369e"
 }

--- a/scripts/companion-kernel-contract.mjs
+++ b/scripts/companion-kernel-contract.mjs
@@ -34,10 +34,11 @@ export const COMPANION_KERNEL_EXPORT_VALUES = Object.freeze({
   companion_party_bytes: COMPANION_ABI.party.bytes,
   companion_skill_slot_bytes: COMPANION_ABI.skillSlots.bytes,
   companion_skill_cooldown_bytes: COMPANION_ABI.skillCooldowns.bytes,
+  companion_play_region_bytes: COMPANION_ABI.playRegion.bytes,
 });
 
 export const COMPANION_KERNEL_DYLINK0 = Object.freeze([
-  // Memory footprint 2189 bytes (0x8d 0x11 as LEB128). Documented moves:
+  // Memory footprint 2197 bytes (0x95 0x11 as LEB128). Documented moves:
   //   309 ->  310  the Toolbox observer gained PARTY_OBSERVED, the byte that
   //                separates "you have no heroes" from "nobody read the party";
   //   310 ->  410  Layout grew by the 25 party-detail address words, at 4 bytes
@@ -76,10 +77,12 @@ export const COMPANION_KERNEL_DYLINK0 = Object.freeze([
   //                sequence state; its 60-byte record remains host-owned.
   //   2185 -> 2189 cached row size validates identity without a periodic
   //                skillbar-table scan on ordinary ticks.
+  //   2189 -> 2197 the independently active play-region publisher adds only
+  //                its pointer and sequence; its 28-byte record is host-owned.
   // This constant exists so a kernel whose footprint moves cannot ship without
   // someone saying why. One page is still the ceiling, and this remains far
   // under it.
-  0x01, 0x05, 0x8d, 0x11, 0x02, 0x00, 0x00,
+  0x01, 0x05, 0x95, 0x11, 0x02, 0x00, 0x00,
 ]);
 
 const WASM_PAGE_BYTES = 65_536;

--- a/src/companion-kernel/abi.rs
+++ b/src/companion-kernel/abi.rs
@@ -32,10 +32,17 @@ pub(crate) const FEATURE_TOOLBOX_FOUNDATION: u32 = 1 << 2;
 pub(crate) const FEATURE_TARGET_OBSERVATION: u32 = 1 << 3;
 pub(crate) const FEATURE_SKILL_SLOT_GEOMETRY: u32 = 1 << 4;
 pub(crate) const FEATURE_SKILL_COOLDOWN_OBSERVATION: u32 = 1 << 5;
+pub(crate) const FEATURE_PLAY_REGION_OBSERVATION: u32 = 1 << 6;
 pub(crate) const KNOWN_FEATURES: u32 =
     FEATURE_NATIVE_CURSOR | FEATURE_GAME_SNAPSHOT | FEATURE_TOOLBOX_FOUNDATION
         | FEATURE_TARGET_OBSERVATION | FEATURE_SKILL_SLOT_GEOMETRY
-        | FEATURE_SKILL_COOLDOWN_OBSERVATION;
+        | FEATURE_SKILL_COOLDOWN_OBSERVATION | FEATURE_PLAY_REGION_OBSERVATION;
+
+pub(crate) const PLAY_REGION_BYTES: u32 = size_of::<PlayRegionSnapshot>() as u32;
+pub(crate) const PLAY_REGION_MAGIC: u32 = 0x5250_5747;
+pub(crate) const PLAY_REGION_ABI_AND_SIZE: u32 = (PLAY_REGION_BYTES << 16) | 1;
+pub(crate) const FLAG_PLAY_REGION_READY: u32 = 1 << 0;
+pub(crate) const FLAG_PLAY_REGION_LOADING: u32 = 1 << 1;
 
 pub(crate) const SKILL_SLOT_BYTES: u32 = size_of::<SkillSlotSnapshot>() as u32;
 pub(crate) const SKILL_SLOT_MAGIC: u32 = 0x534b_5747;
@@ -400,6 +407,17 @@ pub(crate) struct Snapshot {
 }
 
 #[repr(C)]
+pub(crate) struct PlayRegionSnapshot {
+    pub(crate) magic: u32,
+    pub(crate) abi_and_size: u32,
+    pub(crate) sequence: u32,
+    pub(crate) flags: u32,
+    pub(crate) map_id: u32,
+    pub(crate) instance_type: u32,
+    pub(crate) play_region: u32,
+}
+
+#[repr(C)]
 pub(crate) struct CursorSnapshot {
     pub(crate) magic: u32,
     pub(crate) abi_and_size: u32,
@@ -535,3 +553,4 @@ const _: [(); 64] = [(); size_of::<ToolboxSnapshot>()];
 const _: [(); 16] = [(); size_of::<SkillSlotRect>()];
 const _: [(); 156] = [(); size_of::<SkillSlotSnapshot>()];
 const _: [(); 60] = [(); size_of::<SkillCooldownSnapshot>()];
+const _: [(); 28] = [(); size_of::<PlayRegionSnapshot>()];

--- a/src/companion-kernel/lib.rs
+++ b/src/companion-kernel/lib.rs
@@ -42,6 +42,7 @@ mod abi;
 mod cursor;
 mod memory;
 mod party;
+mod play_region;
 mod skill_cooldowns;
 mod skill_slots;
 mod toolbox;
@@ -683,16 +684,23 @@ pub unsafe extern "C" fn companion_init(
     skill_slot_size: u32,
     skill_cooldown_ptr: u32,
     skill_cooldown_size: u32,
+    play_region_ptr: u32,
+    play_region_size: u32,
     features: u32,
 ) -> u32 {
     if features == 0
         || features & !KNOWN_FEATURES != 0
+        || features & FEATURE_GAME_SNAPSHOT != 0
+            && features & FEATURE_PLAY_REGION_OBSERVATION == 0
+        || features & FEATURE_TOOLBOX_FOUNDATION != 0
+            && features & FEATURE_PLAY_REGION_OBSERVATION == 0
         || features & FEATURE_TARGET_OBSERVATION != 0
             && features & FEATURE_GAME_SNAPSHOT == 0
         || features & FEATURE_SKILL_SLOT_GEOMETRY != 0
-            && features & FEATURE_TOOLBOX_FOUNDATION == 0
+            && features & FEATURE_PLAY_REGION_OBSERVATION == 0
         || features & FEATURE_SKILL_COOLDOWN_OBSERVATION != 0
-            && features & FEATURE_TOOLBOX_FOUNDATION == 0
+            && (features & FEATURE_TOOLBOX_FOUNDATION == 0
+                || features & FEATURE_PLAY_REGION_OBSERVATION == 0)
         || config_size != CONFIG_BYTES
         || config_ptr & 3 != 0
         || !contains(config_ptr, config_size)
@@ -736,6 +744,12 @@ pub unsafe extern "C" fn companion_init(
             skill_cooldown_size,
             SKILL_COOLDOWN_BYTES,
         )
+        || !valid_region(
+            features & FEATURE_PLAY_REGION_OBSERVATION != 0,
+            play_region_ptr,
+            play_region_size,
+            PLAY_REGION_BYTES,
+        )
     {
         return 0;
     }
@@ -777,6 +791,9 @@ pub unsafe extern "C" fn companion_init(
         if features & FEATURE_SKILL_COOLDOWN_OBSERVATION != 0 {
             skill_cooldowns::initialize(skill_cooldown_ptr);
         }
+        if features & FEATURE_PLAY_REGION_OBSERVATION != 0 {
+            play_region::initialize(play_region_ptr);
+        }
     }
     1
 }
@@ -813,6 +830,9 @@ pub unsafe extern "C" fn companion_dispatch(kind: u32, a: u32, b: u32, c: u32, _
             if active & FEATURE_SKILL_COOLDOWN_OBSERVATION != 0 {
                 unsafe { skill_cooldowns::tick(layout, c) };
             }
+            if active & FEATURE_PLAY_REGION_OBSERVATION != 0 {
+                unsafe { play_region::tick(layout) };
+            }
         }
         DISPATCH_CURSOR => {
             if unsafe { INITIALIZED } && unsafe { FEATURES } & FEATURE_NATIVE_CURSOR != 0 {
@@ -842,10 +862,15 @@ pub unsafe extern "C" fn companion_dispatch(kind: u32, a: u32, b: u32, c: u32, _
             let available = unsafe { FEATURES };
             if a & !available != 0
                 || a & FEATURE_NATIVE_CURSOR != available & FEATURE_NATIVE_CURSOR
+                || a & FEATURE_PLAY_REGION_OBSERVATION
+                    != available & FEATURE_PLAY_REGION_OBSERVATION
+                || a & FEATURE_TOOLBOX_FOUNDATION != 0
+                    && a & FEATURE_PLAY_REGION_OBSERVATION == 0
                 || a & FEATURE_SKILL_SLOT_GEOMETRY != 0
-                    && a & FEATURE_TOOLBOX_FOUNDATION == 0
+                    && a & FEATURE_PLAY_REGION_OBSERVATION == 0
                 || a & FEATURE_SKILL_COOLDOWN_OBSERVATION != 0
-                    && a & FEATURE_TOOLBOX_FOUNDATION == 0
+                    && (a & FEATURE_TOOLBOX_FOUNDATION == 0
+                        || a & FEATURE_PLAY_REGION_OBSERVATION == 0)
             {
                 return;
             }
@@ -864,7 +889,7 @@ pub unsafe extern "C" fn companion_dispatch(kind: u32, a: u32, b: u32, c: u32, _
 
 #[no_mangle]
 pub extern "C" fn companion_abi() -> u32 {
-    16
+    17
 }
 
 #[no_mangle]
@@ -900,6 +925,11 @@ pub extern "C" fn companion_skill_slot_bytes() -> u32 {
 #[no_mangle]
 pub extern "C" fn companion_skill_cooldown_bytes() -> u32 {
     SKILL_COOLDOWN_BYTES
+}
+
+#[no_mangle]
+pub extern "C" fn companion_play_region_bytes() -> u32 {
+    PLAY_REGION_BYTES
 }
 
 #[no_mangle]

--- a/src/companion-kernel/play_region.rs
+++ b/src/companion-kernel/play_region.rs
@@ -1,0 +1,59 @@
+//! Bounded publication of the current PvE/PvP policy fact.
+//!
+//! This observer deliberately stops at the character context and one indexed
+//! area-table record. It never opens the agent array, so Travel-only recovery
+//! cannot inherit the full snapshot's player scan.
+
+use core::ptr::write_volatile;
+
+use crate::abi::*;
+use crate::{resolve_game, GameState};
+
+static mut POINTER: u32 = 0;
+static mut SEQUENCE: u32 = 0;
+
+unsafe fn publish(flags: u32, map_id: u32, instance_type: u32, play_region: u32) {
+    let next = unsafe { SEQUENCE }.wrapping_add(2) & !1;
+    let snapshot = unsafe { POINTER as *mut PlayRegionSnapshot };
+    unsafe {
+        write_volatile(&mut (*snapshot).sequence, next.wrapping_sub(1));
+        write_volatile(&mut (*snapshot).magic, PLAY_REGION_MAGIC);
+        write_volatile(&mut (*snapshot).abi_and_size, PLAY_REGION_ABI_AND_SIZE);
+        write_volatile(&mut (*snapshot).flags, flags);
+        write_volatile(&mut (*snapshot).map_id, map_id);
+        write_volatile(&mut (*snapshot).instance_type, instance_type);
+        write_volatile(&mut (*snapshot).play_region, play_region);
+        write_volatile(&mut (*snapshot).sequence, next);
+        SEQUENCE = next;
+    }
+}
+
+pub(crate) unsafe fn initialize(pointer: u32) {
+    unsafe {
+        POINTER = pointer;
+        SEQUENCE = 0;
+    }
+    for index in 0..PLAY_REGION_BYTES / 4 {
+        unsafe { write_volatile((pointer + index * 4) as *mut u32, 0) };
+    }
+    unsafe { publish(0, 0, 0, 0) };
+}
+
+pub(crate) unsafe fn tick(layout: Layout) {
+    match unsafe { resolve_game(layout) } {
+        GameState::Ready {
+            map_id,
+            instance_type,
+            play_region,
+            ..
+        } if play_region == PLAY_REGION_PVE || play_region == PLAY_REGION_PVP => unsafe {
+            publish(FLAG_PLAY_REGION_READY, map_id, instance_type, play_region);
+        },
+        GameState::Loading => unsafe {
+            publish(FLAG_PLAY_REGION_LOADING, 0, 0, 0);
+        },
+        GameState::Ready { .. } | GameState::Unavailable => unsafe {
+            publish(0, 0, 0, 0);
+        },
+    }
+}

--- a/src/main/certification/client-module.ts
+++ b/src/main/certification/client-module.ts
@@ -91,9 +91,10 @@ interface PreparedWasmClientModule {
   readonly nativeDoubleClick: boolean;
 }
 
-function capabilityCount(capabilities: EnhancementCapabilities): number {
+function productCapabilityCount(capabilities: EnhancementCapabilities): number {
   return ENHANCEMENT_CAPABILITY_FIELDS.reduce(
-    (count, field) => count + Number(capabilities[field]),
+    (count, field) => count
+      + Number(field !== "playRegionObservation" && capabilities[field]),
     0,
   );
 }
@@ -116,7 +117,7 @@ function enhancementCandidates(
       enhancementCapabilitiesCover(maximum, candidate)
       && enhancementOutputSha256(build, candidate) !== null)
     .sort((left, right) =>
-      capabilityCount(right) - capabilityCount(left)
+      productCapabilityCount(right) - productCapabilityCount(left)
       || Number(left.teamApply) - Number(right.teamApply));
 }
 
@@ -187,6 +188,7 @@ function enhancementCache(
     chatAliases: capabilities.chatAliases,
     skillSlotGeometry: capabilities.skillSlotGeometry,
     skillCooldownObservation: capabilities.skillCooldownObservation,
+    playRegionObservation: capabilities.playRegionObservation,
   };
   return {
     inputSha256: build.sha256,

--- a/src/main/certification/enhancement-build-model.ts
+++ b/src/main/certification/enhancement-build-model.ts
@@ -24,6 +24,7 @@ import {
   ENHANCEMENT_CONFIG_FIELDS,
   type EnhancementCursorLayout,
   type EnhancementObservationBaseLayout,
+  type EnhancementPlayRegionLayout,
   type EnhancementPartyLayout,
   type EnhancementSkillCooldownLayout,
   type EnhancementSkillSlotGeometryLayout,
@@ -103,19 +104,21 @@ export function enhancementConfigWords(
   return ENHANCEMENT_CONFIG_FIELDS.map((field, index) => {
     if (!enhancementConfigWordActive(capabilities, index)) return 0;
     if (field.source === "layout") {
-      const value = field.owner === "observation"
-        ? build.observationBase?.layout[field.key]
-        : field.owner === "target"
-          ? build.targetObservation?.layout[field.key]
-          : field.owner === "cursor"
-            ? build.cursorEvent?.layout[field.key]
-            : field.owner === "party"
-              ? build.partyObservation?.layout[field.key]
-              : field.owner === "storage"
-                ? build.xunlaiAction?.accessProof?.layout[field.key]
-                : field.owner === "skill-slots"
-                  ? build.skillSlotGeometry?.layout[field.key]
-                  : build.skillCooldownObservation?.layout[field.key];
+      const value = field.owner === "play-region"
+        ? build.playRegionObservation?.layout[field.key]
+        : field.owner === "observation"
+          ? build.observationBase?.layout[field.key]
+          : field.owner === "target"
+            ? build.targetObservation?.layout[field.key]
+            : field.owner === "cursor"
+              ? build.cursorEvent?.layout[field.key]
+              : field.owner === "party"
+                ? build.partyObservation?.layout[field.key]
+                : field.owner === "storage"
+                  ? build.xunlaiAction?.accessProof?.layout[field.key]
+                  : field.owner === "skill-slots"
+                    ? build.skillSlotGeometry?.layout[field.key]
+                    : build.skillCooldownObservation?.layout[field.key];
       if (field.owner === "storage" && build.xunlaiAction === undefined) {
         return 0;
       }
@@ -149,6 +152,8 @@ export interface KnownEnhancementBuild {
   tableSlot: number;
   /** Memory facts shared by target and party observation. */
   observationBase?: Readonly<{ layout: EnhancementObservationBaseLayout }>;
+  /** Minimal memory facts used only to determine loading and PvE/PvP policy. */
+  playRegionObservation?: Readonly<{ layout: EnhancementPlayRegionLayout }>;
   /** Exact UI dispatcher shared by party observation and local Travel. */
   uiDispatcher?: Readonly<{
     functionIndex: number;
@@ -320,13 +325,14 @@ export interface KnownEnhancementBuild {
 export function supportedEnhancementCapabilities(
   build: KnownEnhancementBuild,
 ): EnhancementCapabilities {
-  const observationBase = build.observationBase !== undefined;
+  const playRegionObservation = build.playRegionObservation !== undefined;
+  const observationBase = playRegionObservation && build.observationBase !== undefined;
   const targetObservation = observationBase && build.targetObservation !== undefined;
   const partyObservation = observationBase
     && build.uiDispatcher !== undefined
     && build.partyObservation !== undefined;
   const gameThread = build.gameThread !== undefined;
-  const travelAction = build.uiDispatcher !== undefined
+  const travelAction = playRegionObservation && build.uiDispatcher !== undefined
     && gameThread && build.travelAction !== undefined;
   const xunlaiAction = observationBase && build.uiDispatcher !== undefined
     && gameThread && build.xunlaiAction?.accessProof !== undefined;
@@ -338,9 +344,10 @@ export function supportedEnhancementCapabilities(
     travelAction,
     xunlaiAction,
     chatAliases: build.uiDispatcher !== undefined && build.chatAliases !== undefined,
-    skillSlotGeometry: build.skillSlotGeometry !== undefined,
+    skillSlotGeometry: playRegionObservation && build.skillSlotGeometry !== undefined,
     skillCooldownObservation: partyObservation
       && build.skillCooldownObservation !== undefined,
+    playRegionObservation,
   });
 }
 
@@ -370,12 +377,15 @@ export function hasValidEnhancementProfileHashes(
   const storageAccessReaderIndices = storageReaders === undefined
     ? null
     : new Set(Object.values(storageReaders).map(({ functionIndex }) => functionIndex));
-  const hasObservation = build.targetObservation !== undefined
+  const hasPlayRegion = build.playRegionObservation !== undefined;
+  const hasObservation = build.observationBase !== undefined
+    || build.targetObservation !== undefined
     || build.partyObservation !== undefined
     || build.xunlaiAction !== undefined;
   if (hasObservation && build.observationBase === undefined) {
     return false;
   }
+  if (hasObservation && !hasPlayRegion) return false;
   if (build.partyObservation !== undefined && build.uiDispatcher === undefined) {
     return false;
   }

--- a/src/main/certification/enhancement-builds.ts
+++ b/src/main/certification/enhancement-builds.ts
@@ -23,11 +23,10 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
   Object.freeze([
     Object.freeze({
       sha256:
-        "7d0ced840d3dc167b823ed0ad6ed411319faf97316345c8e37620e86d86f536e",
-      // Recomputed when the bounded `/tp` palette signal landed. All profiles move
-      // together whenever the manifest's bytes do, and the manifest carries the
-      // transform ABI and every config word -- so a command-only change also
-      // changes the output of profiles that do not expose commands.
+        "26a71c3e2bf55ab992dce659c1192213858ee25799daa87841ed23a3ddbb601a",
+      // Recomputed from the exact current JSPI artifact when the independent
+      // play-region capability landed. The retained output is the complete
+      // product profile proved by semantic verifier ABI 3.
       //
       // `pnpm check` cannot catch a stale value here. The transform input is a
       // derived game binary this repository does not contain, so nothing in the
@@ -36,65 +35,26 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
       // `transformEnhancementWasm` against the real derived module whenever
       // ENHANCEMENT_TRANSFORM_ABI or any config word changes.
       outputSha256: Object.freeze({
-        "features-01":
-          "e1122d8128c482bb70dd86ded6ca28d49256999899a2d492971f6e0173b4e758",
-        "features-02":
-          "e954703ee701260194dc677c10ae9dc7f0229ac4734beabdc7b34464f1591e36",
-        "features-03":
-          "2b6bfa11cbfc19a6dfb2f24de2fc9568d6ee3fcbd8e95c18fee576532e1aff1d",
-        "features-04":
-          "3710b2721f9758aad0c7158d86804f62818c7c5215ea0777c29ef2e2c6e9ee39",
-        "features-05":
-          "5540ea16565a2ed586a5e5556b58194b4f586337694c3f2c66bb63b01aec08f1",
-        "features-06":
-          "e60119e58bdeb87109dfc715935eeb2fbe33a3906173d05f74678f7cdcebe32a",
-        "features-07":
-          "4e880853ea9f37cebb923b008b30b6e5bd2da657c8976b5129dd39698f91f397",
-        "features-0c":
-          "ec8431fe028151439b8e09e8fe171facb01ab28842f9f0175c1739f26f8b185c",
-        "features-0d":
-          "28ec655aa68bc3fb5df4337be1421893715f4b7379bde8955b23a64ed922e6e6",
-        "features-0e":
-          "fc2a879e1cb2ec6020f72a96136442b7cdbedbf3891767a31ac8298cad79c98a",
-        "features-0f":
-          "52d1cca841a68be0179aeceab1f749c8873f51e7c056dfed354d2ededbdf306d",
-        "features-70":
-          "2e29d4af024f6e05bc017b6cdc2363b071e9fee9c6548be78623bc9f046a59b3",
-        "features-74":
-          "ed8eedf6d75878c77c99aca898d72931d9ff7e2f5d566d56e15fccc0bf03052c",
-        "features-75":
-          "d83360909ff5a1d30f204189be9e01c615f471714c500a1af3dc9f20b5d5a91d",
-        "features-76":
-          "bcc5ecb2ff83fcda0fc406b735328e34c3a9d72d16a0ed168ca8190e35b86c3a",
-        "features-77":
-          "829845f4c8aba0fd747ee8f2b9223a3da5c2769d73e2689c06943096339e3fe7",
-        "features-7c":
-          "37bb6d011d76c4070b39f980bdfaeeaac640a0ab33b63dcdf99c91eeaf364f82",
-        "features-7d":
-          "b5d8dc42e540a8fc0c39b3c22e2fecd7da213b0904108f8fa5bca72981cc006f",
-        "features-7e":
-          "1871c89305a5cdc14d83d6e0337c194549707c71599cd1543869bd2c7d50bf44",
-        "features-7f":
-          "5ec27d6b0ecdf928ff74113fcee052bcbc1b185e098c9d422528bb06e59e9511",
+        "features-3ff":
+          "9ae925f7eb1e314f8b6d4432363cf9082c6ea78d1b87a70947a1203dc24415cb",
       }),
       programId: 1,
-      // Function #477 returns 38,833 as a single i32 constant. The same function
-      // returned 38,797 in the preceding certified client; diagnostics must
-      // confirm that value again during the live patch-day run.
-      buildId: 38833,
+      // The verifier derives this bounded identity from the exact module; it is
+      // diagnostic metadata, never a nearest-build selector.
+      buildId: 3_100_397_719,
       hookFunction: 446,
       hookParams: Object.freeze(["i32"] as const),
       hookResults: Object.freeze([] as const),
       hookBodySha256:
-        "82841ec302481a8960cd7a03aa76732e9a4faf7ec3ea136411fdd86906ea6b05",
+        "a4f73b08ad78397b86ff050bfc25a26ab5a8794ae8f914a4b16399253fbf4635",
       // The input table is fixed at 4,683 entries. The transform extends both
       // limits once and owns only this new terminal entry; statically empty input
       // slot 0 is a game runtime sentinel and must remain untouched.
       tableSlot: 4683,
       observationBase: Object.freeze({
         layout: Object.freeze({
-          contextRoot: 0x5a0ee0,
-          agentArray: 0x5a4e58,
+          contextRoot: 0x5a0e70,
+          agentArray: 0x5a4de8,
           gameContextSlot: 6,
           characterContext: 0x44,
           mapId: 0x198,
@@ -112,7 +72,23 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
           // Exact-build initialised `AreaInfo[mapId]`. Cross-checked against
           // GWToolbox++'s flags: Lion's Arch (55) is PvE, Random Arenas (188)
           // carries the PvP bit, and Isle of Wurms (529) the guild-hall bit.
-          areaInfo: 0x1cc630,
+          areaInfo: 0x1cc5c0,
+          areaInfoCount: 883,
+          areaInfoStride: 0x7c,
+          areaInfoFlags: 0x10,
+        }),
+      }),
+      playRegionObservation: Object.freeze({
+        layout: Object.freeze({
+          contextRoot: 0x5a0e70,
+          gameContextSlot: 6,
+          characterContext: 0x44,
+          mapId: 0x198,
+          isExplorable: 0x19c,
+          currentMapId: 0x234,
+          currentInstanceType: 0x23c,
+          playerNumber: 0x2ac,
+          areaInfo: 0x1cc5c0,
           areaInfoCount: 883,
           areaInfoStride: 0x7c,
           areaInfoFlags: 0x10,
@@ -135,18 +111,18 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
         bodySha256:
           "f09a7a12954169ae595d12d870e69a4c0092003157d72523d626d2a3990241e2",
         producerBodySha256: Object.freeze([
-          "92df16acc44885ad89dac98578a833d2c5c84b8da8cd1f90367c46428685c05c",
-          "d51abe7893b1db5b4f1d212aab9b51901134157766e0c41ead4e1c2b41d08eef",
+          "deada48f4c9ce0b2046f7ab9d416f530c87d24ca0e3fb905f5874abad3e92c41",
+          "2988a05e1a39c1f32f564f5afecf9a4b172a27120c9a9a791ca980804a285100",
         ] as const),
         tableNeighbourBodySha256: Object.freeze([
           "f09a7a12954169ae595d12d870e69a4c0092003157d72523d626d2a3990241e2",
           "cb751dd998dc5591fb1a8d05d08d194a8a7e4670b1a9685816b9a2af8fab7980",
         ] as const),
         layout: Object.freeze({
-          cursorActiveArt: 0x5a16e0,
-          cursorSoftwareModel: 0x5a16e4,
-          cursorShowCount: 0x5a16e8,
-          cursorColorBuffer: 0x298e50,
+          cursorActiveArt: 0x5a1670,
+          cursorSoftwareModel: 0x5a1674,
+          cursorShowCount: 0x5a1678,
+          cursorColorBuffer: 0x298de0,
           cursorArtHotspot: 0x00,
           cursorArtTexture: 0x0c,
           cursorHandleKey: 0x08,
@@ -169,8 +145,8 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
       //
       targetObservation: Object.freeze({
         layout: Object.freeze({
-          manualTargetAgentId: 0x5a394c,
-          automaticTargetAgentId: 0x5a3948,
+          manualTargetAgentId: 0x5a38dc,
+          automaticTargetAgentId: 0x5a38d8,
         }),
       }),
       uiDispatcher: Object.freeze({
@@ -186,7 +162,8 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
       xunlaiAction: Object.freeze({
         openExport: "enhancement_open_storage",
         configureExport: "enhancement_configure_storage",
-        // Exact build-38,833 player access facts. The client readers below
+        // Originally measured on build 38,833 and re-verified against this
+        // exact current client. The readers below
         // independently prove WorldContext::players at +0x80c, Array size at
         // +8, 0x50-byte records, and the three fields used by the kernel.
         accessProof: Object.freeze({
@@ -204,14 +181,14 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
               params: Object.freeze(["i32"] as const),
               results: Object.freeze(["i32"] as const),
               bodySha256:
-                "2a4f5c421482aed52cffc3f58575622a7302492aea86012019b8b683de46cba4",
+                "9232ecf44778323dd0d1f922fbd1d39b3f75d7425886a44019df79f2cf87f93a",
             }),
             "access-flags": Object.freeze({
               functionIndex: 9196,
               params: Object.freeze(["i32"] as const),
               results: Object.freeze(["i32"] as const),
               bodySha256:
-                "620dd5c413423a797119e43a102ae7b2cbe3a633ca41f607bf6a2d7988d1412f",
+                "53fb1be960d2e79c441dd2c29276020cb9a834630fce5a3686035885ca508d29",
             }),
             "player-number": Object.freeze({
               functionIndex: 9205,
@@ -271,7 +248,7 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
           params: Object.freeze(["i32", "i32"] as const),
           results: Object.freeze(["i32"] as const),
           bodySha256:
-            "156c4345c79e43c20b136fa37581d80a62fcf73cf290cabe308ac259387517df",
+            "fcff05250c935e92337fee53cd9f086b22d1ba02a4ff051bd94165f61833a713",
         }),
       }),
       gameThread: Object.freeze({
@@ -285,7 +262,7 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
           results: Object.freeze([] as const),
           tableSlot: 1721,
           bodySha256:
-            "9fb1ca0dee40f5ceef3d0174846ef38af47a8366bfe76cb8da12e86419b40c41",
+            "a3bf3e37cc469f8a0b220fcbb857078fbf427c304f0c07496694d506f5c396d0",
         }),
       }),
       teamApply: Object.freeze({
@@ -300,7 +277,7 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
             params: Object.freeze(["i32", "i32", "i32"] as const),
             results: Object.freeze([] as const),
             bodySha256:
-              "d7f7c74b9cb14ba957ed8de7e74cc18167a3b688301d5f3d765ba04770a8b361",
+              "4746b06f47ce79df6a3879b0b55d6d6430b65544479f4109ca84a56a12738a36",
           }),
         }),
         entries: Object.freeze([
@@ -400,7 +377,7 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
         nearbyPlayerMessages: Object.freeze([
           0x1000_007f, 0x1000_0080,
         ] as const),
-        nearbyPlayerMessageProducers: Object.freeze([8942, 8945] as const),
+        nearbyPlayerMessageProducers: Object.freeze([7880, 8945] as const),
         layout: Object.freeze({
           // GameContext -> PartyContext -> current PartyInfo -> heroes Array.
           // Only owned HeroID/AgentID pairs cross the companion ABI.
@@ -471,6 +448,42 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
           worldProfessionStates: 0x6bc,
           professionStateStride: 0x14,
           worldCharacterSkills: 0x710,
+        }),
+      }),
+      skillSlotGeometry: Object.freeze({
+        initializer: Object.freeze({
+          functionIndex: 15744,
+          params: Object.freeze(["i32", "i32"] as const),
+          results: Object.freeze([] as const),
+          bodySha256:
+            "e4b1af23a4efcbb7fd1c484c4168553c91df5df7e1e40a65ff31bb4ca10790e1",
+          constructorCallOperand: 2186,
+        }),
+        constructor: Object.freeze({
+          functionIndex: 6676,
+          params: Object.freeze([
+            "i32", "i32", "i32", "i32", "i32", "i32",
+          ] as const),
+          results: Object.freeze(["i32"] as const),
+          bodySha256:
+            "a29fca1d30e5fa7dea1ca30f6453acbb8a099e4423c1f05ee43b01cfc3045c41",
+        }),
+        labelAddress: 0x186e1a,
+        layout: Object.freeze({
+          frameArray: 0x5a1fdc,
+          frameCount: 0x5a1fe4,
+          frameBytes: 0x1c8,
+          frameChildOffsetId: 0xb8,
+          frameId: 0xbc,
+          framePositionFlags: 0xd8,
+          frameViewportWidth: 0x104,
+          frameViewportHeight: 0x108,
+          frameScreenLeft: 0x10c,
+          frameScreenBottom: 0x110,
+          frameScreenRight: 0x114,
+          frameScreenTop: 0x118,
+          frameRelation: 0x128,
+          frameState: 0x18c,
         }),
       }),
       skillCooldownObservation: Object.freeze({

--- a/src/main/certification/enhancement-evidence-types.ts
+++ b/src/main/certification/enhancement-evidence-types.ts
@@ -8,6 +8,7 @@ import type { RelocationSpan } from "./semantic-proof.js";
 import type {
   EnhancementCursorLayout,
   EnhancementObservationBaseLayout,
+  EnhancementPlayRegionLayout,
   EnhancementTargetLayout,
 } from "../../shared/enhancement-config.js";
 
@@ -122,6 +123,14 @@ export interface AutomaticTargetLocation {
   readonly hookBodySha256: string;
   readonly observationLayout: EnhancementObservationBaseLayout;
   readonly targetLayout: EnhancementTargetLayout;
+}
+
+/** Exact main-loop and observation-base authority for play-region policy. */
+export interface AutomaticPlayRegionLocation {
+  readonly baseline: KnownEnhancementBuild;
+  readonly hookFunction: number;
+  readonly hookBodySha256: string;
+  readonly playRegionLayout: EnhancementPlayRegionLayout;
 }
 
 export interface AutomaticLocalActionsLocation {

--- a/src/main/certification/enhancement-party-team-proof.ts
+++ b/src/main/certification/enhancement-party-team-proof.ts
@@ -118,6 +118,10 @@ const PARTY_EXACT_ROLES = Object.freeze({
   ]), ["i32", "i32"], []) },
 } as const);
 
+// The exact mutable-static operand paired with the certified context root.
+// Their common relocation delta must agree on every candidate client.
+const PARTY_MAP_LIFECYCLE_STATIC_BASELINE = 1_447_000;
+
 type PartyFunctionRole = (typeof PARTY_EXACT_ROLES)[keyof typeof PARTY_EXACT_ROLES];
 
 const PARTY_DIRTY_ROLES = Object.freeze([
@@ -396,7 +400,10 @@ export function derivePartyObservation(
     || !exactStaticBytesHash(module, worldValues, "world.assert-a", 12, PARTY_IMMUTABLE_HASHES.worldAssertionA)
     || !exactStaticBytesHash(module, worldValues, "world.assert-b", 12, PARTY_IMMUTABLE_HASHES.worldAssertionB)
     || commonRelocationDelta([
-      [soleValue(mapValues, "map.lifecycle-static"), 1_447_112],
+      [
+        soleValue(mapValues, "map.lifecycle-static"),
+        PARTY_MAP_LIFECYCLE_STATIC_BASELINE,
+      ],
       [observation.contextRoot, baselineObservation.contextRoot],
     ]) === null
   ) return null;

--- a/src/main/certification/enhancement-structural-evidence.ts
+++ b/src/main/certification/enhancement-structural-evidence.ts
@@ -9,6 +9,7 @@ export { inspectEnhancementStructuralEvidence } from "./enhancement-structural-r
 export { locateAutomaticCursor } from "./enhancement-cursor-proof.js";
 export {
   inspectTargetRoleCandidates,
+  locateAutomaticPlayRegion,
   locateAutomaticTarget,
   type TargetRoleCandidateDiagnostic,
 } from "./enhancement-target-proof.js";
@@ -19,6 +20,7 @@ export type { EnhancementProofContext } from "./enhancement-wasm-proof-context.j
 export type {
   AutomaticCursorLocation,
   AutomaticLocalActionsLocation,
+  AutomaticPlayRegionLocation,
   AutomaticTargetLocation,
   CursorConsideration,
   CursorEvidenceReport,

--- a/src/main/certification/enhancement-target-proof.ts
+++ b/src/main/certification/enhancement-target-proof.ts
@@ -29,9 +29,11 @@ import type { EnhancementProofContext } from "./enhancement-wasm-proof-context.j
 import type { KnownEnhancementBuild } from "./enhancement-builds.js";
 import type {
   EnhancementObservationBaseLayout,
+  EnhancementPlayRegionLayout,
   EnhancementTargetLayout,
 } from "../../shared/enhancement-config.js";
 import type {
+  AutomaticPlayRegionLocation,
   AutomaticTargetLocation,
   ModuleShape,
 } from "./enhancement-evidence-types.js";
@@ -242,47 +244,33 @@ export function inspectTargetRoleCandidates(
   }
 }
 
-export function deriveObservationLayout(
+/** Exact, agent-independent authority for loading and PvE/PvP policy. */
+export function derivePlayRegionLayout(
   module: ModuleShape,
-): EnhancementObservationBaseLayout | null {
+): EnhancementPlayRegionLayout | null {
   const contextFunction = uniqueRoleFunction(module, TARGET_CONTEXT_ROOT_ROLE);
-  const agentAccessorFunction = uniqueRoleFunction(module, AGENT_ARRAY_ACCESSOR_ROLE);
   const areaLookupFunction = uniqueRoleFunction(module, AREA_LOOKUP_ROLE);
-  const exact = Object.fromEntries(Object.entries(EXACT_TARGET_ROLES).map(
-    ([name, role]) => [name, exactTargetFunction(module, role)],
-  )) as Record<keyof typeof EXACT_TARGET_ROLES, number | null>;
+  const roles = [
+    "gameCharacter", "mapId", "mapState", "currentMap", "instanceType",
+    "playerNumber", "areaCount", "areaFlags",
+  ] as const satisfies readonly (keyof typeof EXACT_TARGET_ROLES)[];
+  const exact = Object.fromEntries(roles.map(
+    (name) => [name, exactTargetFunction(module, EXACT_TARGET_ROLES[name])],
+  )) as Record<(typeof roles)[number], number | null>;
   if (
-    contextFunction === null || agentAccessorFunction === null
-    || areaLookupFunction === null
+    contextFunction === null || areaLookupFunction === null
     || Object.values(exact).some((value) => value === null)
   ) return null;
 
   const context = valuesForRole(functionBody(module, contextFunction), TARGET_CONTEXT_ROOT_ROLE);
-  const accessor = valuesForRole(functionBody(module, agentAccessorFunction), AGENT_ARRAY_ACCESSOR_ROLE);
   const area = valuesForRole(functionBody(module, areaLookupFunction), AREA_LOOKUP_ROLE);
   const contextRoot = soleValue(context, "context.root");
-  const agentArray = soleValue(accessor, "agent-array.base");
-  const agentArraySize = soleValue(accessor, "agent-array.size");
-  const lifecycleMatches = roleFunctions(module, AGENT_ARRAY_LIFECYCLE_ROLE).filter(
-    (functionIndex) => {
-      const values = valuesForRole(
-        functionBody(module, functionIndex), AGENT_ARRAY_LIFECYCLE_ROLE,
-      );
-      return soleValue(values, "agent-array.base") === agentArray
-        && soleValue(values, "agent-array.size") === agentArraySize;
-    },
-  );
-  if (lifecycleMatches.length !== 1) return null;
   const areaInfo = soleValue(area, "area.table");
   if (
-    agentArraySize !== agentArray + 8
-    || codeOperandOccurrences(module, contextRoot) !== 6
-    || codeOperandOccurrences(module, agentArray) !== 41
-    || codeOperandOccurrences(module, agentArraySize) !== 41
+    codeOperandOccurrences(module, contextRoot) !== 6
     || codeOperandOccurrences(module, areaInfo) !== 1
     || commonRelocationDelta([
-      [contextRoot, 0x5a0ee0], [agentArray, 0x5a4e58],
-      [agentArraySize, 0x5a4e60], [areaInfo, 0x1cc630],
+      [contextRoot, 0x5a0ee0], [areaInfo, 0x1cc630],
     ]) === null
   ) return null;
 
@@ -291,13 +279,12 @@ export function deriveObservationLayout(
       !== TARGET_IMMUTABLE_HASHES.areaAssertion
   ) return null;
 
-  const body = (name: keyof typeof EXACT_TARGET_ROLES) =>
+  const body = (name: (typeof roles)[number]) =>
     functionBody(module, exact[name]!);
   const contextBody = functionBody(module, contextFunction);
   const areaBody = functionBody(module, areaLookupFunction);
-  const observation: EnhancementObservationBaseLayout = {
+  const observation: EnhancementPlayRegionLayout = {
     contextRoot,
-    agentArray,
     gameContextSlot: unsignedOperand(contextBody, 17),
     characterContext: unsignedOperand(body("gameCharacter"), 5),
     mapId: unsignedOperand(body("mapId"), 39),
@@ -305,22 +292,12 @@ export function deriveObservationLayout(
     currentMapId: unsignedOperand(body("currentMap"), 11),
     currentInstanceType: unsignedOperand(body("instanceType"), 5),
     playerNumber: unsignedOperand(body("playerNumber"), 11),
-    agentId: unsignedOperand(body("agentFields"), 899),
-    agentX: unsignedOperand(body("agentFields"), 395),
-    agentY: unsignedOperand(body("agentFields"), 367),
-    agentType: unsignedOperand(body("agentFields"), 99),
-    agentPlayerNumber: unsignedOperand(body("agentFields"), 927),
-    agentModelType: unsignedOperand(body("agentModel"), 393),
-    worldContext: unsignedOperand(body("worldContext"), 81),
     areaInfo,
     areaInfoCount: unsignedOperand(body("areaCount"), 36),
     areaInfoStride: unsignedOperand(areaBody, 36),
     areaInfoFlags: unsignedOperand(body("areaFlags"), 21),
   };
-  if (
-    unsignedOperand(body("agentModel"), 365) !== observation.agentPlayerNumber
-    || unsignedOperand(areaBody, 6) < observation.areaInfoCount
-  ) return null;
+  if (unsignedOperand(areaBody, 6) < observation.areaInfoCount) return null;
   const table = staticBytes(
     module,
     observation.areaInfo,
@@ -334,7 +311,6 @@ export function deriveObservationLayout(
 
   return verifyLayout(observation, {
     contextRoot: { sourceRole: "context-root-writer", expression: "relocated static store", occurrences: [11] },
-    agentArray: { sourceRole: "agent-array lifecycle+accessor", expression: "base static", occurrences: [9, 34, 27] },
     gameContextSlot: { sourceRole: "context-root-writer", expression: "context registration slot", occurrences: [17] },
     characterContext: { sourceRole: "game-context character reader", expression: "i32.load offset", occurrences: [5] },
     mapId: { sourceRole: "map-id reader", expression: "i32.load offset", occurrences: [39] },
@@ -342,18 +318,110 @@ export function deriveObservationLayout(
     currentMapId: { sourceRole: "character-context map reader", expression: "i32.load offset", occurrences: [11] },
     currentInstanceType: { sourceRole: "character-context instance reader", expression: "i32.load offset", occurrences: [5] },
     playerNumber: { sourceRole: "character-context player reader", expression: "i32.load offset", occurrences: [11] },
-    agentId: { sourceRole: "agent snapshot copier", expression: "i32.load offset", occurrences: [899] },
-    agentX: { sourceRole: "agent snapshot copier", expression: "f32.load offset", occurrences: [395] },
-    agentY: { sourceRole: "agent snapshot copier", expression: "f32.load offset", occurrences: [367] },
-    agentType: { sourceRole: "agent snapshot copier", expression: "i32.load offset", occurrences: [99] },
-    agentPlayerNumber: { sourceRole: "agent snapshot+model readers", expression: "u16 offset", occurrences: [927, 365] },
-    agentModelType: { sourceRole: "agent model reader", expression: "u16 offset", occurrences: [393] },
-    worldContext: { sourceRole: "world-context slot reader", expression: "slot 19 field load", occurrences: [81] },
     areaInfo: { sourceRole: "area lookup+static content", expression: "unique immutable table", occurrences: [40] },
     areaInfoCount: { sourceRole: "published-area bound", expression: "finite exact bound", occurrences: [36] },
     areaInfoStride: { sourceRole: "area lookup", expression: "index multiplier", occurrences: [36] },
     areaInfoFlags: { sourceRole: "area flags reader", expression: "post-lookup load", occurrences: [21] },
   }).layout;
+}
+
+export function deriveObservationLayout(
+  module: ModuleShape,
+): EnhancementObservationBaseLayout | null {
+  const playRegion = derivePlayRegionLayout(module);
+  const agentAccessorFunction = uniqueRoleFunction(module, AGENT_ARRAY_ACCESSOR_ROLE);
+  const agentFieldsFunction = exactTargetFunction(module, EXACT_TARGET_ROLES.agentFields);
+  const agentModelFunction = exactTargetFunction(module, EXACT_TARGET_ROLES.agentModel);
+  const worldContextFunction = exactTargetFunction(module, EXACT_TARGET_ROLES.worldContext);
+  if (
+    !playRegion || agentAccessorFunction === null || agentFieldsFunction === null
+    || agentModelFunction === null || worldContextFunction === null
+  ) return null;
+  const accessor = valuesForRole(
+    functionBody(module, agentAccessorFunction),
+    AGENT_ARRAY_ACCESSOR_ROLE,
+  );
+  const agentArray = soleValue(accessor, "agent-array.base");
+  const agentArraySize = soleValue(accessor, "agent-array.size");
+  const lifecycleMatches = roleFunctions(module, AGENT_ARRAY_LIFECYCLE_ROLE).filter(
+    (functionIndex) => {
+      const values = valuesForRole(
+        functionBody(module, functionIndex), AGENT_ARRAY_LIFECYCLE_ROLE,
+      );
+      return soleValue(values, "agent-array.base") === agentArray
+        && soleValue(values, "agent-array.size") === agentArraySize;
+    },
+  );
+  if (
+    lifecycleMatches.length !== 1 || agentArraySize !== agentArray + 8
+    || codeOperandOccurrences(module, agentArray) !== 41
+    || codeOperandOccurrences(module, agentArraySize) !== 41
+    || commonRelocationDelta([
+      [playRegion.contextRoot, 0x5a0ee0], [agentArray, 0x5a4e58],
+      [agentArraySize, 0x5a4e60], [playRegion.areaInfo, 0x1cc630],
+    ]) === null
+  ) return null;
+  const agentFields = functionBody(module, agentFieldsFunction);
+  const agentModel = functionBody(module, agentModelFunction);
+  const observation: EnhancementObservationBaseLayout = {
+    ...playRegion,
+    agentArray,
+    agentId: unsignedOperand(agentFields, 899),
+    agentX: unsignedOperand(agentFields, 395),
+    agentY: unsignedOperand(agentFields, 367),
+    agentType: unsignedOperand(agentFields, 99),
+    agentPlayerNumber: unsignedOperand(agentFields, 927),
+    agentModelType: unsignedOperand(agentModel, 393),
+    worldContext: unsignedOperand(functionBody(module, worldContextFunction), 81),
+  };
+  if (unsignedOperand(agentModel, 365) !== observation.agentPlayerNumber) return null;
+  return Object.freeze(observation);
+}
+
+/**
+ * Strict launch authority for the bounded play-region observation.
+ * Proves only the character/map and area-table facts policy consumes. Agent
+ * tables and target selectors belong to the broader observation proof.
+ */
+export function locateAutomaticPlayRegion(
+  input: Uint8Array,
+  baselines: readonly KnownEnhancementBuild[],
+  suppliedContext?: EnhancementProofContext,
+): AutomaticPlayRegionLocation | null {
+  if (!WebAssembly.validate(input) || input.byteLength > MAX_INPUT_BYTES) return null;
+  try {
+    const context = suppliedContext?.inputIdentity === input
+      ? suppliedContext
+      : enhancementProofContext(input);
+    if (!context) return null;
+    const { module } = context;
+    const tick = context.tick.candidate;
+    if (!tick) return null;
+    const tickBody = functionBody(module, tick.functionIndex);
+    if (!bodyMatchesRole(tickBody, CLIENT_TICK_ROLE)) return null;
+    const playRegionLayout = derivePlayRegionLayout(module);
+    if (!playRegionLayout) return null;
+    const matches = baselines.flatMap((baseline): AutomaticPlayRegionLocation[] =>
+      baseline.playRegionObservation
+      && signatureMatches(module, tick.functionIndex, baseline.hookParams, baseline.hookResults)
+        ? [{
+            baseline,
+            hookFunction: tick.functionIndex,
+            hookBodySha256: tick.bodySha256,
+            playRegionLayout,
+          }]
+        : []);
+    if (matches.length === 0) return null;
+    const identity = (value: AutomaticPlayRegionLocation) => JSON.stringify({
+      hookFunction: value.hookFunction,
+      playRegionLayout: value.playRegionLayout,
+    });
+    return matches.every((match) => identity(match) === identity(matches[0]!))
+      ? matches[0]!
+      : null;
+  } catch {
+    return null;
+  }
 }
 
 function deriveTargetLayout(

--- a/src/main/certification/local-client-verification-boundary.ts
+++ b/src/main/certification/local-client-verification-boundary.ts
@@ -98,6 +98,10 @@ function featureFailuresFromVerdicts(
   verdicts: LocalFeatureVerdicts,
 ): LocalFeatureFailures | null {
   const nativeCursor = refusalForFeature("nativeCursor", verdicts.nativeCursor);
+  const playRegionObservation = refusalForFeature(
+    "playRegionObservation",
+    verdicts.playRegionObservation,
+  );
   const targetObservation = refusalForFeature(
     "targetObservation",
     verdicts.targetObservation,
@@ -120,6 +124,7 @@ function featureFailuresFromVerdicts(
   );
   if (
     nativeCursor === null
+    || playRegionObservation === null
     || targetObservation === null
     || partyObservation === null
     || teamApply === null
@@ -131,6 +136,7 @@ function featureFailuresFromVerdicts(
   ) return null;
   return Object.freeze({
     ...(nativeCursor ? { nativeCursor } : {}),
+    ...(playRegionObservation ? { playRegionObservation } : {}),
     ...(targetObservation ? { targetObservation } : {}),
     ...(partyObservation ? { partyObservation } : {}),
     ...(teamApply ? { teamApply } : {}),
@@ -269,6 +275,31 @@ function matchesObservationBase(
     && Object.entries(expected).every(([key, value]) =>
       key === "contextRoot" || key === "agentArray" || key === "areaInfo"
         || candidate[key as keyof typeof candidate] === value);
+}
+
+function matchesPlayRegionObservation(
+  build: SemanticBuild,
+  baseline: KnownEnhancementBuild,
+): boolean {
+  const candidate = build.playRegionObservation?.layout;
+  if (candidate === undefined) return true;
+  const expected = baseline.playRegionObservation?.layout;
+  if (
+    expected === undefined
+    || Object.keys(candidate).sort().join() !== Object.keys(expected).sort().join()
+    || !Object.values(candidate).every(isIndex)
+    || [
+      candidate.contextRoot - expected.contextRoot,
+      candidate.areaInfo - expected.areaInfo,
+    ].some((delta, _index, deltas) => delta !== deltas[0])
+    || Object.entries(expected).some(([key, value]) =>
+      key !== "contextRoot" && key !== "areaInfo"
+      && candidate[key as keyof typeof candidate] !== value)
+  ) return false;
+  const observation = build.observationBase?.layout;
+  return observation === undefined || Object.entries(candidate).every(
+    ([key, value]) => observation[key as keyof typeof observation] === value,
+  );
 }
 
 function matchesTargetObservation(
@@ -494,6 +525,7 @@ function isAutomaticSemanticBuild(
     || !isDigest(build.hookBodySha256)
   ) return false;
   const hasCursor = build.cursorEvent !== undefined;
+  const hasPlayRegion = build.playRegionObservation !== undefined;
   const hasObservation = build.observationBase !== undefined;
   const hasTarget = build.targetObservation !== undefined;
   const hasTravel = build.travelAction !== undefined;
@@ -503,17 +535,20 @@ function isAutomaticSemanticBuild(
   const hasTeam = build.teamApply !== undefined;
   const hasSkillSlotGeometry = build.skillSlotGeometry !== undefined;
   const hasSkillCooldown = build.skillCooldownObservation !== undefined;
-  if (!hasCursor && !hasTarget && !hasTravel && !hasXunlai && !hasAliases
+  if (!hasCursor && !hasPlayRegion && !hasObservation && !hasTarget
+    && !hasTravel && !hasXunlai && !hasAliases
     && !hasParty && !hasTeam && !hasSkillSlotGeometry && !hasSkillCooldown) {
     return false;
   }
   if (
     Object.keys(build.outputSha256).length === 0
     || !Object.values(build.outputSha256).every(isDigest)
-    || (hasTarget && !hasObservation)
-    || (hasXunlai && !hasObservation)
+    || (hasObservation && !hasPlayRegion)
+    || (hasTarget && (!hasPlayRegion || !hasObservation))
+    || (hasTravel && !hasPlayRegion)
+    || (hasXunlai && (!hasPlayRegion || !hasObservation))
     || (hasParty && (!hasObservation || build.uiDispatcher === undefined))
-    || (hasSkillSlotGeometry && !hasParty)
+    || (hasSkillSlotGeometry && !hasPlayRegion)
     || (hasSkillCooldown && (!hasObservation || !hasParty))
     || (hasTeam && (!hasParty || build.gameThread === undefined))
     || ((hasTravel || hasXunlai) && build.gameThread === undefined)
@@ -538,6 +573,7 @@ function isAutomaticSemanticBuild(
   return ENHANCEMENT_BUILDS.some((baseline) =>
     matchesCoreProof(build, baseline)
     && matchesCursorProof(build, baseline)
+    && matchesPlayRegionObservation(build, baseline)
     && matchesObservationBase(build, baseline)
     && matchesTargetObservation(build, baseline)
     && matchesUiDispatcher(build, baseline)

--- a/src/main/certification/local-client-verification-contract.ts
+++ b/src/main/certification/local-client-verification-contract.ts
@@ -58,6 +58,10 @@ export const LOCAL_FEATURE_INVARIANTS = Object.freeze({
     "cursor.active-table-relation",
     "cursor.event-family-layout-anchors",
   ] as const),
+  playRegionObservation: Object.freeze([
+    ...SHARED_FEATURE_INVARIANTS,
+    "play-region.observation-base",
+  ] as const),
   targetObservation: Object.freeze([
     ...SHARED_FEATURE_INVARIANTS,
     "target.observation-selection-anchors",
@@ -151,6 +155,8 @@ type CertifiedXunlaiAction = Readonly<
 export interface LocalFeatureCertificateMap {
   readonly nativeCursor: Readonly<{ core: EnhancementProofCore }>
     & RequiredBuildFact<"cursorEvent">;
+  readonly playRegionObservation: Readonly<{ core: EnhancementProofCore }>
+    & RequiredBuildFact<"playRegionObservation">;
   readonly targetObservation: Readonly<{ core: EnhancementProofCore }>
     & RequiredBuildFact<"observationBase" | "targetObservation">;
   readonly partyObservation: Readonly<{ core: EnhancementProofCore }>
@@ -164,7 +170,9 @@ export interface LocalFeatureCertificateMap {
       | "teamApply"
     >;
   readonly travelAction: Readonly<{ core: EnhancementProofCore }>
-    & RequiredBuildFact<"uiDispatcher" | "gameThread" | "travelAction">;
+    & RequiredBuildFact<
+      "playRegionObservation" | "uiDispatcher" | "gameThread" | "travelAction"
+    >;
   readonly xunlaiAction: Readonly<{
     core: EnhancementProofCore;
     xunlaiAction: CertifiedXunlaiAction;
@@ -172,7 +180,7 @@ export interface LocalFeatureCertificateMap {
   readonly chatAliases: Readonly<{ core: EnhancementProofCore }>
     & RequiredBuildFact<"uiDispatcher" | "chatAliases">;
   readonly skillSlotGeometry: Readonly<{ core: EnhancementProofCore }>
-    & RequiredBuildFact<"skillSlotGeometry">;
+    & RequiredBuildFact<"playRegionObservation" | "skillSlotGeometry">;
   readonly skillCooldownObservation: Readonly<{ core: EnhancementProofCore }>
     & RequiredBuildFact<
       "observationBase" | "partyObservation" | "skillCooldownObservation"
@@ -282,6 +290,10 @@ export function localFeatureVerdictsForBuild(
   const nativeCursor = core !== null && build?.cursorEvent !== undefined
     ? Object.freeze({ core, cursorEvent: build.cursorEvent })
     : null;
+  const playRegionObservation = core !== null
+      && build?.playRegionObservation !== undefined
+    ? Object.freeze({ core, playRegionObservation: build.playRegionObservation })
+    : null;
   const targetObservation = core !== null
       && build?.observationBase !== undefined
       && build.targetObservation !== undefined
@@ -318,11 +330,13 @@ export function localFeatureVerdictsForBuild(
       })
     : null;
   const travelAction = core !== null
-      && build?.uiDispatcher !== undefined
+      && build?.playRegionObservation !== undefined
+      && build.uiDispatcher !== undefined
       && build.gameThread !== undefined
       && build.travelAction !== undefined
     ? Object.freeze({
         core,
+        playRegionObservation: build.playRegionObservation,
         uiDispatcher: build.uiDispatcher,
         gameThread: build.gameThread,
         travelAction: build.travelAction,
@@ -353,8 +367,14 @@ export function localFeatureVerdictsForBuild(
         chatAliases: build.chatAliases,
       })
     : null;
-  const skillSlotGeometry = core !== null && build?.skillSlotGeometry !== undefined
-    ? Object.freeze({ core, skillSlotGeometry: build.skillSlotGeometry })
+  const skillSlotGeometry = core !== null
+      && build?.playRegionObservation !== undefined
+      && build.skillSlotGeometry !== undefined
+    ? Object.freeze({
+        core,
+        playRegionObservation: build.playRegionObservation,
+        skillSlotGeometry: build.skillSlotGeometry,
+      })
     : null;
   const skillCooldownObservation = core !== null
       && build?.observationBase !== undefined
@@ -374,6 +394,13 @@ export function localFeatureVerdictsForBuild(
       nativeCursor,
       failures.nativeCursor,
       "cursor.event-family-layout-anchors",
+    ),
+    playRegionObservation: featureVerdict<"playRegionObservation">(
+      inputSha256,
+      requested.playRegionObservation,
+      playRegionObservation,
+      failures.playRegionObservation,
+      "play-region.observation-base",
     ),
     targetObservation: featureVerdict<"targetObservation">(
       inputSha256,

--- a/src/main/certification/local-client-verifier.ts
+++ b/src/main/certification/local-client-verifier.ts
@@ -34,9 +34,11 @@ import {
   inspectTargetRoleCandidates,
   locateAutomaticCursor,
   locateAutomaticLocalActions,
+  locateAutomaticPlayRegion,
   locateAutomaticTarget,
   type AutomaticCursorLocation,
   type AutomaticLocalActionsLocation,
+  type AutomaticPlayRegionLocation,
   type AutomaticTargetLocation,
   type EnhancementStructuralEvidenceReport,
 } from "./enhancement-structural-evidence.js";
@@ -132,6 +134,14 @@ function failuresForRequested(
   return Object.freeze({
     ...(requested.nativeCursor
       ? { nativeCursor: changedFeature("nativeCursor", invariant) }
+      : {}),
+    ...(requested.playRegionObservation
+      ? {
+          playRegionObservation: changedFeature(
+            "playRegionObservation",
+            invariant,
+          ),
+        }
       : {}),
     ...(requested.targetObservation
       ? { targetObservation: changedFeature("targetObservation", invariant) }
@@ -310,6 +320,7 @@ function diagnoseFeatureFailures(
   input: Uint8Array,
   requested: EnhancementCapabilities,
   locatedCursor: AutomaticCursorLocation | null,
+  locatedPlayRegion: AutomaticPlayRegionLocation | null,
   locatedTarget: AutomaticTargetLocation | null,
   locatedLocal: AutomaticLocalActionsLocation | null,
   locatedSkillSlotGeometry: ReturnType<typeof deriveSkillSlotGeometry>,
@@ -327,6 +338,7 @@ function diagnoseFeatureFailures(
   const needsCooldownEvidence = requested.skillCooldownObservation
     && locatedSkillCooldown === null;
   const needsEvidence = (requested.nativeCursor && !locatedCursor)
+    || (requested.playRegionObservation && !locatedPlayRegion)
     || (requested.targetObservation && !locatedTarget)
     || needsLocalEvidence
     || needsSkillEvidence
@@ -339,6 +351,10 @@ function diagnoseFeatureFailures(
     ? inspectTargetRoleCandidates(input, context)
     : null;
   const targetShared = sharedEvidenceFailure("targetObservation", evidence);
+  const playRegionShared = sharedEvidenceFailure(
+    "playRegionObservation",
+    evidence,
+  );
   const partyUi = uiFailure("partyObservation", evidence);
   const teamUi = uiFailure("teamApply", evidence);
   const travelShared = sharedEvidenceFailure("travelAction", evidence);
@@ -352,6 +368,15 @@ function diagnoseFeatureFailures(
   return Object.freeze({
     ...(requested.nativeCursor && !locatedCursor
       ? { nativeCursor: cursorFailure(evidence) }
+      : {}),
+    ...(requested.playRegionObservation && !locatedPlayRegion
+      ? {
+          playRegionObservation: playRegionShared
+            ?? changedFeature(
+              "playRegionObservation",
+              "play-region.observation-base",
+            ),
+        }
       : {}),
     ...(requested.targetObservation && !locatedTarget
       ? {
@@ -555,6 +580,9 @@ function deriveEnhancementBuild(
   const locatedCursor = requestedCapabilities.nativeCursor
     ? locateAutomaticCursor(templateOutput, ENHANCEMENT_BUILDS, context)
     : null;
+  const locatedPlayRegion = requestedCapabilities.playRegionObservation
+    ? locateAutomaticPlayRegion(templateOutput, ENHANCEMENT_BUILDS, context)
+    : null;
   const locatedTarget = requestedCapabilities.targetObservation
     ? locateAutomaticTarget(templateOutput, ENHANCEMENT_BUILDS, context)
     : null;
@@ -578,6 +606,8 @@ function deriveEnhancementBuild(
   const cursor = locatedCursor?.baseline.cursorEvent;
   const includeCursor = locatedCursor !== null && cursor !== undefined;
   const includeTarget = locatedTarget !== null;
+  const includePlayRegion = requestedCapabilities.playRegionObservation
+    && locatedPlayRegion !== null;
   const includeParty = requestedCapabilities.partyObservation
     && locatedLocal?.observationLayout != null
     && locatedLocal.uiDispatcher != null
@@ -599,7 +629,7 @@ function deriveEnhancementBuild(
     && locatedLocal?.uiDispatcher != null
     && locatedLocal.chatAliases != null;
   const includeSkillSlotGeometry = requestedCapabilities.skillSlotGeometry
-    && includeParty
+    && includePlayRegion
     && locatedSkillSlotGeometry !== null;
   const locatedSkillCooldown = requestedCapabilities.skillCooldownObservation
     ? deriveSkillCooldownObservation(
@@ -614,6 +644,7 @@ function deriveEnhancementBuild(
     templateOutput,
     requestedCapabilities,
     locatedCursor,
+    locatedPlayRegion,
     locatedTarget,
     locatedLocal,
     locatedSkillSlotGeometry,
@@ -624,20 +655,33 @@ function deriveEnhancementBuild(
     || includeXunlai || includeAliases;
   const source = includeCursor
     ? locatedCursor
-    : includeTarget
-      ? locatedTarget
-      : localContributes
-        ? locatedLocal
-        : null;
+    : includePlayRegion
+      ? locatedPlayRegion
+      : includeTarget
+        ? locatedTarget
+        : localContributes
+          ? locatedLocal
+          : null;
   if (source === null || !report.table || report.table.max === null) {
     return Object.freeze({ build: null, failures });
   }
+  const observationLayout = includeTarget
+    ? locatedTarget.observationLayout
+    : includeParty || includeXunlai
+      ? locatedLocal!.observationLayout!
+      : null;
   if (
-    includeTarget
-    && (includeParty || includeXunlai)
-    && !isDeepStrictEqual(
-      locatedTarget.observationLayout,
-      locatedLocal?.observationLayout,
+    includePlayRegion
+    && observationLayout !== null
+    && Object.entries(locatedPlayRegion.playRegionLayout).some(
+      ([key, value]) =>
+        observationLayout[key as keyof typeof observationLayout] !== value,
+    )
+    || [
+      includeTarget ? locatedTarget.observationLayout : null,
+      includeParty || includeXunlai ? locatedLocal?.observationLayout ?? null : null,
+    ].filter((layout) => layout !== null).some(
+      (layout, _index, layouts) => !isDeepStrictEqual(layout, layouts[0]),
     )
   ) {
     return Object.freeze({
@@ -649,6 +693,14 @@ function deriveEnhancementBuild(
               targetObservation: changedFeature(
                 "targetObservation",
                 "target.shared-observation-layout",
+              ),
+            }
+          : {}),
+        ...(requestedCapabilities.playRegionObservation
+          ? {
+              playRegionObservation: changedFeature(
+                "playRegionObservation",
+                "play-region.observation-base",
               ),
             }
           : {}),
@@ -672,11 +724,6 @@ function deriveEnhancementBuild(
     });
   }
   const baseline = source.baseline;
-  const observationLayout = includeTarget
-    ? locatedTarget.observationLayout
-    : includeParty || includeXunlai
-      ? locatedLocal!.observationLayout!
-      : null;
   const provisional: KnownEnhancementBuild = Object.freeze({
     sha256: report.sha256,
     outputSha256: Object.freeze({}),
@@ -704,6 +751,11 @@ function deriveEnhancementBuild(
     } : {}),
     ...(observationLayout ? {
       observationBase: Object.freeze({ layout: observationLayout }),
+    } : {}),
+    ...(includePlayRegion ? {
+      playRegionObservation: Object.freeze({
+        layout: locatedPlayRegion.playRegionLayout,
+      }),
     } : {}),
     ...(includeTarget ? {
       targetObservation: Object.freeze({ layout: locatedTarget.targetLayout }),
@@ -736,6 +788,7 @@ function deriveEnhancementBuild(
     chatAliases: includeAliases,
     skillSlotGeometry: includeSkillSlotGeometry,
     skillCooldownObservation: includeSkillCooldown,
+    playRegionObservation: includePlayRegion,
   });
   const effective = intersectEnhancementCapabilities(requestedCapabilities, maximum);
   const profile = enhancementCapabilityProfile(effective);

--- a/src/main/certification/semantic-proof.ts
+++ b/src/main/certification/semantic-proof.ts
@@ -9,7 +9,7 @@
  */
 import { createHash } from "node:crypto";
 
-export const SEMANTIC_VERIFIER_ABI = 2;
+export const SEMANTIC_VERIFIER_ABI = 3;
 
 export type ProofRefusal = Readonly<{
   inputSha256: string;

--- a/src/main/certification/template-save-compat.ts
+++ b/src/main/certification/template-save-compat.ts
@@ -355,6 +355,65 @@ export const TEMPLATE_SAVE_BUILDS: readonly KnownTemplateSaveBuild[] =
         }),
       ]),
     }),
+    Object.freeze({
+      sha256:
+        "b8cc509714b82b69fdfd79a26ba257aa4c9ef23d90bca9dfcbbd044e371cfb17",
+      outputSha256:
+        "26a71c3e2bf55ab992dce659c1192213858ee25799daa87841ed23a3ddbb601a",
+      importCount: 219,
+      carrierImport: 207,
+      bridges: Object.freeze([
+        Object.freeze({
+          kind: "ensureDirectory" as const,
+          stubFunction: 185,
+          stubBody: Object.freeze([0x00, 0x41, 0x02, 0x0b]),
+          callSites: Object.freeze([
+            Object.freeze({ localFunction: 9541, bodyOffset: 171 }),
+            Object.freeze({ localFunction: 11528, bodyOffset: 142 }),
+            Object.freeze({ localFunction: 12217, bodyOffset: 127 }),
+          ]),
+        }),
+        Object.freeze({
+          kind: "findFiles" as const,
+          stubFunction: 186,
+          stubBody: Object.freeze([0x00, 0x0b]),
+          callSites: Object.freeze([
+            Object.freeze({ localFunction: 9530, bodyOffset: 157 }),
+            Object.freeze({ localFunction: 9531, bodyOffset: 157 }),
+            Object.freeze({ localFunction: 11528, bodyOffset: 210 }),
+            Object.freeze({ localFunction: 12217, bodyOffset: 419 }),
+          ]),
+        }),
+        Object.freeze({
+          kind: "fileBaseName" as const,
+          stubFunction: 197,
+          stubBody: Object.freeze([0x00, 0x41, 0x00, 0x0b]),
+          callSites: Object.freeze([
+            Object.freeze({ localFunction: 9530, bodyOffset: 276 }),
+            Object.freeze({ localFunction: 9531, bodyOffset: 278 }),
+          ]),
+        }),
+        Object.freeze({
+          kind: "deleteFile" as const,
+          stubFunction: 333,
+          stubBody: Object.freeze([
+            0x00, 0x41, 0xca, 0x87, 0xc5, 0x80, 0x00, 0x41,
+            0xa3, 0xbb, 0xc3, 0x80, 0x00, 0x41, 0xc8, 0x06,
+            0x10, 0xc2, 0x82, 0x80, 0x80, 0x00, 0x00, 0x0b,
+          ]),
+          callSites: Object.freeze([
+            Object.freeze({ localFunction: 459, bodyOffset: 201 }),
+          ]),
+        }),
+        Object.freeze({
+          kind: "fileExists" as const,
+          stubFunction: 552,
+          callSites: Object.freeze([
+            Object.freeze({ localFunction: 9541, bodyOffset: 201 }),
+          ]),
+        }),
+      ]),
+    }),
   ]);
 
 function fail(message: string): never {

--- a/src/main/client-runtime.ts
+++ b/src/main/client-runtime.ts
@@ -361,6 +361,12 @@ export class ClientRuntime {
           supported.nativeCursor,
           preparationFailed,
         ),
+        playRegionObservation: optionalFeatureStatus(
+          requested.playRegionObservation,
+          effective.playRegionObservation,
+          supported.playRegionObservation,
+          preparationFailed,
+        ),
         targetObservation: optionalFeatureStatus(
           requested.targetObservation,
           effective.targetObservation,

--- a/src/main/renderer-client-sessions.ts
+++ b/src/main/renderer-client-sessions.ts
@@ -46,6 +46,7 @@ function projectCompatibility(
       chatAliases: status("chatAliases"),
       skillSlotGeometry: status("skillSlotGeometry"),
       skillCooldownObservation: status("skillCooldownObservation"),
+      playRegionObservation: status("playRegionObservation"),
     }),
   });
 }

--- a/src/renderer/certified-companion-installation.ts
+++ b/src/renderer/certified-companion-installation.ts
@@ -286,6 +286,13 @@ export async function installCertifiedCompanion(
         return false;
       }
     };
+    // Withdraw policy inputs before disposing any surface. Region withdrawal
+    // notifies subscribers synchronously; leaving this subscription live could
+    // recreate a readout or overlay during the same teardown transaction.
+    attempt("Tools settings listener disposal", disposeToolSettings);
+    attempt("play-region subscription disposal", () => {
+      disposePlayRegionSubscription();
+    });
     const cursorStateWithdrawn = attempt("cursor state withdrawal", () => {
       if (
         installedCursorState !== null
@@ -305,10 +312,6 @@ export async function installCertifiedCompanion(
       attempt("skill cooldown feed disposal", skillCooldowns.dispose);
       attempt("play-region feed disposal", playRegions.dispose);
     }
-    attempt("Tools settings listener disposal", disposeToolSettings);
-    attempt("play-region subscription disposal", () => {
-      disposePlayRegionSubscription();
-    });
     attempt("Trade alias disable", () => { configureTradeToggle?.(0); });
     if (observerStopped) {
       attempt("profession trace disposal", () => professionTrace?.dispose());

--- a/src/renderer/certified-companion-installation.ts
+++ b/src/renderer/certified-companion-installation.ts
@@ -36,6 +36,8 @@ import {
   COMPANION_SKILL_COOLDOWN_BYTES,
   COMPANION_SKILL_SLOT_BYTES,
 } from "./companion-skill-snapshot.js";
+import { COMPANION_PLAY_REGION_BYTES } from "./companion-play-region-snapshot.js";
+import { createPlayRegionObservationInstallation } from "./play-region-state-installation.js";
 import { createSkillOverlaysInstallation } from "./skill-overlays-installation.js";
 import { validateCompanionOwnedRegions } from "./companion-owned-regions.js";
 import {
@@ -66,7 +68,6 @@ import {
 } from "../shared/companion-kernel-contract.js";
 import {
   enhancementRuntimePolicy,
-  runtimePlayRegion,
   type RuntimePlayRegion,
 } from "./enhancement-runtime-policy.js";
 import {
@@ -140,12 +141,18 @@ export async function installCertifiedCompanion(
   const skills = createSkillOverlaysInstallation(capabilities);
   const skillSlotGeometry = skills.geometry;
   const skillCooldowns = skills.cooldowns;
+  const playRegions = createPlayRegionObservationInstallation(
+    capabilities.playRegionObservation,
+  );
   const observeState = capabilities.targetObservation || capabilities.xunlaiAction;
   const publishObserverState = program === "target-observer";
   const featureFlags =
     (capabilities.nativeCursor ? COMPANION_FEATURE_BITS.nativeCursor : 0)
     | (observeState ? COMPANION_FEATURE_BITS.gameSnapshot : 0)
     | (foundation ? COMPANION_FEATURE_BITS.toolboxFoundation : 0)
+    | (capabilities.playRegionObservation
+      ? COMPANION_FEATURE_BITS.playRegionObservation
+      : 0)
     | (capabilities.targetObservation ? COMPANION_FEATURE_BITS.targetObservation : 0)
     | skills.certifiedFeatureFlags;
   if (featureFlags === 0) return null;
@@ -251,6 +258,7 @@ export async function installCertifiedCompanion(
   let disposeReadout = () => {};
   let disposeToolbox = () => {};
   let disposeToolSettings = () => {};
+  let disposePlayRegionSubscription = () => false;
   let disposeCursorRefresh = () => {};
   let professionTrace: ReturnType<typeof createProfessionCommandTrace> | null = null;
   let installedCallback: CallableFunction | null = null;
@@ -295,8 +303,12 @@ export async function installCertifiedCompanion(
       attempt("skill overlay disposal", skills.disposePresentation);
       attempt("skill-slot feed disposal", skillSlotGeometry.dispose);
       attempt("skill cooldown feed disposal", skillCooldowns.dispose);
+      attempt("play-region feed disposal", playRegions.dispose);
     }
     attempt("Tools settings listener disposal", disposeToolSettings);
+    attempt("play-region subscription disposal", () => {
+      disposePlayRegionSubscription();
+    });
     attempt("Trade alias disable", () => { configureTradeToggle?.(0); });
     if (observerStopped) {
       attempt("profession trace disposal", () => professionTrace?.dispose());
@@ -319,6 +331,7 @@ export async function installCertifiedCompanion(
         });
         attempt("skill-slot allocation release", () => skillSlotGeometry.release(free));
         attempt("skill cooldown allocation release", () => skillCooldowns.release(free));
+        attempt("play-region allocation release", () => playRegions.release(free));
       }
       attempt("command payload release", () => {
         if (payloadPointer) free(payloadPointer);
@@ -406,6 +419,7 @@ export async function installCertifiedCompanion(
     }
     skillSlotGeometry.allocate(exports.malloc as (bytes: number) => unknown);
     skillCooldowns.allocate(exports.malloc as (bytes: number) => unknown);
+    playRegions.allocate(exports.malloc as (bytes: number) => unknown);
     if (capabilities.teamApply) {
       payloadPointer = Number(
         exports.malloc(teamCommands!.TEAM_COMMAND_PAYLOAD_BYTES),
@@ -427,6 +441,7 @@ export async function installCertifiedCompanion(
       || (foundation && !partyPointer)
       || !skillSlotGeometry.allocated
       || !skillCooldowns.allocated
+      || !playRegions.allocated
       || (capabilities.teamApply && !payloadPointer)
       || (storageInstallation !== null && !storageInstallation.region().pointer)
       || (travelInstallation !== null && !travelInstallation.region().pointer)
@@ -460,6 +475,7 @@ export async function installCertifiedCompanion(
         : []),
       ...(skillSlotGeometry.region === null ? [] : [skillSlotGeometry.region]),
       ...(skillCooldowns.region === null ? [] : [skillCooldowns.region]),
+      ...(playRegions.region === null ? [] : [playRegions.region]),
       ...(capabilities.teamApply
         ? [
             {
@@ -556,6 +572,8 @@ export async function installCertifiedCompanion(
       skillKeyBytes: number,
       skillCooldownPointer: number,
       skillCooldownBytes: number,
+      playRegionPointer: number,
+      playRegionBytes: number,
       featureFlags: number,
     ) => number;
     type KernelDispatch = (
@@ -579,6 +597,8 @@ export async function installCertifiedCompanion(
     const kernelSkillSlotBytes = kernel.exports.companion_skill_slot_bytes as KernelScalar;
     const kernelSkillCooldownBytes =
       kernel.exports.companion_skill_cooldown_bytes as KernelScalar;
+    const kernelPlayRegionBytes =
+      kernel.exports.companion_play_region_bytes as KernelScalar;
     if (
       kernelAbi() !== COMPANION_ABI
       || kernelConfigBytes() !== configBytes
@@ -588,6 +608,7 @@ export async function installCertifiedCompanion(
       || kernelPartyBytes() !== COMPANION_PARTY_BYTES
       || kernelSkillSlotBytes() !== COMPANION_SKILL_SLOT_BYTES
       || kernelSkillCooldownBytes() !== COMPANION_SKILL_COOLDOWN_BYTES
+      || kernelPlayRegionBytes() !== COMPANION_PLAY_REGION_BYTES
       || kernelInit(
         snapshotPointer,
         observeState ? COMPANION_SNAPSHOT_BYTES : 0,
@@ -603,6 +624,8 @@ export async function installCertifiedCompanion(
         skillSlotGeometry.bytes,
         skillCooldowns.pointer,
         skillCooldowns.bytes,
+        playRegions.pointer,
+        playRegions.bytes,
         featureFlags,
       ) !== 1
     ) {
@@ -660,17 +683,11 @@ export async function installCertifiedCompanion(
         window.dispatchEvent(new CustomEvent("gw:trade-toggle"));
       }
     };
-    let snapshotPlayRegion: RuntimePlayRegion | null = observeState
-      ? "unknown"
-      : null;
-    let partyPlayRegion: RuntimePlayRegion = foundation
-      ? "unknown"
-      : "pve";
     let readout: ReturnType<typeof createTargetReadout> | null = null;
-    const playRegion = () => runtimePlayRegion(
-      snapshotPlayRegion,
-      partyPlayRegion,
-    );
+    const playRegion = (): RuntimePlayRegion => {
+      const state = playRegions.state;
+      return state.status === "ready" ? state.playRegion : "unknown";
+    };
     const policy = () => enhancementRuntimePolicy(
       program,
       optionalSettings,
@@ -723,10 +740,15 @@ export async function installCertifiedCompanion(
     const syncActiveObservers = () => {
       const active =
         (capabilities.nativeCursor ? COMPANION_FEATURE_BITS.nativeCursor : 0)
-        // Keep the bounded policy observer alive even while optional UI and
-        // commands are denied. It is the only way an unknown region can later
-        // prove that it became PvE without restarting.
-        | (foundation ? COMPANION_FEATURE_BITS.toolboxFoundation : 0)
+        | (foundation && policy().tools
+          ? COMPANION_FEATURE_BITS.toolboxFoundation
+          : 0)
+        // Keep only the bounded policy observer alive while optional UI and
+        // commands are denied. It lets unknown/loading recover without the
+        // heavier party observer or a restart.
+        | (capabilities.playRegionObservation
+          ? COMPANION_FEATURE_BITS.playRegionObservation
+          : 0)
         | (targetEnabled() ? COMPANION_FEATURE_BITS.targetObservation : 0)
         | skills.activeFeatureFlags(
           optionalSettings,
@@ -774,6 +796,7 @@ export async function installCertifiedCompanion(
     const syncStoragePolicy = () => {
       storageInstallation?.update({
         enabled: policy().xunlaiStorage,
+        playRegion: playRegion(),
         state: companionState,
       });
     };
@@ -781,7 +804,7 @@ export async function installCertifiedCompanion(
       travelInstallation?.update({
         enabled: policy().travelPalette,
         playRegion: playRegion(),
-        state: travelGameState(companionState),
+        state: travelGameState(playRegions.state),
       });
     };
     storageInstallation?.mount();
@@ -809,18 +832,20 @@ export async function installCertifiedCompanion(
     const syncToolboxAvailability = () => {
       toolbox?.setEnabled(policy().tools);
     };
-    tracePolicy("launch");
-    const onToolSettings = () => {
-      // The event is only a notification. The validated bridge remains the
-      // single source of truth even if page code dispatches a malformed event.
-      optionalSettings = window.gwToolsSettings();
-      tracePolicy("settings");
+    const syncPolicySurfaces = (reason: "launch" | "region" | "settings") => {
+      tracePolicy(reason);
       syncToolboxAvailability();
       setTargetEnabled();
       syncSkillOverlays();
       syncActiveObservers();
       syncStoragePolicy();
       syncTravelPolicy();
+    };
+    const onToolSettings = () => {
+      // The event is only a notification. The validated bridge remains the
+      // single source of truth even if page code dispatches a malformed event.
+      optionalSettings = window.gwToolsSettings();
+      syncPolicySurfaces("settings");
       configureTradeAlias();
     };
     window.addEventListener("gw:tools-settings", onToolSettings);
@@ -830,10 +855,23 @@ export async function installCertifiedCompanion(
       toolbox?.dispose();
     };
 
+    const playRegionProjection = () => {
+      const state = playRegions.state;
+      return state.status === "ready"
+        ? `ready:${state.playRegion}:${state.mapId}:${state.instanceType}`
+        : `waiting:${state.reason}`;
+    };
+    let previousPlayRegionProjection = playRegionProjection();
+    disposePlayRegionSubscription = playRegions.subscribe(() => {
+      const next = playRegionProjection();
+      if (next === previousPlayRegionProjection) return;
+      previousPlayRegionProjection = next;
+      syncPolicySurfaces("region");
+    });
+
     // Apply opt-in state before the callback becomes reachable from the game.
-    syncActiveObservers();
-    syncStoragePolicy();
-    syncTravelPolicy();
+    playRegions.setActive(true);
+    syncPolicySurfaces("launch");
     configureTradeAlias();
     table.set(manifest.tableSlot, kernelDispatch);
     installedCallback = kernelDispatch;
@@ -844,6 +882,7 @@ export async function installCertifiedCompanion(
       partyPointer,
       skillSlotPointer: skillSlotGeometry.pointer,
       skillCooldownPointer: skillCooldowns.pointer,
+      playRegionPointer: playRegions.pointer,
       hertz: 0,
       lastRenderUs: 0,
       renderSamples: [] as number[],
@@ -939,24 +978,14 @@ export async function installCertifiedCompanion(
     };
     stopObserver = observeCompanion(
       observerRuntime,
-      polledCursor,
+      [polledCursor, travelInstallation].filter(
+        (poller): poller is { poll(): void } => poller !== null,
+      ),
       observeState
-        ? { update: (state) => {
+          ? { update: (state) => {
             companionState = state;
-            const next: RuntimePlayRegion = state.status === "ready"
-              && (state.playRegion === "pve" || state.playRegion === "pvp")
-              ? state.playRegion
-              : "unknown";
-            if (next !== snapshotPlayRegion) {
-              snapshotPlayRegion = next;
-              tracePolicy("region");
-              setTargetEnabled();
-              syncSkillOverlays();
-              syncActiveObservers();
-            }
             readout?.update(state);
             syncStoragePolicy();
-            syncTravelPolicy();
             pollTradeAlias();
           } }
         : null,
@@ -964,23 +993,6 @@ export async function installCertifiedCompanion(
         ? { update: (state) => {
             toolboxObservation = state;
             professionTrace?.poll(state);
-            const party = state.party;
-            const next: RuntimePlayRegion = state.status === "ready"
-              && party?.status === "ready"
-              && (party.playRegion === "pve" || party.playRegion === "pvp")
-              ? party.playRegion
-              : "unknown";
-            const previousRegion = playRegion();
-            if (next !== partyPlayRegion) {
-              partyPlayRegion = next;
-            }
-            if (playRegion() !== previousRegion) {
-              tracePolicy("region");
-              setTargetEnabled();
-              syncSkillOverlays();
-              syncActiveObservers();
-            }
-            syncTravelPolicy();
             pollTradeAlias();
             toolbox?.update(state);
           } }
@@ -989,6 +1001,7 @@ export async function installCertifiedCompanion(
       publishObserverState,
       skillSlotGeometry.sink,
       skillCooldowns.sink,
+      playRegions.sink,
     );
     companionInstallations = installation;
     if (program !== "none") window.gwCompanionRuntime = runtime;

--- a/src/renderer/certified-companion-installation.ts
+++ b/src/renderer/certified-companion-installation.ts
@@ -835,14 +835,17 @@ export async function installCertifiedCompanion(
     const syncToolboxAvailability = () => {
       toolbox?.setEnabled(policy().tools);
     };
-    const syncPolicySurfaces = (reason: "launch" | "region" | "settings") => {
-      tracePolicy(reason);
-      syncToolboxAvailability();
+    const syncLivePolicyConsumers = () => {
       setTargetEnabled();
       syncSkillOverlays();
       syncActiveObservers();
       syncStoragePolicy();
       syncTravelPolicy();
+    };
+    const syncPolicySurfaces = (reason: "region" | "settings") => {
+      tracePolicy(reason);
+      syncToolboxAvailability();
+      syncLivePolicyConsumers();
     };
     const onToolSettings = () => {
       // The event is only a notification. The validated bridge remains the
@@ -874,7 +877,8 @@ export async function installCertifiedCompanion(
 
     // Apply opt-in state before the callback becomes reachable from the game.
     playRegions.setActive(true);
-    syncPolicySurfaces("launch");
+    tracePolicy("launch");
+    syncLivePolicyConsumers();
     configureTradeAlias();
     table.set(manifest.tableSlot, kernelDispatch);
     installedCallback = kernelDispatch;

--- a/src/renderer/client-compatibility-notice.ts
+++ b/src/renderer/client-compatibility-notice.ts
@@ -22,8 +22,9 @@ export type CompatibilityReport = {
 };
 
 type Feature = keyof ClientCompatibility['features'];
+type VisibleFeature = Exclude<Feature, 'playRegionObservation'>;
 
-const FEATURE_NAMES: Readonly<Record<Feature, string>> = Object.freeze({
+const FEATURE_NAMES: Readonly<Record<VisibleFeature, string>> = Object.freeze({
   gameFileSaving: 'Guild Wars file saving',
   nativeCursor: 'Guild Wars cursor',
   targetObservation: 'target distance',
@@ -36,13 +37,15 @@ const FEATURE_NAMES: Readonly<Record<Feature, string>> = Object.freeze({
   skillCooldownObservation: 'skill cooldown observation',
 });
 
-function unavailableFeatures(compatibility: ClientCompatibility): Feature[] {
-  return (Object.keys(compatibility.features) as Feature[]).filter(
+function unavailableFeatures(compatibility: ClientCompatibility): VisibleFeature[] {
+  // Area detection is an internal substrate. Its dependants already carry the
+  // player-facing refusal, so listing it would report one proof failure twice.
+  return (Object.keys(FEATURE_NAMES) as VisibleFeature[]).filter(
     (feature) => compatibility.features[feature].status === 'unavailable',
   );
 }
 
-function unavailableNames(features: readonly Feature[]): string {
+function unavailableNames(features: readonly VisibleFeature[]): string {
   return features.map((feature) => FEATURE_NAMES[feature]).join(', ');
 }
 
@@ -222,7 +225,7 @@ export function renderClientCompatibility(
 
   const report = compatibilityReport(session.compatibility);
   settingsAvailability.open = report.degraded;
-  for (const feature of Object.keys(session.compatibility.features) as Feature[]) {
+  for (const feature of Object.keys(FEATURE_NAMES) as VisibleFeature[]) {
     const status = feature === 'skillCooldownObservation'
       ? cooldownPresentationStatus(session.compatibility.features)
       : session.compatibility.features[feature];

--- a/src/renderer/companion-observer.ts
+++ b/src/renderer/companion-observer.ts
@@ -27,6 +27,10 @@ import {
   readCompanionSkillCooldowns,
   readCompanionSkillSlots,
 } from "./companion-skill-snapshot.js";
+import {
+  type CompanionPlayRegionState,
+  readCompanionPlayRegion,
+} from "./companion-play-region-snapshot.js";
 
 type SnapshotObserverTarget = {
   memory: WebAssembly.Memory;
@@ -35,6 +39,7 @@ type SnapshotObserverTarget = {
   partyPointer: number;
   skillSlotPointer?: number;
   skillCooldownPointer?: number;
+  playRegionPointer?: number;
   snapshotReads: number;
   rejectedSnapshots: number;
   hertz: number;
@@ -52,6 +57,10 @@ type SkillSlotConsumer = {
 
 type SkillCooldownConsumer = {
   update(state: CompanionSkillCooldownState): void;
+};
+
+type PlayRegionConsumer = {
+  update(state: CompanionPlayRegionState): void;
 };
 
 /**
@@ -83,13 +92,14 @@ export function recordCompanionLifecycle(state: PublishedCompanionState) {
 
 export function observeCompanion(
   runtime: SnapshotObserverTarget,
-  cursor: { poll(): void } | null,
+  pollers: readonly { poll(): void }[],
   readout: StateConsumer | null,
   toolbox: ToolboxConsumer | null,
   observeState: boolean,
   publishState: boolean,
   skillSlots: SkillSlotConsumer | null = null,
   skillCooldowns: SkillCooldownConsumer | null = null,
+  playRegion: PlayRegionConsumer | null = null,
 ) {
   let frame = 0;
   let cadenceAt = performance.now();
@@ -100,6 +110,14 @@ export function observeCompanion(
   let partySequence: number | null = null;
   let publishedState: PublishedCompanionState | null = null;
   const observe = () => {
+    // Publish the sole policy fact before any dependent observation from the
+    // same animation frame reaches its consumer.
+    if (playRegion) {
+      playRegion.update(readCompanionPlayRegion(
+        runtime.memory.buffer,
+        runtime.playRegionPointer ?? 0,
+      ));
+    }
     if (observeState) {
       const started = performance.now();
       const state = readCompanionSnapshot(
@@ -178,7 +196,7 @@ export function observeCompanion(
       ));
     }
     // Outside the measured window: lastRenderUs stays the snapshot read cost.
-    cursor?.poll();
+    for (const poller of pollers) poller.poll();
     frame = requestAnimationFrame(observe);
   };
   frame = requestAnimationFrame(observe);

--- a/src/renderer/companion-play-region-snapshot.ts
+++ b/src/renderer/companion-play-region-snapshot.ts
@@ -1,0 +1,72 @@
+/**
+ * Strict decoder for the companion's bounded PvE/PvP policy publication.
+ * No pointer or broader game state crosses this presentation boundary.
+ */
+import { COMPANION_ABI } from "../shared/companion-abi.js";
+
+export const COMPANION_PLAY_REGION_ABI = COMPANION_ABI.playRegion.abi;
+export const COMPANION_PLAY_REGION_BYTES = COMPANION_ABI.playRegion.bytes;
+
+const MAGIC = 0x5250_5747;
+const FLAGS = Object.freeze({ ready: 1, loading: 2 });
+
+export function readCompanionPlayRegion(buffer: ArrayBuffer, pointer: number) {
+  if (
+    !(buffer instanceof ArrayBuffer)
+    || !Number.isInteger(pointer)
+    || pointer < 0
+    || pointer + COMPANION_PLAY_REGION_BYTES > buffer.byteLength
+  ) return Object.freeze({ status: "waiting", reason: "memory" } as const);
+
+  const view = new DataView(buffer, pointer, COMPANION_PLAY_REGION_BYTES);
+  const firstSequence = view.getUint32(8, true);
+  if ((firstSequence & 1) !== 0) {
+    return Object.freeze({ status: "waiting", reason: "writing" } as const);
+  }
+  const magic = view.getUint32(0, true);
+  const abi = view.getUint16(4, true);
+  const bytes = view.getUint16(6, true);
+  const flags = view.getUint32(12, true);
+  const mapId = view.getUint32(16, true);
+  const instanceType = view.getUint32(20, true);
+  const encodedRegion = view.getUint32(24, true);
+  const secondSequence = view.getUint32(8, true);
+  if (
+    magic !== MAGIC
+    || abi !== COMPANION_PLAY_REGION_ABI
+    || bytes !== COMPANION_PLAY_REGION_BYTES
+    || firstSequence !== secondSequence
+    || (secondSequence & 1) !== 0
+    || (flags & ~(FLAGS.ready | FLAGS.loading)) !== 0
+    || flags === (FLAGS.ready | FLAGS.loading)
+  ) return Object.freeze({ status: "waiting", reason: "snapshot" } as const);
+
+  if ((flags & FLAGS.loading) !== 0) {
+    return mapId === 0 && instanceType === 0 && encodedRegion === 0
+      ? Object.freeze({ status: "waiting", reason: "loading" } as const)
+      : Object.freeze({ status: "waiting", reason: "corrupt" } as const);
+  }
+  if ((flags & FLAGS.ready) === 0) {
+    return mapId === 0 && instanceType === 0 && encodedRegion === 0
+      ? Object.freeze({ status: "waiting", reason: "game" } as const)
+      : Object.freeze({ status: "waiting", reason: "corrupt" } as const);
+  }
+  if (
+    mapId === 0
+    || mapId > 2_000
+    || instanceType > 1
+    || (encodedRegion !== 1 && encodedRegion !== 2)
+  ) return Object.freeze({ status: "waiting", reason: "corrupt" } as const);
+
+  return Object.freeze({
+    status: "ready" as const,
+    sequence: secondSequence,
+    mapId,
+    instanceType,
+    playRegion: encodedRegion === 1 ? "pve" as const : "pvp" as const,
+  });
+}
+
+export type CompanionPlayRegionState =
+  | ReturnType<typeof readCompanionPlayRegion>
+  | Readonly<{ status: "waiting"; reason: "stale" }>;

--- a/src/renderer/effective-enhancement-capabilities.ts
+++ b/src/renderer/effective-enhancement-capabilities.ts
@@ -21,5 +21,7 @@ export function effectiveCapabilities(
     skillSlotGeometry: features.skillSlotGeometry.status === "available",
     skillCooldownObservation:
       features.skillCooldownObservation.status === "available",
+    playRegionObservation:
+      features.playRegionObservation.status === "available",
   });
 }

--- a/src/renderer/enhancement-runtime-policy.ts
+++ b/src/renderer/enhancement-runtime-policy.ts
@@ -13,19 +13,6 @@ export type OptionalToolSettings = FeatureActivationSettings;
 
 export type RuntimePlayRegion = "pve" | "pvp" | "unknown";
 
-/**
- * The game snapshot is the canonical region observation when that capability
- * exists. Party state is still required by commands, but it cannot re-enable
- * optional surfaces after a newer snapshot says PvP or unknown. Developer
- * Toolbox profiles have no snapshot observer, so their party is the fallback.
- */
-export function runtimePlayRegion(
-  snapshot: RuntimePlayRegion | null,
-  party: RuntimePlayRegion,
-): RuntimePlayRegion {
-  return snapshot ?? party;
-}
-
 /** One fail-closed answer for optional observers, UI, and commands. */
 export function enhancementRuntimePolicy(
   program: EnhancementProgram,

--- a/src/renderer/enhancement-storage-controller.ts
+++ b/src/renderer/enhancement-storage-controller.ts
@@ -5,6 +5,7 @@
  */
 import type { StorageCommand } from "../shared/storage-command.js";
 import type { CompanionSnapshot } from "./companion-snapshot.js";
+import type { RuntimePlayRegion } from "./enhancement-runtime-policy.js";
 import {
   createStorageCommand,
   initializeStorageDataWindow,
@@ -27,6 +28,7 @@ export type StorageGameState = ReadyStorageGameState | PendingStorageGameState;
 
 export interface StorageAvailability {
   readonly enabled: boolean;
+  readonly playRegion: RuntimePlayRegion;
   readonly state: StorageGameState | null;
 }
 
@@ -42,6 +44,9 @@ function unavailableReason(
 ): string | null {
   if (!active) return "Enhancement installation is no longer active";
   if (!availability.enabled) return "Xunlai storage is turned off in Settings";
+  if (availability.playRegion === "unknown") {
+    return "Storage is waiting to confirm the current region";
+  }
   const state = availability.state;
   if (state?.status !== "ready" || typeof state.xunlaiAccess !== "boolean") {
     return "Storage is waiting to confirm access for this character";
@@ -62,6 +67,7 @@ export function createStorageController(
   let active = true;
   let availability: StorageAvailability = {
     enabled: false,
+    playRegion: "unknown",
     state: null,
   };
   let configuredEnabled: boolean | null = null;
@@ -80,8 +86,9 @@ export function createStorageController(
     const result = configure(payloadPointer, enabled ? 1 : 0);
     configuredEnabled = enabled;
     trace("configured", {
-      enabled,
-      accepted: result === 1,
+        enabled,
+        playRegion: availability.playRegion,
+        accepted: result === 1,
       state: availability.state?.status ?? "missing",
       access: availability.state?.status === "ready"
         ? availability.state.xunlaiAccess
@@ -111,6 +118,7 @@ export function createStorageController(
         ...fields,
         reason: error instanceof Error ? error.message : "unknown storage error",
         enabled: availability.enabled,
+        playRegion: availability.playRegion,
       });
       if (event.detail !== null && typeof event.detail === "object") {
         (event.detail as { error?: unknown }).error = error;
@@ -126,6 +134,7 @@ export function createStorageController(
       availability = next;
       const fields = {
         enabled: next.enabled,
+        playRegion: next.playRegion,
         state: next.state?.status ?? "missing",
         access: next.state?.status === "ready" ? next.state.xunlaiAccess : "unknown",
       } as const;

--- a/src/renderer/enhancement-travel-installation.ts
+++ b/src/renderer/enhancement-travel-installation.ts
@@ -22,6 +22,7 @@ export interface TravelInstallation {
   initialize(): void;
   mount(parent: HTMLElement): void;
   update(availability: TravelAvailability): void;
+  poll(): void;
   command(): TravelCommand | null;
   dispose(free: (pointer: number) => void): void;
 }
@@ -65,6 +66,8 @@ export function createTravelInstallation(
       controller?.update(availability);
       palette?.setEnabled(availability.enabled);
       if (availability.state !== null) palette?.update(availability.state);
+    },
+    poll() {
       if (takeToggle() === 1 && controller?.command.unavailable() === null) {
         window.dispatchEvent(new CustomEvent("gw:travel-toggle"));
       }

--- a/src/renderer/play-region-state-installation.ts
+++ b/src/renderer/play-region-state-installation.ts
@@ -1,0 +1,23 @@
+/**
+ * Memory ownership and freshness boundary for the certified play-region fact.
+ * All policy consumers share this one withdrawn-on-stale state.
+ */
+import {
+  COMPANION_PLAY_REGION_BYTES,
+  type CompanionPlayRegionState,
+} from "./companion-play-region-snapshot.js";
+import { createCompanionRegionInstallation } from "./companion-region-installation.js";
+import { CONTINUOUS_COMPANION_FRESHNESS } from "./companion-sequence-feed.js";
+
+export function createPlayRegionObservationInstallation(available: boolean) {
+  const waiting = Object.freeze({ status: "waiting", reason: "memory" } as const);
+  const stale = Object.freeze({ status: "waiting", reason: "stale" } as const);
+  return createCompanionRegionInstallation<CompanionPlayRegionState>({
+    available,
+    name: "play region",
+    bytes: COMPANION_PLAY_REGION_BYTES,
+    waiting,
+    stale,
+    freshness: CONTINUOUS_COMPANION_FRESHNESS,
+  });
+}

--- a/src/shared/companion-abi.ts
+++ b/src/shared/companion-abi.ts
@@ -3,7 +3,7 @@
  * Renderer, scripts, and tests derive their ABI constants from this descriptor.
  */
 export const COMPANION_ABI = Object.freeze({
-  kernel: 16,
+  kernel: 17,
   config: Object.freeze({ bytes: 444 }),
   snapshot: Object.freeze({ abi: 3, bytes: 64 }),
   cursor: Object.freeze({ abi: 1, bytes: 4_160 }),
@@ -11,6 +11,7 @@ export const COMPANION_ABI = Object.freeze({
   party: Object.freeze({ abi: 7, bytes: 1_560 }),
   skillSlots: Object.freeze({ abi: 1, bytes: 156 }),
   skillCooldowns: Object.freeze({ abi: 1, bytes: 60 }),
+  playRegion: Object.freeze({ abi: 1, bytes: 28 }),
 });
 
 export const COMPANION_FEATURE_BITS = Object.freeze({
@@ -20,6 +21,7 @@ export const COMPANION_FEATURE_BITS = Object.freeze({
   targetObservation: 1 << 3,
   skillSlotGeometry: 1 << 4,
   skillCooldownObservation: 1 << 5,
+  playRegionObservation: 1 << 6,
 });
 
 export const COMPANION_DISPATCH_KINDS = Object.freeze({

--- a/src/shared/companion-kernel-contract.ts
+++ b/src/shared/companion-kernel-contract.ts
@@ -25,6 +25,7 @@ export const COMPANION_KERNEL_SIGNATURES: readonly Readonly<{
   { name: "companion_party_bytes", typeIndex: 2 },
   { name: "companion_skill_slot_bytes", typeIndex: 2 },
   { name: "companion_skill_cooldown_bytes", typeIndex: 2 },
+  { name: "companion_play_region_bytes", typeIndex: 2 },
 ]);
 
 export const COMPANION_KERNEL_EXPORTS = Object.freeze(
@@ -70,8 +71,8 @@ function encodeSection(id: number, payload: number[]): number[] {
  */
 export function companionKernelSignatureBytes(): Uint8Array<ArrayBuffer> {
   const types = [
-    // Seven region pointer/size pairs and the feature word.
-    i32FunctionType(15, true),
+    // Eight region pointer/size pairs and the feature word.
+    i32FunctionType(17, true),
     i32FunctionType(6, false),
     i32FunctionType(0, true),
   ];

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -629,6 +629,7 @@ export interface ClientCompatibility {
     chatAliases: OptionalFeatureStatus;
     skillSlotGeometry: OptionalFeatureStatus;
     skillCooldownObservation: OptionalFeatureStatus;
+    playRegionObservation: OptionalFeatureStatus;
   }>;
 }
 

--- a/src/shared/enhancement-config.ts
+++ b/src/shared/enhancement-config.ts
@@ -103,13 +103,16 @@ export interface EnhancementLayout {
   frameState: number;
 }
 
-export type EnhancementObservationBaseLayout = Pick<EnhancementLayout,
+export type EnhancementPlayRegionLayout = Pick<EnhancementLayout,
   | "contextRoot" | "gameContextSlot" | "characterContext" | "mapId"
   | "isExplorable" | "currentMapId" | "currentInstanceType" | "playerNumber"
+  | "areaInfo" | "areaInfoCount" | "areaInfoStride" | "areaInfoFlags"
+>;
+export type EnhancementObservationBaseLayout = EnhancementPlayRegionLayout & Pick<
+  EnhancementLayout,
   | "agentArray" | "agentId" | "agentX" | "agentY" | "agentType"
   | "agentPlayerNumber" | "agentModelType"
-  | "worldContext" | "areaInfo" | "areaInfoCount" | "areaInfoStride"
-  | "areaInfoFlags"
+  | "worldContext"
 >;
 export type EnhancementTargetLayout = Pick<EnhancementLayout,
   | "manualTargetAgentId" | "automaticTargetAgentId"
@@ -140,9 +143,14 @@ export type EnhancementPartyLayout = Omit<EnhancementLayout,
   | keyof EnhancementSkillCooldownLayout
 >;
 
-type Owner = "observation" | "target" | "cursor" | "party" | "storage"
+type Owner = "play-region" | "observation" | "target" | "cursor" | "party" | "storage"
   | "skill-slots" | "skill-cooldown";
 type ConfigField =
+  | Readonly<{
+    source: "layout";
+    owner: "play-region";
+    key: keyof EnhancementPlayRegionLayout;
+  }>
   | Readonly<{
     source: "layout";
     owner: "observation";
@@ -172,6 +180,11 @@ type ConfigField =
 const observation = (
   ...keys: readonly (keyof EnhancementObservationBaseLayout)[]
 ): readonly ConfigField[] => keys.map((key) => ({ source: "layout", key, owner: "observation" }));
+const playRegion = (
+  ...keys: readonly (keyof EnhancementPlayRegionLayout)[]
+): readonly ConfigField[] => keys.map((key) => ({
+  source: "layout", key, owner: "play-region",
+}));
 const target = (
   ...keys: readonly (keyof EnhancementTargetLayout)[]
 ): readonly ConfigField[] => keys.map((key) => ({ source: "layout", key, owner: "target" }));
@@ -196,16 +209,21 @@ const skillCooldown = (
 }));
 
 export const ENHANCEMENT_CONFIG_FIELDS = Object.freeze([
-  ...observation("contextRoot", "agentArray"),
+  ...playRegion("contextRoot"),
+  ...observation("agentArray"),
   ...target("manualTargetAgentId", "automaticTargetAgentId"),
-  ...observation("gameContextSlot", "characterContext", "mapId", "isExplorable", "currentMapId", "currentInstanceType", "playerNumber", "agentId"),
+  ...playRegion(
+    "gameContextSlot", "characterContext", "mapId", "isExplorable",
+    "currentMapId", "currentInstanceType", "playerNumber",
+  ),
+  ...observation("agentId"),
   ...observation("agentX", "agentY", "agentType"),
   ...observation("agentPlayerNumber", "agentModelType"),
   ...cursor("cursorActiveArt", "cursorSoftwareModel", "cursorShowCount", "cursorColorBuffer", "cursorArtHotspot", "cursorArtTexture", "cursorHandleKey", "cursorHandleObject", "cursorViewTexture", "cursorTextureType", "cursorTextureWidth", "cursorTextureHeight"),
   ...party("partyContext", "playerParty", "partyHeroes", "heroMemberStride", "heroAgentId", "heroOwnerPlayerId", "heroId", "heroLevel", "partyPlayers", "partyHenchmen", "partyFlag", "accountContextSlot", "accountUnlockedSkills"),
   ...observation("worldContext"),
   ...party("worldHeroFlags", "heroFlagStride", "flagHeroId", "flagAgentId", "flagBehavior", "worldHeroInfo", "heroInfoStride", "infoHeroId", "infoAgentId", "infoLevel", "infoPrimary", "infoSecondary", "infoAppearanceBitmap", "worldSkillbars", "skillbarStride", "skillbarAgentId", "skillbarSkills", "skillSlotStride", "skillSlotId", "skillbarDisabled", "worldAttributes", "attributeStride", "attributeAgentId", "attributeEntries", "attributeEntryStride", "attributeEntryId", "attributeEntryRank"),
-  ...observation("areaInfo", "areaInfoCount", "areaInfoStride", "areaInfoFlags"),
+  ...playRegion("areaInfo", "areaInfoCount", "areaInfoStride", "areaInfoFlags"),
   ...party("worldProfessionStates", "professionStateStride", "worldCharacterSkills"),
   ...storage("worldPlayers", "playerRecordStride", "playerRecordAgentId", "playerRecordAccessFlags", "playerRecordNumber", "areaInfoType"),
   ...skillSlots(

--- a/src/shared/enhancement-contracts.ts
+++ b/src/shared/enhancement-contracts.ts
@@ -43,14 +43,14 @@ const CAPABILITY_DEFINITIONS = Object.freeze([
   },
   {
     id: "targetObservation",
-    requiresAll: [],
+    requiresAll: ["playRegionObservation"],
     requiresAny: [],
     configOwners: ["observation", "target"],
     hooks: [],
   },
   {
     id: "partyObservation",
-    requiresAll: [],
+    requiresAll: ["playRegionObservation"],
     requiresAny: [],
     configOwners: ["observation", "party"],
     hooks: ["ui"],
@@ -64,14 +64,14 @@ const CAPABILITY_DEFINITIONS = Object.freeze([
   },
   {
     id: "travelAction",
-    requiresAll: [],
+    requiresAll: ["playRegionObservation"],
     requiresAny: [],
     configOwners: [],
     hooks: [],
   },
   {
     id: "xunlaiAction",
-    requiresAll: [],
+    requiresAll: ["playRegionObservation"],
     requiresAny: [],
     configOwners: ["observation", "storage"],
     hooks: [],
@@ -85,7 +85,7 @@ const CAPABILITY_DEFINITIONS = Object.freeze([
   },
   {
     id: "skillSlotGeometry",
-    requiresAll: ["partyObservation"],
+    requiresAll: ["playRegionObservation"],
     requiresAny: [],
     configOwners: ["skill-slots"],
     hooks: [],
@@ -95,6 +95,13 @@ const CAPABILITY_DEFINITIONS = Object.freeze([
     requiresAll: ["partyObservation"],
     requiresAny: [],
     configOwners: ["skill-cooldown"],
+    hooks: [],
+  },
+  {
+    id: "playRegionObservation",
+    requiresAll: [],
+    requiresAny: [],
+    configOwners: ["play-region"],
     hooks: [],
   },
 ] as const);
@@ -183,6 +190,7 @@ export const NO_ENHANCEMENT_CAPABILITIES: EnhancementCapabilities = Object.freez
   chatAliases: false,
   skillSlotGeometry: false,
   skillCooldownObservation: false,
+  playRegionObservation: false,
 });
 
 function isExactBooleanRecord<Key extends string>(
@@ -216,6 +224,7 @@ export function parseEnhancementCapabilities(
     chatAliases: value.chatAliases,
     skillSlotGeometry: value.skillSlotGeometry,
     skillCooldownObservation: value.skillCooldownObservation,
+    playRegionObservation: value.playRegionObservation,
   });
 }
 
@@ -240,12 +249,13 @@ export function enhancementCapabilityProfile(
 /** Named product/developer choices. Certificates and caches use only bit identities. */
 export const ENHANCEMENT_CAPABILITY_PRESETS = Object.freeze({
   cursor: capabilitiesFromMask(0x01),
-  target: capabilitiesFromMask(0x02),
-  party: capabilitiesFromMask(0x84),
-  cursorParty: capabilitiesFromMask(0x85),
-  storage: capabilitiesFromMask(0x70),
-  partyCommandsStorage: capabilitiesFromMask(0xfc),
-  all: capabilitiesFromMask(0x1ff),
+  region: capabilitiesFromMask(0x200),
+  target: capabilitiesFromMask(0x202),
+  party: capabilitiesFromMask(0x284),
+  cursorParty: capabilitiesFromMask(0x285),
+  storage: capabilitiesFromMask(0x270),
+  partyCommandsStorage: capabilitiesFromMask(0x2fc),
+  all: capabilitiesFromMask(0x3ff),
 });
 
 export {
@@ -253,7 +263,7 @@ export {
   ENHANCEMENT_LAYOUT_WORD_COUNT,
   ENHANCEMENT_PARTY_DIRTY_MESSAGE_COUNT,
 } from "./enhancement-config.js";
-export const ENHANCEMENT_TRANSFORM_ABI = 40;
+export const ENHANCEMENT_TRANSFORM_ABI = 41;
 
 export function enhancementConfigWordActive(
   capabilities: EnhancementCapabilities,

--- a/src/shared/travel-command.ts
+++ b/src/shared/travel-command.ts
@@ -5,7 +5,7 @@
 import type { TravelRequest } from "./travel.js";
 
 export const TRAVEL_WAITING_REASONS = [
-  "game", "loading", "memory", "writing", "snapshot", "corrupt", "cursor",
+  "game", "loading", "memory", "writing", "snapshot", "corrupt", "cursor", "stale",
 ] as const;
 export type TravelWaitingReason = (typeof TRAVEL_WAITING_REASONS)[number];
 export type TravelGameState =

--- a/tests/client-artifact/template-save-recert.test.ts
+++ b/tests/client-artifact/template-save-recert.test.ts
@@ -175,6 +175,7 @@ test("the template-save verifier makes a fail-closed decision for a real client"
     chatAliases: true,
     skillSlotGeometry: true,
     skillCooldownObservation: true,
+    playRegionObservation: true,
   });
 
   // If this is a statically shipped build, the shape locator must still
@@ -281,8 +282,9 @@ test("the template-save verifier makes a fail-closed decision for a real client"
   assert.deepEqual(capabilitiesOf(addressDecision), {
     nativeCursor: true, targetObservation: false, partyObservation: false,
     teamApply: false, travelAction: true, xunlaiAction: false, chatAliases: true,
-    skillSlotGeometry: false,
+    skillSlotGeometry: true,
     skillCooldownObservation: false,
+    playRegionObservation: true,
   });
   assert.deepEqual(addressDecision.reasons, []);
   const addressTemplateBuild = addressDecision.templateSaveBuild;
@@ -291,37 +293,18 @@ test("the template-save verifier makes a fail-closed decision for a real client"
   assert.ok(addressTemplateBuild);
   assert.ok(addressEnhancementBuild);
   assert.ok(addressCapabilities);
-  const addressTemplate = rewriteTemplateSaveWasm(
-    changedAddressReference,
-    addressTemplateBuild,
-  );
-  const addressTemplateBodies = parseCode(sectionById(
-    splitSections(addressTemplate),
-    10,
-  ));
-  const addressOutputSections = splitSections(transformEnhancementWasm(
-    addressTemplate,
-    addressEnhancementBuild,
-    addressCapabilities,
-  ));
-  const addressOutputBodies = parseCode(sectionById(addressOutputSections, 10));
-  const addressAliasParser = addressEnhancementBuild.chatAliases!.parser.functionIndex
-    - derived.importCount;
-  assert.notDeepEqual(
-    addressOutputBodies[addressAliasParser],
-    addressTemplateBodies[addressAliasParser],
-    "Travel-only degradation must retain its proved /tp parser alias",
-  );
-  const addressExports = parseExports(sectionById(addressOutputSections, 7));
-  assert.equal(addressExports.some(
-    (entry) => entry.name === addressEnhancementBuild.travelAction!.enqueueExport,
-  ), true);
-  assert.equal(addressExports.some(
-    (entry) => entry.name === local.enhancementBuild!.xunlaiAction!.openExport,
-  ), false);
-  assert.equal(addressExports.some(
-    (entry) => entry.name === local.enhancementBuild!.teamApply!.thunkExport,
-  ), false);
+  assert.deepEqual(effectiveCapabilitiesOf(addressDecision), {
+    nativeCursor: true,
+    targetObservation: false,
+    partyObservation: false,
+    teamApply: false,
+    travelAction: true,
+    xunlaiAction: false,
+    chatAliases: true,
+    skillSlotGeometry: true,
+    skillCooldownObservation: false,
+    playRegionObservation: true,
+  });
 
   const targetMutations = [
     { local: 7327 - derived.importCount, offset: 132, label: "target occurrence ledger", shared: false },
@@ -342,9 +325,14 @@ test("the template-save verifier makes a fail-closed decision for a real client"
     assert.ok(refusal.templateSaveBuild, mutation.label);
     assert.ok(refusal.enhancementBuild?.cursorEvent, mutation.label);
     assert.equal(refusal.enhancementBuild.targetObservation, undefined, mutation.label);
-    assert.equal(capabilitiesOf(refusal)?.travelAction, true, mutation.label);
+    assert.equal(capabilitiesOf(refusal)?.travelAction, !mutation.shared, mutation.label);
     assert.equal(capabilitiesOf(refusal)?.chatAliases, true, mutation.label);
     assert.equal(capabilitiesOf(refusal)?.xunlaiAction, !mutation.shared, mutation.label);
+    assert.equal(
+      capabilitiesOf(refusal)?.playRegionObservation,
+      !mutation.shared,
+      mutation.label,
+    );
     assert.deepEqual(refusal.reasons, [], mutation.label);
   }
 

--- a/tests/electron/client-compatibility.spec.ts
+++ b/tests/electron/client-compatibility.spec.ts
@@ -225,6 +225,7 @@ test.describe("client compatibility", () => {
             features: {
               gameFileSaving: { status: "unavailable", reason: "game-update" },
               nativeCursor: { status: "unavailable", reason: "game-update" },
+              playRegionObservation: { status: "off" },
               targetObservation: { status: "off" },
               partyObservation: { status: "off" },
               teamApply: { status: "off" },

--- a/tests/electron/input-travel.spec.ts
+++ b/tests/electron/input-travel.spec.ts
@@ -37,6 +37,7 @@ test.describe("renderer Travel input", () => {
           playRegion: "pve",
           state: { status: "ready", mapId: 133 },
         });
+        installation.poll();
       });
 
       await expect(page.getByRole("dialog", { name: "Quick Travel" })).toBeVisible();

--- a/tests/fixtures/enhancement-transform.ts
+++ b/tests/fixtures/enhancement-transform.ts
@@ -14,6 +14,7 @@ import {
 
 export const UNSUPPORTED_ALL_CAPABILITIES: EnhancementCapabilities = Object.freeze({
   nativeCursor: true,
+  playRegionObservation: true,
   targetObservation: true,
   partyObservation: true,
   teamApply: false,
@@ -25,6 +26,7 @@ export const UNSUPPORTED_ALL_CAPABILITIES: EnhancementCapabilities = Object.free
 });
 export const CURSOR_ONLY: EnhancementCapabilities = Object.freeze({
   nativeCursor: true,
+  playRegionObservation: false,
   targetObservation: false,
   partyObservation: false,
   teamApply: false,
@@ -36,6 +38,7 @@ export const CURSOR_ONLY: EnhancementCapabilities = Object.freeze({
 });
 export const CURSOR_TARGET: EnhancementCapabilities = Object.freeze({
   nativeCursor: true,
+  playRegionObservation: true,
   targetObservation: true,
   partyObservation: false,
   teamApply: false,
@@ -47,6 +50,7 @@ export const CURSOR_TARGET: EnhancementCapabilities = Object.freeze({
 });
 export const TARGET_ONLY: EnhancementCapabilities = Object.freeze({
   nativeCursor: false,
+  playRegionObservation: true,
   targetObservation: true,
   partyObservation: false,
   teamApply: false,
@@ -58,6 +62,7 @@ export const TARGET_ONLY: EnhancementCapabilities = Object.freeze({
 });
 export const STORAGE_ONLY: EnhancementCapabilities = Object.freeze({
   nativeCursor: false,
+  playRegionObservation: true,
   targetObservation: false,
   partyObservation: false,
   teamApply: false,
@@ -69,6 +74,7 @@ export const STORAGE_ONLY: EnhancementCapabilities = Object.freeze({
 });
 export const CURSOR_TOOLBOX: EnhancementCapabilities = Object.freeze({
   nativeCursor: true,
+  playRegionObservation: true,
   targetObservation: false,
   partyObservation: true,
   teamApply: false,
@@ -80,6 +86,7 @@ export const CURSOR_TOOLBOX: EnhancementCapabilities = Object.freeze({
 });
 export const NO_CAPABILITIES: EnhancementCapabilities = Object.freeze({
   nativeCursor: false,
+  playRegionObservation: false,
   targetObservation: false,
   partyObservation: false,
   teamApply: false,
@@ -91,6 +98,7 @@ export const NO_CAPABILITIES: EnhancementCapabilities = Object.freeze({
 });
 export const CURSOR_TOOLBOX_COMMANDS: EnhancementCapabilities = Object.freeze({
   nativeCursor: true,
+  playRegionObservation: true,
   targetObservation: false,
   partyObservation: true,
   teamApply: true,
@@ -102,6 +110,7 @@ export const CURSOR_TOOLBOX_COMMANDS: EnhancementCapabilities = Object.freeze({
 });
 export const CURSOR_TARGET_TOOLBOX_COMMANDS: EnhancementCapabilities = Object.freeze({
   nativeCursor: true,
+  playRegionObservation: true,
   targetObservation: true,
   partyObservation: true,
   teamApply: true,
@@ -113,6 +122,7 @@ export const CURSOR_TARGET_TOOLBOX_COMMANDS: EnhancementCapabilities = Object.fr
 });
 export const CURSOR_TOOLBOX_STORAGE: EnhancementCapabilities = Object.freeze({
   nativeCursor: true,
+  playRegionObservation: true,
   targetObservation: false,
   partyObservation: true,
   teamApply: false,
@@ -137,25 +147,25 @@ export const PARTY_DIRTY_MESSAGES = Object.freeze([
 
 const PLACEHOLDER_OUTPUTS: EnhancementOutputHashes = Object.freeze({
   "features-01": "0".repeat(64),
-  "features-02": "0".repeat(64),
-  "features-03": "0".repeat(64),
-  "features-04": "0".repeat(64),
-  "features-05": "0".repeat(64),
-  "features-06": "0".repeat(64),
-  "features-07": "0".repeat(64),
-  "features-0c": "0".repeat(64),
-  "features-0d": "0".repeat(64),
-  "features-0e": "0".repeat(64),
-  "features-0f": "0".repeat(64),
-  "features-70": "0".repeat(64),
-  "features-74": "0".repeat(64),
-  "features-75": "0".repeat(64),
-  "features-76": "0".repeat(64),
-  "features-77": "0".repeat(64),
-  "features-7c": "0".repeat(64),
-  "features-7d": "0".repeat(64),
-  "features-7e": "0".repeat(64),
-  "features-7f": "0".repeat(64),
+  "features-202": "0".repeat(64),
+  "features-203": "0".repeat(64),
+  "features-204": "0".repeat(64),
+  "features-205": "0".repeat(64),
+  "features-206": "0".repeat(64),
+  "features-207": "0".repeat(64),
+  "features-20c": "0".repeat(64),
+  "features-20d": "0".repeat(64),
+  "features-20e": "0".repeat(64),
+  "features-20f": "0".repeat(64),
+  "features-270": "0".repeat(64),
+  "features-274": "0".repeat(64),
+  "features-275": "0".repeat(64),
+  "features-276": "0".repeat(64),
+  "features-277": "0".repeat(64),
+  "features-27c": "0".repeat(64),
+  "features-27d": "0".repeat(64),
+  "features-27e": "0".repeat(64),
+  "features-27f": "0".repeat(64),
 });
 
 function uleb(value: number): number[] {
@@ -456,6 +466,12 @@ export function manifest(bytes: Uint8Array): KnownEnhancementBuild {
       agentId: 10, agentX: 11, agentY: 12, agentType: 13,
       agentPlayerNumber: 14, agentModelType: 15,
       worldContext: 46,
+      areaInfo: 72, areaInfoCount: 73, areaInfoStride: 74, areaInfoFlags: 75,
+    } },
+    playRegionObservation: { layout: {
+      contextRoot: 1, gameContextSlot: 6, characterContext: 4,
+      mapId: 5, isExplorable: 6, currentMapId: 7,
+      currentInstanceType: 8, playerNumber: 9,
       areaInfo: 72, areaInfoCount: 73, areaInfoStride: 74, areaInfoFlags: 75,
     } },
     targetObservation: { layout: {

--- a/tests/fixtures/enhancements.ts
+++ b/tests/fixtures/enhancements.ts
@@ -26,6 +26,10 @@ import {
   COMPANION_SKILL_SLOT_BYTES,
 } from "../../src/renderer/companion-skill-snapshot.ts";
 import {
+  COMPANION_PLAY_REGION_BYTES,
+  readCompanionPlayRegion,
+} from "../../src/renderer/companion-play-region-snapshot.ts";
+import {
   ENHANCEMENT_CONFIG_WORD_COUNT,
   ENHANCEMENT_LAYOUT_WORD_COUNT,
 } from "../../src/shared/enhancement-contracts.ts";
@@ -109,9 +113,13 @@ export const FEATURE_SKILL_SLOT_GEOMETRY =
   COMPANION_FEATURE_BITS.skillSlotGeometry;
 export const FEATURE_SKILL_COOLDOWN_OBSERVATION =
   COMPANION_FEATURE_BITS.skillCooldownObservation;
+export const FEATURE_PLAY_REGION_OBSERVATION =
+  COMPANION_FEATURE_BITS.playRegionObservation;
+export { COMPANION_PLAY_REGION_BYTES };
 export const ALL_FEATURES = FEATURE_NATIVE_CURSOR
   | FEATURE_GAME_SNAPSHOT
-  | FEATURE_TARGET_OBSERVATION;
+  | FEATURE_TARGET_OBSERVATION
+  | FEATURE_PLAY_REGION_OBSERVATION;
 
 export interface SnapshotOverrides {
   sequence?: number;
@@ -277,6 +285,7 @@ export const ADDRESSES = Object.freeze({
   party: 0xa800,
   skillSlots: 0xc000,
   skillCooldowns: 0xc100,
+  playRegion: 0xc200,
   partyContext: 0xa000,
   partyInfo: 0xa100,
   heroBuffer: 0xa200,
@@ -379,6 +388,8 @@ export interface KernelOverrides {
   skillSlotSize?: number;
   skillCooldownPointer?: number;
   skillCooldownSize?: number;
+  playRegionPointer?: number;
+  playRegionSize?: number;
   toolboxSize?: number;
 }
 
@@ -405,6 +416,8 @@ export type KernelInit = (
   skillSlotSize: number,
   skillCooldownPointer: number,
   skillCooldownSize: number,
+  playRegionPointer: number,
+  playRegionSize: number,
   features: number,
 ) => number;
 export type KernelDispatch = (
@@ -575,6 +588,14 @@ export async function createKernel(
           ?? ((features & FEATURE_SKILL_COOLDOWN_OBSERVATION) !== 0
             ? COMPANION_SKILL_COOLDOWN_BYTES
             : 0),
+        overrides.playRegionPointer
+          ?? ((features & FEATURE_PLAY_REGION_OBSERVATION) !== 0
+            ? ADDRESSES.playRegion
+            : 0),
+        overrides.playRegionSize
+          ?? ((features & FEATURE_PLAY_REGION_OBSERVATION) !== 0
+            ? COMPANION_PLAY_REGION_BYTES
+            : 0),
         features,
       );
     },
@@ -618,6 +639,7 @@ export async function createKernel(
     skillSlots: () => readCompanionSkillSlots(memory.buffer, ADDRESSES.skillSlots),
     skillCooldowns: () =>
       readCompanionSkillCooldowns(memory.buffer, ADDRESSES.skillCooldowns),
+    playRegion: () => readCompanionPlayRegion(memory.buffer, ADDRESSES.playRegion),
     field: (offset: number) => view.getUint32(ADDRESSES.cursor + offset, true),
     header: () => readCompanionCursorHeader(memory.buffer, ADDRESSES.cursor),
     published: () => readCompanionCursorPixels(memory.buffer, ADDRESSES.cursor),

--- a/tests/helpers/packaged-enhancement-fixture.ts
+++ b/tests/helpers/packaged-enhancement-fixture.ts
@@ -127,6 +127,7 @@ export const ENHANCEMENT_BUILD =
   ENHANCEMENT_BUILDS[0] ?? assert.fail("the canonical Enhancement build table is empty");
 export const TARGET_ONLY: EnhancementCapabilities = Object.freeze({
   nativeCursor: false,
+  playRegionObservation: true,
   targetObservation: true,
   partyObservation: false,
   teamApply: false,
@@ -138,6 +139,7 @@ export const TARGET_ONLY: EnhancementCapabilities = Object.freeze({
 });
 export const TOOLBOX_PROGRAM_CAPABILITIES: EnhancementCapabilities = Object.freeze({
   nativeCursor: true,
+  playRegionObservation: true,
   targetObservation: false,
   partyObservation: true,
   teamApply: false,
@@ -149,6 +151,7 @@ export const TOOLBOX_PROGRAM_CAPABILITIES: EnhancementCapabilities = Object.free
 });
 export const PRODUCT_TOOLS_CAPABILITIES: EnhancementCapabilities = Object.freeze({
   nativeCursor: true,
+  playRegionObservation: true,
   targetObservation: true,
   partyObservation: true,
   teamApply: true,
@@ -160,6 +163,7 @@ export const PRODUCT_TOOLS_CAPABILITIES: EnhancementCapabilities = Object.freeze
 });
 export const TARGET_OFF_PRODUCT_CAPABILITIES: EnhancementCapabilities = Object.freeze({
   nativeCursor: true,
+  playRegionObservation: true,
   targetObservation: false,
   partyObservation: true,
   teamApply: true,

--- a/tests/helpers/packaged-enhancement-scenarios.ts
+++ b/tests/helpers/packaged-enhancement-scenarios.ts
@@ -301,7 +301,7 @@ export async function assertTargetReadoutLifecycle() {
         {
           name: "enhancement.installed",
           companionAbi: COMPANION_ABI.kernel,
-          capabilityProfile: "features-02",
+          capabilityProfile: "features-202",
           installation: 1,
         },
         {

--- a/tests/helpers/packaged-enhancement-scenarios.ts
+++ b/tests/helpers/packaged-enhancement-scenarios.ts
@@ -1236,6 +1236,8 @@ export async function assertRollbackAfterTablePublication() {
       (rollbackCursorPointer + COMPANION_CURSOR_BYTES + 7) & ~7;
     const rollbackPartyPointer =
       rollbackToolboxPointer + COMPANION_TOOLBOX_BYTES;
+    const rollbackPlayRegionPointer =
+      rollbackPartyPointer + COMPANION_PARTY_BYTES;
     assert.deepEqual(result, {
       allocations: [
         { pointer: 0x1000, size: 65_551 },
@@ -1246,10 +1248,12 @@ export async function assertRollbackAfterTablePublication() {
         { pointer: rollbackCursorPointer, size: COMPANION_CURSOR_BYTES },
         { pointer: rollbackToolboxPointer, size: COMPANION_TOOLBOX_BYTES },
         { pointer: rollbackPartyPointer, size: COMPANION_PARTY_BYTES },
+        { pointer: rollbackPlayRegionPointer, size: COMPANION_PLAY_REGION_BYTES },
       ],
       freed: [
         rollbackToolboxPointer,
         rollbackPartyPointer,
+        rollbackPlayRegionPointer,
         rollbackCursorPointer,
         rollbackConfigPointer,
         0x1000,

--- a/tests/helpers/packaged-enhancement-scenarios.ts
+++ b/tests/helpers/packaged-enhancement-scenarios.ts
@@ -1020,6 +1020,7 @@ export async function assertToolboxFoundationLifecycle() {
     assert.deepEqual(result.after.freed, [
       statePointer,
       partyPointer,
+      playRegionPointer,
       commandPointer,
       storagePointer,
       travelPointer,

--- a/tests/helpers/packaged-enhancement-scenarios.ts
+++ b/tests/helpers/packaged-enhancement-scenarios.ts
@@ -171,6 +171,7 @@ export async function assertTargetReadoutLifecycle() {
           65_551,
           64,
           CONFIG_BYTES,
+          COMPANION_ABI.playRegion.bytes,
         ],
         globalRuntimeIsRuntime: true,
         hook: ENHANCEMENT_BUILD.tableSlot + 1,

--- a/tests/helpers/packaged-enhancement-scenarios.ts
+++ b/tests/helpers/packaged-enhancement-scenarios.ts
@@ -252,7 +252,8 @@ export async function assertTargetReadoutLifecycle() {
       "pagehide did not dispose the target readout",
     );
     assert.deepEqual(disposed, {
-      freed: [0x1000, 0x11_010, 0x11_050],
+      // Runtime allocation, target snapshot, config, and policy region.
+      freed: [0x1000, 0x11_010, 0x11_050, 0x11_210],
       hook: 0,
       // Cleanup withdraws the published runtime by writing null over it.
       runtime: null,

--- a/tests/helpers/packaged-enhancement-scenarios.ts
+++ b/tests/helpers/packaged-enhancement-scenarios.ts
@@ -11,6 +11,7 @@ import {
 import { TEAM_COMMAND_PAYLOAD_BYTES } from "../../src/renderer/enhancement-team-commands.ts";
 import { STORAGE_DATA_WINDOW_BYTES } from "../../src/renderer/enhancement-storage-command.ts";
 import { TRAVEL_PAYLOAD_BYTES } from "../../src/renderer/enhancement-travel-command.ts";
+import { COMPANION_PLAY_REGION_BYTES } from "../../src/renderer/companion-play-region-snapshot.ts";
 import { COMPANION_ABI } from "../../src/shared/companion-abi.ts";
 import {
   closePackaged,
@@ -896,7 +897,8 @@ export async function assertToolboxFoundationLifecycle() {
     const cursorPointer = (configPointer + CONFIG_BYTES + 7) & ~7;
     const statePointer = (cursorPointer + COMPANION_CURSOR_BYTES + 7) & ~7;
     const partyPointer = statePointer + COMPANION_TOOLBOX_BYTES;
-    const commandPointer = partyPointer + COMPANION_PARTY_BYTES;
+    const playRegionPointer = partyPointer + COMPANION_PARTY_BYTES;
+    const commandPointer = (playRegionPointer + COMPANION_PLAY_REGION_BYTES + 7) & ~7;
     const storagePointer = commandPointer + TEAM_COMMAND_PAYLOAD_BYTES;
     const travelPointer = (storagePointer + STORAGE_DATA_WINDOW_BYTES + 7) & ~7;
     assert.deepEqual(result.before.allocations, [
@@ -920,6 +922,10 @@ export async function assertToolboxFoundationLifecycle() {
       {
         pointer: partyPointer,
         size: COMPANION_PARTY_BYTES,
+      },
+      {
+        pointer: playRegionPointer,
+        size: COMPANION_PLAY_REGION_BYTES,
       },
       {
         pointer: commandPointer,

--- a/tests/integration/enhancements-kernel.test.ts
+++ b/tests/integration/enhancements-kernel.test.ts
@@ -5,6 +5,7 @@ import {
   ALL_FEATURES,
   COMPANION_CURSOR_BYTES,
   COMPANION_PARTY_BYTES,
+  COMPANION_PLAY_REGION_BYTES,
   COMPANION_TOOLBOX_BYTES,
   CONFIG_BYTES,
   createKernel,
@@ -13,6 +14,7 @@ import {
   DETAIL,
   FEATURE_NATIVE_CURSOR,
   FEATURE_GAME_SNAPSHOT,
+  FEATURE_PLAY_REGION_OBSERVATION,
   FEATURE_TOOLBOX_FOUNDATION,
   installCursorGraph,
   installGameGraph,
@@ -30,6 +32,15 @@ import {
   sameCompanionToolboxState,
 } from "../fixtures/enhancements.ts";
 
+const GAME_SNAPSHOT_FEATURES =
+  FEATURE_GAME_SNAPSHOT | FEATURE_PLAY_REGION_OBSERVATION;
+const TOOLBOX_FEATURES =
+  FEATURE_TOOLBOX_FOUNDATION | FEATURE_PLAY_REGION_OBSERVATION;
+const GAME_TOOLBOX_FEATURES =
+  FEATURE_GAME_SNAPSHOT
+  | FEATURE_TOOLBOX_FOUNDATION
+  | FEATURE_PLAY_REGION_OBSERVATION;
+
 describe("Companion kernel", () => {
   it("returns from adversarial callback scalars without panicking", async () => {
     const kernel = await createKernel();
@@ -40,8 +51,7 @@ describe("Companion kernel", () => {
       kernel.init({
         features:
           FEATURE_NATIVE_CURSOR
-          | FEATURE_GAME_SNAPSHOT
-          | FEATURE_TOOLBOX_FOUNDATION,
+          | GAME_TOOLBOX_FEATURES,
       }),
       1,
     );
@@ -169,7 +179,7 @@ describe("Companion kernel", () => {
     installCursorGraph(readoutOnly.view);
     paintCursor(readoutOnly.view, 2);
     assert.equal(
-      readoutOnly.init({ features: FEATURE_GAME_SNAPSHOT }),
+      readoutOnly.init({ features: GAME_SNAPSHOT_FEATURES }),
       1,
     );
     assert.equal(readoutOnly.field(CURSOR.magic), 0);
@@ -193,7 +203,9 @@ describe("Companion kernel", () => {
       9,
     );
 
-    kernel.activeFeatures(FEATURE_NATIVE_CURSOR);
+    kernel.activeFeatures(
+      FEATURE_NATIVE_CURSOR | FEATURE_PLAY_REGION_OBSERVATION,
+    );
     kernel.view.setUint32(ADDRESSES.agentBuffer + 9 * 4, 0xffff_fffc, true);
     kernel.tick();
     const policy = decoded(
@@ -211,19 +223,19 @@ describe("Companion kernel", () => {
 
     const readoutOnly = await createKernel();
     readoutOnly.config.fill(0, MESSAGE_CONFIG_START);
-    assert.equal(readoutOnly.init({ features: FEATURE_GAME_SNAPSHOT }), 1);
+    assert.equal(readoutOnly.init({ features: GAME_SNAPSHOT_FEATURES }), 1);
 
     const toolbox = await createKernel();
     toolbox.config.fill(0, MESSAGE_CONFIG_START);
     assert.equal(
-      toolbox.init({ features: FEATURE_TOOLBOX_FOUNDATION }),
+      toolbox.init({ features: TOOLBOX_FEATURES }),
       0,
     );
 
     const missingDirty = await createKernel();
     missingDirty.config[MESSAGE_CONFIG_START + 3] = 0;
     assert.equal(
-      missingDirty.init({ features: FEATURE_TOOLBOX_FOUNDATION }),
+      missingDirty.init({ features: TOOLBOX_FEATURES }),
       0,
     );
 
@@ -231,7 +243,7 @@ describe("Companion kernel", () => {
     duplicateDirty.config[MESSAGE_CONFIG_START + 4] =
       duplicateDirty.config[MESSAGE_CONFIG_START + 3]!;
     assert.equal(
-      duplicateDirty.init({ features: FEATURE_TOOLBOX_FOUNDATION }),
+      duplicateDirty.init({ features: TOOLBOX_FEATURES }),
       0,
     );
   });
@@ -239,7 +251,7 @@ describe("Companion kernel", () => {
   it("observes Toolbox heroes and the exact player agent", async () => {
     const kernel = await createKernel();
     installGameGraph(kernel.view);
-    assert.equal(kernel.init({ features: FEATURE_TOOLBOX_FOUNDATION }), 1);
+    assert.equal(kernel.init({ features: TOOLBOX_FEATURES }), 1);
     kernel.tick();
     const toolbox = readyToolbox(kernel.toolbox());
     assert.equal(toolbox.heroAvailable, true);
@@ -256,7 +268,7 @@ describe("Companion kernel", () => {
   it("publishes a roster whose unread fields admit they are unread", async () => {
     const kernel = await createKernel();
     installGameGraph(kernel.view);
-    assert.equal(kernel.init({ features: FEATURE_TOOLBOX_FOUNDATION }), 1);
+    assert.equal(kernel.init({ features: TOOLBOX_FEATURES }), 1);
     kernel.tick();
 
     const party = kernel.party();
@@ -290,7 +302,7 @@ describe("Companion kernel", () => {
   it("retracts the roster when the party cannot be read", async () => {
     const kernel = await createKernel();
     installGameGraph(kernel.view);
-    assert.equal(kernel.init({ features: FEATURE_TOOLBOX_FOUNDATION }), 1);
+    assert.equal(kernel.init({ features: TOOLBOX_FEATURES }), 1);
     kernel.tick();
     assert.equal(readyParty(kernel.party()).slotCount, 1);
 
@@ -313,7 +325,7 @@ describe("Companion kernel", () => {
     const kernel = await createKernel({ partyDetail: true });
     installGameGraph(kernel.view);
     installPartyDetailGraph(kernel.view);
-    assert.equal(kernel.init({ features: FEATURE_TOOLBOX_FOUNDATION }), 1);
+    assert.equal(kernel.init({ features: TOOLBOX_FEATURES }), 1);
     kernel.tick();
 
     const party = readyParty(kernel.party());
@@ -428,7 +440,7 @@ describe("Companion kernel", () => {
       // certified bound makes that group reject without damaging the roster.
       kernel.view.setUint32(ADDRESSES.world + detail.offset + 4, 65, true);
       kernel.view.setUint32(ADDRESSES.world + detail.offset + 8, 65, true);
-      assert.equal(kernel.init({ features: FEATURE_TOOLBOX_FOUNDATION }), 1);
+    assert.equal(kernel.init({ features: TOOLBOX_FEATURES }), 1);
       kernel.tick();
 
       const party = readyParty(kernel.party());
@@ -444,7 +456,7 @@ describe("Companion kernel", () => {
     const kernel = await createKernel({ partyDetail: true });
     installGameGraph(kernel.view);
     installPartyDetailGraph(kernel.view);
-    assert.equal(kernel.init({ features: FEATURE_TOOLBOX_FOUNDATION }), 1);
+    assert.equal(kernel.init({ features: TOOLBOX_FEATURES }), 1);
     kernel.tick();
 
     const party = readyParty(kernel.party());
@@ -475,7 +487,7 @@ describe("Companion kernel", () => {
       4,
       true,
     );
-    assert.equal(kernel.init({ features: FEATURE_TOOLBOX_FOUNDATION }), 1);
+    assert.equal(kernel.init({ features: TOOLBOX_FEATURES }), 1);
     kernel.tick();
 
     const party = readyParty(kernel.party());
@@ -512,7 +524,7 @@ describe("Companion kernel", () => {
       129,
       true,
     );
-    assert.equal(kernel.init({ features: FEATURE_TOOLBOX_FOUNDATION }), 1);
+    assert.equal(kernel.init({ features: TOOLBOX_FEATURES }), 1);
     kernel.tick();
 
     const party = readyParty(kernel.party());
@@ -530,7 +542,7 @@ describe("Companion kernel", () => {
     const kernel = await createKernel({ partyDetail: true });
     installGameGraph(kernel.view);
     installPartyDetailGraph(kernel.view);
-    assert.equal(kernel.init({ features: FEATURE_TOOLBOX_FOUNDATION }), 1);
+    assert.equal(kernel.init({ features: TOOLBOX_FEATURES }), 1);
     kernel.tick();
     assert.equal(readyParty(kernel.party()).inOutpost, true);
 
@@ -551,7 +563,7 @@ describe("Companion kernel", () => {
     const kernel = await createKernel({ partyDetail: true });
     installGameGraph(kernel.view);
     installPartyDetailGraph(kernel.view);
-    assert.equal(kernel.init({ features: FEATURE_TOOLBOX_FOUNDATION }), 1);
+    assert.equal(kernel.init({ features: TOOLBOX_FEATURES }), 1);
     kernel.tick();
 
     // Exactly the three invested ranks. Air Magic (8) is what the padding at
@@ -581,7 +593,7 @@ describe("Companion kernel", () => {
   it("republishes the roster only when the roster changed", async () => {
     const kernel = await createKernel();
     installGameGraph(kernel.view);
-    assert.equal(kernel.init({ features: FEATURE_TOOLBOX_FOUNDATION }), 1);
+    assert.equal(kernel.init({ features: TOOLBOX_FEATURES }), 1);
     kernel.tick();
     const { sequence, generation } = readyParty(kernel.party());
 
@@ -609,7 +621,7 @@ describe("Companion kernel", () => {
   it("reads only the party header while its sequence is unchanged", async () => {
     const kernel = await createKernel();
     installGameGraph(kernel.view);
-    assert.equal(kernel.init({ features: FEATURE_TOOLBOX_FOUNDATION }), 1);
+    assert.equal(kernel.init({ features: TOOLBOX_FEATURES }), 1);
     kernel.tick();
 
     const first = readChangedCompanionParty(
@@ -639,7 +651,7 @@ describe("Companion kernel", () => {
   it("traverses party state only for the exact dirty-message set", async () => {
     const kernel = await createKernel();
     installGameGraph(kernel.view);
-    assert.equal(kernel.init({ features: FEATURE_TOOLBOX_FOUNDATION }), 1);
+    assert.equal(kernel.init({ features: TOOLBOX_FEATURES }), 1);
     kernel.tick();
     const ready = readyToolbox(kernel.toolbox());
     assert.equal(ready.heroAvailable, true);
@@ -705,7 +717,7 @@ describe("Companion kernel", () => {
     installGameGraph(kernel.view);
     assert.equal(
       kernel.init({
-        features: FEATURE_GAME_SNAPSHOT | FEATURE_TOOLBOX_FOUNDATION,
+        features: GAME_TOOLBOX_FEATURES,
       }),
       1,
     );
@@ -737,7 +749,7 @@ describe("Companion kernel", () => {
     // the target readout's 4,096-entry agent search.
     kernel.view.setUint32(ADDRESSES.agentArray + 4, 5_000, true);
     kernel.view.setUint32(ADDRESSES.agentArray + 8, 5_000, true);
-    assert.equal(kernel.init({ features: FEATURE_TOOLBOX_FOUNDATION }), 1);
+    assert.equal(kernel.init({ features: TOOLBOX_FEATURES }), 1);
 
     kernel.tick();
     let state = readyToolbox(kernel.toolbox());
@@ -816,7 +828,7 @@ describe("Companion kernel", () => {
   it("compares Toolbox projections by decoded value", async () => {
     const kernel = await createKernel();
     installGameGraph(kernel.view);
-    assert.equal(kernel.init({ features: FEATURE_TOOLBOX_FOUNDATION }), 1);
+    assert.equal(kernel.init({ features: TOOLBOX_FEATURES }), 1);
     kernel.tick();
     const first = kernel.toolbox();
     assert.equal(sameCompanionToolboxState(null, first), false);
@@ -833,7 +845,7 @@ describe("Companion kernel", () => {
   it("reads only the Toolbox header while its generation is unchanged", async () => {
     const kernel = await createKernel();
     installGameGraph(kernel.view);
-    assert.equal(kernel.init({ features: FEATURE_TOOLBOX_FOUNDATION }), 1);
+    assert.equal(kernel.init({ features: TOOLBOX_FEATURES }), 1);
     kernel.tick();
 
     const first = readChangedCompanionToolbox(
@@ -870,8 +882,7 @@ describe("Companion kernel", () => {
     paintCursor(kernel.view, 7);
     assert.equal(kernel.init({
       features: FEATURE_NATIVE_CURSOR
-        | FEATURE_GAME_SNAPSHOT
-        | FEATURE_TOOLBOX_FOUNDATION,
+        | GAME_TOOLBOX_FEATURES,
     }), 1);
     const before = new Uint8Array(kernel.memory.buffer).slice();
 
@@ -887,6 +898,10 @@ describe("Companion kernel", () => {
       [ADDRESSES.cursor, ADDRESSES.cursor + COMPANION_CURSOR_BYTES],
       [ADDRESSES.toolbox, ADDRESSES.toolbox + COMPANION_TOOLBOX_BYTES],
       [ADDRESSES.party, ADDRESSES.party + COMPANION_PARTY_BYTES],
+      [
+        ADDRESSES.playRegion,
+        ADDRESSES.playRegion + COMPANION_PLAY_REGION_BYTES,
+      ],
       [ADDRESSES.companionRuntime, ADDRESSES.companionRuntime + 65_536],
     ] as const;
     const after = new Uint8Array(kernel.memory.buffer);
@@ -916,7 +931,7 @@ describe("Companion kernel", () => {
     );
     assert.equal(
       kernel.init({
-        features: FEATURE_GAME_SNAPSHOT,
+        features: GAME_SNAPSHOT_FEATURES,
         snapshotPointer: 0,
         snapshotSize: 0,
       }),
@@ -932,7 +947,7 @@ describe("Companion kernel", () => {
     );
     assert.equal(
       kernel.init({
-        features: FEATURE_GAME_SNAPSHOT,
+        features: GAME_SNAPSHOT_FEATURES,
         cursorPointer: ADDRESSES.cursor,
         cursorSize: COMPANION_CURSOR_BYTES,
       }),

--- a/tests/integration/enhancements-xunlai-kernel.test.ts
+++ b/tests/integration/enhancements-xunlai-kernel.test.ts
@@ -6,18 +6,22 @@ import {
   decoded,
   DETAIL,
   FEATURE_GAME_SNAPSHOT,
+  FEATURE_PLAY_REGION_OBSERVATION,
   installGameGraph,
   PLAYER_RECORD_ADDRESS,
   readCompanionSnapshot,
   XUNLAI_CONFIG_START,
 } from "../fixtures/enhancements.ts";
 
+const XUNLAI_FEATURES =
+  FEATURE_GAME_SNAPSHOT | FEATURE_PLAY_REGION_OBSERVATION;
+
 describe("Companion Xunlai access kernel", () => {
   it("publishes access from the player record without a party", async () => {
     const kernel = await createKernel({ partyDetail: true });
     installGameGraph(kernel.view);
     kernel.view.setUint32(ADDRESSES.game + 0x4c, 0, true);
-    assert.equal(kernel.init({ features: FEATURE_GAME_SNAPSHOT }), 1);
+    assert.equal(kernel.init({ features: XUNLAI_FEATURES }), 1);
 
     kernel.tick();
     const storageOnly = decoded(
@@ -84,7 +88,7 @@ describe("Companion Xunlai access kernel", () => {
   it("revokes access on corrupt records and character transitions", async () => {
     const kernel = await createKernel({ partyDetail: true });
     installGameGraph(kernel.view);
-    assert.equal(kernel.init({ features: FEATURE_GAME_SNAPSHOT }), 1);
+    assert.equal(kernel.init({ features: XUNLAI_FEATURES }), 1);
     const access = () =>
       decoded(readCompanionSnapshot(kernel.memory.buffer, ADDRESSES.snapshot))
         .xunlaiAccess;
@@ -136,7 +140,7 @@ describe("Companion Xunlai access kernel", () => {
     const kernel = await createKernel();
     installGameGraph(kernel.view);
     kernel.config.fill(0, XUNLAI_CONFIG_START, XUNLAI_CONFIG_START + 6);
-    assert.equal(kernel.init({ features: FEATURE_GAME_SNAPSHOT }), 1);
+    assert.equal(kernel.init({ features: XUNLAI_FEATURES }), 1);
 
     kernel.tick();
     assert.equal(

--- a/tests/integration/play-region-kernel.test.ts
+++ b/tests/integration/play-region-kernel.test.ts
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  ADDRESSES,
+  createKernel,
+  FEATURE_GAME_SNAPSHOT,
+  FEATURE_PLAY_REGION_OBSERVATION,
+  FEATURE_SKILL_COOLDOWN_OBSERVATION,
+  FEATURE_SKILL_SLOT_GEOMETRY,
+  FEATURE_TOOLBOX_FOUNDATION,
+  installGameGraph,
+} from "../fixtures/enhancements.ts";
+
+const AREA_133 = ADDRESSES.areaInfo + 133 * 0x7c;
+
+describe("play-region kernel", () => {
+  it("publishes the bounded area policy without traversing the agent array", async () => {
+    const kernel = await createKernel();
+    installGameGraph(kernel.view);
+    kernel.view.setUint32(ADDRESSES.agentArray, 0xffff_fffc, true);
+    kernel.view.setUint32(ADDRESSES.agentArray + 4, 0xffff_ffff, true);
+    kernel.view.setUint32(ADDRESSES.agentArray + 8, 0xffff_ffff, true);
+    assert.equal(kernel.init({ features: FEATURE_PLAY_REGION_OBSERVATION }), 1);
+
+    kernel.tick();
+    assert.deepEqual(kernel.playRegion(), {
+      status: "ready",
+      sequence: 4,
+      mapId: 133,
+      instanceType: 0,
+      playRegion: "pve",
+    });
+
+    kernel.view.setUint32(AREA_133 + 0x10, 1, true);
+    kernel.tick();
+    assert.deepEqual(kernel.playRegion(), {
+      status: "ready",
+      sequence: 6,
+      mapId: 133,
+      instanceType: 0,
+      playRegion: "pvp",
+    });
+  });
+
+  it("publishes loading and withdraws malformed area data", async () => {
+    const kernel = await createKernel();
+    installGameGraph(kernel.view);
+    assert.equal(kernel.init({ features: FEATURE_PLAY_REGION_OBSERVATION }), 1);
+
+    kernel.view.setUint32(ADDRESSES.character + 0x23c, 2, true);
+    kernel.tick();
+    assert.deepEqual(kernel.playRegion(), {
+      status: "waiting", reason: "loading",
+    });
+
+    kernel.view.setUint32(ADDRESSES.character + 0x23c, 0, true);
+    kernel.view.setUint32(AREA_133 + 0x0c, 22, true);
+    kernel.tick();
+    assert.deepEqual(kernel.playRegion(), {
+      status: "waiting", reason: "game",
+    });
+  });
+
+  it("requires its exact region and cannot be deactivated after init", async () => {
+    const invalid = await createKernel();
+    assert.equal(invalid.init({
+      features: FEATURE_PLAY_REGION_OBSERVATION,
+      playRegionSize: 24,
+    }), 0);
+
+    const kernel = await createKernel();
+    installGameGraph(kernel.view);
+    assert.equal(kernel.init({ features: FEATURE_PLAY_REGION_OBSERVATION }), 1);
+    kernel.activeFeatures(0);
+    kernel.tick();
+    const first = kernel.playRegion();
+    assert.equal(first.status, "ready");
+    kernel.tick();
+    const second = kernel.playRegion();
+    assert.equal(second.status, "ready");
+    if (first.status === "ready" && second.status === "ready") {
+      assert.equal(second.sequence, first.sequence + 2);
+    }
+  });
+
+  it("decouples geometry from Toolbox while cooldowns retain their party dependency", async () => {
+    const geometryWithoutRegion = await createKernel();
+    assert.equal(geometryWithoutRegion.init({
+      features: FEATURE_SKILL_SLOT_GEOMETRY,
+    }), 0);
+
+    const geometry = await createKernel();
+    assert.equal(geometry.init({
+      features: FEATURE_PLAY_REGION_OBSERVATION | FEATURE_SKILL_SLOT_GEOMETRY,
+    }), 1);
+
+    const cooldownWithoutRegion = await createKernel({ partyDetail: true });
+    assert.equal(cooldownWithoutRegion.init({
+      features: FEATURE_SKILL_COOLDOWN_OBSERVATION,
+    }), 0);
+
+    const cooldownWithoutParty = await createKernel({ partyDetail: true });
+    assert.equal(cooldownWithoutParty.init({
+      features:
+        FEATURE_PLAY_REGION_OBSERVATION | FEATURE_SKILL_COOLDOWN_OBSERVATION,
+    }), 0);
+
+    const cooldown = await createKernel({ partyDetail: true });
+    assert.equal(cooldown.init({
+      features:
+        FEATURE_PLAY_REGION_OBSERVATION
+        | FEATURE_TOOLBOX_FOUNDATION
+        | FEATURE_SKILL_COOLDOWN_OBSERVATION,
+    }), 1);
+  });
+
+  it("is required by every native observation that publishes region-dependent state", async () => {
+    const cases = [
+      { name: "game snapshot", feature: FEATURE_GAME_SNAPSHOT },
+      { name: "Toolbox foundation", feature: FEATURE_TOOLBOX_FOUNDATION },
+      { name: "skill-slot geometry", feature: FEATURE_SKILL_SLOT_GEOMETRY },
+      {
+        name: "skill cooldowns",
+        feature:
+          FEATURE_TOOLBOX_FOUNDATION | FEATURE_SKILL_COOLDOWN_OBSERVATION,
+      },
+    ] as const;
+
+    for (const { name, feature } of cases) {
+      const withoutRegion = await createKernel({ partyDetail: true });
+      assert.equal(
+        withoutRegion.init({ features: feature }),
+        0,
+        `${name} must fail closed without play-region observation`,
+      );
+
+      const withRegion = await createKernel({ partyDetail: true });
+      assert.equal(
+        withRegion.init({ features: feature | FEATURE_PLAY_REGION_OBSERVATION }),
+        1,
+        `${name} must accept its declared play-region substrate`,
+      );
+    }
+  });
+
+  it("rejects active observer masks that detach dependants from the policy substrate", async () => {
+    const kernel = await createKernel({ partyDetail: true });
+    installGameGraph(kernel.view);
+    assert.equal(kernel.init({
+      features: FEATURE_PLAY_REGION_OBSERVATION | FEATURE_TOOLBOX_FOUNDATION,
+    }), 1);
+
+    kernel.activeFeatures(FEATURE_PLAY_REGION_OBSERVATION);
+    kernel.tick();
+    const disabled = kernel.toolbox();
+    assert.equal(disabled.status, "ready");
+    if (disabled.status !== "ready") return;
+    const disabledSequence = disabled.sequence;
+
+    kernel.activeFeatures(FEATURE_TOOLBOX_FOUNDATION);
+    kernel.tick();
+    const stillDisabled = kernel.toolbox();
+    assert.equal(stillDisabled.status, "ready");
+    if (stillDisabled.status !== "ready") return;
+    assert.equal(stillDisabled.sequence, disabledSequence,
+      "an invalid active mask must leave Toolbox disabled");
+
+    kernel.activeFeatures(
+      FEATURE_PLAY_REGION_OBSERVATION | FEATURE_TOOLBOX_FOUNDATION,
+    );
+    kernel.tick();
+    const enabled = kernel.toolbox();
+    assert.equal(enabled.status, "ready");
+    if (enabled.status !== "ready") return;
+    assert.notEqual(enabled.sequence, disabledSequence);
+  });
+});

--- a/tests/integration/play-region-snapshot.test.ts
+++ b/tests/integration/play-region-snapshot.test.ts
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  COMPANION_PLAY_REGION_BYTES,
+  readCompanionPlayRegion,
+} from "../../src/renderer/companion-play-region-snapshot.ts";
+
+function snapshot(overrides: Readonly<{
+  magic?: number;
+  abi?: number;
+  bytes?: number;
+  sequence?: number;
+  flags?: number;
+  mapId?: number;
+  instanceType?: number;
+  playRegion?: number;
+}> = {}) {
+  const buffer = new ArrayBuffer(COMPANION_PLAY_REGION_BYTES);
+  const view = new DataView(buffer);
+  view.setUint32(0, overrides.magic ?? 0x5250_5747, true);
+  view.setUint16(4, overrides.abi ?? 1, true);
+  view.setUint16(6, overrides.bytes ?? COMPANION_PLAY_REGION_BYTES, true);
+  view.setUint32(8, overrides.sequence ?? 2, true);
+  view.setUint32(12, overrides.flags ?? 1, true);
+  view.setUint32(16, overrides.mapId ?? 133, true);
+  view.setUint32(20, overrides.instanceType ?? 0, true);
+  view.setUint32(24, overrides.playRegion ?? 1, true);
+  return buffer;
+}
+
+describe("play-region snapshot ABI", () => {
+  it("decodes only a complete certified PvE or PvP record", () => {
+    assert.deepEqual(readCompanionPlayRegion(snapshot(), 0), {
+      status: "ready",
+      sequence: 2,
+      mapId: 133,
+      instanceType: 0,
+      playRegion: "pve",
+    });
+    assert.deepEqual(readCompanionPlayRegion(snapshot({
+      mapId: 248,
+      instanceType: 1,
+      playRegion: 2,
+    }), 0), {
+      status: "ready",
+      sequence: 2,
+      mapId: 248,
+      instanceType: 1,
+      playRegion: "pvp",
+    });
+  });
+
+  it("fails closed for memory, torn headers, contradictory flags, and values", () => {
+    assert.deepEqual(readCompanionPlayRegion(new ArrayBuffer(27), 0), {
+      status: "waiting", reason: "memory",
+    });
+    assert.deepEqual(readCompanionPlayRegion(snapshot({ sequence: 3 }), 0), {
+      status: "waiting", reason: "writing",
+    });
+    assert.deepEqual(readCompanionPlayRegion(snapshot({ magic: 0 }), 0), {
+      status: "waiting", reason: "snapshot",
+    });
+    assert.deepEqual(readCompanionPlayRegion(snapshot({ flags: 3 }), 0), {
+      status: "waiting", reason: "snapshot",
+    });
+    assert.deepEqual(readCompanionPlayRegion(snapshot({ mapId: 2_001 }), 0), {
+      status: "waiting", reason: "corrupt",
+    });
+    assert.deepEqual(readCompanionPlayRegion(snapshot({ playRegion: 0 }), 0), {
+      status: "waiting", reason: "corrupt",
+    });
+  });
+
+  it("requires loading and unavailable publications to clear every value", () => {
+    assert.deepEqual(readCompanionPlayRegion(snapshot({
+      flags: 2, mapId: 0, instanceType: 0, playRegion: 0,
+    }), 0), { status: "waiting", reason: "loading" });
+    assert.deepEqual(readCompanionPlayRegion(snapshot({
+      flags: 0, mapId: 0, instanceType: 0, playRegion: 0,
+    }), 0), { status: "waiting", reason: "game" });
+    assert.deepEqual(readCompanionPlayRegion(snapshot({ flags: 2 }), 0), {
+      status: "waiting", reason: "corrupt",
+    });
+    assert.deepEqual(readCompanionPlayRegion(snapshot({ flags: 0 }), 0), {
+      status: "waiting", reason: "corrupt",
+    });
+  });
+});

--- a/tests/integration/skill-cooldown-kernel.test.ts
+++ b/tests/integration/skill-cooldown-kernel.test.ts
@@ -8,6 +8,7 @@ import {
   COOLDOWN_CONFIG_START,
   createKernel,
   DETAIL,
+  FEATURE_PLAY_REGION_OBSERVATION,
   FEATURE_SKILL_COOLDOWN_OBSERVATION,
   FEATURE_TOOLBOX_FOUNDATION,
   installGameGraph,
@@ -30,7 +31,8 @@ describe("skill cooldown kernel", () => {
     }
     assert.equal(kernel.init({
       features:
-        FEATURE_TOOLBOX_FOUNDATION | FEATURE_SKILL_COOLDOWN_OBSERVATION,
+        FEATURE_TOOLBOX_FOUNDATION | FEATURE_PLAY_REGION_OBSERVATION
+          | FEATURE_SKILL_COOLDOWN_OBSERVATION,
     }), 1);
     kernel.tick(0, 10_000);
     const ready = kernel.skillCooldowns();

--- a/tests/integration/skill-slot-geometry-kernel.test.ts
+++ b/tests/integration/skill-slot-geometry-kernel.test.ts
@@ -6,6 +6,7 @@ import { describe, it } from "node:test";
 import {
   ADDRESSES,
   createKernel,
+  FEATURE_PLAY_REGION_OBSERVATION,
   FEATURE_SKILL_SLOT_GEOMETRY,
   FEATURE_TOOLBOX_FOUNDATION,
   installDuplicateSkillSlot,
@@ -18,7 +19,8 @@ describe("skill-slot geometry kernel", () => {
     installSkillBarGraph(kernel.view);
     assert.equal(kernel.init({ features: FEATURE_SKILL_SLOT_GEOMETRY }), 0);
     assert.equal(kernel.init({
-      features: FEATURE_TOOLBOX_FOUNDATION | FEATURE_SKILL_SLOT_GEOMETRY,
+      features: FEATURE_TOOLBOX_FOUNDATION | FEATURE_PLAY_REGION_OBSERVATION
+        | FEATURE_SKILL_SLOT_GEOMETRY,
     }), 1);
     kernel.tick(1);
     const ready = kernel.skillSlots();
@@ -44,7 +46,8 @@ describe("skill-slot geometry kernel", () => {
     installSkillBarGraph(kernel.view);
     installDuplicateSkillSlot(kernel.view);
     assert.equal(kernel.init({
-      features: FEATURE_TOOLBOX_FOUNDATION | FEATURE_SKILL_SLOT_GEOMETRY,
+      features: FEATURE_TOOLBOX_FOUNDATION | FEATURE_PLAY_REGION_OBSERVATION
+        | FEATURE_SKILL_SLOT_GEOMETRY,
     }), 1);
     kernel.tick(1);
     assert.deepEqual(kernel.skillSlots(), { status: "waiting", reason: "frame" });
@@ -55,7 +58,8 @@ describe("skill-slot geometry kernel", () => {
     installSkillBarGraph(kernel.view);
     installDuplicateSkillSlot(kernel.view, 1, false);
     assert.equal(kernel.init({
-      features: FEATURE_TOOLBOX_FOUNDATION | FEATURE_SKILL_SLOT_GEOMETRY,
+      features: FEATURE_TOOLBOX_FOUNDATION | FEATURE_PLAY_REGION_OBSERVATION
+        | FEATURE_SKILL_SLOT_GEOMETRY,
     }), 1);
     kernel.tick(1);
     assert.equal(kernel.skillSlots().status, "ready");

--- a/tests/unit/active-client.test.ts
+++ b/tests/unit/active-client.test.ts
@@ -17,6 +17,7 @@ function generation(wasmPath: string, size: number): ClientGeneration {
       features: {
         gameFileSaving: supported ? available : unavailable,
         nativeCursor: supported ? available : unavailable,
+        playRegionObservation: { status: "off" },
         targetObservation: { status: "off" },
         partyObservation: { status: "off" },
         teamApply: { status: "off" },

--- a/tests/unit/client-certification.test.ts
+++ b/tests/unit/client-certification.test.ts
@@ -24,6 +24,7 @@ const ALL_CAPABILITIES = Object.freeze({
   chatAliases: true,
   skillSlotGeometry: false,
   skillCooldownObservation: false,
+  playRegionObservation: true,
 });
 
 function localVerification(

--- a/tests/unit/client-compatibility-notice.test.ts
+++ b/tests/unit/client-compatibility-notice.test.ts
@@ -22,11 +22,13 @@ const unavailable = (reason: "game-update" | "preparation-failed") =>
 function compatibility(
   overrides: Partial<ClientCompatibility["features"]> = {},
 ): ClientCompatibility {
+  const { playRegionObservation = off, ...visibleOverrides } = overrides;
   return {
     clientSha256: "a".repeat(64),
     features: {
       gameFileSaving: available,
       nativeCursor: off,
+      playRegionObservation,
       targetObservation: off,
       partyObservation: off,
       teamApply: off,
@@ -35,7 +37,7 @@ function compatibility(
       chatAliases: off,
       skillSlotGeometry: off,
       skillCooldownObservation: off,
-      ...overrides,
+      ...visibleOverrides,
     },
   };
 }
@@ -197,6 +199,7 @@ describe("client compatibility notice", () => {
                     const features = {
                       gameFileSaving,
                       nativeCursor,
+                      playRegionObservation: off,
                       targetObservation,
                       partyObservation,
                       teamApply,

--- a/tests/unit/client-module.test.ts
+++ b/tests/unit/client-module.test.ts
@@ -57,6 +57,7 @@ const CURSOR_TOOLBOX: EnhancementCapabilities = Object.freeze({
   chatAliases: false,
   skillSlotGeometry: false,
   skillCooldownObservation: false,
+  playRegionObservation: true,
 });
 const CURSOR_ONLY: EnhancementCapabilities = Object.freeze({
   nativeCursor: true,
@@ -68,6 +69,7 @@ const CURSOR_ONLY: EnhancementCapabilities = Object.freeze({
   chatAliases: false,
   skillSlotGeometry: false,
   skillCooldownObservation: false,
+  playRegionObservation: false,
 });
 const CURSOR_TARGET: EnhancementCapabilities = Object.freeze({
   nativeCursor: true,
@@ -79,6 +81,7 @@ const CURSOR_TARGET: EnhancementCapabilities = Object.freeze({
   chatAliases: false,
   skillSlotGeometry: false,
   skillCooldownObservation: false,
+  playRegionObservation: true,
 });
 const NO_CAPABILITIES: EnhancementCapabilities = Object.freeze({
   nativeCursor: false,
@@ -90,6 +93,7 @@ const NO_CAPABILITIES: EnhancementCapabilities = Object.freeze({
   chatAliases: false,
   skillSlotGeometry: false,
   skillCooldownObservation: false,
+  playRegionObservation: false,
 });
 
 const scratchDirs: string[] = [];
@@ -234,11 +238,11 @@ function certifyTemplate(input: Uint8Array): KnownTemplateSaveBuild {
 
 function enhancementBuild(input: Uint8Array): KnownEnhancementBuild {
   const fixtureProfiles = Object.freeze([
-    "features-01", "features-02", "features-03", "features-04",
-    "features-05", "features-06", "features-07", "features-0c",
-    "features-0d", "features-0e", "features-0f", "features-70",
-    "features-74", "features-75", "features-76", "features-77",
-    "features-7c", "features-7d", "features-7e", "features-7f",
+    "features-01", "features-202", "features-203", "features-204",
+    "features-205", "features-206", "features-207", "features-20c",
+    "features-20d", "features-20e", "features-20f", "features-270",
+    "features-274", "features-275", "features-276", "features-277",
+    "features-27c", "features-27d", "features-27e", "features-27f",
   ] satisfies readonly EnhancementCapabilityProfile[]);
   const draft: KnownEnhancementBuild = {
     sha256: sha256(input),
@@ -260,6 +264,12 @@ function enhancementBuild(input: Uint8Array): KnownEnhancementBuild {
       agentX: 11, agentY: 12, agentType: 13,
       worldContext: 46, areaInfo: 72, areaInfoCount: 73,
       areaInfoStride: 74, areaInfoFlags: 75,
+    } },
+    playRegionObservation: { layout: {
+      contextRoot: 1, gameContextSlot: 6, characterContext: 4,
+      mapId: 5, isExplorable: 6, currentMapId: 7,
+      currentInstanceType: 8, playerNumber: 9, areaInfo: 72,
+      areaInfoCount: 73, areaInfoStride: 74, areaInfoFlags: 75,
     } },
     xunlaiAction: {
         openExport: "enhancement_open_storage",
@@ -918,7 +928,7 @@ describe("client module preparation", () => {
     assert.equal(rebuilt.failure, null);
     assert.equal(
       sha256(await readFile(rebuilt.wasmPath)),
-      value.enhancementBuild.outputSha256["features-05"],
+      value.enhancementBuild.outputSha256["features-205"],
     );
   });
 
@@ -929,7 +939,7 @@ describe("client module preparation", () => {
       ...value.enhancementBuild,
       outputSha256: {
         ...complete,
-        "features-05": "0".repeat(64),
+        "features-205": "0".repeat(64),
       } satisfies EnhancementOutputHashes,
     };
 

--- a/tests/unit/companion-kernel-seal.test.ts
+++ b/tests/unit/companion-kernel-seal.test.ts
@@ -22,6 +22,7 @@ import {
   COMPANION_SNAPSHOT_BYTES,
   COMPANION_TOOLBOX_BYTES,
 } from "../../src/renderer/companion-snapshot.ts";
+import { COMPANION_PLAY_REGION_BYTES } from "../../src/renderer/companion-play-region-snapshot.ts";
 import { ENHANCEMENT_CONFIG_WORD_COUNT } from "../../src/shared/enhancement-contracts.ts";
 import {
   COMPANION_KERNEL_HASH_BINDING,
@@ -92,8 +93,8 @@ function fixture(options: FixtureOptions = {}): Uint8Array<ArrayBuffer> {
   );
   const startFunction = signatures.length;
   const types = [
-    // companion_init: seven region pointer/size pairs plus the feature word.
-    functionType(15, true),
+    // companion_init: eight region pointer/size pairs plus the feature word.
+    functionType(17, true),
     functionType(6, false),
     functionType(0, true),
     functionType(0, false),
@@ -190,6 +191,7 @@ describe("companion kernel build contract", () => {
       { name: "companion_party_bytes", typeIndex: 2 },
       { name: "companion_skill_slot_bytes", typeIndex: 2 },
       { name: "companion_skill_cooldown_bytes", typeIndex: 2 },
+      { name: "companion_play_region_bytes", typeIndex: 2 },
     ]);
   });
 
@@ -256,6 +258,7 @@ describe("companion kernel build contract", () => {
       companion_skill_slot_bytes: COMPANION_KERNEL_EXPORT_VALUES.companion_skill_slot_bytes,
       companion_skill_cooldown_bytes:
         COMPANION_KERNEL_EXPORT_VALUES.companion_skill_cooldown_bytes,
+      companion_play_region_bytes: COMPANION_PLAY_REGION_BYTES,
     });
     // One export per value, so a region added to the kernel cannot be left
     // unverified by forgetting to state its size.

--- a/tests/unit/companion-observer-pollers.test.ts
+++ b/tests/unit/companion-observer-pollers.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { observeCompanion } from "../../src/renderer/companion-observer.js";
+
+test("frame pollers run on every observer frame without an observation change", () => {
+  const previousRequest = globalThis.requestAnimationFrame;
+  const previousCancel = globalThis.cancelAnimationFrame;
+  const scheduled: FrameRequestCallback[] = [];
+  let cancelled = 0;
+  globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+    scheduled.push(callback);
+    return 7;
+  }) as typeof requestAnimationFrame;
+  globalThis.cancelAnimationFrame = ((handle: number) => {
+    assert.equal(handle, 7);
+    cancelled += 1;
+  }) as typeof cancelAnimationFrame;
+
+  try {
+    let polls = 0;
+    const stop = observeCompanion(
+      {
+        memory: new WebAssembly.Memory({ initial: 1 }),
+        snapshotPointer: 0,
+        toolboxPointer: 0,
+        partyPointer: 0,
+        snapshotReads: 0,
+        rejectedSnapshots: 0,
+        hertz: 0,
+        lastRenderUs: 0,
+        renderSamples: [],
+      },
+      [{ poll: () => { polls += 1; } }],
+      null,
+      null,
+      false,
+      false,
+    );
+
+    for (let frame = 0; frame < 3; frame += 1) {
+      const callback = scheduled.shift();
+      if (!callback) throw new Error("observer did not schedule its next frame");
+      callback(frame * 16);
+    }
+    assert.equal(polls, 3);
+    stop();
+    assert.equal(cancelled, 1);
+  } finally {
+    globalThis.requestAnimationFrame = previousRequest;
+    globalThis.cancelAnimationFrame = previousCancel;
+  }
+});

--- a/tests/unit/effective-enhancement-capabilities.test.ts
+++ b/tests/unit/effective-enhancement-capabilities.test.ts
@@ -37,6 +37,7 @@ function session(capabilities: EnhancementCapabilities): ClientSession {
       chatAliases: selected(capabilities.chatAliases),
       skillSlotGeometry: selected(capabilities.skillSlotGeometry),
       skillCooldownObservation: selected(capabilities.skillCooldownObservation),
+      playRegionObservation: selected(capabilities.playRegionObservation),
     },
   };
   return {
@@ -49,7 +50,7 @@ function session(capabilities: EnhancementCapabilities): ClientSession {
 
 describe("effective Enhancement capability boundary", () => {
   it("reproduces every served profile from Main's session, independent of request", () => {
-    for (let mask = 1; mask <= 0x7f; mask += 1) {
+    for (let mask = 1; mask <= 0x3ff; mask += 1) {
       const capabilities = enhancementCapabilitiesForProfile(
         `features-${mask.toString(16).padStart(2, "0")}`,
       );
@@ -59,7 +60,7 @@ describe("effective Enhancement capability boundary", () => {
   });
 
   it("does not revive off or unavailable features", () => {
-    const capabilities = enhancementCapabilitiesForProfile("features-0f");
+    const capabilities = enhancementCapabilitiesForProfile("features-20f");
     assert.ok(capabilities);
     const original = session(capabilities);
     const value: ClientSession = {
@@ -78,6 +79,7 @@ describe("effective Enhancement capability boundary", () => {
           chatAliases: off,
           skillSlotGeometry: off,
           skillCooldownObservation: off,
+          playRegionObservation: off,
         },
       },
     };
@@ -92,6 +94,7 @@ describe("effective Enhancement capability boundary", () => {
       chatAliases: false,
       skillSlotGeometry: false,
       skillCooldownObservation: false,
+      playRegionObservation: false,
     });
   });
 

--- a/tests/unit/enhancement-client-chain.test.ts
+++ b/tests/unit/enhancement-client-chain.test.ts
@@ -18,6 +18,7 @@ import { TEMPLATE_SAVE_BUILDS } from "../../src/main/certification/template-save
 
 const NO_CAPABILITIES = Object.freeze({
   nativeCursor: false,
+  playRegionObservation: false,
   targetObservation: false,
   partyObservation: false,
   teamApply: false,
@@ -29,11 +30,11 @@ const NO_CAPABILITIES = Object.freeze({
 });
 describe("Enhancement client chain", () => {
   it("source-pins every executable capability profile", () => {
-    // Seven booleans have 127 non-empty combinations. Team Apply requires
-    // Party observation, and chat aliases require Travel or Xunlai to give
-    // them an action they can truthfully expose.
-    const profiles = Array.from({ length: 127 }, (_, index) => {
-      const profile = `features-${(index + 1).toString(16).padStart(2, "0")}` as
+    // Enumerate the complete ten-bit wire vocabulary. The registry rejects
+    // masks whose declared dependencies are absent.
+    const profiles = Array.from({ length: 1_023 }, (_, index) => {
+      const mask = index + 1;
+      const profile = `features-${mask.toString(16).padStart(mask < 0x100 ? 2 : 3, "0")}` as
         EnhancementCapabilityProfile;
       const capabilities = enhancementCapabilitiesForProfile(profile);
       return capabilities
@@ -43,10 +44,10 @@ describe("Enhancement client chain", () => {
           ]]
         : [];
     }).flat();
-    assert.equal(profiles.length, 83);
-    assert.equal(new Set(profiles.map(([, value]) => JSON.stringify(value))).size, 83);
+    assert.equal(profiles.length, 281);
+    assert.equal(new Set(profiles.map(([, value]) => JSON.stringify(value))).size, 281);
     const teamProfiles = profiles.filter(([, capabilities]) => capabilities.teamApply);
-    assert.equal(teamProfiles.length, 28);
+    assert.equal(teamProfiles.length, 112);
     assert.ok(teamProfiles.every(([, capabilities]) => capabilities.partyObservation));
     for (const [profile, capabilities] of profiles) {
       assert.equal(enhancementCapabilityProfile(capabilities), profile);
@@ -64,6 +65,7 @@ describe("Enhancement client chain", () => {
       // Commands without the Toolbox that would drive them are refused.
       {
         nativeCursor: false,
+        playRegionObservation: false,
         targetObservation: false,
         partyObservation: false,
         teamApply: true,
@@ -100,7 +102,7 @@ describe("Enhancement client chain", () => {
     const cursorOnly: KnownEnhancementBuild = {
       ...full,
       outputSha256: Object.freeze({
-        "features-01": full.outputSha256["features-01"]!,
+        "features-01": "a".repeat(64),
       }),
     };
     delete cursorOnly.targetObservation;
@@ -116,7 +118,7 @@ describe("Enhancement client chain", () => {
     const partyOnly: KnownEnhancementBuild = {
       ...full,
       outputSha256: Object.freeze({
-        "features-04": full.outputSha256["features-04"]!,
+        "features-204": "b".repeat(64),
       }),
     };
     delete partyOnly.cursorEvent;
@@ -126,7 +128,7 @@ describe("Enhancement client chain", () => {
     delete partyOnly.xunlaiAction;
     delete partyOnly.travelAction;
     delete partyOnly.chatAliases;
-    assert.deepEqual(enhancementProfilesForBuild(partyOnly), ["features-04"]);
+    assert.deepEqual(enhancementProfilesForBuild(partyOnly), ["features-204"]);
     assert.equal(hasValidEnhancementProfileHashes(partyOnly), true);
 
     const missingObservationBase = { ...partyOnly };
@@ -211,8 +213,8 @@ describe("Enhancement client chain", () => {
       hasValidEnhancementProfileHashes({
         ...cursorOnly,
         outputSha256: Object.freeze({
-          "features-01": full.outputSha256["features-01"]!,
-          "features-02": full.outputSha256["features-02"]!,
+          "features-01": "a".repeat(64),
+          "features-202": "c".repeat(64),
         }),
       }),
       false,

--- a/tests/unit/enhancement-command-transform.test.ts
+++ b/tests/unit/enhancement-command-transform.test.ts
@@ -217,6 +217,7 @@ describe("Enhancement command transform", () => {
     const build = manifest(input);
     const aliasesOnly = {
       nativeCursor: false,
+      playRegionObservation: false,
       targetObservation: false,
       partyObservation: false,
       teamApply: false,
@@ -236,7 +237,11 @@ describe("Enhancement command transform", () => {
     );
 
     for (const action of ["travelAction", "xunlaiAction"] as const) {
-      const capabilities = { ...aliasesOnly, [action]: true };
+      const capabilities = {
+        ...aliasesOnly,
+        playRegionObservation: true,
+        [action]: true,
+      };
       const effective = intersectEnhancementCapabilities(capabilities, capabilities);
       assert.equal(effective.chatAliases, true, action);
       const output = transformEnhancementWasm(input, build, effective);

--- a/tests/unit/enhancement-runtime-policy.test.ts
+++ b/tests/unit/enhancement-runtime-policy.test.ts
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   enhancementRuntimePolicy,
-  runtimePlayRegion,
 } from "../../src/renderer/enhancement-runtime-policy.js";
 
 const off = Object.freeze({
@@ -72,13 +71,6 @@ test("runtime-gated commands fail closed while storage keeps its refusal reason"
     assert.equal(enhancementRuntimePolicy("none", on, region).targetReadout, false);
     assert.equal(enhancementRuntimePolicy("none", on, region).tools, true);
   }
-});
-
-test("a snapshot remains authoritative when party evidence disagrees", () => {
-  assert.equal(runtimePlayRegion("pvp", "pve"), "pvp");
-  assert.equal(runtimePlayRegion("unknown", "pve"), "unknown");
-  assert.equal(runtimePlayRegion("pve", "pvp"), "pve");
-  assert.equal(runtimePlayRegion(null, "pve"), "pve");
 });
 
 test("product tool settings remain live once the capability is present", () => {

--- a/tests/unit/enhancement-storage-controller.test.ts
+++ b/tests/unit/enhancement-storage-controller.test.ts
@@ -32,10 +32,12 @@ test("the storage controller owns policy, events, deduplication, and teardown", 
 
     controller.update({
       enabled: true,
+      playRegion: "pve",
       state: accessible,
     });
     controller.update({
       enabled: true,
+      playRegion: "pve",
       state: accessible,
     });
     assert.deepEqual(configurations, [[256, 0], [256, 1]]);
@@ -47,6 +49,7 @@ test("the storage controller owns policy, events, deduplication, and teardown", 
 
     controller.update({
       enabled: false,
+      playRegion: "pve",
       state: accessible,
     });
     const refusedDetail: { error?: Error } = {};
@@ -89,15 +92,32 @@ test("storage fails closed without a confirmed character access proof", () => {
       { status: "waiting" as const },
       { status: "ready" as const, xunlaiAccess: null },
       { status: "ready" as const, xunlaiAccess: false },
-    ]) controller.update({ enabled: true, state });
+    ]) controller.update({ enabled: true, playRegion: "pve", state });
     assert.deepEqual(configurations, [[512, 0]]);
 
-    controller.update({ enabled: true, state: accessible });
+    controller.update({ enabled: true, playRegion: "pve", state: accessible });
     controller.update({
       enabled: true,
+      playRegion: "unknown",
+      state: accessible,
+    });
+    controller.update({
+      enabled: true,
+      playRegion: "pvp",
+      state: accessible,
+    });
+    controller.update({
+      enabled: true,
+      playRegion: "pve",
       state: { ...accessible, xunlaiAccess: false },
     });
-    assert.deepEqual(configurations, [[512, 0], [512, 1], [512, 0]]);
+    assert.deepEqual(configurations, [
+      [512, 0],
+      [512, 1],
+      [512, 0],
+      [512, 1],
+      [512, 0],
+    ]);
     controller.dispose();
   } finally {
     Object.defineProperty(globalThis, "window", {
@@ -126,10 +146,12 @@ test("storage development traces identify the live refusal without account data"
     );
     controller.update({
       enabled: true,
+      playRegion: "pve",
       state: { status: "ready", xunlaiAccess: false },
     });
     controller.update({
       enabled: true,
+      playRegion: "pve",
       state: { status: "ready", xunlaiAccess: false },
     });
     eventTarget.dispatchEvent(new CustomEvent("gw:storage-open", {

--- a/tests/unit/enhancement-transform.test.ts
+++ b/tests/unit/enhancement-transform.test.ts
@@ -36,6 +36,7 @@ import {
 
 const PARTY_ONLY: EnhancementCapabilities = Object.freeze({
   nativeCursor: false,
+  playRegionObservation: true,
   targetObservation: false,
   partyObservation: true,
   teamApply: false,
@@ -288,6 +289,7 @@ describe("targeted Enhancement WebAssembly transform", () => {
         manifest(input),
         {
           nativeCursor: true,
+          playRegionObservation: false,
           targetObservation: true,
           partyObservation: false,
           teamApply: true,
@@ -563,7 +565,7 @@ describe("targeted Enhancement WebAssembly transform", () => {
     delete partyOnlyBuild.targetObservation;
     delete partyOnlyBuild.teamApply;
     partyOnlyBuild.outputSha256 = Object.freeze({
-      "features-04": build.outputSha256["features-04"]!,
+      "features-204": build.outputSha256["features-204"]!,
     });
     const transformed = transformEnhancementWasm(
       input,

--- a/tests/unit/enhancements-are-derived-from-their-registry.test.ts
+++ b/tests/unit/enhancements-are-derived-from-their-registry.test.ts
@@ -97,7 +97,7 @@ test("one capability plan derives hooks without losing feature identity", () => 
   );
   // No user selection reaches cursor + target any more; it stays certified
   // developer-side vocabulary with the same hook plan as cursor-only.
-  const cursorTarget = enhancementCapabilitiesForProfile("features-03");
+  const cursorTarget = enhancementCapabilitiesForProfile("features-203");
   assert.ok(cursorTarget);
   assert.notDeepEqual(cursorOnly, cursorTarget);
   assert.deepEqual(enhancementHooksFor(cursorOnly), {
@@ -118,26 +118,26 @@ test("one capability plan derives hooks without losing feature identity", () => 
   ]) {
     assert.deepEqual(
       enhancementCapabilitiesFor(selection, "cursor-observer"),
-      { nativeCursor: true, targetObservation: false, partyObservation: false, teamApply: false, travelAction: false, xunlaiAction: false, chatAliases: false, skillSlotGeometry: false, skillCooldownObservation: false },
+      { nativeCursor: true, targetObservation: false, partyObservation: false, teamApply: false, travelAction: false, xunlaiAction: false, chatAliases: false, skillSlotGeometry: false, skillCooldownObservation: false, playRegionObservation: false },
     );
     assert.deepEqual(
       enhancementCapabilitiesFor(selection, "target-observer"),
-      { nativeCursor: false, targetObservation: true, partyObservation: false, teamApply: false, travelAction: false, xunlaiAction: false, chatAliases: false, skillSlotGeometry: false, skillCooldownObservation: false },
+      { nativeCursor: false, targetObservation: true, partyObservation: false, teamApply: false, travelAction: false, xunlaiAction: false, chatAliases: false, skillSlotGeometry: false, skillCooldownObservation: false, playRegionObservation: true },
     );
     assert.deepEqual(
       enhancementCapabilitiesFor(selection, "toolbox-foundation"),
-      { nativeCursor: false, targetObservation: false, partyObservation: true, teamApply: false, travelAction: false, xunlaiAction: false, chatAliases: false, skillSlotGeometry: true, skillCooldownObservation: false },
+      { nativeCursor: false, targetObservation: false, partyObservation: true, teamApply: false, travelAction: false, xunlaiAction: false, chatAliases: false, skillSlotGeometry: true, skillCooldownObservation: false, playRegionObservation: true },
     );
     // The read foundation and the write program differ by exactly this bit,
     // and no saved setting reaches the second: choosing the panel can never
     // carry the ability to send a packet in with it.
     assert.deepEqual(
       enhancementCapabilitiesFor(selection, "toolbox-commands"),
-      { nativeCursor: false, targetObservation: false, partyObservation: true, teamApply: true, travelAction: true, xunlaiAction: true, chatAliases: true, skillSlotGeometry: true, skillCooldownObservation: false },
+      { nativeCursor: false, targetObservation: false, partyObservation: true, teamApply: true, travelAction: true, xunlaiAction: true, chatAliases: true, skillSlotGeometry: true, skillCooldownObservation: false, playRegionObservation: true },
     );
     assert.deepEqual(
       enhancementCapabilitiesFor(selection, "xunlai-storage"),
-      { nativeCursor: false, targetObservation: false, partyObservation: false, teamApply: false, travelAction: true, xunlaiAction: true, chatAliases: true, skillSlotGeometry: false, skillCooldownObservation: false },
+      { nativeCursor: false, targetObservation: false, partyObservation: false, teamApply: false, travelAction: true, xunlaiAction: true, chatAliases: true, skillSlotGeometry: false, skillCooldownObservation: false, playRegionObservation: true },
     );
   }
 });
@@ -145,11 +145,11 @@ test("one capability plan derives hooks without losing feature identity", () => 
 test("launch intent resolves to the canonical frozen capability profiles", () => {
   const cases = [
     [{ nativeCursor: true, tools: false }, "none", "features-01"],
-    [{ nativeCursor: true, tools: true }, "none", "features-1ff"],
+    [{ nativeCursor: true, tools: true }, "none", "features-3ff"],
     [{ nativeCursor: false, tools: false }, "cursor-observer", "features-01"],
-    [{ nativeCursor: true, tools: false }, "target-observer", "features-02"],
-    [{ nativeCursor: false, tools: false }, "toolbox-foundation", "features-84"],
-    [{ nativeCursor: false, tools: false }, "xunlai-storage", "features-70"],
+    [{ nativeCursor: true, tools: false }, "target-observer", "features-202"],
+    [{ nativeCursor: false, tools: false }, "toolbox-foundation", "features-284"],
+    [{ nativeCursor: false, tools: false }, "xunlai-storage", "features-270"],
   ] as const;
   for (const [selection, program, profile] of cases) {
     const resolved = enhancementCapabilitiesFor(selection, program);
@@ -158,11 +158,11 @@ test("launch intent resolves to the canonical frozen capability profiles", () =>
     assert.equal(Object.isFrozen(resolved), true);
   }
   // Cursor + target keeps its identity even though no launch path selects it.
-  const cursorTarget = enhancementCapabilitiesForProfile("features-03");
+  const cursorTarget = enhancementCapabilitiesForProfile("features-203");
   assert.ok(cursorTarget);
   assert.equal(
     enhancementCapabilityProfile(cursorTarget),
-    "features-03",
+    "features-203",
   );
   assert.equal(
     enhancementCapabilityProfile(enhancementCapabilitiesFor(
@@ -184,6 +184,7 @@ test("the capability wire contract is exact and has one empty value", () => {
     chatAliases: true,
     skillSlotGeometry: true,
     skillCooldownObservation: true,
+    playRegionObservation: true,
   });
   assert.ok(all);
   assert.equal(Object.isFrozen(all), true);
@@ -211,6 +212,7 @@ test("the capability wire contract is exact and has one empty value", () => {
     chatAliases: false,
     skillSlotGeometry: false,
     skillCooldownObservation: false,
+    playRegionObservation: false,
   });
 
   assert.equal(parseEnhancementCapabilities({ ...all, extra: false }), null);
@@ -274,6 +276,7 @@ test("renderer consumes main's effective subset instead of launch intent", () =>
         gameFileSaving: available,
         nativeCursor: available,
         targetObservation: available,
+        playRegionObservation: available,
         partyObservation: available,
         teamApply: unavailable,
         travelAction: unavailable,
@@ -283,5 +286,5 @@ test("renderer consumes main's effective subset instead of launch intent", () =>
         skillCooldownObservation: { status: "off" },
       },
     },
-  }), enhancementCapabilitiesForProfile("features-07"));
+  }), enhancementCapabilitiesForProfile("features-207"));
 });

--- a/tests/unit/extended-memory-runtime.test.ts
+++ b/tests/unit/extended-memory-runtime.test.ts
@@ -19,7 +19,7 @@ describe("extended memory runtime result", () => {
   it("reports the certified active profile and cap", () => {
     assert.deepEqual(extendedMemoryRuntimeStatus({
       status: "active",
-      profile: "features-0d",
+      profile: "features-20d",
       effectiveCapBytes: EXTENDED_MEMORY_MAX_BYTES,
     }), {
       requestedAtLaunch: true,

--- a/tests/unit/extended-memory.test.ts
+++ b/tests/unit/extended-memory.test.ts
@@ -38,7 +38,7 @@ describe("certified extended memory transform", () => {
   it("accepts only canonical valid runtime feature profiles", () => {
     assert.equal(isExtendedMemoryProfile("off"), true);
     assert.equal(isExtendedMemoryProfile("features-01"), true);
-    assert.equal(isExtendedMemoryProfile("features-7f"), true);
+    assert.equal(isExtendedMemoryProfile("features-27f"), true);
     assert.equal(isExtendedMemoryProfile("features-00"), false);
     assert.equal(isExtendedMemoryProfile("features-08"), false);
     assert.equal(isExtendedMemoryProfile("features-80"), false);
@@ -95,7 +95,7 @@ describe("certified extended memory transform", () => {
         k: "wasm.extendedMemory",
         mode: "active",
         requested: true,
-        profile: "features-05",
+        profile: "features-205",
         capBytes: EXTENDED_MEMORY_MAX_BYTES,
         fallbackReason: "none",
       }),
@@ -106,7 +106,7 @@ describe("certified extended memory transform", () => {
         fields: {
           mode: "active",
           requested: true,
-          profile: "features-05",
+          profile: "features-205",
           capBytes: EXTENDED_MEMORY_MAX_BYTES,
           fallbackReason: "none",
         },

--- a/tests/unit/feature-contracts.test.ts
+++ b/tests/unit/feature-contracts.test.ts
@@ -27,14 +27,14 @@ test("the capability registry is the ordered wire vocabulary", () => {
     },
     {
       id: "targetObservation",
-      requiresAll: [],
+      requiresAll: ["playRegionObservation"],
       requiresAny: [],
       configOwners: ["observation", "target"],
       hooks: [],
     },
     {
       id: "partyObservation",
-      requiresAll: [],
+      requiresAll: ["playRegionObservation"],
       requiresAny: [],
       configOwners: ["observation", "party"],
       hooks: ["ui"],
@@ -48,14 +48,14 @@ test("the capability registry is the ordered wire vocabulary", () => {
     },
     {
       id: "travelAction",
-      requiresAll: [],
+      requiresAll: ["playRegionObservation"],
       requiresAny: [],
       configOwners: [],
       hooks: [],
     },
     {
       id: "xunlaiAction",
-      requiresAll: [],
+      requiresAll: ["playRegionObservation"],
       requiresAny: [],
       configOwners: ["observation", "storage"],
       hooks: [],
@@ -69,7 +69,7 @@ test("the capability registry is the ordered wire vocabulary", () => {
     },
     {
       id: "skillSlotGeometry",
-      requiresAll: ["partyObservation"],
+      requiresAll: ["playRegionObservation"],
       requiresAny: [],
       configOwners: ["skill-slots"],
       hooks: [],
@@ -81,12 +81,19 @@ test("the capability registry is the ordered wire vocabulary", () => {
       configOwners: ["skill-cooldown"],
       hooks: [],
     },
+    {
+      id: "playRegionObservation",
+      requiresAll: [],
+      requiresAny: [],
+      configOwners: ["play-region"],
+      hooks: [],
+    },
   ]);
   assert.deepEqual(
     ENHANCEMENT_CAPABILITY_CONTRACTS.map(({ id }) => id),
     ENHANCEMENT_CAPABILITY_FIELDS,
   );
-  assert.equal(new Set(ENHANCEMENT_CAPABILITY_FIELDS).size, 9);
+  assert.equal(new Set(ENHANCEMENT_CAPABILITY_FIELDS).size, 10);
   for (const contract of ENHANCEMENT_CAPABILITY_CONTRACTS) {
     assert.equal(Object.isFrozen(contract), true, contract.id);
     assert.equal(Object.isFrozen(contract.requiresAll), true, contract.id);

--- a/tests/unit/local-client-verifier.test.ts
+++ b/tests/unit/local-client-verifier.test.ts
@@ -28,6 +28,7 @@ const NONE: EnhancementCapabilities = Object.freeze({
   chatAliases: false,
   skillSlotGeometry: false,
   skillCooldownObservation: false,
+  playRegionObservation: false,
 });
 const ALL: EnhancementCapabilities = Object.freeze({
   ...NONE,
@@ -38,19 +39,26 @@ const ALL: EnhancementCapabilities = Object.freeze({
   travelAction: true,
   xunlaiAction: true,
   chatAliases: true,
-  skillSlotGeometry: false,
-  skillCooldownObservation: false,
+  skillSlotGeometry: true,
+  skillCooldownObservation: true,
+  playRegionObservation: true,
 });
 const CURSOR: EnhancementCapabilities = Object.freeze({
   ...NONE,
   nativeCursor: true,
 });
+const REGION: EnhancementCapabilities = Object.freeze({
+  ...NONE,
+  playRegionObservation: true,
+});
 const TARGET: EnhancementCapabilities = Object.freeze({
   ...NONE,
+  playRegionObservation: true,
   targetObservation: true,
 });
 const STORAGE: EnhancementCapabilities = Object.freeze({
   ...NONE,
+  playRegionObservation: true,
   travelAction: true,
   xunlaiAction: true,
   chatAliases: true,
@@ -59,12 +67,13 @@ const STORAGE: EnhancementCapabilities = Object.freeze({
 });
 const PARTY_TEAM: EnhancementCapabilities = Object.freeze({
   ...NONE,
+  playRegionObservation: true,
   partyObservation: true,
   teamApply: true,
 });
 const SKILL_SLOTS: EnhancementCapabilities = Object.freeze({
   ...NONE,
-  partyObservation: true,
+  playRegionObservation: true,
   skillSlotGeometry: true,
 });
 type ProvedVerification = Extract<LocalClientVerification, { status: "proved" }>;
@@ -92,7 +101,7 @@ function valid(): ProvedVerification {
   return verificationFor({
     ...ENHANCEMENT,
     outputSha256: {
-      "features-7f": ENHANCEMENT.outputSha256["features-7f"]!,
+      "features-3ff": ENHANCEMENT.outputSha256["features-3ff"]!,
     },
   }, ALL);
 }
@@ -134,12 +143,13 @@ function automaticCursor(): ProvedVerification {
 
 function automaticTarget(): ProvedVerification {
   const observation = ENHANCEMENT.observationBase!.layout;
+  const playRegion = ENHANCEMENT.playRegionObservation!.layout;
   const target = ENHANCEMENT.targetObservation!.layout;
   const delta = -112;
   return verificationFor(
     {
       sha256: ENHANCEMENT.sha256,
-      outputSha256: { "features-02": "5".repeat(64) },
+      outputSha256: { "features-202": "5".repeat(64) },
       programId: ENHANCEMENT.programId,
       buildId: ENHANCEMENT.buildId + 1,
       hookFunction: ENHANCEMENT.hookFunction + 1,
@@ -153,6 +163,13 @@ function automaticTarget(): ProvedVerification {
           contextRoot: observation.contextRoot + delta,
           agentArray: observation.agentArray + delta,
           areaInfo: observation.areaInfo + delta,
+        },
+      },
+      playRegionObservation: {
+        layout: {
+          ...playRegion,
+          contextRoot: playRegion.contextRoot + delta,
+          areaInfo: playRegion.areaInfo + delta,
         },
       },
       targetObservation: {
@@ -173,7 +190,7 @@ function automaticLocalActions(): ProvedVerification {
   return verificationFor(
     {
       ...target.enhancementBuild!,
-      outputSha256: { "features-70": "7".repeat(64) },
+      outputSha256: { "features-270": "7".repeat(64) },
       uiDispatcher: {
         ...ENHANCEMENT.uiDispatcher!,
         bodySha256: "e".repeat(64),
@@ -225,7 +242,7 @@ function automaticPartyTeam(): ProvedVerification {
   return verificationFor(
     {
       ...localActions.enhancementBuild!,
-      outputSha256: { "features-0c": "b".repeat(64) },
+      outputSha256: { "features-20c": "b".repeat(64) },
       partyObservation: {
         ...party,
         playerChatProducer: party.playerChatProducer + 1,
@@ -301,6 +318,21 @@ function automaticSkillSlots(): ProvedVerification {
 }
 
 describe("local client verification boundary", () => {
+  it("certifies play region directly from the exact observation base", () => {
+    const verdicts = localFeatureVerdictsForBuild(
+      TEMPLATE.outputSha256,
+      REGION,
+      ENHANCEMENT,
+    );
+    assert.equal(verdicts.playRegionObservation.status, "proved");
+    if (verdicts.playRegionObservation.status !== "proved") return;
+    assert.equal(
+      verdicts.playRegionObservation.value.playRegionObservation,
+      ENHANCEMENT.playRegionObservation,
+    );
+    assert.equal(verdicts.targetObservation.status, "not-requested");
+    assert.equal(verdicts.partyObservation.status, "not-requested");
+  });
   it("accepts the verifier's complete baseline proof", () => {
     assert.equal(isLocalClientVerification(valid(), TEMPLATE.sha256, ALL), true);
   });
@@ -308,7 +340,13 @@ describe("local client verification boundary", () => {
   it("rejects an exact authored row that did not cross semantic proof", () => {
     assert.equal(
       isLocalClientVerification(
-        verificationFor(ENHANCEMENT, ALL),
+        verificationFor({
+          ...ENHANCEMENT,
+          outputSha256: {
+            ...ENHANCEMENT.outputSha256,
+            "features-01": "f".repeat(64),
+          },
+        }, ALL),
         TEMPLATE.sha256,
       ),
       false,
@@ -341,7 +379,7 @@ describe("local client verification boundary", () => {
     const relocated = verificationFor(
       {
         ...ENHANCEMENT,
-        outputSha256: { "features-7f": ENHANCEMENT.outputSha256["features-7f"]! },
+        outputSha256: { "features-3ff": ENHANCEMENT.outputSha256["features-3ff"]! },
         hookFunction: ENHANCEMENT.hookFunction + 1,
       },
       ALL,
@@ -396,6 +434,14 @@ describe("local client verification boundary", () => {
   it("accepts independent local-action proofs and rejects one bad Xunlai field", () => {
     const derived = automaticLocalActions();
     assert.equal(isLocalClientVerification(derived, TEMPLATE.sha256, STORAGE), true);
+    const travelVerdict = derived.featureVerdicts.travelAction;
+    assert.equal(travelVerdict.status, "proved");
+    if (travelVerdict.status === "proved") {
+      assert.equal(
+        travelVerdict.value.playRegionObservation,
+        derived.enhancementBuild!.playRegionObservation,
+      );
+    }
     assert.equal(isLocalClientVerification({
       ...derived,
       enhancementBuild: {
@@ -453,6 +499,14 @@ describe("local client verification boundary", () => {
       isLocalClientVerification(derived, TEMPLATE.sha256, SKILL_SLOTS),
       true,
     );
+    const geometryVerdict = derived.featureVerdicts.skillSlotGeometry;
+    assert.equal(geometryVerdict.status, "proved");
+    if (geometryVerdict.status === "proved") {
+      assert.equal(
+        geometryVerdict.value.playRegionObservation,
+        derived.enhancementBuild!.playRegionObservation,
+      );
+    }
 
     type MutableSkillSlotProof = Record<string, unknown> & {
       initializer: Record<string, unknown>;

--- a/tests/unit/play-region-observation-installation.test.ts
+++ b/tests/unit/play-region-observation-installation.test.ts
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { createPlayRegionObservationInstallation } from "../../src/renderer/play-region-state-installation.ts";
+
+const ready = (sequence: number, mapId = 81) => Object.freeze({
+  status: "ready" as const,
+  sequence,
+  mapId,
+  instanceType: 0,
+  playRegion: "pve" as const,
+});
+
+test("play-region authority withdraws on staleness and requires a newer publication to recover", (context) => {
+  let now = 0;
+  context.mock.method(performance, "now", () => now);
+  context.mock.timers.enable({ apis: ["setTimeout"] });
+
+  const installation = createPlayRegionObservationInstallation(true);
+  installation.setActive(true);
+  installation.sink?.update(ready(2));
+  assert.deepEqual(installation.state, ready(2));
+
+  now = 499;
+  context.mock.timers.tick(499);
+  assert.deepEqual(installation.state, ready(2));
+
+  now = 500;
+  context.mock.timers.tick(1);
+  assert.deepEqual(installation.state, { status: "waiting", reason: "stale" });
+
+  installation.sink?.update(ready(2, 55));
+  assert.deepEqual(
+    installation.state,
+    { status: "waiting", reason: "stale" },
+    "the frozen sequence cannot restore authority with different payload bytes",
+  );
+  installation.sink?.update(ready(4, 55));
+  assert.deepEqual(installation.state, ready(4, 55));
+
+  installation.setActive(false);
+  assert.deepEqual(installation.state, { status: "waiting", reason: "stale" });
+  installation.sink?.update(ready(6, 449));
+  assert.deepEqual(
+    installation.state,
+    { status: "waiting", reason: "stale" },
+    "inactive observations cannot restore withdrawn authority",
+  );
+
+  installation.setActive(true);
+  installation.sink?.update(ready(4, 449));
+  assert.deepEqual(
+    installation.state,
+    { status: "waiting", reason: "stale" },
+    "reactivation still requires a sequence newer than the last accepted record",
+  );
+  installation.sink?.update(ready(6, 449));
+  assert.deepEqual(installation.state, ready(6, 449));
+
+  installation.dispose();
+});

--- a/tests/unit/renderer-client-sessions.test.ts
+++ b/tests/unit/renderer-client-sessions.test.ts
@@ -18,6 +18,7 @@ const base: ClientSession = {
       chatAliases: { status: "available" },
       skillSlotGeometry: { status: "available" },
       skillCooldownObservation: { status: "off" },
+      playRegionObservation: { status: "off" },
     },
   },
   extendedMemory: {

--- a/tests/unit/the-companion-abi-is-exact-across-typescript-and-rust.test.ts
+++ b/tests/unit/the-companion-abi-is-exact-across-typescript-and-rust.test.ts
@@ -21,6 +21,7 @@ const FEATURE_NAMES = Object.freeze({
   targetObservation: "FEATURE_TARGET_OBSERVATION",
   skillSlotGeometry: "FEATURE_SKILL_SLOT_GEOMETRY",
   skillCooldownObservation: "FEATURE_SKILL_COOLDOWN_OBSERVATION",
+  playRegionObservation: "FEATURE_PLAY_REGION_OBSERVATION",
 } as const);
 
 const DISPATCH_NAMES = Object.freeze({


### PR DESCRIPTION
Tools availability previously inferred PvE/PvP state from broader target or party observations. That kept unrelated agent and roster reads alive, made Travel-only recovery depend on heavyweight state, and allowed policy consumers to disagree when one feed became stale.

This PR adds one independently certified, bounded play-region capability. Its exact-client proof covers only the character/map fields and immutable area table needed to identify loading, PvE, and PvP. A dedicated sequence-protected companion region becomes the sole renderer policy authority; stale, malformed, loading, or unavailable state withdraws every dependent surface and recovers only after a newer valid publication.

The native and TypeScript contracts now enforce the same dependency graph. Skill geometry depends only on the narrow region substrate, while cooldown observation intentionally retains its Party dependency for the next stack layer. The review also restores steady-state Travel toggle polling, prevents stale Xunlai access from remaining enabled, and stops the heavier Toolbox observer when no policy-approved consumer needs it.

## Invariants

- Region certification does not require agent-array, target-selector, or party evidence.
- The kernel rejects snapshot, Toolbox, geometry, or cooldown feature masks that omit their declared substrate; cooldown still requires both region and Party.
- The region feed is always active, sequence-protected, and fail-closed after 500 ms without a newer publication.
- Travel and Xunlai never act from unknown or stale policy state.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:links`
- `pnpm test:unit` — 1,218 passed
- `pnpm test:policy` — 174 passed
- `pnpm tools:test` — 102 passed
- `pnpm build` — companion kernel rebuilt and sealed
- `pnpm test:integration` — 64 passed
- `pnpm test:release` — 25 passed
- Exact current-client verifier — all 10 capabilities proved
- Exact current-client artifact suite — 3 passed

Electron/E2E was intentionally not run because it disrupts Matthias's parallel game session. No game, Electron, or long-running Node process was started or killed.

Implemented and reviewed with Codex using three independent certification, runtime-safety, and maintainability reviews.
