### PR TITLE
refactor(tools): align runtime policy with feature ids

### DIFF
--- a/src/renderer/certified-companion-installation.ts
+++ b/src/renderer/certified-companion-installation.ts
@@ -483,7 +483,7 @@ export async function installCertifiedCompanion(
         program,
         playRegion: playRegion(),
         nativeCursor: capabilities.nativeCursor,
-        teamManagement: active.teamManagement,
+        teamManagement: active.teamApply,
         xunlaiStorage: active.xunlaiStorage,
         targetReadout: active.targetReadout,
         commands: commands !== null,
@@ -494,6 +494,8 @@ export async function installCertifiedCompanion(
       console.debug(`[tools:dev] policy ${JSON.stringify({ reason, ...summary })}`);
     };
     const targetEnabled = () => policy().targetReadout;
+    const skillGeometryEnabled = () =>
+      policy().skillKeyLabels || policy().skillCooldowns;
     const setTargetEnabled = () => {
       if (!observeState) return;
       if (targetEnabled()) readout ??= createTargetReadout(document.body);
@@ -504,8 +506,8 @@ export async function installCertifiedCompanion(
     };
     const syncSkillOverlays = () => skills.sync(
       policySnapshot().settings,
-      policy().skillSlotGeometry,
-      policy().skillCooldownOverlay,
+      skillGeometryEnabled(),
+      policy().skillCooldowns,
     );
     setTargetEnabled();
     syncSkillOverlays();
@@ -518,7 +520,7 @@ export async function installCertifiedCompanion(
     // live permission gates and supplies fresh game and party observations.
     let toolboxObservation: ToolboxObservation | null = null;
     let companionState: CompanionSnapshot | null = null;
-    const teamEnabled = () => policy().teamManagement;
+    const teamEnabled = () => policy().teamApply;
     const syncActiveObservers = () => {
       const active =
         (capabilities.nativeCursor ? COMPANION_FEATURE_BITS.nativeCursor : 0)
@@ -534,8 +536,8 @@ export async function installCertifiedCompanion(
         | (targetEnabled() ? COMPANION_FEATURE_BITS.targetObservation : 0)
         | skills.activeFeatureFlags(
           policySnapshot().settings,
-          policy().skillSlotGeometry,
-          policy().skillCooldownOverlay,
+          skillGeometryEnabled(),
+          policy().skillCooldowns,
         );
       kernelDispatch(
         COMPANION_DISPATCH_KINDS.activeFeatures,
@@ -584,7 +586,7 @@ export async function installCertifiedCompanion(
     };
     const syncTravelPolicy = () => {
       travelInstallation?.update({
-        enabled: policy().travelPalette,
+        enabled: policy().travel,
         playRegion: playRegion(),
         state: travelGameState(policySnapshot().playRegionState),
       });

--- a/src/renderer/enhancement-runtime-policy.ts
+++ b/src/renderer/enhancement-runtime-policy.ts
@@ -7,19 +7,21 @@ import {
   featureActivationRequested,
   featureRegionAllowsRequest,
   type FeatureActivationSettings,
+  type FeatureId,
 } from "../shared/feature-contracts.js";
 
 export type OptionalToolSettings = FeatureActivationSettings;
 
 export type RuntimePlayRegion = "pve" | "pvp" | "unknown";
+type RuntimeFeaturePolicy = Readonly<Record<FeatureId, boolean>>;
 
 /** One fail-closed answer for optional observers, UI, and commands. */
 export function enhancementRuntimePolicy(
   program: EnhancementProgram,
   settings: OptionalToolSettings,
   playRegion: RuntimePlayRegion,
-) {
-  const requested = (id: Parameters<typeof featureActivationRequested>[0]) =>
+): RuntimeFeaturePolicy {
+  const requested = (id: FeatureId) =>
     featureActivationRequested(id, settings)
       && featureRegionAllowsRequest(id, playRegion);
   const developerToolbox = program === "toolbox-foundation"
@@ -34,16 +36,15 @@ export function enhancementRuntimePolicy(
     tools: developerToolbox || requested("tools"),
     targetReadout: program === "target-observer"
       || requested("targetReadout"),
-    teamManagement: featureRegionAllowsRequest("teamApply", playRegion)
+    teamApply: featureRegionAllowsRequest("teamApply", playRegion)
       && (developerTeam || requested("teamApply")),
     // The storage controller owns live access refusal and its user-facing
     // reason. This value means requested, not currently available.
     xunlaiStorage:
       developerStorage || requested("xunlaiStorage"),
-    travelPalette: featureRegionAllowsRequest("travel", playRegion)
+    travel: featureRegionAllowsRequest("travel", playRegion)
       && (developerStorage || requested("travel")),
-    skillSlotGeometry:
-      requested("skillKeyLabels") || requested("skillCooldowns"),
-    skillCooldownOverlay: requested("skillCooldowns"),
-  });
+    skillKeyLabels: requested("skillKeyLabels"),
+    skillCooldowns: requested("skillCooldowns"),
+  } satisfies Record<FeatureId, boolean>);
 }

--- a/tests/unit/companion-policy-source.test.ts
+++ b/tests/unit/companion-policy-source.test.ts
@@ -55,11 +55,11 @@ describe("companion policy source", () => {
         policy: {
           tools: false,
           targetReadout: false,
-          teamManagement: false,
+          teamApply: false,
           xunlaiStorage: false,
-          travelPalette: false,
-          skillSlotGeometry: false,
-          skillCooldownOverlay: false,
+          travel: false,
+          skillKeyLabels: false,
+          skillCooldowns: false,
         },
       },
     });

--- a/tests/unit/enhancement-runtime-policy.test.ts
+++ b/tests/unit/enhancement-runtime-policy.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import {
   enhancementRuntimePolicy,
 } from "../../src/renderer/enhancement-runtime-policy.js";
+import { FEATURE_SELECTION_POLICIES } from "../../src/shared/feature-contracts.js";
 
 const off = Object.freeze({
   gwonmacTools: false,
@@ -18,38 +19,38 @@ test("developer programs replace saved optional-tool selection in PvE", () => {
   assert.deepEqual(enhancementRuntimePolicy("toolbox-foundation", off, "pve"), {
     tools: true,
     targetReadout: false,
-    teamManagement: false,
+    teamApply: false,
     xunlaiStorage: false,
-    travelPalette: false,
-    skillSlotGeometry: false,
-    skillCooldownOverlay: false,
+    travel: false,
+    skillKeyLabels: false,
+    skillCooldowns: false,
   });
   assert.deepEqual(enhancementRuntimePolicy("toolbox-commands", off, "pve"), {
     tools: true,
     targetReadout: false,
-    teamManagement: true,
+    teamApply: true,
     xunlaiStorage: true,
-    travelPalette: true,
-    skillSlotGeometry: false,
-    skillCooldownOverlay: false,
+    travel: true,
+    skillKeyLabels: false,
+    skillCooldowns: false,
   });
   assert.deepEqual(enhancementRuntimePolicy("xunlai-storage", off, "pve"), {
     tools: true,
     targetReadout: false,
-    teamManagement: false,
+    teamApply: false,
     xunlaiStorage: true,
-    travelPalette: true,
-    skillSlotGeometry: false,
-    skillCooldownOverlay: false,
+    travel: true,
+    skillKeyLabels: false,
+    skillCooldowns: false,
   });
   assert.deepEqual(enhancementRuntimePolicy("target-observer", off, "pve"), {
     tools: false,
     targetReadout: true,
-    teamManagement: false,
+    teamApply: false,
     xunlaiStorage: false,
-    travelPalette: false,
-    skillSlotGeometry: false,
-    skillCooldownOverlay: false,
+    travel: false,
+    skillKeyLabels: false,
+    skillCooldowns: false,
   });
 });
 
@@ -64,10 +65,10 @@ test("runtime-gated commands fail closed while storage keeps its refusal reason"
     skillCooldownOverlayEnabled: false,
   });
   for (const region of ["unknown", "pvp"] as const) {
-    assert.equal(enhancementRuntimePolicy("toolbox-commands", on, region).teamManagement, false);
-    assert.equal(enhancementRuntimePolicy("none", on, region).teamManagement, false);
+    assert.equal(enhancementRuntimePolicy("toolbox-commands", on, region).teamApply, false);
+    assert.equal(enhancementRuntimePolicy("none", on, region).teamApply, false);
     assert.equal(enhancementRuntimePolicy("none", on, region).xunlaiStorage, true);
-    assert.equal(enhancementRuntimePolicy("none", on, region).travelPalette, false);
+    assert.equal(enhancementRuntimePolicy("none", on, region).travel, false);
     assert.equal(enhancementRuntimePolicy("none", on, region).targetReadout, false);
     assert.equal(enhancementRuntimePolicy("none", on, region).tools, true);
   }
@@ -85,22 +86,23 @@ test("product tool settings remain live once the capability is present", () => {
   }, "pve"), {
     tools: true,
     targetReadout: false,
-    teamManagement: true,
+    teamApply: true,
     xunlaiStorage: false,
-    travelPalette: true,
-    skillSlotGeometry: true,
-    skillCooldownOverlay: true,
+    travel: true,
+    skillKeyLabels: false,
+    skillCooldowns: true,
   });
 });
 
-test("skill geometry runs only for configured labels or enabled cooldowns", () => {
+test("skill feature selection distinguishes labels from cooldowns", () => {
   const empty = enhancementRuntimePolicy("none", {
     ...off,
     gwonmacTools: true,
     skillKeyBindings: [null, null, null, null, null, null, null, null],
     skillCooldownOverlayEnabled: false,
   }, "pve");
-  assert.equal(empty.skillSlotGeometry, false);
+  assert.equal(empty.skillKeyLabels, false);
+  assert.equal(empty.skillCooldowns, false);
   const labels = enhancementRuntimePolicy("none", {
     ...off,
     gwonmacTools: true,
@@ -119,8 +121,15 @@ test("skill geometry runs only for configured labels or enabled cooldowns", () =
     ],
     skillCooldownOverlayEnabled: false,
   }, "pve");
-  assert.equal(labels.skillSlotGeometry, true);
-  assert.equal(labels.skillCooldownOverlay, false);
+  assert.equal(labels.skillKeyLabels, true);
+  assert.equal(labels.skillCooldowns, false);
+});
+
+test("runtime policy projects every registered feature exactly once", () => {
+  assert.deepEqual(
+    Object.keys(enhancementRuntimePolicy("none", off, "unknown")).sort(),
+    Object.keys(FEATURE_SELECTION_POLICIES).sort(),
+  );
 });
 
 test("local Tools availability never depends on a live-game safety gate", () => {


### PR DESCRIPTION
## What changed

The live renderer policy now returns one boolean for every canonical `FeatureId`, using the same names as `FEATURE_SELECTION_POLICIES`.

The former parallel vocabulary (`teamManagement`, `travelPalette`, `skillSlotGeometry`, and `skillCooldownOverlay`) is gone. Shared skill geometry is now derived at its actual consumer boundary from `skillKeyLabels || skillCooldowns`.

## Why

The feature registry already defined Settings activation and coarse region policy, but the live policy projected a separate set of aliases. A future feature could be added to Settings without being represented at runtime.

The return type, `satisfies` check, and runtime key-set invariant now make that drift fail visibly.

## Invariant

- every registered feature has exactly one live-policy value;
- registry additions and removals fail type checking until the runtime projection is updated;
- the emitted runtime object has exactly the registry vocabulary;
- developer program overrides retain their existing scope;
- PvE/PvP/unknown behavior is unchanged;
- skill geometry remains active for labels or cooldowns, while cooldown observation remains cooldown-only.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm build`
- `pnpm test:unit` — 1,249 passed
- `pnpm test:policy` — 174 passed
- `pnpm test:integration` — 66 passed
- `pnpm test:release` — 25 passed
- `pnpm tools:test` — 102 passed
- `pnpm check:links`
- `node scripts/verify-companion-kernel.mjs`
- independent runtime, certification, and maintainability reviews — no findings

Local Electron/E2E and packaged-app tests were intentionally not run because they open intrusive windows; they remain covered by CI/manual approval.

- [x] I kept this pull request focused.
- [x] I ran the relevant non-E2E checks.
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [x] No user-facing documentation changed.
