### PR TITLE
fix(input): repeat chat history and cursor arrows while held

### DIFF
--- a/docs/process-model.md
+++ b/docs/process-model.md
@@ -194,8 +194,11 @@ Before the first window exists, Electron writes the bundle-specific persistent
 repeat keydowns to hidden text proxies for printable characters, Backspace,
 Delete, and navigation keys. It does not change the global macOS preference,
 create a timer, or synthesize repeat cadence. macOS remains the sole repeat
-clock. Automated tests prove how Chromium handles supplied repeat events. A
-packaged physical test proves that AppKit supplies them to the current client.
+clock. Guild Wars treats arrows as transitions, so the renderer puts a release
+before each native repeated arrow press. This lets chat history and cursor
+movement follow the native cadence. Automated tests prove how Chromium handles
+supplied repeat events. A packaged physical test proves that AppKit supplies
+them to the current client.
 
 Certified Core supplies native double-click and the Guild Wars cursor. Core is
 required behavior. It is not a saved player preference. If an ArenaNet build

--- a/src/renderer/input.ts
+++ b/src/renderer/input.ts
@@ -44,6 +44,13 @@ const TRACED_MODIFIERS: Readonly<Record<string, 'ctrl' | 'shift' | 'alt'>> = {
   Alt: 'alt',
 };
 
+const REPEATED_ARROW_KEYS = new Set([
+  'ArrowUp',
+  'ArrowDown',
+  'ArrowLeft',
+  'ArrowRight',
+]);
+
 const isCommandKey = (code: string): boolean =>
   code === 'MetaLeft' || code === 'MetaRight';
 
