### PR TITLE
refactor(tools): isolate companion kernel trust boundary

### DIFF
--- a/scripts/seal-companion-kernel.mjs
+++ b/scripts/seal-companion-kernel.mjs
@@ -13,8 +13,8 @@ export const COMPANION_KERNEL_CANDIDATE =
   "build/.companion-kernel.unsealed.wasm";
 export const COMPANION_KERNEL_ARTIFACT =
   "build/renderer/companion-kernel.wasm";
-export const COMPANION_RENDERER =
-  "build/renderer/certified-companion-installation.js";
+export const COMPANION_KERNEL_LOADER =
+  "build/renderer/companion-kernel-loader.js";
 export const COMPANION_KERNEL_HASH_PLACEHOLDER =
   "__COMPANION_KERNEL_SHA256_PLACEHOLDER__";
 export const COMPANION_KERNEL_HASH_BINDING =
@@ -29,7 +29,7 @@ export function companionKernelSha256(bytes) {
 }
 
 /** @param {string} source @param {string} expectedSha256 */
-export function verifySealedCompanionRenderer(source, expectedSha256) {
+export function verifySealedCompanionLoader(source, expectedSha256) {
   const declaration = new RegExp(
     `const ${COMPANION_KERNEL_HASH_BINDING} = "([a-f0-9]{64})";`,
     "g",
@@ -51,7 +51,7 @@ export function verifySealedCompanionRenderer(source, expectedSha256) {
 }
 
 /** @param {string} source @param {string} sha256 */
-export function sealCompanionRendererSource(source, sha256) {
+export function sealCompanionLoaderSource(source, sha256) {
   if (!/^[a-f0-9]{64}$/.test(sha256)) {
     throw new Error("companion kernel seal is not a SHA-256 digest");
   }
@@ -59,10 +59,10 @@ export function sealCompanionRendererSource(source, sha256) {
     source.includes(COMPANION_KERNEL_HASH_BINDING)
     || source.includes(COMPANION_KERNEL_HASH_PLACEHOLDER)
   ) {
-    throw new Error("companion renderer already contains a kernel seal");
+    throw new Error("companion kernel loader already contains a seal");
   }
   if (source.split(COMPILE_MARKER).length !== 2) {
-    throw new Error("companion renderer compile boundary is not unique");
+    throw new Error("companion kernel loader compile boundary is not unique");
   }
   const check =
     `const ${COMPANION_KERNEL_HASH_BINDING} = `
@@ -73,73 +73,73 @@ export function sealCompanionRendererSource(source, sha256) {
   const sealed = source
     .replace(COMPILE_MARKER, check)
     .replace(COMPANION_KERNEL_HASH_PLACEHOLDER, sha256);
-  verifySealedCompanionRenderer(sealed, sha256);
+  verifySealedCompanionLoader(sealed, sha256);
   return sealed;
 }
 
 /**
- * Validate the rustc candidate, prepare the renderer seal, then publish each
+ * Validate the rustc candidate, prepare the loader seal, then publish each
  * through an atomic rename with the served artifact last. A failed candidate
  * never reaches the served path.
  *
- * @param {{candidatePath?: string, artifactPath?: string, rendererPath?: string}} [paths]
+ * @param {{candidatePath?: string, artifactPath?: string, loaderPath?: string}} [paths]
  */
 export function sealCompanionKernelBuild(paths = {}) {
   const candidatePath = paths.candidatePath ?? COMPANION_KERNEL_CANDIDATE;
   const artifactPath = paths.artifactPath ?? COMPANION_KERNEL_ARTIFACT;
-  const rendererPath = paths.rendererPath ?? COMPANION_RENDERER;
+  const loaderPath = paths.loaderPath ?? COMPANION_KERNEL_LOADER;
   if (candidatePath === artifactPath) {
     throw new Error("companion candidate and artifact paths must differ");
   }
 
-  const rendererTemp = `${rendererPath}.seal-${process.pid}.tmp`;
-  const restoreTemp = `${rendererPath}.restore-${process.pid}.tmp`;
-  let renderer;
-  let rendererMode;
-  let rendererPublished = false;
+  const loaderTemp = `${loaderPath}.seal-${process.pid}.tmp`;
+  const restoreTemp = `${loaderPath}.restore-${process.pid}.tmp`;
+  let loader;
+  let loaderMode;
+  let loaderPublished = false;
   try {
     const candidate = readFileSync(candidatePath);
     validateCompanionKernelContract(candidate);
     const sha256 = companionKernelSha256(candidate);
-    renderer = readFileSync(rendererPath, "utf8");
-    rendererMode = statSync(rendererPath).mode & 0o777;
-    const sealedRenderer = sealCompanionRendererSource(renderer, sha256);
-    writeFileSync(rendererTemp, sealedRenderer, {
-      mode: rendererMode,
+    loader = readFileSync(loaderPath, "utf8");
+    loaderMode = statSync(loaderPath).mode & 0o777;
+    const sealedLoader = sealCompanionLoaderSource(loader, sha256);
+    writeFileSync(loaderTemp, sealedLoader, {
+      mode: loaderMode,
     });
-    renameSync(rendererTemp, rendererPath);
-    rendererPublished = true;
+    renameSync(loaderTemp, loaderPath);
+    loaderPublished = true;
     renameSync(candidatePath, artifactPath);
-    verifySealedCompanionRenderer(readFileSync(rendererPath, "utf8"), sha256);
+    verifySealedCompanionLoader(readFileSync(loaderPath, "utf8"), sha256);
     if (companionKernelSha256(readFileSync(artifactPath)) !== sha256) {
       throw new Error("published companion kernel changed during sealing");
     }
     return sha256;
   } catch (error) {
     // The artifact is the activation boundary. Never leave one behind from a
-    // failed seal, and restore the original renderer after a later failure.
+    // failed seal, and restore the original loader after a later failure.
     rmSync(artifactPath, { force: true });
-    rmSync(rendererTemp, { force: true });
+    rmSync(loaderTemp, { force: true });
     if (
-      rendererPublished
-      && renderer !== undefined
-      && rendererMode !== undefined
+      loaderPublished
+      && loader !== undefined
+      && loaderMode !== undefined
     ) {
       try {
-        writeFileSync(restoreTemp, renderer, { mode: rendererMode });
-        renameSync(restoreTemp, rendererPath);
+        writeFileSync(restoreTemp, loader, { mode: loaderMode });
+        renameSync(restoreTemp, loaderPath);
       } catch {
         rmSync(restoreTemp, { force: true });
       }
     }
     throw error;
   } finally {
-    rmSync(rendererTemp, { force: true });
+    rmSync(loaderTemp, { force: true });
     rmSync(restoreTemp, { force: true });
   }
 }
 
 if (process.argv[1] && pathToFileURL(process.argv[1]).href === import.meta.url) {
   sealCompanionKernelBuild();
-  console.log("sealed companion kernel artifact and renderer hash");
+  console.log("sealed companion kernel artifact and loader hash");
 }

--- a/scripts/verify-companion-kernel.mjs
+++ b/scripts/verify-companion-kernel.mjs
@@ -10,9 +10,9 @@ import {
 } from "./companion-kernel-contract.mjs";
 import {
   COMPANION_KERNEL_ARTIFACT,
-  COMPANION_RENDERER,
+  COMPANION_KERNEL_LOADER,
   companionKernelSha256,
-  verifySealedCompanionRenderer,
+  verifySealedCompanionLoader,
 } from "./seal-companion-kernel.mjs";
 
 const artifact = COMPANION_KERNEL_ARTIFACT;
@@ -36,8 +36,8 @@ assert.doesNotMatch(
 
 const bytes = readFileSync(artifact);
 const module = validateCompanionKernelContract(bytes);
-verifySealedCompanionRenderer(
-  readFileSync(COMPANION_RENDERER, "utf8"),
+verifySealedCompanionLoader(
+  readFileSync(COMPANION_KERNEL_LOADER, "utf8"),
   companionKernelSha256(bytes),
 );
 

--- a/src/renderer/certified-companion-installation.ts
+++ b/src/renderer/certified-companion-installation.ts
@@ -279,8 +279,15 @@ export async function installCertifiedCompanion(
       }
     });
     const observerStopped = attempt("observer disposal", stopObserver);
+    // Cursor refresh owns DOM listeners that call cursorEventCount(), which
+    // reads the kernel runtime allocation. Its disposal is therefore an
+    // independent runtime-memory barrier, not a consequence of stopping the
+    // animation-frame observer.
+    const cursorRefreshDisposed = attempt(
+      "cursor refresh disposal",
+      disposeCursorRefresh,
+    );
     if (observerStopped) {
-      attempt("cursor refresh disposal", disposeCursorRefresh);
       attempt("cursor disposal", disposeCursor);
       attempt("target readout disposal", disposeReadout);
       attempt("Toolbox disposal", disposeToolbox);
@@ -334,9 +341,11 @@ export async function installCertifiedCompanion(
           if (snapshotPointer) free(snapshotPointer);
         });
       }
-      attempt("runtime allocation release", () => {
-        if (runtimeAllocation) free(runtimeAllocation);
-      });
+      if (cursorRefreshDisposed) {
+        attempt("runtime allocation release", () => {
+          if (runtimeAllocation) free(runtimeAllocation);
+        });
+      }
     }
     const runtimeWithdrawn = attempt("runtime withdrawal", () => {
       if (window.gwCompanionRuntime === installedRuntime) {

--- a/src/renderer/certified-companion-installation.ts
+++ b/src/renderer/certified-companion-installation.ts
@@ -32,14 +32,13 @@ import {
   COMPANION_PARTY_BYTES,
   type CompanionSnapshot,
 } from "./companion-snapshot.js";
-import {
-  COMPANION_SKILL_COOLDOWN_BYTES,
-  COMPANION_SKILL_SLOT_BYTES,
-} from "./companion-skill-snapshot.js";
-import { COMPANION_PLAY_REGION_BYTES } from "./companion-play-region-snapshot.js";
 import { createPlayRegionObservationInstallation } from "./play-region-state-installation.js";
 import { createSkillOverlaysInstallation } from "./skill-overlays-installation.js";
-import { validateCompanionOwnedRegions } from "./companion-owned-regions.js";
+import {
+  COMPANION_KERNEL_RUNTIME_ALIGN,
+  COMPANION_KERNEL_RUNTIME_BYTES,
+  validateCompanionOwnedRegions,
+} from "./companion-owned-regions.js";
 import {
   observeCompanion,
   recordCompanionLifecycle,
@@ -61,11 +60,7 @@ import {
   COMPANION_DISPATCH_KINDS,
   COMPANION_FEATURE_BITS,
 } from "../shared/companion-abi.js";
-import {
-  COMPANION_KERNEL_EXPORTS,
-  COMPANION_KERNEL_IMPORTS,
-  companionKernelSignatureBytes,
-} from "../shared/companion-kernel-contract.js";
+import { installCompanionKernel } from "./companion-kernel-loader.js";
 import {
   enhancementRuntimePolicy,
   type RuntimePlayRegion,
@@ -77,7 +72,6 @@ import {
 } from "./profession-command-trace.js";
 
 const COMPANION_ABI = COMPANION_DESCRIPTOR.kernel;
-const COMPANION_RUNTIME_BYTES = 65_536;
 /**
  * The side module's `__memory_base` must be 16-byte aligned: the wasm linker
  * places the module's data segments at fixed offsets *from* this base, so a
@@ -89,23 +83,6 @@ const COMPANION_RUNTIME_BYTES = 65_536;
  * not 16. So the block is over-allocated by the alignment and the base is
  * rounded up inside it; the raw pointer is what has to be freed.
  */
-const COMPANION_RUNTIME_ALIGN = 16;
-const companionKernelSignatureModule = new WebAssembly.Module(
-  companionKernelSignatureBytes(),
-);
-
-// A Wasm import is the platform's exact function-type check. JavaScript
-// reflection cannot distinguish i32 from f32/f64 or void from i32.
-function hasExactCompanionSignatures(exports: WebAssembly.Exports): boolean {
-  try {
-    new WebAssembly.Instance(companionKernelSignatureModule, {
-      kernel: exports,
-    });
-    return true;
-  } catch {
-    return false;
-  }
-}
 
 let companionInstallations = 0;
 
@@ -400,14 +377,16 @@ export async function installCertifiedCompanion(
   };
   try {
     runtimeAllocation = Number(
-      exports.malloc(COMPANION_RUNTIME_BYTES + COMPANION_RUNTIME_ALIGN - 1),
+      exports.malloc(
+        COMPANION_KERNEL_RUNTIME_BYTES + COMPANION_KERNEL_RUNTIME_ALIGN - 1,
+      ),
     );
     // Rounded with arithmetic rather than a bitmask: pointers reach past what
     // a 32-bit bitwise operation can represent as the heap grows.
     const runtimePointer = runtimeAllocation === 0
       ? 0
-      : Math.ceil(runtimeAllocation / COMPANION_RUNTIME_ALIGN)
-        * COMPANION_RUNTIME_ALIGN;
+      : Math.ceil(runtimeAllocation / COMPANION_KERNEL_RUNTIME_ALIGN)
+        * COMPANION_KERNEL_RUNTIME_ALIGN;
     if (observeState) {
       snapshotPointer = Number(exports.malloc(COMPANION_SNAPSHOT_BYTES));
     }
@@ -460,8 +439,8 @@ export async function installCertifiedCompanion(
       {
         name: "runtime",
         pointer: runtimePointer,
-        size: COMPANION_RUNTIME_BYTES,
-        align: COMPANION_RUNTIME_ALIGN,
+        size: COMPANION_KERNEL_RUNTIME_BYTES,
+        align: COMPANION_KERNEL_RUNTIME_ALIGN,
       },
       ...(observeState
         ? [{ name: "snapshot", pointer: snapshotPointer, size: COMPANION_SNAPSHOT_BYTES, align: 4 }]
@@ -501,14 +480,13 @@ export async function installCertifiedCompanion(
       ...(travelInstallation === null ? [] : [travelInstallation.region()]),
     ];
     validateCompanionOwnedRegions(ownedRegions, memory.buffer.byteLength);
-    const runtimeEnd = runtimePointer + COMPANION_RUNTIME_BYTES;
     // A side module is normally loaded by Emscripten's dynamic linker, which
     // supplies zeroed BSS. We are the loader here, so establish that invariant
     // for this whole private block before its active data segment is applied.
     new Uint8Array(
       memory.buffer,
       runtimePointer,
-      COMPANION_RUNTIME_BYTES,
+      COMPANION_KERNEL_RUNTIME_BYTES,
     ).fill(0);
     new Uint32Array(
       memory.buffer,
@@ -518,122 +496,45 @@ export async function installCertifiedCompanion(
     storageInstallation?.initialize(memory);
     travelInstallation?.initialize();
 
-    const response = await fetch("companion-kernel.wasm");
-    if (!response.ok) throw new Error("Companion kernel is unavailable");
-    const kernelBytes = await response.arrayBuffer();
-    const kernelSha256 = [...new Uint8Array(
-      await crypto.subtle.digest("SHA-256", kernelBytes),
-    )].map((byte) => byte.toString(16).padStart(2, "0")).join("");
-    const kernelModule = await WebAssembly.compile(kernelBytes);
-    const imports = WebAssembly.Module.imports(kernelModule)
-      .map((entry) => `${entry.module}.${entry.name}:${entry.kind}`)
-      .sort();
-    if (JSON.stringify(imports) !== JSON.stringify(COMPANION_KERNEL_IMPORTS)) {
-      throw new Error("Companion kernel import surface is invalid");
-    }
-    const kernelExports = WebAssembly.Module.exports(kernelModule)
-      .map((entry) => `${entry.name}:${entry.kind}`)
-      .sort();
-    if (JSON.stringify(kernelExports) !== JSON.stringify(COMPANION_KERNEL_EXPORTS)) {
-      throw new Error("Companion kernel export surface is invalid");
-    }
-    const immutableI32 = (value: number) => new WebAssembly.Global(
-      { value: "i32", mutable: false },
-      value,
-    );
-    const kernel = await WebAssembly.instantiate(kernelModule, {
-      env: {
-        memory,
-        __indirect_function_table: new WebAssembly.Table({
-          initial: 0,
-          maximum: 0,
-          element: "anyfunc",
-        }),
-        __memory_base: immutableI32(runtimePointer),
-        __stack_pointer: new WebAssembly.Global(
-          { value: "i32", mutable: true },
-          runtimeEnd,
-        ),
-        __table_base: immutableI32(0),
+    const kernel = await installCompanionKernel({
+      memory,
+      runtimePointer,
+      featureFlags,
+      regions: {
+        snapshot: {
+          pointer: snapshotPointer,
+          bytes: observeState ? COMPANION_SNAPSHOT_BYTES : 0,
+        },
+        config: { pointer: configPointer, bytes: configBytes },
+        cursor: {
+          pointer: cursorPointer,
+          bytes: capabilities.nativeCursor ? COMPANION_CURSOR_BYTES : 0,
+        },
+        toolbox: {
+          pointer: toolboxPointer,
+          bytes: foundation ? COMPANION_TOOLBOX_BYTES : 0,
+        },
+        party: {
+          pointer: partyPointer,
+          bytes: foundation ? COMPANION_PARTY_BYTES : 0,
+        },
+        skillSlots: {
+          pointer: skillSlotGeometry.pointer,
+          bytes: skillSlotGeometry.bytes,
+        },
+        skillCooldowns: {
+          pointer: skillCooldowns.pointer,
+          bytes: skillCooldowns.bytes,
+        },
+        playRegion: {
+          pointer: playRegions.pointer,
+          bytes: playRegions.bytes,
+        },
       },
     });
-    if (!hasExactCompanionSignatures(kernel.exports)) {
-      throw new Error("Companion kernel export signatures are invalid");
-    }
-    type KernelInit = (
-      snapshotPointer: number,
-      snapshotBytes: number,
-      configPointer: number,
-      configBytes: number,
-      cursorPointer: number,
-      cursorBytes: number,
-      toolboxPointer: number,
-      toolboxBytes: number,
-      partyPointer: number,
-      partyBytes: number,
-      skillSlotPointer: number,
-      skillKeyBytes: number,
-      skillCooldownPointer: number,
-      skillCooldownBytes: number,
-      playRegionPointer: number,
-      playRegionBytes: number,
-      featureFlags: number,
-    ) => number;
-    type KernelDispatch = (
-      messageId: number,
-      wParam: number,
-      lParam: number,
-      cursorData: number,
-      cursorWidth: number,
-      cursorHeight: number,
-    ) => void;
-    type KernelScalar = () => number;
-    const kernelInit = kernel.exports.companion_init as KernelInit;
-    const kernelDispatch = kernel.exports.companion_dispatch as KernelDispatch;
-    const cursorEventCount = kernel.exports.companion_cursor_event_count as KernelScalar;
-    const kernelAbi = kernel.exports.companion_abi as KernelScalar;
-    const kernelConfigBytes = kernel.exports.companion_config_bytes as KernelScalar;
-    const kernelSnapshotBytes = kernel.exports.companion_snapshot_bytes as KernelScalar;
-    const kernelCursorBytes = kernel.exports.companion_cursor_bytes as KernelScalar;
-    const kernelToolboxBytes = kernel.exports.companion_toolbox_bytes as KernelScalar;
-    const kernelPartyBytes = kernel.exports.companion_party_bytes as KernelScalar;
-    const kernelSkillSlotBytes = kernel.exports.companion_skill_slot_bytes as KernelScalar;
-    const kernelSkillCooldownBytes =
-      kernel.exports.companion_skill_cooldown_bytes as KernelScalar;
-    const kernelPlayRegionBytes =
-      kernel.exports.companion_play_region_bytes as KernelScalar;
-    if (
-      kernelAbi() !== COMPANION_ABI
-      || kernelConfigBytes() !== configBytes
-      || kernelSnapshotBytes() !== COMPANION_SNAPSHOT_BYTES
-      || kernelCursorBytes() !== COMPANION_CURSOR_BYTES
-      || kernelToolboxBytes() !== COMPANION_TOOLBOX_BYTES
-      || kernelPartyBytes() !== COMPANION_PARTY_BYTES
-      || kernelSkillSlotBytes() !== COMPANION_SKILL_SLOT_BYTES
-      || kernelSkillCooldownBytes() !== COMPANION_SKILL_COOLDOWN_BYTES
-      || kernelPlayRegionBytes() !== COMPANION_PLAY_REGION_BYTES
-      || kernelInit(
-        snapshotPointer,
-        observeState ? COMPANION_SNAPSHOT_BYTES : 0,
-        configPointer,
-        configBytes,
-        cursorPointer,
-        capabilities.nativeCursor ? COMPANION_CURSOR_BYTES : 0,
-        toolboxPointer,
-        foundation ? COMPANION_TOOLBOX_BYTES : 0,
-        partyPointer,
-        foundation ? COMPANION_PARTY_BYTES : 0,
-        skillSlotGeometry.pointer,
-        skillSlotGeometry.bytes,
-        skillCooldowns.pointer,
-        skillCooldowns.bytes,
-        playRegions.pointer,
-        playRegions.bytes,
-        featureFlags,
-      ) !== 1
-    ) {
-      throw new Error("Companion kernel rejected its ABI");
-    }
+    const kernelSha256 = kernel.sha256;
+    const kernelDispatch = kernel.dispatch;
+    const cursorEventCount = kernel.cursorEventCount;
 
     let cursorRefreshes = 0;
     let hiddenRetry: HiddenCursorRetry | null = null;

--- a/src/renderer/companion-kernel-loader.ts
+++ b/src/renderer/companion-kernel-loader.ts
@@ -1,0 +1,251 @@
+/**
+ * Loads and verifies the fixed companion side module before it can receive
+ * pointers or become reachable from the game callback table.
+ *
+ * This is the complete executable-boundary check before caller-owned pointers
+ * are used: exact imports, exact
+ * exports, exact Wasm function signatures, fixed ABI/region sizes, and the
+ * side module's private aligned memory base. It initializes the verified
+ * kernel, but grants no feature policy and never publishes or enables a hook.
+ */
+import {
+  COMPANION_ABI,
+} from "../shared/companion-abi.js";
+import {
+  COMPANION_KERNEL_EXPORTS,
+  COMPANION_KERNEL_IMPORTS,
+  companionKernelSignatureBytes,
+} from "../shared/companion-kernel-contract.js";
+import { COMPANION_PLAY_REGION_BYTES } from "./companion-play-region-snapshot.js";
+import {
+  COMPANION_SKILL_COOLDOWN_BYTES,
+  COMPANION_SKILL_SLOT_BYTES,
+} from "./companion-skill-snapshot.js";
+import {
+  COMPANION_CURSOR_BYTES,
+  COMPANION_PARTY_BYTES,
+  COMPANION_SNAPSHOT_BYTES,
+  COMPANION_TOOLBOX_BYTES,
+} from "./companion-snapshot.js";
+import {
+  COMPANION_KERNEL_RUNTIME_ALIGN,
+  COMPANION_KERNEL_RUNTIME_BYTES,
+  validateCompanionOwnedRegions,
+} from "./companion-owned-regions.js";
+
+type CompanionKernelInit = (
+  snapshotPointer: number,
+  snapshotBytes: number,
+  configPointer: number,
+  configBytes: number,
+  cursorPointer: number,
+  cursorBytes: number,
+  toolboxPointer: number,
+  toolboxBytes: number,
+  partyPointer: number,
+  partyBytes: number,
+  skillSlotPointer: number,
+  skillSlotBytes: number,
+  skillCooldownPointer: number,
+  skillCooldownBytes: number,
+  playRegionPointer: number,
+  playRegionBytes: number,
+  featureFlags: number,
+) => number;
+
+type CompanionKernelDispatch = (
+  messageId: number,
+  wParam: number,
+  lParam: number,
+  cursorData: number,
+  cursorWidth: number,
+  cursorHeight: number,
+) => void;
+
+type LoadedCompanionKernel = Readonly<{
+  dispatch: CompanionKernelDispatch;
+  cursorEventCount: () => number;
+  sha256: string;
+}>;
+
+type KernelRegion = Readonly<{ pointer: number; bytes: number }>;
+type CompanionKernelRequest = Readonly<{
+  memory: WebAssembly.Memory;
+  runtimePointer: number;
+  featureFlags: number;
+  regions: Readonly<{
+    snapshot: KernelRegion;
+    config: KernelRegion;
+    cursor: KernelRegion;
+    toolbox: KernelRegion;
+    party: KernelRegion;
+    skillSlots: KernelRegion;
+    skillCooldowns: KernelRegion;
+    playRegion: KernelRegion;
+  }>;
+}>;
+
+const signatureModule = new WebAssembly.Module(companionKernelSignatureBytes());
+
+function exactSurface(
+  actual: readonly WebAssembly.ModuleImportDescriptor[]
+    | readonly WebAssembly.ModuleExportDescriptor[],
+  expected: readonly string[],
+): boolean {
+  const names = actual
+    .map((entry) => "module" in entry
+      ? `${entry.module}.${entry.name}:${entry.kind}`
+      : `${entry.name}:${entry.kind}`)
+    .sort();
+  return JSON.stringify(names) === JSON.stringify(expected);
+}
+
+function hasExactSignatures(exports: WebAssembly.Exports): boolean {
+  try {
+    new WebAssembly.Instance(signatureModule, { kernel: exports });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function runtimeEnd(request: CompanionKernelRequest): number {
+  const sharedRegions = Object.entries(request.regions)
+    .filter(([, region]) => region.bytes > 0)
+    .map(([name, region]) => ({
+      name,
+      pointer: region.pointer,
+      size: region.bytes,
+      align: 4,
+    }));
+  validateCompanionOwnedRegions([
+    {
+      name: "kernel runtime",
+      pointer: request.runtimePointer,
+      size: COMPANION_KERNEL_RUNTIME_BYTES,
+      align: COMPANION_KERNEL_RUNTIME_ALIGN,
+    },
+    ...sharedRegions,
+  ], request.memory.buffer.byteLength);
+  return request.runtimePointer + COMPANION_KERNEL_RUNTIME_BYTES;
+}
+
+type BoundCompanionKernel = Omit<LoadedCompanionKernel, "sha256">;
+
+/** Deterministic ABI binding kept separate so every positional word is tested. */
+function bindCompanionKernel(
+  exports: WebAssembly.Exports,
+  request: CompanionKernelRequest,
+): BoundCompanionKernel {
+  const companionAbi = exports.companion_abi as () => number;
+  const configBytes = exports.companion_config_bytes as () => number;
+  const snapshotBytes = exports.companion_snapshot_bytes as () => number;
+  const cursorBytes = exports.companion_cursor_bytes as () => number;
+  const toolboxBytes = exports.companion_toolbox_bytes as () => number;
+  const partyBytes = exports.companion_party_bytes as () => number;
+  const skillSlotBytes = exports.companion_skill_slot_bytes as () => number;
+  const skillCooldownBytes = exports.companion_skill_cooldown_bytes as () => number;
+  const playRegionBytes = exports.companion_play_region_bytes as () => number;
+  const { regions } = request;
+  if (
+    companionAbi() !== COMPANION_ABI.kernel
+    || configBytes() !== regions.config.bytes
+    || snapshotBytes() !== COMPANION_SNAPSHOT_BYTES
+    || cursorBytes() !== COMPANION_CURSOR_BYTES
+    || toolboxBytes() !== COMPANION_TOOLBOX_BYTES
+    || partyBytes() !== COMPANION_PARTY_BYTES
+    || skillSlotBytes() !== COMPANION_SKILL_SLOT_BYTES
+    || skillCooldownBytes() !== COMPANION_SKILL_COOLDOWN_BYTES
+    || playRegionBytes() !== COMPANION_PLAY_REGION_BYTES
+  ) {
+    throw new Error("Companion kernel rejected its ABI");
+  }
+  const init = exports.companion_init as CompanionKernelInit;
+  if (init(
+    regions.snapshot.pointer,
+    regions.snapshot.bytes,
+    regions.config.pointer,
+    regions.config.bytes,
+    regions.cursor.pointer,
+    regions.cursor.bytes,
+    regions.toolbox.pointer,
+    regions.toolbox.bytes,
+    regions.party.pointer,
+    regions.party.bytes,
+    regions.skillSlots.pointer,
+    regions.skillSlots.bytes,
+    regions.skillCooldowns.pointer,
+    regions.skillCooldowns.bytes,
+    regions.playRegion.pointer,
+    regions.playRegion.bytes,
+    request.featureFlags,
+  ) !== 1) {
+    throw new Error("Companion kernel rejected its ABI");
+  }
+  return Object.freeze({
+    dispatch: exports.companion_dispatch as CompanionKernelDispatch,
+    cursorEventCount: exports.companion_cursor_event_count as () => number,
+  });
+}
+
+export async function initializeCompanionKernelBytes(
+  kernelBytes: ArrayBuffer,
+  request: CompanionKernelRequest,
+): Promise<LoadedCompanionKernel> {
+  const { memory, runtimePointer } = request;
+  const runtimeStackEnd = runtimeEnd(request);
+  const kernelSha256 = [...new Uint8Array(
+    await crypto.subtle.digest("SHA-256", kernelBytes),
+  )]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+  const kernelModule = await WebAssembly.compile(kernelBytes);
+  if (!exactSurface(
+    WebAssembly.Module.imports(kernelModule),
+    COMPANION_KERNEL_IMPORTS,
+  )) {
+    throw new Error("Companion kernel import surface is invalid");
+  }
+  if (!exactSurface(
+    WebAssembly.Module.exports(kernelModule),
+    COMPANION_KERNEL_EXPORTS,
+  )) {
+    throw new Error("Companion kernel export surface is invalid");
+  }
+  const immutableI32 = (value: number) => new WebAssembly.Global(
+    { value: "i32", mutable: false },
+    value,
+  );
+  const instance = await WebAssembly.instantiate(kernelModule, {
+    env: {
+      memory,
+      __indirect_function_table: new WebAssembly.Table({
+        initial: 0,
+        maximum: 0,
+        element: "anyfunc",
+      }),
+      __memory_base: immutableI32(runtimePointer),
+      __stack_pointer: new WebAssembly.Global(
+        { value: "i32", mutable: true },
+        runtimeStackEnd,
+      ),
+      __table_base: immutableI32(0),
+    },
+  });
+  if (!hasExactSignatures(instance.exports)) {
+    throw new Error("Companion kernel export signatures are invalid");
+  }
+  const bound = bindCompanionKernel(instance.exports, request);
+  return Object.freeze({
+    ...bound,
+    sha256: kernelSha256,
+  });
+}
+
+export async function installCompanionKernel(
+  request: CompanionKernelRequest,
+): Promise<LoadedCompanionKernel> {
+  const response = await fetch("companion-kernel.wasm");
+  if (!response.ok) throw new Error("Companion kernel is unavailable");
+  return initializeCompanionKernelBytes(await response.arrayBuffer(), request);
+}

--- a/src/renderer/companion-owned-regions.ts
+++ b/src/renderer/companion-owned-regions.ts
@@ -9,6 +9,9 @@ export type CompanionOwnedRegion = Readonly<{
   align: number;
 }>;
 
+export const COMPANION_KERNEL_RUNTIME_BYTES = 65_536;
+export const COMPANION_KERNEL_RUNTIME_ALIGN = 16;
+
 export function validateCompanionOwnedRegions(
   regions: readonly CompanionOwnedRegion[],
   heapBytes: number,

--- a/tests/helpers/companion-kernel-fixture.ts
+++ b/tests/helpers/companion-kernel-fixture.ts
@@ -1,0 +1,174 @@
+/**
+ * Builds the smallest companion side module that exercises the exact runtime
+ * and release contract. Mutations stay explicit so both gates share one
+ * adversarial fixture vocabulary.
+ */
+import {
+  COMPANION_KERNEL_DYLINK0,
+  COMPANION_KERNEL_EXPORT_VALUES,
+} from "../../scripts/companion-kernel-contract.mjs";
+import { COMPANION_KERNEL_SIGNATURES } from "../../src/shared/companion-kernel-contract.ts";
+
+export interface CompanionKernelFixtureOptions {
+  readonly start?: boolean;
+  readonly wrongDylink?: boolean;
+  readonly extraImport?: boolean;
+  readonly missingImport?: boolean;
+  readonly extraExport?: boolean;
+  readonly missingExport?: boolean;
+  readonly outOfFootprintData?: boolean;
+  readonly wrongSignature?: boolean;
+  readonly initResult?: number;
+  readonly cursorEventCount?: number;
+  readonly expectedInitArguments?: readonly number[];
+  readonly exportValueOverrides?: Readonly<Partial<
+    Record<keyof typeof COMPANION_KERNEL_EXPORT_VALUES, number>
+  >>;
+}
+
+function uleb(value: number): number[] {
+  const bytes: number[] = [];
+  do {
+    let byte = value & 0x7f;
+    value = Math.floor(value / 0x80);
+    if (value !== 0) byte |= 0x80;
+    bytes.push(byte);
+  } while (value !== 0);
+  return bytes;
+}
+
+function sleb(value: number): number[] {
+  const bytes: number[] = [];
+  let remaining = value;
+  for (;;) {
+    const byte = remaining & 0x7f;
+    remaining >>= 7;
+    const sign = (byte & 0x40) !== 0;
+    if ((remaining === 0 && !sign) || (remaining === -1 && sign)) {
+      bytes.push(byte);
+      return bytes;
+    }
+    bytes.push(byte | 0x80);
+  }
+}
+
+function name(value: string): number[] {
+  const bytes = new TextEncoder().encode(value);
+  return [...uleb(bytes.byteLength), ...bytes];
+}
+
+function section(id: number, body: readonly number[]): number[] {
+  return [id, ...uleb(body.length), ...body];
+}
+
+function functionType(params: number, result: boolean): number[] {
+  return [
+    0x60,
+    ...uleb(params),
+    ...Array.from({ length: params }, () => 0x7f),
+    ...(result ? [1, 0x7f] : [0]),
+  ];
+}
+
+function importEntry(
+  field: string,
+  kind: number,
+  descriptor: readonly number[],
+): number[] {
+  return [...name("env"), ...name(field), kind, ...descriptor];
+}
+
+export function companionKernelFixture(
+  options: CompanionKernelFixtureOptions = {},
+): Uint8Array<ArrayBuffer> {
+  const signatures = COMPANION_KERNEL_SIGNATURES.map(
+    ({ name: exportName, typeIndex }, functionIndex) => ({
+      exportName,
+      typeIndex,
+      functionIndex,
+    }),
+  );
+  const startFunction = signatures.length;
+  const types = [
+    functionType(17, true),
+    functionType(6, false),
+    functionType(0, true),
+    functionType(0, false),
+  ];
+  const dylink = [...COMPANION_KERNEL_DYLINK0];
+  if (options.wrongDylink) dylink[2] = (dylink[2] ?? 0) ^ 1;
+  const canonicalImports = [
+    importEntry("__indirect_function_table", 1, [0x70, 0, 0]),
+    importEntry("__memory_base", 3, [0x7f, 0]),
+    importEntry("__stack_pointer", 3, [0x7f, 1]),
+    importEntry("__table_base", 3, [0x7f, 0]),
+    importEntry("memory", 2, [0, 1]),
+  ];
+  const imports = [
+    ...(options.missingImport ? canonicalImports.slice(1) : canonicalImports),
+    ...(options.extraImport
+      ? [importEntry("unexpected", 3, [0x7f, 0])]
+      : []),
+  ];
+  const functionTypes = signatures.map(({ typeIndex }) => typeIndex);
+  if (options.wrongSignature) functionTypes[0] = 2;
+  if (options.start) functionTypes.push(3);
+  const canonicalExports = signatures.map(({ exportName, functionIndex }) => [
+    ...name(exportName),
+    0,
+    ...uleb(functionIndex),
+  ]);
+  const exports = options.missingExport
+    ? canonicalExports.slice(1)
+    : canonicalExports;
+  if (options.extraExport) {
+    exports.push([...name("unexpected"), 0, ...uleb(0)]);
+  }
+  const bodies = signatures.map(({ exportName, typeIndex }) => {
+    if (typeIndex === 1) return [0, 0x0b];
+    if (
+      exportName === "companion_init"
+      && options.expectedInitArguments !== undefined
+    ) {
+      if (options.expectedInitArguments.length !== 17) {
+        throw new Error("companion fixture init expectation must have 17 words");
+      }
+      const comparisons = options.expectedInitArguments.flatMap(
+        (value, index) => [
+          0x20, ...uleb(index),
+          0x41, ...sleb(value),
+          0x46,
+          ...(index === 0 ? [] : [0x71]),
+        ],
+      );
+      return [0, ...comparisons, 0x0b];
+    }
+    const value = exportName === "companion_init"
+      ? (options.initResult ?? 1)
+      : exportName === "companion_cursor_event_count"
+        ? (options.cursorEventCount ?? 23)
+        : options.exportValueOverrides?.[
+          exportName as keyof typeof COMPANION_KERNEL_EXPORT_VALUES
+        ] ?? COMPANION_KERNEL_EXPORT_VALUES[
+          exportName as keyof typeof COMPANION_KERNEL_EXPORT_VALUES
+        ];
+    return [0, 0x41, ...sleb(value), 0x0b];
+  });
+  if (options.start) bodies.push([0, 0x0b]);
+  return Uint8Array.from([
+    0, 97, 115, 109, 1, 0, 0, 0,
+    ...section(0, [...name("dylink.0"), ...dylink]),
+    ...section(1, [...uleb(types.length), ...types.flat()]),
+    ...section(2, [...uleb(imports.length), ...imports.flat()]),
+    ...section(3, [...uleb(functionTypes.length), ...functionTypes]),
+    ...section(7, [...uleb(exports.length), ...exports.flat()]),
+    ...(options.start ? section(8, uleb(startFunction)) : []),
+    ...section(10, [
+      ...uleb(bodies.length),
+      ...bodies.flatMap((body) => [...uleb(body.length), ...body]),
+    ]),
+    ...(options.outOfFootprintData
+      ? section(11, [1, 0, 0x41, 0, 0x0b, 1, 0xa5])
+      : []),
+  ]);
+}

--- a/tests/helpers/packaged-enhancement-scenarios.ts
+++ b/tests/helpers/packaged-enhancement-scenarios.ts
@@ -349,7 +349,7 @@ export async function assertTargetReadoutLifecycle() {
 }
 
 export async function assertCleanupSafetyGates() {
-  for (const gate of ["observer", "callback", "hook"] as const) {
+  for (const gate of ["observer", "cursor-refresh", "callback", "hook"] as const) {
     const fixture = await launchPackaged(`gw-packaged-cleanup-${gate}-`, {});
     try {
       const pageErrors: string[] = [];
@@ -358,7 +358,7 @@ export async function assertCleanupSafetyGates() {
         const { Module } = globalThis as PageGlobals;
         return typeof Module?.socket?.connect === "function";
       });
-      if (gate === "hook") {
+      if (gate === "hook" || gate === "cursor-refresh") {
         await fixture.page.evaluate(async () => {
           const surfaceSpecifier = "./surface-controller.js";
           const { installSurfaceController }:
@@ -380,9 +380,13 @@ export async function assertCleanupSafetyGates() {
       await installTargetReadout(
         fixture.page,
         installableManifestModule(
-          gate === "hook" ? TOOLBOX_PROGRAM_CAPABILITIES : TARGET_ONLY,
+          gate === "hook" || gate === "cursor-refresh"
+            ? TOOLBOX_PROGRAM_CAPABILITIES
+            : TARGET_ONLY,
         ),
-        gate === "hook" ? TOOLBOX_PROGRAM_CAPABILITIES : TARGET_ONLY,
+        gate === "hook" || gate === "cursor-refresh"
+          ? TOOLBOX_PROGRAM_CAPABILITIES
+          : TARGET_ONLY,
       );
       const result = await fixture.page.evaluate((failureGate) => {
         const probe = (globalThis as ReadoutPageGlobals).__targetReadoutFixture;
@@ -400,6 +404,7 @@ export async function assertCleanupSafetyGates() {
           consoleError(message, detail);
         };
         const cancelFrame = globalThis.cancelAnimationFrame;
+        const removeEventListener = globalThis.removeEventListener;
         if (failureGate === "hook") {
           const globalValue = Object.getOwnPropertyDescriptor(
             WebAssembly.Global.prototype,
@@ -426,6 +431,17 @@ export async function assertCleanupSafetyGates() {
           globalThis.cancelAnimationFrame = () => {
             throw new Error("intentional observer stop failure");
           };
+        } else if (failureGate === "cursor-refresh") {
+          globalThis.removeEventListener = ((
+            type: string,
+            listener: EventListenerOrEventListenerObject,
+            options?: boolean | EventListenerOptions,
+          ) => {
+            if (type === "mousedown") {
+              throw new Error("intentional cursor refresh disposal failure");
+            }
+            removeEventListener.call(globalThis, type, listener, options);
+          }) as typeof globalThis.removeEventListener;
         } else {
           const setTable = probe.table.set.bind(probe.table);
           probe.table.set = ((index: number, value: CallableFunction | null) => {
@@ -439,6 +455,7 @@ export async function assertCleanupSafetyGates() {
           dispatchEvent(new Event("pagehide"));
         } finally {
           globalThis.cancelAnimationFrame = cancelFrame;
+          globalThis.removeEventListener = removeEventListener;
           console.error = consoleError;
         }
         return {
@@ -449,6 +466,7 @@ export async function assertCleanupSafetyGates() {
           reports,
           runtimeStatus: window.gwCompanionRuntime?.status ?? null,
           runtimeRetained: window.gwCompanionRuntime === probe.runtime,
+          runtimeMemoryFreed: probe.freed.includes(probe.allocations[0]!.pointer),
           tableEmpty: probe.table.get(probe.table.length - 1) === null,
           toolboxCount: document.querySelectorAll("#toolbox-foundation").length,
         };
@@ -463,9 +481,22 @@ export async function assertCleanupSafetyGates() {
           reports: [["Companion cleanup failed during observer disposal"]],
           runtimeStatus: null,
           runtimeRetained: false,
+          runtimeMemoryFreed: true,
           tableEmpty: true,
           toolboxCount: 0,
         });
+      } else if (gate === "cursor-refresh") {
+        assert.equal(result.cursorStatePublished, false);
+        assert.equal(result.hook, 0);
+        assert.equal(result.readoutCount, 0);
+        assert.deepEqual(result.reports, [[
+          "Companion cleanup failed during cursor refresh disposal",
+        ]]);
+        assert.equal(result.runtimeStatus, null);
+        assert.equal(result.runtimeRetained, false);
+        assert.equal(result.runtimeMemoryFreed, false);
+        assert.equal(result.tableEmpty, true);
+        assert.equal(result.toolboxCount, 0);
       } else if (gate === "callback") {
         assert.deepEqual(result, {
           cursorStatePublished: false,
@@ -475,6 +506,7 @@ export async function assertCleanupSafetyGates() {
           reports: [["Companion cleanup failed during callback withdrawal"]],
           runtimeStatus: null,
           runtimeRetained: false,
+          runtimeMemoryFreed: false,
           tableEmpty: false,
           toolboxCount: 0,
         });
@@ -487,6 +519,7 @@ export async function assertCleanupSafetyGates() {
           reports: [["Companion cleanup could not disable dispatch"]],
           runtimeStatus: "installed",
           runtimeRetained: true,
+          runtimeMemoryFreed: false,
           tableEmpty: false,
           toolboxCount: 1,
         });

--- a/tests/unit/companion-kernel-loader.test.ts
+++ b/tests/unit/companion-kernel-loader.test.ts
@@ -1,0 +1,148 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { initializeCompanionKernelBytes } from "../../src/renderer/companion-kernel-loader.ts";
+import { ENHANCEMENT_CONFIG_WORD_COUNT } from "../../src/shared/enhancement-contracts.ts";
+import { COMPANION_PLAY_REGION_BYTES } from "../../src/renderer/companion-play-region-snapshot.ts";
+import {
+  COMPANION_SKILL_COOLDOWN_BYTES,
+  COMPANION_SKILL_SLOT_BYTES,
+} from "../../src/renderer/companion-skill-snapshot.ts";
+import {
+  COMPANION_CURSOR_BYTES,
+  COMPANION_PARTY_BYTES,
+  COMPANION_SNAPSHOT_BYTES,
+  COMPANION_TOOLBOX_BYTES,
+} from "../../src/renderer/companion-snapshot.ts";
+import { COMPANION_KERNEL_EXPORT_VALUES } from "../../scripts/companion-kernel-contract.mjs";
+import { companionKernelFixture } from "../helpers/companion-kernel-fixture.ts";
+
+const CONFIG_BYTES = ENHANCEMENT_CONFIG_WORD_COUNT * 4;
+const FEATURE_FLAGS = 999;
+
+function request() {
+  return {
+    memory: new WebAssembly.Memory({ initial: 10 }),
+    runtimePointer: 524_288,
+    featureFlags: FEATURE_FLAGS,
+    regions: {
+      snapshot: { pointer: 65_536, bytes: COMPANION_SNAPSHOT_BYTES },
+      config: { pointer: 131_072, bytes: CONFIG_BYTES },
+      cursor: { pointer: 196_608, bytes: COMPANION_CURSOR_BYTES },
+      toolbox: { pointer: 262_144, bytes: COMPANION_TOOLBOX_BYTES },
+      party: { pointer: 327_680, bytes: COMPANION_PARTY_BYTES },
+      skillSlots: { pointer: 393_216, bytes: COMPANION_SKILL_SLOT_BYTES },
+      skillCooldowns: { pointer: 409_600, bytes: COMPANION_SKILL_COOLDOWN_BYTES },
+      playRegion: { pointer: 425_984, bytes: COMPANION_PLAY_REGION_BYTES },
+    },
+  } as const;
+}
+
+function initArguments(): readonly number[] {
+  return [
+    65_536, COMPANION_SNAPSHOT_BYTES,
+    131_072, CONFIG_BYTES,
+    196_608, COMPANION_CURSOR_BYTES,
+    262_144, COMPANION_TOOLBOX_BYTES,
+    327_680, COMPANION_PARTY_BYTES,
+    393_216, COMPANION_SKILL_SLOT_BYTES,
+    409_600, COMPANION_SKILL_COOLDOWN_BYTES,
+    425_984, COMPANION_PLAY_REGION_BYTES,
+    FEATURE_FLAGS,
+  ];
+}
+
+async function sha256(bytes: Uint8Array<ArrayBuffer>): Promise<string> {
+  return [...new Uint8Array(await crypto.subtle.digest("SHA-256", bytes))]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+describe("companion kernel loader", () => {
+  it("verifies, initializes, and projects only the canonical kernel", async () => {
+    const bytes = companionKernelFixture({
+      expectedInitArguments: initArguments(),
+      cursorEventCount: 23,
+    });
+
+    const kernel = await initializeCompanionKernelBytes(bytes.buffer, request());
+
+    assert.equal(kernel.sha256, await sha256(bytes));
+    assert.equal(kernel.cursorEventCount(), 23);
+    assert.doesNotThrow(() => kernel.dispatch(1, 2, 3, 4, 5, 6));
+  });
+
+  it("refuses extra and missing imports and exports", async () => {
+    for (const [options, refusal] of [
+      [{ extraImport: true }, /import surface is invalid/],
+      [{ missingImport: true }, /import surface is invalid/],
+      [{ extraExport: true }, /export surface is invalid/],
+      [{ missingExport: true }, /export surface is invalid/],
+    ] as const) {
+      await assert.rejects(
+        initializeCompanionKernelBytes(
+          companionKernelFixture(options).buffer,
+          request(),
+        ),
+        refusal,
+      );
+    }
+  });
+
+  it("refuses a canonical name with the wrong function signature", async () => {
+    await assert.rejects(
+      initializeCompanionKernelBytes(
+        companionKernelFixture({ wrongSignature: true }).buffer,
+        request(),
+      ),
+      /export signatures are invalid/,
+    );
+  });
+
+  it("refuses every mismatched ABI scalar", async () => {
+    const scalarNames = Object.keys(
+      COMPANION_KERNEL_EXPORT_VALUES,
+    ) as (keyof typeof COMPANION_KERNEL_EXPORT_VALUES)[];
+    for (const scalarName of scalarNames) {
+      await assert.rejects(
+        initializeCompanionKernelBytes(
+          companionKernelFixture({
+            exportValueOverrides: { [scalarName]: -1 },
+          }).buffer,
+          request(),
+        ),
+        /rejected its ABI/,
+        scalarName,
+      );
+    }
+  });
+
+  it("does not expose dispatch authority when initialization refuses", async () => {
+    await assert.rejects(
+      initializeCompanionKernelBytes(
+        companionKernelFixture({ initResult: 0 }).buffer,
+        request(),
+      ),
+      /rejected its ABI/,
+    );
+  });
+
+  it("uses the canonical allocation validator before compilation", async () => {
+    await assert.rejects(
+      initializeCompanionKernelBytes(new ArrayBuffer(0), {
+        ...request(),
+        runtimePointer: 524_289,
+      }),
+      /not 16-byte aligned/,
+    );
+    await assert.rejects(
+      initializeCompanionKernelBytes(new ArrayBuffer(0), {
+        ...request(),
+        regions: {
+          ...request().regions,
+          config: { pointer: 524_288, bytes: CONFIG_BYTES },
+        },
+      }),
+      /kernel runtime\/config allocations overlap/,
+    );
+  });
+});

--- a/tests/unit/companion-kernel-seal.test.ts
+++ b/tests/unit/companion-kernel-seal.test.ts
@@ -10,7 +10,6 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { after, describe, it } from "node:test";
 import {
-  COMPANION_KERNEL_DYLINK0,
   COMPANION_KERNEL_EXPORT_VALUES,
   COMPANION_KERNEL_IMPORTS,
   COMPANION_KERNEL_SIGNATURES,
@@ -29,122 +28,14 @@ import {
   COMPANION_KERNEL_HASH_PLACEHOLDER,
   companionKernelSha256,
   sealCompanionKernelBuild,
-  verifySealedCompanionRenderer,
+  verifySealedCompanionLoader,
 } from "../../scripts/seal-companion-kernel.mjs";
-
-interface FixtureOptions {
-  readonly start?: boolean;
-  readonly wrongDylink?: boolean;
-  readonly extraImport?: boolean;
-  readonly extraExport?: boolean;
-  readonly outOfFootprintData?: boolean;
-  readonly wrongSignature?: boolean;
-}
+import { companionKernelFixture } from "../helpers/companion-kernel-fixture.ts";
 
 const roots: string[] = [];
 after(() => {
   for (const root of roots) rmSync(root, { recursive: true, force: true });
 });
-
-function uleb(value: number): number[] {
-  const bytes: number[] = [];
-  do {
-    let byte = value & 0x7f;
-    value = Math.floor(value / 0x80);
-    if (value !== 0) byte |= 0x80;
-    bytes.push(byte);
-  } while (value !== 0);
-  return bytes;
-}
-
-function name(value: string): number[] {
-  const bytes = new TextEncoder().encode(value);
-  return [...uleb(bytes.byteLength), ...bytes];
-}
-
-function section(id: number, body: readonly number[]): number[] {
-  return [id, ...uleb(body.length), ...body];
-}
-
-function functionType(params: number, result: boolean): number[] {
-  return [
-    0x60,
-    ...uleb(params),
-    ...Array.from({ length: params }, () => 0x7f),
-    ...(result ? [1, 0x7f] : [0]),
-  ];
-}
-
-function importEntry(
-  field: string,
-  kind: number,
-  descriptor: readonly number[],
-): number[] {
-  return [...name("env"), ...name(field), kind, ...descriptor];
-}
-
-function fixture(options: FixtureOptions = {}): Uint8Array<ArrayBuffer> {
-  const signatures = COMPANION_KERNEL_SIGNATURES.map(
-    ({ name: exportName, typeIndex }, functionIndex) => ({
-      exportName,
-      typeIndex,
-      functionIndex,
-    }),
-  );
-  const startFunction = signatures.length;
-  const types = [
-    // companion_init: eight region pointer/size pairs plus the feature word.
-    functionType(17, true),
-    functionType(6, false),
-    functionType(0, true),
-    functionType(0, false),
-  ];
-  const dylink = [...COMPANION_KERNEL_DYLINK0];
-  if (options.wrongDylink) dylink[2] = (dylink[2] ?? 0) ^ 1;
-  const imports = [
-    importEntry("__indirect_function_table", 1, [0x70, 0, 0]),
-    importEntry("__memory_base", 3, [0x7f, 0]),
-    importEntry("__stack_pointer", 3, [0x7f, 1]),
-    importEntry("__table_base", 3, [0x7f, 0]),
-    importEntry("memory", 2, [0, 1]),
-    ...(options.extraImport
-      ? [importEntry("unexpected", 3, [0x7f, 0])]
-      : []),
-  ];
-  const functionTypes = signatures.map(({ typeIndex }) => typeIndex);
-  if (options.wrongSignature) functionTypes[0] = 2;
-  if (options.start) functionTypes.push(3);
-  const exports = signatures.map(({ exportName, functionIndex }) => [
-    ...name(exportName),
-    0,
-    ...uleb(functionIndex),
-  ]);
-  if (options.extraExport) {
-    exports.push([...name("unexpected"), 0, ...uleb(0)]);
-  }
-  const bodies = signatures.map(({ typeIndex }) =>
-    typeIndex === 1
-      ? [0, 0x0b]
-      : [0, 0x41, 0, 0x0b],
-  );
-  if (options.start) bodies.push([0, 0x0b]);
-  return Uint8Array.from([
-    0, 97, 115, 109, 1, 0, 0, 0,
-    ...section(0, [...name("dylink.0"), ...dylink]),
-    ...section(1, [...uleb(types.length), ...types.flat()]),
-    ...section(2, [...uleb(imports.length), ...imports.flat()]),
-    ...section(3, [...uleb(functionTypes.length), ...functionTypes]),
-    ...section(7, [...uleb(exports.length), ...exports.flat()]),
-    ...(options.start ? section(8, uleb(startFunction)) : []),
-    ...section(10, [
-      ...uleb(bodies.length),
-      ...bodies.flatMap((body) => [...uleb(body.length), ...body]),
-    ]),
-    ...(options.outOfFootprintData
-      ? section(11, [1, 0, 0x41, 0, 0x0b, 1, 0xa5])
-      : []),
-  ]);
-}
 
 function workspace(): {
   readonly root: string;
@@ -196,7 +87,7 @@ describe("companion kernel build contract", () => {
   });
 
   it("accepts exactly the fixed side-module surface", () => {
-    const bytes = fixture();
+    const bytes = companionKernelFixture();
     assert.equal(WebAssembly.validate(bytes), true);
     assert.doesNotThrow(() => validateCompanionKernelContract(bytes));
   });
@@ -206,13 +97,13 @@ describe("companion kernel build contract", () => {
       () => validateCompanionKernelContract(Uint8Array.of(0, 1, 2)),
       /invalid WebAssembly/,
     );
-    const start = fixture({ start: true });
+    const start = companionKernelFixture({ start: true });
     assert.equal(WebAssembly.validate(start), true);
     assert.throws(
       () => validateCompanionKernelContract(start),
       /must not contain a start function/,
     );
-    const dylink = fixture({ wrongDylink: true });
+    const dylink = companionKernelFixture({ wrongDylink: true });
     assert.equal(WebAssembly.validate(dylink), true);
     assert.throws(
       () => validateCompanionKernelContract(dylink),
@@ -222,17 +113,17 @@ describe("companion kernel build contract", () => {
 
   it("rejects extra imports and exports rather than allow-listing by prefix", () => {
     assert.throws(
-      () => validateCompanionKernelContract(fixture({ extraImport: true })),
+      () => validateCompanionKernelContract(companionKernelFixture({ extraImport: true })),
       /import surface is invalid/,
     );
     assert.throws(
-      () => validateCompanionKernelContract(fixture({ extraExport: true })),
+      () => validateCompanionKernelContract(companionKernelFixture({ extraExport: true })),
       /export surface is invalid/,
     );
   });
 
   it("rejects a named export with the wrong exact function type", () => {
-    const bytes = fixture({ wrongSignature: true });
+    const bytes = companionKernelFixture({ wrongSignature: true });
     assert.equal(WebAssembly.validate(bytes), true);
     assert.throws(
       () => validateCompanionKernelContract(bytes),
@@ -272,7 +163,7 @@ describe("companion kernel build contract", () => {
   });
 
   it("rejects active data writes outside the declared private footprint", () => {
-    const bytes = fixture({ outOfFootprintData: true });
+    const bytes = companionKernelFixture({ outOfFootprintData: true });
     assert.equal(WebAssembly.validate(bytes), true);
     assert.throws(
       () => validateCompanionKernelContract(bytes),
@@ -284,21 +175,21 @@ describe("companion kernel build contract", () => {
 describe("companion kernel build seal", () => {
   it("publishes validated bytes and checks their sealed hash before compile", () => {
     const files = workspace();
-    const bytes = fixture();
+    const bytes = companionKernelFixture();
     writeFileSync(files.candidate, bytes);
     writeFileSync(files.renderer, rendererSource);
 
     const sha256 = sealCompanionKernelBuild({
       candidatePath: files.candidate,
       artifactPath: files.artifact,
-      rendererPath: files.renderer,
+      loaderPath: files.renderer,
     });
 
     assert.equal(existsSync(files.candidate), false);
     assert.deepEqual(new Uint8Array(readFileSync(files.artifact)), bytes);
     assert.equal(sha256, companionKernelSha256(bytes));
     const renderer = readFileSync(files.renderer, "utf8");
-    verifySealedCompanionRenderer(renderer, sha256);
+    verifySealedCompanionLoader(renderer, sha256);
     assert.match(
       renderer,
       new RegExp(`const ${COMPANION_KERNEL_HASH_BINDING} = "${sha256}";`),
@@ -320,7 +211,7 @@ describe("companion kernel build seal", () => {
       () => sealCompanionKernelBuild({
         candidatePath: files.candidate,
         artifactPath: files.artifact,
-        rendererPath: files.renderer,
+        loaderPath: files.renderer,
       }),
       /invalid WebAssembly/,
     );
@@ -330,7 +221,7 @@ describe("companion kernel build seal", () => {
 
   it("removes the artifact and restores the renderer if final publication fails", () => {
     const files = workspace();
-    const bytes = fixture();
+    const bytes = companionKernelFixture();
     const unavailableArtifact = path.join(
       files.root,
       "missing",
@@ -343,7 +234,7 @@ describe("companion kernel build seal", () => {
       () => sealCompanionKernelBuild({
         candidatePath: files.candidate,
         artifactPath: unavailableArtifact,
-        rendererPath: files.renderer,
+        loaderPath: files.renderer,
       }),
       /ENOENT/,
     );


### PR DESCRIPTION
## What changed

The companion installer no longer mixes UI lifecycle work with WebAssembly trust checks. A focused loader now owns the kernel fetch, sealed SHA-256 check, exact import/export/signature verification, canonical memory validation, ABI scalar checks, initialization, and the narrow dispatch projection.

The release sealer and verifier now target that loader directly. Runtime and release tests share one deterministic Wasm fixture, so they exercise the same contract and adversarial mutations.

## Why

The installer had become the owner of allocation, policy, presentation, observation, rollback, and executable verification in one file. That made the most security-sensitive boundary difficult to review and easy to weaken while changing unrelated UI behavior.

This layer extracts one concrete boundary without adding a plugin registry or generic lifecycle framework. The installer still owns activation, policy, publication, and rollback.

## Invariant

No companion bytes can initialize or expose dispatch authority unless all of these checks pass first:

- the runtime and every non-empty shared region are aligned, in bounds, signed-32-bit safe, and non-overlapping;
- the module has the exact reviewed import and export surfaces;
- every exported function has the exact Wasm signature;
- every ABI and region-size scalar matches the canonical contract;
- all eight pointer/size pairs and the feature word are accepted in the fixed 17-word order; and
- the fetched bytes match the build-sealed SHA-256 before compilation.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `node scripts/verify-companion-kernel.mjs`
- `pnpm test:unit` — 1,229 passed
- `pnpm test:policy` — 174 passed
- `pnpm test:integration` — 66 passed
- `pnpm test:release` — 25 passed
- `pnpm tools:test` — 102 passed
- `pnpm check:links`
- Independent maintainability, runtime/security, and certification reviews: no remaining findings

Electron/E2E tests were intentionally not run locally. GitHub CI owns those checks.

- [x] I kept this pull request focused.
- [x] I ran the relevant checks.
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [x] I updated contract comments and release tooling where the invariant changed.
