### PR TITLE
refactor(tools): own companion core memory

### DIFF
--- a/src/renderer/certified-companion-installation.ts
+++ b/src/renderer/certified-companion-installation.ts
@@ -26,17 +26,11 @@ import {
 } from "./cursor-refresh.js";
 import { createToolboxLifecycle } from "./toolbox-foundation.js";
 import {
-  COMPANION_CURSOR_BYTES,
-  COMPANION_SNAPSHOT_BYTES,
-  COMPANION_TOOLBOX_BYTES,
-  COMPANION_PARTY_BYTES,
   type CompanionSnapshot,
 } from "./companion-snapshot.js";
 import { createPlayRegionObservationInstallation } from "./play-region-state-installation.js";
 import { createSkillOverlaysInstallation } from "./skill-overlays-installation.js";
 import {
-  COMPANION_KERNEL_RUNTIME_ALIGN,
-  COMPANION_KERNEL_RUNTIME_BYTES,
   validateCompanionOwnedRegions,
 } from "./companion-owned-regions.js";
 import {
@@ -61,13 +55,13 @@ import {
   COMPANION_FEATURE_BITS,
 } from "../shared/companion-abi.js";
 import { installCompanionKernel } from "./companion-kernel-loader.js";
+import { allocateCompanionCoreMemory } from "./companion-core-memory-installation.js";
 import {
   enhancementRuntimePolicy,
   type RuntimePlayRegion,
 } from "./enhancement-runtime-policy.js";
 import {
   createProfessionCommandTrace,
-  PROFESSION_COMMAND_TRACE_BYTES,
   type ProfessionCommandTraceReader,
 } from "./profession-command-trace.js";
 
@@ -201,8 +195,8 @@ export async function installCertifiedCompanion(
     throw new Error("the aliases profile derived a module with no Trade Chat toggle");
   }
   // The guard above proves `free` is callable, but WebAssembly exports are typed
-  // as the bare `Function`, so the kernel's ABI has to be named here or the five
-  // call sites below stop checking what they pass.
+  // as the bare `Function`. Name its ABI before handing it to the allocation
+  // owners and the cleanup transaction.
   const free = exports.free as (pointer: number) => void;
   if (manifest.tableSlot >= table.length) {
     throw new Error(`Enhancement table slot ${manifest.tableSlot} is out of bounds`);
@@ -220,16 +214,7 @@ export async function installCertifiedCompanion(
     throw new Error("Enhancement hook global is immutable");
   }
 
-  let snapshotPointer = 0;
-  let configPointer = 0;
-  let cursorPointer = 0;
-  let toolboxPointer = 0;
-  let partyPointer = 0;
-  let payloadPointer = 0;
-  let professionTracePointer = 0;
-  // What malloc returned, which is what free must be given. The aligned base
-  // used by the module lives inside it and is not a valid argument to free.
-  let runtimeAllocation = 0;
+  let coreMemory: ReturnType<typeof allocateCompanionCoreMemory> | null = null;
   let stopObserver = () => {};
   let disposeCursor = () => {};
   let disposeReadout = () => {};
@@ -310,40 +295,18 @@ export async function installCertifiedCompanion(
     });
     if (callbackWithdrawn) {
       if (observerStopped) {
-        attempt("Toolbox allocation release", () => {
-          if (toolboxPointer) free(toolboxPointer);
-        });
-        attempt("party allocation release", () => {
-          if (partyPointer) free(partyPointer);
+        attempt("core observer memory release", () => {
+          coreMemory?.releaseObserverMemory();
         });
         attempt("skill-slot allocation release", () => skillSlotGeometry.release(free));
         attempt("skill cooldown allocation release", () => skillCooldowns.release(free));
         attempt("play-region allocation release", () => playRegions.release(free));
       }
-      attempt("command payload release", () => {
-        if (payloadPointer) free(payloadPointer);
-      });
       attempt("storage disposal", () => storageInstallation?.dispose(free));
       attempt("Travel disposal", () => travelInstallation?.dispose(free));
-      if (observerStopped) {
-        attempt("profession trace allocation release", () => {
-          if (professionTracePointer) free(professionTracePointer);
-        });
-        attempt("cursor allocation release", () => {
-          if (cursorPointer) free(cursorPointer);
-        });
-      }
-      attempt("configuration allocation release", () => {
-        if (configPointer) free(configPointer);
-      });
-      if (observerStopped) {
-        attempt("snapshot allocation release", () => {
-          if (snapshotPointer) free(snapshotPointer);
-        });
-      }
       if (cursorRefreshDisposed) {
-        attempt("runtime allocation release", () => {
-          if (runtimeAllocation) free(runtimeAllocation);
+        attempt("core callback memory release", () => {
+          coreMemory?.releaseCallbackMemory();
         });
       }
     }
@@ -385,148 +348,60 @@ export async function installCertifiedCompanion(
     }
   };
   try {
-    runtimeAllocation = Number(
-      exports.malloc(
-        COMPANION_KERNEL_RUNTIME_BYTES + COMPANION_KERNEL_RUNTIME_ALIGN - 1,
-      ),
-    );
-    // Rounded with arithmetic rather than a bitmask: pointers reach past what
-    // a 32-bit bitwise operation can represent as the heap grows.
-    const runtimePointer = runtimeAllocation === 0
-      ? 0
-      : Math.ceil(runtimeAllocation / COMPANION_KERNEL_RUNTIME_ALIGN)
-        * COMPANION_KERNEL_RUNTIME_ALIGN;
-    if (observeState) {
-      snapshotPointer = Number(exports.malloc(COMPANION_SNAPSHOT_BYTES));
-    }
-    const configBytes = manifest.configWords.length * Uint32Array.BYTES_PER_ELEMENT;
-    configPointer = Number(exports.malloc(configBytes));
-    if (capabilities.nativeCursor) {
-      cursorPointer = Number(exports.malloc(COMPANION_CURSOR_BYTES));
-    }
-    if (foundation) {
-      toolboxPointer = Number(exports.malloc(COMPANION_TOOLBOX_BYTES));
-      partyPointer = Number(exports.malloc(COMPANION_PARTY_BYTES));
-    }
+    coreMemory = allocateCompanionCoreMemory({
+      memory,
+      malloc: exports.malloc as (bytes: number) => unknown,
+      free,
+      configWords: manifest.configWords,
+      needs: {
+        snapshot: observeState,
+        cursor: capabilities.nativeCursor,
+        toolbox: foundation,
+        commandPayloadBytes: capabilities.teamApply
+          ? teamCommands!.TEAM_COMMAND_PAYLOAD_BYTES
+          : 0,
+        professionTrace:
+          capabilities.teamApply && window.gwNative.init.development,
+      },
+    });
+    const core = coreMemory;
     skillSlotGeometry.allocate(exports.malloc as (bytes: number) => unknown);
     skillCooldowns.allocate(exports.malloc as (bytes: number) => unknown);
     playRegions.allocate(exports.malloc as (bytes: number) => unknown);
-    if (capabilities.teamApply) {
-      payloadPointer = Number(
-        exports.malloc(teamCommands!.TEAM_COMMAND_PAYLOAD_BYTES),
-      );
-      if (window.gwNative.init.development) {
-        professionTracePointer = Number(
-          exports.malloc(PROFESSION_COMMAND_TRACE_BYTES),
-        );
-      }
-    }
     storageInstallation?.allocate(exports.malloc as (bytes: number) => unknown);
     travelInstallation?.allocate(exports.malloc as (bytes: number) => unknown);
     if (
-      !runtimeAllocation
-      || !configPointer
-      || (observeState && !snapshotPointer)
-      || (capabilities.nativeCursor && !cursorPointer)
-      || (foundation && !toolboxPointer)
-      || (foundation && !partyPointer)
-      || !skillSlotGeometry.allocated
+      !skillSlotGeometry.allocated
       || !skillCooldowns.allocated
       || !playRegions.allocated
-      || (capabilities.teamApply && !payloadPointer)
       || (storageInstallation !== null && !storageInstallation.region().pointer)
       || (travelInstallation !== null && !travelInstallation.region().pointer)
-      || (
-        capabilities.teamApply
-        && window.gwNative.init.development
-        && !professionTracePointer
-      )
     ) {
       throw new Error("Companion allocation failed");
     }
     const ownedRegions = [
-      {
-        name: "runtime",
-        pointer: runtimePointer,
-        size: COMPANION_KERNEL_RUNTIME_BYTES,
-        align: COMPANION_KERNEL_RUNTIME_ALIGN,
-      },
-      ...(observeState
-        ? [{ name: "snapshot", pointer: snapshotPointer, size: COMPANION_SNAPSHOT_BYTES, align: 4 }]
-        : []),
-      { name: "config", pointer: configPointer, size: configBytes, align: 4 },
-      ...(capabilities.nativeCursor
-        ? [{ name: "cursor", pointer: cursorPointer, size: COMPANION_CURSOR_BYTES, align: 4 }]
-        : []),
-      ...(foundation
-        ? [
-            { name: "toolbox", pointer: toolboxPointer, size: COMPANION_TOOLBOX_BYTES, align: 4 },
-            { name: "party", pointer: partyPointer, size: COMPANION_PARTY_BYTES, align: 4 },
-          ]
-        : []),
+      ...core.regions,
       ...(skillSlotGeometry.region === null ? [] : [skillSlotGeometry.region]),
       ...(skillCooldowns.region === null ? [] : [skillCooldowns.region]),
       ...(playRegions.region === null ? [] : [playRegions.region]),
-      ...(capabilities.teamApply
-        ? [
-            {
-              name: "command payload",
-              pointer: payloadPointer,
-              size: teamCommands!.TEAM_COMMAND_PAYLOAD_BYTES,
-              align: 4,
-            },
-            ...(professionTracePointer
-              ? [{
-                  name: "profession trace",
-                  pointer: professionTracePointer,
-                  size: PROFESSION_COMMAND_TRACE_BYTES,
-                  align: 4,
-                }]
-              : []),
-          ]
-        : []),
       ...(storageInstallation === null ? [] : [storageInstallation.region()]),
       ...(travelInstallation === null ? [] : [travelInstallation.region()]),
     ];
     validateCompanionOwnedRegions(ownedRegions, memory.buffer.byteLength);
-    // A side module is normally loaded by Emscripten's dynamic linker, which
-    // supplies zeroed BSS. We are the loader here, so establish that invariant
-    // for this whole private block before its active data segment is applied.
-    new Uint8Array(
-      memory.buffer,
-      runtimePointer,
-      COMPANION_KERNEL_RUNTIME_BYTES,
-    ).fill(0);
-    new Uint32Array(
-      memory.buffer,
-      configPointer,
-      manifest.configWords.length,
-    ).set(manifest.configWords);
+    core.initialize();
     storageInstallation?.initialize(memory);
     travelInstallation?.initialize();
 
     const kernel = await installCompanionKernel({
       memory,
-      runtimePointer,
+      runtimePointer: core.runtimePointer,
       featureFlags,
       regions: {
-        snapshot: {
-          pointer: snapshotPointer,
-          bytes: observeState ? COMPANION_SNAPSHOT_BYTES : 0,
-        },
-        config: { pointer: configPointer, bytes: configBytes },
-        cursor: {
-          pointer: cursorPointer,
-          bytes: capabilities.nativeCursor ? COMPANION_CURSOR_BYTES : 0,
-        },
-        toolbox: {
-          pointer: toolboxPointer,
-          bytes: foundation ? COMPANION_TOOLBOX_BYTES : 0,
-        },
-        party: {
-          pointer: partyPointer,
-          bytes: foundation ? COMPANION_PARTY_BYTES : 0,
-        },
+        snapshot: core.snapshot,
+        config: core.config,
+        cursor: core.cursor,
+        toolbox: core.toolbox,
+        party: core.party,
         skillSlots: {
           pointer: skillSlotGeometry.pointer,
           bytes: skillSlotGeometry.bytes,
@@ -566,7 +441,7 @@ export async function installCertifiedCompanion(
       cursor = createCursorConsumer({
         element,
         memory,
-        cursorPointer,
+        cursorPointer: core.cursor.pointer,
         // The empty string hands the canvas back to the stylesheet theme.
         fallback: "",
         // Hold the last art through a click-armed transition: the hide is a
@@ -679,7 +554,7 @@ export async function installCertifiedCompanion(
     };
     const commands = commandEnqueue === null ? null : teamCommands!.createTeamApplyCommands({
       memory,
-      payloadPointer,
+      payloadPointer: core.commandPayloadPointer,
       send: commandEnqueue,
       development: window.gwNative.init.development,
       ready: () => {
@@ -735,10 +610,10 @@ export async function installCertifiedCompanion(
             ),
         })
       : null;
-    if (professionTracePointer !== 0 && professionTraceReader !== null) {
+    if (core.professionTracePointer !== 0 && professionTraceReader !== null) {
       professionTrace = createProfessionCommandTrace(
         memory,
-        professionTracePointer,
+        core.professionTracePointer,
         professionTraceReader,
       );
     }
@@ -794,9 +669,9 @@ export async function installCertifiedCompanion(
     installedCallback = kernelDispatch;
     const observerRuntime = {
       memory,
-      snapshotPointer,
-      toolboxPointer,
-      partyPointer,
+      snapshotPointer: core.snapshot.pointer,
+      toolboxPointer: core.toolbox.pointer,
+      partyPointer: core.party.pointer,
       skillSlotPointer: skillSlotGeometry.pointer,
       skillCooldownPointer: skillCooldowns.pointer,
       playRegionPointer: playRegions.pointer,

--- a/src/renderer/companion-core-memory-installation.ts
+++ b/src/renderer/companion-core-memory-installation.ts
@@ -1,0 +1,235 @@
+/**
+ * Owns the fixed host allocations used directly by the companion kernel.
+ * Feature-specific region installations stay separate; the transaction root
+ * combines all descriptors before any pointer reaches the side module.
+ */
+import {
+  COMPANION_CURSOR_BYTES,
+  COMPANION_PARTY_BYTES,
+  COMPANION_SNAPSHOT_BYTES,
+  COMPANION_TOOLBOX_BYTES,
+} from "./companion-snapshot.js";
+import {
+  COMPANION_KERNEL_RUNTIME_ALIGN,
+  COMPANION_KERNEL_RUNTIME_BYTES,
+  type CompanionOwnedRegion,
+  validateCompanionOwnedRegions,
+} from "./companion-owned-regions.js";
+import { PROFESSION_COMMAND_TRACE_BYTES } from "./profession-command-trace.js";
+
+type KernelRegion = Readonly<{ pointer: number; bytes: number }>;
+
+type CompanionCoreMemoryNeeds = Readonly<{
+  snapshot: boolean;
+  cursor: boolean;
+  toolbox: boolean;
+  commandPayloadBytes: number;
+  professionTrace: boolean;
+}>;
+
+type Allocation = Readonly<{
+  name: string;
+  pointer: number;
+  release: "observer" | "callback";
+}>;
+
+function releaseAllocations(
+  allocations: readonly Allocation[],
+  free: (pointer: number) => void,
+  message: string,
+): void {
+  const failures: unknown[] = [];
+  for (const allocation of allocations) {
+    try {
+      free(allocation.pointer);
+    } catch (cause) {
+      failures.push(new Error(`Failed to free ${allocation.name}`, { cause }));
+    }
+  }
+  if (failures.length > 0) throw new AggregateError(failures, message);
+}
+
+export function allocateCompanionCoreMemory(input: Readonly<{
+  memory: WebAssembly.Memory;
+  malloc(bytes: number): unknown;
+  free(pointer: number): void;
+  configWords: readonly number[];
+  needs: CompanionCoreMemoryNeeds;
+}>) {
+  const { memory, malloc, free, configWords, needs } = input;
+  if (
+    configWords.length === 0
+    || !Number.isSafeInteger(needs.commandPayloadBytes)
+    || needs.commandPayloadBytes < 0
+    || (needs.professionTrace && needs.commandPayloadBytes === 0)
+  ) {
+    throw new Error("Companion core memory request is invalid");
+  }
+
+  const allocated: Allocation[] = [];
+  const allocatedPointers = new Set<number>();
+  const take = (
+    name: string,
+    bytes: number,
+    release: Allocation["release"],
+  ): number => {
+    const pointer = Number(malloc(bytes));
+    if (!Number.isSafeInteger(pointer) || pointer <= 0) {
+      throw new Error(`Companion ${name} allocation failed`);
+    }
+    if (allocatedPointers.has(pointer)) {
+      throw new Error(`Companion ${name} allocation reused a live pointer`);
+    }
+    allocatedPointers.add(pointer);
+    allocated.push({ name, pointer, release });
+    return pointer;
+  };
+  try {
+    const runtimeAllocation = take(
+      "runtime",
+      COMPANION_KERNEL_RUNTIME_BYTES + COMPANION_KERNEL_RUNTIME_ALIGN - 1,
+      "callback",
+    );
+    const runtimePointer = Math.ceil(
+      runtimeAllocation / COMPANION_KERNEL_RUNTIME_ALIGN,
+    ) * COMPANION_KERNEL_RUNTIME_ALIGN;
+    const snapshotPointer = needs.snapshot
+      ? take("snapshot", COMPANION_SNAPSHOT_BYTES, "observer")
+      : 0;
+    const configBytes = configWords.length * Uint32Array.BYTES_PER_ELEMENT;
+    const configPointer = take("config", configBytes, "callback");
+    const cursorPointer = needs.cursor
+      ? take("cursor", COMPANION_CURSOR_BYTES, "observer")
+      : 0;
+    const toolboxPointer = needs.toolbox
+      ? take("Toolbox", COMPANION_TOOLBOX_BYTES, "observer")
+      : 0;
+    const partyPointer = needs.toolbox
+      ? take("party", COMPANION_PARTY_BYTES, "observer")
+      : 0;
+    const commandPayloadPointer = needs.commandPayloadBytes > 0
+      ? take("command payload", needs.commandPayloadBytes, "callback")
+      : 0;
+    const professionTracePointer = needs.professionTrace
+      ? take("profession trace", PROFESSION_COMMAND_TRACE_BYTES, "observer")
+      : 0;
+
+    const region = (
+      name: string,
+      pointer: number,
+      size: number,
+      align = 4,
+    ): CompanionOwnedRegion => Object.freeze({ name, pointer, size, align });
+    const regions = Object.freeze([
+      region(
+        "runtime",
+        runtimePointer,
+        COMPANION_KERNEL_RUNTIME_BYTES,
+        COMPANION_KERNEL_RUNTIME_ALIGN,
+      ),
+      ...(needs.snapshot
+        ? [region("snapshot", snapshotPointer, COMPANION_SNAPSHOT_BYTES)]
+        : []),
+      region("config", configPointer, configBytes),
+      ...(needs.cursor
+        ? [region("cursor", cursorPointer, COMPANION_CURSOR_BYTES)]
+        : []),
+      ...(needs.toolbox
+        ? [
+            region("toolbox", toolboxPointer, COMPANION_TOOLBOX_BYTES),
+            region("party", partyPointer, COMPANION_PARTY_BYTES),
+          ]
+        : []),
+      ...(needs.commandPayloadBytes > 0
+        ? [region(
+            "command payload",
+            commandPayloadPointer,
+            needs.commandPayloadBytes,
+          )]
+        : []),
+      ...(needs.professionTrace
+        ? [region(
+            "profession trace",
+            professionTracePointer,
+            PROFESSION_COMMAND_TRACE_BYTES,
+          )]
+        : []),
+    ]);
+    validateCompanionOwnedRegions(regions, memory.buffer.byteLength);
+    const kernelRegion = (pointer: number, bytes: number): KernelRegion =>
+      Object.freeze({ pointer, bytes });
+    let initialized = false;
+    let observerReleased = false;
+    let callbackReleased = false;
+    return Object.freeze({
+      runtimePointer,
+      snapshot: kernelRegion(
+        snapshotPointer,
+        needs.snapshot ? COMPANION_SNAPSHOT_BYTES : 0,
+      ),
+      config: kernelRegion(configPointer, configBytes),
+      cursor: kernelRegion(
+        cursorPointer,
+        needs.cursor ? COMPANION_CURSOR_BYTES : 0,
+      ),
+      toolbox: kernelRegion(
+        toolboxPointer,
+        needs.toolbox ? COMPANION_TOOLBOX_BYTES : 0,
+      ),
+      party: kernelRegion(
+        partyPointer,
+        needs.toolbox ? COMPANION_PARTY_BYTES : 0,
+      ),
+      commandPayloadPointer,
+      professionTracePointer,
+      regions,
+      initialize() {
+        if (observerReleased || callbackReleased) {
+          throw new Error("Companion core memory has been released");
+        }
+        if (initialized) return;
+        new Uint8Array(
+          memory.buffer,
+          runtimePointer,
+          COMPANION_KERNEL_RUNTIME_BYTES,
+        ).fill(0);
+        new Uint32Array(memory.buffer, configPointer, configWords.length)
+          .set(configWords);
+        initialized = true;
+      },
+      releaseObserverMemory() {
+        if (observerReleased) return;
+        observerReleased = true;
+        releaseAllocations(
+          allocated.filter(({ release }) => release === "observer").reverse(),
+          free,
+          "Companion observer memory release failed",
+        );
+      },
+      releaseCallbackMemory() {
+        if (callbackReleased) return;
+        callbackReleased = true;
+        releaseAllocations(
+          allocated.filter(({ release }) => release === "callback").reverse(),
+          free,
+          "Companion callback memory release failed",
+        );
+      },
+    });
+  } catch (cause) {
+    try {
+      releaseAllocations(
+        [...allocated].reverse(),
+        free,
+        "Companion partial allocation rollback failed",
+      );
+    } catch (rollback) {
+      throw new AggregateError(
+        [cause, rollback],
+        "Companion core memory allocation and rollback failed",
+        { cause: rollback },
+      );
+    }
+    throw cause;
+  }
+}

--- a/tests/helpers/packaged-enhancement-scenarios.ts
+++ b/tests/helpers/packaged-enhancement-scenarios.ts
@@ -1067,6 +1067,8 @@ export async function assertToolboxFoundationLifecycle() {
       aggregateMessage: "Companion cleanup was incomplete",
       failures: [
         "Companion cleanup failed during core observer memory release",
+        "Companion cleanup failed during storage disposal",
+        "Companion cleanup failed during Travel disposal",
       ],
     }]);
     assert.deepEqual(result.after.storageConfigurations.at(-1), [0, 0]);

--- a/tests/helpers/packaged-enhancement-scenarios.ts
+++ b/tests/helpers/packaged-enhancement-scenarios.ts
@@ -930,9 +930,9 @@ export async function assertToolboxFoundationLifecycle() {
     const cursorPointer = (configPointer + CONFIG_BYTES + 7) & ~7;
     const statePointer = (cursorPointer + COMPANION_CURSOR_BYTES + 7) & ~7;
     const partyPointer = statePointer + COMPANION_TOOLBOX_BYTES;
-    const playRegionPointer = partyPointer + COMPANION_PARTY_BYTES;
-    const commandPointer = (playRegionPointer + COMPANION_PLAY_REGION_BYTES + 7) & ~7;
-    const storagePointer = commandPointer + TEAM_COMMAND_PAYLOAD_BYTES;
+    const commandPointer = partyPointer + COMPANION_PARTY_BYTES;
+    const playRegionPointer = (commandPointer + TEAM_COMMAND_PAYLOAD_BYTES + 7) & ~7;
+    const storagePointer = (playRegionPointer + COMPANION_PLAY_REGION_BYTES + 7) & ~7;
     const travelPointer = (storagePointer + STORAGE_DATA_WINDOW_BYTES + 7) & ~7;
     assert.deepEqual(result.before.allocations, [
       { pointer: 0x1000, size: 65_551 },
@@ -957,12 +957,12 @@ export async function assertToolboxFoundationLifecycle() {
         size: COMPANION_PARTY_BYTES,
       },
       {
-        pointer: playRegionPointer,
-        size: COMPANION_PLAY_REGION_BYTES,
-      },
-      {
         pointer: commandPointer,
         size: TEAM_COMMAND_PAYLOAD_BYTES,
+      },
+      {
+        pointer: playRegionPointer,
+        size: COMPANION_PLAY_REGION_BYTES,
       },
       {
         pointer: storagePointer,
@@ -1051,24 +1051,22 @@ export async function assertToolboxFoundationLifecycle() {
     assert.equal(result.before.cursorStyle, "");
 
     assert.deepEqual(result.after.freed, [
-      statePointer,
       partyPointer,
+      statePointer,
+      cursorPointer,
+      snapshotPointer,
       playRegionPointer,
-      commandPointer,
       storagePointer,
       travelPointer,
-      cursorPointer,
+      commandPointer,
       configPointer,
-      snapshotPointer,
       0x1000,
     ]);
     assert.deepEqual(result.after.cleanupReports, [{
       message: "companion cleanup failed",
       aggregateMessage: "Companion cleanup was incomplete",
       failures: [
-        "Companion cleanup failed during Toolbox allocation release",
-        "Companion cleanup failed during storage disposal",
-        "Companion cleanup failed during Travel disposal",
+        "Companion cleanup failed during core observer memory release",
       ],
     }]);
     assert.deepEqual(result.after.storageConfigurations.at(-1), [0, 0]);

--- a/tests/helpers/packaged-enhancement-scenarios.ts
+++ b/tests/helpers/packaged-enhancement-scenarios.ts
@@ -1284,10 +1284,10 @@ export async function assertRollbackAfterTablePublication() {
         { pointer: rollbackPlayRegionPointer, size: COMPANION_PLAY_REGION_BYTES },
       ],
       freed: [
-        rollbackToolboxPointer,
         rollbackPartyPointer,
-        rollbackPlayRegionPointer,
+        rollbackToolboxPointer,
         rollbackCursorPointer,
+        rollbackPlayRegionPointer,
         rollbackConfigPointer,
         0x1000,
       ],
@@ -1300,7 +1300,7 @@ export async function assertRollbackAfterTablePublication() {
         cause: "intentional post-table failure",
         errors: [
           "intentional post-table failure",
-          "Companion cleanup failed during Toolbox allocation release",
+          "Companion cleanup failed during core observer memory release",
         ],
       },
       replacementCursorStatePreserved: true,

--- a/tests/unit/companion-core-memory-installation.test.ts
+++ b/tests/unit/companion-core-memory-installation.test.ts
@@ -1,0 +1,356 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { allocateCompanionCoreMemory } from "../../src/renderer/companion-core-memory-installation.ts";
+import {
+  COMPANION_KERNEL_RUNTIME_BYTES,
+  validateCompanionOwnedRegions,
+} from "../../src/renderer/companion-owned-regions.ts";
+
+const CONFIG = Object.freeze([0x1122_3344, 0xaabb_ccdd, 7]);
+
+function allocator(options: Readonly<{
+  failAt?: number;
+  throwingFree?: number;
+}> = {}) {
+  let next = 8;
+  const allocations: { pointer: number; bytes: number }[] = [];
+  const frees: number[] = [];
+  return {
+    allocations,
+    frees,
+    malloc(bytes: number) {
+      if (allocations.length === options.failAt) return 0;
+      const pointer = next;
+      allocations.push({ pointer, bytes });
+      next = Math.ceil((pointer + bytes) / 8) * 8;
+      return pointer;
+    },
+    free(pointer: number) {
+      frees.push(pointer);
+      if (pointer === options.throwingFree) throw new Error("free refused");
+    },
+  };
+}
+
+function allocate(
+  heap = new WebAssembly.Memory({ initial: 8 }),
+  fake = allocator(),
+) {
+  const core = allocateCompanionCoreMemory({
+    memory: heap,
+    malloc: fake.malloc,
+    free: fake.free,
+    configWords: CONFIG,
+    needs: {
+      snapshot: true,
+      cursor: true,
+      toolbox: true,
+      commandPayloadBytes: 128,
+      professionTrace: true,
+    },
+  });
+  core.initialize();
+  return {
+    fake,
+    heap,
+    core,
+  };
+}
+
+describe("companion core memory installation", () => {
+  it("owns aligned runtime, exact config, and explicit kernel regions", () => {
+    const heap = new WebAssembly.Memory({ initial: 8 });
+    new Uint8Array(heap.buffer).fill(0xa5);
+    const { core, fake } = allocate(heap);
+
+    assert.equal(core.runtimePointer, 16);
+    assert.equal(
+      new Uint8Array(
+        heap.buffer,
+        core.runtimePointer,
+        COMPANION_KERNEL_RUNTIME_BYTES,
+      ).every((byte) => byte === 0),
+      true,
+    );
+    assert.deepEqual(
+      [...new Uint32Array(heap.buffer, core.config.pointer, CONFIG.length)],
+      CONFIG,
+    );
+    assert.deepEqual(core.regions.map(({ name }) => name), [
+      "runtime",
+      "snapshot",
+      "config",
+      "cursor",
+      "toolbox",
+      "party",
+      "command payload",
+      "profession trace",
+    ]);
+    assert.equal(core.runtimePointer, fake.allocations[0]!.pointer + 8);
+    assert.equal(core.commandPayloadPointer, fake.allocations[6]!.pointer);
+    assert.equal(core.professionTracePointer, fake.allocations[7]!.pointer);
+  });
+
+  it("allocates no observer or command memory when it is not needed", () => {
+    const fake = allocator();
+    const core = allocateCompanionCoreMemory({
+      memory: new WebAssembly.Memory({ initial: 8 }),
+      malloc: fake.malloc,
+      free: fake.free,
+      configWords: CONFIG,
+      needs: {
+        snapshot: false,
+        cursor: false,
+        toolbox: false,
+        commandPayloadBytes: 0,
+        professionTrace: false,
+      },
+    });
+    core.initialize();
+
+    assert.deepEqual(core.regions.map(({ name }) => name), ["runtime", "config"]);
+    assert.deepEqual(fake.allocations.map(({ bytes }) => bytes), [
+      COMPANION_KERNEL_RUNTIME_BYTES + 15,
+      CONFIG.length * Uint32Array.BYTES_PER_ELEMENT,
+    ]);
+    assert.deepEqual(core.snapshot, { pointer: 0, bytes: 0 });
+    assert.deepEqual(core.cursor, { pointer: 0, bytes: 0 });
+    assert.deepEqual(core.toolbox, { pointer: 0, bytes: 0 });
+    assert.deepEqual(core.party, { pointer: 0, bytes: 0 });
+    core.releaseObserverMemory();
+    assert.deepEqual(fake.frees, []);
+  });
+
+  it("rolls back every partial allocation in reverse order", () => {
+    for (let failAt = 0; failAt < 8; failAt += 1) {
+      const fake = allocator({ failAt });
+      assert.throws(
+        () => allocateCompanionCoreMemory({
+          memory: new WebAssembly.Memory({ initial: 8 }),
+          malloc: fake.malloc,
+          free: fake.free,
+          configWords: CONFIG,
+          needs: {
+            snapshot: true,
+            cursor: true,
+            toolbox: true,
+            commandPayloadBytes: 128,
+            professionTrace: true,
+          },
+        }),
+        /allocation failed/,
+      );
+      assert.deepEqual(
+        fake.frees,
+        fake.allocations.map(({ pointer }) => pointer).reverse(),
+        `allocation ${failAt}`,
+      );
+    }
+  });
+
+  it("rolls back when the completed layout does not fit memory", () => {
+    const fake = allocator();
+    assert.throws(
+      () => allocateCompanionCoreMemory({
+        memory: new WebAssembly.Memory({ initial: 1 }),
+        malloc: fake.malloc,
+        free: fake.free,
+        configWords: CONFIG,
+        needs: {
+          snapshot: true,
+          cursor: true,
+          toolbox: true,
+          commandPayloadBytes: 128,
+          professionTrace: true,
+        },
+      }),
+      /ends past the heap/,
+    );
+    assert.deepEqual(
+      fake.frees,
+      fake.allocations.map(({ pointer }) => pointer).reverse(),
+    );
+  });
+
+  it("does not write runtime or config bytes before explicit initialization", () => {
+    const heap = new WebAssembly.Memory({ initial: 8 });
+    new Uint8Array(heap.buffer).fill(0xa5);
+    const fake = allocator();
+    const core = allocateCompanionCoreMemory({
+      memory: heap,
+      malloc: fake.malloc,
+      free: fake.free,
+      configWords: CONFIG,
+      needs: {
+        snapshot: false,
+        cursor: false,
+        toolbox: false,
+        commandPayloadBytes: 0,
+        professionTrace: false,
+      },
+    });
+
+    assert.equal(
+      new Uint8Array(heap.buffer, core.runtimePointer, 16)
+        .every((byte) => byte === 0xa5),
+      true,
+    );
+    assert.equal(
+      new Uint8Array(heap.buffer, core.config.pointer, core.config.bytes)
+        .every((byte) => byte === 0xa5),
+      true,
+    );
+    core.initialize();
+    assert.equal(
+      new Uint8Array(heap.buffer, core.runtimePointer, 16)
+        .every((byte) => byte === 0),
+      true,
+    );
+    assert.deepEqual(
+      [...new Uint32Array(heap.buffer, core.config.pointer, CONFIG.length)],
+      CONFIG,
+    );
+  });
+
+  it("rolls back a reused allocation pointer exactly once", () => {
+    const frees: number[] = [];
+    let calls = 0;
+    assert.throws(
+      () => allocateCompanionCoreMemory({
+        memory: new WebAssembly.Memory({ initial: 8 }),
+        malloc: () => {
+          calls += 1;
+          return 8;
+        },
+        free: (pointer) => frees.push(pointer),
+        configWords: CONFIG,
+        needs: {
+          snapshot: true,
+          cursor: false,
+          toolbox: false,
+          commandPayloadBytes: 0,
+          professionTrace: false,
+        },
+      }),
+      /reused a live pointer/,
+    );
+    assert.equal(calls, 2);
+    assert.deepEqual(frees, [8]);
+  });
+
+  it("reports both allocation and rollback failures", () => {
+    const baseline = allocator();
+    allocate(new WebAssembly.Memory({ initial: 8 }), baseline);
+    const refused = baseline.allocations[1]!.pointer;
+    const fake = allocator({ failAt: 3, throwingFree: refused });
+
+    assert.throws(
+      () => allocateCompanionCoreMemory({
+        memory: new WebAssembly.Memory({ initial: 8 }),
+        malloc: fake.malloc,
+        free: fake.free,
+        configWords: CONFIG,
+        needs: {
+          snapshot: true,
+          cursor: true,
+          toolbox: true,
+          commandPayloadBytes: 128,
+          professionTrace: true,
+        },
+      }),
+      (error) => {
+        assert.ok(error instanceof AggregateError);
+        assert.equal(error.errors.length, 2);
+        assert.match(String(error.errors[0]), /cursor allocation failed/);
+        assert.match(String(error.errors[1]), /partial allocation rollback failed/);
+        assert.ok(error.errors[1] instanceof AggregateError);
+        assert.match(
+          String(error.errors[1].errors[0]),
+          /Failed to free snapshot/,
+        );
+        return true;
+      },
+    );
+    assert.equal(fake.frees.length, 3);
+  });
+
+  it("releases the observer and callback safety groups once", () => {
+    const { core, fake } = allocate();
+    const pointers = fake.allocations.map(({ pointer }) => pointer);
+
+    core.releaseObserverMemory();
+    core.releaseObserverMemory();
+    assert.deepEqual(fake.frees, [
+      pointers[7], pointers[5], pointers[4], pointers[3], pointers[1],
+    ]);
+
+    core.releaseCallbackMemory();
+    core.releaseCallbackMemory();
+    assert.deepEqual(fake.frees, [
+      pointers[7], pointers[5], pointers[4], pointers[3], pointers[1],
+      pointers[6], pointers[2], pointers[0],
+    ]);
+    assert.notEqual(core.runtimePointer, pointers[0]);
+  });
+
+  it("cannot initialize after either release group runs", () => {
+    for (const release of ["observer", "callback"] as const) {
+      for (const initializedBeforeRelease of [false, true]) {
+        const fake = allocator();
+        const core = allocateCompanionCoreMemory({
+          memory: new WebAssembly.Memory({ initial: 8 }),
+          malloc: fake.malloc,
+          free: fake.free,
+          configWords: CONFIG,
+          needs: {
+            snapshot: true,
+            cursor: false,
+            toolbox: false,
+            commandPayloadBytes: 0,
+            professionTrace: false,
+          },
+        });
+        if (initializedBeforeRelease) core.initialize();
+        if (release === "observer") core.releaseObserverMemory();
+        else core.releaseCallbackMemory();
+        assert.throws(
+          () => core.initialize(),
+          /core memory has been released/,
+          `${release}, initialized: ${initializedBeforeRelease}`,
+        );
+      }
+    }
+  });
+
+  it("continues a release after one free refuses", () => {
+    const first = allocator();
+    allocate(new WebAssembly.Memory({ initial: 8 }), first);
+    const refused = first.allocations[4]!.pointer;
+    const fake = allocator({ throwingFree: refused });
+    const { core } = allocate(new WebAssembly.Memory({ initial: 8 }), fake);
+
+    assert.throws(
+      () => core.releaseObserverMemory(),
+      /observer memory release failed/,
+    );
+    assert.equal(fake.frees.length, 5);
+    core.releaseObserverMemory();
+    assert.equal(fake.frees.length, 5);
+  });
+
+  it("composes with child-region overlap validation", () => {
+    const { core, heap } = allocate();
+    assert.throws(
+      () => validateCompanionOwnedRegions([
+        ...core.regions,
+        {
+          name: "child",
+          pointer: core.config.pointer,
+          size: 4,
+          align: 4,
+        },
+      ], heap.buffer.byteLength),
+      /config\/child allocations overlap/,
+    );
+  });
+});


### PR DESCRIPTION
## What changed

The certified companion installer no longer owns eight independent raw allocation variables and their rollback rules. A focused core-memory owner now allocates the kernel runtime, config, snapshot, cursor, Toolbox, party, command payload, and development trace as one explicit transaction.

Feature-specific skill, play-region, storage, and travel regions remain separate. The installer still validates the complete composed layout before any bytes are initialized or any pointer reaches the side module.

## Why

Allocation, initialization, and cleanup were spread through the transaction root. That made it easy for a new capability to miss rollback, free the aligned interior runtime pointer, or release memory before its observer/callback owner was withdrawn.

This extraction gives fixed kernel memory one owner while keeping policy, hooks, and feature lifecycles out of a generic abstraction.

## Invariant

- every required allocation is positive, unique, aligned, bounded, and non-overlapping;
- partial allocation rolls back once in reverse order and preserves both primary and rollback failures;
- no runtime/config bytes are written before the complete composed region layout validates;
- observer-owned memory and callback-owned memory have separate idempotent release groups;
- initialization is refused after either release group runs;
- the original malloc result, never the aligned interior runtime pointer, is freed.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm test:unit` — 1,240 passed
- `pnpm test:policy` — 174 passed
- `pnpm test:integration` — 66 passed
- `pnpm test:release` — 25 passed
- `pnpm tools:test` — 102 passed
- `pnpm check:links`
- `node scripts/verify-companion-kernel.mjs`
- independent runtime, certification, and maintainability reviews — no findings

Local Electron/E2E and packaged-app tests were intentionally not run because they open intrusive windows; they remain covered by CI/manual approval.

- [x] I kept this pull request focused.
- [x] I ran the relevant non-E2E checks.
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [x] No user-facing documentation changed.
