### PR TITLE
refactor(tools): centralize live feature policy

### DIFF
--- a/src/renderer/certified-companion-installation.ts
+++ b/src/renderer/certified-companion-installation.ts
@@ -56,10 +56,7 @@ import {
 } from "../shared/companion-abi.js";
 import { installCompanionKernel } from "./companion-kernel-loader.js";
 import { allocateCompanionCoreMemory } from "./companion-core-memory-installation.js";
-import {
-  enhancementRuntimePolicy,
-  type RuntimePlayRegion,
-} from "./enhancement-runtime-policy.js";
+import { createCompanionPolicySource } from "./companion-policy-source.js";
 import {
   createProfessionCommandTrace,
   type ProfessionCommandTraceReader,
@@ -219,8 +216,7 @@ export async function installCertifiedCompanion(
   let disposeCursor = () => {};
   let disposeReadout = () => {};
   let disposeToolbox = () => {};
-  let disposeToolSettings = () => {};
-  let disposePlayRegionSubscription = () => false;
+  let disposePolicySource = () => {};
   let disposeCursorRefresh = () => {};
   let professionTrace: ReturnType<typeof createProfessionCommandTrace> | null = null;
   let installedCallback: CallableFunction | null = null;
@@ -251,10 +247,7 @@ export async function installCertifiedCompanion(
     // Withdraw policy inputs before disposing any surface. Region withdrawal
     // notifies subscribers synchronously; leaving this subscription live could
     // recreate a readout or overlay during the same teardown transaction.
-    attempt("Tools settings listener disposal", disposeToolSettings);
-    attempt("play-region subscription disposal", () => {
-      disposePlayRegionSubscription();
-    });
+    attempt("policy source disposal", disposePolicySource);
     const cursorStateWithdrawn = attempt("cursor state withdrawal", () => {
       if (
         installedCursorState !== null
@@ -461,26 +454,27 @@ export async function installCertifiedCompanion(
       installedCursorState = () => cursor?.state ?? null;
       window.gwCursorState = installedCursorState;
     }
-    let optionalSettings = window.gwToolsSettings();
-    skills.mount(document.body, optionalSettings);
+    const policySource = createCompanionPolicySource({
+      program,
+      readSettings: window.gwToolsSettings,
+      settingsEvents: window,
+      readPlayRegion: () => playRegions.state,
+      subscribePlayRegion: playRegions.subscribe,
+    });
+    disposePolicySource = policySource.dispose;
+    const policySnapshot = () => policySource.snapshot;
+    skills.mount(document.body, policySnapshot().settings);
     const configureTradeAlias = () => {
-      configureTradeToggle?.(optionalSettings.gwonmacTools ? 1 : 0);
+      configureTradeToggle?.(policySnapshot().settings.gwonmacTools ? 1 : 0);
     };
     const pollTradeAlias = () => {
-      if (takeTradeToggle?.() === 1 && optionalSettings.gwonmacTools) {
+      if (takeTradeToggle?.() === 1 && policySnapshot().settings.gwonmacTools) {
         window.dispatchEvent(new CustomEvent("gw:trade-toggle"));
       }
     };
     let readout: ReturnType<typeof createTargetReadout> | null = null;
-    const playRegion = (): RuntimePlayRegion => {
-      const state = playRegions.state;
-      return state.status === "ready" ? state.playRegion : "unknown";
-    };
-    const policy = () => enhancementRuntimePolicy(
-      program,
-      optionalSettings,
-      playRegion(),
-    );
+    const playRegion = () => policySnapshot().playRegion;
+    const policy = () => policySnapshot().policy;
     let lastPolicyTrace = "";
     const tracePolicy = (reason: "launch" | "region" | "settings") => {
       if (!window.gwNative.init.development) return;
@@ -509,7 +503,7 @@ export async function installCertifiedCompanion(
       }
     };
     const syncSkillOverlays = () => skills.sync(
-      optionalSettings,
+      policySnapshot().settings,
       policy().skillSlotGeometry,
       policy().skillCooldownOverlay,
     );
@@ -539,7 +533,7 @@ export async function installCertifiedCompanion(
           : 0)
         | (targetEnabled() ? COMPANION_FEATURE_BITS.targetObservation : 0)
         | skills.activeFeatureFlags(
-          optionalSettings,
+          policySnapshot().settings,
           policy().skillSlotGeometry,
           policy().skillCooldownOverlay,
         );
@@ -592,7 +586,7 @@ export async function installCertifiedCompanion(
       travelInstallation?.update({
         enabled: policy().travelPalette,
         playRegion: playRegion(),
-        state: travelGameState(playRegions.state),
+        state: travelGameState(policySnapshot().playRegionState),
       });
     };
     storageInstallation?.mount();
@@ -632,39 +626,22 @@ export async function installCertifiedCompanion(
       syncToolboxAvailability();
       syncLivePolicyConsumers();
     };
-    const onToolSettings = () => {
-      // The event is only a notification. The validated bridge remains the
-      // single source of truth even if page code dispatches a malformed event.
-      optionalSettings = window.gwToolsSettings();
-      syncPolicySurfaces("settings");
-      configureTradeAlias();
-    };
-    window.addEventListener("gw:tools-settings", onToolSettings);
-    disposeToolSettings = () =>
-      window.removeEventListener("gw:tools-settings", onToolSettings);
     disposeToolbox = () => {
       toolbox?.dispose();
     };
 
-    const playRegionProjection = () => {
-      const state = playRegions.state;
-      return state.status === "ready"
-        ? `ready:${state.playRegion}:${state.mapId}:${state.instanceType}`
-        : `waiting:${state.reason}`;
-    };
-    let previousPlayRegionProjection = playRegionProjection();
-    disposePlayRegionSubscription = playRegions.subscribe(() => {
-      const next = playRegionProjection();
-      if (next === previousPlayRegionProjection) return;
-      previousPlayRegionProjection = next;
-      syncPolicySurfaces("region");
-    });
-
     // Apply opt-in state before the callback becomes reachable from the game.
     playRegions.setActive(true);
-    tracePolicy("launch");
-    syncLivePolicyConsumers();
-    configureTradeAlias();
+    policySource.subscribe(({ reason }) => {
+      if (reason === "launch") {
+        tracePolicy(reason);
+        syncLivePolicyConsumers();
+        configureTradeAlias();
+        return;
+      }
+      syncPolicySurfaces(reason);
+      if (reason === "settings") configureTradeAlias();
+    });
     table.set(manifest.tableSlot, kernelDispatch);
     installedCallback = kernelDispatch;
     const observerRuntime = {

--- a/src/renderer/companion-policy-source.ts
+++ b/src/renderer/companion-policy-source.ts
@@ -1,0 +1,127 @@
+/**
+ * Canonical renderer source for saved feature settings and certified play-region
+ * policy. Presentation and command modules consume one immutable snapshot
+ * instead of wiring the same settings/region listeners independently.
+ */
+import type { EnhancementProgram } from "../shared/enhancement-contracts.js";
+import type { CompanionPlayRegionState } from "./companion-play-region-snapshot.js";
+import {
+  enhancementRuntimePolicy,
+  type OptionalToolSettings,
+  type RuntimePlayRegion,
+} from "./enhancement-runtime-policy.js";
+
+type CompanionPolicyReason = "launch" | "region" | "settings";
+
+type CompanionPolicySnapshot<
+  Settings extends OptionalToolSettings = OptionalToolSettings,
+> = Readonly<{
+  settings: Settings;
+  playRegion: RuntimePlayRegion;
+  playRegionState: CompanionPlayRegionState;
+  policy: ReturnType<typeof enhancementRuntimePolicy>;
+}>;
+
+type PolicyUpdate<Settings extends OptionalToolSettings> = Readonly<{
+  reason: CompanionPolicyReason;
+  snapshot: CompanionPolicySnapshot<Settings>;
+}>;
+
+function projectPlayRegion(state: CompanionPlayRegionState): string {
+  return state.status === "ready"
+    ? `ready:${state.playRegion}:${state.mapId}:${state.instanceType}`
+    : `waiting:${state.reason}`;
+}
+
+export function createCompanionPolicySource<Settings extends OptionalToolSettings>(
+  input: Readonly<{
+    program: EnhancementProgram;
+    readSettings(): Settings;
+    settingsEvents: Pick<EventTarget, "addEventListener" | "removeEventListener">;
+    readPlayRegion(): CompanionPlayRegionState;
+    subscribePlayRegion(
+      listener: (state: CompanionPlayRegionState) => void,
+    ): () => void;
+  }>,
+) {
+  const listeners = new Set<(update: PolicyUpdate<Settings>) => void>();
+  let disposed = false;
+  let settings = input.readSettings();
+  let playRegionState = input.readPlayRegion();
+  let playRegionProjection = projectPlayRegion(playRegionState);
+  const makeSnapshot = (): CompanionPolicySnapshot<Settings> => {
+    const playRegion = playRegionState.status === "ready"
+      ? playRegionState.playRegion
+      : "unknown";
+    return Object.freeze({
+      settings,
+      playRegion,
+      playRegionState,
+      policy: enhancementRuntimePolicy(input.program, settings, playRegion),
+    });
+  };
+  let snapshot = makeSnapshot();
+  const publish = (reason: Exclude<CompanionPolicyReason, "launch">) => {
+    snapshot = makeSnapshot();
+    const update = Object.freeze({ reason, snapshot });
+    for (const listener of listeners) listener(update);
+  };
+  const onSettings = () => {
+    if (disposed) return;
+    // The event is only a notification. The validated bridge remains the
+    // source of truth even if page code dispatches a forged event payload.
+    settings = input.readSettings();
+    publish("settings");
+  };
+  input.settingsEvents.addEventListener("gw:tools-settings", onSettings);
+  let unsubscribePlayRegion: () => void;
+  try {
+    unsubscribePlayRegion = input.subscribePlayRegion((state) => {
+      if (disposed) return;
+      const projection = projectPlayRegion(state);
+      if (projection === playRegionProjection) return;
+      playRegionState = state;
+      playRegionProjection = projection;
+      publish("region");
+    });
+  } catch (cause) {
+    input.settingsEvents.removeEventListener("gw:tools-settings", onSettings);
+    throw cause;
+  }
+
+  return Object.freeze({
+    get snapshot() { return snapshot; },
+    subscribe(listener: (update: PolicyUpdate<Settings>) => void) {
+      if (disposed) return () => {};
+      listeners.add(listener);
+      try {
+        listener(Object.freeze({ reason: "launch", snapshot }));
+      } catch (cause) {
+        listeners.delete(listener);
+        throw cause;
+      }
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      const failures: unknown[] = [];
+      try {
+        input.settingsEvents.removeEventListener("gw:tools-settings", onSettings);
+      } catch (cause) {
+        failures.push(cause);
+      }
+      try {
+        unsubscribePlayRegion();
+      } catch (cause) {
+        failures.push(cause);
+      }
+      listeners.clear();
+      if (failures.length > 0) {
+        throw new AggregateError(failures, "Companion policy source disposal failed");
+      }
+    },
+  });
+}

--- a/tests/helpers/packaged-enhancement-fixture.ts
+++ b/tests/helpers/packaged-enhancement-fixture.ts
@@ -652,13 +652,17 @@ export async function assertPackagedOffSession() {
       allResources.some((url) => new URL(url).pathname === "/Gw.jspi.wasm"),
       "the runtime-init proof never fetched the served game module",
     );
+    const loadedEnhancementResources = [
+      ...new Set(allResources.filter(enhancementResource)),
+    ];
     assert.deepEqual(
-      [...new Set(allResources.filter(enhancementResource))],
+      loadedEnhancementResources.filter(
+        (url) => url !== "gw://app/enhancement-runtime-policy.js",
+      ),
       [
         "gw://app/enhancement-cursor.js",
         "gw://app/enhancement-readout.js",
         "gw://app/enhancement-manifest.js",
-        "gw://app/enhancement-runtime-policy.js",
       ],
       "required Core did not stop at the unproved module manifest",
     );

--- a/tests/unit/companion-policy-source.test.ts
+++ b/tests/unit/companion-policy-source.test.ts
@@ -1,0 +1,211 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createCompanionPolicySource } from "../../src/renderer/companion-policy-source.js";
+import type { CompanionPlayRegionState } from "../../src/renderer/companion-play-region-snapshot.js";
+import { DEFAULT_SETTINGS } from "../../src/shared/contracts.js";
+
+function fixture() {
+  const settingsEvents = new EventTarget();
+  let settings = { ...DEFAULT_SETTINGS };
+  let region: CompanionPlayRegionState = Object.freeze({
+    status: "waiting",
+    reason: "memory",
+  });
+  const regionListeners = new Set<(state: CompanionPlayRegionState) => void>();
+  let regionUnsubscribes = 0;
+  const source = createCompanionPolicySource({
+    program: "none",
+    readSettings: () => settings,
+    settingsEvents,
+    readPlayRegion: () => region,
+    subscribePlayRegion(listener) {
+      regionListeners.add(listener);
+      listener(region);
+      return () => {
+        regionUnsubscribes += 1;
+        regionListeners.delete(listener);
+      };
+    },
+  });
+  return {
+    source,
+    settingsEvents,
+    setSettings(next: typeof settings) { settings = next; },
+    publishRegion(next: CompanionPlayRegionState) {
+      region = next;
+      for (const listener of regionListeners) listener(next);
+    },
+    get regionUnsubscribes() { return regionUnsubscribes; },
+  };
+}
+
+describe("companion policy source", () => {
+  it("publishes one canonical launch snapshot", () => {
+    const test = fixture();
+    const updates: unknown[] = [];
+    test.source.subscribe((update) => updates.push(update));
+
+    assert.equal(updates.length, 1);
+    assert.deepEqual(updates[0], {
+      reason: "launch",
+      snapshot: {
+        settings: DEFAULT_SETTINGS,
+        playRegion: "unknown",
+        playRegionState: { status: "waiting", reason: "memory" },
+        policy: {
+          tools: false,
+          targetReadout: false,
+          teamManagement: false,
+          xunlaiStorage: false,
+          travelPalette: false,
+          skillSlotGeometry: false,
+          skillCooldownOverlay: false,
+        },
+      },
+    });
+  });
+
+  it("rereads settings instead of trusting the event payload", () => {
+    const test = fixture();
+    const updates: Array<{ reason: string; tools: boolean }> = [];
+    test.source.subscribe(({ reason, snapshot }) => {
+      updates.push({ reason, tools: snapshot.policy.tools });
+    });
+    test.setSettings({ ...DEFAULT_SETTINGS, gwonmacTools: true });
+    test.settingsEvents.dispatchEvent(new CustomEvent("gw:tools-settings", {
+      detail: { gwonmacTools: false },
+    }));
+
+    assert.deepEqual(updates, [
+      { reason: "launch", tools: false },
+      { reason: "settings", tools: true },
+    ]);
+  });
+
+  it("deduplicates equal region values and withdraws policy on waiting", () => {
+    const test = fixture();
+    const updates: Array<{ reason: string; region: string }> = [];
+    test.source.subscribe(({ reason, snapshot }) => {
+      updates.push({ reason, region: snapshot.playRegion });
+    });
+    const pve = Object.freeze({
+      status: "ready" as const,
+      sequence: 2,
+      mapId: 42,
+      instanceType: 0,
+      playRegion: "pve" as const,
+    });
+    test.publishRegion(pve);
+    test.publishRegion({ ...pve, sequence: 4 });
+    test.publishRegion(Object.freeze({ status: "waiting", reason: "stale" }));
+
+    assert.deepEqual(updates, [
+      { reason: "launch", region: "unknown" },
+      { reason: "region", region: "pve" },
+      { reason: "region", region: "unknown" },
+    ]);
+  });
+
+  it("detaches both inputs and stops publication on disposal", () => {
+    const test = fixture();
+    let publications = 0;
+    test.source.subscribe(() => { publications += 1; });
+    test.source.dispose();
+    test.source.dispose();
+    test.setSettings({ ...DEFAULT_SETTINGS, gwonmacTools: true });
+    test.settingsEvents.dispatchEvent(new Event("gw:tools-settings"));
+    test.publishRegion(Object.freeze({
+      status: "ready",
+      sequence: 2,
+      mapId: 42,
+      instanceType: 0,
+      playRegion: "pve",
+    }));
+
+    assert.equal(publications, 1);
+    assert.equal(test.regionUnsubscribes, 1);
+  });
+
+  it("rolls back a settings listener when region subscription fails", () => {
+    const settingsEvents = new EventTarget();
+    let settingsReads = 0;
+    assert.throws(
+      () => createCompanionPolicySource({
+        program: "none",
+        readSettings() {
+          settingsReads += 1;
+          return DEFAULT_SETTINGS;
+        },
+        settingsEvents,
+        readPlayRegion: () => ({ status: "waiting", reason: "memory" }),
+        subscribePlayRegion() {
+          throw new Error("subscription refused");
+        },
+      }),
+      /subscription refused/,
+    );
+    settingsEvents.dispatchEvent(new Event("gw:tools-settings"));
+    assert.equal(settingsReads, 1);
+  });
+
+  it("does not retain a subscriber whose launch callback throws", () => {
+    const test = fixture();
+    let calls = 0;
+    assert.throws(
+      () => test.source.subscribe(() => {
+        calls += 1;
+        throw new Error("surface refused launch");
+      }),
+      /surface refused launch/,
+    );
+    test.setSettings({ ...DEFAULT_SETTINGS, gwonmacTools: true });
+    test.settingsEvents.dispatchEvent(new Event("gw:tools-settings"));
+    assert.equal(calls, 1);
+  });
+
+  it("stops an individually unsubscribed consumer", () => {
+    const test = fixture();
+    let calls = 0;
+    const unsubscribe = test.source.subscribe(() => { calls += 1; });
+    unsubscribe();
+    unsubscribe();
+    test.setSettings({ ...DEFAULT_SETTINGS, gwonmacTools: true });
+    test.settingsEvents.dispatchEvent(new Event("gw:tools-settings"));
+    assert.equal(calls, 1);
+  });
+
+  it("withdraws every reachable listener when input disposal refuses", () => {
+    const settingsEvents = new EventTarget();
+    let settingsReads = 0;
+    let publications = 0;
+    const source = createCompanionPolicySource({
+      program: "none",
+      readSettings() {
+        settingsReads += 1;
+        return DEFAULT_SETTINGS;
+      },
+      settingsEvents,
+      readPlayRegion: () => ({ status: "waiting", reason: "memory" }),
+      subscribePlayRegion(listener) {
+        listener({ status: "waiting", reason: "memory" });
+        return () => { throw new Error("region unsubscribe refused"); };
+      },
+    });
+    source.subscribe(() => { publications += 1; });
+
+    assert.throws(
+      () => source.dispose(),
+      (error) => {
+        assert(error instanceof AggregateError);
+        assert.match(error.message, /policy source disposal failed/);
+        assert.equal(error.errors.length, 1);
+        assert.match(String(error.errors[0]), /region unsubscribe refused/);
+        return true;
+      },
+    );
+    settingsEvents.dispatchEvent(new Event("gw:tools-settings"));
+    source.subscribe(() => { publications += 1; });
+    assert.equal(settingsReads, 1);
+    assert.equal(publications, 1);
+  });
+});


### PR DESCRIPTION
## What changed

Optional Tools features now consume one immutable live-policy snapshot that combines validated saved settings with the certified play-region state.

The source owns the `gw:tools-settings` notification listener, authoritative settings reread, play-region subscription, policy-relevant deduplication, synchronous launch snapshot, and fail-closed disposal. The transaction root still owns native activation masks, UI synchronization, commands, and rollback.

## Why

Every new overlay or command otherwise had to repeat the same settings event wiring, region projection, stale/loading withdrawal, PvP gate, and teardown ordering. That duplication already caused a teardown race in a lower stack layer.

This is deliberately smaller than a plugin framework: it centralizes the two shared policy inputs and nothing else.

## Invariant

- settings event payloads are never trusted; the validated bridge is reread;
- certified waiting, loading, stale, and unavailable region states become `unknown` and withdraw PvE-only features;
- settings, raw region state, projected region, and computed policy come from one publication;
- equal policy-relevant region values do not cause redundant surface work;
- construction, individual subscription, and source disposal are rollback-safe and idempotent;
- policy inputs detach before any surface or feed is disposed.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm test:unit` — 1,248 passed
- `pnpm test:policy` — 174 passed
- `pnpm test:integration` — 66 passed
- `pnpm test:release` — 25 passed
- `pnpm tools:test` — 102 passed
- `pnpm check:links`
- `node scripts/verify-companion-kernel.mjs`
- independent runtime, certification, and maintainability reviews — no findings

Local Electron/E2E and packaged-app tests were intentionally not run because they open intrusive windows; they remain covered by CI/manual approval.

- [x] I kept this pull request focused.
- [x] I ran the relevant non-E2E checks.
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [x] No user-facing documentation changed.