@@ -499,6 +506,13 @@ export const installGameInput = ({
     const held = heldKeys.get(event.code);
     const key = clientKey(event, event.repeat ? held?.key : undefined);
     if (event.repeat && held) {
+      // Guild Wars treats arrows as transitions, not held-state updates. Its
+      // hidden proxy forwards the native repeat to the canvas, but the game
+      // ignores that keydown while the first press is still held. Restate the
+      // missing release before each AppKit repeat. The physical key remains in
+      // heldKeys, so interruption cleanup and the final trusted keyup still
+      // release it normally. AppKit remains the only repeat clock.
+      if (REPEATED_ARROW_KEYS.has(key)) dispatchKeyRelease(held);
       traceKey(event, 'down', 'observed');
       return;
     }

--- a/tests/electron/input-text-repeat.spec.ts
+++ b/tests/electron/input-text-repeat.spec.ts
@@ -1,9 +1,10 @@
 /**
  * Chromium hidden-proxy contract probe for physical repeats.
  *
- * It asserts every trusted browser edit instead of only the final value. The
- * native process policy and a live client check cover the AppKit boundary;
- * this test does not imitate the closed-source client's forwarding glue.
+ * It asserts every browser edit and arrow transition instead of only the final
+ * value. The native process policy and a live client check cover the AppKit
+ * boundary; this test does not imitate the closed-source client's forwarding
+ * glue.
  */
 import { expect, test } from '@playwright/test';
 import { closeOffline, launchCachedClient } from './fixtures.mjs';
@@ -27,9 +28,10 @@ type EditObservation = {
 type RepeatProbe = {
   keyboard: KeyboardObservation[];
   edits: EditObservation[];
+  arrowTransitions: string[];
 };
 
-test('Chromium preserves supplied repeat events in hidden-proxy editing', async () => {
+test('native repeat edits text and retriggers hidden-proxy arrows', async () => {
   const fixture = await launchCachedClient('gw-text-repeat-contract-');
   try {
     const { app, page } = fixture;
@@ -43,7 +45,8 @@ test('Chromium preserves supplied repeat events in hidden-proxy editing', async 
         throw new Error('OSK contract fixture is incomplete');
       }
       const host = window as typeof window & { __repeatProbe?: RepeatProbe };
-      host.__repeatProbe = { keyboard: [], edits: [] };
+      host.__repeatProbe = { keyboard: [], edits: [], arrowTransitions: [] };
+      const heldArrows = new Set<string>();
       const observeKeyboard = (event: KeyboardEvent) => {
         host.__repeatProbe?.keyboard.push({
           phase: event.type as 'keydown' | 'keyup',
@@ -51,6 +54,13 @@ test('Chromium preserves supplied repeat events in hidden-proxy editing', async 
           repeat: event.repeat,
           trusted: event.isTrusted,
         });
+        if (!event.key.startsWith('Arrow')) return;
+        if (event.type === 'keyup') {
+          heldArrows.delete(event.code);
+        } else if (!heldArrows.has(event.code)) {
+          heldArrows.add(event.code);
+          host.__repeatProbe?.arrowTransitions.push(event.key);
+        }
       };
       field.addEventListener('keydown', observeKeyboard);
       field.addEventListener('keyup', observeKeyboard);
@@ -109,6 +119,15 @@ test('Chromium preserves supplied repeat events in hidden-proxy editing', async 
       field.setSelectionRange(2, 2);
     });
     await held('Delete', 'Delete', 46);
+
+    for (const [code, keyValue, virtualKeyCode] of [
+      ['ArrowUp', 'ArrowUp', 38],
+      ['ArrowDown', 'ArrowDown', 40],
+      ['ArrowLeft', 'ArrowLeft', 37],
+      ['ArrowRight', 'ArrowRight', 39],
+    ] as const) {
+      await held(code, keyValue, virtualKeyCode);
+    }
     await page.evaluate(() => {
       const field = document.getElementById('osk-input-text') as HTMLInputElement;
       field.value = 'abcdef';
@@ -144,9 +163,22 @@ test('Chromium preserves supplied repeat events in hidden-proxy editing', async 
     const probe = await page.evaluate(() =>
       (window as typeof window & { __repeatProbe?: RepeatProbe }).__repeatProbe);
     expect(probe).toBeDefined();
-    expect(probe!.keyboard.every(({ trusted }) => trusted)).toBe(true);
+    expect(probe!.keyboard.filter(({ trusted }) => !trusted).map(({ phase, code }) => ({
+      phase, code,
+    }))).toEqual([
+      ...Array(2).fill({ phase: 'keyup', code: 'ArrowUp' }),
+      ...Array(2).fill({ phase: 'keyup', code: 'ArrowDown' }),
+      ...Array(2).fill({ phase: 'keyup', code: 'ArrowLeft' }),
+      ...Array(2).fill({ phase: 'keyup', code: 'ArrowRight' }),
+    ]);
     expect(probe!.keyboard.filter(({ phase, repeat }) => phase === 'keydown' && repeat))
-      .toHaveLength(12);
+      .toHaveLength(20);
+    expect(probe!.arrowTransitions).toEqual([
+      ...Array(3).fill('ArrowUp'),
+      ...Array(3).fill('ArrowDown'),
+      ...Array(3).fill('ArrowLeft'),
+      ...Array(3).fill('ArrowRight'),
+    ]);
 
     expect(probe!.edits.every(({ trusted }) => trusted)).toBe(true);
     expect(probe!.edits.map(({ phase, inputType, data }) => ({


### PR DESCRIPTION
Holding an arrow key in a Guild Wars text field moved only once. Chat history did not continue through earlier or later messages, and Left/Right did not continue moving the cursor, even though macOS supplied native repeat keydowns.

Guild Wars treats these arrow inputs as transitions and ignores a repeated keydown while the first press remains held. The renderer now restates the missing release before each native repeated arrow press. It keeps the physical key in the existing held-key map, so final release and interruption cleanup remain unchanged. macOS remains the only repeat clock; this adds no timer or second input path.

The Electron regression covers Up, Down, Left, and Right. Each hold must produce one initial transition and one transition for every supplied native repeat. The existing text insertion and deletion repeat assertions remain in the same contract test.

## Verification

- `pnpm run check` — 1,291 unit tests, 177 policy tests, and 110 Tools tests passed
- `pnpm build`
- `pnpm exec playwright test tests/electron/input-text-repeat.spec.ts --config tests/electron/playwright.config.ts` — 1 passed
- Physical Guild Wars verification on macOS — chat history and cursor arrows repeated while held

## Attribution

Implemented and reviewed with Codex. Diagnosis used the privacy-safe input harness supplied by the player. Automated coverage uses the repository's Playwright Electron harness; Matthias completed the physical live-client verification.
