### PR TITLE
refactor(tools): certify player skillbars independently

### DIFF
--- a/src/companion-kernel/lib.rs
+++ b/src/companion-kernel/lib.rs
@@ -699,8 +699,7 @@ pub unsafe extern "C" fn companion_init(
         || features & FEATURE_SKILL_SLOT_GEOMETRY != 0
             && features & FEATURE_PLAY_REGION_OBSERVATION == 0
         || features & FEATURE_SKILL_COOLDOWN_OBSERVATION != 0
-            && (features & FEATURE_TOOLBOX_FOUNDATION == 0
-                || features & FEATURE_PLAY_REGION_OBSERVATION == 0)
+            && features & FEATURE_PLAY_REGION_OBSERVATION == 0
         || config_size != CONFIG_BYTES
         || config_ptr & 3 != 0
         || !contains(config_ptr, config_size)
@@ -869,8 +868,7 @@ pub unsafe extern "C" fn companion_dispatch(kind: u32, a: u32, b: u32, c: u32, _
                 || a & FEATURE_SKILL_SLOT_GEOMETRY != 0
                     && a & FEATURE_PLAY_REGION_OBSERVATION == 0
                 || a & FEATURE_SKILL_COOLDOWN_OBSERVATION != 0
-                    && (a & FEATURE_TOOLBOX_FOUNDATION == 0
-                        || a & FEATURE_PLAY_REGION_OBSERVATION == 0)
+                    && a & FEATURE_PLAY_REGION_OBSERVATION == 0
             {
                 return;
             }

--- a/src/main/certification/enhancement-build-model.ts
+++ b/src/main/certification/enhancement-build-model.ts
@@ -24,7 +24,9 @@ import {
   ENHANCEMENT_CONFIG_FIELDS,
   type EnhancementCursorLayout,
   type EnhancementObservationBaseLayout,
+  type EnhancementPartySkillbarLayout,
   type EnhancementPlayRegionLayout,
+  type EnhancementPlayerSkillbarLayout,
   type EnhancementPartyLayout,
   type EnhancementSkillCooldownLayout,
   type EnhancementSkillSlotGeometryLayout,
@@ -104,21 +106,43 @@ export function enhancementConfigWords(
   return ENHANCEMENT_CONFIG_FIELDS.map((field, index) => {
     if (!enhancementConfigWordActive(capabilities, index)) return 0;
     if (field.source === "layout") {
-      const value = field.owner === "play-region"
-        ? build.playRegionObservation?.layout[field.key]
-        : field.owner === "observation"
-          ? build.observationBase?.layout[field.key]
-          : field.owner === "target"
-            ? build.targetObservation?.layout[field.key]
-            : field.owner === "cursor"
-              ? build.cursorEvent?.layout[field.key]
-              : field.owner === "party"
-                ? build.partyObservation?.layout[field.key]
-                : field.owner === "storage"
-                  ? build.xunlaiAction?.accessProof?.layout[field.key]
-                  : field.owner === "skill-slots"
-                    ? build.skillSlotGeometry?.layout[field.key]
-                    : build.skillCooldownObservation?.layout[field.key];
+      let value: number | undefined;
+      switch (field.owner) {
+        case "play-region":
+          value = build.playRegionObservation?.layout[field.key];
+          break;
+        case "observation":
+          value = build.observationBase?.layout[field.key];
+          break;
+        case "target":
+          value = build.targetObservation?.layout[field.key];
+          break;
+        case "cursor":
+          value = build.cursorEvent?.layout[field.key];
+          break;
+        case "party":
+          value = build.partyObservation?.layout[field.key];
+          break;
+        case "player-skillbar":
+          value = build.playerSkillbarObservation?.coreLayout[field.key];
+          break;
+        case "party-skillbar":
+          value = build.playerSkillbarObservation?.partyLayout[field.key];
+          break;
+        case "storage":
+          value = build.xunlaiAction?.accessProof?.layout[field.key];
+          break;
+        case "skill-slots":
+          value = build.skillSlotGeometry?.layout[field.key];
+          break;
+        case "skill-cooldown":
+          value = build.skillCooldownObservation?.layout[field.key];
+          break;
+        default: {
+          const unreachable: never = field;
+          return unreachable;
+        }
+      }
       if (field.owner === "storage" && build.xunlaiAction === undefined) {
         return 0;
       }
@@ -154,6 +178,35 @@ export interface KnownEnhancementBuild {
   observationBase?: Readonly<{ layout: EnhancementObservationBaseLayout }>;
   /** Minimal memory facts used only to determine loading and PvE/PvP policy. */
   playRegionObservation?: Readonly<{ layout: EnhancementPlayRegionLayout }>;
+  /** Exact player skillbar row shared by Party projection and cooldown reads. */
+  playerSkillbarObservation?: Readonly<{
+    worldLifecycle: Readonly<{
+      functionIndex: number;
+      params: readonly ["i32"];
+      results: readonly ["i32"];
+      bodySha256: string;
+    }>;
+    update: Readonly<{
+      functionIndex: number;
+      params: readonly [];
+      results: readonly [];
+      bodySha256: string;
+    }>;
+    rowReader: Readonly<{
+      functionIndex: number;
+      params: readonly ["i32", "i32", "i32"];
+      results: readonly ["i32"];
+      bodySha256: string;
+    }>;
+    slotReader: Readonly<{
+      functionIndex: number;
+      params: readonly ["i32", "i32", "i32"];
+      results: readonly ["i32"];
+      bodySha256: string;
+    }>;
+    coreLayout: EnhancementPlayerSkillbarLayout;
+    partyLayout: EnhancementPartySkillbarLayout;
+  }>;
   /** Exact UI dispatcher shared by party observation and local Travel. */
   uiDispatcher?: Readonly<{
     functionIndex: number;
@@ -327,8 +380,9 @@ export function supportedEnhancementCapabilities(
 ): EnhancementCapabilities {
   const playRegionObservation = build.playRegionObservation !== undefined;
   const observationBase = playRegionObservation && build.observationBase !== undefined;
+  const playerSkillbarObservation = build.playerSkillbarObservation !== undefined;
   const targetObservation = observationBase && build.targetObservation !== undefined;
-  const partyObservation = observationBase
+  const partyObservation = observationBase && playerSkillbarObservation
     && build.uiDispatcher !== undefined
     && build.partyObservation !== undefined;
   const gameThread = build.gameThread !== undefined;
@@ -345,7 +399,8 @@ export function supportedEnhancementCapabilities(
     xunlaiAction,
     chatAliases: build.uiDispatcher !== undefined && build.chatAliases !== undefined,
     skillSlotGeometry: playRegionObservation && build.skillSlotGeometry !== undefined,
-    skillCooldownObservation: partyObservation
+    skillCooldownObservation: playRegionObservation && observationBase
+      && playerSkillbarObservation
       && build.skillCooldownObservation !== undefined,
     playRegionObservation,
   });
@@ -378,14 +433,19 @@ export function hasValidEnhancementProfileHashes(
     ? null
     : new Set(Object.values(storageReaders).map(({ functionIndex }) => functionIndex));
   const hasPlayRegion = build.playRegionObservation !== undefined;
+  const hasPlayerSkillbar = build.playerSkillbarObservation !== undefined;
   const hasObservation = build.observationBase !== undefined
+    || build.playerSkillbarObservation !== undefined
     || build.targetObservation !== undefined
     || build.partyObservation !== undefined
+    || build.skillCooldownObservation !== undefined
     || build.xunlaiAction !== undefined;
   if (hasObservation && build.observationBase === undefined) {
     return false;
   }
   if (hasObservation && !hasPlayRegion) return false;
+  if (build.partyObservation !== undefined && !hasPlayerSkillbar) return false;
+  if (build.skillCooldownObservation !== undefined && !hasPlayerSkillbar) return false;
   if (build.partyObservation !== undefined && build.uiDispatcher === undefined) {
     return false;
   }

--- a/src/main/certification/enhancement-builds.ts
+++ b/src/main/certification/enhancement-builds.ts
@@ -26,7 +26,7 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
         "26a71c3e2bf55ab992dce659c1192213858ee25799daa87841ed23a3ddbb601a",
       // Recomputed from the exact current JSPI artifact when the independent
       // play-region capability landed. The retained output is the complete
-      // product profile proved by semantic verifier ABI 3.
+      // product profile proved by semantic verifier ABI 4.
       //
       // `pnpm check` cannot catch a stale value here. The transform input is a
       // derived game binary this repository does not contain, so nothing in the
@@ -36,7 +36,7 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
       // ENHANCEMENT_TRANSFORM_ABI or any config word changes.
       outputSha256: Object.freeze({
         "features-3ff":
-          "9ae925f7eb1e314f8b6d4432363cf9082c6ea78d1b87a70947a1203dc24415cb",
+          "03afee84b380d01f974c9949656beaa1d15b7f22ae771990c1c27f3ca92c68da",
       }),
       programId: 1,
       // The verifier derives this bounded identity from the exact module; it is
@@ -93,6 +93,14 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
           areaInfoStride: 0x7c,
           areaInfoFlags: 0x10,
         }),
+      }),
+      playerSkillbarObservation: Object.freeze({
+        worldLifecycle: Object.freeze({ functionIndex: 8812, params: ["i32"] as const, results: ["i32"] as const, bodySha256: "b0109c7c853a7d01586172aef66ab14f4d192fbe4f5ea7514553e0821d0dcb5a" }),
+        update: Object.freeze({ functionIndex: 8698, params: [] as const, results: [] as const, bodySha256: "c72cdcbdae22e520f42edbcf2fd56545bad7a014b078ed77ebd284181f523d61" }),
+        rowReader: Object.freeze({ functionIndex: 8701, params: ["i32", "i32", "i32"] as const, results: ["i32"] as const, bodySha256: "7b8b5c65a126fae2edfa517a4706244a0d2352c628fde208d049ecf82dfa4e72" }),
+        slotReader: Object.freeze({ functionIndex: 8702, params: ["i32", "i32", "i32"] as const, results: ["i32"] as const, bodySha256: "ee41be1f4dcaf8e5822fc024e41cbbad74cf293cdafb2b89a8691aeb680e68b5" }),
+        coreLayout: Object.freeze({ worldSkillbars: 0x6f0, skillbarStride: 0xbc, skillbarAgentId: 0, skillbarSkills: 4, skillSlotStride: 0x14 }),
+        partyLayout: Object.freeze({ skillSlotId: 0x0c, skillbarDisabled: 0xa4 }),
       }),
       cursorEvent: Object.freeze({
         functionIndex: 2469,
@@ -422,13 +430,6 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
           // mercenary rule itself is untestable on an account that owns none, so
           // the kernel publishes mercenaries as *unknown* rather than guessing.
           infoAppearanceBitmap: 0x48,
-          worldSkillbars: 0x6f0,
-          skillbarStride: 0xbc,
-          skillbarAgentId: 0x00,
-          skillbarSkills: 0x04,
-          skillSlotStride: 0x14,
-          skillSlotId: 0x0c,
-          skillbarDisabled: 0xa4,
           // Certified live in the same outpost. The stride is proved outright: the
           // words at +0x43c from each row are the next row's agent id. Every real
           // entry satisfies `index == id`, and the set of entries present is each

--- a/src/main/certification/enhancement-local-actions-proof.ts
+++ b/src/main/certification/enhancement-local-actions-proof.ts
@@ -545,8 +545,9 @@ function deriveTravelContextResolver(
 export function locateAutomaticLocalActions(
   input: Uint8Array,
   baselines: readonly KnownEnhancementBuild[],
-  suppliedContext?: EnhancementProofContext,
-  suppliedObservationLayout?: EnhancementObservationBaseLayout,
+  suppliedContext: EnhancementProofContext | undefined,
+  suppliedObservationLayout: EnhancementObservationBaseLayout | undefined,
+  suppliedPlayerSkillbar: KnownEnhancementBuild["playerSkillbarObservation"] | null,
 ): AutomaticLocalActionsLocation | null {
   if (!WebAssembly.validate(input) || input.byteLength > MAX_INPUT_BYTES) return null;
   try {
@@ -677,9 +678,11 @@ export function locateAutomaticLocalActions(
       const chatAliases = uiDispatcher
         ? isolatedProof(() => deriveChatAliases(module, baseline, uiDispatcher))
         : null;
-      const partyObservation = party && uiDispatcher && observationLayout && uiEvidence
+      const partyObservation = suppliedPlayerSkillbar
+          && uiDispatcher && observationLayout && uiEvidence
         ? isolatedProof(() => derivePartyObservation(
-            module, baseline, observationLayout, uiDispatcher, uiEvidence, decoded,
+            module, baseline, observationLayout, suppliedPlayerSkillbar,
+            uiDispatcher, uiEvidence, decoded,
           ))
         : null;
       const teamApply = partyObservation && gameThread

--- a/src/main/certification/enhancement-party-team-proof.ts
+++ b/src/main/certification/enhancement-party-team-proof.ts
@@ -5,6 +5,7 @@
 import { verifyLayout } from "./semantic-proof.js";
 import { messageRelations } from "./enhancement-structural-report.js";
 import { derivePartyCalleeGraph } from "./enhancement-party-callee-proof.js";
+import { playerSkillbarRoleCandidateCounts } from "./enhancement-player-skillbar-proof.js";
 import {
   bodyMatchesRole,
   commonRelocationDelta,
@@ -17,7 +18,6 @@ import {
   signatureMatches,
   signedOperand,
   soleValue,
-  staticBytesHash,
   staticCStringHash,
   uniqueExactFunction,
   uniqueRoleFunction,
@@ -35,17 +35,6 @@ import type {
   PlayerChatUiEvidenceReport,
 } from "./enhancement-evidence-types.js";
 
-const PARTY_WORLD_LIFECYCLE_ROLE = semanticRole(
-  3_279,
-  "878f00dc4ea68f51e5a79f507e37b0a5df3c32b561ca6d35c966a888d0cd022b",
-  Object.freeze([
-    { start: 1_342, end: 1_347, role: "world.assert-a", addressClass: "immutable-data" },
-    { start: 1_395, end: 1_400, role: "world.assert-b", addressClass: "immutable-data" },
-  ]),
-  ["i32"],
-  ["i32"],
-);
-
 const PARTY_PLAYER_PARTY_ROLE = semanticRole(
   338,
   "99d85ceb2072d683b1933603fb195f6fef2a27c1b11d3f0a235e850441be1df5",
@@ -58,17 +47,6 @@ const PARTY_PLAYER_PARTY_ROLE = semanticRole(
     { start: 306, end: 311, role: "party.ui", addressClass: "function-index" },
   ]),
   ["i32", "i32", "i32", "i32"],
-  [],
-);
-
-const PARTY_SKILLBAR_UPDATE_ROLE = semanticRole(
-  468,
-  "5c17e22a87d68e79e2d258992d623f3ec83dca62d74a063d46e06f7fd426093c",
-  Object.freeze([
-    { start: 45, end: 50, role: "skillbar.assertion", addressClass: "immutable-data" },
-    { start: 450, end: 455, role: "party.ui", addressClass: "function-index" },
-  ]),
-  [],
   [],
 );
 
@@ -110,8 +88,6 @@ const PARTY_EXACT_ROLES = Object.freeze({
   professionPrimary: { bodySha256: "5b3490ae4c66dad083b8cbea456d2e47d41ff794e9c03aa15acdf2b6523915ec", params: ["i32", "i32"], results: ["i32"] },
   professionSecondary: { bodySha256: "92fe2aa71777d546d797a4f7850cb59b1693f3b2937021dd5cebc85933403e07", params: ["i32", "i32"], results: ["i32"] },
   professionUnlocked: { bodySha256: "7a1b17e51097a6599a036629fdcc630afa0850bacb0f2998d0ad8107d39ec9b5", params: ["i32", "i32"], results: ["i32"] },
-  skillbarReader: { bodySha256: "7b8b5c65a126fae2edfa517a4706244a0d2352c628fde208d049ecf82dfa4e72", params: ["i32", "i32", "i32"], results: ["i32"] },
-  skillSlotReader: { bodySha256: "ee41be1f4dcaf8e5822fc024e41cbbad74cf293cdafb2b89a8691aeb680e68b5", params: ["i32", "i32", "i32"], results: ["i32"] },
   characterUnlockReader: { semantic: semanticRole(128, "1d6008c169d1dacfa8cde21d77a071336d056d2fa14677c3d468154d8689532a", Object.freeze([
     { start: 23, end: 28, role: "unlocks.resolve", addressClass: "function-index" },
     { start: 111, end: 116, role: "unlocks.ui", addressClass: "function-index" },
@@ -160,9 +136,6 @@ const PARTY_DIRTY_ROLES = Object.freeze([
 
 const PARTY_IMMUTABLE_HASHES = Object.freeze({
   playerPartyAssertion: "11e293befd3a98a58c54d320146aab4746f2456cfe5fefd40eca2c48d28366bb",
-  skillbarAssertion: "f450663f1e90de4ae2e581b6dc777b81f6c9e019bff3e5d2e60665099862e3f0",
-  worldAssertionA: "435ae0e5b5663ba229fe0a312a2f3d83b4896302f9517b56d88f996ba7ea896d",
-  worldAssertionB: "f7d0c7a8263c7a799862d8a513123d901e4f1cc30bc1d86da870bf5f2ec5aad6",
 });
 
 const TEAM_SENDER_IMMUTABLE_HASHES = Object.freeze([
@@ -275,9 +248,8 @@ export function inspectPartyTeamRoleCandidates(
     ...Object.values(PARTY_EXACT_ROLES).map(
       (role) => exactPartyFunctionCount(module, role),
     ),
-    roleFunctions(module, PARTY_WORLD_LIFECYCLE_ROLE).length,
+    ...playerSkillbarRoleCandidateCounts(module),
     roleFunctions(module, PARTY_PLAYER_PARTY_ROLE).length,
-    roleFunctions(module, PARTY_SKILLBAR_UPDATE_ROLE).length,
     ...PARTY_DIRTY_ROLES.map((role) => roleFunctions(module, role).length),
   ]);
 
@@ -330,20 +302,11 @@ export function inspectPartyTeamRoleAmbiguities(
   });
 }
 
-function exactStaticBytesHash(
-  module: ModuleShape,
-  values: Map<string, number[]>,
-  role: string,
-  length: number,
-  expected: string,
-): boolean {
-  return staticBytesHash(module, soleValue(values, role), length) === expected;
-}
-
 export function derivePartyObservation(
   module: ModuleShape,
   baseline: KnownEnhancementBuild,
   observation: EnhancementObservationBaseLayout,
+  playerSkillbar: NonNullable<KnownEnhancementBuild["playerSkillbarObservation"]>,
   uiDispatcher: NonNullable<KnownEnhancementBuild["uiDispatcher"]>,
   uiEvidence: NonNullable<PlayerChatUiEvidenceReport["candidate"]>,
   suppliedDecoded?: readonly DecodedFunction[],
@@ -363,12 +326,9 @@ export function derivePartyObservation(
     exactPartyFunction(module, PARTY_EXACT_ROLES.professionSecondary),
     exactPartyFunction(module, PARTY_EXACT_ROLES.professionUnlocked),
   ];
-  const skillbarReaderFunction = exactPartyFunction(module, PARTY_EXACT_ROLES.skillbarReader);
-  const skillSlotReaderFunction = exactPartyFunction(module, PARTY_EXACT_ROLES.skillSlotReader);
   const characterUnlockFunction = exactPartyFunction(module, PARTY_EXACT_ROLES.characterUnlockReader);
-  const worldFunction = uniqueRoleFunction(module, PARTY_WORLD_LIFECYCLE_ROLE);
+  const worldFunction = playerSkillbar.worldLifecycle.functionIndex;
   const playerPartyFunction = uniqueRoleFunction(module, PARTY_PLAYER_PARTY_ROLE);
-  const skillbarUpdateFunction = uniqueRoleFunction(module, PARTY_SKILLBAR_UPDATE_ROLE);
   const dirtyFunctions = PARTY_DIRTY_ROLES.map((role) => uniqueRoleFunction(module, role));
   const infoFunction = dirtyFunctions[1] ?? null;
   const mapLoadedFunction = dirtyFunctions[2] ?? null;
@@ -376,29 +336,19 @@ export function derivePartyObservation(
     partyInfoFunction === null || partyFlagFunction === null || accountFunction === null
     || flagFunction === null || infoFunction === null || attributesFunction === null
     || professionFunctions.some((value) => value === null)
-    || skillbarReaderFunction === null || skillSlotReaderFunction === null
-    || characterUnlockFunction === null || worldFunction === null
-    || playerPartyFunction === null || skillbarUpdateFunction === null
+    || characterUnlockFunction === null || playerPartyFunction === null
     || mapLoadedFunction === null || dirtyFunctions.some((value) => value === null)
   ) return null;
 
   const worldBody = functionBody(module, worldFunction);
   const playerPartyBody = functionBody(module, playerPartyFunction);
-  const skillbarUpdateBody = functionBody(module, skillbarUpdateFunction);
   const mapLoadedBody = functionBody(module, mapLoadedFunction);
-  const worldValues = valuesForRole(worldBody, PARTY_WORLD_LIFECYCLE_ROLE);
   const playerPartyValues = valuesForRole(playerPartyBody, PARTY_PLAYER_PARTY_ROLE);
-  const skillbarValues = valuesForRole(skillbarUpdateBody, PARTY_SKILLBAR_UPDATE_ROLE);
   const mapValues = valuesForRole(mapLoadedBody, PARTY_DIRTY_ROLES[2]);
   if (
     staticCStringHash(module, soleValue(playerPartyValues, "party.membership-assertion"))
       !== PARTY_IMMUTABLE_HASHES.playerPartyAssertion
     || soleValue(playerPartyValues, "party.ui") !== uiDispatcher.functionIndex
-    || staticCStringHash(module, soleValue(skillbarValues, "skillbar.assertion"))
-      !== PARTY_IMMUTABLE_HASHES.skillbarAssertion
-    || soleValue(skillbarValues, "party.ui") !== uiDispatcher.functionIndex
-    || !exactStaticBytesHash(module, worldValues, "world.assert-a", 12, PARTY_IMMUTABLE_HASHES.worldAssertionA)
-    || !exactStaticBytesHash(module, worldValues, "world.assert-b", 12, PARTY_IMMUTABLE_HASHES.worldAssertionB)
     || commonRelocationDelta([
       [
         soleValue(mapValues, "map.lifecycle-static"),
@@ -429,8 +379,6 @@ export function derivePartyObservation(
   const infoBody = functionBody(module, infoFunction);
   const attributesBody = functionBody(module, attributesFunction);
   const professionBodies = professionFunctions.map((value) => functionBody(module, value!));
-  const skillbarReaderBody = functionBody(module, skillbarReaderFunction);
-  const skillSlotReaderBody = functionBody(module, skillSlotReaderFunction);
   const characterUnlockBody = functionBody(module, characterUnlockFunction);
   const observedAttributeCalls = valuesForRole(
     attributesBody,
@@ -487,8 +435,6 @@ export function derivePartyObservation(
   ) return null;
 
   const heroMemberStride = signedOperand(heroAddBody, 142);
-  const skillbarSkills = unsignedOperand(skillbarUpdateBody, 352);
-  const slotTotalOffset = unsignedOperand(skillSlotReaderBody, 144);
   const professionStateStride = unsignedOperand(professionBodies[0]!, 18);
   const layout: EnhancementPartyLayout = {
     partyContext: unsignedOperand(heroAddBody, 30),
@@ -517,13 +463,6 @@ export function derivePartyObservation(
     infoPrimary: unsignedOperand(infoBody, 454),
     infoSecondary: unsignedOperand(infoBody, 447),
     infoAppearanceBitmap: unsignedOperand(infoBody, 412),
-    worldSkillbars: unsignedOperand(worldBody, 983),
-    skillbarStride: unsignedOperand(skillbarUpdateBody, 236),
-    skillbarAgentId: unsignedOperand(skillbarReaderBody, 126),
-    skillbarSkills,
-    skillSlotStride: unsignedOperand(skillSlotReaderBody, 137),
-    skillSlotId: slotTotalOffset - skillbarSkills,
-    skillbarDisabled: unsignedOperand(skillbarReaderBody, 136),
     worldAttributes: unsignedOperand(worldBody, 2_826),
     attributeStride: unsignedOperand(attributesBody, 35),
     attributeAgentId: 0,
@@ -541,12 +480,7 @@ export function derivePartyObservation(
     || unsignedOperand(flagBody, 103) !== layout.heroFlagStride
     || unsignedOperand(flagBody, 119) !== layout.flagAgentId
     || [1, 2, 3].some((index) => unsignedOperand(professionBodies[index]!, 18) !== professionStateStride)
-    || unsignedOperand(skillbarUpdateBody, 269) !== layout.skillbarStride
-    || unsignedOperand(skillbarUpdateBody, 323) !== layout.skillbarStride
-    || unsignedOperand(skillbarReaderBody, 18) !== layout.skillbarStride
-    || unsignedOperand(skillSlotReaderBody, 18) !== layout.skillbarStride
     || unsignedOperand(characterUnlockBody, 70) !== layout.worldCharacterSkills
-    || unsignedOperand(skillbarUpdateBody, 223) !== layout.worldSkillbars
   ) return null;
 
   const verified = verifyLayout(layout, {
@@ -576,13 +510,6 @@ export function derivePartyObservation(
     infoPrimary: { sourceRole: "HeroDataAdded", expression: "primary profession store", occurrences: [454] },
     infoSecondary: { sourceRole: "HeroDataAdded", expression: "secondary profession store", occurrences: [447] },
     infoAppearanceBitmap: { sourceRole: "HeroDataAdded", expression: "appearance bitmap store", occurrences: [412] },
-    worldSkillbars: { sourceRole: "WorldContext lifecycle+skillbar update", expression: "array field", occurrences: [983, 223] },
-    skillbarStride: { sourceRole: "skillbar update+readers", expression: "row multiplier", occurrences: [236, 269, 323, 18] },
-    skillbarAgentId: { sourceRole: "skillbar reader", expression: "first row key", occurrences: [126] },
-    skillbarSkills: { sourceRole: "skillbar update", expression: "first repeated slot field", occurrences: [352] },
-    skillSlotStride: { sourceRole: "skill slot reader", expression: "slot index multiplier", occurrences: [137] },
-    skillSlotId: { sourceRole: "skillbar update+slot reader", expression: "total id offset minus slot base", occurrences: [144, 352] },
-    skillbarDisabled: { sourceRole: "skillbar reader", expression: "disabled field load", occurrences: [136] },
     worldAttributes: { sourceRole: "WorldContext lifecycle", expression: "array clear field", occurrences: [2_826] },
     attributeStride: { sourceRole: "attribute writer", expression: "row multiplier", occurrences: [35, 68, 124] },
     attributeAgentId: { sourceRole: "attribute writer", expression: "first row key", occurrences: [0] },

--- a/src/main/certification/enhancement-player-skillbar-proof.ts
+++ b/src/main/certification/enhancement-player-skillbar-proof.ts
@@ -1,0 +1,170 @@
+/**
+ * Exact, UI-independent authority for the player skillbar row and eight slots.
+ * Party presentation and cooldown timing consume this shared proof as peers.
+ */
+import { verifyLayout } from "./semantic-proof.js";
+import {
+  functionBody,
+  functionBodySha256,
+  roleFunctions,
+  semanticRole,
+  signatureMatches,
+  soleValue,
+  staticBytesHash,
+  staticCStringHash,
+  uniqueExactFunction,
+  uniqueRoleFunction,
+  unsignedOperand,
+  valuesForRole,
+} from "./enhancement-wasm-proof-context.js";
+import type { ModuleShape } from "./enhancement-evidence-types.js";
+import type { KnownEnhancementBuild } from "./enhancement-builds.js";
+
+export const PLAYER_SKILLBAR_WORLD_ROLE = semanticRole(
+  3_279,
+  "878f00dc4ea68f51e5a79f507e37b0a5df3c32b561ca6d35c966a888d0cd022b",
+  Object.freeze([
+    { start: 1_342, end: 1_347, role: "world.assert-a", addressClass: "immutable-data" },
+    { start: 1_395, end: 1_400, role: "world.assert-b", addressClass: "immutable-data" },
+  ]),
+  ["i32"],
+  ["i32"],
+);
+
+export const PLAYER_SKILLBAR_UPDATE_ROLE = semanticRole(
+  468,
+  "5c17e22a87d68e79e2d258992d623f3ec83dca62d74a063d46e06f7fd426093c",
+  Object.freeze([
+    { start: 45, end: 50, role: "skillbar.assertion", addressClass: "immutable-data" },
+    { start: 450, end: 455, role: "party.ui", addressClass: "function-index" },
+  ]),
+  [],
+  [],
+);
+
+const ROW_READER = Object.freeze({
+  bodySha256: "7b8b5c65a126fae2edfa517a4706244a0d2352c628fde208d049ecf82dfa4e72",
+  params: Object.freeze(["i32", "i32", "i32"] as const),
+  results: Object.freeze(["i32"] as const),
+});
+const SLOT_READER = Object.freeze({
+  bodySha256: "ee41be1f4dcaf8e5822fc024e41cbbad74cf293cdafb2b89a8691aeb680e68b5",
+  params: Object.freeze(["i32", "i32", "i32"] as const),
+  results: Object.freeze(["i32"] as const),
+});
+const IMMUTABLE = Object.freeze({
+  skillbar: "f450663f1e90de4ae2e581b6dc777b81f6c9e019bff3e5d2e60665099862e3f0",
+  worldA: "435ae0e5b5663ba229fe0a312a2f3d83b4896302f9517b56d88f996ba7ea896d",
+  worldB: "f7d0c7a8263c7a799862d8a513123d901e4f1cc30bc1d86da870bf5f2ec5aad6",
+});
+
+export function playerSkillbarRoleCandidateCounts(module: ModuleShape): readonly number[] {
+  const exactCount = (role: Readonly<{
+    bodySha256: string;
+    params: readonly string[];
+    results: readonly string[];
+  }>): number => {
+    let count = 0;
+    for (
+      let index = module.functionImportCount;
+      index < module.functionTypeIndices.length;
+      index += 1
+    ) {
+      if (
+        signatureMatches(module, index, role.params, role.results)
+        && functionBodySha256(module, index) === role.bodySha256
+      ) count += 1;
+    }
+    return count;
+  };
+  return Object.freeze([
+    roleFunctions(module, PLAYER_SKILLBAR_WORLD_ROLE).length,
+    roleFunctions(module, PLAYER_SKILLBAR_UPDATE_ROLE).length,
+    exactCount(ROW_READER),
+    exactCount(SLOT_READER),
+  ]);
+}
+
+export function derivePlayerSkillbarObservation(
+  module: ModuleShape,
+): NonNullable<KnownEnhancementBuild["playerSkillbarObservation"]> | null {
+  const world = uniqueRoleFunction(module, PLAYER_SKILLBAR_WORLD_ROLE);
+  const update = uniqueRoleFunction(module, PLAYER_SKILLBAR_UPDATE_ROLE);
+  const rowReader = uniqueExactFunction(
+    module, ROW_READER.bodySha256, ROW_READER.params, ROW_READER.results,
+  );
+  const slotReader = uniqueExactFunction(
+    module, SLOT_READER.bodySha256, SLOT_READER.params, SLOT_READER.results,
+  );
+  if (world === null || update === null || rowReader === null || slotReader === null) {
+    return null;
+  }
+  const worldBody = functionBody(module, world);
+  const updateBody = functionBody(module, update);
+  const rowBody = functionBody(module, rowReader);
+  const slotBody = functionBody(module, slotReader);
+  const worldValues = valuesForRole(worldBody, PLAYER_SKILLBAR_WORLD_ROLE);
+  const updateValues = valuesForRole(updateBody, PLAYER_SKILLBAR_UPDATE_ROLE);
+  if (
+    staticCStringHash(module, soleValue(updateValues, "skillbar.assertion"))
+      !== IMMUTABLE.skillbar
+    || staticBytesHash(module, soleValue(worldValues, "world.assert-a"), 12)
+      !== IMMUTABLE.worldA
+    || staticBytesHash(module, soleValue(worldValues, "world.assert-b"), 12)
+      !== IMMUTABLE.worldB
+  ) return null;
+
+  const worldSkillbars = unsignedOperand(worldBody, 983);
+  const skillbarStride = unsignedOperand(updateBody, 236);
+  const skillbarSkills = unsignedOperand(updateBody, 352);
+  const slotTotalOffset = unsignedOperand(slotBody, 144);
+  const coreLayout = {
+    worldSkillbars,
+    skillbarStride,
+    skillbarAgentId: unsignedOperand(rowBody, 126),
+    skillbarSkills,
+    skillSlotStride: unsignedOperand(slotBody, 137),
+  };
+  const partyLayout = {
+    skillSlotId: slotTotalOffset - skillbarSkills,
+    skillbarDisabled: unsignedOperand(rowBody, 136),
+  };
+  if (
+    slotTotalOffset < skillbarSkills
+    || unsignedOperand(updateBody, 223) !== worldSkillbars
+    || unsignedOperand(updateBody, 269) !== skillbarStride
+    || unsignedOperand(updateBody, 323) !== skillbarStride
+    || unsignedOperand(rowBody, 18) !== skillbarStride
+    || unsignedOperand(slotBody, 18) !== skillbarStride
+  ) return null;
+
+  return Object.freeze({
+    worldLifecycle: Object.freeze({
+      functionIndex: world, params: ["i32"] as const, results: ["i32"] as const,
+      bodySha256: functionBodySha256(module, world),
+    }),
+    update: Object.freeze({
+      functionIndex: update, params: [] as const, results: [] as const,
+      bodySha256: functionBodySha256(module, update),
+    }),
+    rowReader: Object.freeze({
+      functionIndex: rowReader, params: ROW_READER.params, results: ROW_READER.results,
+      bodySha256: ROW_READER.bodySha256,
+    }),
+    slotReader: Object.freeze({
+      functionIndex: slotReader, params: SLOT_READER.params, results: SLOT_READER.results,
+      bodySha256: SLOT_READER.bodySha256,
+    }),
+    coreLayout: verifyLayout(coreLayout, {
+      worldSkillbars: { sourceRole: "world lifecycle+skillbar update", expression: "array field", occurrences: [983, 223] },
+      skillbarStride: { sourceRole: "skillbar update+readers", expression: "row multiplier", occurrences: [236, 269, 323, 18] },
+      skillbarAgentId: { sourceRole: "skillbar row reader", expression: "row key", occurrences: [126] },
+      skillbarSkills: { sourceRole: "skillbar update", expression: "eight-slot base", occurrences: [352] },
+      skillSlotStride: { sourceRole: "skill slot reader", expression: "slot multiplier", occurrences: [137] },
+    }).layout,
+    partyLayout: verifyLayout(partyLayout, {
+      skillSlotId: { sourceRole: "skillbar update+slot reader", expression: "id offset from slot base", occurrences: [144, 352] },
+      skillbarDisabled: { sourceRole: "skillbar row reader", expression: "disabled field", occurrences: [136] },
+    }).layout,
+  });
+}

--- a/src/main/certification/enhancement-skill-cooldown-proof.ts
+++ b/src/main/certification/enhancement-skill-cooldown-proof.ts
@@ -4,7 +4,6 @@
  * already-certified skill-bar row layout, then requires one exact reader whose
  * control flow performs the bounded timestamp-minus-clock calculation.
  */
-import type { EnhancementPartyLayout } from "../../shared/enhancement-config.js";
 import type { KnownEnhancementBuild } from "./enhancement-builds.js";
 import type { EnhancementProofContext } from "./enhancement-wasm-proof-context.js";
 import {
@@ -39,9 +38,10 @@ export type SkillCooldownObservationProof = NonNullable<
 
 export function deriveSkillCooldownObservation(
   context: EnhancementProofContext,
-  party: EnhancementPartyLayout | null | undefined,
+  playerSkillbar: KnownEnhancementBuild["playerSkillbarObservation"] | null | undefined,
 ): SkillCooldownObservationProof | null {
-  if (!party) return null;
+  if (!playerSkillbar) return null;
+  const skillbar = playerSkillbar.coreLayout;
   const reader = uniqueExactFunction(
     context.module,
     RECHARGE_READER.bodySha256,
@@ -61,19 +61,19 @@ export function deriveSkillCooldownObservation(
     body,
     READER_OPERANDS.rechargeOffsets[0],
   );
-  const rechargeOffset = totalRechargeOffset - party.skillbarSkills;
+  const rechargeOffset = totalRechargeOffset - skillbar.skillbarSkills;
   if (
     READER_OPERANDS.rowStrides.some(
-      (at) => unsignedOperand(body, at) !== party.skillbarStride,
+      (at) => unsignedOperand(body, at) !== skillbar.skillbarStride,
     )
     || unsignedOperand(body, READER_OPERANDS.slotBound) !== 8
-    || unsignedOperand(body, READER_OPERANDS.slotStride) !== party.skillSlotStride
+    || unsignedOperand(body, READER_OPERANDS.slotStride) !== skillbar.skillSlotStride
     || READER_OPERANDS.rechargeOffsets.some(
       (at) => unsignedOperand(body, at) !== totalRechargeOffset,
     )
     || unsignedOperand(body, READER_OPERANDS.timerCall) !== timer
     || rechargeOffset < 0
-    || rechargeOffset + 4 > party.skillSlotStride
+    || rechargeOffset + 4 > skillbar.skillSlotStride
   ) return null;
 
   return Object.freeze({

--- a/src/main/certification/local-client-verification-boundary.ts
+++ b/src/main/certification/local-client-verification-boundary.ts
@@ -508,6 +508,39 @@ function matchesSkillCooldownObservation(
     && isDeepStrictEqual(candidate.layout, expected.layout);
 }
 
+function matchesPlayerSkillbarObservation(
+  build: SemanticBuild,
+  baseline: KnownEnhancementBuild,
+): boolean {
+  const candidate = build.playerSkillbarObservation;
+  const expected = baseline.playerSkillbarObservation;
+  if (candidate === undefined) return true;
+  if (expected === undefined) return false;
+  const proof = (
+    value: Readonly<{
+      functionIndex: number;
+      bodySha256: string;
+      params: readonly string[];
+      results: readonly string[];
+    }>,
+    reference: Readonly<{
+      functionIndex: number;
+      bodySha256: string;
+      params: readonly string[];
+      results: readonly string[];
+    }>,
+  ) => isIndex(value.functionIndex)
+    && isDigest(value.bodySha256)
+    && isDeepStrictEqual(value.params, reference.params)
+    && isDeepStrictEqual(value.results, reference.results);
+  return proof(candidate.worldLifecycle, expected.worldLifecycle)
+    && proof(candidate.update, expected.update)
+    && proof(candidate.rowReader, expected.rowReader)
+    && proof(candidate.slotReader, expected.slotReader)
+    && isDeepStrictEqual(candidate.coreLayout, expected.coreLayout)
+    && isDeepStrictEqual(candidate.partyLayout, expected.partyLayout);
+}
+
 function isAutomaticSemanticBuild(
   value: unknown,
   inputSha256: string,
@@ -534,10 +567,12 @@ function isAutomaticSemanticBuild(
   const hasParty = build.partyObservation !== undefined;
   const hasTeam = build.teamApply !== undefined;
   const hasSkillSlotGeometry = build.skillSlotGeometry !== undefined;
+  const hasPlayerSkillbar = build.playerSkillbarObservation !== undefined;
   const hasSkillCooldown = build.skillCooldownObservation !== undefined;
   if (!hasCursor && !hasPlayRegion && !hasObservation && !hasTarget
     && !hasTravel && !hasXunlai && !hasAliases
-    && !hasParty && !hasTeam && !hasSkillSlotGeometry && !hasSkillCooldown) {
+    && !hasParty && !hasTeam && !hasSkillSlotGeometry
+    && !hasPlayerSkillbar && !hasSkillCooldown) {
     return false;
   }
   if (
@@ -547,9 +582,11 @@ function isAutomaticSemanticBuild(
     || (hasTarget && (!hasPlayRegion || !hasObservation))
     || (hasTravel && !hasPlayRegion)
     || (hasXunlai && (!hasPlayRegion || !hasObservation))
-    || (hasParty && (!hasObservation || build.uiDispatcher === undefined))
+    || (hasPlayerSkillbar && (!hasPlayRegion || !hasObservation))
+    || (hasParty && (!hasObservation || !hasPlayerSkillbar
+      || build.uiDispatcher === undefined))
     || (hasSkillSlotGeometry && !hasPlayRegion)
-    || (hasSkillCooldown && (!hasObservation || !hasParty))
+    || (hasSkillCooldown && (!hasPlayRegion || !hasObservation || !hasPlayerSkillbar))
     || (hasTeam && (!hasParty || build.gameThread === undefined))
     || ((hasTravel || hasXunlai) && build.gameThread === undefined)
     || ((hasTravel || hasXunlai || hasAliases) && build.uiDispatcher === undefined)
@@ -582,6 +619,7 @@ function isAutomaticSemanticBuild(
     && matchesXunlaiAction(build, baseline)
     && matchesChatAliases(build, baseline)
     && matchesPartyObservation(build, baseline)
+    && matchesPlayerSkillbarObservation(build, baseline)
     && matchesTeamApply(build, baseline)
     && matchesSkillSlotGeometry(build)
     && matchesSkillCooldownObservation(build, baseline)

--- a/src/main/certification/local-client-verification-contract.ts
+++ b/src/main/certification/local-client-verification-contract.ts
@@ -104,6 +104,8 @@ export const LOCAL_FEATURE_INVARIANTS = Object.freeze({
   ] as const),
   skillCooldownObservation: Object.freeze([
     ...SHARED_FEATURE_INVARIANTS,
+    "skill-cooldown.observation-base",
+    "skill-cooldown.player-skillbar",
     "skill-cooldown.recharge-reader",
     "skill-cooldown.precise-timer",
   ] as const),
@@ -183,7 +185,8 @@ export interface LocalFeatureCertificateMap {
     & RequiredBuildFact<"playRegionObservation" | "skillSlotGeometry">;
   readonly skillCooldownObservation: Readonly<{ core: EnhancementProofCore }>
     & RequiredBuildFact<
-      "observationBase" | "partyObservation" | "skillCooldownObservation"
+      | "playRegionObservation" | "observationBase"
+      | "playerSkillbarObservation" | "skillCooldownObservation"
     >;
 }
 
@@ -377,13 +380,15 @@ export function localFeatureVerdictsForBuild(
       })
     : null;
   const skillCooldownObservation = core !== null
-      && build?.observationBase !== undefined
-      && build.partyObservation !== undefined
+      && build?.playRegionObservation !== undefined
+      && build.observationBase !== undefined
+      && build.playerSkillbarObservation !== undefined
       && build.skillCooldownObservation !== undefined
     ? Object.freeze({
         core,
+        playRegionObservation: build.playRegionObservation,
         observationBase: build.observationBase,
-        partyObservation: build.partyObservation,
+        playerSkillbarObservation: build.playerSkillbarObservation,
         skillCooldownObservation: build.skillCooldownObservation,
       })
     : null;

--- a/src/main/certification/local-client-verifier.ts
+++ b/src/main/certification/local-client-verifier.ts
@@ -48,6 +48,11 @@ import {
   type LocalActionRoleDiagnostics,
 } from "./enhancement-local-actions-proof.js";
 import { transformEnhancementWasm } from "./enhancement-transform.js";
+import { deriveObservationLayout } from "./enhancement-target-proof.js";
+import {
+  derivePlayerSkillbarObservation,
+  playerSkillbarRoleCandidateCounts,
+} from "./enhancement-player-skillbar-proof.js";
 import {
   enhancementProofContext,
   type EnhancementProofContext,
@@ -324,6 +329,8 @@ function diagnoseFeatureFailures(
   locatedTarget: AutomaticTargetLocation | null,
   locatedLocal: AutomaticLocalActionsLocation | null,
   locatedSkillSlotGeometry: ReturnType<typeof deriveSkillSlotGeometry>,
+  cooldownObservationLayout: ReturnType<typeof deriveObservationLayout>,
+  locatedPlayerSkillbar: ReturnType<typeof derivePlayerSkillbarObservation>,
   locatedSkillCooldown: ReturnType<typeof deriveSkillCooldownObservation>,
   context: EnhancementProofContext,
 ): LocalFeatureFailures {
@@ -336,7 +343,9 @@ function diagnoseFeatureFailures(
   const needsSkillEvidence = requested.skillSlotGeometry
     && locatedSkillSlotGeometry === null;
   const needsCooldownEvidence = requested.skillCooldownObservation
-    && locatedSkillCooldown === null;
+    && (cooldownObservationLayout === null
+      || locatedPlayerSkillbar === null
+      || locatedSkillCooldown === null);
   const needsEvidence = (requested.nativeCursor && !locatedCursor)
     || (requested.playRegionObservation && !locatedPlayRegion)
     || (requested.targetObservation && !locatedTarget)
@@ -365,6 +374,10 @@ function diagnoseFeatureFailures(
     "skillCooldownObservation",
     evidence,
   );
+  const ambiguousSkillbarCandidates = needsCooldownEvidence
+      && locatedPlayerSkillbar === null
+    ? playerSkillbarRoleCandidateCounts(context.module).find((count) => count > 1)
+    : undefined;
   return Object.freeze({
     ...(requested.nativeCursor && !locatedCursor
       ? { nativeCursor: cursorFailure(evidence) }
@@ -541,9 +554,20 @@ function diagnoseFeatureFailures(
     ...(needsCooldownEvidence
       ? {
           skillCooldownObservation: cooldownShared
+            ?? (ambiguousSkillbarCandidates !== undefined
+              ? ambiguousFeature(
+                  "skillCooldownObservation",
+                  "skill-cooldown.player-skillbar",
+                  ambiguousSkillbarCandidates,
+                )
+              : null)
             ?? changedFeature(
               "skillCooldownObservation",
-              "skill-cooldown.recharge-reader",
+              cooldownObservationLayout === null
+                ? "skill-cooldown.observation-base"
+                : locatedPlayerSkillbar === null
+                  ? "skill-cooldown.player-skillbar"
+                  : "skill-cooldown.recharge-reader",
             ),
         }
       : {}),
@@ -586,8 +610,14 @@ function deriveEnhancementBuild(
   const locatedTarget = requestedCapabilities.targetObservation
     ? locateAutomaticTarget(templateOutput, ENHANCEMENT_BUILDS, context)
     : null;
+  const cooldownObservationLayout = requestedCapabilities.skillCooldownObservation
+    ? deriveObservationLayout(context.module)
+    : null;
+  const locatedPlayerSkillbar = requestedCapabilities.partyObservation
+      || requestedCapabilities.skillCooldownObservation
+    ? derivePlayerSkillbarObservation(context.module)
+    : null;
   const wantsLocal = requestedCapabilities.partyObservation
-    || requestedCapabilities.skillCooldownObservation
     || requestedCapabilities.teamApply
     || requestedCapabilities.travelAction
     || requestedCapabilities.xunlaiAction
@@ -598,6 +628,7 @@ function deriveEnhancementBuild(
         ENHANCEMENT_BUILDS,
         context,
         locatedTarget?.observationLayout,
+        locatedPlayerSkillbar,
       )
     : null;
   const locatedSkillSlotGeometry = requestedCapabilities.skillSlotGeometry
@@ -634,11 +665,13 @@ function deriveEnhancementBuild(
   const locatedSkillCooldown = requestedCapabilities.skillCooldownObservation
     ? deriveSkillCooldownObservation(
         context,
-        locatedLocal?.partyObservation?.layout,
+        locatedPlayerSkillbar,
       )
     : null;
   const includeSkillCooldown = requestedCapabilities.skillCooldownObservation
-    && includeParty
+    && includePlayRegion
+    && cooldownObservationLayout !== null
+    && locatedPlayerSkillbar !== null
     && locatedSkillCooldown !== null;
   const failures = diagnoseFeatureFailures(
     templateOutput,
@@ -648,6 +681,8 @@ function deriveEnhancementBuild(
     locatedTarget,
     locatedLocal,
     locatedSkillSlotGeometry,
+    cooldownObservationLayout,
+    locatedPlayerSkillbar,
     locatedSkillCooldown,
     context,
   );
@@ -669,7 +704,9 @@ function deriveEnhancementBuild(
     ? locatedTarget.observationLayout
     : includeParty || includeXunlai
       ? locatedLocal!.observationLayout!
-      : null;
+      : includeSkillCooldown
+        ? cooldownObservationLayout
+        : null;
   if (
     includePlayRegion
     && observationLayout !== null
@@ -769,6 +806,9 @@ function deriveEnhancementBuild(
     ...(includeAliases ? { chatAliases: locatedLocal!.chatAliases! } : {}),
     ...(includeParty ? {
       partyObservation: locatedLocal.partyObservation,
+    } : {}),
+    ...(includeParty || includeSkillCooldown ? {
+      playerSkillbarObservation: locatedPlayerSkillbar!,
     } : {}),
     ...(includeTeam ? { teamApply: locatedLocal!.teamApply! } : {}),
     ...(includeSkillSlotGeometry

--- a/src/main/certification/semantic-proof.ts
+++ b/src/main/certification/semantic-proof.ts
@@ -9,7 +9,7 @@
  */
 import { createHash } from "node:crypto";
 
-export const SEMANTIC_VERIFIER_ABI = 3;
+export const SEMANTIC_VERIFIER_ABI = 4;
 
 export type ProofRefusal = Readonly<{
   inputSha256: string;

--- a/src/shared/enhancement-config.ts
+++ b/src/shared/enhancement-config.ts
@@ -136,15 +136,29 @@ export type EnhancementSkillSlotGeometryLayout = Pick<EnhancementLayout,
 export type EnhancementSkillCooldownLayout = Pick<EnhancementLayout,
   | "skillSlotRecharge"
 >;
-export type EnhancementPartyLayout = Omit<EnhancementLayout,
-  keyof EnhancementObservationBaseLayout | keyof EnhancementTargetLayout
-  | keyof EnhancementCursorLayout | keyof EnhancementStorageLayout
-  | keyof EnhancementSkillSlotGeometryLayout
-  | keyof EnhancementSkillCooldownLayout
+export type EnhancementPlayerSkillbarLayout = Pick<EnhancementLayout,
+  | "worldSkillbars" | "skillbarStride" | "skillbarAgentId"
+  | "skillbarSkills" | "skillSlotStride"
+>;
+export type EnhancementPartySkillbarLayout = Pick<EnhancementLayout,
+  | "skillSlotId" | "skillbarDisabled"
+>;
+export type EnhancementPartyLayout = Pick<EnhancementLayout,
+  | "partyContext" | "playerParty" | "partyHeroes" | "heroMemberStride"
+  | "heroAgentId" | "heroOwnerPlayerId" | "heroId" | "heroLevel"
+  | "partyPlayers" | "partyHenchmen" | "partyFlag" | "accountContextSlot"
+  | "accountUnlockedSkills" | "worldHeroFlags" | "heroFlagStride"
+  | "flagHeroId" | "flagAgentId" | "flagBehavior" | "worldHeroInfo"
+  | "heroInfoStride" | "infoHeroId" | "infoAgentId" | "infoLevel"
+  | "infoPrimary" | "infoSecondary" | "infoAppearanceBitmap"
+  | "worldAttributes" | "attributeStride" | "attributeAgentId"
+  | "attributeEntries" | "attributeEntryStride" | "attributeEntryId"
+  | "attributeEntryRank" | "worldProfessionStates"
+  | "professionStateStride" | "worldCharacterSkills"
 >;
 
 type Owner = "play-region" | "observation" | "target" | "cursor" | "party" | "storage"
-  | "skill-slots" | "skill-cooldown";
+  | "player-skillbar" | "party-skillbar" | "skill-slots" | "skill-cooldown";
 type ConfigField =
   | Readonly<{
     source: "layout";
@@ -159,6 +173,16 @@ type ConfigField =
   | Readonly<{ source: "layout"; owner: "target"; key: keyof EnhancementTargetLayout }>
   | Readonly<{ source: "layout"; owner: "cursor"; key: keyof EnhancementCursorLayout }>
   | Readonly<{ source: "layout"; owner: "party"; key: keyof EnhancementPartyLayout }>
+  | Readonly<{
+    source: "layout";
+    owner: "player-skillbar";
+    key: keyof EnhancementPlayerSkillbarLayout;
+  }>
+  | Readonly<{
+    source: "layout";
+    owner: "party-skillbar";
+    key: keyof EnhancementPartySkillbarLayout;
+  }>
   | Readonly<{ source: "layout"; owner: "storage"; key: keyof EnhancementStorageLayout }>
   | Readonly<{
     source: "layout";
@@ -194,6 +218,16 @@ const cursor = (
 const party = (
   ...keys: readonly (keyof EnhancementPartyLayout)[]
 ): readonly ConfigField[] => keys.map((key) => ({ source: "layout", key, owner: "party" }));
+const playerSkillbar = (
+  ...keys: readonly (keyof EnhancementPlayerSkillbarLayout)[]
+): readonly ConfigField[] => keys.map((key) => ({
+  source: "layout", key, owner: "player-skillbar",
+}));
+const partySkillbar = (
+  ...keys: readonly (keyof EnhancementPartySkillbarLayout)[]
+): readonly ConfigField[] => keys.map((key) => ({
+  source: "layout", key, owner: "party-skillbar",
+}));
 const storage = (
   ...keys: readonly (keyof EnhancementStorageLayout)[]
 ): readonly ConfigField[] => keys.map((key) => ({ source: "layout", key, owner: "storage" }));
@@ -222,7 +256,13 @@ export const ENHANCEMENT_CONFIG_FIELDS = Object.freeze([
   ...cursor("cursorActiveArt", "cursorSoftwareModel", "cursorShowCount", "cursorColorBuffer", "cursorArtHotspot", "cursorArtTexture", "cursorHandleKey", "cursorHandleObject", "cursorViewTexture", "cursorTextureType", "cursorTextureWidth", "cursorTextureHeight"),
   ...party("partyContext", "playerParty", "partyHeroes", "heroMemberStride", "heroAgentId", "heroOwnerPlayerId", "heroId", "heroLevel", "partyPlayers", "partyHenchmen", "partyFlag", "accountContextSlot", "accountUnlockedSkills"),
   ...observation("worldContext"),
-  ...party("worldHeroFlags", "heroFlagStride", "flagHeroId", "flagAgentId", "flagBehavior", "worldHeroInfo", "heroInfoStride", "infoHeroId", "infoAgentId", "infoLevel", "infoPrimary", "infoSecondary", "infoAppearanceBitmap", "worldSkillbars", "skillbarStride", "skillbarAgentId", "skillbarSkills", "skillSlotStride", "skillSlotId", "skillbarDisabled", "worldAttributes", "attributeStride", "attributeAgentId", "attributeEntries", "attributeEntryStride", "attributeEntryId", "attributeEntryRank"),
+  ...party("worldHeroFlags", "heroFlagStride", "flagHeroId", "flagAgentId", "flagBehavior", "worldHeroInfo", "heroInfoStride", "infoHeroId", "infoAgentId", "infoLevel", "infoPrimary", "infoSecondary", "infoAppearanceBitmap"),
+  ...playerSkillbar(
+    "worldSkillbars", "skillbarStride", "skillbarAgentId",
+    "skillbarSkills", "skillSlotStride",
+  ),
+  ...partySkillbar("skillSlotId", "skillbarDisabled"),
+  ...party("worldAttributes", "attributeStride", "attributeAgentId", "attributeEntries", "attributeEntryStride", "attributeEntryId", "attributeEntryRank"),
   ...playRegion("areaInfo", "areaInfoCount", "areaInfoStride", "areaInfoFlags"),
   ...party("worldProfessionStates", "professionStateStride", "worldCharacterSkills"),
   ...storage("worldPlayers", "playerRecordStride", "playerRecordAgentId", "playerRecordAccessFlags", "playerRecordNumber", "areaInfoType"),
@@ -242,6 +282,20 @@ export const ENHANCEMENT_CONFIG_FIELDS = Object.freeze([
 export const ENHANCEMENT_LAYOUT_FIELDS = Object.freeze(
   ENHANCEMENT_CONFIG_FIELDS.flatMap((field) => field.source === "layout" ? [field.key] : []),
 ) as readonly (keyof EnhancementLayout)[];
+
+type ConfiguredLayoutKey = Extract<
+  (typeof ENHANCEMENT_CONFIG_FIELDS)[number],
+  { source: "layout" }
+>["key"];
+type LayoutOwnershipIsExhaustive =
+  Exclude<keyof EnhancementLayout, ConfiguredLayoutKey> extends never
+    ? Exclude<ConfiguredLayoutKey, keyof EnhancementLayout> extends never
+      ? true
+      : false
+    : false;
+/** Compile-time guard: every layout field must have a declared config owner. */
+export const ENHANCEMENT_LAYOUT_OWNERSHIP_IS_EXHAUSTIVE:
+  LayoutOwnershipIsExhaustive = true;
 
 export const ENHANCEMENT_LAYOUT_WORD_COUNT = ENHANCEMENT_LAYOUT_FIELDS.length;
 export const ENHANCEMENT_PARTY_DIRTY_MESSAGE_COUNT = ENHANCEMENT_CONFIG_FIELDS

--- a/src/shared/enhancement-contracts.ts
+++ b/src/shared/enhancement-contracts.ts
@@ -52,7 +52,9 @@ const CAPABILITY_DEFINITIONS = Object.freeze([
     id: "partyObservation",
     requiresAll: ["playRegionObservation"],
     requiresAny: [],
-    configOwners: ["observation", "party"],
+    configOwners: [
+      "observation", "party", "player-skillbar", "party-skillbar",
+    ],
     hooks: ["ui"],
   },
   {
@@ -92,9 +94,9 @@ const CAPABILITY_DEFINITIONS = Object.freeze([
   },
   {
     id: "skillCooldownObservation",
-    requiresAll: ["partyObservation"],
+    requiresAll: ["playRegionObservation"],
     requiresAny: [],
-    configOwners: ["skill-cooldown"],
+    configOwners: ["observation", "player-skillbar", "skill-cooldown"],
     hooks: [],
   },
   {
@@ -263,7 +265,7 @@ export {
   ENHANCEMENT_LAYOUT_WORD_COUNT,
   ENHANCEMENT_PARTY_DIRTY_MESSAGE_COUNT,
 } from "./enhancement-config.js";
-export const ENHANCEMENT_TRANSFORM_ABI = 41;
+export const ENHANCEMENT_TRANSFORM_ABI = 42;
 
 export function enhancementConfigWordActive(
   capabilities: EnhancementCapabilities,

--- a/tests/client-artifact/template-save-recert.test.ts
+++ b/tests/client-artifact/template-save-recert.test.ts
@@ -482,6 +482,52 @@ test("the template-save verifier makes a fail-closed decision for a real client"
   assert.equal(dispatcherRefusal.partyObservation, false);
   assert.equal(dispatcherRefusal.teamApply, false);
 
+  for (const mutation of [
+    { functionIndex: 8812, operand: 983, label: "world lifecycle" },
+    { functionIndex: 8698, operand: 236, label: "skillbar update" },
+    { functionIndex: 8701, operand: 126, label: "skillbar row reader" },
+    { functionIndex: 8702, operand: 137, label: "skill slot reader" },
+  ] as const) {
+    const changedSkillbarProof = rewriteCode(bytes, (bodies) => {
+      const body = bodies[mutation.functionIndex - derived.importCount]!;
+      body[mutation.operand] = body[mutation.operand]! ^ 1;
+    });
+    assert.equal(
+      WebAssembly.validate(new Uint8Array(changedSkillbarProof)),
+      true,
+      mutation.label,
+    );
+    const refusal = capabilitiesOf(verifyLocalClientBytes(changedSkillbarProof))!;
+    assert.equal(refusal.partyObservation, false, mutation.label);
+    assert.equal(refusal.skillCooldownObservation, false, mutation.label);
+    assert.equal(refusal.targetObservation, true, mutation.label);
+    assert.equal(refusal.skillSlotGeometry, true, mutation.label);
+  }
+
+  const duplicateSkillbarReader = sameSignatureDestination(parsed, 8701);
+  const ambiguousSkillbar = rewriteCode(bytes, (bodies) => {
+    bodies[duplicateSkillbarReader - derived.importCount]
+      = bodies[8701 - derived.importCount]!.slice();
+  });
+  assert.equal(WebAssembly.validate(new Uint8Array(ambiguousSkillbar)), true);
+  const ambiguousSkillbarVerification = verifyLocalClientBytes(ambiguousSkillbar);
+  const ambiguousSkillbarVerdict = ambiguousSkillbarVerification
+    .featureVerdicts?.skillCooldownObservation;
+  assert.equal(ambiguousSkillbarVerdict?.status, "ambiguous");
+  if (ambiguousSkillbarVerdict?.status === "ambiguous") {
+    assert.equal(
+      ambiguousSkillbarVerdict.invariant,
+      "skill-cooldown.player-skillbar",
+    );
+    assert.equal(ambiguousSkillbarVerdict.candidates, 2);
+  }
+  const ambiguousSkillbarCapabilities = capabilitiesOf(
+    ambiguousSkillbarVerification,
+  )!;
+  assert.equal(ambiguousSkillbarCapabilities.partyObservation, false);
+  assert.equal(ambiguousSkillbarCapabilities.targetObservation, true);
+  assert.equal(ambiguousSkillbarCapabilities.skillSlotGeometry, true);
+
   const changedRechargeReader = rewriteCode(bytes, (bodies) => {
     const body = bodies[8704 - derived.importCount]!;
     body[137] = 9; // certified slot bound is exactly eight

--- a/tests/fixtures/enhancement-transform.ts
+++ b/tests/fixtures/enhancement-transform.ts
@@ -486,6 +486,29 @@ export function manifest(bytes: Uint8Array): KnownEnhancementBuild {
       hideHeroPanelMessage: 0x1000_01a3,
       showHeroPanelMessage: 0x1000_01a4,
     },
+    playerSkillbarObservation: {
+      worldLifecycle: {
+        functionIndex: 0, params: ["i32"], results: ["i32"],
+        bodySha256: createHash("sha256").update(commandBody(bytes, 0)).digest("hex"),
+      },
+      update: {
+        functionIndex: 1, params: [], results: [],
+        bodySha256: createHash("sha256").update(commandBody(bytes, 1)).digest("hex"),
+      },
+      rowReader: {
+        functionIndex: 2, params: ["i32", "i32", "i32"], results: ["i32"],
+        bodySha256: createHash("sha256").update(commandBody(bytes, 2)).digest("hex"),
+      },
+      slotReader: {
+        functionIndex: 3, params: ["i32", "i32", "i32"], results: ["i32"],
+        bodySha256: createHash("sha256").update(commandBody(bytes, 3)).digest("hex"),
+      },
+      coreLayout: {
+        worldSkillbars: 58, skillbarStride: 59, skillbarAgentId: 60,
+        skillbarSkills: 61, skillSlotStride: 62,
+      },
+      partyLayout: { skillSlotId: 63, skillbarDisabled: 64 },
+    },
     partyObservation: {
       partyDirtyMessages: PARTY_DIRTY_MESSAGES,
       playerChatProducer: 5,
@@ -505,9 +528,6 @@ export function manifest(bytes: Uint8Array): KnownEnhancementBuild {
       worldHeroInfo: 52, heroInfoStride: 53, infoHeroId: 54,
       infoAgentId: 40, infoLevel: 41,
       infoPrimary: 55, infoSecondary: 56, infoAppearanceBitmap: 57,
-      worldSkillbars: 58, skillbarStride: 59, skillbarAgentId: 60,
-      skillbarSkills: 61, skillSlotStride: 62, skillSlotId: 63,
-      skillbarDisabled: 64,
       worldAttributes: 65,
       attributeStride: 66,
       attributeAgentId: 67,

--- a/tests/fixtures/enhancements.ts
+++ b/tests/fixtures/enhancements.ts
@@ -33,7 +33,10 @@ import {
   ENHANCEMENT_CONFIG_WORD_COUNT,
   ENHANCEMENT_LAYOUT_WORD_COUNT,
 } from "../../src/shared/enhancement-contracts.ts";
-import { ENHANCEMENT_LAYOUT_FIELDS } from "../../src/shared/enhancement-config.ts";
+import {
+  ENHANCEMENT_CONFIG_FIELDS,
+  ENHANCEMENT_LAYOUT_FIELDS,
+} from "../../src/shared/enhancement-config.ts";
 
 // Every read returns a discriminated union: `reason` belongs to the members
 // that rejected the region, the decoded fields to the members that accepted
@@ -365,6 +368,49 @@ export const SKILL_CONFIG_START = ENHANCEMENT_LAYOUT_FIELDS.indexOf("frameArray"
 export const COOLDOWN_CONFIG_START = ENHANCEMENT_LAYOUT_FIELDS.indexOf(
   "skillSlotRecharge",
 );
+
+function setConfigField(
+  config: Uint32Array,
+  key: (typeof ENHANCEMENT_LAYOUT_FIELDS)[number],
+  value: number,
+): void {
+  const index = ENHANCEMENT_LAYOUT_FIELDS.indexOf(key);
+  if (index < 0) throw new Error(`unknown Enhancement config field ${key}`);
+  config[index] = value;
+}
+
+/** Installs only the observation and player-skillbar words cooldown owns. */
+export function installPlayerSkillbarConfig(config: Uint32Array): void {
+  const seeded = config.slice();
+  const owners = new Set([
+    "play-region", "observation", "player-skillbar", "skill-cooldown",
+  ]);
+  config.fill(0);
+  ENHANCEMENT_CONFIG_FIELDS.forEach((field, index) => {
+    if (owners.has(field.owner)) config[index] = seeded[index]!;
+  });
+  setConfigField(config, "worldContext", DETAIL.worldContext);
+  setConfigField(config, "worldSkillbars", DETAIL.skillbars);
+  setConfigField(config, "skillbarStride", DETAIL.skillbarStride);
+  setConfigField(config, "skillbarAgentId", DETAIL.skillbarAgentId);
+  setConfigField(config, "skillbarSkills", DETAIL.skillbarSkills);
+  setConfigField(config, "skillSlotStride", DETAIL.skillSlotStride);
+  setConfigField(config, "skillSlotRecharge", 0x08);
+}
+
+/** Installs a bounded skillbar array without any Party/detail tables. */
+export function installPlayerSkillbarGraph(
+  view: DataView,
+  agentIds: readonly number[] = [7],
+): void {
+  view.setUint32(ADDRESSES.world + DETAIL.skillbars, ADDRESSES.skillbarBuffer, true);
+  view.setUint32(ADDRESSES.world + DETAIL.skillbars + 4, agentIds.length, true);
+  view.setUint32(ADDRESSES.world + DETAIL.skillbars + 8, agentIds.length, true);
+  agentIds.forEach((agentId, index) => {
+    const row = ADDRESSES.skillbarBuffer + index * DETAIL.skillbarStride;
+    view.setUint32(row + DETAIL.skillbarAgentId, agentId, true);
+  });
+}
 export const PLAYER_RECORD_INDEX = 42;
 export const PLAYER_RECORD_ADDRESS =
   ADDRESSES.playerRecordBuffer + PLAYER_RECORD_INDEX * DETAIL.playerStride;

--- a/tests/integration/play-region-kernel.test.ts
+++ b/tests/integration/play-region-kernel.test.ts
@@ -9,6 +9,7 @@ import {
   FEATURE_SKILL_SLOT_GEOMETRY,
   FEATURE_TOOLBOX_FOUNDATION,
   installGameGraph,
+  installPlayerSkillbarConfig,
 } from "../fixtures/enhancements.ts";
 
 const AREA_133 = ADDRESSES.areaInfo + 133 * 0x7c;
@@ -83,7 +84,7 @@ describe("play-region kernel", () => {
     }
   });
 
-  it("decouples geometry from Toolbox while cooldowns retain their party dependency", async () => {
+  it("decouples both skill observations from Toolbox", async () => {
     const geometryWithoutRegion = await createKernel();
     assert.equal(geometryWithoutRegion.init({
       features: FEATURE_SKILL_SLOT_GEOMETRY,
@@ -94,22 +95,17 @@ describe("play-region kernel", () => {
       features: FEATURE_PLAY_REGION_OBSERVATION | FEATURE_SKILL_SLOT_GEOMETRY,
     }), 1);
 
-    const cooldownWithoutRegion = await createKernel({ partyDetail: true });
+    const cooldownWithoutRegion = await createKernel();
+    installPlayerSkillbarConfig(cooldownWithoutRegion.config);
     assert.equal(cooldownWithoutRegion.init({
       features: FEATURE_SKILL_COOLDOWN_OBSERVATION,
     }), 0);
 
-    const cooldownWithoutParty = await createKernel({ partyDetail: true });
-    assert.equal(cooldownWithoutParty.init({
-      features:
-        FEATURE_PLAY_REGION_OBSERVATION | FEATURE_SKILL_COOLDOWN_OBSERVATION,
-    }), 0);
-
-    const cooldown = await createKernel({ partyDetail: true });
+    const cooldown = await createKernel();
+    installPlayerSkillbarConfig(cooldown.config);
     assert.equal(cooldown.init({
       features:
         FEATURE_PLAY_REGION_OBSERVATION
-        | FEATURE_TOOLBOX_FOUNDATION
         | FEATURE_SKILL_COOLDOWN_OBSERVATION,
     }), 1);
   });
@@ -121,8 +117,7 @@ describe("play-region kernel", () => {
       { name: "skill-slot geometry", feature: FEATURE_SKILL_SLOT_GEOMETRY },
       {
         name: "skill cooldowns",
-        feature:
-          FEATURE_TOOLBOX_FOUNDATION | FEATURE_SKILL_COOLDOWN_OBSERVATION,
+        feature: FEATURE_SKILL_COOLDOWN_OBSERVATION,
       },
     ] as const;
 
@@ -173,5 +168,32 @@ describe("play-region kernel", () => {
     assert.equal(enabled.status, "ready");
     if (enabled.status !== "ready") return;
     assert.notEqual(enabled.sequence, disabledSequence);
+
+    const cooldown = await createKernel({ partyDetail: true });
+    assert.equal(cooldown.init({
+      features:
+        FEATURE_PLAY_REGION_OBSERVATION | FEATURE_SKILL_COOLDOWN_OBSERVATION,
+    }), 1);
+    cooldown.activeFeatures(FEATURE_PLAY_REGION_OBSERVATION);
+    cooldown.tick();
+    const cooldownSequence = cooldown.view.getUint32(
+      ADDRESSES.skillCooldowns + 8,
+      true,
+    );
+    cooldown.activeFeatures(FEATURE_SKILL_COOLDOWN_OBSERVATION);
+    cooldown.tick();
+    assert.equal(
+      cooldown.view.getUint32(ADDRESSES.skillCooldowns + 8, true),
+      cooldownSequence,
+      "an invalid active mask must leave cooldown observation disabled",
+    );
+    cooldown.activeFeatures(
+      FEATURE_PLAY_REGION_OBSERVATION | FEATURE_SKILL_COOLDOWN_OBSERVATION,
+    );
+    cooldown.tick();
+    assert.notEqual(
+      cooldown.view.getUint32(ADDRESSES.skillCooldowns + 8, true),
+      cooldownSequence,
+    );
   });
 });

--- a/tests/integration/skill-cooldown-kernel.test.ts
+++ b/tests/integration/skill-cooldown-kernel.test.ts
@@ -3,37 +3,51 @@
  */
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
+import { ENHANCEMENT_LAYOUT_FIELDS } from "../../src/shared/enhancement-config.ts";
 import {
   ADDRESSES,
-  COOLDOWN_CONFIG_START,
   createKernel,
   DETAIL,
   FEATURE_PLAY_REGION_OBSERVATION,
   FEATURE_SKILL_COOLDOWN_OBSERVATION,
-  FEATURE_TOOLBOX_FOUNDATION,
   installGameGraph,
-  installPartyDetailGraph,
+  installPlayerSkillbarConfig,
+  installPlayerSkillbarGraph,
 } from "../fixtures/enhancements.ts";
+
+const FEATURES = FEATURE_PLAY_REGION_OBSERVATION
+  | FEATURE_SKILL_COOLDOWN_OBSERVATION;
+
+function rechargeAddress(row: number, slot: number): number {
+  return row + DETAIL.skillbarSkills + slot * DETAIL.skillSlotStride + 0x08;
+}
+
+function installRechargeRow(
+  view: DataView,
+  row: number,
+  gameTimer = 10_000,
+): void {
+  for (let slot = 0; slot < 8; slot += 1) {
+    view.setUint32(
+      rechargeAddress(row, slot),
+      slot === 0 ? 0 : gameTimer + slot * 1_000,
+      true,
+    );
+  }
+}
 
 describe("skill cooldown kernel", () => {
   it("publishes only a complete, bounded player recharge row", async () => {
-    const kernel = await createKernel({ partyDetail: true });
+    const kernel = await createKernel();
     installGameGraph(kernel.view);
-    installPartyDetailGraph(kernel.view);
-    kernel.config[COOLDOWN_CONFIG_START] = 0x08;
-    const playerRow = ADDRESSES.skillbarBuffer + 2 * DETAIL.skillbarStride;
-    for (let slot = 0; slot < 8; slot += 1) {
-      kernel.view.setUint32(
-        playerRow + DETAIL.skillbarSkills + slot * DETAIL.skillSlotStride + 0x08,
-        slot === 0 ? 0 : 10_000 + slot * 1_000,
-        true,
-      );
+    installPlayerSkillbarConfig(kernel.config);
+    for (const key of ["partyContext", "skillSlotId", "skillbarDisabled"] as const) {
+      assert.equal(kernel.config[ENHANCEMENT_LAYOUT_FIELDS.indexOf(key)], 0);
     }
-    assert.equal(kernel.init({
-      features:
-        FEATURE_TOOLBOX_FOUNDATION | FEATURE_PLAY_REGION_OBSERVATION
-          | FEATURE_SKILL_COOLDOWN_OBSERVATION,
-    }), 1);
+    installPlayerSkillbarGraph(kernel.view);
+    const playerRow = ADDRESSES.skillbarBuffer;
+    installRechargeRow(kernel.view, playerRow);
+    assert.equal(kernel.init({ features: FEATURES }), 1);
     kernel.tick(0, 10_000);
     const ready = kernel.skillCooldowns();
     assert.equal(ready.status, "ready");
@@ -44,10 +58,70 @@ describe("skill cooldown kernel", () => {
     ]);
 
     kernel.view.setUint32(
-      playerRow + DETAIL.skillbarSkills + 3 * DETAIL.skillSlotStride + 0x08,
+      rechargeAddress(playerRow, 3),
       10_000 + 1_800_001,
       true,
     );
+    kernel.tick(0, 10_000);
+    assert.deepEqual(kernel.skillCooldowns(), {
+      status: "waiting",
+      reason: "game",
+    });
+  });
+
+  it("caches the validated row and rescans only after its identity fails", async () => {
+    const kernel = await createKernel();
+    installGameGraph(kernel.view);
+    installPlayerSkillbarConfig(kernel.config);
+    installPlayerSkillbarGraph(kernel.view, [77, 88, 7]);
+    const playerRow = ADDRESSES.skillbarBuffer + 2 * DETAIL.skillbarStride;
+    installRechargeRow(kernel.view, playerRow);
+    assert.equal(kernel.init({ features: FEATURES }), 1);
+    kernel.tick(0, 10_000);
+    assert.equal(kernel.skillCooldowns().status, "ready");
+
+    kernel.view.setUint32(ADDRESSES.skillbarBuffer, 7, true);
+    kernel.view.setUint32(
+      ADDRESSES.skillbarBuffer + DETAIL.skillbarStride,
+      7,
+      true,
+    );
+    kernel.tick(0, 10_000);
+    assert.equal(
+      kernel.skillCooldowns().status,
+      "ready",
+      "ordinary ticks validate only the cached player row",
+    );
+
+    kernel.view.setUint32(playerRow, 99, true);
+    kernel.tick(0, 10_000);
+    assert.deepEqual(kernel.skillCooldowns(), {
+      status: "waiting",
+      reason: "game",
+    });
+  });
+
+  it("withdraws the whole record while loading or in PvP", async () => {
+    const kernel = await createKernel();
+    installGameGraph(kernel.view);
+    installPlayerSkillbarConfig(kernel.config);
+    installPlayerSkillbarGraph(kernel.view);
+    installRechargeRow(kernel.view, ADDRESSES.skillbarBuffer);
+    assert.equal(kernel.init({ features: FEATURES }), 1);
+    kernel.tick(0, 10_000);
+    assert.equal(kernel.skillCooldowns().status, "ready");
+
+    kernel.view.setUint32(ADDRESSES.character + 0x23c, 2, true);
+    kernel.tick(0, 10_000);
+    assert.deepEqual(kernel.skillCooldowns(), {
+      status: "waiting",
+      reason: "loading",
+    });
+
+    kernel.view.setUint32(ADDRESSES.character + 0x23c, 0, true);
+    kernel.tick(0, 10_000);
+    assert.equal(kernel.skillCooldowns().status, "ready");
+    kernel.view.setUint32(ADDRESSES.areaInfo + 133 * 0x7c + 0x10, 1, true);
     kernel.tick(0, 10_000);
     assert.deepEqual(kernel.skillCooldowns(), {
       status: "waiting",

--- a/tests/unit/client-compatibility-notice.test.ts
+++ b/tests/unit/client-compatibility-notice.test.ts
@@ -283,6 +283,33 @@ describe("client compatibility notice", () => {
     );
   });
 
+  it("keeps the complete cooldown presentation available without party observation", () => {
+    const dom = compatibilityDom();
+    renderClientCompatibility(dom.root, {
+      appVersion: "2026.7.0",
+      extendedMemory: STANDARD_MEMORY,
+      healthToken: null,
+      compatibility: compatibility({
+        playRegionObservation: available,
+        partyObservation: unavailable("game-update"),
+        skillSlotGeometry: available,
+        skillCooldownObservation: available,
+      }),
+    });
+    assert.equal(
+      dom.element("settings-feature-partyObservation").textContent,
+      "Unavailable",
+    );
+    assert.equal(
+      dom.element("settings-feature-skillSlotGeometry").textContent,
+      "Available",
+    );
+    assert.equal(
+      dom.element("settings-feature-skillCooldownObservation").textContent,
+      "Available",
+    );
+  });
+
   it("dismisses the launcher even when acknowledgement cannot persist", async () => {
     const dom = compatibilityDom();
     let acknowledgements = 0;

--- a/tests/unit/client-module.test.ts
+++ b/tests/unit/client-module.test.ts
@@ -405,6 +405,29 @@ function enhancementBuild(input: Uint8Array): KnownEnhancementBuild {
       hideHeroPanelMessage: 0x1000_01a3,
       showHeroPanelMessage: 0x1000_01a4,
     },
+    playerSkillbarObservation: {
+      worldLifecycle: {
+        functionIndex: 0, params: ["i32"], results: ["i32"],
+        bodySha256: sha256(parseCode(sectionById(splitSections(input), 10))[0]!),
+      },
+      update: {
+        functionIndex: 1, params: [], results: [],
+        bodySha256: sha256(parseCode(sectionById(splitSections(input), 10))[1]!),
+      },
+      rowReader: {
+        functionIndex: 2, params: ["i32", "i32", "i32"], results: ["i32"],
+        bodySha256: sha256(parseCode(sectionById(splitSections(input), 10))[2]!),
+      },
+      slotReader: {
+        functionIndex: 3, params: ["i32", "i32", "i32"], results: ["i32"],
+        bodySha256: sha256(parseCode(sectionById(splitSections(input), 10))[3]!),
+      },
+      coreLayout: {
+        worldSkillbars: 58, skillbarStride: 59, skillbarAgentId: 60,
+        skillbarSkills: 61, skillSlotStride: 62,
+      },
+      partyLayout: { skillSlotId: 63, skillbarDisabled: 64 },
+    },
     partyObservation: {
       partyDirtyMessages: [
         0x1000_0038,
@@ -449,13 +472,6 @@ function enhancementBuild(input: Uint8Array): KnownEnhancementBuild {
       infoPrimary: 55,
       infoSecondary: 56,
       infoAppearanceBitmap: 57,
-      worldSkillbars: 58,
-      skillbarStride: 59,
-      skillbarAgentId: 60,
-      skillbarSkills: 61,
-      skillSlotStride: 62,
-      skillSlotId: 63,
-      skillbarDisabled: 64,
       worldAttributes: 65,
       attributeStride: 66,
       attributeAgentId: 67,

--- a/tests/unit/enhancement-client-chain.test.ts
+++ b/tests/unit/enhancement-client-chain.test.ts
@@ -44,8 +44,8 @@ describe("Enhancement client chain", () => {
           ]]
         : [];
     }).flat();
-    assert.equal(profiles.length, 281);
-    assert.equal(new Set(profiles.map(([, value]) => JSON.stringify(value))).size, 281);
+    assert.equal(profiles.length, 337);
+    assert.equal(new Set(profiles.map(([, value]) => JSON.stringify(value))).size, 337);
     const teamProfiles = profiles.filter(([, capabilities]) => capabilities.teamApply);
     assert.equal(teamProfiles.length, 112);
     assert.ok(teamProfiles.every(([, capabilities]) => capabilities.partyObservation));
@@ -114,6 +114,15 @@ describe("Enhancement client chain", () => {
     delete cursorOnly.chatAliases;
     assert.deepEqual(enhancementProfilesForBuild(cursorOnly), ["features-01"]);
     assert.equal(hasValidEnhancementProfileHashes(cursorOnly), true);
+
+    const orphanSkillbar = { ...cursorOnly };
+    delete orphanSkillbar.playRegionObservation;
+    delete orphanSkillbar.observationBase;
+    assert.equal(
+      hasValidEnhancementProfileHashes(orphanSkillbar),
+      false,
+      "player-skillbar facts cannot carry unactionable memory authority",
+    );
 
     const partyOnly: KnownEnhancementBuild = {
       ...full,

--- a/tests/unit/feature-contracts.test.ts
+++ b/tests/unit/feature-contracts.test.ts
@@ -5,11 +5,20 @@ import {
   ENHANCEMENT_CAPABILITY_CONTRACTS,
   ENHANCEMENT_CAPABILITY_FIELDS,
   NO_ENHANCEMENT_CAPABILITIES,
+  enhancementCapabilitiesForProfile,
+  enhancementConfigWordActive,
   enhancementHooksFor,
   intersectEnhancementCapabilities,
   validEnhancementCapabilities,
   type EnhancementCapability,
 } from "../../src/shared/enhancement-contracts.ts";
+import {
+  ENHANCEMENT_CONFIG_FIELDS,
+  ENHANCEMENT_CONFIG_WORD_COUNT,
+  ENHANCEMENT_LAYOUT_FIELDS,
+  ENHANCEMENT_LAYOUT_OWNERSHIP_IS_EXHAUSTIVE,
+  ENHANCEMENT_LAYOUT_WORD_COUNT,
+} from "../../src/shared/enhancement-config.ts";
 import {
   FEATURE_SELECTION_POLICIES,
   featureActivationRequested,
@@ -36,7 +45,9 @@ test("the capability registry is the ordered wire vocabulary", () => {
       id: "partyObservation",
       requiresAll: ["playRegionObservation"],
       requiresAny: [],
-      configOwners: ["observation", "party"],
+      configOwners: [
+        "observation", "party", "player-skillbar", "party-skillbar",
+      ],
       hooks: ["ui"],
     },
     {
@@ -76,9 +87,9 @@ test("the capability registry is the ordered wire vocabulary", () => {
     },
     {
       id: "skillCooldownObservation",
-      requiresAll: ["partyObservation"],
+      requiresAll: ["playRegionObservation"],
       requiresAny: [],
-      configOwners: ["skill-cooldown"],
+      configOwners: ["observation", "player-skillbar", "skill-cooldown"],
       hooks: [],
     },
     {
@@ -143,6 +154,40 @@ test("dependency pruning is derived from capability contracts", () => {
       ui: contract.id === "partyObservation",
     }, contract.id);
   }
+});
+
+test("cooldown owns the reusable player skillbar core without Party", () => {
+  assert.equal(ENHANCEMENT_CONFIG_WORD_COUNT * Uint32Array.BYTES_PER_ELEMENT, 444);
+  assert.equal(ENHANCEMENT_LAYOUT_WORD_COUNT, 98);
+  assert.equal(ENHANCEMENT_LAYOUT_OWNERSHIP_IS_EXHAUSTIVE, true);
+  assert.equal(
+    new Set(ENHANCEMENT_LAYOUT_FIELDS).size,
+    ENHANCEMENT_LAYOUT_FIELDS.length,
+    "every positional layout word has exactly one owner",
+  );
+
+  const cooldown = enhancementCapabilitiesForProfile("features-300");
+  assert.ok(cooldown);
+  const cooldownOwners = new Set([
+    "play-region", "observation", "player-skillbar", "skill-cooldown",
+  ]);
+  ENHANCEMENT_CONFIG_FIELDS.forEach((field, index) => {
+    assert.equal(
+      enhancementConfigWordActive(cooldown, index),
+      cooldownOwners.has(field.owner),
+      `${field.owner}:${"key" in field ? field.key : field.source}`,
+    );
+  });
+
+  const party = enhancementCapabilitiesForProfile("features-284");
+  assert.ok(party);
+  const activeOwners = new Set(
+    ENHANCEMENT_CONFIG_FIELDS.filter((_, index) =>
+      enhancementConfigWordActive(party, index)).map(({ owner }) => owner),
+  );
+  assert.equal(activeOwners.has("player-skillbar"), true);
+  assert.equal(activeOwners.has("party-skillbar"), true);
+  assert.equal(activeOwners.has("skill-cooldown"), false);
 });
 
 test("feature selection policies are deeply immutable", () => {

--- a/tests/unit/local-client-verifier.test.ts
+++ b/tests/unit/local-client-verifier.test.ts
@@ -76,6 +76,11 @@ const SKILL_SLOTS: EnhancementCapabilities = Object.freeze({
   playRegionObservation: true,
   skillSlotGeometry: true,
 });
+const COOLDOWN: EnhancementCapabilities = Object.freeze({
+  ...NONE,
+  playRegionObservation: true,
+  skillCooldownObservation: true,
+});
 type ProvedVerification = Extract<LocalClientVerification, { status: "proved" }>;
 
 function verificationFor(
@@ -243,6 +248,7 @@ function automaticPartyTeam(): ProvedVerification {
     {
       ...localActions.enhancementBuild!,
       outputSha256: { "features-20c": "b".repeat(64) },
+      playerSkillbarObservation: ENHANCEMENT.playerSkillbarObservation!,
       partyObservation: {
         ...party,
         playerChatProducer: party.playerChatProducer + 1,
@@ -315,6 +321,24 @@ function automaticSkillSlots(): ProvedVerification {
       },
     },
   }, SKILL_SLOTS);
+}
+
+function automaticCooldown(): ProvedVerification {
+  return verificationFor({
+    sha256: ENHANCEMENT.sha256,
+    outputSha256: { "features-300": "8".repeat(64) },
+    programId: ENHANCEMENT.programId,
+    buildId: ENHANCEMENT.buildId,
+    hookFunction: ENHANCEMENT.hookFunction,
+    hookParams: ENHANCEMENT.hookParams,
+    hookResults: ENHANCEMENT.hookResults,
+    hookBodySha256: ENHANCEMENT.hookBodySha256,
+    tableSlot: ENHANCEMENT.tableSlot,
+    playRegionObservation: ENHANCEMENT.playRegionObservation!,
+    observationBase: ENHANCEMENT.observationBase!,
+    playerSkillbarObservation: ENHANCEMENT.playerSkillbarObservation!,
+    skillCooldownObservation: ENHANCEMENT.skillCooldownObservation!,
+  }, COOLDOWN);
 }
 
 describe("local client verification boundary", () => {
@@ -551,6 +575,48 @@ describe("local client verification boundary", () => {
         false,
       );
     }
+  });
+
+  it("certifies cooldown from the player skillbar without Party or UI authority", () => {
+    const derived = automaticCooldown();
+    assert.equal(
+      isLocalClientVerification(derived, TEMPLATE.sha256, COOLDOWN),
+      true,
+    );
+    const build = derived.enhancementBuild!;
+    assert.equal(build.partyObservation, undefined);
+    assert.equal(build.uiDispatcher, undefined);
+    assert.equal(build.gameThread, undefined);
+    assert.equal(derived.featureVerdicts.partyObservation.status, "not-requested");
+    assert.equal(
+      derived.featureVerdicts.skillCooldownObservation.status,
+      "proved",
+    );
+
+    const withoutSkillbar = { ...build };
+    delete withoutSkillbar.playerSkillbarObservation;
+    assert.equal(isLocalClientVerification({
+      ...derived,
+      enhancementBuild: withoutSkillbar,
+      featureVerdicts: localFeatureVerdictsForBuild(
+        TEMPLATE.outputSha256,
+        COOLDOWN,
+        withoutSkillbar,
+      ),
+    }, TEMPLATE.sha256, COOLDOWN), false);
+
+    const orphanSkillbar = { ...build };
+    delete orphanSkillbar.playRegionObservation;
+    delete orphanSkillbar.observationBase;
+    assert.equal(isLocalClientVerification({
+      ...derived,
+      enhancementBuild: orphanSkillbar,
+      featureVerdicts: localFeatureVerdictsForBuild(
+        TEMPLATE.outputSha256,
+        COOLDOWN,
+        orphanSkillbar,
+      ),
+    }, TEMPLATE.sha256, COOLDOWN), false);
   });
 
   it("accepts a template-only proof and requires no enhancement behind failure", () => {

--- a/tests/unit/skill-cooldown-party-independence.test.ts
+++ b/tests/unit/skill-cooldown-party-independence.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { ENHANCEMENT_CONFIG_FIELDS } from "../../src/shared/enhancement-config.ts";
+import {
+  ENHANCEMENT_CAPABILITY_CONTRACTS,
+  enhancementCapabilitiesForProfile,
+  enhancementConfigWordActive,
+  enhancementHooksFor,
+} from "../../src/shared/enhancement-contracts.ts";
+
+test("the minimal cooldown profile needs play-region policy but no Party or UI hook", () => {
+  const capabilities = enhancementCapabilitiesForProfile("features-300");
+  assert.ok(capabilities);
+  assert.equal(capabilities.playRegionObservation, true);
+  assert.equal(capabilities.skillCooldownObservation, true);
+  assert.equal(capabilities.partyObservation, false);
+  assert.equal(capabilities.skillSlotGeometry, false);
+  assert.deepEqual(enhancementHooksFor(capabilities), {
+    tick: true,
+    cursor: false,
+    ui: false,
+  });
+
+  const contract = ENHANCEMENT_CAPABILITY_CONTRACTS.find(
+    ({ id }) => id === "skillCooldownObservation",
+  );
+  assert.deepEqual(contract, {
+    id: "skillCooldownObservation",
+    requiresAll: ["playRegionObservation"],
+    requiresAny: [],
+    configOwners: ["observation", "player-skillbar", "skill-cooldown"],
+    hooks: [],
+  });
+});
+
+test("the minimal cooldown profile activates only its shared read substrate", () => {
+  const capabilities = enhancementCapabilitiesForProfile("features-300");
+  assert.ok(capabilities);
+  const activeOwners = new Set([
+    "play-region",
+    "observation",
+    "player-skillbar",
+    "skill-cooldown",
+  ]);
+
+  ENHANCEMENT_CONFIG_FIELDS.forEach((field, index) => {
+    assert.equal(
+      enhancementConfigWordActive(capabilities, index),
+      activeOwners.has(field.owner),
+      `${field.owner}:${field.source === "layout" ? field.key : index}`,
+    );
+  });
+
+  assert.equal(
+    ENHANCEMENT_CONFIG_FIELDS.some(
+      (field, index) => field.owner === "party"
+        && enhancementConfigWordActive(capabilities, index),
+    ),
+    false,
+  );
+  assert.equal(
+    ENHANCEMENT_CONFIG_FIELDS.some(
+      (field, index) => field.owner === "party-skillbar"
+        && enhancementConfigWordActive(capabilities, index),
+    ),
+    false,
+  );
+});


### PR DESCRIPTION
## What changed

Cooldown observation no longer depends on the much broader Party/UI proof. The exact player skillbar row and its eight-slot layout now form one reusable, UI-independent proof substrate consumed by Party projection and cooldown timing as peers.

## Why

The previous dependency made a Party-only proof failure withdraw an otherwise safe read-only cooldown display. It also duplicated skillbar layout authority inside the Party fact. This change gives the shared memory contract one positive owner per field and lets future bounded skillbar observations reuse the same certified substrate without acquiring Party or game-command authority.

## Invariant

- `features-300` is the minimal cooldown profile: PlayRegion + cooldown, no Party, UI hook, game-thread action, or Party config words.
- The player-skillbar proof requires unique exact world/update/row/slot roles, immutable anchors, exact operands, and full boundary revalidation.
- Orphan player-skillbar facts are refused without both region policy and the observation base.
- The native collector scans at most 64 rows only after identity/cache validation fails, reads exactly eight slots, and publishes all-or-nothing state.
- Any malformed slot, duplicate row, loading state, PvP state, stale identity, or ambiguous proof withdraws the complete cooldown record.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:links`
- `pnpm test:unit` — 1,223 passed
- `pnpm test:policy` — 174 passed
- `pnpm tools:test` — 102 passed
- `pnpm test:integration` — 66 passed
- `pnpm test:release` — 25 passed
- `pnpm build`
- `node scripts/verify-companion-kernel.mjs`
- exact JSPi verifier — all ten capabilities proved with semantic verifier ABI 4
- exact-client artifact suite — 3 passed, including mutations of all four skillbar proof roles and duplicate-role ambiguity
- no local Electron or E2E tests were run

- [x] I kept this pull request focused.
- [x] I ran the relevant checks.
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [x] Documentation is unchanged because this is an internal proof-boundary refactor with no new user setting or surface.
