### PR TITLE
refactor(certification): isolate skill proof contributions

### DIFF
--- a/docs/skill-cooldowns.md
+++ b/docs/skill-cooldowns.md
@@ -52,8 +52,10 @@ The feature proof is owned by
 
 The exact build record is in
 [`enhancement-builds.ts`](../src/main/certification/enhancement-builds.ts), and
-the transformation checks are in
-[`enhancement-transform.ts`](../src/main/certification/enhancement-transform.ts).
+the skill-owned body and call-site checks are in
+[`enhancement-skill-transform.ts`](../src/main/certification/enhancement-skill-transform.ts).
+The root [`enhancement-transform.ts`](../src/main/certification/enhancement-transform.ts)
+still owns exact-input selection, cross-feature ordering, and assembly.
 Mutation tests independently alter the reader bound and timer operand and prove
 that cooldown certification withdraws while the other Tools capabilities stay
 available.

--- a/src/main/certification/enhancement-skill-transform.ts
+++ b/src/main/certification/enhancement-skill-transform.ts
@@ -1,0 +1,186 @@
+/**
+ * Feature-owned certification and byte rewrite for skill HUD observation.
+ * The root transform still owns cross-feature ordering and index allocation.
+ */
+import { createHash } from "node:crypto";
+import type { EnhancementCapabilities } from "../../shared/enhancement-contracts.js";
+import {
+  concat,
+  paddedIndex,
+  uleb,
+  type FunctionType,
+} from "../core/wasm-binary.js";
+import type { KnownEnhancementBuild } from "./enhancement-builds.js";
+
+export type ResolvedSkillFunction = Readonly<{
+  localIndex: number;
+  typeIndex: number;
+  type: FunctionType;
+}>;
+
+type ResolveFunction = (
+  label: string,
+  functionIndex: number,
+  expectedParams: readonly string[],
+  expectedResults: readonly string[],
+) => ResolvedSkillFunction;
+
+type SkillSlotGeometryCertificate = NonNullable<
+  KnownEnhancementBuild["skillSlotGeometry"]
+>;
+type SkillCooldownCertificate = NonNullable<
+  KnownEnhancementBuild["skillCooldownObservation"]
+>;
+
+export type EnhancementSkillTransformResolution = Readonly<{
+  geometry: Readonly<{
+    certificate: SkillSlotGeometryCertificate;
+    initializer: ResolvedSkillFunction;
+    constructor: ResolvedSkillFunction;
+  }> | null;
+  cooldown: Readonly<{
+    certificate: SkillCooldownCertificate;
+    reader: ResolvedSkillFunction;
+    timer: ResolvedSkillFunction;
+  }> | null;
+}>;
+
+function bodyHash(
+  bodies: readonly Uint8Array[],
+  importCount: number,
+  functionIndex: number,
+  fail: (message: string) => never,
+): string {
+  const body = bodies[functionIndex - importCount];
+  if (!body) fail(`function ${functionIndex} has no body`);
+  return createHash("sha256").update(body).digest("hex");
+}
+
+/** Resolve and verify the exact skill functions selected by this profile. */
+export function resolveEnhancementSkillTransform(options: Readonly<{
+  build: KnownEnhancementBuild;
+  capabilities: EnhancementCapabilities;
+  bodies: readonly Uint8Array[];
+  importCount: number;
+  resolveFunction: ResolveFunction;
+  fail: (message: string) => never;
+}>): EnhancementSkillTransformResolution {
+  const {
+    build,
+    capabilities,
+    bodies,
+    importCount,
+    resolveFunction,
+    fail,
+  } = options;
+  let geometry: EnhancementSkillTransformResolution["geometry"] = null;
+  if (capabilities.skillSlotGeometry) {
+    const certificate = build.skillSlotGeometry
+      ?? fail("skill-slot geometry is not certified");
+    const initializer = resolveFunction(
+      "SkillBar initializer",
+      certificate.initializer.functionIndex,
+      certificate.initializer.params,
+      certificate.initializer.results,
+    );
+    const constructor = resolveFunction(
+      "SkillBar frame constructor",
+      certificate.constructor.functionIndex,
+      certificate.constructor.params,
+      certificate.constructor.results,
+    );
+    if (
+      bodyHash(bodies, importCount, certificate.initializer.functionIndex, fail)
+        !== certificate.initializer.bodySha256
+      || bodyHash(bodies, importCount, certificate.constructor.functionIndex, fail)
+        !== certificate.constructor.bodySha256
+    ) fail("SkillBar frame capture bodies do not match their certificates");
+    const operand = certificate.initializer.constructorCallOperand;
+    const body = bodies[initializer.localIndex]!;
+    const expected = paddedIndex(certificate.constructor.functionIndex);
+    if (
+      body[operand - 1] !== 0x10
+      || expected.some((byte, index) => body[operand + index] !== byte)
+    ) fail("SkillBar constructor call site does not match its certificate");
+    geometry = { certificate, initializer, constructor };
+  }
+
+  let cooldown: EnhancementSkillTransformResolution["cooldown"] = null;
+  if (capabilities.skillCooldownObservation) {
+    const certificate = build.skillCooldownObservation
+      ?? fail("skill cooldown observation is not certified");
+    const reader = resolveFunction(
+      "skill recharge reader",
+      certificate.reader.functionIndex,
+      certificate.reader.params,
+      certificate.reader.results,
+    );
+    const timer = resolveFunction(
+      "precise skill timer",
+      certificate.timer.functionIndex,
+      certificate.timer.params,
+      certificate.timer.results,
+    );
+    if (
+      bodyHash(bodies, importCount, certificate.reader.functionIndex, fail)
+        !== certificate.reader.bodySha256
+      || bodyHash(bodies, importCount, certificate.timer.functionIndex, fail)
+        !== certificate.timer.bodySha256
+    ) fail("skill cooldown bodies do not match their certificates");
+    const operand = certificate.reader.timerCallOperand;
+    const body = bodies[reader.localIndex]!;
+    const expected = paddedIndex(certificate.timer.functionIndex);
+    if (
+      body[operand - 1] !== 0x10
+      || expected.some((byte, index) => body[operand + index] !== byte)
+    ) fail("skill timer call site does not match its certificate");
+    cooldown = { certificate, reader, timer };
+  }
+
+  return { geometry, cooldown };
+}
+
+/** Append the capture wrapper and replace only the certified call operand. */
+export function rewriteSkillBarConstructorCapture(options: Readonly<{
+  resolution: EnhancementSkillTransformResolution;
+  nextBodies: Uint8Array[];
+  skillBarFrameGlobalIndex: number;
+  appendFunction: (typeIndex: number, body: Uint8Array) => number;
+}>): void {
+  const {
+    resolution,
+    nextBodies,
+    skillBarFrameGlobalIndex,
+    appendFunction,
+  } = options;
+  const geometry = resolution.geometry;
+  if (!geometry) return;
+  const {
+    certificate: skillSlotGeometry,
+    initializer: skillInitializer,
+    constructor: skillConstructor,
+  } = geometry;
+
+  const wrapperIndex = appendFunction(
+    skillConstructor.typeIndex,
+    concat(
+      // One i32 local holds the constructor result while it is published.
+      uleb(1), uleb(1), Uint8Array.of(0x7f),
+      ...Array.from({ length: 6 }, (_, index) =>
+        concat(Uint8Array.of(0x20), uleb(index))),
+      Uint8Array.of(0x10), uleb(skillSlotGeometry.constructor.functionIndex),
+      Uint8Array.of(0x22), uleb(6),
+      Uint8Array.of(0x24), uleb(skillBarFrameGlobalIndex),
+      Uint8Array.of(0x20), uleb(6),
+      Uint8Array.of(0x0b),
+    ),
+  );
+  const rewrittenInitializer = new Uint8Array(
+    nextBodies[skillInitializer.localIndex]!,
+  );
+  rewrittenInitializer.set(
+    paddedIndex(wrapperIndex),
+    skillSlotGeometry.initializer.constructorCallOperand,
+  );
+  nextBodies[skillInitializer.localIndex] = rewrittenInitializer;
+}

