### PR TITLE
fix(tools): polish cooldown settings

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -161,6 +161,10 @@ range band.
   move the wheel. Control, Option, Shift, and Command become part of the label.
   **Clear** restores the native number for that slot. Labels do not change the
   Guild Wars controls.
+- **Skill cooldowns** show the remaining recharge time over each unavailable
+  skill. In **Settings → Tools**, you can turn the numbers off and choose Guild
+  Wars red, native cream, warm gold, icy blue, or a custom color. This display
+  reads the game's existing recharge state; it does not activate skills.
 
 The same pane lists **Keyboard shortcuts**. Choose **Change**, then press a
 Command shortcut to replace the default. Letter and number shortcuts use their
@@ -193,8 +197,8 @@ transitions, and unknown regions. The saved Build and Team library stays
 available. Apply checks policy before each step and stops when the state
 changes.
 
-Skill key labels also stop outside a confirmed PvE region. Their saved display
-bindings remain in Settings.
+Skill key labels and cooldown numbers also stop outside a confirmed PvE region.
+Their saved display settings remain in Settings.
 
 The saved library still works when live client integration is unavailable. You
 can edit, import, and export. Live party data, storage opening, Travel, and Apply remain

--- a/src/renderer/settings-skill-cooldowns.ts
+++ b/src/renderer/settings-skill-cooldowns.ts
@@ -17,7 +17,6 @@ type FeedbackTone = "neutral" | "progress" | "success" | "warning" | "error";
 
 export function bindSkillCooldownSettings(options: Readonly<{
   fieldset: HTMLFieldSetElement;
-  settings: () => AppSettings | null;
   persist: (patch: Pick<AppSettings, "skillCooldownColor">) => Promise<unknown>;
   recoverAfterPersistFailure: (message: string) => Promise<void>;
   feedback: (message: string, tone: FeedbackTone, resetAfter?: number) => void;

--- a/src/renderer/settings.ts
+++ b/src/renderer/settings.ts
@@ -285,7 +285,6 @@
   const skillCooldownSettings = import('./settings-skill-cooldowns.js').then((module) =>
     module.bindSkillCooldownSettings({
       fieldset: byId('settings-skill-cooldowns') as HTMLFieldSetElement,
-      settings: () => currentSettings,
       persist: (patch) => persistSettings(patch),
       recoverAfterPersistFailure: recoverSettingsAfterFailedWrite,
       feedback: setFeedback,

--- a/tests/electron/settings-tools-updates.spec.ts
+++ b/tests/electron/settings-tools-updates.spec.ts
@@ -407,6 +407,59 @@ test.describe("tools and update settings", () => {
     }
   });
 
+  test("persists and re-renders skill cooldown presentation settings", async () => {
+    const fixture = await launchOffline(
+      "gw-settings-skill-cooldowns-e2e-",
+      {},
+      async (userData) => {
+        await writeFile(
+          path.join(userData, "settings.json"),
+          JSON.stringify({ gwonmacTools: true }),
+          { mode: 0o600 },
+        );
+      },
+    );
+    try {
+      const { app, page } = fixture;
+      await openControls(app, page);
+      const fieldset = page.locator("#settings-skill-cooldowns");
+      await expect(fieldset).toBeVisible();
+
+      const enabled = fieldset.locator('[name="skillCooldownOverlayEnabled"]');
+      await enabled.uncheck();
+      await expect.poll(() => page.evaluate(async () =>
+        (await window.gwNative.settings.get()).skillCooldownOverlayEnabled,
+      )).toBe(false);
+
+      await fieldset.locator('[name="skillCooldownColorChoice"][value="gold"]')
+        .check();
+      await expect.poll(() => page.evaluate(async () =>
+        (await window.gwNative.settings.get()).skillCooldownColor,
+      )).toEqual({ kind: "preset", preset: "gold" });
+
+      await fieldset.locator('[name="skillCooldownColorChoice"][value="custom"]')
+        .check();
+      const customHex = fieldset.locator('[name="skillCooldownCustomHex"]');
+      await customHex.fill("#123abc");
+      await customHex.press("Tab");
+      await expect.poll(() => page.evaluate(async () =>
+        (await window.gwNative.settings.get()).skillCooldownColor,
+      )).toEqual({ kind: "custom", value: "#123abc" });
+
+      await page.locator("#settings-done").click();
+      await openControls(app, page);
+      await expect(enabled).not.toBeChecked();
+      await expect(
+        fieldset.locator('[name="skillCooldownColorChoice"][value="custom"]'),
+      ).toBeChecked();
+      await expect(customHex).toHaveValue("#123abc");
+      await expect(fieldset.locator(".skill-cooldown-glyph"))
+        .toHaveText("2.9");
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
   test("the application menu opens Settings and the dedicated Updates pane", async () => {
     const fixture = await launchOffline("gw-settings-menu-e2e-");
     try {

--- a/tests/unit/settings-skill-cooldowns.test.ts
+++ b/tests/unit/settings-skill-cooldowns.test.ts
@@ -2,7 +2,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { bindSkillCooldownSettings } from "../../src/renderer/settings-skill-cooldowns.ts";
-import { DEFAULT_SETTINGS, type AppSettings } from "../../src/shared/contracts.ts";
+import { DEFAULT_SETTINGS } from "../../src/shared/contracts.ts";
 import type { SkillCooldownColor } from "../../src/shared/skill-cooldowns.ts";
 
 type Listener = () => void;
@@ -84,7 +84,7 @@ class FakeFieldset extends FakeElement {
   }
 }
 
-function fixture(settings: AppSettings, fail = false) {
+function fixture(fail = false) {
   const document = new FakeDocument();
   const fieldset = new FakeFieldset(document);
   const saved: SkillCooldownColor[] = [];
@@ -92,7 +92,6 @@ function fixture(settings: AppSettings, fail = false) {
   let recoveries = 0;
   const binder = bindSkillCooldownSettings({
     fieldset: fieldset as unknown as HTMLFieldSetElement,
-    settings: () => settings,
     persist: async ({ skillCooldownColor }) => {
       if (fail) throw new Error("disk full");
       saved.push(skillCooldownColor);
@@ -107,7 +106,7 @@ const flush = () => new Promise<void>((resolve) => setImmediate(resolve));
 
 test("cooldown settings render the canonical choice and shared preview", () => {
   const settings = { ...DEFAULT_SETTINGS, gwonmacTools: true };
-  const view = fixture(settings);
+  const view = fixture();
   view.binder.render(settings);
   assert.equal(view.fieldset.hidden, false);
   assert.equal(view.fieldset.enabled.checked, settings.skillCooldownOverlayEnabled);
@@ -118,7 +117,7 @@ test("cooldown settings render the canonical choice and shared preview", () => {
 
 test("cooldown settings reject malformed custom colors and persist valid colors", async () => {
   const settings = { ...DEFAULT_SETTINGS, gwonmacTools: true };
-  const view = fixture(settings);
+  const view = fixture();
   view.binder.render(settings);
   view.fieldset.choices.forEach((choice) => { choice.checked = choice.value === "custom"; });
   view.fieldset.choices[4]!.dispatch("change");
@@ -149,7 +148,7 @@ test("cooldown settings reject malformed custom colors and persist valid colors"
 
 test("cooldown settings recover the active state after a failed write", async () => {
   const settings = { ...DEFAULT_SETTINGS, gwonmacTools: true };
-  const view = fixture(settings, true);
+  const view = fixture(true);
   view.binder.render(settings);
   view.fieldset.choices.forEach((choice) => { choice.checked = choice.value === "gold"; });
   view.fieldset.choices[2]!.dispatch("change");


### PR DESCRIPTION
Skill cooldown controls were implemented, but the user guide did not explain them, the real Settings form lacked persistence coverage, and the cooldown binder exposed an unused settings callback.\n\nThis follow-up keeps the public behavior simple and closes those review gaps:\n- documents cooldown enable/color controls and confirmed-PvE withdrawal\n- verifies enable, preset, custom color, persistence, and re-rendering through the real Settings form\n- removes the unused binder dependency\n\nChecks:\n- \n- \n- 28 focused unit tests\n- \n\nLocal Electron/E2E tests were intentionally not run because they disrupt parallel work; CI owns that verification.