### PR TITLE
fix(tools): support safe outposts and toggle interfaces

### DIFF
--- a/apps/tools/src/ToolsApp.team-management.test.ts
+++ b/apps/tools/src/ToolsApp.team-management.test.ts
@@ -787,7 +787,7 @@ describe("ToolsApp team management", () => {
       .find((button) => button.text().includes("Apply team"))!;
 
     expect(apply.attributes("disabled")).toBeDefined();
-    expect(wrapper.text()).toContain("Apply team is unavailable in PvP");
+    expect(wrapper.text()).toContain("Apply team is unavailable during PvP play");
     wrapper.unmount();
   });
 

--- a/apps/tools/src/team-apply-presentation.ts
+++ b/apps/tools/src/team-apply-presentation.ts
@@ -15,9 +15,9 @@ export function teamApplyRuntimePresentation(
   const guidance = (() => {
     switch (problem.rule) {
       case "party-unavailable": return "Enter the game on a character and wait for party observation.";
-      case "pvp": return "Travel to a PvE outpost. Your saved builds and teams remain available.";
-      case "region-unknown": return "Wait for the region check, or travel to a PvE outpost.";
-      case "not-outpost": return "Travel to any PvE outpost before applying.";
+      case "pvp": return "Leave the PvP match before applying. Your saved builds and teams remain available.";
+      case "region-unknown": return "Wait for the region check, or travel to an outpost.";
+      case "not-outpost": return "Travel to any outpost before applying.";
       case "outpost-unknown": return "Wait for the outpost check to finish.";
       case "partial-roster": return "Wait until every party member is visible to GWonMac.";
       case "mode-unobserved": return "Wait for Normal or Hard Mode to be observed.";
@@ -32,10 +32,10 @@ export function teamApplyRuntimePresentation(
   let message = "";
   switch (problem.rule) {
     case "party-unavailable": message = "Waiting for a playable character and party observation."; break;
-    case "pvp": message = "Apply team is unavailable in PvP and guild halls."; break;
+    case "pvp": message = "Apply team is unavailable during PvP play."; break;
     case "region-unknown": message = "Apply team is unavailable until GWonMac identifies the current region."; break;
-    case "not-outpost": message = "Enter a PvE outpost to apply this team."; break;
-    case "outpost-unknown": message = "Waiting to confirm that this is a PvE outpost."; break;
+    case "not-outpost": message = "Enter an outpost to apply this team."; break;
+    case "outpost-unknown": message = "Waiting to confirm that this is an outpost."; break;
     case "partial-roster": message = "Waiting until the complete party roster is observed."; break;
     case "mode-unobserved": message = "Waiting for the current Normal or Hard Mode observation."; break;
     case "player-unobserved": message = "Your own character has not been observed yet."; break;

--- a/docs/enhancement-development.md
+++ b/docs/enhancement-development.md
@@ -20,13 +20,14 @@ The first enable selects a Tools-capable module and requires a restart. The
 current optional features are:
 
 - **Apply teams in Guild Wars** (Beta): allow one explicit Apply action in a
-  certified PvE outpost. Build and Team authoring remains local and independent.
+  certified supported outpost. Build and Team authoring remains local and
+  independent.
 - **Target distance and range** (Test): show the selected target's distance and
   range band.
 - **Xunlai storage**: open the normal storage UI from the Tools title bar,
-  Command-Shift-C, `/chest`, or `/xunlai` in a certified PvE outpost. It has a
-  separate Settings opt-in and requires a live snapshot that proves the current
-  character can access storage. It does not depend on party observation.
+  Command-Shift-C, `/chest`, or `/xunlai` in a certified supported outpost. It
+  has a separate Settings opt-in and requires a live snapshot that proves the
+  current character can access storage. It does not depend on party observation.
 - **Quick Travel palette**: Command-T or `/tp` opens host-owned destination
   autocomplete and 1–9 shortcuts. A named, bounded Travel action reaches the
   certified client dispatcher only from the game-thread drain. It has a separate
@@ -178,9 +179,10 @@ geometry is active when either `skillKeyLabels` or `skillCooldowns` is active;
 it is not a second product feature or setting.
 
 Region selection has three explicit strengths: `any`, `non-pvp`, and `pve`.
-`non-pvp` matches GWToolbox++: unknown or loading state remains eligible, but a
-positively identified PvP map or guild hall withdraws the feature. Developer
-programs can replace saved selection, never the registered region rule.
+`non-pvp` keeps unknown or loading state eligible. A confirmed safe region
+includes PvE, guild halls, and PvP outposts. Only a PvP explorable instance is
+active PvP play and withdraws the feature. Developer programs can replace saved
+selection, never the registered region rule.
 
 Choose the smallest path:
 
@@ -428,7 +430,7 @@ contains zero access words, Xunlai stays disabled, and the independently
 certified Travel action remains available. Never substitute party state or a
 guessed offset.
 
-Run `pnpm enhancements:live xunlai-storage` from a supported PvE outpost. The
+Run `pnpm enhancements:live xunlai-storage` from a supported outpost. The
 scenario records only the tri-state access result and two complete action
 cycles from the same named action used by the button and shortcut. Each cycle
 opens storage, closes it with Escape, and proves that bounded two-button

--- a/docs/future-effect-durations.md
+++ b/docs/future-effect-durations.md
@@ -36,9 +36,10 @@ answer:
   a documented derived view.
 - Treat party effects and hostile-agent debuffs as separate capabilities. Do
   not infer them from skill-bar recharge or animation state.
-- Keep the present PvE-only Tools policy by default. Any PvP availability needs
-  a separate fairness review proving that the UI reveals only information the
-  stock client already gives that player.
+- Keep the present active-PvP restriction by default. Guild halls and PvP
+  outposts are supported, but availability during a PvP match needs a separate
+  fairness review. The review must prove that the UI reveals only information
+  the stock client already gives that player.
 - Require exact hashes, exact function signatures and operands, unique matches,
   bounded reads, sequence-protected publication, and feature-local fail-closed
   behavior, as the cooldown observer does.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -187,14 +187,14 @@ Command shortcut to replace the default. Letter and number shortcuts use their
 physical keyboard positions, so they stay stable when Option or the active
 keyboard layout changes. Control remains available to Guild Wars. Delete clears a shortcut, Escape
 cancels recording. **Show or hide GWonMac Tools** uses Command-B by default,
-and **Show or hide Trade Chat** uses Command-Shift-B. **Restore default
-shortcuts** also restores Command-Shift-C for Xunlai storage, Command-T for
-Travel, and Command-Shift-B for Trade Chat. Shortcuts work only while the
-Guild Wars window is active. GWonMac keeps normal editing and application
-shortcuts such as Command-C and Command-Q, plus Travel's Command-1 through
-Command-9 assignments, reserved.
+**Show or hide Trade Chat** uses Command-Shift-B, and **Show or hide Quick
+Travel** uses Command-T. Press the same interface shortcut again to close it.
+**Restore default shortcuts** also restores Command-Shift-C for Xunlai storage.
+Shortcuts work only while the Guild Wars window is active. GWonMac keeps normal
+editing and application shortcuts such as Command-C and Command-Q, plus
+Travel's Command-1 through Command-9 assignments, reserved.
 
-In a supported PvE outpost, turn on **Open Xunlai storage** in
+In a supported outpost, turn on **Open Xunlai storage** in
 **Settings → Tools**, then choose **Storage** in the Tools title bar or press
 Command-Shift-C. You can also type `/chest` or `/xunlai` in chat. GWonMac opens
 the normal Xunlai window locally. It does not
@@ -208,11 +208,10 @@ button and shortcut explain that storage is unavailable. The slash commands
 remain with Guild Wars while access is unconfirmed or refused. Party roster
 observation does not control storage, and `/tp` remains independent.
 
-The complete Tools surface, including Builds and Teams and Trade Chat, closes
-in positively identified PvP maps and guild halls. Xunlai storage also stops,
-its shortcut reports that it is unavailable, and `/chest` and `/xunlai` remain
-with Guild Wars. Apply checks policy before each step and stops when the state
-changes.
+The complete Tools surface works in PvE outposts, PvP outposts, and guild
+halls. During active PvP play, Tools and Xunlai storage close, their shortcuts
+report that they are unavailable, and `/chest` and `/xunlai` remain with Guild
+Wars. Apply checks policy before each step and stops when the state changes.
 
 At login, during loading, or when the region cannot be identified, the saved
 Build and Team library and Trade Chat remain available. Live observation,

--- a/docs/wasm-host.md
+++ b/docs/wasm-host.md
@@ -197,8 +197,7 @@ After that restart, these choices update during the session:
 
 - **Apply teams in Guild Wars** controls only the fixed Team Apply operations.
   The local Tools panel and saved Build/Team library remain available whenever
-  the master Tools setting is on, except in positively identified PvP maps and
-  guild halls.
+  the master Tools setting is on, except during active PvP play.
 - **Target distance and range** controls the shipped Test readout and its target
   observation.
 - Saved **Skill key labels** select only renderer-owned labels over the
@@ -206,9 +205,10 @@ After that restart, these choices update during the session:
   bindings, and the renderer never turns a label into game input.
 
 Disabled optional observers stop their domain reads. Core cursor observation
-stays active. A small map-policy projection remains active so the app can close
-the complete Tools surface and Xunlai storage in PvP and guild halls, while
-stricter live features also withdraw during transitions and unknown regions.
+stays active. A small map-policy projection combines ArenaNet's map flag with
+the instance type. Guild halls and PvP outposts remain supported; active PvP
+play closes Tools and Xunlai storage. Stricter live features also withdraw
+during transitions and unknown regions.
 
 If live integration is unavailable, the host can still mount the saved-library
 part of Tools. Players can edit, import, and export builds and teams. Live party
@@ -263,7 +263,7 @@ queues a fixed `{ agent: 0, type: 0, data: 3 }` DataWindow payload, then calls
 the certified client DataWindow handler at the existing game-thread drain. It
 does not send that payload to ArenaNet. The action is enabled only with its
 separate Tools setting and a fresh snapshot that proves the current player is
-in a supported PvE outpost and can access storage. Every snapshot update
+in a supported outpost and can access storage. Every snapshot update
 resynchronizes the action, so loading, character, account, and map transitions
 revoke stale access immediately.
 
@@ -312,8 +312,8 @@ running the reset again safely finishes it. Window-position cleanup is a
 separate best-effort action and cannot change that result.
 
 Team Apply requires enabled Tools and Apply teams in Guild Wars, a proved Team
-Apply capability, a positively classified PvE outpost, fresh party state, and
-an explicit player action.
+Apply capability, a positively classified supported outpost, fresh party state,
+and an explicit player action.
 
 The runner checks policy before each command and while it confirms results. A
 map transition or policy change stops the operation. A refusal is an explicit

--- a/src/companion-kernel/lib.rs
+++ b/src/companion-kernel/lib.rs
@@ -178,8 +178,17 @@ impl State {
     }
 }
 
-/** The client-owned map policy used by GWToolbox++ itself. */
-unsafe fn classify_play_region(layout: Layout, map_id: u32) -> u32 {
+/**
+ * The Tools safety region derived from the client-owned map policy.
+ *
+ * ArenaNet marks guild halls and PvP outposts as PvP maps too. They are safe
+ * outpost instances, so only a PvP explorable instance is active PvP play.
+ */
+unsafe fn classify_play_region(
+    layout: Layout,
+    map_id: u32,
+    instance_type: u32,
+) -> u32 {
     if layout.area_info == 0
         || layout.area_info_count == 0
         || layout.area_info_stride < 20
@@ -203,7 +212,7 @@ unsafe fn classify_play_region(layout: Layout, map_id: u32) -> u32 {
     else {
         return PLAY_REGION_UNKNOWN;
     };
-    if flags & (0x0004_0001 | 0x0080_0000) != 0 {
+    if flags & (0x0004_0001 | 0x0080_0000) != 0 && instance_type == 1 {
         PLAY_REGION_PVP
     } else {
         PLAY_REGION_PVE
@@ -400,7 +409,9 @@ pub(crate) unsafe fn resolve_game(layout: Layout) -> GameState {
         map_id,
         instance_type,
         player_number,
-        play_region: unsafe { classify_play_region(layout, map_id) },
+        play_region: unsafe {
+            classify_play_region(layout, map_id, instance_type)
+        },
     }
 }
 

--- a/src/main/window-menu.ts
+++ b/src/main/window-menu.ts
@@ -180,7 +180,7 @@ export function installApplicationMenu({
         },
         {
           id: "open-travel",
-          label: "Open Travel",
+          label: "Show or hide Quick Travel",
           click: withGameOwner((win) => toggleTravel(win)),
         },
         {

--- a/src/renderer/certified-companion-installation.ts
+++ b/src/renderer/certified-companion-installation.ts
@@ -557,7 +557,7 @@ export async function installCertifiedCompanion(
         if (currentRegion !== "pve") {
           throw new Error(
             currentRegion === "pvp"
-              ? "GWonMac Tools are unavailable in PvP"
+              ? "GWonMac Tools are unavailable during PvP play"
               : "GWonMac Tools are unavailable while the region is unknown",
           );
         }
@@ -566,10 +566,10 @@ export async function installCertifiedCompanion(
           throw new Error("no party has been observed yet");
         }
         if (observed.party?.playRegion !== "pve") {
-          throw new Error("team commands require a confirmed PvE party");
+          throw new Error("team commands require a confirmed supported party");
         }
         if (observed.party?.inOutpost !== true) {
-          throw new Error("team commands require a confirmed PvE outpost");
+          throw new Error("team commands require a confirmed supported outpost");
         }
         return observed;
       },

--- a/src/renderer/enhancement-runtime-policy.ts
+++ b/src/renderer/enhancement-runtime-policy.ts
@@ -32,8 +32,7 @@ export function enhancementRuntimePolicy(
       && (developerSelected || featureActivationRequested(id, settings));
   return Object.freeze({
     // The local Tools host remains reachable without a live observation, but
-    // follows Toolbox++ by withdrawing in positively identified PvP maps and
-    // guild halls.
+    // withdraws when the certified region reports active PvP play.
     tools: selected("tools", developerToolbox),
     targetReadout: selected(
       "targetReadout",

--- a/src/renderer/enhancement-storage-controller.ts
+++ b/src/renderer/enhancement-storage-controller.ts
@@ -44,7 +44,7 @@ function unavailableReason(
 ): string | null {
   if (!active) return "Enhancement installation is no longer active";
   if (availability.playRegion === "pvp") {
-    return "Xunlai storage is unavailable in PvP and guild halls";
+    return "Xunlai storage is unavailable during PvP play";
   }
   if (!availability.enabled) return "Xunlai storage is turned off in Settings";
   if (availability.playRegion === "unknown") {

--- a/src/renderer/enhancement-travel-controller.ts
+++ b/src/renderer/enhancement-travel-controller.ts
@@ -33,8 +33,13 @@ function unavailableReason(
   availability: TravelAvailability,
 ): string | null {
   if (!active) return "Enhancement installation is no longer active";
+  if (availability.playRegion === "pvp") {
+    return "Travel is unavailable during PvP play";
+  }
   if (!availability.enabled) return "Travel is turned off in Settings";
-  if (availability.playRegion !== "pve") return "Travel is available in PvE";
+  if (availability.playRegion === "unknown") {
+    return "Travel is waiting to confirm the current region";
+  }
   if (availability.state?.status !== "ready") {
     return availability.state?.reason === "loading"
       ? "Travel is unavailable while a map is loading"

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -457,7 +457,7 @@
             <input type="checkbox" name="gwonmacTools" aria-describedby="settings-tools-help">
             <span>Enable optional Tools Beta</span>
           </label>
-          <p id="settings-tools-help" class="settings-note">The first enable needs one restart. After that, changes apply immediately. Tools close in PvP and guild halls; saved Builds and Teams stay available at login and when live integration is unavailable.</p>
+          <p id="settings-tools-help" class="settings-note">The first enable needs one restart. After that, changes apply immediately. Tools work in outposts and guild halls, and close during PvP play. Saved Builds and Teams stay available at login and when live integration is unavailable.</p>
           <p id="settings-tools-off" class="settings-note">Enable Tools Beta to choose individual tools and keyboard shortcuts.</p>
           <div id="settings-tools-config">
             <fieldset id="settings-tool-features" hidden>
@@ -504,7 +504,7 @@
                 <button type="button" class="ui-link settings-shortcut-replace" hidden>Replace existing shortcut</button>
               </div>
               <div class="settings-shortcut-row" data-shortcut-action="travel.open">
-                <span class="settings-shortcut-name">Open Travel</span>
+                <span class="settings-shortcut-name">Show or hide Quick Travel</span>
                 <kbd class="settings-shortcut-value">—</kbd>
                 <button type="button" class="ui-button settings-shortcut-change">Change</button>
                 <p class="settings-shortcut-message" role="status" aria-live="polite" hidden></p>

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -382,7 +382,7 @@ export interface AppSettings {
   gwonmacTools: boolean;
   /** Allow explicit Apply team commands when live-game policy also permits. */
   teamManagement: boolean;
-  /** Allow the explicit local Xunlai window command in supported PvE outposts. */
+  /** Allow the explicit local Xunlai window command in supported outposts. */
   xunlaiStorage: boolean;
   /** Allow the focused Travel palette and its explicit map command. */
   travelPalette: boolean;

--- a/src/shared/feature-contracts.ts
+++ b/src/shared/feature-contracts.ts
@@ -77,8 +77,7 @@ export const FEATURE_SELECTION_POLICIES = defineFeatureSelectionPolicies({
       master: "gwonmacTools",
     },
     // The storage controller still owns the stronger, fresh access gate.
-    // This coarse rule matches Toolbox++ by withdrawing the complete feature
-    // in positively identified PvP maps and guild halls.
+    // This coarse rule withdraws the complete feature during active PvP play.
     region: "non-pvp",
   },
   travel: {

--- a/src/shared/keyboard-shortcuts.ts
+++ b/src/shared/keyboard-shortcuts.ts
@@ -40,7 +40,7 @@ export const SHORTCUT_LABELS: Readonly<Record<ShortcutAction, string>> =
     "tools.toggle": "Show or hide GWonMac Tools",
     "trade.toggle": "Show or hide Trade Chat",
     "storage.open": "Open Xunlai storage",
-    "travel.open": "Open Travel",
+    "travel.open": "Show or hide Quick Travel",
   });
 
 export interface ShortcutInput {

--- a/tests/electron/input-toolbox.spec.ts
+++ b/tests/electron/input-toolbox.spec.ts
@@ -281,6 +281,14 @@ test.describe("renderer Tools input", () => {
       });
       await expect(trade).toBeVisible();
       await expect(tool).toBeVisible();
+      await page.evaluate(() => {
+        window.dispatchEvent(new CustomEvent("gw:trade-toggle", { cancelable: true }));
+      });
+      await expect(trade).toBeHidden();
+      await page.evaluate(() => {
+        window.dispatchEvent(new CustomEvent("gw:trade-toggle", { cancelable: true }));
+      });
+      await expect(trade).toBeVisible();
       await page.getByRole("button", { name: "Trade action" }).click();
       await expect(trade).toHaveAttribute("data-active", "true");
       await expect(tool).toHaveAttribute("data-active", "false");

--- a/tests/electron/input-travel.spec.ts
+++ b/tests/electron/input-travel.spec.ts
@@ -97,6 +97,24 @@ test.describe("renderer Travel input", () => {
       await expect(palette.getByRole("heading", { name: "Favorites" })).toBeVisible();
       await expect(palette.locator(".travel-favorite-grid .travel-favorite")).toHaveCount(6);
 
+      // Every shortcut that shows a GWonMac interface is a toggle. A second
+      // Travel request closes the same palette and returns focus to the game.
+      await page.evaluate(() => {
+        window.dispatchEvent(new CustomEvent("gw:travel-toggle", {
+          cancelable: true,
+          detail: {},
+        }));
+      });
+      await expect(palette).toBeHidden();
+      await expect.poll(() => isDomActiveElement(canvas)).toBe(true);
+      await page.evaluate(() => {
+        window.dispatchEvent(new CustomEvent("gw:travel-toggle", {
+          cancelable: true,
+          detail: {},
+        }));
+      });
+      await expect(palette).toBeVisible();
+
       // Native modal work is above non-modal surfaces. The first Escape closes
       // Settings and restores Travel; the palette remains open underneath.
       await page.evaluate(() => {

--- a/tests/electron/settings-tools-updates.spec.ts
+++ b/tests/electron/settings-tools-updates.spec.ts
@@ -693,7 +693,7 @@ test.describe("tools and update settings", () => {
         "Guild Wars cursor",
       );
       await expect(controls).toContainText(
-        "Tools close in PvP and guild halls; saved Builds and Teams stay available at login and when live integration is unavailable",
+        "Tools work in outposts and guild halls, and close during PvP play",
       );
       await expect(controls).toContainText("Apply teams in Guild Wars");
       await expect(page.locator('input[name="nativeCursor"]')).toHaveCount(0);

--- a/tests/helpers/packaged-enhancement-scenarios.ts
+++ b/tests/helpers/packaged-enhancement-scenarios.ts
@@ -98,8 +98,8 @@ async function installTargetReadout(
 
     // This scenario exercises the target presentation lifecycle, not native
     // play-region discovery (the Toolbox scenario proves that separately).
-    // Publish an explicit certified-shape PvE policy snapshot so the PvE-only
-    // target consumer starts from the same region precondition as a live tick.
+    // Publish an explicit certified-shape supported-region snapshot so the
+    // target consumer starts from the same precondition as a live tick.
     const playRegionPointer = allocations[3]?.pointer;
     if (playRegionPointer === undefined) {
       throw new Error("target readout play-region allocation is missing");
@@ -894,6 +894,8 @@ export async function assertToolboxFoundationLifecycle() {
       }
 
       view.setUint32(area + layout.areaInfoFlags, 1, true);
+      view.setUint32(game.character + layout.isExplorable, 1, true);
+      view.setUint32(game.character + layout.currentInstanceType, 1, true);
       pendingTradeToggles = 1;
       callback(0, 126, 0, 0, 0, 0);
       await new Promise<void>((resolve, reject) => {
@@ -946,6 +948,7 @@ export async function assertToolboxFoundationLifecycle() {
         tradeConfiguration: tradeConfigurations.at(-1),
       };
       view.setUint32(game.character + layout.currentInstanceType, 0, true);
+      view.setUint32(game.character + layout.isExplorable, 0, true);
       view.setUint32(area + layout.areaInfoFlags, 0, true);
       callback(0, 128, 0, 0, 0, 0);
       callback(1, 1, 2, 3, 4, 5);

--- a/tests/integration/enhancements-xunlai-kernel.test.ts
+++ b/tests/integration/enhancements-xunlai-kernel.test.ts
@@ -54,9 +54,20 @@ describe("Companion Xunlai access kernel", () => {
     assert.equal(
       decoded(readCompanionSnapshot(kernel.memory.buffer, ADDRESSES.snapshot))
         .xunlaiAccess,
+      true,
+    );
+
+    kernel.view.setUint32(ADDRESSES.character + 0x19c, 1, true);
+    kernel.view.setUint32(ADDRESSES.character + 0x23c, 1, true);
+    kernel.tick();
+    assert.equal(
+      decoded(readCompanionSnapshot(kernel.memory.buffer, ADDRESSES.snapshot))
+        .xunlaiAccess,
       false,
     );
 
+    kernel.view.setUint32(ADDRESSES.character + 0x19c, 0, true);
+    kernel.view.setUint32(ADDRESSES.character + 0x23c, 0, true);
     kernel.view.setUint32(area + 0x10, 0, true);
     kernel.view.setUint32(area + DETAIL.areaInfoType, 7, true);
     kernel.tick();

--- a/tests/integration/play-region-kernel.test.ts
+++ b/tests/integration/play-region-kernel.test.ts
@@ -32,6 +32,8 @@ describe("play-region kernel", () => {
       playRegion: "pve",
     });
 
+    // Guild halls and PvP outposts carry the PvP area flag, but an outpost is
+    // not active player-versus-player play and remains supported.
     kernel.view.setUint32(AREA_133 + 0x10, 1, true);
     kernel.tick();
     assert.deepEqual(kernel.playRegion(), {
@@ -39,6 +41,17 @@ describe("play-region kernel", () => {
       sequence: 6,
       mapId: 133,
       instanceType: 0,
+      playRegion: "pve",
+    });
+
+    kernel.view.setUint32(ADDRESSES.character + 0x19c, 1, true);
+    kernel.view.setUint32(ADDRESSES.character + 0x23c, 1, true);
+    kernel.tick();
+    assert.deepEqual(kernel.playRegion(), {
+      status: "ready",
+      sequence: 8,
+      mapId: 133,
+      instanceType: 1,
       playRegion: "pvp",
     });
   });

--- a/tests/integration/skill-cooldown-kernel.test.ts
+++ b/tests/integration/skill-cooldown-kernel.test.ts
@@ -169,6 +169,15 @@ describe("skill cooldown kernel", () => {
     assert.equal(kernel.skillCooldowns().status, "ready");
     kernel.view.setUint32(ADDRESSES.areaInfo + 133 * 0x7c + 0x10, 1, true);
     kernel.tick(0, 10_000);
+    assert.equal(
+      kernel.skillCooldowns().status,
+      "ready",
+      "PvP outposts remain supported",
+    );
+
+    kernel.view.setUint32(ADDRESSES.character + 0x19c, 1, true);
+    kernel.view.setUint32(ADDRESSES.character + 0x23c, 1, true);
+    kernel.tick(0, 10_000);
     assert.deepEqual(kernel.skillCooldowns(), {
       status: "waiting",
       reason: "game",

--- a/tests/unit/companion-policy-source.test.ts
+++ b/tests/unit/companion-policy-source.test.ts
@@ -106,7 +106,7 @@ describe("companion policy source", () => {
     ]);
   });
 
-  it("withdraws local Tools only for a positively identified PvP map", () => {
+  it("withdraws local Tools only for positively identified active PvP play", () => {
     const test = fixture();
     test.setSettings({ ...DEFAULT_SETTINGS, gwonmacTools: true });
     test.settingsEvents.dispatchEvent(new Event("gw:tools-settings"));

--- a/tests/unit/enhancement-runtime-policy.test.ts
+++ b/tests/unit/enhancement-runtime-policy.test.ts
@@ -75,7 +75,7 @@ test("unknown regions keep local Tools while live PvE features fail closed", () 
   });
 });
 
-test("confirmed PvP and guild halls disable every product and developer tool", () => {
+test("confirmed active PvP play disables every product and developer tool", () => {
   const on = Object.freeze({
     gwonmacTools: true,
     targetReadout: true,
@@ -170,7 +170,7 @@ test("runtime policy projects every registered feature exactly once", () => {
   );
 });
 
-test("local Tools require their setting or developer program and only confirmed PvP blocks them", () => {
+test("local Tools require their setting or developer program and only active PvP blocks them", () => {
   const regions = ["pve", "pvp", "unknown"] as const;
   const programs = [
     "none",

--- a/tests/unit/enhancement-storage-controller.test.ts
+++ b/tests/unit/enhancement-storage-controller.test.ts
@@ -111,7 +111,7 @@ test("storage fails closed without a confirmed character access proof", () => {
       cancelable: true,
       detail: refusedDetail,
     }));
-    assert.match(refusedDetail.error?.message ?? "", /PvP and guild halls/);
+    assert.match(refusedDetail.error?.message ?? "", /during PvP play/);
     controller.update({
       enabled: true,
       playRegion: "pve",


### PR DESCRIPTION
Guild halls and PvP outposts were classified like active PvP matches. That withdrew every Tool and made Command-T fall back to the non-toggleable Tools settings pane instead of Quick Travel.

## What changed

The certified region policy now combines ArenaNet's PvP map flag with the instance type. Guild halls and PvP outposts remain supported, while PvP explorable instances still withdraw Tools.

Every shortcut that shows a GWonMac interface now has an explicit toggle contract and matching copy:

- Command-B shows or hides Builds & Teams.
- Command-Shift-B shows or hides Trade Chat.
- Command-T shows or hides Quick Travel.

Xunlai storage remains an Open action because it controls Guild Wars' native storage window.

## Why

The map flag alone is too broad: ArenaNet also applies it to safe outpost instances. Using the already-certified instance type keeps one region authority and avoids per-tool exceptions.

## Invariant

The play-region kernel reports a PvP-flagged outpost as supported and the same map as blocked when its instance becomes explorable. Renderer tests prove that a second Trade Chat or Quick Travel toggle closes the visible interface.

## Verification

- [x] `pnpm check`
- [x] `pnpm build`
- [x] Play-region kernel integration tests: 6 passed
- [x] Focused Electron Tools and Travel tests: 5 passed
- [x] I kept this pull request focused.
- [x] I ran the relevant checks.
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [x] I updated documentation when behavior or an invariant changed.

Implemented and verified with the Codex desktop agent.