--- a/src/main/certification/enhancement-transform.ts
+++ b/src/main/certification/enhancement-transform.ts
@@ -33,6 +33,10 @@ import {
 } from "./enhancement-builds.js";
 import { applyFeatureContributions } from "./enhancement-transform-features.js";
 import {
+  resolveEnhancementSkillTransform,
+  rewriteSkillBarConstructorCapture,
+} from "./enhancement-skill-transform.js";
+import {
   PROFESSION_TRACE_WORDS,
   professionTraceGlobals,
   type ProfessionTraceGlobals,
@@ -47,7 +51,6 @@ import {
   parseIndexVector,
   parseExports,
   parseTypes,
-  paddedIndex,
   sectionById,
   sleb,
   splitSections,
@@ -257,8 +260,6 @@ function resolveEnhancementTransform(
     : null;
   const travelAction = build.travelAction!;
   const chatAliases = build.chatAliases!;
-  const skillSlotGeometry = build.skillSlotGeometry!;
-  const skillCooldown = build.skillCooldownObservation!;
   const hasActionQueue = capabilities.teamApply
     || capabilities.travelAction
     || capabilities.xunlaiAction;
@@ -336,68 +337,16 @@ function resolveEnhancementTransform(
     if (!body) fail(`function ${functionIndex} has no body`);
     return createHash("sha256").update(body).digest("hex");
   };
-  const skillInitializer = capabilities.skillSlotGeometry
-    ? resolveHook(
-        "SkillBar initializer",
-        skillSlotGeometry.initializer.functionIndex,
-        skillSlotGeometry.initializer.params,
-        skillSlotGeometry.initializer.results,
-      )
-    : null;
-  const skillConstructor = capabilities.skillSlotGeometry
-    ? resolveHook(
-        "SkillBar frame constructor",
-        skillSlotGeometry.constructor.functionIndex,
-        skillSlotGeometry.constructor.params,
-        skillSlotGeometry.constructor.results,
-      )
-    : null;
-  const skillCooldownReader = capabilities.skillCooldownObservation
-    ? resolveHook(
-        "skill recharge reader",
-        skillCooldown.reader.functionIndex,
-        skillCooldown.reader.params,
-        skillCooldown.reader.results,
-      )
-    : null;
-  const skillTimer = capabilities.skillCooldownObservation
-    ? resolveHook(
-        "precise skill timer",
-        skillCooldown.timer.functionIndex,
-        skillCooldown.timer.params,
-        skillCooldown.timer.results,
-      )
-    : null;
-  if (skillInitializer && skillConstructor) {
-    if (
-      bodyHash(skillSlotGeometry.initializer.functionIndex)
-        !== skillSlotGeometry.initializer.bodySha256
-      || bodyHash(skillSlotGeometry.constructor.functionIndex)
-        !== skillSlotGeometry.constructor.bodySha256
-    ) fail("SkillBar frame capture bodies do not match their certificates");
-    const operand = skillSlotGeometry.initializer.constructorCallOperand;
-    const body = bodies[skillInitializer.localIndex]!;
-    const expected = paddedIndex(skillSlotGeometry.constructor.functionIndex);
-    if (
-      body[operand - 1] !== 0x10
-      || expected.some((byte, index) => body[operand + index] !== byte)
-    ) fail("SkillBar constructor call site does not match its certificate");
-  }
-  if (skillCooldownReader && skillTimer) {
-    if (
-      bodyHash(skillCooldown.reader.functionIndex)
-        !== skillCooldown.reader.bodySha256
-      || bodyHash(skillCooldown.timer.functionIndex)
-        !== skillCooldown.timer.bodySha256
-    ) fail("skill cooldown bodies do not match their certificates");
-    const operand = skillCooldown.reader.timerCallOperand;
-    const body = bodies[skillCooldownReader.localIndex]!;
-    const expected = paddedIndex(skillCooldown.timer.functionIndex);
-    if (
-      body[operand - 1] !== 0x10
-      || expected.some((byte, index) => body[operand + index] !== byte)
-    ) fail("skill timer call site does not match its certificate");
-  }
+  const skillResolution = resolveEnhancementSkillTransform({
+    build,
+    capabilities,
+    bodies,
+    importCount,
+    resolveFunction: resolveHook,
+    fail,
+  });
+  const skillInitializer = skillResolution.geometry?.initializer ?? null;
+  const skillConstructor = skillResolution.geometry?.constructor ?? null;
   if (bodyHash(build.hookFunction) !== build.hookBodySha256) {
     fail("tick body does not match its semantic fingerprint");
   }
@@ -703,10 +652,7 @@ function resolveEnhancementTransform(
     xunlaiAction,
     travelAction,
     chatAliases,
-    skillSlotGeometry,
-    skillCooldown,
-    skillInitializer,
-    skillConstructor,
+    skillResolution,
     commands,
     professionBuilder,
     skillBuilder,
@@ -743,9 +689,7 @@ function assembleEnhancementTransform(
     table,
     nextTableSize,
     hasActionQueue,
-    skillSlotGeometry,
-    skillInitializer,
-    skillConstructor,
+    skillResolution,
   } = resolution;
 
   const globals = vectorPayload(sectionById(sections, 6));
@@ -854,6 +798,8 @@ function assembleEnhancementTransform(
   };
   const selectedOriginalIndices = selected.map((hook) =>
     appendFunction(hook.typeIndex, bodies[hook.localIndex]!));
+  const skillTimerFunctionIndex = skillResolution.cooldown
+    ?.certificate.timer.functionIndex ?? null;
   const uiHookIndex = selected.findIndex((hook) =>
     hook.dispatchKind === COMPANION_DISPATCH_KINDS.ui);
   const uiOriginalIndex = selectedHooks.ui
@@ -872,35 +818,17 @@ function assembleEnhancementTransform(
         : null,
       capabilities.skillCooldownObservation
         && hook.dispatchKind === COMPANION_DISPATCH_KINDS.tick
-        ? resolution.skillCooldown.timer.functionIndex
+        ? skillTimerFunctionIndex
         : null,
     );
   });
 
-  if (skillInitializer && skillConstructor) {
-    const wrapperIndex = appendFunction(
-      skillConstructor.typeIndex,
-      concat(
-        // One i32 local holds the constructor result while it is published.
-        uleb(1), uleb(1), Uint8Array.of(0x7f),
-        ...Array.from({ length: 6 }, (_, index) =>
-          concat(Uint8Array.of(0x20), uleb(index))),
-        Uint8Array.of(0x10), uleb(skillSlotGeometry.constructor.functionIndex),
-        Uint8Array.of(0x22), uleb(6),
-        Uint8Array.of(0x24), uleb(skillBarFrameGlobalIndex),
-        Uint8Array.of(0x20), uleb(6),
-        Uint8Array.of(0x0b),
-      ),
-    );
-    const rewrittenInitializer = new Uint8Array(
-      nextBodies[skillInitializer.localIndex]!,
-    );
-    rewrittenInitializer.set(
-      paddedIndex(wrapperIndex),
-      skillSlotGeometry.initializer.constructorCallOperand,
-    );
-    nextBodies[skillInitializer.localIndex] = rewrittenInitializer;
-  }
+  rewriteSkillBarConstructorCapture({
+    resolution: skillResolution,
+    nextBodies,
+    skillBarFrameGlobalIndex,
+    appendFunction,
+  });
 
   const addedFunctionExports: Array<Readonly<{ name: string; index: number }>> = [];
   applyFeatureContributions(resolution, {

--- a/src/main/certification/local-client-skillbar-verifier.ts
+++ b/src/main/certification/local-client-skillbar-verifier.ts
@@ -1,0 +1,173 @@
+/**
+ * Skillbar-only slice of local client verification.
+ *
+ * It owns the geometry, player-row, and recharge proof relationship plus their
+ * feature-local diagnostics and build fragment. Shared module evidence and
+ * cross-domain observation-layout agreement remain with the root verifier.
+ */
+import type { EnhancementCapabilities } from "../../shared/enhancement-contracts.js";
+import type { KnownEnhancementBuild } from "./enhancement-builds.js";
+import {
+  derivePlayerSkillbarObservation,
+  playerSkillbarRoleCandidateCounts,
+} from "./enhancement-player-skillbar-proof.js";
+import { deriveSkillCooldownObservation } from "./enhancement-skill-cooldown-proof.js";
+import { deriveSkillSlotGeometry } from "./enhancement-skill-slot-geometry-proof.js";
+import { deriveObservationLayout } from "./enhancement-target-proof.js";
+import type {
+  LocalFeatureFailure,
+  LocalFeatureFailures,
+} from "./local-client-verification-contract.js";
+import type { EnhancementProofContext } from "./enhancement-wasm-proof-context.js";
+
+type SkillbarBuildFragment = Partial<Pick<KnownEnhancementBuild,
+  | "playerSkillbarObservation"
+  | "skillSlotGeometry"
+  | "skillCooldownObservation"
+>>;
+
+type LocalSkillbarBuildFragments = Readonly<{
+  beforeTeam: Pick<SkillbarBuildFragment, "playerSkillbarObservation">;
+  afterTeam: Omit<SkillbarBuildFragment, "playerSkillbarObservation">;
+}>;
+
+function includedProof<T>(included: boolean, proof: T | null): T | null | undefined {
+  return included ? proof : undefined;
+}
+
+export type LocalSkillbarProofs = Readonly<{
+  requestedGeometry: boolean;
+  requestedCooldown: boolean;
+  playerSkillbar:
+    NonNullable<KnownEnhancementBuild["playerSkillbarObservation"]> | null;
+  cooldownObservationLayout: ReturnType<typeof deriveObservationLayout>;
+  geometry: ReturnType<typeof deriveSkillSlotGeometry>;
+  cooldown: ReturnType<typeof deriveSkillCooldownObservation>;
+  includeGeometry: boolean;
+  includeCooldown: boolean;
+  needsStructuralEvidence: boolean;
+  ambiguousPlayerSkillbarCandidates?: number;
+}>;
+
+export function deriveLocalSkillbarProofs(
+  requested: EnhancementCapabilities,
+  context: EnhancementProofContext,
+  playRegionAvailable: boolean,
+): LocalSkillbarProofs {
+  const playerSkillbar = requested.partyObservation
+      || requested.skillCooldownObservation
+    ? derivePlayerSkillbarObservation(context.module)
+    : null;
+  const cooldownObservationLayout = requested.skillCooldownObservation
+    ? deriveObservationLayout(context.module)
+    : null;
+  const geometry = requested.skillSlotGeometry
+    ? deriveSkillSlotGeometry(context)
+    : null;
+  const cooldown = requested.skillCooldownObservation
+    ? deriveSkillCooldownObservation(context, playerSkillbar)
+    : null;
+  const includeGeometry = requested.skillSlotGeometry
+    && playRegionAvailable
+    && geometry !== null;
+  const includeCooldown = requested.skillCooldownObservation
+    && playRegionAvailable
+    && cooldownObservationLayout !== null
+    && playerSkillbar !== null
+    && cooldown !== null;
+  const needsGeometryEvidence = requested.skillSlotGeometry && geometry === null;
+  const needsCooldownEvidence = requested.skillCooldownObservation
+    && (cooldownObservationLayout === null
+      || playerSkillbar === null
+      || cooldown === null);
+  const ambiguousPlayerSkillbarCandidates = needsCooldownEvidence
+      && playerSkillbar === null
+    ? playerSkillbarRoleCandidateCounts(context.module).find((count) => count > 1)
+    : undefined;
+  return Object.freeze({
+    requestedGeometry: requested.skillSlotGeometry,
+    requestedCooldown: requested.skillCooldownObservation,
+    playerSkillbar,
+    cooldownObservationLayout,
+    geometry,
+    cooldown,
+    includeGeometry,
+    includeCooldown,
+    needsStructuralEvidence: needsGeometryEvidence || needsCooldownEvidence,
+    ...(ambiguousPlayerSkillbarCandidates === undefined
+      ? {}
+      : { ambiguousPlayerSkillbarCandidates }),
+  });
+}
+
+type SharedSkillbarFailures = Readonly<{
+  skillSlotGeometry: LocalFeatureFailure<"skillSlotGeometry"> | null;
+  skillCooldownObservation:
+    LocalFeatureFailure<"skillCooldownObservation"> | null;
+}>;
+
+export function diagnoseLocalSkillbarFailures(
+  proofs: LocalSkillbarProofs,
+  shared: SharedSkillbarFailures,
+): LocalFeatureFailures {
+  const needsGeometryEvidence = proofs.requestedGeometry && proofs.geometry === null;
+  const needsCooldownEvidence = proofs.requestedCooldown
+    && (proofs.cooldownObservationLayout === null
+      || proofs.playerSkillbar === null
+      || proofs.cooldown === null);
+  return Object.freeze({
+    ...(needsGeometryEvidence
+      ? {
+          skillSlotGeometry: shared.skillSlotGeometry ?? Object.freeze({
+            status: "changed" as const,
+            invariant: "skill-slots.frame-constructor" as const,
+          }),
+        }
+      : {}),
+    ...(needsCooldownEvidence
+      ? {
+          skillCooldownObservation: shared.skillCooldownObservation
+            ?? (proofs.ambiguousPlayerSkillbarCandidates === undefined
+              ? null
+              : Object.freeze({
+                  status: "ambiguous" as const,
+                  invariant: "skill-cooldown.player-skillbar" as const,
+                  candidates: proofs.ambiguousPlayerSkillbarCandidates,
+                }))
+            ?? Object.freeze({
+              status: "changed" as const,
+              invariant: proofs.cooldownObservationLayout === null
+                ? "skill-cooldown.observation-base" as const
+                : proofs.playerSkillbar === null
+                  ? "skill-cooldown.player-skillbar" as const
+                  : "skill-cooldown.recharge-reader" as const,
+            }),
+        }
+      : {}),
+  });
+}
+
+export function localSkillbarBuildFragment(
+  proofs: LocalSkillbarProofs,
+  includeParty: boolean,
+): LocalSkillbarBuildFragments | null {
+  const playerSkillbar = includedProof(
+    includeParty || proofs.includeCooldown,
+    proofs.playerSkillbar,
+  );
+  const geometry = includedProof(proofs.includeGeometry, proofs.geometry);
+  const cooldown = includedProof(proofs.includeCooldown, proofs.cooldown);
+  if (playerSkillbar === null || geometry === null || cooldown === null) return null;
+
+  return Object.freeze({
+    beforeTeam: Object.freeze({
+      ...(playerSkillbar === undefined
+        ? {}
+        : { playerSkillbarObservation: playerSkillbar }),
+    }),
+    afterTeam: Object.freeze({
+      ...(geometry === undefined ? {} : { skillSlotGeometry: geometry }),
+      ...(cooldown === undefined ? {} : { skillCooldownObservation: cooldown }),
+    }),
+  });
+}

--- a/src/main/certification/local-client-verifier.ts
+++ b/src/main/certification/local-client-verifier.ts
@@ -48,11 +48,6 @@ import {
   type LocalActionRoleDiagnostics,
 } from "./enhancement-local-actions-proof.js";
 import { transformEnhancementWasm } from "./enhancement-transform.js";
-import { deriveObservationLayout } from "./enhancement-target-proof.js";
-import {
-  derivePlayerSkillbarObservation,
-  playerSkillbarRoleCandidateCounts,
-} from "./enhancement-player-skillbar-proof.js";
 import {
   enhancementProofContext,
   type EnhancementProofContext,
@@ -71,8 +66,12 @@ import {
   type LocalFeatureInvariant,
 } from "./local-client-verification-contract.js";
 import { SEMANTIC_VERIFIER_ABI } from "./semantic-proof.js";
-import { deriveSkillSlotGeometry } from "./enhancement-skill-slot-geometry-proof.js";
-import { deriveSkillCooldownObservation } from "./enhancement-skill-cooldown-proof.js";
+import {
+  deriveLocalSkillbarProofs,
+  diagnoseLocalSkillbarFailures,
+  localSkillbarBuildFragment,
+  type LocalSkillbarProofs,
+} from "./local-client-skillbar-verifier.js";
 
 export { isLocalClientVerification } from "./local-client-verification-boundary.js";
 export {
@@ -328,10 +327,7 @@ function diagnoseFeatureFailures(
   locatedPlayRegion: AutomaticPlayRegionLocation | null,
   locatedTarget: AutomaticTargetLocation | null,
   locatedLocal: AutomaticLocalActionsLocation | null,
-  locatedSkillSlotGeometry: ReturnType<typeof deriveSkillSlotGeometry>,
-  cooldownObservationLayout: ReturnType<typeof deriveObservationLayout>,
-  locatedPlayerSkillbar: ReturnType<typeof derivePlayerSkillbarObservation>,
-  locatedSkillCooldown: ReturnType<typeof deriveSkillCooldownObservation>,
+  skillbar: LocalSkillbarProofs,
   context: EnhancementProofContext,
 ): LocalFeatureFailures {
   const needsLocalEvidence = (requested.partyObservation
@@ -340,18 +336,11 @@ function diagnoseFeatureFailures(
     || (requested.travelAction && !locatedLocal?.travelAction)
     || (requested.xunlaiAction && !locatedLocal?.xunlaiAction)
     || (requested.chatAliases && !locatedLocal?.chatAliases);
-  const needsSkillEvidence = requested.skillSlotGeometry
-    && locatedSkillSlotGeometry === null;
-  const needsCooldownEvidence = requested.skillCooldownObservation
-    && (cooldownObservationLayout === null
-      || locatedPlayerSkillbar === null
-      || locatedSkillCooldown === null);
   const needsEvidence = (requested.nativeCursor && !locatedCursor)
     || (requested.playRegionObservation && !locatedPlayRegion)
     || (requested.targetObservation && !locatedTarget)
     || needsLocalEvidence
-    || needsSkillEvidence
-    || needsCooldownEvidence;
+    || skillbar.needsStructuralEvidence;
   const evidence = needsEvidence ? structuralEvidence(input, context) : null;
   const roles = needsLocalEvidence
     ? inspectLocalActionRoleCandidates(input, ENHANCEMENT_BUILDS, context)
@@ -369,15 +358,13 @@ function diagnoseFeatureFailures(
   const travelShared = sharedEvidenceFailure("travelAction", evidence);
   const xunlaiShared = sharedEvidenceFailure("xunlaiAction", evidence);
   const aliasesShared = sharedEvidenceFailure("chatAliases", evidence);
-  const skillShared = sharedEvidenceFailure("skillSlotGeometry", evidence);
-  const cooldownShared = sharedEvidenceFailure(
-    "skillCooldownObservation",
-    evidence,
-  );
-  const ambiguousSkillbarCandidates = needsCooldownEvidence
-      && locatedPlayerSkillbar === null
-    ? playerSkillbarRoleCandidateCounts(context.module).find((count) => count > 1)
-    : undefined;
+  const skillbarFailures = diagnoseLocalSkillbarFailures(skillbar, {
+    skillSlotGeometry: sharedEvidenceFailure("skillSlotGeometry", evidence),
+    skillCooldownObservation: sharedEvidenceFailure(
+      "skillCooldownObservation",
+      evidence,
+    ),
+  });
   return Object.freeze({
     ...(requested.nativeCursor && !locatedCursor
       ? { nativeCursor: cursorFailure(evidence) }
@@ -542,35 +529,7 @@ function diagnoseFeatureFailures(
               : changedFeature("chatAliases", "chat.alias-parser-anchor")),
         }
       : {}),
-    ...(needsSkillEvidence
-      ? {
-          skillSlotGeometry: skillShared
-            ?? changedFeature(
-              "skillSlotGeometry",
-              "skill-slots.frame-constructor",
-            ),
-        }
-      : {}),
-    ...(needsCooldownEvidence
-      ? {
-          skillCooldownObservation: cooldownShared
-            ?? (ambiguousSkillbarCandidates !== undefined
-              ? ambiguousFeature(
-                  "skillCooldownObservation",
-                  "skill-cooldown.player-skillbar",
-                  ambiguousSkillbarCandidates,
-                )
-              : null)
-            ?? changedFeature(
-              "skillCooldownObservation",
-              cooldownObservationLayout === null
-                ? "skill-cooldown.observation-base"
-                : locatedPlayerSkillbar === null
-                  ? "skill-cooldown.player-skillbar"
-                  : "skill-cooldown.recharge-reader",
-            ),
-        }
-      : {}),
+    ...skillbarFailures,
   });
 }
 
@@ -610,13 +569,13 @@ function deriveEnhancementBuild(
   const locatedTarget = requestedCapabilities.targetObservation
     ? locateAutomaticTarget(templateOutput, ENHANCEMENT_BUILDS, context)
     : null;
-  const cooldownObservationLayout = requestedCapabilities.skillCooldownObservation
-    ? deriveObservationLayout(context.module)
-    : null;
-  const locatedPlayerSkillbar = requestedCapabilities.partyObservation
-      || requestedCapabilities.skillCooldownObservation
-    ? derivePlayerSkillbarObservation(context.module)
-    : null;
+  const includePlayRegion = requestedCapabilities.playRegionObservation
+    && locatedPlayRegion !== null;
+  const skillbar = deriveLocalSkillbarProofs(
+    requestedCapabilities,
+    context,
+    includePlayRegion,
+  );
   const wantsLocal = requestedCapabilities.partyObservation
     || requestedCapabilities.teamApply
     || requestedCapabilities.travelAction
@@ -628,17 +587,12 @@ function deriveEnhancementBuild(
         ENHANCEMENT_BUILDS,
         context,
         locatedTarget?.observationLayout,
-        locatedPlayerSkillbar,
+        skillbar.playerSkillbar,
       )
-    : null;
-  const locatedSkillSlotGeometry = requestedCapabilities.skillSlotGeometry
-    ? deriveSkillSlotGeometry(context)
     : null;
   const cursor = locatedCursor?.baseline.cursorEvent;
   const includeCursor = locatedCursor !== null && cursor !== undefined;
   const includeTarget = locatedTarget !== null;
-  const includePlayRegion = requestedCapabilities.playRegionObservation
-    && locatedPlayRegion !== null;
   const includeParty = requestedCapabilities.partyObservation
     && locatedLocal?.observationLayout != null
     && locatedLocal.uiDispatcher != null
@@ -659,20 +613,6 @@ function deriveEnhancementBuild(
   const includeAliases = requestedCapabilities.chatAliases
     && locatedLocal?.uiDispatcher != null
     && locatedLocal.chatAliases != null;
-  const includeSkillSlotGeometry = requestedCapabilities.skillSlotGeometry
-    && includePlayRegion
-    && locatedSkillSlotGeometry !== null;
-  const locatedSkillCooldown = requestedCapabilities.skillCooldownObservation
-    ? deriveSkillCooldownObservation(
-        context,
-        locatedPlayerSkillbar,
-      )
-    : null;
-  const includeSkillCooldown = requestedCapabilities.skillCooldownObservation
-    && includePlayRegion
-    && cooldownObservationLayout !== null
-    && locatedPlayerSkillbar !== null
-    && locatedSkillCooldown !== null;
   const failures = diagnoseFeatureFailures(
     templateOutput,
     requestedCapabilities,
@@ -680,10 +620,7 @@ function deriveEnhancementBuild(
     locatedPlayRegion,
     locatedTarget,
     locatedLocal,
-    locatedSkillSlotGeometry,
-    cooldownObservationLayout,
-    locatedPlayerSkillbar,
-    locatedSkillCooldown,
+    skillbar,
     context,
   );
   const localContributes = includeParty || includeTeam || includeTravel
@@ -704,8 +641,8 @@ function deriveEnhancementBuild(
     ? locatedTarget.observationLayout
     : includeParty || includeXunlai
       ? locatedLocal!.observationLayout!
-      : includeSkillCooldown
-        ? cooldownObservationLayout
+      : skillbar.includeCooldown
+        ? skillbar.cooldownObservationLayout
         : null;
   if (
     includePlayRegion
@@ -761,6 +698,10 @@ function deriveEnhancementBuild(
     });
   }
   const baseline = source.baseline;
+  const skillbarBuild = localSkillbarBuildFragment(skillbar, includeParty);
+  if (skillbarBuild === null) {
+    return Object.freeze({ build: null, failures });
+  }
   const provisional: KnownEnhancementBuild = Object.freeze({
     sha256: report.sha256,
     outputSha256: Object.freeze({}),
@@ -807,16 +748,9 @@ function deriveEnhancementBuild(
     ...(includeParty ? {
       partyObservation: locatedLocal.partyObservation,
     } : {}),
-    ...(includeParty || includeSkillCooldown ? {
-      playerSkillbarObservation: locatedPlayerSkillbar!,
-    } : {}),
+    ...skillbarBuild.beforeTeam,
     ...(includeTeam ? { teamApply: locatedLocal!.teamApply! } : {}),
-    ...(includeSkillSlotGeometry
-      ? { skillSlotGeometry: locatedSkillSlotGeometry }
-      : {}),
-    ...(includeSkillCooldown
-      ? { skillCooldownObservation: locatedSkillCooldown }
-      : {}),
+    ...skillbarBuild.afterTeam,
   });
   const maximum: EnhancementCapabilities = Object.freeze({
     nativeCursor: includeCursor,
@@ -826,8 +760,8 @@ function deriveEnhancementBuild(
     travelAction: includeTravel,
     xunlaiAction: includeXunlai,
     chatAliases: includeAliases,
-    skillSlotGeometry: includeSkillSlotGeometry,
-    skillCooldownObservation: includeSkillCooldown,
+    skillSlotGeometry: skillbar.includeGeometry,
+    skillCooldownObservation: skillbar.includeCooldown,
     playRegionObservation: includePlayRegion,
   });
   const effective = intersectEnhancementCapabilities(requestedCapabilities, maximum);

--- a/tests/unit/enhancement-skill-transform.test.ts
+++ b/tests/unit/enhancement-skill-transform.test.ts
@@ -1,0 +1,211 @@
+import { createHash } from "node:crypto";
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { EnhancementCapabilities } from "../../src/shared/enhancement-contracts.js";
+import type { KnownEnhancementBuild } from "../../src/main/certification/enhancement-builds.js";
+import {
+  resolveEnhancementSkillTransform,
+  rewriteSkillBarConstructorCapture,
+} from "../../src/main/certification/enhancement-skill-transform.js";
+import { concat, paddedIndex, uleb } from "../../src/main/core/wasm-binary.js";
+
+const capabilities: EnhancementCapabilities = Object.freeze({
+  nativeCursor: false,
+  targetObservation: false,
+  partyObservation: false,
+  teamApply: false,
+  travelAction: false,
+  xunlaiAction: false,
+  chatAliases: false,
+  skillSlotGeometry: true,
+  skillCooldownObservation: true,
+  playRegionObservation: true,
+});
+
+const hash = (body: Uint8Array) =>
+  createHash("sha256").update(body).digest("hex");
+
+const initializer = concat(Uint8Array.of(0), Uint8Array.of(0x10), paddedIndex(1), Uint8Array.of(0x0b));
+const constructor = Uint8Array.of(0, 0x41, 0, 0x0b);
+const reader = concat(Uint8Array.of(0), Uint8Array.of(0x10), paddedIndex(3), Uint8Array.of(0x0b));
+const timer = Uint8Array.of(0, 0x41, 0, 0x0b);
+const bodies = [initializer, constructor, reader, timer] as const;
+
+function build(): KnownEnhancementBuild {
+  return {
+    sha256: "0".repeat(64),
+    outputSha256: {},
+    programId: 1,
+    buildId: 1,
+    hookFunction: 0,
+    hookParams: ["i32"],
+    hookResults: [],
+    hookBodySha256: "0".repeat(64),
+    tableSlot: 1,
+    skillSlotGeometry: {
+      initializer: {
+        functionIndex: 0,
+        params: ["i32", "i32"],
+        results: [],
+        bodySha256: hash(initializer),
+        constructorCallOperand: 2,
+      },
+      constructor: {
+        functionIndex: 1,
+        params: ["i32", "i32", "i32", "i32", "i32", "i32"],
+        results: ["i32"],
+        bodySha256: hash(constructor),
+      },
+      labelAddress: 0,
+      layout: {} as never,
+    },
+    skillCooldownObservation: {
+      reader: {
+        functionIndex: 2,
+        params: ["i32", "i32", "i32"],
+        results: ["i32"],
+        bodySha256: hash(reader),
+        timerCallOperand: 2,
+      },
+      timer: {
+        functionIndex: 3,
+        params: [],
+        results: ["i32"],
+        bodySha256: hash(timer),
+      },
+      layout: {} as never,
+    },
+  };
+}
+
+const fail = (message: string): never => {
+  throw new Error(`enhancement transform: ${message}`);
+};
+
+function resolve(
+  candidate = build(),
+  selectedCapabilities = capabilities,
+) {
+  const labels: string[] = [];
+  const resolution = resolveEnhancementSkillTransform({
+    build: candidate,
+    capabilities: selectedCapabilities,
+    bodies,
+    importCount: 0,
+    resolveFunction: (label, functionIndex) => {
+      labels.push(label);
+      return {
+        localIndex: functionIndex,
+        typeIndex: 40 + functionIndex,
+        type: { params: [], results: [] },
+      };
+    },
+    fail,
+  });
+  return { labels, resolution };
+}
+
+test("skill transform resolves and verifies only its four certified functions", () => {
+  const { labels, resolution } = resolve();
+  assert.deepEqual(labels, [
+    "SkillBar initializer",
+    "SkillBar frame constructor",
+    "skill recharge reader",
+    "precise skill timer",
+  ]);
+  assert.ok(resolution.geometry);
+  assert.ok(resolution.cooldown);
+});
+
+test("unselected skill facts stay absent and selected missing facts fail clearly", () => {
+  const original = build();
+  const withoutSkillFacts: KnownEnhancementBuild = {
+    sha256: original.sha256,
+    outputSha256: original.outputSha256,
+    programId: original.programId,
+    buildId: original.buildId,
+    hookFunction: original.hookFunction,
+    hookParams: original.hookParams,
+    hookResults: original.hookResults,
+    hookBodySha256: original.hookBodySha256,
+    tableSlot: original.tableSlot,
+  };
+  const unselected = resolve(withoutSkillFacts, {
+    ...capabilities,
+    skillSlotGeometry: false,
+    skillCooldownObservation: false,
+  });
+  assert.deepEqual(unselected.labels, []);
+  assert.deepEqual(unselected.resolution, { geometry: null, cooldown: null });
+  assert.throws(
+    () => resolve(withoutSkillFacts),
+    /skill-slot geometry is not certified/u,
+  );
+});
+
+test("skill transform refuses changed bodies and changed certified call operands", () => {
+  const original = build();
+  const changedBody: KnownEnhancementBuild = {
+    ...original,
+    skillSlotGeometry: {
+      ...original.skillSlotGeometry!,
+      constructor: {
+        ...original.skillSlotGeometry!.constructor,
+        bodySha256: "0".repeat(64),
+      },
+    },
+  };
+  assert.throws(
+    () => resolve(changedBody),
+    /SkillBar frame capture bodies do not match their certificates/u,
+  );
+
+  const changedSite: KnownEnhancementBuild = {
+    ...original,
+    skillCooldownObservation: {
+      ...original.skillCooldownObservation!,
+      reader: {
+        ...original.skillCooldownObservation!.reader,
+        timerCallOperand: 3,
+      },
+    },
+  };
+  assert.throws(
+    () => resolve(changedSite),
+    /skill timer call site does not match its certificate/u,
+  );
+});
+
+test("SkillBar capture rewrites only the certified operand and preserves wrapper bytes", () => {
+  const { resolution } = resolve();
+  const nextBodies = bodies.map((body) => new Uint8Array(body));
+  let wrapper: Uint8Array | null = null;
+  rewriteSkillBarConstructorCapture({
+    resolution,
+    nextBodies,
+    skillBarFrameGlobalIndex: 12,
+    appendFunction: (typeIndex, body) => {
+      assert.equal(typeIndex, 41);
+      wrapper = body;
+      return 99;
+    },
+  });
+
+  const expectedInitializer = new Uint8Array(initializer);
+  expectedInitializer.set(paddedIndex(99), 2);
+  assert.deepEqual(nextBodies[0], expectedInitializer);
+  assert.deepEqual(nextBodies.slice(1), bodies.slice(1));
+  assert.deepEqual(
+    wrapper,
+    concat(
+      uleb(1), uleb(1), Uint8Array.of(0x7f),
+      ...Array.from({ length: 6 }, (_, index) =>
+        concat(Uint8Array.of(0x20), uleb(index))),
+      Uint8Array.of(0x10), uleb(1),
+      Uint8Array.of(0x22), uleb(6),
+      Uint8Array.of(0x24), uleb(12),
+      Uint8Array.of(0x20), uleb(6),
+      Uint8Array.of(0x0b),
+    ),
+  );
+});

--- a/tests/unit/local-client-skillbar-verifier.test.ts
+++ b/tests/unit/local-client-skillbar-verifier.test.ts
@@ -1,0 +1,162 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { ENHANCEMENT_BUILDS } from "../../src/main/certification/enhancement-builds.js";
+import {
+  diagnoseLocalSkillbarFailures,
+  localSkillbarBuildFragment,
+  type LocalSkillbarProofs,
+} from "../../src/main/certification/local-client-skillbar-verifier.js";
+
+const build = ENHANCEMENT_BUILDS[0]!;
+
+function proofs(
+  overrides: Partial<LocalSkillbarProofs> = {},
+): LocalSkillbarProofs {
+  return Object.freeze({
+    requestedGeometry: true,
+    requestedCooldown: true,
+    playerSkillbar: build.playerSkillbarObservation!,
+    cooldownObservationLayout: build.observationBase!.layout,
+    geometry: build.skillSlotGeometry!,
+    cooldown: build.skillCooldownObservation!,
+    includeGeometry: true,
+    includeCooldown: true,
+    needsStructuralEvidence: false,
+    ...overrides,
+  });
+}
+
+const noSharedFailures = Object.freeze({
+  skillSlotGeometry: null,
+  skillCooldownObservation: null,
+});
+
+test("skillbar diagnostics preserve feature-local failure precedence", () => {
+  const missingObservation = diagnoseLocalSkillbarFailures(proofs({
+    cooldownObservationLayout: null,
+    playerSkillbar: null,
+    cooldown: null,
+    includeCooldown: false,
+    needsStructuralEvidence: true,
+  }), noSharedFailures);
+  assert.deepEqual(missingObservation.skillCooldownObservation, {
+    status: "changed",
+    invariant: "skill-cooldown.observation-base",
+  });
+
+  const ambiguousPlayerBar = diagnoseLocalSkillbarFailures(proofs({
+    playerSkillbar: null,
+    cooldown: null,
+    includeCooldown: false,
+    needsStructuralEvidence: true,
+    ambiguousPlayerSkillbarCandidates: 2,
+  }), noSharedFailures);
+  assert.deepEqual(ambiguousPlayerBar.skillCooldownObservation, {
+    status: "ambiguous",
+    invariant: "skill-cooldown.player-skillbar",
+    candidates: 2,
+  });
+
+  const missingReader = diagnoseLocalSkillbarFailures(proofs({
+    cooldown: null,
+    includeCooldown: false,
+    needsStructuralEvidence: true,
+  }), noSharedFailures);
+  assert.deepEqual(missingReader.skillCooldownObservation, {
+    status: "changed",
+    invariant: "skill-cooldown.recharge-reader",
+  });
+});
+
+test("shared module failures override skillbar-specific diagnostics", () => {
+  const failures = diagnoseLocalSkillbarFailures(proofs({
+    geometry: null,
+    cooldown: null,
+    includeGeometry: false,
+    includeCooldown: false,
+    needsStructuralEvidence: true,
+  }), {
+    skillSlotGeometry: {
+      status: "changed",
+      invariant: "module.analysis-budget",
+    },
+    skillCooldownObservation: {
+      status: "changed",
+      invariant: "module.wasm-validation",
+    },
+  });
+  assert.deepEqual(failures, {
+    skillSlotGeometry: {
+      status: "changed",
+      invariant: "module.analysis-budget",
+    },
+    skillCooldownObservation: {
+      status: "changed",
+      invariant: "module.wasm-validation",
+    },
+  });
+});
+
+test("the build fragment keeps cooldown independent from Party UI authority", () => {
+  const fragment = localSkillbarBuildFragment(proofs(), false);
+  assert.ok(fragment);
+  assert.equal(
+    fragment.beforeTeam.playerSkillbarObservation,
+    build.playerSkillbarObservation,
+  );
+  assert.equal(fragment.afterTeam.skillSlotGeometry, build.skillSlotGeometry);
+  assert.equal(
+    fragment.afterTeam.skillCooldownObservation,
+    build.skillCooldownObservation,
+  );
+  assert.deepEqual(Object.keys({
+    partyObservation: build.partyObservation,
+    ...fragment.beforeTeam,
+    teamApply: build.teamApply,
+    ...fragment.afterTeam,
+  }), [
+    "partyObservation",
+    "playerSkillbarObservation",
+    "teamApply",
+    "skillSlotGeometry",
+    "skillCooldownObservation",
+  ]);
+
+  const partyOnly = localSkillbarBuildFragment(proofs({
+    requestedGeometry: false,
+    requestedCooldown: false,
+    geometry: null,
+    cooldownObservationLayout: null,
+    cooldown: null,
+    includeGeometry: false,
+    includeCooldown: false,
+  }), true);
+  assert.deepEqual(partyOnly, {
+    beforeTeam: {
+      playerSkillbarObservation: build.playerSkillbarObservation,
+    },
+    afterTeam: {},
+  });
+});
+
+test("the build fragment refuses inconsistent include flags", () => {
+  assert.equal(localSkillbarBuildFragment(proofs({
+    playerSkillbar: null,
+  }), false), null);
+  assert.equal(localSkillbarBuildFragment(proofs({
+    geometry: null,
+  }), false), null);
+  assert.equal(localSkillbarBuildFragment(proofs({
+    cooldown: null,
+  }), false), null);
+  assert.equal(localSkillbarBuildFragment(proofs({
+    requestedGeometry: false,
+    requestedCooldown: false,
+    playerSkillbar: null,
+    cooldownObservationLayout: null,
+    geometry: null,
+    cooldown: null,
+    includeGeometry: false,
+    includeCooldown: false,
+  }), true), null);
+});


### PR DESCRIPTION
Skill certification had grown two general-purpose roots close to 1,000 lines by adding feature-specific proof, diagnostics, and byte rewriting directly into their orchestration paths. That made the next certified observation harder to add safely.

This refactor moves only the cohesive skill-owned work behind two compile-time boundaries. `enhancement-skill-transform.ts` owns selected skill certificate resolution, exact body/call-site checks, and the constructor capture rewrite. `local-client-skillbar-verifier.ts` owns skillbar/cooldown proof derivation, feature-local diagnostic precedence, and the ordered build fragments. The roots continue to own cross-feature ordering, allocation, shared structural evidence, capability composition, and final assembly.

Selected capabilities now require their exact certificate explicitly; unselected facts remain explicitly absent. No runtime plugin API, registry, compatibility path, native offset, or new authority is introduced, and valid transformed bytes/build fingerprints remain unchanged.

Stacked on the preceding `fix/skill-observation-hardening` PR.

Verification:

- `pnpm check` — 1,263 unit, 174 policy, and 102 Tools UI tests
- focused transform/verifier tests, including exact wrapper bytes and build-property order
- `pnpm build`
- reproducible companion-kernel verification
- integration 66/66, release 25/25, exact-client artifact 3/3
- `pnpm package:built`

Electron and E2E tests were intentionally not run locally because they disrupt parallel work.
