### PR TITLE
feat(relog): return to character after game reload

### DIFF
--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -100,6 +100,14 @@ Wars produced no cursor event. It cannot originate a click. Team Apply acts
 only after an explicit player command. These actions do not permit autonomous
 play.
 
+After an explicit Reload command, the app may send one Return after saved login
+is restored and one only while the certified native Play control is visible.
+It sends a third Return only while the certified native reconnect dialog is
+visible. If Guild Wars has started loading the selected character, no third
+input is sent. This is bounded session restoration: it expires after 30
+seconds, cannot change the selected character, cannot repeat a step, and loses
+automatic pre-game input when the exact client build is not certified.
+
 ## Evidence standard
 
 Consequential privacy, data, release, update, and performance claims need

--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -64,6 +64,40 @@ events because those ephemeral owners cannot be correlated safely after restart.
 Level 2 is refused while more than one game window is open because Electron's
 Chromium tracer is process-wide. Level 1 remains available per game window.
 
+## Reload feedback loop
+
+**Help → Diagnostics → Copy Reload Trace** copies one account's latest reload
+story. It comes from the main flight recorder, so it keeps Command-Q and native
+dialog rows from before navigation and joins them to the replacement renderer's
+login, character, and reconnect rows. Each row states the synchronized gap from
+the preceding row. A UI event has at most one observer-frame of receipt
+uncertainty.
+
+`outside-current` counts recorder events belonging to other reload attempts; only `omitted`
+means the clipboard size limit removed events from this trace.
+`relog.finished outcome=restored` means the exact reconnect dialog was observed
+and accepted once, followed by a certified playable explorable instance.
+`outcome=outpost` means the character reached a certified playable outpost.
+Loading is transition evidence only and can never complete the workflow.
+
+The trace contains only closed stages, outcomes, and bounded native-control
+state. It contains no Guild Wars UI text, dispatcher parameters, pointers,
+credentials, account identifiers, paths, coordinates, chat, packets, or
+pixels. Do not paste a full console or login-screen image as a substitute.
+
+For production relog qualification, compare two traces from the same exact
+client build with automatic return enabled and add no input:
+
+1. Start in a playable outpost. Reload with automatic return enabled, add no
+   input, wait until playable, then copy the trace. It must end in `outpost`.
+2. Start in an explorable area. Reload, add no input, wait until playable, then
+   copy the trace. It must end in `restored`.
+
+Production reload uses exact-build certificates for the native Play, Selector,
+Yes, and No labels. A probe row reports `hashed`, `matched`, and `visible`
+four-bit masks in that order. Production sends Return only after both exact
+controls for the current stage resolve as visible in the live frame table.
+
 ## Export contents
 
 A current ZIP contains a manifest, report, summary, current events,

--- a/docs/enhancement-development.md
+++ b/docs/enhancement-development.md
@@ -123,13 +123,13 @@ paste the complete console or account/login screens.
 ### Reconnect UI discovery
 
 Production reload uses the closed `preGameControls` capability. Its exact-build
-proof pins four internal label addresses, Guild Wars' label-hash function, the
-frame-relation initializer, and the live frame layout. The observer follows the
-same lookup boundary as GWCA `GetFrameByLabel`: certification derives those
-four hashes from the exact client hash body, then runtime scans `frame_hash_id`
-in the bounded live frame table without calling back into game code. The renderer can read
-only `unknown`, `character-select`, `reconnect`, or `loading`; it cannot read
-frame pointers, hashes, arbitrary labels, or invoke a generic UI action.
+proof pins five internal label addresses, Guild Wars' label-hash function, and
+the live frame layout. The observer follows the same lookup boundary as
+GWCA `GetFrameByLabel`. Certification derives the five hashes from the exact
+client hash body. Runtime scans `frame_hash_id` in the bounded live frame table
+without calling back into game code. The renderer can read only `unknown`,
+`character-select`, `reconnect`, or `loading`; it cannot read frame pointers,
+hashes, arbitrary labels, or invoke a generic UI action.
 The same closed boundary can later support another explicit pre-game workflow,
 such as character switching, after that workflow defines its own bounded input
 authority.
@@ -140,10 +140,10 @@ Run the unpackaged developer probe with:
 GW_LIVE_SMOKE=1 pnpm enhancements:live -- --scenario reconnect-discovery --leave-open
 ```
 
-The `reconnect-probe` program selects the same bounded pre-game controls and
-play-region readers that required Core uses in production. It exposes no raw
-UI messages, frame pointers, labels, or generic input surface. A packaged build
-always refuses this developer program.
+The `reconnect-probe` program selects the same bounded pre-game controls,
+play-region readers, and native cursor that required Core uses in production.
+It exposes no raw UI messages, frame pointers, labels, or generic input surface.
+A packaged build always refuses this developer program.
 
 Run the outpost and explorable procedures under [Reload feedback
 loop](diagnostics.md#reload-feedback-loop) separately. With automatic return

--- a/docs/enhancement-development.md
+++ b/docs/enhancement-development.md
@@ -120,6 +120,39 @@ first request through its final success, refusal, or timeout. Also record the
 visible map/outpost and whether the character should have Xunlai access. Do not
 paste the complete console or account/login screens.
 
+### Reconnect UI discovery
+
+Production reload uses the closed `preGameControls` capability. Its exact-build
+proof pins four internal label addresses, Guild Wars' label-hash function, the
+frame-relation initializer, and the live frame layout. The observer follows the
+same lookup boundary as GWCA `GetFrameByLabel`: certification derives those
+four hashes from the exact client hash body, then runtime scans `frame_hash_id`
+in the bounded live frame table without calling back into game code. The renderer can read
+only `unknown`, `character-select`, `reconnect`, or `loading`; it cannot read
+frame pointers, hashes, arbitrary labels, or invoke a generic UI action.
+The same closed boundary can later support another explicit pre-game workflow,
+such as character switching, after that workflow defines its own bounded input
+authority.
+
+Run the unpackaged developer probe with:
+
+```sh
+GW_LIVE_SMOKE=1 pnpm enhancements:live -- --scenario reconnect-discovery --leave-open
+```
+
+The `reconnect-probe` program selects the same bounded pre-game controls and
+play-region readers that required Core uses in production. It exposes no raw
+UI messages, frame pointers, labels, or generic input surface. A packaged build
+always refuses this developer program.
+
+Run the outpost and explorable procedures under [Reload feedback
+loop](diagnostics.md#reload-feedback-loop) separately. With automatic return
+enabled, add no input: the scenario now requires a certified terminal
+`outpost` or `restored` row. It gives an operator checkpoint, includes exact
+client/build evidence in its structured result, and writes the copied redacted transcript to
+`test-results/enhancements-live/reconnect-discovery.txt`. It takes no screenshot
+on failure and requires `--allow-update` before client data may be updated.
+
 For an input or Xunlai interaction failure, also open
 **Help → Diagnostics → Show Input Trace**. Clear it, then open Xunlai once,
 close the native storage window with Escape, click empty ground, hold both

--- a/docs/process-model.md
+++ b/docs/process-model.md
@@ -239,7 +239,7 @@ omitted.
 Reload diagnostics are a separate, account-owned projection of the main flight
 recorder. **Copy Reload Trace** survives renderer replacement and joins
 Command-Q, the native sheet, reload, automatic-input outcomes, and the
-developer-only bounded UI-message probe. It never changes an input decision and
+certified pre-game state probe. It never changes an input decision and
 does not make the renderer-memory input trace persistent.
 
 ### Packaged input qualification

--- a/docs/process-model.md
+++ b/docs/process-model.md
@@ -170,6 +170,25 @@ blur Guild Wars. Settings, Tools, Travel, warnings, and game text fields remain
 part of the active game window, so they do not mute game audio. A real window
 blur still reaches Guild Wars and releases held input.
 
+Main owns one account-local reload workflow. Memory warnings, Command-R, crash
+retry, and Command-Q use it. The workflow closes only the owning renderer's
+sockets, gives its filesystem sync up to 1.5 seconds, and navigates only that
+window. An automatic-relog intent is bound to that `BrowserWindow` and consumed
+once by its replacement document. The replacement renderer uses the active
+client session as its launch gate; complete-game data may keep downloading in
+the background without making reload wait for that download to finish.
+
+Automatic relog follows certified observed boundaries. Returning saved
+credentials permits one Return to submit the login screen. A successful
+account-token request waits for the exact native Play and Selector controls
+before selecting the current character. It sends another Return only while the
+exact native reconnect controls are visible. Loading is transition evidence,
+not success: completion requires a fresh bounded play-region publication with
+a valid map, instance type, and player. Existing session progress or a physical
+Return cancels the related synthetic one. Losing focus pauses input. The
+renderer records each boundary and shows the current step; after 30 seconds it
+names where progress stopped.
+
 Right-drag uses pointer lock and a virtual cursor. The host bounds drag
 recycling so camera movement can continue. The host normalizes supported
 physical keyboard positions before the official client receives them. Text
@@ -216,6 +235,12 @@ clears the memory. The trace is not persisted, exported with diagnostics, or
 sent over the network. Copy keeps the newest complete rows that fit the same
 bounded clipboard contract used elsewhere and states how many older rows were
 omitted.
+
+Reload diagnostics are a separate, account-owned projection of the main flight
+recorder. **Copy Reload Trace** survives renderer replacement and joins
+Command-Q, the native sheet, reload, automatic-input outcomes, and the
+developer-only bounded UI-message probe. It never changes an input decision and
+does not make the renderer-memory input trace persistent.
 
 ### Packaged input qualification
 
@@ -333,6 +358,12 @@ Closing the Single Account game window quits the application. Closing one
 Multiple Accounts game window closes only that profile. Application quit saves
 all live renderer filesystems in parallel, closes sockets, stops background
 work, flushes diagnostics, and exits through one bounded cleanup path.
+
+Command-Q opens an account-owned native dialog while a game window is active.
+Reload and Quit Game affect that account only. The Account Picker keeps the
+ordinary application Quit command because it has no game account to reload.
+The physical Q claim lasts only until that dialog settles; Cancel re-arms the
+shortcut even when AppKit consumed the original key-up.
 
 Main-to-renderer events stop after the window or its `webContents` is destroyed.
 The app attempts renderer recovery only after unexpected renderer loss. It does

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -60,6 +60,18 @@ can restore it or permanently delete it after a native confirmation.
 Every account window is independently controlled. The app does not broadcast
 keyboard, mouse, or controller input between windows.
 
+Press Command-Q in a game window to choose **Reload Guild Wars**, **Quit Game**,
+or **Cancel**. Both actions affect only that account. Select **Return to my
+character automatically** to keep the preference for every account and future
+app launches. The same option is available under **Settings → Advanced** and on the
+memory warning.
+The app submits the restored saved login, then selects the current character as
+soon as the certified Play control is ready. It accepts Guild Wars' default
+reconnect choice only when the certified reconnect dialog is present. Without
+one, it observes that Guild Wars started loading the selected character and
+sends no extra input. A status line shows each step. If it cannot advance
+within 30 seconds, the line says where it stopped.
+
 A local source build has a temporary identity. It does not share saved-login
 access with the published Release app.
 
@@ -291,9 +303,10 @@ If the current Guild Wars version does not support 4 GB mode, the app uses the
 ordinary 2 GB mode. The larger limit can delay a memory-related crash. It
 cannot stop memory that continues to grow.
 
-When the app warns about memory, choose **Reload Guild Wars**. Guild Wars
-normally reconnects. Reload in an outpost when you want the lowest gameplay
-risk.
+When the app warns about memory, choose whether to return to the selected
+character automatically, then choose **Reload Guild Wars**. This uses the same
+saved preference as Command-Q and **View → Reload Guild Wars**. Reload in an
+outpost when you want the lowest gameplay risk.
 
 ## Updates
 
@@ -387,6 +400,9 @@ opens its GitHub issue form immediately. GitHub issues are public.
   identifiers, and controller identifiers. Pointer rows say only whether the
   click belonged to the game canvas, a GWonMac surface, a text or secret field,
   or another element. Closing it discards the trace.
+- Use **Copy Reload Trace** after a reload or failed automatic return. It joins
+  Command-Q, the quit/reload dialog, reload, login, character selection, and
+  reconnect timing for this game window without copying account or UI text.
 - Holding a character, Backspace, Delete, Left Arrow, or Right Arrow in Guild
   Wars text fields follows the repeat delay and speed configured in macOS
   Keyboard settings. gwonmac stores an app-specific press-and-hold preference;

--- a/scripts/enhancements-live.ts
+++ b/scripts/enhancements-live.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import type { Readable } from "node:stream";
 import { fileURLToPath } from "node:url";
 import { chromium } from "playwright";
-import type { Browser, Page } from "playwright";
+import type { Browser, BrowserContext, Page } from "playwright";
 // The sources, not `build/`. Importing the compiled copy made the contract a
 // second source of truth: a stale `build/` typechecked against a
 // `EnhancementDoctorReport` that no longer existed. `pnpm enhancements:live` loads this
@@ -142,6 +142,37 @@ function waitForExit(): Promise<Shutdown> {
   });
 }
 
+const GAME_RENDERER_URL = "gw://app/";
+
+/**
+ * Bind live automation to one account window, never the Multiple Accounts Hub.
+ * CDP page order is creation order, so `pages()[0]` is the Hub in Multi mode.
+ */
+async function waitForGamePage(context: BrowserContext): Promise<Page> {
+  const deadline = Date.now() + 30 * 60_000;
+  let checkpointWritten = false;
+  while (Date.now() < deadline) {
+    const games = context.pages().filter((candidate) =>
+      candidate.url() === GAME_RENDERER_URL
+    );
+    if (games.length === 1) return games[0]!;
+    if (games.length > 1) {
+      throw new Error(
+        "Enhancement live run requires exactly one open account window",
+      );
+    }
+    if (!checkpointWritten) {
+      console.log(JSON.stringify({
+        checkpoint: "waiting-for-account-window",
+        please: "open exactly one account from the Multiple Accounts Hub",
+      }));
+      checkpointWritten = true;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error("No Guild Wars account window opened within 30 minutes");
+}
+
 const endpoint = await debuggingEndpoint(stderr);
 
 let browser: Browser | undefined;
@@ -159,7 +190,7 @@ try {
   browser = await chromium.connectOverCDP(endpoint);
   const context = browser.contexts()[0];
   if (!context) throw new Error("Electron exposed no browser context");
-  const page = context.pages()[0] ?? await context.waitForEvent("page");
+  const page = await waitForGamePage(context);
   failurePage = page;
   const cdp = await context.newCDPSession(page);
   await cdp.send("Performance.enable");
@@ -291,6 +322,7 @@ try {
   // pixels on failure.
   if (
     plan.scenario.program !== "toolbox-foundation"
+    && plan.scenario.program !== "reconnect-probe"
     && failurePage
     && !failurePage.isClosed()
   ) {

--- a/scripts/enhancements-live/result.ts
+++ b/scripts/enhancements-live/result.ts
@@ -17,6 +17,7 @@ export function projectLiveResult(
     const ready = state?.status === "ready" ? state : null;
     const runtime = window.gwCompanionRuntime;
     const diagnostics = await window.gwNative.diagnostics.current();
+    const clientSession = await window.gwNative.client.session();
     const settings = await window.gwNative.settings.get();
     const storage = await window.navigator.storage.estimate();
     const p95 = (metric: string) =>
@@ -32,6 +33,7 @@ export function projectLiveResult(
       Number(((Number(diagnostics.latest[metric]) || 0) / 1_000).toFixed(1));
     return {
       scenario: name,
+      appVersion: clientSession.appVersion,
       supported: runtime?.status === "installed",
       buildId: typeof runtime?.buildId === "number" ? runtime.buildId : null,
       companionAbi: numeric(runtime?.companionAbi),

--- a/scripts/enhancements-live/scenarios.ts
+++ b/scripts/enhancements-live/scenarios.ts
@@ -17,12 +17,15 @@
 // automation surface being present. That separation is the property this
 // module protects.
 import type { StdioOptions } from "node:child_process";
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
 import type { CDPSession, Page } from "playwright";
 import type { AutomationCommand } from "../../src/shared/automation.js";
 import type { EnhancementProgram } from "../../src/shared/enhancement-contracts.js";
 import type { EnhancementDoctorReport } from "../../src/tools/enhancement-workspace.js";
 import { BENCHMARK_ARMS, isBalancedOrder } from "./benchmark.js";
 import { runToolboxFoundation, runToolboxHeroPanel } from "./toolbox-scenarios.js";
+import { operatorCheckpoint } from "./scenario-checkpoint.js";
 
 export type LiveTier = "automation" | "observation" | "graphics-observation";
 export type LiveReadiness = "frontend" | "observer" | "toolbox" | "cursor" | "storage";
@@ -721,6 +724,39 @@ export const SCENARIOS: Readonly<Record<string, LiveScenario>> = Object.freeze({
         throw new Error(
           "Xunlai storage did not surrender world interaction after closing",
         );
+      }
+    },
+  }),
+  "reconnect-discovery": Object.freeze({
+    tier: "automation",
+    program: "reconnect-probe",
+    readiness: "frontend",
+    async run({ page }: AutomationContext) {
+      await operatorCheckpoint(
+        "Choose one run: (1) start in an outpost, or (2) start in an explorable area. "
+        + "Use Command-Q → Reload Guild Wars with automatic return enabled. Do not add input. "
+        + "When the character is playable, choose Help → Diagnostics → "
+        + "Copy Reload Trace, then return here.",
+      );
+      const transcript = await page.evaluate(() => window.gwNative.clipboard.readText());
+      const outputDirectory = path.join(
+        process.cwd(),
+        "test-results",
+        "enhancements-live",
+      );
+      await mkdir(outputDirectory, { recursive: true });
+      const output = path.join(outputDirectory, "reconnect-discovery.txt");
+      await writeFile(output, transcript, "utf8");
+      return Object.freeze({ transcript, output });
+    },
+    validate(result: { evidence?: { transcript: string; output: string } }) {
+      if (
+        !result.evidence?.transcript.startsWith("gwonmac reload trace —")
+        || !result.evidence.transcript.includes("gameReload.requested")
+        || !/relog\.finished outcome=(restored|outpost)/
+          .test(result.evidence.transcript)
+      ) {
+        throw new Error("relog qualification did not reach a certified terminal branch");
       }
     },
   }),

--- a/scripts/verify-stable-beta-roundtrip.ts
+++ b/scripts/verify-stable-beta-roundtrip.ts
@@ -223,6 +223,7 @@ const candidateSettingsDomains = Array.from(
       skillCooldownOverlayEnabled: cycle(booleanValues, index),
       skillCooldownColor: { kind: "preset", preset: "red" },
       extendedMemoryEnabled: cycle(booleanValues, index + 1),
+      autoRelogAfterReload: cycle(booleanValues, index),
       showDiagnostics: cycle(booleanValues, index),
       dataStrategy: "full",
       autoCheckUpdates: false,

--- a/src/companion-kernel/lib.rs
+++ b/src/companion-kernel/lib.rs
@@ -855,14 +855,14 @@ pub unsafe extern "C" fn companion_dispatch(kind: u32, a: u32, b: u32, c: u32, _
             }
         }
         DISPATCH_UI => {
-            if !unsafe { INITIALIZED }
-                || unsafe { ACTIVE_FEATURES } & FEATURE_TOOLBOX_FOUNDATION == 0
-            {
+            if !unsafe { INITIALIZED } {
                 return;
             }
             unsafe {
                 let layout = LAYOUT;
-                toolbox::observe_ui(layout, a, b);
+                if ACTIVE_FEATURES & FEATURE_TOOLBOX_FOUNDATION != 0 {
+                    toolbox::observe_ui(layout, a, b);
+                }
             }
         }
         DISPATCH_ACTIVE_FEATURES => {

--- a/src/main/certification/client-module.ts
+++ b/src/main/certification/client-module.ts
@@ -189,6 +189,7 @@ function enhancementCache(
     skillSlotGeometry: capabilities.skillSlotGeometry,
     skillCooldownObservation: capabilities.skillCooldownObservation,
     playRegionObservation: capabilities.playRegionObservation,
+    preGameControls: capabilities.preGameControls,
   };
   return {
     inputSha256: build.sha256,

--- a/src/main/certification/enhancement-build-model.ts
+++ b/src/main/certification/enhancement-build-model.ts
@@ -356,6 +356,39 @@ export interface KnownEnhancementBuild {
     labelAddress: number;
     layout: EnhancementSkillSlotGeometryLayout;
   }>;
+  /** Exact label-hash authority and frame layout used by reload automation. */
+  preGameControls?: Readonly<{
+    hashFunction: Readonly<{
+      functionIndex: number;
+      params: readonly ["i32", "i32"];
+      results: readonly ["i32"];
+      bodySha256: string;
+    }>;
+    relationInitializer: Readonly<{
+      functionIndex: number;
+      params: readonly ["i32", "i32", "i32", "i32"];
+      results: readonly ["i32"];
+      bodySha256: string;
+    }>;
+    labels: Readonly<{
+      play: number;
+      selector: number;
+      yes: number;
+      no: number;
+      reconnectDialog: number;
+    }>;
+    labelHashes: Readonly<{
+      play: number;
+      selector: number;
+      yes: number;
+      no: number;
+    }>;
+    layout: Pick<EnhancementSkillSlotGeometryLayout,
+      "frameArray" | "frameCount" | "frameBytes" | "frameId"
+      | "frameRelation" | "frameState"> & Pick<EnhancementPlayRegionLayout,
+      "contextRoot" | "gameContextSlot" | "characterContext"
+      | "currentInstanceType"> & Readonly<{ frameHashId: number }>;
+  }>;
   /** Exact reader and clock authority for player skill recharge timestamps. */
   skillCooldownObservation?: Readonly<{
     reader: Readonly<{
@@ -403,6 +436,7 @@ export function supportedEnhancementCapabilities(
       && playerSkillbarObservation
       && build.skillCooldownObservation !== undefined,
     playRegionObservation,
+    preGameControls: playRegionObservation && build.preGameControls !== undefined,
   });
 }
 

--- a/src/main/certification/enhancement-build-model.ts
+++ b/src/main/certification/enhancement-build-model.ts
@@ -364,12 +364,6 @@ export interface KnownEnhancementBuild {
       results: readonly ["i32"];
       bodySha256: string;
     }>;
-    relationInitializer: Readonly<{
-      functionIndex: number;
-      params: readonly ["i32", "i32", "i32", "i32"];
-      results: readonly ["i32"];
-      bodySha256: string;
-    }>;
     labels: Readonly<{
       play: number;
       selector: number;
@@ -382,10 +376,11 @@ export interface KnownEnhancementBuild {
       selector: number;
       yes: number;
       no: number;
+      reconnectDialog: number;
     }>;
     layout: Pick<EnhancementSkillSlotGeometryLayout,
       "frameArray" | "frameCount" | "frameBytes" | "frameId"
-      | "frameRelation" | "frameState"> & Pick<EnhancementPlayRegionLayout,
+      | "frameState"> & Pick<EnhancementPlayRegionLayout,
       "contextRoot" | "gameContextSlot" | "characterContext"
       | "currentInstanceType"> & Readonly<{ frameHashId: number }>;
   }>;

--- a/src/main/certification/enhancement-builds.ts
+++ b/src/main/certification/enhancement-builds.ts
@@ -26,7 +26,7 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
         "26a71c3e2bf55ab992dce659c1192213858ee25799daa87841ed23a3ddbb601a",
       // Recomputed from the exact current JSPI artifact when the independent
       // play-region capability landed. The retained output is the complete
-      // product profile proved by semantic verifier ABI 4.
+      // product profile proved by semantic verifier ABI 6.
       //
       // `pnpm check` cannot catch a stale value here. The transform input is a
       // derived game binary this repository does not contain, so nothing in the
@@ -35,8 +35,10 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
       // `transformEnhancementWasm` against the real derived module whenever
       // ENHANCEMENT_TRANSFORM_ABI or any config word changes.
       outputSha256: Object.freeze({
-        "features-3ff":
-          "03afee84b380d01f974c9949656beaa1d15b7f22ae771990c1c27f3ca92c68da",
+        "features-601":
+          "d7be0111174e0c80d0095ce360756720eed9a02072d3dcb819d5c64e0b4572a0",
+        "features-7ff":
+          "fba87e066408647da3979ab65ee5d3863b58b713a73627c78e3201aa23243fba",
       }),
       programId: 1,
       // The verifier derives this bounded identity from the exact module; it is
@@ -485,6 +487,48 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
           frameScreenTop: 0x118,
           frameRelation: 0x128,
           frameState: 0x18c,
+        }),
+      }),
+      preGameControls: Object.freeze({
+        hashFunction: Object.freeze({
+          functionIndex: 365,
+          params: Object.freeze(["i32", "i32"] as const),
+          results: Object.freeze(["i32"] as const),
+          bodySha256:
+            "90e009c029d1a6fb53f0e7b92d72583497455266a64841d34ac56905289ac95b",
+        }),
+        relationInitializer: Object.freeze({
+          functionIndex: 6548,
+          params: Object.freeze(["i32", "i32", "i32", "i32"] as const),
+          results: Object.freeze(["i32"] as const),
+          bodySha256:
+            "91bbf0aa603cb47b3b3a1c7ea2a7062730794600897f16cd94c41a6151214199",
+        }),
+        labels: Object.freeze({
+          play: 0x1765ea,
+          selector: 0x1766c8,
+          yes: 0x176972,
+          no: 0x176980,
+          reconnectDialog: 0x1769c4,
+        }),
+        labelHashes: Object.freeze({
+          play: 0x0b041d2a,
+          selector: 0x31616b12,
+          yes: 0x535d1967,
+          no: 0xd698c3c1,
+        }),
+        layout: Object.freeze({
+          frameArray: 0x5a1fdc,
+          frameCount: 0x5a1fe4,
+          frameBytes: 0x1c8,
+          frameId: 0xbc,
+          frameRelation: 0x128,
+          frameHashId: 0x134,
+          frameState: 0x18c,
+          contextRoot: 0x5a0e70,
+          gameContextSlot: 6,
+          characterContext: 0x44,
+          currentInstanceType: 0x23c,
         }),
       }),
       skillCooldownObservation: Object.freeze({

--- a/src/main/certification/enhancement-builds.ts
+++ b/src/main/certification/enhancement-builds.ts
@@ -36,9 +36,9 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
       // ENHANCEMENT_TRANSFORM_ABI or any config word changes.
       outputSha256: Object.freeze({
         "features-601":
-          "d7be0111174e0c80d0095ce360756720eed9a02072d3dcb819d5c64e0b4572a0",
+          "200341f7bbeb50ab2ab9125a869c7fa61d7b1569d9c760e98acbe026f94ba6bb",
         "features-7ff":
-          "fba87e066408647da3979ab65ee5d3863b58b713a73627c78e3201aa23243fba",
+          "c4b31ca957bf5b8d74e97eb8bd8f816cf448bca5d0b8d56f1037bc7a96c4d638",
       }),
       programId: 1,
       // The verifier derives this bounded identity from the exact module; it is
@@ -497,13 +497,6 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
           bodySha256:
             "90e009c029d1a6fb53f0e7b92d72583497455266a64841d34ac56905289ac95b",
         }),
-        relationInitializer: Object.freeze({
-          functionIndex: 6548,
-          params: Object.freeze(["i32", "i32", "i32", "i32"] as const),
-          results: Object.freeze(["i32"] as const),
-          bodySha256:
-            "91bbf0aa603cb47b3b3a1c7ea2a7062730794600897f16cd94c41a6151214199",
-        }),
         labels: Object.freeze({
           play: 0x1765ea,
           selector: 0x1766c8,
@@ -516,13 +509,13 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
           selector: 0x31616b12,
           yes: 0x535d1967,
           no: 0xd698c3c1,
+          reconnectDialog: 0xfa61451e,
         }),
         layout: Object.freeze({
           frameArray: 0x5a1fdc,
           frameCount: 0x5a1fe4,
           frameBytes: 0x1c8,
           frameId: 0xbc,
-          frameRelation: 0x128,
           frameHashId: 0x134,
           frameState: 0x18c,
           contextRoot: 0x5a0e70,

--- a/src/main/certification/enhancement-policy.ts
+++ b/src/main/certification/enhancement-policy.ts
@@ -54,6 +54,6 @@ export function requestedEnhancementCapabilities(
   if (program !== "none") {
     return enhancementCapabilitiesFor(enhancementSelectionFor(settings), program);
   }
-  if (!settings.gwonmacTools) return ENHANCEMENT_CAPABILITY_PRESETS.cursor;
+  if (!settings.gwonmacTools) return ENHANCEMENT_CAPABILITY_PRESETS.core;
   return ENHANCEMENT_CAPABILITY_PRESETS.all;
 }

--- a/src/main/certification/enhancement-pre-game-proof.ts
+++ b/src/main/certification/enhancement-pre-game-proof.ts
@@ -1,0 +1,162 @@
+/**
+ * Exact-build proof for the four native frames used by reload automation.
+ *
+ * The proof starts at unique UTF-16 labels and binds the game's exact label
+ * hash and FrameRelation initializer. A translated caption, screen position,
+ * or nearby generic Yes button grants no authority.
+ */
+import { isDeepStrictEqual } from "node:util";
+import type { KnownEnhancementBuild } from "./enhancement-builds.js";
+import {
+  codeOperandOccurrences,
+  functionBodySha256,
+  signatureMatches,
+  staticBytes,
+  uniqueExactFunction,
+  type EnhancementProofContext,
+} from "./enhancement-wasm-proof-context.js";
+
+const HASH_FUNCTION_SHA256 =
+  "90e009c029d1a6fb53f0e7b92d72583497455266a64841d34ac56905289ac95b";
+const RELATION_INITIALIZER_SHA256 =
+  "91bbf0aa603cb47b3b3a1c7ea2a7062730794600897f16cd94c41a6151214199";
+const HASH_TABLE_ADDRESS = 1_249_776;
+
+const LABELS = Object.freeze({
+  play: "Play",
+  selector: "Selector",
+  yes: "BtnYes",
+  no: "BtnNo",
+  reconnectDialog: "DlgReconnect",
+});
+
+type Proof = NonNullable<KnownEnhancementBuild["preGameControls"]>;
+
+function utf16Le(value: string): Uint8Array {
+  const bytes = new Uint8Array((value.length + 1) * 2);
+  const view = new DataView(bytes.buffer);
+  for (let index = 0; index < value.length; index += 1) {
+    view.setUint16(index * 2, value.charCodeAt(index), true);
+  }
+  return bytes;
+}
+
+/** Exact, side-effect-free translation of the certified client hash body. */
+function labelHash(context: EnhancementProofContext, value: string): number | null {
+  const bytes = staticBytes(context.module, HASH_TABLE_ADDRESS, 16 * 4);
+  if (!bytes) return null;
+  const table = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  let result = 844_963_502;
+  let rolling = 3_804_322_973;
+  let sum = 561_029_770;
+  for (const character of value) {
+    const code = character.charCodeAt(0);
+    const normalized = ((code - 97) & 0xffff) < 26 ? code - 32 : code;
+    rolling = (normalized ^ (rolling << 3)) >>> 0;
+    sum = (table.getUint32((rolling & 15) * 4, true) + sum) >>> 0;
+    result = ((sum + rolling) ^ result) >>> 0;
+  }
+  return result;
+}
+
+function uniqueStaticAddress(
+  context: EnhancementProofContext,
+  needle: Uint8Array,
+): number | null {
+  const matches: number[] = [];
+  for (const segment of context.module.dataSegments) {
+    for (let at = segment.bytes.indexOf(needle[0]!); at >= 0;) {
+      if (
+        at + needle.byteLength <= segment.bytes.byteLength
+        && needle.every((byte, index) => segment.bytes[at + index] === byte)
+      ) matches.push(segment.base + at);
+      at = segment.bytes.indexOf(needle[0]!, at + 1);
+    }
+  }
+  return matches.length === 1 ? matches[0]! : null;
+}
+
+function exactLabel(
+  context: EnhancementProofContext,
+  value: string,
+): number | null {
+  const encoded = utf16Le(value);
+  const address = uniqueStaticAddress(context, encoded);
+  if (
+    address === null
+    || codeOperandOccurrences(context.module, address) !== 1
+    || !isDeepStrictEqual(staticBytes(context.module, address, encoded.length), encoded)
+  ) return null;
+  return address;
+}
+
+export function derivePreGameControls(
+  context: EnhancementProofContext,
+  frameLayout: Proof["layout"],
+): Proof | null {
+  const play = exactLabel(context, LABELS.play);
+  const selector = exactLabel(context, LABELS.selector);
+  const yes = exactLabel(context, LABELS.yes);
+  const no = exactLabel(context, LABELS.no);
+  const reconnectDialog = exactLabel(context, LABELS.reconnectDialog);
+  if (play === null || selector === null || yes === null || no === null
+    || reconnectDialog === null) return null;
+  const hashFunction = uniqueExactFunction(
+    context.module,
+    HASH_FUNCTION_SHA256,
+    ["i32", "i32"],
+    ["i32"],
+  );
+  const relationInitializer = uniqueExactFunction(
+    context.module,
+    RELATION_INITIALIZER_SHA256,
+    ["i32", "i32", "i32", "i32"],
+    ["i32"],
+  );
+  if (hashFunction === null || relationInitializer === null
+    || !signatureMatches(context.module, hashFunction, ["i32", "i32"], ["i32"])
+    || !signatureMatches(
+      context.module,
+      relationInitializer,
+      ["i32", "i32", "i32", "i32"],
+      ["i32"],
+    )) return null;
+  const labelHashes = {
+    play: labelHash(context, LABELS.play),
+    selector: labelHash(context, LABELS.selector),
+    yes: labelHash(context, LABELS.yes),
+    no: labelHash(context, LABELS.no),
+  };
+  if (Object.values(labelHashes).some((hash) => hash === null || hash === 0)) {
+    return null;
+  }
+
+  return Object.freeze({
+    hashFunction: Object.freeze({
+      functionIndex: hashFunction,
+      params: Object.freeze(["i32", "i32"] as const),
+      results: Object.freeze(["i32"] as const),
+      bodySha256: functionBodySha256(context.module, hashFunction),
+    }),
+    relationInitializer: Object.freeze({
+      functionIndex: relationInitializer,
+      params: Object.freeze(["i32", "i32", "i32", "i32"] as const),
+      results: Object.freeze(["i32"] as const),
+      bodySha256: functionBodySha256(context.module, relationInitializer),
+    }),
+    labels: Object.freeze({
+      play,
+      selector,
+      yes,
+      no,
+      reconnectDialog,
+    }),
+    labelHashes: Object.freeze({
+      play: labelHashes.play!,
+      selector: labelHashes.selector!,
+      yes: labelHashes.yes!,
+      no: labelHashes.no!,
+    }),
+    layout: Object.freeze({ ...frameLayout }),
+  });
+}

--- a/src/main/certification/enhancement-pre-game-proof.ts
+++ b/src/main/certification/enhancement-pre-game-proof.ts
@@ -1,9 +1,9 @@
 /**
- * Exact-build proof for the four native frames used by reload automation.
+ * Exact-build proof for the five native frames used by reload automation.
  *
  * The proof starts at unique UTF-16 labels and binds the game's exact label
- * hash and FrameRelation initializer. A translated caption, screen position,
- * or nearby generic Yes button grants no authority.
+ * hash implementation. A translated caption, screen position, or nearby
+ * generic Yes button grants no authority.
  */
 import { isDeepStrictEqual } from "node:util";
 import type { KnownEnhancementBuild } from "./enhancement-builds.js";
@@ -18,8 +18,6 @@ import {
 
 const HASH_FUNCTION_SHA256 =
   "90e009c029d1a6fb53f0e7b92d72583497455266a64841d34ac56905289ac95b";
-const RELATION_INITIALIZER_SHA256 =
-  "91bbf0aa603cb47b3b3a1c7ea2a7062730794600897f16cd94c41a6151214199";
 const HASH_TABLE_ADDRESS = 1_249_776;
 
 const LABELS = Object.freeze({
@@ -107,25 +105,16 @@ export function derivePreGameControls(
     ["i32", "i32"],
     ["i32"],
   );
-  const relationInitializer = uniqueExactFunction(
-    context.module,
-    RELATION_INITIALIZER_SHA256,
-    ["i32", "i32", "i32", "i32"],
-    ["i32"],
-  );
-  if (hashFunction === null || relationInitializer === null
-    || !signatureMatches(context.module, hashFunction, ["i32", "i32"], ["i32"])
-    || !signatureMatches(
-      context.module,
-      relationInitializer,
-      ["i32", "i32", "i32", "i32"],
-      ["i32"],
-    )) return null;
+  if (hashFunction === null
+    || !signatureMatches(context.module, hashFunction, ["i32", "i32"], ["i32"])) {
+    return null;
+  }
   const labelHashes = {
     play: labelHash(context, LABELS.play),
     selector: labelHash(context, LABELS.selector),
     yes: labelHash(context, LABELS.yes),
     no: labelHash(context, LABELS.no),
+    reconnectDialog: labelHash(context, LABELS.reconnectDialog),
   };
   if (Object.values(labelHashes).some((hash) => hash === null || hash === 0)) {
     return null;
@@ -137,12 +126,6 @@ export function derivePreGameControls(
       params: Object.freeze(["i32", "i32"] as const),
       results: Object.freeze(["i32"] as const),
       bodySha256: functionBodySha256(context.module, hashFunction),
-    }),
-    relationInitializer: Object.freeze({
-      functionIndex: relationInitializer,
-      params: Object.freeze(["i32", "i32", "i32", "i32"] as const),
-      results: Object.freeze(["i32"] as const),
-      bodySha256: functionBodySha256(context.module, relationInitializer),
     }),
     labels: Object.freeze({
       play,
@@ -156,6 +139,7 @@ export function derivePreGameControls(
       selector: labelHashes.selector!,
       yes: labelHashes.yes!,
       no: labelHashes.no!,
+      reconnectDialog: labelHashes.reconnectDialog!,
     }),
     layout: Object.freeze({ ...frameLayout }),
   });

--- a/src/main/certification/enhancement-pre-game-transform.ts
+++ b/src/main/certification/enhancement-pre-game-transform.ts
@@ -1,0 +1,224 @@
+/**
+ * Owns the closed WASM transform for certified pre-game frame observation.
+ * It mirrors GWCA's GetFrameByLabel boundary inside the game module and exports
+ * only a closed state enum plus a privacy-safe diagnostic mask.
+ */
+import { concat, sleb, uleb, type FunctionType } from "../core/wasm-binary.js";
+import { ENHANCEMENT_TRANSFORM_ABI } from "../../shared/enhancement-contracts.js";
+import type { KnownEnhancementBuild } from "./enhancement-builds.js";
+
+type Certificate = NonNullable<KnownEnhancementBuild["preGameControls"]>;
+
+export type ResolvedPreGameFunction = Readonly<{
+  localIndex: number;
+  typeIndex: number;
+  type: FunctionType;
+}>;
+
+export type EnhancementPreGameResolution = Readonly<{
+  certificate: Certificate;
+  hashFunction: ResolvedPreGameFunction;
+  relationInitializer: ResolvedPreGameFunction;
+}> | null;
+
+type ResolveFunction = (
+  label: string,
+  functionIndex: number,
+  expectedParams: readonly string[],
+  expectedResults: readonly string[],
+) => ResolvedPreGameFunction;
+
+export function resolveEnhancementPreGameTransform(options: Readonly<{
+  build: KnownEnhancementBuild;
+  enabled: boolean;
+  resolveFunction: ResolveFunction;
+  bodyHash: (functionIndex: number) => string;
+  fail: (message: string) => never;
+}>): EnhancementPreGameResolution {
+  if (!options.enabled) return null;
+  const certificate = options.build.preGameControls
+    ?? options.fail("pre-game controls are not certified");
+  const hashFunction = options.resolveFunction(
+    "pre-game label hash",
+    certificate.hashFunction.functionIndex,
+    certificate.hashFunction.params,
+    certificate.hashFunction.results,
+  );
+  const relationInitializer = options.resolveFunction(
+    "frame relation initializer",
+    certificate.relationInitializer.functionIndex,
+    certificate.relationInitializer.params,
+    certificate.relationInitializer.results,
+  );
+  for (const entry of [certificate.hashFunction, certificate.relationInitializer]) {
+    if (options.bodyHash(entry.functionIndex) !== entry.bodySha256) {
+      options.fail("pre-game frame bodies do not match their certificates");
+    }
+  }
+  return { certificate, hashFunction, relationInitializer };
+}
+
+function rejectWithMaskIf(condition: Uint8Array): Uint8Array {
+  return concat(
+    condition, Uint8Array.of(0x04, 0x40),
+    Uint8Array.of(0x20), uleb(0), Uint8Array.of(0x0f, 0x0b),
+  );
+}
+
+function addBooleanBit(condition: Uint8Array, bit: number): Uint8Array {
+  return concat(
+    Uint8Array.of(0x20), uleb(0), condition,
+    Uint8Array.of(0x41), sleb(1 << bit), Uint8Array.of(0x6c, 0x72, 0x21), uleb(0),
+  );
+}
+
+function visibleFrame(frameLocal: number, frameState: number): Uint8Array {
+  return concat(
+    Uint8Array.of(0x20), uleb(frameLocal), Uint8Array.of(0x28), uleb(2),
+    uleb(frameState), Uint8Array.of(0x22), uleb(10),
+    Uint8Array.of(0x41), sleb(4), Uint8Array.of(0x71, 0x45, 0x45),
+    Uint8Array.of(0x20), uleb(10), Uint8Array.of(0x41), sleb(0x200),
+    Uint8Array.of(0x71, 0x45, 0x71),
+  );
+}
+
+/** True when `pointer + bytes` would exceed a non-4-GiB memory. */
+function outsideMemory(pointerLocal: number, bytes: Uint8Array): Uint8Array {
+  return concat(
+    Uint8Array.of(0x20), uleb(11), Uint8Array.of(0x45, 0x45),
+    Uint8Array.of(0x20), uleb(pointerLocal), Uint8Array.of(0x20), uleb(11),
+    bytes, Uint8Array.of(0x6b, 0x4b, 0x71),
+  );
+}
+
+/**
+ * Returns a privacy-safe probe mask while resolving labels exactly as GWCA's
+ * GetFrameByLabel does: hash each UTF-16 label with the game's own function,
+ * then compare it with FrameRelation::frame_hash_id in the live frame table.
+ *
+ * bits 0..3:  the Play, Selector, Yes, and No label hashes are nonzero
+ * bits 4..7:  a valid live frame has the corresponding frame_hash_id
+ * bits 8..11: that exact frame is currently visible
+ * bit 12:     Yes and No are both visible
+ * bit 13:     Play and Selector are both visible
+ * bits 14..18: valid count, array, frame pointer, frame id, and live hash seen
+ * bits 24..30: the Enhancement transform ABI that produced this reader
+ */
+export function preGameDiagnosticReader(
+  certificate: Certificate,
+): Uint8Array {
+  const { layout } = certificate;
+  const hashes = [
+    certificate.labelHashes.play,
+    certificate.labelHashes.selector,
+    certificate.labelHashes.yes,
+    certificate.labelHashes.no,
+  ] as const;
+  const matchOne = (hashLocal: number, bit: number): Uint8Array => concat(
+    Uint8Array.of(0x20), uleb(9), Uint8Array.of(0x20), uleb(hashLocal),
+    Uint8Array.of(0x46, 0x04, 0x40),
+    Uint8Array.of(0x20), uleb(0), Uint8Array.of(0x41), sleb(1 << (bit + 4)),
+    Uint8Array.of(0x72, 0x21), uleb(0),
+    addBooleanBit(visibleFrame(8, layout.frameState), bit + 8),
+    Uint8Array.of(0x0b),
+  );
+  return concat(
+    // mask, four hashes, count, array, index, frame, hash, state, memory bytes.
+    uleb(1), uleb(12), Uint8Array.of(0x7f),
+    Uint8Array.of(0x41), sleb(ENHANCEMENT_TRANSFORM_ABI << 24),
+    Uint8Array.of(0x21), uleb(0),
+    Uint8Array.of(0x3f, 0x00, 0x41), sleb(65_536),
+    Uint8Array.of(0x6c, 0x21), uleb(11),
+    ...hashes.map((hash, index) => concat(
+      Uint8Array.of(0x41), sleb(hash), Uint8Array.of(0x21), uleb(index + 1),
+      addBooleanBit(concat(
+        Uint8Array.of(0x20), uleb(index + 1), Uint8Array.of(0x45, 0x45),
+      ), index),
+    )),
+    Uint8Array.of(0x41), sleb(layout.frameCount),
+    Uint8Array.of(0x28), uleb(2), uleb(0), Uint8Array.of(0x22), uleb(5),
+    rejectWithMaskIf(Uint8Array.of(0x45)),
+    rejectWithMaskIf(concat(
+      Uint8Array.of(0x20), uleb(5), Uint8Array.of(0x41), sleb(16_384),
+      Uint8Array.of(0x4b),
+    )),
+    addBooleanBit(Uint8Array.of(0x41, 0x01), 14),
+    Uint8Array.of(0x41), sleb(layout.frameArray),
+    Uint8Array.of(0x28), uleb(2), uleb(0), Uint8Array.of(0x22), uleb(6),
+    rejectWithMaskIf(Uint8Array.of(0x45)),
+    rejectWithMaskIf(outsideMemory(6, concat(
+      Uint8Array.of(0x20), uleb(5), Uint8Array.of(0x41), sleb(4),
+      Uint8Array.of(0x6c),
+    ))),
+    addBooleanBit(Uint8Array.of(0x41, 0x01), 15),
+    Uint8Array.of(0x41), sleb(0), Uint8Array.of(0x21), uleb(7),
+    Uint8Array.of(0x02, 0x40, 0x03, 0x40),
+      Uint8Array.of(0x20), uleb(7), Uint8Array.of(0x20), uleb(5),
+      Uint8Array.of(0x4f, 0x0d), uleb(1),
+      Uint8Array.of(0x20), uleb(6), Uint8Array.of(0x20), uleb(7),
+      Uint8Array.of(0x41), sleb(4), Uint8Array.of(0x6c, 0x6a),
+      Uint8Array.of(0x28), uleb(2), uleb(0), Uint8Array.of(0x22), uleb(8),
+      Uint8Array.of(0x04, 0x40),
+        outsideMemory(8, concat(Uint8Array.of(0x41), sleb(layout.frameBytes))),
+        Uint8Array.of(0x45, 0x04, 0x40),
+          addBooleanBit(Uint8Array.of(0x41, 0x01), 16),
+          Uint8Array.of(0x20), uleb(8), Uint8Array.of(0x28), uleb(2),
+          uleb(layout.frameId), Uint8Array.of(0x20), uleb(7),
+          Uint8Array.of(0x46, 0x04, 0x40),
+            addBooleanBit(Uint8Array.of(0x41, 0x01), 17),
+            Uint8Array.of(0x20), uleb(8), Uint8Array.of(0x28), uleb(2),
+            uleb(layout.frameHashId), Uint8Array.of(0x21), uleb(9),
+            addBooleanBit(concat(
+              Uint8Array.of(0x20), uleb(9), Uint8Array.of(0x45, 0x45),
+            ), 18),
+            matchOne(1, 0), matchOne(2, 1), matchOne(3, 2), matchOne(4, 3),
+          Uint8Array.of(0x0b),
+        Uint8Array.of(0x0b),
+      Uint8Array.of(0x0b),
+      Uint8Array.of(0x20), uleb(7), Uint8Array.of(0x41), sleb(1),
+      Uint8Array.of(0x6a, 0x21), uleb(7), Uint8Array.of(0x0c), uleb(0),
+    Uint8Array.of(0x0b, 0x0b),
+    addBooleanBit(concat(
+      Uint8Array.of(0x20), uleb(0), Uint8Array.of(0x41), sleb(0x0c00),
+      Uint8Array.of(0x71, 0x41), sleb(0x0c00), Uint8Array.of(0x46),
+    ), 12),
+    addBooleanBit(concat(
+      Uint8Array.of(0x20), uleb(0), Uint8Array.of(0x41), sleb(0x0300),
+      Uint8Array.of(0x71, 0x41), sleb(0x0300), Uint8Array.of(0x46),
+    ), 13),
+    Uint8Array.of(0x20), uleb(0), Uint8Array.of(0x0b),
+  );
+}
+
+/** Returns 0 unknown, 1 character select ready, 2 reconnect, or 3 loading. */
+export function preGameStateReader(
+  certificate: Certificate,
+  diagnosticReaderIndex: number,
+): Uint8Array {
+  return concat(
+    // local 0 = diagnostic mask; local 1 = context traversal scratch.
+    uleb(1), uleb(2), Uint8Array.of(0x7f),
+    Uint8Array.of(0x10), uleb(diagnosticReaderIndex), Uint8Array.of(0x21), uleb(0),
+    Uint8Array.of(0x20), uleb(0), Uint8Array.of(0x41), sleb(1 << 12),
+    Uint8Array.of(0x71, 0x04, 0x40, 0x41), sleb(2), Uint8Array.of(0x0f, 0x0b),
+    Uint8Array.of(0x20), uleb(0), Uint8Array.of(0x41), sleb(1 << 13),
+    Uint8Array.of(0x71, 0x04, 0x40, 0x41), sleb(1), Uint8Array.of(0x0f, 0x0b),
+    Uint8Array.of(0x41), sleb(certificate.layout.contextRoot),
+    Uint8Array.of(0x28), uleb(2), uleb(0), Uint8Array.of(0x22), uleb(1),
+    Uint8Array.of(0x04, 0x40),
+      Uint8Array.of(0x20), uleb(1), Uint8Array.of(0x28), uleb(2),
+      uleb(certificate.layout.gameContextSlot * 4), Uint8Array.of(0x22), uleb(1),
+      Uint8Array.of(0x04, 0x40),
+        Uint8Array.of(0x20), uleb(1), Uint8Array.of(0x28), uleb(2),
+        uleb(certificate.layout.characterContext), Uint8Array.of(0x22), uleb(1),
+        Uint8Array.of(0x04, 0x40),
+          Uint8Array.of(0x20), uleb(1), Uint8Array.of(0x28), uleb(2),
+          uleb(certificate.layout.currentInstanceType),
+          Uint8Array.of(0x41), sleb(2), Uint8Array.of(0x46, 0x04, 0x40, 0x41),
+          sleb(3), Uint8Array.of(0x0f, 0x0b),
+        Uint8Array.of(0x0b),
+      Uint8Array.of(0x0b),
+    Uint8Array.of(0x0b),
+    Uint8Array.of(0x41), sleb(0), Uint8Array.of(0x0b),
+  );
+}

--- a/src/main/certification/enhancement-pre-game-transform.ts
+++ b/src/main/certification/enhancement-pre-game-transform.ts
@@ -18,7 +18,6 @@ export type ResolvedPreGameFunction = Readonly<{
 export type EnhancementPreGameResolution = Readonly<{
   certificate: Certificate;
   hashFunction: ResolvedPreGameFunction;
-  relationInitializer: ResolvedPreGameFunction;
 }> | null;
 
 type ResolveFunction = (
@@ -44,18 +43,11 @@ export function resolveEnhancementPreGameTransform(options: Readonly<{
     certificate.hashFunction.params,
     certificate.hashFunction.results,
   );
-  const relationInitializer = options.resolveFunction(
-    "frame relation initializer",
-    certificate.relationInitializer.functionIndex,
-    certificate.relationInitializer.params,
-    certificate.relationInitializer.results,
-  );
-  for (const entry of [certificate.hashFunction, certificate.relationInitializer]) {
-    if (options.bodyHash(entry.functionIndex) !== entry.bodySha256) {
-      options.fail("pre-game frame bodies do not match their certificates");
-    }
+  if (options.bodyHash(certificate.hashFunction.functionIndex)
+    !== certificate.hashFunction.bodySha256) {
+    options.fail("pre-game frame body does not match its certificate");
   }
-  return { certificate, hashFunction, relationInitializer };
+  return { certificate, hashFunction };
 }
 
 function rejectWithMaskIf(condition: Uint8Array): Uint8Array {
@@ -82,11 +74,25 @@ function visibleFrame(frameLocal: number, frameState: number): Uint8Array {
   );
 }
 
+const PRE_GAME_LOCALS = Object.freeze({
+  mask: 0,
+  firstHash: 1,
+  count: 6,
+  array: 7,
+  index: 8,
+  frame: 9,
+  liveHash: 10,
+  frameState: 11,
+  memoryBytes: 12,
+});
+
 /** True when `pointer + bytes` would exceed a non-4-GiB memory. */
 function outsideMemory(pointerLocal: number, bytes: Uint8Array): Uint8Array {
   return concat(
-    Uint8Array.of(0x20), uleb(11), Uint8Array.of(0x45, 0x45),
-    Uint8Array.of(0x20), uleb(pointerLocal), Uint8Array.of(0x20), uleb(11),
+    Uint8Array.of(0x20), uleb(PRE_GAME_LOCALS.memoryBytes),
+    Uint8Array.of(0x45, 0x45),
+    Uint8Array.of(0x20), uleb(pointerLocal), Uint8Array.of(0x20),
+    uleb(PRE_GAME_LOCALS.memoryBytes),
     bytes, Uint8Array.of(0x6b, 0x4b, 0x71),
   );
 }
@@ -102,6 +108,8 @@ function outsideMemory(pointerLocal: number, bytes: Uint8Array): Uint8Array {
  * bit 12:     Yes and No are both visible
  * bit 13:     Play and Selector are both visible
  * bits 14..18: valid count, array, frame pointer, frame id, and live hash seen
+ * bits 19..21: DlgReconnect hash, live match, and visibility
+ * bit 22:     DlgReconnect, Yes, and No are all visible
  * bits 24..30: the Enhancement transform ABI that produced this reader
  */
 export function preGameDiagnosticReader(
@@ -113,70 +121,98 @@ export function preGameDiagnosticReader(
     certificate.labelHashes.selector,
     certificate.labelHashes.yes,
     certificate.labelHashes.no,
+    certificate.labelHashes.reconnectDialog,
   ] as const;
-  const matchOne = (hashLocal: number, bit: number): Uint8Array => concat(
-    Uint8Array.of(0x20), uleb(9), Uint8Array.of(0x20), uleb(hashLocal),
+  const matchOne = (
+    hashLocal: number,
+    matchedBit: number,
+    visibleBit: number,
+  ): Uint8Array => concat(
+    Uint8Array.of(0x20), uleb(PRE_GAME_LOCALS.liveHash),
+    Uint8Array.of(0x20), uleb(hashLocal),
     Uint8Array.of(0x46, 0x04, 0x40),
-    Uint8Array.of(0x20), uleb(0), Uint8Array.of(0x41), sleb(1 << (bit + 4)),
-    Uint8Array.of(0x72, 0x21), uleb(0),
-    addBooleanBit(visibleFrame(8, layout.frameState), bit + 8),
+    Uint8Array.of(0x20), uleb(PRE_GAME_LOCALS.mask), Uint8Array.of(0x41),
+    sleb(1 << matchedBit), Uint8Array.of(0x72, 0x21),
+    uleb(PRE_GAME_LOCALS.mask),
+    addBooleanBit(
+      visibleFrame(PRE_GAME_LOCALS.frame, layout.frameState),
+      visibleBit,
+    ),
     Uint8Array.of(0x0b),
   );
   return concat(
-    // mask, four hashes, count, array, index, frame, hash, state, memory bytes.
-    uleb(1), uleb(12), Uint8Array.of(0x7f),
+    // mask, five hashes, count, array, index, frame, hash, state, memory bytes.
+    uleb(1), uleb(13), Uint8Array.of(0x7f),
     Uint8Array.of(0x41), sleb(ENHANCEMENT_TRANSFORM_ABI << 24),
-    Uint8Array.of(0x21), uleb(0),
+    Uint8Array.of(0x21), uleb(PRE_GAME_LOCALS.mask),
     Uint8Array.of(0x3f, 0x00, 0x41), sleb(65_536),
-    Uint8Array.of(0x6c, 0x21), uleb(11),
+    Uint8Array.of(0x6c, 0x21), uleb(PRE_GAME_LOCALS.memoryBytes),
     ...hashes.map((hash, index) => concat(
-      Uint8Array.of(0x41), sleb(hash), Uint8Array.of(0x21), uleb(index + 1),
+      Uint8Array.of(0x41), sleb(hash), Uint8Array.of(0x21),
+      uleb(PRE_GAME_LOCALS.firstHash + index),
       addBooleanBit(concat(
-        Uint8Array.of(0x20), uleb(index + 1), Uint8Array.of(0x45, 0x45),
-      ), index),
+        Uint8Array.of(0x20), uleb(PRE_GAME_LOCALS.firstHash + index),
+        Uint8Array.of(0x45, 0x45),
+      ), index < 4 ? index : 19),
     )),
     Uint8Array.of(0x41), sleb(layout.frameCount),
-    Uint8Array.of(0x28), uleb(2), uleb(0), Uint8Array.of(0x22), uleb(5),
+    Uint8Array.of(0x28), uleb(2), uleb(0), Uint8Array.of(0x22),
+    uleb(PRE_GAME_LOCALS.count),
     rejectWithMaskIf(Uint8Array.of(0x45)),
     rejectWithMaskIf(concat(
-      Uint8Array.of(0x20), uleb(5), Uint8Array.of(0x41), sleb(16_384),
+      Uint8Array.of(0x20), uleb(PRE_GAME_LOCALS.count),
+      Uint8Array.of(0x41), sleb(16_384),
       Uint8Array.of(0x4b),
     )),
     addBooleanBit(Uint8Array.of(0x41, 0x01), 14),
     Uint8Array.of(0x41), sleb(layout.frameArray),
-    Uint8Array.of(0x28), uleb(2), uleb(0), Uint8Array.of(0x22), uleb(6),
+    Uint8Array.of(0x28), uleb(2), uleb(0), Uint8Array.of(0x22),
+    uleb(PRE_GAME_LOCALS.array),
     rejectWithMaskIf(Uint8Array.of(0x45)),
-    rejectWithMaskIf(outsideMemory(6, concat(
-      Uint8Array.of(0x20), uleb(5), Uint8Array.of(0x41), sleb(4),
+    rejectWithMaskIf(outsideMemory(PRE_GAME_LOCALS.array, concat(
+      Uint8Array.of(0x20), uleb(PRE_GAME_LOCALS.count),
+      Uint8Array.of(0x41), sleb(4),
       Uint8Array.of(0x6c),
     ))),
     addBooleanBit(Uint8Array.of(0x41, 0x01), 15),
-    Uint8Array.of(0x41), sleb(0), Uint8Array.of(0x21), uleb(7),
+    Uint8Array.of(0x41), sleb(0), Uint8Array.of(0x21),
+    uleb(PRE_GAME_LOCALS.index),
     Uint8Array.of(0x02, 0x40, 0x03, 0x40),
-      Uint8Array.of(0x20), uleb(7), Uint8Array.of(0x20), uleb(5),
+      Uint8Array.of(0x20), uleb(PRE_GAME_LOCALS.index), Uint8Array.of(0x20),
+      uleb(PRE_GAME_LOCALS.count),
       Uint8Array.of(0x4f, 0x0d), uleb(1),
-      Uint8Array.of(0x20), uleb(6), Uint8Array.of(0x20), uleb(7),
+      Uint8Array.of(0x20), uleb(PRE_GAME_LOCALS.array), Uint8Array.of(0x20),
+      uleb(PRE_GAME_LOCALS.index),
       Uint8Array.of(0x41), sleb(4), Uint8Array.of(0x6c, 0x6a),
-      Uint8Array.of(0x28), uleb(2), uleb(0), Uint8Array.of(0x22), uleb(8),
+      Uint8Array.of(0x28), uleb(2), uleb(0), Uint8Array.of(0x22),
+      uleb(PRE_GAME_LOCALS.frame),
       Uint8Array.of(0x04, 0x40),
-        outsideMemory(8, concat(Uint8Array.of(0x41), sleb(layout.frameBytes))),
+        outsideMemory(PRE_GAME_LOCALS.frame, concat(
+          Uint8Array.of(0x41), sleb(layout.frameBytes),
+        )),
         Uint8Array.of(0x45, 0x04, 0x40),
           addBooleanBit(Uint8Array.of(0x41, 0x01), 16),
-          Uint8Array.of(0x20), uleb(8), Uint8Array.of(0x28), uleb(2),
-          uleb(layout.frameId), Uint8Array.of(0x20), uleb(7),
+          Uint8Array.of(0x20), uleb(PRE_GAME_LOCALS.frame),
+          Uint8Array.of(0x28), uleb(2), uleb(layout.frameId),
+          Uint8Array.of(0x20), uleb(PRE_GAME_LOCALS.index),
           Uint8Array.of(0x46, 0x04, 0x40),
             addBooleanBit(Uint8Array.of(0x41, 0x01), 17),
-            Uint8Array.of(0x20), uleb(8), Uint8Array.of(0x28), uleb(2),
-            uleb(layout.frameHashId), Uint8Array.of(0x21), uleb(9),
+            Uint8Array.of(0x20), uleb(PRE_GAME_LOCALS.frame),
+            Uint8Array.of(0x28), uleb(2), uleb(layout.frameHashId),
+            Uint8Array.of(0x21), uleb(PRE_GAME_LOCALS.liveHash),
             addBooleanBit(concat(
-              Uint8Array.of(0x20), uleb(9), Uint8Array.of(0x45, 0x45),
+              Uint8Array.of(0x20), uleb(PRE_GAME_LOCALS.liveHash),
+              Uint8Array.of(0x45, 0x45),
             ), 18),
-            matchOne(1, 0), matchOne(2, 1), matchOne(3, 2), matchOne(4, 3),
+            matchOne(1, 4, 8), matchOne(2, 5, 9),
+            matchOne(3, 6, 10), matchOne(4, 7, 11),
+            matchOne(5, 20, 21),
           Uint8Array.of(0x0b),
         Uint8Array.of(0x0b),
       Uint8Array.of(0x0b),
-      Uint8Array.of(0x20), uleb(7), Uint8Array.of(0x41), sleb(1),
-      Uint8Array.of(0x6a, 0x21), uleb(7), Uint8Array.of(0x0c), uleb(0),
+      Uint8Array.of(0x20), uleb(PRE_GAME_LOCALS.index),
+      Uint8Array.of(0x41), sleb(1), Uint8Array.of(0x6a, 0x21),
+      uleb(PRE_GAME_LOCALS.index), Uint8Array.of(0x0c), uleb(0),
     Uint8Array.of(0x0b, 0x0b),
     addBooleanBit(concat(
       Uint8Array.of(0x20), uleb(0), Uint8Array.of(0x41), sleb(0x0c00),
@@ -186,6 +222,11 @@ export function preGameDiagnosticReader(
       Uint8Array.of(0x20), uleb(0), Uint8Array.of(0x41), sleb(0x0300),
       Uint8Array.of(0x71, 0x41), sleb(0x0300), Uint8Array.of(0x46),
     ), 13),
+    addBooleanBit(concat(
+      Uint8Array.of(0x20), uleb(PRE_GAME_LOCALS.mask),
+      Uint8Array.of(0x41), sleb(0x20_0c00), Uint8Array.of(0x71, 0x41),
+      sleb(0x20_0c00), Uint8Array.of(0x46),
+    ), 22),
     Uint8Array.of(0x20), uleb(0), Uint8Array.of(0x0b),
   );
 }
@@ -199,7 +240,7 @@ export function preGameStateReader(
     // local 0 = diagnostic mask; local 1 = context traversal scratch.
     uleb(1), uleb(2), Uint8Array.of(0x7f),
     Uint8Array.of(0x10), uleb(diagnosticReaderIndex), Uint8Array.of(0x21), uleb(0),
-    Uint8Array.of(0x20), uleb(0), Uint8Array.of(0x41), sleb(1 << 12),
+    Uint8Array.of(0x20), uleb(0), Uint8Array.of(0x41), sleb(1 << 22),
     Uint8Array.of(0x71, 0x04, 0x40, 0x41), sleb(2), Uint8Array.of(0x0f, 0x0b),
     Uint8Array.of(0x20), uleb(0), Uint8Array.of(0x41), sleb(1 << 13),
     Uint8Array.of(0x71, 0x04, 0x40, 0x41), sleb(1), Uint8Array.of(0x0f, 0x0b),

--- a/src/main/certification/enhancement-transform.ts
+++ b/src/main/certification/enhancement-transform.ts
@@ -602,16 +602,10 @@ function resolveEnhancementTransform(
       name: "SkillBar frame constructor",
       functionIndex: skillConstructor.localIndex + importCount,
     }] : []),
-    ...(preGameResolution ? [
-      {
-        name: "pre-game label hash",
-        functionIndex: preGameResolution.hashFunction.localIndex + importCount,
-      },
-      {
-        name: "frame relation initializer",
-        functionIndex: preGameResolution.relationInitializer.localIndex + importCount,
-      },
-    ] : []),
+    ...(preGameResolution ? [{
+      name: "pre-game label hash",
+      functionIndex: preGameResolution.hashFunction.localIndex + importCount,
+    }] : []),
   ];
   const roleByFunction = new Map<number, string>();
   for (const role of exclusiveRoles) {

--- a/src/main/certification/enhancement-transform.ts
+++ b/src/main/certification/enhancement-transform.ts
@@ -37,6 +37,11 @@ import {
   rewriteSkillBarConstructorCapture,
 } from "./enhancement-skill-transform.js";
 import {
+  preGameDiagnosticReader,
+  preGameStateReader,
+  resolveEnhancementPreGameTransform,
+} from "./enhancement-pre-game-transform.js";
+import {
   PROFESSION_TRACE_WORDS,
   professionTraceGlobals,
   type ProfessionTraceGlobals,
@@ -73,6 +78,8 @@ declare const WebAssembly: {
 };
 
 export const ENHANCEMENT_HOOK_EXPORT = "enhancement_hook_slot";
+export const ENHANCEMENT_PRE_GAME_STATE_EXPORT = "enhancement_pre_game_state";
+export const ENHANCEMENT_PRE_GAME_DIAGNOSTIC_EXPORT = "enhancement_pre_game_diagnostic";
 export const ENHANCEMENT_MANIFEST_SECTION = "enhancement_manifest";
 
 const DISPATCH_PARAMS = 6;
@@ -345,6 +352,13 @@ function resolveEnhancementTransform(
     resolveFunction: resolveHook,
     fail,
   });
+  const preGameResolution = resolveEnhancementPreGameTransform({
+    build,
+    enabled: capabilities.preGameControls,
+    resolveFunction: resolveHook,
+    bodyHash,
+    fail,
+  });
   const skillInitializer = skillResolution.geometry?.initializer ?? null;
   const skillConstructor = skillResolution.geometry?.constructor ?? null;
   if (bodyHash(build.hookFunction) !== build.hookBodySha256) {
@@ -588,6 +602,16 @@ function resolveEnhancementTransform(
       name: "SkillBar frame constructor",
       functionIndex: skillConstructor.localIndex + importCount,
     }] : []),
+    ...(preGameResolution ? [
+      {
+        name: "pre-game label hash",
+        functionIndex: preGameResolution.hashFunction.localIndex + importCount,
+      },
+      {
+        name: "frame relation initializer",
+        functionIndex: preGameResolution.relationInitializer.localIndex + importCount,
+      },
+    ] : []),
   ];
   const roleByFunction = new Map<number, string>();
   for (const role of exclusiveRoles) {
@@ -653,6 +677,7 @@ function resolveEnhancementTransform(
     travelAction,
     chatAliases,
     skillResolution,
+    preGameResolution,
     commands,
     professionBuilder,
     skillBuilder,
@@ -690,6 +715,7 @@ function assembleEnhancementTransform(
     nextTableSize,
     hasActionQueue,
     skillResolution,
+    preGameResolution,
   } = resolution;
 
   const globals = vectorPayload(sectionById(sections, 6));
@@ -697,6 +723,9 @@ function assembleEnhancementTransform(
   const existingExports = parseExports(sectionById(sections, 7));
   const addedExportNames = [
     ENHANCEMENT_HOOK_EXPORT,
+    ...(capabilities.preGameControls
+      ? [ENHANCEMENT_PRE_GAME_STATE_EXPORT, ENHANCEMENT_PRE_GAME_DIAGNOSTIC_EXPORT]
+      : []),
     ...(capabilities.teamApply
       ? [teamApply.thunkExport, teamApply.professionTrace.readerExport]
       : []),
@@ -787,6 +816,9 @@ function assembleEnhancementTransform(
   const tradeToggleTypeIndex = capabilities.chatAliases
     ? appendType({ params: [], results: [0x7f] })
     : null;
+  const preGameStateTypeIndex = capabilities.preGameControls
+    ? appendType({ params: [], results: [0x7f] })
+    : null;
 
   const nextFunctionTypes = [...functionTypes];
   const nextBodies = [...bodies];
@@ -831,6 +863,23 @@ function assembleEnhancementTransform(
   });
 
   const addedFunctionExports: Array<Readonly<{ name: string; index: number }>> = [];
+  if (preGameResolution) {
+    const diagnosticIndex = appendFunction(
+      preGameStateTypeIndex!,
+      preGameDiagnosticReader(preGameResolution.certificate),
+    );
+    addedFunctionExports.push({
+      name: ENHANCEMENT_PRE_GAME_STATE_EXPORT,
+      index: appendFunction(
+        preGameStateTypeIndex!,
+        preGameStateReader(preGameResolution.certificate, diagnosticIndex),
+      ),
+    });
+    addedFunctionExports.push({
+      name: ENHANCEMENT_PRE_GAME_DIAGNOSTIC_EXPORT,
+      index: diagnosticIndex,
+    });
+  }
   applyFeatureContributions(resolution, {
     nextBodies,
     appendFunction,

--- a/src/main/certification/local-client-verification-boundary.ts
+++ b/src/main/certification/local-client-verification-boundary.ts
@@ -122,6 +122,10 @@ function featureFailuresFromVerdicts(
     "skillCooldownObservation",
     verdicts.skillCooldownObservation,
   );
+  const preGameControls = refusalForFeature(
+    "preGameControls",
+    verdicts.preGameControls,
+  );
   if (
     nativeCursor === null
     || playRegionObservation === null
@@ -133,6 +137,7 @@ function featureFailuresFromVerdicts(
     || chatAliases === null
     || skillSlotGeometry === null
     || skillCooldownObservation === null
+    || preGameControls === null
   ) return null;
   return Object.freeze({
     ...(nativeCursor ? { nativeCursor } : {}),
@@ -145,6 +150,7 @@ function featureFailuresFromVerdicts(
     ...(chatAliases ? { chatAliases } : {}),
     ...(skillSlotGeometry ? { skillSlotGeometry } : {}),
     ...(skillCooldownObservation ? { skillCooldownObservation } : {}),
+    ...(preGameControls ? { preGameControls } : {}),
   });
 }
 
@@ -508,6 +514,15 @@ function matchesSkillCooldownObservation(
     && isDeepStrictEqual(candidate.layout, expected.layout);
 }
 
+function matchesPreGameControls(
+  build: SemanticBuild,
+  baseline: KnownEnhancementBuild,
+): boolean {
+  return build.preGameControls === undefined
+    || (baseline.preGameControls !== undefined
+      && isDeepStrictEqual(build.preGameControls, baseline.preGameControls));
+}
+
 function matchesPlayerSkillbarObservation(
   build: SemanticBuild,
   baseline: KnownEnhancementBuild,
@@ -569,10 +584,11 @@ function isAutomaticSemanticBuild(
   const hasSkillSlotGeometry = build.skillSlotGeometry !== undefined;
   const hasPlayerSkillbar = build.playerSkillbarObservation !== undefined;
   const hasSkillCooldown = build.skillCooldownObservation !== undefined;
+  const hasPreGameControls = build.preGameControls !== undefined;
   if (!hasCursor && !hasPlayRegion && !hasObservation && !hasTarget
     && !hasTravel && !hasXunlai && !hasAliases
     && !hasParty && !hasTeam && !hasSkillSlotGeometry
-    && !hasPlayerSkillbar && !hasSkillCooldown) {
+    && !hasPlayerSkillbar && !hasSkillCooldown && !hasPreGameControls) {
     return false;
   }
   if (
@@ -623,6 +639,7 @@ function isAutomaticSemanticBuild(
     && matchesTeamApply(build, baseline)
     && matchesSkillSlotGeometry(build)
     && matchesSkillCooldownObservation(build, baseline)
+    && matchesPreGameControls(build, baseline)
   );
 }
 

--- a/src/main/certification/local-client-verification-contract.ts
+++ b/src/main/certification/local-client-verification-contract.ts
@@ -109,6 +109,12 @@ export const LOCAL_FEATURE_INVARIANTS = Object.freeze({
     "skill-cooldown.recharge-reader",
     "skill-cooldown.precise-timer",
   ] as const),
+  preGameControls: Object.freeze([
+    ...SHARED_FEATURE_INVARIANTS,
+    "pre-game.exact-frame-labels",
+    "pre-game.label-hash-function",
+    "pre-game.frame-layout",
+  ] as const),
 } as const satisfies Readonly<
   Record<LocalClientFeature, readonly string[]>
 >);
@@ -188,6 +194,8 @@ export interface LocalFeatureCertificateMap {
       | "playRegionObservation" | "observationBase"
       | "playerSkillbarObservation" | "skillCooldownObservation"
     >;
+  readonly preGameControls: Readonly<{ core: EnhancementProofCore }>
+    & RequiredBuildFact<"preGameControls">;
 }
 
 export type LocalFeatureVerdict<Feature extends LocalClientFeature> =
@@ -392,6 +400,9 @@ export function localFeatureVerdictsForBuild(
         skillCooldownObservation: build.skillCooldownObservation,
       })
     : null;
+  const preGameControls = core !== null && build?.preGameControls !== undefined
+    ? Object.freeze({ core, preGameControls: build.preGameControls })
+    : null;
   return Object.freeze({
     nativeCursor: featureVerdict<"nativeCursor">(
       inputSha256,
@@ -462,6 +473,13 @@ export function localFeatureVerdictsForBuild(
       skillCooldownObservation,
       failures.skillCooldownObservation,
       "skill-cooldown.recharge-reader",
+    ),
+    preGameControls: featureVerdict<"preGameControls">(
+      inputSha256,
+      requested.preGameControls,
+      preGameControls,
+      failures.preGameControls,
+      "pre-game.exact-frame-labels",
     ),
   });
 }

--- a/src/main/certification/local-client-verifier.ts
+++ b/src/main/certification/local-client-verifier.ts
@@ -72,6 +72,7 @@ import {
   localSkillbarBuildFragment,
   type LocalSkillbarProofs,
 } from "./local-client-skillbar-verifier.js";
+import { derivePreGameControls } from "./enhancement-pre-game-proof.js";
 
 export { isLocalClientVerification } from "./local-client-verification-boundary.js";
 export {
@@ -175,6 +176,9 @@ function failuresForRequested(
             invariant,
           ),
         }
+      : {}),
+    ...(requested.preGameControls
+      ? { preGameControls: changedFeature("preGameControls", invariant) }
       : {}),
   });
 }
@@ -576,6 +580,16 @@ function deriveEnhancementBuild(
     context,
     includePlayRegion,
   );
+  const preGameBaseline = ENHANCEMENT_BUILDS.at(-1) ?? null;
+  const preGameControls = requestedCapabilities.preGameControls
+      && preGameBaseline?.preGameControls
+    ? derivePreGameControls(
+        context,
+        preGameBaseline.preGameControls.layout,
+      )
+    : null;
+  const includePreGame = requestedCapabilities.preGameControls
+    && preGameControls !== null;
   const wantsLocal = requestedCapabilities.partyObservation
     || requestedCapabilities.teamApply
     || requestedCapabilities.travelAction
@@ -623,6 +637,17 @@ function deriveEnhancementBuild(
     skillbar,
     context,
   );
+  const completeFailures: LocalFeatureFailures = Object.freeze({
+    ...failures,
+    ...(requestedCapabilities.preGameControls && !includePreGame
+      ? {
+          preGameControls: changedFeature(
+            "preGameControls",
+            "pre-game.exact-frame-labels",
+          ),
+        }
+      : {}),
+  });
   const localContributes = includeParty || includeTeam || includeTravel
     || includeXunlai || includeAliases;
   const source = includeCursor
@@ -633,9 +658,15 @@ function deriveEnhancementBuild(
         ? locatedTarget
         : localContributes
           ? locatedLocal
-          : null;
+          : includePreGame && preGameBaseline
+            ? Object.freeze({
+                baseline: preGameBaseline,
+                hookFunction: preGameBaseline.hookFunction,
+                hookBodySha256: preGameBaseline.hookBodySha256,
+              })
+            : null;
   if (source === null || !report.table || report.table.max === null) {
-    return Object.freeze({ build: null, failures });
+    return Object.freeze({ build: null, failures: completeFailures });
   }
   const observationLayout = includeTarget
     ? locatedTarget.observationLayout
@@ -748,6 +779,7 @@ function deriveEnhancementBuild(
     ...(includeParty ? {
       partyObservation: locatedLocal.partyObservation,
     } : {}),
+    ...(includePreGame ? { preGameControls: preGameControls! } : {}),
     ...skillbarBuild.beforeTeam,
     ...(includeTeam ? { teamApply: locatedLocal!.teamApply! } : {}),
     ...skillbarBuild.afterTeam,
@@ -763,6 +795,7 @@ function deriveEnhancementBuild(
     skillSlotGeometry: skillbar.includeGeometry,
     skillCooldownObservation: skillbar.includeCooldown,
     playRegionObservation: includePlayRegion,
+    preGameControls: includePreGame,
   });
   const effective = intersectEnhancementCapabilities(requestedCapabilities, maximum);
   const profile = enhancementCapabilityProfile(effective);
@@ -781,7 +814,7 @@ function deriveEnhancementBuild(
       ...provisional,
       outputSha256: Object.freeze(outputSha256),
     }),
-    failures,
+    failures: completeFailures,
   });
 }
 

--- a/src/main/certification/local-client-verifier.ts
+++ b/src/main/certification/local-client-verifier.ts
@@ -580,7 +580,12 @@ function deriveEnhancementBuild(
     context,
     includePlayRegion,
   );
-  const preGameBaseline = ENHANCEMENT_BUILDS.at(-1) ?? null;
+  // Automatic input may use frame offsets only from this exact transformed
+  // client. Labels and function bodies can be re-derived on a future build,
+  // but they do not prove that the frame table and context layout stayed put.
+  const preGameBaseline = ENHANCEMENT_BUILDS.find(
+    (build) => build.sha256 === report.sha256,
+  ) ?? null;
   const preGameControls = requestedCapabilities.preGameControls
       && preGameBaseline?.preGameControls
     ? derivePreGameControls(
@@ -643,7 +648,9 @@ function deriveEnhancementBuild(
       ? {
           preGameControls: changedFeature(
             "preGameControls",
-            "pre-game.exact-frame-labels",
+            preGameBaseline
+              ? "pre-game.exact-frame-labels"
+              : "pre-game.frame-layout",
           ),
         }
       : {}),

--- a/src/main/certification/semantic-proof.ts
+++ b/src/main/certification/semantic-proof.ts
@@ -9,7 +9,7 @@
  */
 import { createHash } from "node:crypto";
 
-export const SEMANTIC_VERIFIER_ABI = 4;
+export const SEMANTIC_VERIFIER_ABI = 6;
 
 export type ProofRefusal = Readonly<{
   inputSha256: string;

--- a/src/main/client-runtime.ts
+++ b/src/main/client-runtime.ts
@@ -411,6 +411,12 @@ export class ClientRuntime {
           supported.skillCooldownObservation,
           preparationFailed,
         ),
+        preGameControls: optionalFeatureStatus(
+          requested.preGameControls,
+          effective.preGameControls,
+          supported.preGameControls,
+          preparationFailed,
+        ),
       },
     };
     gauge("wasm.templateSaveCompatible", prepared.gameFileSaving.status === "available");

--- a/src/main/core/settings.ts
+++ b/src/main/core/settings.ts
@@ -194,6 +194,7 @@ export function parseSettings(raw: unknown): AppSettings {
     "targetReadout",
     "skillCooldownOverlayEnabled",
     "extendedMemoryEnabled",
+    "autoRelogAfterReload",
   ] as const) {
     if (setting in src) out[setting] = asBool(src[setting], setting);
   }

--- a/src/main/diagnostics.ts
+++ b/src/main/diagnostics.ts
@@ -19,6 +19,8 @@ import {
 import { recorder, sweepDiagnosticsDirectory } from "./diagnostics/recorder.js";
 import { startSampling, stopSampling } from "./diagnostics/samplers.js";
 import { windowRegistry } from "./window-registry.js";
+import { parseLogRecords } from "./diagnostics/report.js";
+import { formatRelogTranscript } from "./diagnostics/relog-transcript.js";
 
 export {
   count,
@@ -84,4 +86,15 @@ export async function stopDiagnostics(): Promise<void> {
   // A session that is never exported still bounds itself at quit rather than
   // waiting for the next launch to sweep.
   await discardTrace();
+}
+
+/** Copy surface input: a closed projection, not the recorder's raw JSONL. */
+export async function reloadTranscriptForWindow(win: BrowserWindow): Promise<string> {
+  const ownerId = windowRegistry.requireDiagnosticOwnerForWindow(win);
+  const exported = await recorder.exportedEvents(ownerId);
+  return formatRelogTranscript({
+    records: parseLogRecords(exported.text),
+    ownerId,
+    completeFromStart: exported.completeFromStart,
+  });
 }

--- a/src/main/diagnostics/relog-transcript.ts
+++ b/src/main/diagnostics/relog-transcript.ts
@@ -20,10 +20,9 @@ const RELOG_EVENTS = new Set([
   "relog.preGameProbe",
   "relog.inputSettled",
   "relog.finished",
-  "relog.timedOut",
 ]);
 
-const TERMINAL_EVENTS = new Set(["relog.finished", "relog.timedOut"]);
+const TERMINAL_EVENTS = new Set(["relog.finished"]);
 
 function scalar(fields: LogRecord["fields"], key: string): string | null {
   const value = fields[key];
@@ -63,6 +62,8 @@ function details(
         + `visible=0x${((mask >>> 8) & 0x0f).toString(16)} `
         + `characterPair=${Boolean(mask & 0x2000)} `
         + `reconnectPair=${Boolean(mask & 0x1000)} `
+        + `reconnectDialog=${Boolean(mask & 0x20_0000)} `
+        + `reconnectExact=${Boolean(mask & 0x40_0000)} `
         + `table=${Boolean(mask & 0x4000)}/${Boolean(mask & 0x8000)} `
         + `frames=${Boolean(mask & 0x10000)}/${Boolean(mask & 0x20000)} `
         + `liveHash=${Boolean(mask & 0x40000)}`;
@@ -83,8 +84,13 @@ function traceStart(records: readonly LogRecord[]): number {
     }
   }
   if (reload >= 0) {
+    if (records[reload]!.fields.cause !== "command-q") return reload;
     for (let index = reload; index >= 0; index -= 1) {
       const record = records[index]!;
+      if (index < reload && (
+        record.name === "gameReload.requested"
+        || TERMINAL_EVENTS.has(record.name)
+      )) break;
       if (
         record.name === "commandQ.shortcut"
         && record.fields.phase === "claimed"

--- a/src/main/diagnostics/relog-transcript.ts
+++ b/src/main/diagnostics/relog-transcript.ts
@@ -1,0 +1,151 @@
+/**
+ * Owns the privacy-safe view of one account's reload events.
+ * It accepts recorder records internally but never returns raw JSONL.
+ */
+import { CLIPBOARD_TEXT_CEILING } from "../../shared/contracts.js";
+import type { LogRecord } from "./flight-recorder.js";
+
+const RELOG_EVENTS = new Set([
+  "commandQ.shortcut",
+  "quitReloadDialog.lifecycle",
+  "gameReload.requested",
+  "gameReload.syncIncomplete",
+  "gameReload.loaded",
+  "relog.intentClaimed",
+  "relog.savedCredentialsLoaded",
+  "relog.loginSubmitted",
+  "relog.tokenRequested",
+  "relog.tokenAccepted",
+  "relog.characterSubmitted",
+  "relog.preGameProbe",
+  "relog.inputSettled",
+  "relog.finished",
+  "relog.timedOut",
+]);
+
+const TERMINAL_EVENTS = new Set(["relog.finished", "relog.timedOut"]);
+
+function scalar(fields: LogRecord["fields"], key: string): string | null {
+  const value = fields[key];
+  return typeof value === "string" || typeof value === "number"
+    || typeof value === "boolean" ? String(value) : null;
+}
+
+function details(
+  record: LogRecord,
+): string {
+  const fields = record.fields;
+  switch (record.name) {
+    case "commandQ.shortcut":
+      return [scalar(fields, "phase"), scalar(fields, "reason")]
+        .filter(Boolean).join(" ");
+    case "quitReloadDialog.lifecycle":
+      return [scalar(fields, "phase"), scalar(fields, "action"),
+        scalar(fields, "autoRelog") === null
+          ? null
+          : `auto=${scalar(fields, "autoRelog")}`]
+        .filter(Boolean).join(" ");
+    case "gameReload.requested":
+    case "gameReload.loaded":
+      return `cause=${scalar(fields, "cause") ?? "unknown"}`;
+    case "gameReload.syncIncomplete":
+      return `outcome=${scalar(fields, "outcome") ?? "unknown"}`;
+    case "relog.inputSettled":
+      return `stage=${scalar(fields, "stage") ?? "unknown"} `
+        + `outcome=${scalar(fields, "outcome") ?? "unknown"}`;
+    case "relog.preGameProbe": {
+      const mask = Number(scalar(fields, "mask") ?? 0) >>> 0;
+      return `state=${scalar(fields, "state") ?? "unknown"} `
+        + `abi=${(mask >>> 24) & 0x7f} `
+        + `trap=${Boolean(mask & 0x8000_0000)} `
+        + `hashed=0x${(mask & 0x0f).toString(16)} `
+        + `matched=0x${((mask >>> 4) & 0x0f).toString(16)} `
+        + `visible=0x${((mask >>> 8) & 0x0f).toString(16)} `
+        + `characterPair=${Boolean(mask & 0x2000)} `
+        + `reconnectPair=${Boolean(mask & 0x1000)} `
+        + `table=${Boolean(mask & 0x4000)}/${Boolean(mask & 0x8000)} `
+        + `frames=${Boolean(mask & 0x10000)}/${Boolean(mask & 0x20000)} `
+        + `liveHash=${Boolean(mask & 0x40000)}`;
+    }
+    case "relog.finished":
+      return `outcome=${scalar(fields, "outcome") ?? "unknown"}`;
+    default:
+      return "";
+  }
+}
+
+function traceStart(records: readonly LogRecord[]): number {
+  let reload = -1;
+  for (let index = records.length - 1; index >= 0; index -= 1) {
+    if (records[index]!.name === "gameReload.requested") {
+      reload = index;
+      break;
+    }
+  }
+  if (reload >= 0) {
+    for (let index = reload; index >= 0; index -= 1) {
+      const record = records[index]!;
+      if (
+        record.name === "commandQ.shortcut"
+        && record.fields.phase === "claimed"
+      ) return index;
+    }
+    return reload;
+  }
+  for (let index = records.length - 1; index >= 0; index -= 1) {
+    const record = records[index]!;
+    if (record.name === "commandQ.shortcut" && record.fields.phase === "claimed") {
+      return index;
+    }
+  }
+  return -1;
+}
+
+export function formatRelogTranscript(input: Readonly<{
+  records: readonly LogRecord[];
+  ownerId: number;
+  completeFromStart: boolean;
+  ceiling?: number;
+}>): string {
+  const matching = input.records
+    .filter((record) => record.ownerId === input.ownerId && RELOG_EVENTS.has(record.name))
+    .sort((left, right) => left.seq - right.seq);
+  const start = traceStart(matching);
+  const candidate = start < 0 ? [] : matching.slice(start);
+  const terminal = candidate.findIndex((record) => TERMINAL_EVENTS.has(record.name));
+  const selected = terminal < 0 ? candidate : candidate.slice(0, terminal + 1);
+  const complete = start >= 0 && terminal >= 0;
+  const outsideCurrent = matching.length - selected.length;
+  const source = (record: LogRecord) => record.subsystem === "renderer"
+    ? "renderer" : "main";
+  let previousUs: number | null = null;
+  const rows = selected.map((record, index) => {
+    const gap = previousUs === null ? "—" : `${Math.max(0, record.tsUs - previousUs) / 1_000}`;
+    previousUs = record.tsUs;
+    const detail = details(record);
+    return {
+      text: `${String(index + 1).padStart(4, "0")}  ${gap.padStart(7)}ms  `
+        + `${source(record).padEnd(8)} ${record.name}${detail ? ` ${detail}` : ""}`,
+    };
+  });
+  let omitted = 0;
+  const ceiling = Math.min(
+    input.ceiling ?? CLIPBOARD_TEXT_CEILING,
+    CLIPBOARD_TEXT_CEILING,
+  );
+  const render = () => [
+    `gwonmac reload trace — ${selected.length} events, ${rows.length} rows`,
+    "privacy: no text, credentials, account identifiers, paths, coordinates, pointers, packets, or UI parameter values",
+    `status: ${complete ? "complete" : "incomplete"}; recorder-start=${input.completeFromStart ? "complete" : "truncated"}; outside-current=${outsideCurrent}; omitted=${omitted}`,
+    "columns: sequence  gap  source  event  closed fields",
+    "",
+    ...(rows.length > 0 ? rows.map((row) => row.text) : ["(no reload boundary is available)"]),
+  ].join("\n");
+  let transcript = render();
+  while (transcript.length > ceiling && rows.length > 0) {
+    rows.shift();
+    omitted += 1;
+    transcript = render();
+  }
+  return transcript.slice(0, ceiling);
+}

--- a/src/main/diagnostics/renderer.ts
+++ b/src/main/diagnostics/renderer.ts
@@ -19,6 +19,7 @@ import {
   type RendererMetrics,
   type RendererMilestone,
   type RendererMilestoneFields,
+  type RendererMilestoneFieldsByName,
   type TextureMemorySnapshot,
   type WasmMemoryProbeStatus,
 } from "../../shared/diagnostics.js";
@@ -365,6 +366,48 @@ export function recordRendererMilestone(
   if (name === "build.info" && fields && "programId" in fields) {
     recorder.setLatest("client.programId", fields.programId, ownerId);
     recorder.setLatest("client.buildId", fields.buildId, ownerId);
+  }
+  if (name === "relog.inputSettled") {
+    if (!fields || !("stage" in fields)) return;
+    recordEvent(
+      {
+        k: "relog.inputSettled",
+        clockSynchronized: state.clockSynchronized,
+        stage: fields.stage,
+        outcome: fields.outcome,
+      },
+      { timestampUs },
+      ownerId,
+    );
+    return;
+  }
+  if (name === "relog.preGameProbe") {
+    if (!fields || !("mask" in fields)) return;
+    recordEvent(
+      {
+        k: "relog.preGameProbe",
+        clockSynchronized: state.clockSynchronized,
+        state: fields.state,
+        mask: fields.mask,
+      },
+      { timestampUs },
+      ownerId,
+    );
+    return;
+  }
+  if (name === "relog.finished") {
+    if (!fields || !("outcome" in fields)) return;
+    const relogFields = fields as RendererMilestoneFieldsByName["relog.finished"];
+    recordEvent(
+      {
+        k: "relog.finished",
+        clockSynchronized: state.clockSynchronized,
+        outcome: relogFields.outcome,
+      },
+      { timestampUs },
+      ownerId,
+    );
+    return;
   }
   if (name === "wasm.abort") {
     // IPC validation guarantees these fields for this name; a call without

--- a/src/main/diagnostics/schema-fields.ts
+++ b/src/main/diagnostics/schema-fields.ts
@@ -8,11 +8,13 @@
  */
 import {
   EVENT_CHANNELS,
+  GAME_RELOAD_CAUSES,
   IPC,
   RENDERER_COMMAND_OUTCOMES,
   type AppUpdateErrorCode,
   type EventChannel,
   type InvokeChannel,
+  type GameReloadCause,
   type RendererCommand,
   type RendererCommandOutcome,
   type SocketCloseReason,
@@ -52,6 +54,11 @@ export interface EventSpec {
 
 export const finiteNumber: FieldGuard<number> = (value): value is number =>
   typeof value === "number" && Number.isFinite(value);
+export const uint32: FieldGuard<number> = (value): value is number =>
+  typeof value === "number"
+  && Number.isInteger(value)
+  && value >= 0
+  && value <= 0xffff_ffff;
 export const boolean: FieldGuard<boolean> = (value): value is boolean =>
   typeof value === "boolean";
 
@@ -142,6 +149,7 @@ export const captureAction = literal(RENDERER_CAPTURE_ACTIONS);
 export const incompleteCommandOutcome = literal(
   INCOMPLETE_RENDERER_COMMAND_OUTCOMES,
 );
+export const gameReloadCause = literal<GameReloadCause>(GAME_RELOAD_CAUSES);
 export const appUpdateErrorCode = literal([
   "rate-limited",
   "offline",

--- a/src/main/diagnostics/schema-protocol-renderer.ts
+++ b/src/main/diagnostics/schema-protocol-renderer.ts
@@ -179,19 +179,19 @@ export const PROTOCOL_AND_RENDERER_EVENT_SCHEMA = {
   // Renderer recovery and renderer-originated fixed events.
   "gameReload.requested": {
     scope: "owner",
-    subsystem: "renderer",
+    subsystem: "app",
     level: "info",
     fields: { cause: gameReloadCause },
   },
   "gameReload.syncIncomplete": {
     scope: "owner",
-    subsystem: "renderer",
+    subsystem: "app",
     level: "warn",
     fields: { outcome: incompleteCommandOutcome },
   },
   "gameReload.loaded": {
     scope: "owner",
-    subsystem: "renderer",
+    subsystem: "app",
     level: "info",
     fields: { cause: gameReloadCause },
   },
@@ -472,12 +472,6 @@ export const PROTOCOL_AND_RENDERER_EVENT_SCHEMA = {
     scope: "owner",
     subsystem: "renderer",
     level: "info",
-    fields: { clockSynchronized: boolean },
-  },
-  "relog.timedOut": {
-    scope: "owner",
-    subsystem: "renderer",
-    level: "warn",
     fields: { clockSynchronized: boolean },
   },
   "wasm.instantiate.begin": {

--- a/src/main/diagnostics/schema-protocol-renderer.ts
+++ b/src/main/diagnostics/schema-protocol-renderer.ts
@@ -5,6 +5,9 @@
 import type { EventSpec } from "./schema-fields.js";
 import { ALLOWED_PORTS } from "../core/allowlists.js";
 import {
+  RELOG_INPUT_OUTCOMES,
+  RELOG_INPUT_STAGES,
+  RELOG_TERMINAL_OUTCOMES,
   WASM_ABORT_REASON_KINDS,
   WASM_GROWTH_OUTCOMES,
   WASM_MEMORY_PROBE_STATUSES,
@@ -19,6 +22,7 @@ import {
   closeReason,
   code,
   finiteNumber,
+  gameReloadCause,
   incompleteCommandOutcome,
   invokeChannel,
   isRendererFingerprint,
@@ -32,6 +36,7 @@ import {
   snapshotPriority,
   socketFailureCode,
   socketSendStatus,
+  uint32,
 } from "./schema-fields.js";
 
 export const PROTOCOL_AND_RENDERER_EVENT_SCHEMA = {
@@ -172,6 +177,78 @@ export const PROTOCOL_AND_RENDERER_EVENT_SCHEMA = {
   },
 
   // Renderer recovery and renderer-originated fixed events.
+  "gameReload.requested": {
+    scope: "owner",
+    subsystem: "renderer",
+    level: "info",
+    fields: { cause: gameReloadCause },
+  },
+  "gameReload.syncIncomplete": {
+    scope: "owner",
+    subsystem: "renderer",
+    level: "warn",
+    fields: { outcome: incompleteCommandOutcome },
+  },
+  "gameReload.loaded": {
+    scope: "owner",
+    subsystem: "renderer",
+    level: "info",
+    fields: { cause: gameReloadCause },
+  },
+  "commandQ.shortcut": {
+    scope: "owner",
+    subsystem: "app",
+    level: "info",
+    fields: {
+      phase: literal(["claimed", "repeat-contained", "rearmed"] as const),
+      reason: literal([
+        "none",
+        "keyup",
+        "dialog-settled",
+        "appkit-release",
+        "error",
+      ] as const),
+    },
+  },
+  "quitReloadDialog.lifecycle": {
+    scope: "owner",
+    subsystem: "app",
+    level: "info",
+    fields: {
+      phase: literal(["requested", "opened", "settled"] as const),
+      action: literal(["pending", "reload", "quit", "cancel", "failed"] as const),
+      autoRelog: nullable(boolean),
+    },
+  },
+  "relog.inputSettled": {
+    scope: "owner",
+    subsystem: "renderer",
+    level: "info",
+    fields: {
+      stage: literal(RELOG_INPUT_STAGES),
+      outcome: literal(RELOG_INPUT_OUTCOMES),
+      clockSynchronized: boolean,
+    },
+  },
+  "relog.preGameProbe": {
+    scope: "owner",
+    subsystem: "renderer",
+    level: "debug",
+    fields: {
+      state: literal(["unknown", "character-select", "reconnect", "loading"] as const),
+      mask: uint32,
+      clockSynchronized: boolean,
+    },
+  },
+  "relog.finished": {
+    scope: "owner",
+    subsystem: "renderer",
+    level: "info",
+    fields: {
+      outcome: literal(RELOG_TERMINAL_OUTCOMES),
+      clockSynchronized: boolean,
+    },
+  },
   "renderer.processExitedDuringQuit": {
     scope: "owner",
     subsystem: "renderer",
@@ -359,6 +436,48 @@ export const PROTOCOL_AND_RENDERER_EVENT_SCHEMA = {
     scope: "owner",
     subsystem: "renderer",
     level: "info",
+    fields: { clockSynchronized: boolean },
+  },
+  "relog.intentClaimed": {
+    scope: "owner",
+    subsystem: "renderer",
+    level: "info",
+    fields: { clockSynchronized: boolean },
+  },
+  "relog.savedCredentialsLoaded": {
+    scope: "owner",
+    subsystem: "renderer",
+    level: "info",
+    fields: { clockSynchronized: boolean },
+  },
+  "relog.loginSubmitted": {
+    scope: "owner",
+    subsystem: "renderer",
+    level: "info",
+    fields: { clockSynchronized: boolean },
+  },
+  "relog.tokenRequested": {
+    scope: "owner",
+    subsystem: "renderer",
+    level: "info",
+    fields: { clockSynchronized: boolean },
+  },
+  "relog.tokenAccepted": {
+    scope: "owner",
+    subsystem: "renderer",
+    level: "info",
+    fields: { clockSynchronized: boolean },
+  },
+  "relog.characterSubmitted": {
+    scope: "owner",
+    subsystem: "renderer",
+    level: "info",
+    fields: { clockSynchronized: boolean },
+  },
+  "relog.timedOut": {
+    scope: "owner",
+    subsystem: "renderer",
+    level: "warn",
     fields: { clockSynchronized: boolean },
   },
   "wasm.instantiate.begin": {

--- a/src/main/game-reload.ts
+++ b/src/main/game-reload.ts
@@ -1,0 +1,95 @@
+/**
+ * The one account-local game reload workflow.
+ *
+ * Main owns navigation and native sockets, so renderer warnings, menu actions,
+ * and crash recovery all ask this owner instead of reloading their own page.
+ * A relog intent belongs to the exact BrowserWindow and is consumed once by
+ * the replacement document; it cannot move with focus to another account.
+ */
+import type { BrowserWindow } from "electron";
+import type {
+  AppSettings,
+  GameReloadCause,
+  RendererCommandOutcome,
+} from "../shared/contracts.js";
+import type { SocketManager } from "./core/sockets.js";
+import { logEvent } from "./diagnostics.js";
+import { sendRendererCommand } from "./renderer-commands.js";
+import { windowRegistry } from "./window-registry.js";
+
+const RELOAD_SYNC_BUDGET_MS = 1_500;
+
+export interface GameReloadDependencies {
+  sockets: SocketManager;
+  getSettings(): Promise<AppSettings>;
+  rendererUrl: string;
+}
+
+export class GameReloader {
+  private readonly active = new WeakMap<BrowserWindow, Promise<void>>();
+  private readonly relogIntents = new WeakSet<BrowserWindow>();
+
+  constructor(private readonly dependencies: GameReloadDependencies) {}
+
+  reload(win: BrowserWindow, cause: GameReloadCause): Promise<void> {
+    const current = this.active.get(win);
+    if (current) return current;
+
+    const operation = this.reloadOnce(win, cause).finally(() => {
+      this.active.delete(win);
+    });
+    this.active.set(win, operation);
+    return operation;
+  }
+
+  claimRelogIntent(win: BrowserWindow): boolean {
+    if (!this.relogIntents.has(win)) return false;
+    this.relogIntents.delete(win);
+    return true;
+  }
+
+  private async reloadOnce(
+    win: BrowserWindow,
+    cause: GameReloadCause,
+  ): Promise<void> {
+    if (win.isDestroyed() || win.webContents.isDestroyed()) return;
+    const ownerId = windowRegistry.requireDiagnosticOwnerForWindow(win);
+    const autoRelogAfterReload = await this.dependencies.getSettings()
+      .then((settings) => settings.autoRelogAfterReload)
+      .catch(() => false);
+    if (autoRelogAfterReload) this.relogIntents.add(win);
+    else this.relogIntents.delete(win);
+
+    logEvent({ k: "gameReload.requested", cause }, ownerId);
+    const sync = sendRendererCommand(win, { type: "filesystem.sync" });
+    this.dependencies.sockets.closeAll(win.webContents.id);
+    const syncOutcome = await boundedSync(sync);
+    if (syncOutcome !== "completed") {
+      logEvent({ k: "gameReload.syncIncomplete", outcome: syncOutcome }, ownerId);
+    }
+
+    if (win.isDestroyed() || win.webContents.isDestroyed()) {
+      this.relogIntents.delete(win);
+      return;
+    }
+    try {
+      await win.loadURL(this.dependencies.rendererUrl);
+      logEvent({ k: "gameReload.loaded", cause }, ownerId);
+    } catch (error) {
+      this.relogIntents.delete(win);
+      throw error;
+    }
+  }
+}
+
+async function boundedSync(
+  sync: Promise<RendererCommandOutcome>,
+): Promise<RendererCommandOutcome> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const budget = new Promise<"timed-out">((resolve) => {
+    timer = setTimeout(() => resolve("timed-out"), RELOAD_SYNC_BUDGET_MS);
+  });
+  const outcome = await Promise.race([sync, budget]);
+  if (timer !== null) clearTimeout(timer);
+  return outcome;
+}

--- a/src/main/game-reload.ts
+++ b/src/main/game-reload.ts
@@ -13,23 +13,34 @@ import type {
   RendererCommandOutcome,
 } from "../shared/contracts.js";
 import type { SocketManager } from "./core/sockets.js";
-import { logEvent } from "./diagnostics.js";
-import { sendRendererCommand } from "./renderer-commands.js";
-import { windowRegistry } from "./window-registry.js";
+import type { logEvent } from "./diagnostics.js";
 
 const RELOAD_SYNC_BUDGET_MS = 1_500;
+const RELOG_INTENT_BUDGET_MS = 5 * 60_000;
+
+type RelogIntent = Readonly<{
+  expiresAt: number;
+  sourceDocumentId: number;
+}>;
 
 export interface GameReloadDependencies {
-  sockets: SocketManager;
+  sockets: Pick<SocketManager, "closeAll">;
   getSettings(): Promise<AppSettings>;
+  diagnosticOwner(win: BrowserWindow): number;
+  record: typeof logEvent;
+  sync(win: BrowserWindow): Promise<RendererCommandOutcome>;
+  load(win: BrowserWindow, url: string): Promise<void>;
   rendererUrl: string;
 }
 
 export class GameReloader {
   private readonly active = new WeakMap<BrowserWindow, Promise<void>>();
-  private readonly relogIntents = new WeakSet<BrowserWindow>();
+  private readonly relogIntents = new WeakMap<BrowserWindow, RelogIntent>();
+  private readonly dependencies: GameReloadDependencies;
 
-  constructor(private readonly dependencies: GameReloadDependencies) {}
+  constructor(dependencies: GameReloadDependencies) {
+    this.dependencies = dependencies;
+  }
 
   reload(win: BrowserWindow, cause: GameReloadCause): Promise<void> {
     const current = this.active.get(win);
@@ -43,7 +54,15 @@ export class GameReloader {
   }
 
   claimRelogIntent(win: BrowserWindow): boolean {
-    if (!this.relogIntents.has(win)) return false;
+    const intent = this.relogIntents.get(win);
+    if (!intent) return false;
+    if (
+      Date.now() > intent.expiresAt
+      || win.webContents.mainFrame.routingId === intent.sourceDocumentId
+    ) {
+      if (Date.now() > intent.expiresAt) this.relogIntents.delete(win);
+      return false;
+    }
     this.relogIntents.delete(win);
     return true;
   }
@@ -53,19 +72,27 @@ export class GameReloader {
     cause: GameReloadCause,
   ): Promise<void> {
     if (win.isDestroyed() || win.webContents.isDestroyed()) return;
-    const ownerId = windowRegistry.requireDiagnosticOwnerForWindow(win);
-    const autoRelogAfterReload = await this.dependencies.getSettings()
-      .then((settings) => settings.autoRelogAfterReload)
-      .catch(() => false);
-    if (autoRelogAfterReload) this.relogIntents.add(win);
+    const ownerId = this.dependencies.diagnosticOwner(win);
+    const autoRelogAfterReload = (
+      await this.dependencies.getSettings()
+    ).autoRelogAfterReload;
+    if (autoRelogAfterReload) {
+      this.relogIntents.set(win, {
+        expiresAt: Date.now() + RELOG_INTENT_BUDGET_MS,
+        sourceDocumentId: win.webContents.mainFrame.routingId,
+      });
+    }
     else this.relogIntents.delete(win);
 
-    logEvent({ k: "gameReload.requested", cause }, ownerId);
-    const sync = sendRendererCommand(win, { type: "filesystem.sync" });
+    this.dependencies.record({ k: "gameReload.requested", cause }, ownerId);
+    const sync = this.dependencies.sync(win);
     this.dependencies.sockets.closeAll(win.webContents.id);
     const syncOutcome = await boundedSync(sync);
     if (syncOutcome !== "completed") {
-      logEvent({ k: "gameReload.syncIncomplete", outcome: syncOutcome }, ownerId);
+      this.dependencies.record(
+        { k: "gameReload.syncIncomplete", outcome: syncOutcome },
+        ownerId,
+      );
     }
 
     if (win.isDestroyed() || win.webContents.isDestroyed()) {
@@ -73,8 +100,8 @@ export class GameReloader {
       return;
     }
     try {
-      await win.loadURL(this.dependencies.rendererUrl);
-      logEvent({ k: "gameReload.loaded", cause }, ownerId);
+      await this.dependencies.load(win, this.dependencies.rendererUrl);
+      this.dependencies.record({ k: "gameReload.loaded", cause }, ownerId);
     } catch (error) {
       this.relogIntents.delete(win);
       throw error;

--- a/src/main/ipc-values.ts
+++ b/src/main/ipc-values.ts
@@ -9,6 +9,9 @@ import type {
   WasmAbortReasonKind,
 } from "../shared/diagnostics.js";
 import {
+  RELOG_INPUT_OUTCOMES,
+  RELOG_INPUT_STAGES,
+  RELOG_TERMINAL_OUTCOMES,
   RENDERER_MILESTONES,
   WASM_ABORT_REASON_KINDS,
   WASM_GROWTH_OUTCOMES,
@@ -100,6 +103,36 @@ export function parseRendererMilestoneArgs(args: readonly unknown[]): ParsedMile
     milestoneFields = {
       programId: record.programId as string | number,
       buildId: record.buildId as string | number,
+    };
+  } else if (name === "relog.preGameProbe") {
+    const states = ["unknown", "character-select", "reconnect", "loading"];
+    const valid = recordIsObject && Object.keys(record).length === 2
+      && typeof record.state === "string" && states.includes(record.state)
+      && typeof record.mask === "number" && Number.isInteger(record.mask)
+      && record.mask >= 0 && record.mask <= 0xffff_ffff;
+    if (!valid) throw new ValidationError("invalid renderer milestone");
+    milestoneFields = {
+      state: record.state as "unknown" | "character-select" | "reconnect" | "loading",
+      mask: record.mask as number,
+    };
+  } else if (name === "relog.inputSettled") {
+    const valid = recordIsObject && Object.keys(record).length === 2
+      && typeof record.stage === "string"
+      && (RELOG_INPUT_STAGES as readonly string[]).includes(record.stage)
+      && typeof record.outcome === "string"
+      && (RELOG_INPUT_OUTCOMES as readonly string[]).includes(record.outcome);
+    if (!valid) throw new ValidationError("invalid renderer milestone");
+    milestoneFields = {
+      stage: record.stage as (typeof RELOG_INPUT_STAGES)[number],
+      outcome: record.outcome as (typeof RELOG_INPUT_OUTCOMES)[number],
+    };
+  } else if (name === "relog.finished") {
+    const valid = recordIsObject && Object.keys(record).length === 1
+      && typeof record.outcome === "string"
+      && (RELOG_TERMINAL_OUTCOMES as readonly string[]).includes(record.outcome);
+    if (!valid) throw new ValidationError("invalid renderer milestone");
+    milestoneFields = {
+      outcome: record.outcome as (typeof RELOG_TERMINAL_OUTCOMES)[number],
     };
   } else if (name === "wasm.abort") {
     const valid = recordIsObject && Object.keys(record).length === 3

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -35,6 +35,8 @@ import {
   type EnhancementRuntimeFeature,
   type ExternalLinkKind,
   type FullDownloadOutcome,
+  GAME_RELOAD_CAUSES,
+  type GameReloadCause,
   type GraphicsDiagnostics,
   type InvokeChannel,
   type GameTextEditRequest,
@@ -193,6 +195,8 @@ export interface IpcContext extends TradeIpcContext {
   ) => Promise<AccountsState>;
   useSingleAccountMode: () => Promise<void>;
   requestQuit: (win: BrowserWindow) => void;
+  reloadGame: (win: BrowserWindow, cause: GameReloadCause) => Promise<void>;
+  claimRelogIntent: (win: BrowserWindow) => boolean;
   loadAccountTemplates: (win: BrowserWindow) => Promise<AccountTemplateLibrary | null>;
   saveAccountTemplates: (
     win: BrowserWindow,
@@ -220,6 +224,13 @@ const one =
     exact(args, 1);
     return parse(args[0]);
   };
+
+const asGameReloadCause = one((value: unknown): GameReloadCause => {
+  if (!GAME_RELOAD_CAUSES.includes(value as GameReloadCause)) {
+    throw new ValidationError("unknown game reload cause");
+  }
+  return value as GameReloadCause;
+});
 
 const asString = (what: string) =>
   one((value: unknown): string => {
@@ -667,6 +678,11 @@ export function registerIpcHandlers(ctx: IpcContext): {
     }),
 
     appRequestQuit: channel(nothing, (win) => ctx.requestQuit(win)),
+
+    appReloadGame: channel(asGameReloadCause, (win, cause) =>
+      ctx.reloadGame(win, cause)),
+
+    appClaimRelogIntent: channel(nothing, (win) => ctx.claimRelogIntent(win)),
 
     clipboardWriteText: channel(asClipboardText, (_win, text) => {
       clipboard.writeText(text);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -94,6 +94,7 @@ import {
   flushWindowState,
   prepareWindowState,
   RENDERER_URL,
+  requestGameQuit,
   type WindowHost,
   updateLongRunningTaskFeedback,
 } from "./window.js";
@@ -138,6 +139,7 @@ import {
 } from "./accounts-window.js";
 import { MultipleAccountsController } from "./multiple-accounts-controller.js";
 import { BuildLibraryCoordinator } from "./core/build-library-coordinator.js";
+import { GameReloader } from "./game-reload.js";
 
 // The public app name changed after alpha profiles already existed. Keep that
 // one profile as the canonical home so the rename cannot strand saved login,
@@ -367,6 +369,11 @@ function buildWindowHost(
   enhancementProgram: EnhancementProgram,
   diagnosticProfile: DiagnosticProfile,
 ): WindowHost {
+  const gameReloader = new GameReloader({
+    sockets,
+    getSettings: () => preferences.getSettings(),
+    rendererUrl: RENDERER_URL,
+  });
   return {
     sockets,
     enhancementSelection,
@@ -389,16 +396,9 @@ function buildWindowHost(
     markPerformanceProblem,
     startCapture: startDiagnosticCapture,
     stopCapture: stopDiagnosticCaptureForWindow,
-    reloadGame: (win) => {
-      void (async () => {
-        // A refused template generation specifically asks for a reload. The
-        // command reports that as `failed`; it never rejects, and navigation
-        // must still establish the next projection generation.
-        await sendRendererCommand(win, { type: "filesystem.sync" });
-        sockets.closeAll(win.webContents.id);
-        await win.loadURL(RENDERER_URL);
-      })();
-    },
+    reloadGame: (win, cause) => gameReloader.reload(win, cause),
+    claimRelogIntent: (win) => gameReloader.claimRelogIntent(win),
+    requestQuit: requestGameQuit,
     prepareRendererRecovery: async () => {
       await clientRuntime.recoverRendererCrash();
     },
@@ -786,7 +786,9 @@ if (primaryInstance) void app.whenReady().then(async () => {
     deleteAccount: (parent, profileId) => accounts.delete(parent, profileId),
     loadAccountTemplates: (win) => accounts.loadTemplates(win),
     saveAccountTemplates: (win, entries) => accounts.saveTemplates(win, entries),
-    requestQuit: (win) => accounts.requestQuit(win),
+    requestQuit: requestGameQuit,
+    reloadGame: (win, cause) => host.reloadGame(win, cause),
+    claimRelogIntent: (win) => host.claimRelogIntent(win),
     useSingleAccountMode: () => accounts.useSingleMode(),
   });
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -372,6 +372,11 @@ function buildWindowHost(
   const gameReloader = new GameReloader({
     sockets,
     getSettings: () => preferences.getSettings(),
+    diagnosticOwner: (win) =>
+      windowRegistry.requireDiagnosticOwnerForWindow(win),
+    record: logEvent,
+    sync: (win) => sendRendererCommand(win, { type: "filesystem.sync" }),
+    load: (win, url) => win.loadURL(url),
     rendererUrl: RENDERER_URL,
   });
   return {

--- a/src/main/multiple-accounts-controller.ts
+++ b/src/main/multiple-accounts-controller.ts
@@ -57,7 +57,6 @@ import {
 } from "./protocol.js";
 import { applyPendingSessionStorageReset } from "./settings-actions.js";
 import {
-  closeProfileWindow,
   createMainWindow,
   prepareWindowState,
   resetRendererRecovery,
@@ -400,12 +399,6 @@ export class MultipleAccountsController {
           saveAccountTemplateLibrary(this.options.paths.multiSharedTemplates, library),
       });
     });
-  }
-
-  requestQuit(win: BrowserWindow): void {
-    const context = windowRegistry.contextForWebContents(win.webContents.id);
-    if (context?.mode === "multi") void closeProfileWindow(win);
-    else app.quit();
   }
 
   private activeWorkspace(): MultiWorkspace {

--- a/src/main/renderer-client-sessions.ts
+++ b/src/main/renderer-client-sessions.ts
@@ -47,6 +47,7 @@ function projectCompatibility(
       skillSlotGeometry: status("skillSlotGeometry"),
       skillCooldownObservation: status("skillCooldownObservation"),
       playRegionObservation: status("playRegionObservation"),
+      preGameControls: status("preGameControls"),
     }),
   });
 }

--- a/src/main/window-menu.ts
+++ b/src/main/window-menu.ts
@@ -10,6 +10,7 @@
 import {
   app,
   BrowserWindow,
+  clipboard,
   dialog,
   Menu,
   shell,
@@ -20,7 +21,8 @@ import {
   EXTERNAL_URLS,
   type GameTextEditCommand,
 } from "../shared/contracts.js";
-import { logEvent } from "./diagnostics.js";
+import { errorCode } from "../shared/errors.js";
+import { logEvent, reloadTranscriptForWindow } from "./diagnostics.js";
 import { exportDiagnosticsReport } from "./diagnostics-export.js";
 import {
   editWindowText,
@@ -86,6 +88,143 @@ function withGameOwner(
   };
 }
 
+const activeQuitOrReloadDialogs = new WeakMap<BrowserWindow, Promise<void>>();
+const AUTO_RELOG_LABEL = "Return to my character automatically";
+
+async function readAutoRelogPreference(host: WindowHost): Promise<boolean> {
+  try {
+    return (await host.getSettings()).autoRelogAfterReload;
+  } catch (error) {
+    logEvent({ k: "settings.loadFailed", code: errorCode(error) });
+    return false;
+  }
+}
+
+async function saveAutoRelogPreference(
+  host: WindowHost,
+  previous: boolean,
+  next: boolean,
+): Promise<void> {
+  if (previous === next) return;
+  try {
+    await host.updateSettings({ autoRelogAfterReload: next });
+  } catch (error) {
+    logEvent({ k: "settings.saveFailed", code: errorCode(error) });
+  }
+}
+
+function runExclusiveReloadDialog(
+  win: BrowserWindow,
+  show: () => Promise<void>,
+): Promise<void> {
+  const active = activeQuitOrReloadDialogs.get(win);
+  if (active) return active;
+  const operation = show().finally(() => {
+    if (activeQuitOrReloadDialogs.get(win) === operation) {
+      activeQuitOrReloadDialogs.delete(win);
+    }
+  });
+  activeQuitOrReloadDialogs.set(win, operation);
+  return operation;
+}
+
+/** The one Quit-or-Reload workflow used by the menu and physical Command-Q. */
+export function showQuitOrReloadGame(
+  host: WindowHost,
+  win: BrowserWindow,
+): Promise<void> {
+  return runExclusiveReloadDialog(
+    win,
+    () => showQuitOrReloadGameOnce(host, win),
+  );
+}
+
+function showReloadGame(host: WindowHost, win: BrowserWindow): Promise<void> {
+  return runExclusiveReloadDialog(win, async () => {
+    void resetGameInput(win);
+    const autoRelog = await readAutoRelogPreference(host);
+    const result = await dialog.showMessageBox(win, {
+      type: "none",
+      buttons: ["Reload Guild Wars", "Cancel"],
+      defaultId: 0,
+      cancelId: 1,
+      noLink: true,
+      message: "Reload Guild Wars?",
+      detail:
+        "This account restarts with fresh memory. Other accounts stay open.",
+      checkboxLabel: AUTO_RELOG_LABEL,
+      checkboxChecked: autoRelog,
+    });
+    await saveAutoRelogPreference(host, autoRelog, result.checkboxChecked);
+    if (result.response === 0) await host.reloadGame(win, "menu");
+  });
+}
+
+async function showQuitOrReloadGameOnce(
+  host: WindowHost,
+  win: BrowserWindow,
+): Promise<void> {
+  const ownerId = windowRegistry.requireDiagnosticOwnerForWindow(win);
+  const recordDialog = (
+    phase: "requested" | "opened" | "settled",
+    action: "pending" | "reload" | "quit" | "cancel" | "failed",
+    autoRelog: boolean | null,
+  ) => {
+    try {
+      logEvent({
+        k: "quitReloadDialog.lifecycle",
+        phase,
+        action,
+        autoRelog,
+      }, ownerId);
+    } catch {
+      // Diagnostics are passive: a recorder failure cannot trap the sheet.
+    }
+  };
+  recordDialog("requested", "pending", null);
+  // Sending the reset is synchronous; only its acknowledgement is async.
+  // A busy game renderer may take the full five-second command timeout to
+  // answer, but a native Command-Q dialog must never wait on the renderer it
+  // may be about to reload or quit.
+  void resetGameInput(win);
+  const autoRelogAfterReload = await readAutoRelogPreference(host);
+  recordDialog("opened", "pending", autoRelogAfterReload);
+  let result: Awaited<ReturnType<typeof dialog.showMessageBox>>;
+  try {
+    result = await dialog.showMessageBox(win, {
+      type: "none",
+      buttons: ["Reload Guild Wars", "Quit Game", "Cancel"],
+      defaultId: 0,
+      cancelId: 2,
+      noLink: true,
+      message: "Quit or reload Guild Wars?",
+      detail:
+        "Reload restarts this account with fresh memory. Other accounts stay open.",
+      checkboxLabel: AUTO_RELOG_LABEL,
+      checkboxChecked: autoRelogAfterReload,
+    });
+  } catch (error) {
+    recordDialog("settled", "failed", autoRelogAfterReload);
+    throw error;
+  }
+  const action = result.response === 0
+    ? "reload"
+    : result.response === 1
+      ? "quit"
+      : "cancel";
+  recordDialog("settled", action, result.checkboxChecked);
+  await saveAutoRelogPreference(
+    host,
+    autoRelogAfterReload,
+    result.checkboxChecked,
+  );
+  if (result.response === 0) {
+    await host.reloadGame(win, "command-q");
+  } else if (result.response === 1) {
+    host.requestQuit(win);
+  }
+}
+
 export function installApplicationMenu({
   host,
   resetWindowState,
@@ -125,7 +264,12 @@ export function installApplicationMenu({
               { role: "hideOthers" as const },
               { role: "unhide" as const },
               { type: "separator" as const },
-              { role: "quit" as const },
+              {
+                id: "quit-or-reload-game",
+                label: "Quit or Reload Game…",
+                accelerator: "CommandOrControl+Q",
+                click: withGameOwner((win) => showQuitOrReloadGame(host, win)),
+              },
             ],
           },
         ]
@@ -194,23 +338,9 @@ export function installApplicationMenu({
         },
         {
           id: "reload-game",
-          label: "Reload Game",
+          label: "Reload Guild Wars…",
           accelerator: "CmdOrCtrl+R",
-          click: withGameOwner(async (win) => {
-            await resetGameInput(win);
-            if (host.sockets.size(win.webContents.id) > 0) {
-              const { response } = await dialog.showMessageBox(win, {
-                type: "warning",
-                buttons: ["Reload", "Cancel"],
-                defaultId: 1,
-                cancelId: 1,
-                message: "Reload the game?",
-                detail: "Live game sockets are open and will be closed.",
-              });
-              if (response !== 0) return;
-            }
-            host.reloadGame(win);
-          }),
+          click: withGameOwner((win) => showReloadGame(host, win)),
         },
         ...(dev
           ? [
@@ -264,6 +394,14 @@ export function installApplicationMenu({
         {
           label: "Diagnostics",
           submenu: [
+            {
+              id: "copy-reload-trace",
+              label: "Copy Reload Trace",
+              click: withGameOwner(async (win) => {
+                clipboard.writeText(await reloadTranscriptForWindow(win));
+              }),
+            },
+            { type: "separator" },
             {
               id: "export-diagnostics",
               label: "Export Recent Diagnostics…",

--- a/src/main/window-menu.ts
+++ b/src/main/window-menu.ts
@@ -91,25 +91,53 @@ function withGameOwner(
 const activeQuitOrReloadDialogs = new WeakMap<BrowserWindow, Promise<void>>();
 const AUTO_RELOG_LABEL = "Return to my character automatically";
 
-async function readAutoRelogPreference(host: WindowHost): Promise<boolean> {
+async function readAutoRelogPreference(host: WindowHost): Promise<boolean | null> {
   try {
     return (await host.getSettings()).autoRelogAfterReload;
   } catch (error) {
     logEvent({ k: "settings.loadFailed", code: errorCode(error) });
-    return false;
+    return null;
   }
 }
 
 async function saveAutoRelogPreference(
   host: WindowHost,
-  previous: boolean,
+  previous: boolean | null,
   next: boolean,
-): Promise<void> {
-  if (previous === next) return;
+): Promise<boolean> {
+  if (previous === next) return true;
   try {
     await host.updateSettings({ autoRelogAfterReload: next });
+    return true;
   } catch (error) {
     logEvent({ k: "settings.saveFailed", code: errorCode(error) });
+    return false;
+  }
+}
+
+async function showAutoRelogSettingsError(win: BrowserWindow): Promise<void> {
+  await dialog.showMessageBox(win, {
+    type: "error",
+    buttons: ["OK"],
+    message: "Reload setting is unavailable",
+    detail: "Guild Wars was not reloaded. Try again so automatic return matches your choice.",
+  });
+}
+
+async function reloadGameOrShowError(
+  host: WindowHost,
+  win: BrowserWindow,
+  cause: "menu" | "command-q",
+): Promise<void> {
+  try {
+    await host.reloadGame(win, cause);
+  } catch {
+    await dialog.showMessageBox(win, {
+      type: "error",
+      buttons: ["OK"],
+      message: "Guild Wars could not reload",
+      detail: "Your account stayed open. Try Reload Guild Wars again.",
+    });
   }
 }
 
@@ -153,10 +181,17 @@ function showReloadGame(host: WindowHost, win: BrowserWindow): Promise<void> {
       detail:
         "This account restarts with fresh memory. Other accounts stay open.",
       checkboxLabel: AUTO_RELOG_LABEL,
-      checkboxChecked: autoRelog,
+      checkboxChecked: autoRelog ?? false,
     });
-    await saveAutoRelogPreference(host, autoRelog, result.checkboxChecked);
-    if (result.response === 0) await host.reloadGame(win, "menu");
+    if (result.response !== 0) return;
+    if (
+      autoRelog === null
+      || !await saveAutoRelogPreference(host, autoRelog, result.checkboxChecked)
+    ) {
+      await showAutoRelogSettingsError(win);
+      return;
+    }
+    await reloadGameOrShowError(host, win, "menu");
   });
 }
 
@@ -201,7 +236,7 @@ async function showQuitOrReloadGameOnce(
       detail:
         "Reload restarts this account with fresh memory. Other accounts stay open.",
       checkboxLabel: AUTO_RELOG_LABEL,
-      checkboxChecked: autoRelogAfterReload,
+      checkboxChecked: autoRelogAfterReload ?? false,
     });
   } catch (error) {
     recordDialog("settled", "failed", autoRelogAfterReload);
@@ -213,15 +248,34 @@ async function showQuitOrReloadGameOnce(
       ? "quit"
       : "cancel";
   recordDialog("settled", action, result.checkboxChecked);
-  await saveAutoRelogPreference(
-    host,
-    autoRelogAfterReload,
-    result.checkboxChecked,
-  );
   if (result.response === 0) {
-    await host.reloadGame(win, "command-q");
+    if (
+      autoRelogAfterReload === null
+      || !await saveAutoRelogPreference(
+        host,
+        autoRelogAfterReload,
+        result.checkboxChecked,
+      )
+    ) {
+      await showAutoRelogSettingsError(win);
+      return;
+    }
+    await reloadGameOrShowError(host, win, "command-q");
   } else if (result.response === 1) {
+    if (autoRelogAfterReload !== null) {
+      await saveAutoRelogPreference(
+        host,
+        autoRelogAfterReload,
+        result.checkboxChecked,
+      );
+    }
     host.requestQuit(win);
+  } else if (autoRelogAfterReload !== null) {
+    await saveAutoRelogPreference(
+      host,
+      autoRelogAfterReload,
+      result.checkboxChecked,
+    );
   }
 }
 

--- a/src/main/window-shortcuts.ts
+++ b/src/main/window-shortcuts.ts
@@ -31,6 +31,11 @@ const tracedKey = (key: string) => {
 interface ShortcutActions {
   run(action: ShortcutAction): void;
   edit(command: GameTextEditCommand): void;
+  quitOrReload(): void | Promise<void>;
+  recordCommandQ?(
+    phase: "claimed" | "repeat-contained" | "rearmed",
+    reason: "none" | "keyup" | "dialog-settled" | "appkit-release" | "error",
+  ): void;
 }
 
 type ClaimedKey = 'capture' | 'skill-capture' | 'shortcut' | GameTextEditCommand;
@@ -60,7 +65,10 @@ class WindowShortcuts {
   #skillCapture: ((result: SkillKeyCaptureResult) => void) | null = null;
   #claimedCodes = new Map<string, ClaimedKey>();
 
-  constructor(win: BrowserWindow, actions: ShortcutActions) {
+  constructor(
+    win: BrowserWindow,
+    actions: ShortcutActions,
+  ) {
     this.#actions = actions;
     win.webContents.on("before-input-event", (event, input) => {
       if (input.type === "keyUp") {
@@ -80,6 +88,7 @@ class WindowShortcuts {
         });
         if (decision) {
           this.#claimedCodes.delete(input.code);
+          if (input.code === "KeyQ") this.#recordCommandQ("rearmed", "keyup");
           event.preventDefault();
         }
         return;
@@ -104,6 +113,9 @@ class WindowShortcuts {
           decision: claimedDecision(claimed),
         });
         event.preventDefault();
+        if (input.code === "KeyQ") {
+          this.#recordCommandQ("repeat-contained", "none");
+        }
         return;
       }
       if (this.#capture) {
@@ -163,6 +175,46 @@ class WindowShortcuts {
         });
         this.#claimedCodes.set(input.code, edit);
         this.#actions.edit(edit);
+        return;
+      }
+      if (
+        input.meta &&
+        !input.control &&
+        !input.shift &&
+        !input.alt &&
+        input.code === "KeyQ"
+      ) {
+        event.preventDefault();
+        recordMainInput(win, {
+          source: 'main', kind: 'native-key', phase: 'down',
+          key: tracedKey(input.key), repeat: input.isAutoRepeat,
+          decision: 'shortcut',
+        });
+        this.#claimedCodes.set(input.code, 'shortcut');
+        this.#recordCommandQ("claimed", "none");
+        if (!input.isAutoRepeat) {
+          // AppKit gives the native sheet ownership before the physical Q-up
+          // reaches webContents. Keep repeats contained while the sheet is
+          // open, then re-arm Q when its operation settles instead of waiting
+          // for a release Electron may never deliver.
+          const rearm = (reason: "dialog-settled" | "error") => {
+            if (this.#claimedCodes.delete(input.code)) {
+              this.#recordCommandQ("rearmed", reason);
+            }
+          };
+          try {
+            void Promise.resolve(this.#actions.quitOrReload()).then(
+              () => rearm("dialog-settled"),
+              (error) => {
+                console.error('quit or reload shortcut failed', error);
+                rearm("error");
+              },
+            );
+          } catch (error) {
+            console.error('quit or reload shortcut failed', error);
+            rearm("error");
+          }
+        }
         return;
       }
       for (const [action, binding] of Object.entries(this.#shortcuts)) {
@@ -226,7 +278,21 @@ class WindowShortcuts {
   }
 
   release(code: string): void {
-    this.#claimedCodes.delete(code);
+    const claimed = this.#claimedCodes.delete(code);
+    if (claimed && code === "KeyQ") {
+      this.#recordCommandQ("rearmed", "appkit-release");
+    }
+  }
+
+  #recordCommandQ(
+    phase: "claimed" | "repeat-contained" | "rearmed",
+    reason: "none" | "keyup" | "dialog-settled" | "appkit-release" | "error",
+  ): void {
+    try {
+      this.#actions.recordCommandQ?.(phase, reason);
+    } catch {
+      // Observation must never alter shortcut containment or rearming.
+    }
   }
 
   #finish(result: ShortcutCaptureResult): void {

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -18,6 +18,7 @@ import type {
   AppSettingsPatch,
   DownloadProgress,
   DiagnosticProfile,
+  GameReloadCause,
   RendererInit,
 } from "../shared/contracts.js";
 import { RENDERER_INIT_ARGUMENT } from "../shared/contracts.js";
@@ -50,7 +51,10 @@ import {
   toggleTools,
   toggleTravel,
 } from "./renderer-commands.js";
-import { installApplicationMenu } from "./window-menu.js";
+import {
+  installApplicationMenu,
+  showQuitOrReloadGame,
+} from "./window-menu.js";
 import {
   installWindowShortcuts,
   updateWindowShortcuts,
@@ -72,7 +76,9 @@ export interface WindowHost {
   markPerformanceProblem: (win: BrowserWindow) => void;
   startCapture: (win: BrowserWindow, level: 1 | 2) => Promise<void>;
   stopCapture: (win: BrowserWindow) => Promise<void>;
-  reloadGame: (win: BrowserWindow) => void;
+  reloadGame: (win: BrowserWindow, cause: GameReloadCause) => Promise<void>;
+  claimRelogIntent: (win: BrowserWindow) => boolean;
+  requestQuit: (win: BrowserWindow) => void;
   prepareRendererRecovery: () => Promise<void>;
   gameWindowClosed?: () => void;
 }
@@ -345,6 +351,13 @@ export function closeProfileWindow(win: BrowserWindow): Promise<void> {
   return operation;
 }
 
+/** Close one profile in Multi mode, or the application in Single mode. */
+export function requestGameQuit(win: BrowserWindow): void {
+  const context = windowRegistry.contextForWebContents(win.webContents.id);
+  if (context?.mode === "multi") void closeProfileWindow(win);
+  else app.quit();
+}
+
 /** The only renderer URL, and it carries no configuration. */
 export const RENDERER_URL = "gw://app/";
 
@@ -534,6 +547,12 @@ export function createMainWindow(
     },
     edit(command) {
       void editWindowText(win, command);
+    },
+    quitOrReload() {
+      return showQuitOrReloadGame(host, win);
+    },
+    recordCommandQ(phase, reason) {
+      logEvent({ k: "commandQ.shortcut", phase, reason }, diagnosticOwnerId);
     },
   });
   void host.getSettings().then((settings) => {

--- a/src/preload/preload.body.cjs
+++ b/src/preload/preload.body.cjs
@@ -260,6 +260,8 @@ const api = {
     openExternal: (kind) => ipcRenderer.invoke(IPC.appOpenExternal, kind),
     reveal: (kind) => ipcRenderer.invoke(IPC.appRevealPath, kind),
     requestQuit: () => ipcRenderer.invoke(IPC.appRequestQuit),
+    reloadGame: (cause) => ipcRenderer.invoke(IPC.appReloadGame, cause),
+    claimRelogIntent: () => ipcRenderer.invoke(IPC.appClaimRelogIntent),
   },
   clipboard: {
     writeText: (text) => ipcRenderer.invoke(IPC.clipboardWriteText, text),

--- a/src/renderer/automatic-character-return.ts
+++ b/src/renderer/automatic-character-return.ts
@@ -1,0 +1,401 @@
+/**
+ * Owns one reload's automatic return from saved login to a playable character.
+ * The classic host reports only the credential and account-token boundaries;
+ * this controller owns input authority, certified-state progression, feedback,
+ * expiry, and the single terminal diagnostic.
+ */
+import type {
+  RendererMilestone,
+  RendererMilestoneFieldsByName,
+  RelogInputStage,
+  RelogTerminalOutcome,
+} from "../shared/diagnostics.js";
+import {
+  isRelogCharacterEntryState,
+  isRelogPostCharacterState,
+  relogOutcomeForPlayable,
+} from "./relog-progression.js";
+
+const AUTHORITY_BUDGET_MS = 30_000;
+const STATUS_REVEAL_DELAY_MS = 350;
+
+type RecordMilestone = <Name extends RendererMilestone>(
+  name: Name,
+  ...fields: Name extends keyof RendererMilestoneFieldsByName
+    ? [RendererMilestoneFieldsByName[Name]]
+    : []
+) => void;
+
+export type AutomaticCharacterReturn = Readonly<{
+  savedCredentialsLoaded(): void;
+  tokenRequested(request: XMLHttpRequest): void;
+  clearStatus(): void;
+  dispose(): void;
+}>;
+
+type ActiveRun = {
+  ended: boolean;
+  expiresAt: number;
+  loginStarted: boolean;
+  tokenAccepted: boolean;
+  observedNonPlayable: boolean;
+  lastStep: string;
+  deadlineTimer: ReturnType<typeof setTimeout> | null;
+};
+
+type Dependencies = Readonly<{
+  claimIntent(): Promise<boolean>;
+  input(): GameInputController | null;
+  record: RecordMilestone;
+}>;
+
+const didAdvance = (outcome: AutomaticEnterOutcome): boolean =>
+  outcome === "sent" || outcome === "physical" || outcome === "progressed";
+
+const afterClientPaint = (): Promise<void> => new Promise((resolve) => {
+  requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+});
+
+const nextObservation = (): Promise<void> => new Promise((resolve) => {
+  if (document.visibilityState === "visible") {
+    requestAnimationFrame(() => resolve());
+  } else {
+    setTimeout(resolve, 25);
+  }
+});
+
+export function installAutomaticCharacterReturn(
+  dependencies: Dependencies,
+): AutomaticCharacterReturn {
+  let disposed = false;
+  let run: ActiveRun | null = null;
+  let revealTimer: ReturnType<typeof setTimeout> | null = null;
+  let statusVisible = false;
+
+  const cancelReveal = () => {
+    if (revealTimer === null) return;
+    clearTimeout(revealTimer);
+    revealTimer = null;
+  };
+
+  const clearStatus = () => {
+    cancelReveal();
+    if (!statusVisible) return;
+    statusVisible = false;
+    const status = document.getElementById("login-status");
+    if (status) status.hidden = true;
+  };
+
+  const showStatus = (text: string) => {
+    cancelReveal();
+    const status = document.getElementById("login-status");
+    if (!status) return;
+    statusVisible = true;
+    status.textContent = text;
+    status.hidden = false;
+  };
+
+  const deferStatus = (text: string) => {
+    clearStatus();
+    revealTimer = setTimeout(() => {
+      revealTimer = null;
+      showStatus(text);
+    }, STATUS_REVEAL_DELAY_MS);
+  };
+
+  const isActive = (candidate: ActiveRun): boolean =>
+    !disposed
+    && run === candidate
+    && !candidate.ended
+    && performance.now() <= candidate.expiresAt;
+
+  const finish = (
+    candidate: ActiveRun,
+    outcome: RelogTerminalOutcome,
+  ): boolean => {
+    if (candidate.ended || run !== candidate) return false;
+    candidate.ended = true;
+    if (candidate.deadlineTimer !== null) {
+      clearTimeout(candidate.deadlineTimer);
+      candidate.deadlineTimer = null;
+    }
+    dependencies.input()?.cancelAutomaticEnter();
+    dependencies.record("relog.finished", { outcome });
+    if (outcome === "timed-out") {
+      showStatus(
+        `Automatic return stopped while ${candidate.lastStep}. Press Return to continue.`,
+      );
+    } else {
+      clearStatus();
+    }
+    return true;
+  };
+
+  const step = (
+    candidate: ActiveRun,
+    name:
+      | "relog.intentClaimed"
+      | "relog.savedCredentialsLoaded"
+      | "relog.loginSubmitted"
+      | "relog.tokenRequested"
+      | "relog.tokenAccepted"
+      | "relog.characterSubmitted",
+    description: string,
+    status: string,
+  ) => {
+    if (!isActive(candidate)) return;
+    candidate.lastStep = description;
+    dependencies.record(name);
+    deferStatus(status);
+  };
+
+  const recordInput = (
+    stage: RelogInputStage,
+    outcome: AutomaticEnterOutcome,
+  ) => dependencies.record("relog.inputSettled", { stage, outcome });
+
+  const waitForFocus = async (candidate: ActiveRun): Promise<boolean> => {
+    if (!isActive(candidate)) return false;
+    if (document.hasFocus()) return true;
+    return new Promise((resolve) => {
+      const remaining = candidate.expiresAt - performance.now();
+      if (remaining <= 0) {
+        resolve(false);
+        return;
+      }
+      const focused = () => settle(isActive(candidate));
+      const timer = setTimeout(() => settle(false), remaining);
+      const settle = (value: boolean) => {
+        clearTimeout(timer);
+        window.removeEventListener("focus", focused);
+        resolve(value);
+      };
+      window.addEventListener("focus", focused, { once: true });
+    });
+  };
+
+  const sendWhenFocused = async (
+    candidate: ActiveRun,
+    send: () => Promise<AutomaticEnterOutcome>,
+  ): Promise<AutomaticEnterOutcome> => {
+    while (isActive(candidate)) {
+      if (!await waitForFocus(candidate) || !isActive(candidate)) {
+        return "unfocused";
+      }
+      const outcome = await send();
+      if (!isActive(candidate)) return "cancelled";
+      if (outcome !== "unfocused" && (
+        outcome !== "cancelled" || document.hasFocus()
+      )) return outcome;
+    }
+    return "unfocused";
+  };
+
+  const observe = (candidate: ActiveRun) => {
+    const controls = window.gwPreGameControls;
+    const state = controls?.state() ?? "unknown";
+    const playable = controls?.playable() ?? null;
+    if (state !== "unknown" || playable === null) {
+      candidate.observedNonPlayable = true;
+    }
+    return {
+      state,
+      playable,
+      mask: controls?.diagnosticMask() ?? 0,
+    };
+  };
+
+  const waitForProgress = async (
+    candidate: ActiveRun,
+    acceptsState: (state: PreGameState) => boolean,
+    acceptsPlayable: boolean,
+  ): Promise<Readonly<{
+    state: PreGameState;
+    playable: "outpost" | "explorable" | null;
+  }> | null> => {
+    let previousProbe = "";
+    while (isActive(candidate)) {
+      const observation = observe(candidate);
+      const probe = `${observation.state}:${observation.mask}`;
+      if (probe !== previousProbe) {
+        previousProbe = probe;
+        dependencies.record("relog.preGameProbe", {
+          state: observation.state,
+          mask: observation.mask,
+        });
+      }
+      if (acceptsState(observation.state)) return observation;
+      if (
+        acceptsPlayable
+        && candidate.observedNonPlayable
+        && observation.state === "unknown"
+        && observation.playable !== null
+      ) return observation;
+      await nextObservation();
+    }
+    return null;
+  };
+
+  const completeWhenPlayable = (
+    candidate: ActiveRun,
+    playable: "outpost" | "explorable" | null,
+  ): boolean => {
+    const outcome = relogOutcomeForPlayable(playable);
+    return outcome !== null && finish(candidate, outcome);
+  };
+
+  const continueAfterToken = async (candidate: ActiveRun): Promise<void> => {
+    const entry = await waitForProgress(
+      candidate,
+      isRelogCharacterEntryState,
+      false,
+    );
+    if (!entry || !isActive(candidate)) return;
+
+    const input = dependencies.input();
+    const characterOutcome: AutomaticEnterOutcome = entry.state === "character-select"
+      ? input
+        ? await sendWhenFocused(candidate, () => input.playSelectedCharacter())
+        : "cancelled"
+      : "progressed";
+    recordInput("character", characterOutcome);
+    if (!didAdvance(characterOutcome) || !isActive(candidate)) {
+      candidate.lastStep = characterOutcome === "unfocused"
+        ? "waiting for the game window to regain focus"
+        : "waiting at character selection";
+      return;
+    }
+
+    step(
+      candidate,
+      "relog.characterSubmitted",
+      "checking for a previous session",
+      "Character selected. Restoring your session…",
+    );
+    const branch = entry.state === "reconnect"
+      ? entry
+      : await waitForProgress(candidate, isRelogPostCharacterState, true);
+    if (!branch || !isActive(candidate)) return;
+    if (completeWhenPlayable(candidate, branch.playable)) return;
+
+    const restoreOutcome: AutomaticEnterOutcome = branch.state === "reconnect"
+      ? input
+        ? await sendWhenFocused(candidate, () => input.acceptReconnect())
+        : "cancelled"
+      : "progressed";
+    recordInput("reconnect", restoreOutcome);
+    if (!didAdvance(restoreOutcome) || !isActive(candidate)) {
+      candidate.lastStep = restoreOutcome === "unfocused"
+        ? "the reconnect window lost focus"
+        : "waiting for session restoration";
+      return;
+    }
+
+    candidate.lastStep = "waiting for the character to become playable";
+    deferStatus("Guild Wars is loading your character…");
+    const terminal = await waitForProgress(candidate, () => false, true);
+    if (terminal) completeWhenPlayable(candidate, terminal.playable);
+  };
+
+  const intent = dependencies.claimIntent().then((armed) => {
+    if (!armed || disposed) return null;
+    const candidate: ActiveRun = {
+      ended: false,
+      expiresAt: performance.now() + AUTHORITY_BUDGET_MS,
+      loginStarted: false,
+      tokenAccepted: false,
+      observedNonPlayable: false,
+      lastStep: "waiting for saved login",
+      deadlineTimer: null,
+    };
+    candidate.deadlineTimer = setTimeout(() => {
+      finish(candidate, "timed-out");
+    }, AUTHORITY_BUDGET_MS);
+    run = candidate;
+    step(
+      candidate,
+      "relog.intentClaimed",
+      "waiting for saved login",
+      "Reloaded. Waiting for saved login…",
+    );
+    return candidate;
+  }).catch(() => null);
+
+  const savedCredentialsLoaded = () => {
+    void intent.then(async (candidate) => {
+      if (!candidate || !isActive(candidate) || candidate.loginStarted) return;
+      candidate.loginStarted = true;
+      step(
+        candidate,
+        "relog.savedCredentialsLoaded",
+        "preparing the login screen",
+        "Saved login loaded. Signing in…",
+      );
+      await afterClientPaint();
+      if (!isActive(candidate)) return;
+      const input = dependencies.input();
+      const outcome = input
+        ? await sendWhenFocused(
+            candidate,
+            () => input.submitSavedLogin(candidate.expiresAt),
+          )
+        : "cancelled";
+      recordInput("login", outcome);
+      if (didAdvance(outcome) && isActive(candidate)) {
+        step(
+          candidate,
+          "relog.loginSubmitted",
+          "waiting for sign-in",
+          "Sign-in submitted. Waiting for Guild Wars…",
+        );
+      } else if (isActive(candidate)) {
+        candidate.lastStep = outcome === "unfocused"
+          ? "waiting for the game window to regain focus"
+          : "waiting at the login screen";
+      }
+    });
+  };
+
+  const tokenRequested = (request: XMLHttpRequest) => {
+    void intent.then((candidate) => {
+      if (!candidate || !isActive(candidate) || candidate.tokenAccepted) return;
+      step(
+        candidate,
+        "relog.tokenRequested",
+        "waiting for sign-in to finish",
+        "Guild Wars is signing in…",
+      );
+      request.addEventListener("loadend", () => {
+        if (
+          !isActive(candidate)
+          || candidate.tokenAccepted
+          || request.status < 200
+          || request.status >= 300
+        ) return;
+        candidate.tokenAccepted = true;
+        step(
+          candidate,
+          "relog.tokenAccepted",
+          "preparing character selection",
+          "Signed in. Returning to your character…",
+        );
+        void continueAfterToken(candidate);
+      }, { once: true });
+    });
+  };
+
+  return Object.freeze({
+    savedCredentialsLoaded,
+    tokenRequested,
+    clearStatus,
+    dispose() {
+      disposed = true;
+      cancelReveal();
+      if (run && !run.ended) {
+        run.ended = true;
+        if (run.deadlineTimer !== null) clearTimeout(run.deadlineTimer);
+      }
+      dependencies.input()?.cancelAutomaticEnter();
+    },
+  });
+}

--- a/src/renderer/certified-companion-installation.ts
+++ b/src/renderer/certified-companion-installation.ts
@@ -188,6 +188,22 @@ export async function installCertifiedCompanion(
         ? exports.enhancement_take_trade_toggle as () => number
         : null)
     : null;
+  const preGameStateReader = capabilities.preGameControls
+    ? (typeof exports.enhancement_pre_game_state === "function"
+        ? exports.enhancement_pre_game_state as () => number
+        : null)
+    : null;
+  const preGameDiagnosticReader = capabilities.preGameControls
+    ? (typeof exports.enhancement_pre_game_diagnostic === "function"
+        ? exports.enhancement_pre_game_diagnostic as () => number
+        : null)
+    : null;
+  if (
+    capabilities.preGameControls
+    && (preGameStateReader === null || preGameDiagnosticReader === null)
+  ) {
+    throw new Error("the pre-game profile derived a module with incomplete readers");
+  }
   if (capabilities.chatAliases && (!configureTradeToggle || !takeTradeToggle)) {
     throw new Error("the aliases profile derived a module with no Trade Chat toggle");
   }
@@ -222,6 +238,7 @@ export async function installCertifiedCompanion(
   let installedCallback: CallableFunction | null = null;
   let installedCursorState: NonNullable<typeof window.gwCursorState> | null = null;
   let installedRuntime: object | null = null;
+  let installedPreGameControls: PreGameControls | null = null;
   let cleaned = false;
   let telemetryInstalled = false;
   const cleanup = (): readonly Error[] => {
@@ -306,6 +323,11 @@ export async function installCertifiedCompanion(
     const runtimeWithdrawn = attempt("runtime withdrawal", () => {
       if (window.gwCompanionRuntime === installedRuntime) {
         window.gwCompanionRuntime = null;
+      }
+    });
+    attempt("pre-game controls withdrawal", () => {
+      if (window.gwPreGameControls === installedPreGameControls) {
+        window.gwPreGameControls = null;
       }
     });
     // Only a completed installation records a withdrawal; a rollback after a
@@ -736,6 +758,35 @@ export async function installCertifiedCompanion(
         ? runtimeProjection
         : Object.assign(runtimeProjection, commands));
     installedRuntime = runtime;
+    if (preGameStateReader) {
+      installedPreGameControls = Object.freeze({
+        state(): PreGameState {
+          try {
+            switch (Number(preGameStateReader()) >>> 0) {
+              case 1: return "character-select";
+              case 2: return "reconnect";
+              case 3: return "loading";
+              default: return "unknown";
+            }
+          } catch {
+            return "unknown";
+          }
+        },
+        playable() {
+          const state = policySnapshot().playRegionState;
+          if (state.status !== "ready") return null;
+          return state.instanceType === 0 ? "outpost" : "explorable";
+        },
+        diagnosticMask(): number {
+          try {
+            return Number(preGameDiagnosticReader!()) >>> 0;
+          } catch {
+            return 0x8000_0000;
+          }
+        },
+      });
+      window.gwPreGameControls = installedPreGameControls;
+    }
     // The retry loop rides the observer's own cadence: it runs exactly when
     // the consumer polls, and pauses with it when the page is hidden.
     const polledCursor = cursor === null ? null : {

--- a/src/renderer/client-compatibility-notice.ts
+++ b/src/renderer/client-compatibility-notice.ts
@@ -22,7 +22,7 @@ export type CompatibilityReport = {
 };
 
 type Feature = keyof ClientCompatibility['features'];
-type VisibleFeature = Exclude<Feature, 'playRegionObservation'>;
+type VisibleFeature = Exclude<Feature, 'playRegionObservation' | 'preGameControls'>;
 
 const FEATURE_NAMES: Readonly<Record<VisibleFeature, string>> = Object.freeze({
   gameFileSaving: 'Guild Wars file saving',

--- a/src/renderer/client-launch-readiness.ts
+++ b/src/renderer/client-launch-readiness.ts
@@ -15,11 +15,9 @@ export function launchProgressForSession(
   progress: DownloadProgress,
   session: ClientSession,
 ): DownloadProgress {
-  if (
-    session.extendedMemory === null ||
-    progress.phase === "ready" ||
-    progress.phase === "error"
-  ) return progress;
+  if (session.extendedMemory === null || progress.phase !== "image") {
+    return progress;
+  }
   return {
     ...progress,
     phase: "ready",

--- a/src/renderer/client-launch-readiness.ts
+++ b/src/renderer/client-launch-readiness.ts
@@ -1,0 +1,28 @@
+/**
+ * Project app-global preparation progress onto one renderer's launch gate.
+ *
+ * A playable client starts its complete-data download in the background. That
+ * changes global progress to `image`, but it must not make a replacement
+ * renderer wait for the background download to finish. The session's active
+ * memory result is the canonical proof that this renderer can boot now.
+ */
+import type {
+  ClientSession,
+  DownloadProgress,
+} from "../shared/contracts.js";
+
+export function launchProgressForSession(
+  progress: DownloadProgress,
+  session: ClientSession,
+): DownloadProgress {
+  if (
+    session.extendedMemory === null ||
+    progress.phase === "ready" ||
+    progress.phase === "error"
+  ) return progress;
+  return {
+    ...progress,
+    phase: "ready",
+    label: "Starting Guild Wars",
+  };
+}

--- a/src/renderer/commands.ts
+++ b/src/renderer/commands.ts
@@ -116,7 +116,10 @@
         break;
       case 'filesystem.sync':
         await new Promise<void>((resolve, reject) => {
-          const fs = window.Module?.FS;
+          // ArenaNet's generated glue publishes FS on the global object.
+          // Module.FS is a throwing compatibility getter unless the client was
+          // built with FS in EXPORTED_RUNTIME_METHODS.
+          const fs = window.FS;
           if (!fs) {
             resolve();
             return;

--- a/src/renderer/effective-enhancement-capabilities.ts
+++ b/src/renderer/effective-enhancement-capabilities.ts
@@ -23,5 +23,6 @@ export function effectiveCapabilities(
       features.skillCooldownObservation.status === "available",
     playRegionObservation:
       features.playRegionObservation.status === "available",
+    preGameControls: features.preGameControls.status === "available",
   });
 }

--- a/src/renderer/failure-messages.ts
+++ b/src/renderer/failure-messages.ts
@@ -264,7 +264,8 @@ export function memoryWarningCopy(
     dismissButton: MEMORY_DISMISS,
     explanation:
       `This session can use up to ${capGb} GB. Reloading starts Guild Wars `
-      + 'with fresh memory and puts you back where you were. The experimental '
+      + 'with fresh memory. With automatic return enabled, gwonmac signs in '
+      + 'and returns to the selected character. The experimental '
       + '4 GB limit provides more headroom, but it cannot stop continued '
       + 'memory growth.',
   };

--- a/src/renderer/gw-native.d.ts
+++ b/src/renderer/gw-native.d.ts
@@ -54,9 +54,10 @@ declare global {
 
   interface GameInputController {
     releaseAll(): void;
+    cancelAutomaticEnter(): void;
     setLoginProviderChooser(visible: boolean): void;
     expectCharacterSelection(): void;
-    submitSavedLogin(): Promise<AutomaticEnterOutcome>;
+    submitSavedLogin(expiresAt?: number): Promise<AutomaticEnterOutcome>;
     playSelectedCharacter(): Promise<AutomaticEnterOutcome>;
     acceptReconnect(): Promise<AutomaticEnterOutcome>;
   }

--- a/src/renderer/gw-native.d.ts
+++ b/src/renderer/gw-native.d.ts
@@ -56,7 +56,17 @@ declare global {
     releaseAll(): void;
     setLoginProviderChooser(visible: boolean): void;
     expectCharacterSelection(): void;
+    submitSavedLogin(): Promise<AutomaticEnterOutcome>;
+    playSelectedCharacter(): Promise<AutomaticEnterOutcome>;
+    acceptReconnect(): Promise<AutomaticEnterOutcome>;
   }
+
+  type AutomaticEnterOutcome =
+    | "sent"
+    | "physical"
+    | "progressed"
+    | "unfocused"
+    | "cancelled";
 
   interface GwonmacSurfaceHandle {
     setOpen(open: boolean): void;
@@ -187,6 +197,14 @@ declare global {
     setHookEnabledForBenchmark(enabled: boolean): void;
   }
 
+  type PreGameState = "unknown" | "character-select" | "reconnect" | "loading";
+
+  interface PreGameControls {
+    state(): PreGameState;
+    playable(): "outpost" | "explorable" | null;
+    diagnosticMask(): number;
+  }
+
   interface EnhancementAutomation {
     set(stage: string): void;
     read(): Readonly<{
@@ -204,13 +222,13 @@ declare global {
 
   interface Window {
     readonly gwNative: GwNativeApi;
+    FS?: {
+      syncfs(
+        populate: boolean,
+        callback: (error?: unknown) => void,
+      ): void;
+    };
     Module?: {
-      FS?: {
-        syncfs(
-          populate: boolean,
-          callback: (error?: unknown) => void,
-        ): void;
-      };
       canvas?: HTMLCanvasElement & { offscreen?: OffscreenCanvas };
     };
     gwApplySettings?(settings: AppSettings): void;
@@ -246,6 +264,7 @@ declare global {
       buildId: number;
     }>;
     gwCompanionRuntime?: CompanionDeveloperRuntime | CompanionObserverRuntime | null;
+    gwPreGameControls?: PreGameControls | null;
     gwCompanionState?: PublishedCompanionState;
     /** The cursor's bounded presentation state; present once the nativeCursor enhancement installs. */
     gwCursorState?(): Readonly<{

--- a/src/renderer/harness.css
+++ b/src/renderer/harness.css
@@ -84,7 +84,7 @@ html,body { width:100%; height:100%; margin:0; overflow:hidden;
   display: flex;
   align-items: center;
   gap: 16px;
-  max-width: min(92vw, 540px);
+  max-width: min(92vw, 600px);
   box-sizing: border-box;
   padding: 11px 13px;
   border: 1px solid var(--ui-warning-border);
@@ -114,7 +114,7 @@ html,body { width:100%; height:100%; margin:0; overflow:hidden;
   color: var(--ui-text-bright);
 }
 #memory-notice.critical #memory-notice-label { color: var(--ui-danger); }
-.memory-notice-copy { min-width: 0; }
+.memory-notice-copy { min-width: 250px; flex: 1; }
 #memory-notice-detail {
   font: var(--ui-font-size-sm)/1.5 var(--ui-font-readable);
   letter-spacing: .01em;
@@ -139,9 +139,16 @@ html,body { width:100%; height:100%; margin:0; overflow:hidden;
   color: var(--ui-text-muted);
   font: var(--ui-font-size-sm)/1.5 var(--ui-font-readable);
 }
+.memory-notice-relog {
+  width: fit-content;
+  margin-top: 8px;
+}
 #memory-notice-actions { display: flex; gap: 8px; flex-shrink: 0; }
 #memory-notice-actions button {
   flex: 0 0 auto;
+}
+#memory-notice-actions button:disabled {
+  cursor: wait;
 }
 
 /* Reduced motion keeps the feedback and drops the travel: a cross-fade in

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -209,12 +209,9 @@ async function escalateRepeatedCrash(): Promise<void> {
 let disposeSocketHost = () => {};
 let disposeHostOnlyTools = () => {};
 const native = () => window.gwNative;
-let relogIntent: Promise<boolean> = Promise.resolve(false);
-let relogIntentExpiresAt = 0;
-let relogIntentConsumed = false;
-let relogLoginSubmissionStarted = false;
-let relogDeadlineTimer: ReturnType<typeof setTimeout> | null = null;
-let relogLastStep = 'waiting for saved login';
+let automaticCharacterReturn:
+  | import('./automatic-character-return.js').AutomaticCharacterReturn
+  | null = null;
 const diagnosticProfile = native().init.diagnosticProfile;
 const glOverridesEnabled = diagnosticProfile === 'standard';
 const presentationPath = diagnosticProfile === 'direct-canvas'
@@ -590,25 +587,6 @@ async function fetchSnapshotRange(
 // interactive Steam sign-in produced no login. Transient and non-blocking —
 // the login screen itself stays entirely the client's.
 let loginStatusTimer: ReturnType<typeof setTimeout> | null = null;
-let relogStatusRevealTimer: ReturnType<typeof setTimeout> | null = null;
-let relogStatusVisible = false;
-const RELOG_STATUS_REVEAL_DELAY_MS = 350;
-
-function cancelRelogStatusReveal(): void {
-  if (relogStatusRevealTimer === null) return;
-  clearTimeout(relogStatusRevealTimer);
-  relogStatusRevealTimer = null;
-}
-
-function clearRelogStatus(): void {
-  cancelRelogStatusReveal();
-  if (!relogStatusVisible) return;
-  if (loginStatusTimer) clearTimeout(loginStatusTimer);
-  loginStatusTimer = null;
-  relogStatusVisible = false;
-  const status = document.getElementById('login-status');
-  if (status) status.hidden = true;
-}
 
 function showLoginStatus(
   reason: import('../shared/contracts.js').SteamRefusalReason,
@@ -618,8 +596,7 @@ function showLoginStatus(
     const text = describeSteamRefusal(reason);
     const status = document.getElementById('login-status');
     if (!text || !status) return;
-    cancelRelogStatusReveal();
-    relogStatusVisible = false;
+    automaticCharacterReturn?.clearStatus();
     status.textContent = text;
     status.hidden = false;
     if (loginStatusTimer) clearTimeout(loginStatusTimer);
@@ -628,184 +605,6 @@ function showLoginStatus(
       loginStatusTimer = null;
     }, 12_000);
   })();
-}
-
-function showRelogStatus(text: string, hideAfterMs?: number): void {
-  cancelRelogStatusReveal();
-  const status = document.getElementById('login-status');
-  if (!status) return;
-  relogStatusVisible = true;
-  status.textContent = text;
-  status.hidden = false;
-  if (loginStatusTimer) clearTimeout(loginStatusTimer);
-  loginStatusTimer = hideAfterMs === undefined ? null : setTimeout(() => {
-    status.hidden = true;
-    relogStatusVisible = false;
-    loginStatusTimer = null;
-  }, hideAfterMs);
-}
-
-function deferRelogStatus(text: string): void {
-  clearRelogStatus();
-  relogStatusRevealTimer = setTimeout(() => {
-    relogStatusRevealTimer = null;
-    showRelogStatus(text);
-  }, RELOG_STATUS_REVEAL_DELAY_MS);
-}
-
-function recordRelogStep(
-  name: Extract<
-    import('../shared/diagnostics.js').RendererMilestone,
-    `relog.${string}`
-  >,
-  step: string,
-  status: string,
-): void {
-  relogLastStep = step;
-  milestone(name);
-  deferRelogStatus(status);
-}
-
-function beginRelogFeedback(): void {
-  recordRelogStep(
-    'relog.intentClaimed',
-    'waiting for saved login',
-    'Reloaded. Waiting for saved login…',
-  );
-  relogDeadlineTimer = setTimeout(() => {
-    milestone('relog.timedOut');
-    milestone('relog.finished', { outcome: 'timed-out' });
-    showRelogStatus(
-      `Automatic return stopped while ${relogLastStep}. Press Return to continue.`,
-    );
-  }, 30_000);
-}
-
-function recordRelogInput(
-  stage: import('../shared/diagnostics.js').RelogInputStage,
-  outcome: AutomaticEnterOutcome,
-): void {
-  milestone('relog.inputSettled', { stage, outcome });
-}
-
-function finishRelogFeedback(outcome: 'restored' | 'outpost'): void {
-  if (relogDeadlineTimer !== null) clearTimeout(relogDeadlineTimer);
-  relogDeadlineTimer = null;
-  clearRelogStatus();
-  milestone('relog.finished', { outcome });
-}
-
-const afterClientPaint = (): Promise<void> => new Promise((resolve) => {
-  requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
-});
-
-async function waitForPreGameState(
-  accepted: (state: PreGameState) => boolean,
-): Promise<PreGameState | null> {
-  let previousProbe = "";
-  while (performance.now() <= relogIntentExpiresAt) {
-    const controls = window.gwPreGameControls;
-    const state = controls?.state() ?? 'unknown';
-    const mask = controls?.diagnosticMask() ?? 0;
-    const probe = `${state}:${mask}`;
-    if (probe !== previousProbe) {
-      previousProbe = probe;
-      milestone('relog.preGameProbe', { state, mask });
-    }
-    if (accepted(state)) return state;
-    await new Promise<void>((resolve) => {
-      if (document.visibilityState === 'visible') {
-        requestAnimationFrame(() => resolve());
-      } else {
-        setTimeout(resolve, 25);
-      }
-    });
-  }
-  return null;
-}
-
-async function waitForPlayableRelogState(): Promise<'outpost' | 'explorable' | null> {
-  const { observeRelogPlayableTransition } = await import('./relog-progression.js');
-  let observedNonPlayable = false;
-  while (performance.now() <= relogIntentExpiresAt) {
-    const playable = window.gwPreGameControls?.playable() ?? null;
-    const observation = observeRelogPlayableTransition(
-      observedNonPlayable,
-      playable,
-    );
-    observedNonPlayable = observation.observedNonPlayable;
-    if (observation.outcome !== null) return playable;
-    await new Promise<void>((resolve) => {
-      if (document.visibilityState === 'visible') {
-        requestAnimationFrame(() => resolve());
-      } else {
-        setTimeout(resolve, 25);
-      }
-    });
-  }
-  return null;
-}
-
-const waitForDocumentFocus = (): Promise<boolean> => {
-  if (document.hasFocus()) return Promise.resolve(true);
-  const remaining = relogIntentExpiresAt - performance.now();
-  if (remaining <= 0) return Promise.resolve(false);
-  return new Promise((resolve) => {
-    const focused = () => settle(true);
-    const timer = setTimeout(() => settle(false), remaining);
-    const settle = (value: boolean) => {
-      clearTimeout(timer);
-      window.removeEventListener('focus', focused);
-      resolve(value);
-    };
-    window.addEventListener('focus', focused, { once: true });
-  });
-};
-
-async function sendRelogEnterWhenFocused(
-  send: () => Promise<AutomaticEnterOutcome>,
-): Promise<AutomaticEnterOutcome> {
-  while (performance.now() <= relogIntentExpiresAt) {
-    if (!await waitForDocumentFocus()) return 'unfocused';
-    const outcome = await send();
-    if (outcome !== 'unfocused' && (outcome !== 'cancelled' || document.hasFocus())) {
-      return outcome;
-    }
-  }
-  return 'unfocused';
-}
-
-async function submitSavedLoginForRelog(): Promise<void> {
-  const armed = await relogIntent;
-  if (
-    !armed ||
-    relogIntentConsumed ||
-    relogLoginSubmissionStarted ||
-    performance.now() > relogIntentExpiresAt
-  ) return;
-  relogLoginSubmissionStarted = true;
-  recordRelogStep(
-    'relog.savedCredentialsLoaded',
-    'preparing the login screen',
-    'Saved login loaded. Signing in…',
-  );
-  await afterClientPaint();
-  const loginInput = inputHost;
-  const outcome = loginInput
-    ? await sendRelogEnterWhenFocused(() => loginInput.submitSavedLogin())
-    : 'cancelled';
-  recordRelogInput('login', outcome);
-  if (outcome === 'sent' || outcome === 'physical' || outcome === 'progressed') {
-    recordRelogStep(
-      'relog.loginSubmitted',
-      'waiting for sign-in',
-      'Sign-in submitted. Waiting for Guild Wars…',
-    );
-  } else {
-    relogLastStep = outcome === 'unfocused'
-      ? 'waiting for the game window to regain focus'
-      : 'waiting at the login screen';
-  }
 }
 
 addEventListener('beforeunload', () => {
@@ -818,7 +617,7 @@ addEventListener('beforeunload', () => {
   controllerPrompts?.dispose();
   controllerPrompts = null;
   disposeMemoryWarningSettings();
-  if (relogDeadlineTimer !== null) clearTimeout(relogDeadlineTimer);
+  automaticCharacterReturn?.dispose();
   delete window.gwVirtualGamepad;
   delete window.gwControllerPromptTextureStats;
 });
@@ -972,7 +771,7 @@ Module = {
         throw new Error('no stored credentials');
       }
       log('secureStorage: returning saved credentials');
-      void submitSavedLoginForRelog();
+      automaticCharacterReturn?.savedCredentialsLoaded();
       return stored;
     },
     async storeCredentials(username, password) {
@@ -1287,100 +1086,7 @@ function loadGlue(isProxyRouteLabel: (route: string) => boolean) {
         // including when the player chose not to save credentials.
         if (path === '/webgate/my_account/token.xml') {
           inputHost?.expectCharacterSelection();
-          void relogIntent.then((armed) => {
-            if (!armed || relogIntentConsumed) return;
-            recordRelogStep(
-              'relog.tokenRequested',
-              'waiting for sign-in to finish',
-              'Guild Wars is signing in…',
-            );
-          });
-          this.addEventListener('loadend', () => {
-            void relogIntent.then((armed) => {
-              if (
-                !armed ||
-                relogIntentConsumed ||
-                performance.now() > relogIntentExpiresAt ||
-                this.status < 200 ||
-                this.status >= 300
-              ) return;
-              relogIntentConsumed = true;
-              recordRelogStep(
-                'relog.tokenAccepted',
-                'preparing character selection',
-                'Signed in. Returning to your character…',
-              );
-              void (async () => {
-                const {
-                  isRelogCharacterEntryState,
-                  isRelogPostCharacterState,
-                  relogOutcomeForPlayable,
-                } = await import('./relog-progression.js');
-                const characterState = await waitForPreGameState(
-                  isRelogCharacterEntryState,
-                );
-                if (characterState === null) {
-                  relogLastStep = 'waiting for certified character selection';
-                  return;
-                }
-                const characterInput = inputHost;
-                const outcome: AutomaticEnterOutcome = characterState === 'reconnect'
-                  ? 'progressed'
-                  : characterInput
-                    ? await sendRelogEnterWhenFocused(
-                      () => characterInput.playSelectedCharacter(),
-                    )
-                    : 'cancelled';
-                recordRelogInput('character', outcome);
-                if (
-                  outcome !== 'sent'
-                  && outcome !== 'physical'
-                  && outcome !== 'progressed'
-                ) {
-                  relogLastStep = outcome === 'unfocused'
-                    ? 'waiting for the game window to regain focus'
-                    : 'waiting at character selection';
-                  return;
-                }
-                milestone('relog.characterSubmitted');
-                relogLastStep = 'checking for a previous session';
-                deferRelogStatus('Character selected. Restoring your session…');
-                const branch = characterState === 'reconnect'
-                  ? 'reconnect'
-                  : await waitForPreGameState(isRelogPostCharacterState);
-                if (branch === null) {
-                  relogLastStep = 'waiting for a certified reconnect or loading state';
-                  return;
-                }
-                // Only the exact certified reconnect frame receives a second
-                // Return. Loading is a transition, never terminal evidence.
-                const restoreOutcome: AutomaticEnterOutcome = branch === 'loading'
-                  ? 'progressed'
-                  : characterInput
-                    ? await sendRelogEnterWhenFocused(
-                      () => characterInput.acceptReconnect(),
-                    )
-                    : 'cancelled';
-                recordRelogInput('reconnect', restoreOutcome);
-                if (
-                  restoreOutcome !== 'sent'
-                  && restoreOutcome !== 'physical'
-                  && restoreOutcome !== 'progressed'
-                ) {
-                  relogLastStep = restoreOutcome === 'unfocused'
-                    ? 'the reconnect window lost focus'
-                    : 'waiting for session restoration';
-                  return;
-                }
-                relogLastStep = 'waiting for the character to become playable';
-                deferRelogStatus('Guild Wars is loading your character…');
-                const playable = await waitForPlayableRelogState();
-                if (playable === null) return;
-                const finalOutcome = relogOutcomeForPlayable(playable);
-                if (finalOutcome !== null) finishRelogFeedback(finalOutcome);
-              })();
-            });
-          }, { once: true });
+          automaticCharacterReturn?.tokenRequested(this);
         }
         return origOpen.call(this, method, rewritten, ...rest);
       }
@@ -1513,15 +1219,14 @@ function loadGlue(isProxyRouteLabel: (route: string) => boolean) {
     );
     return;
   }
-  relogIntent = native().app.claimRelogIntent()
-    .then((armed) => {
-      // Expiry can only withdraw an explicit one-shot intent. It never grants
-      // authority to send input, so slow or manual login safely falls back.
-      relogIntentExpiresAt = armed ? performance.now() + 30_000 : 0;
-      if (armed) beginRelogFeedback();
-      return armed;
-    })
-    .catch(() => false);
+  const { installAutomaticCharacterReturn } = await import(
+    './automatic-character-return.js'
+  );
+  automaticCharacterReturn = installAutomaticCharacterReturn({
+    claimIntent: () => native().app.claimRelogIntent(),
+    input: () => inputHost,
+    record: milestone,
+  });
   milestone('renderer.loaded');
   let isProxyRouteLabel: (route: string) => boolean;
   try {

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -195,7 +195,7 @@ let crashRecorded = false;
 
 /**
  * How many client launches have crashed this app run. Main's flight recorder
- * owns the tally (it survives the location.reload() a Retry performs and
+ * owns the tally (it survives the account-local page reload a Retry performs and
  * dies with the process), so the renderer records the crash first and then
  * reads the count back — browser storage is deliberately not used anywhere
  * in this app. A count that cannot be read degrades to the first-crash
@@ -209,6 +209,12 @@ async function escalateRepeatedCrash(): Promise<void> {
 let disposeSocketHost = () => {};
 let disposeHostOnlyTools = () => {};
 const native = () => window.gwNative;
+let relogIntent: Promise<boolean> = Promise.resolve(false);
+let relogIntentExpiresAt = 0;
+let relogIntentConsumed = false;
+let relogLoginSubmissionStarted = false;
+let relogDeadlineTimer: ReturnType<typeof setTimeout> | null = null;
+let relogLastStep = 'waiting for saved login';
 const diagnosticProfile = native().init.diagnosticProfile;
 const glOverridesEnabled = diagnosticProfile === 'standard';
 const presentationPath = diagnosticProfile === 'direct-canvas'
@@ -373,6 +379,7 @@ let heapWatch: import('./heap-pressure.js').HeapPressureWatch | null = null;
 let heapWarning:
   | import('./memory-warning.js').MemoryWarningPresenter
   | null = null;
+let disposeMemoryWarningSettings = () => {};
 let heapCapRequested = false;
 function requestHeapCap() {
   if (heapCapRequested) return;
@@ -382,7 +389,7 @@ function requestHeapCap() {
     import('./heap-pressure.js'),
     import('./memory-warning.js'),
   ])
-    .then(([
+    .then(async ([
       { WASM_HEAP_CAP_BYTES },
       { createHeapPressureWatch },
       { bindMemoryWarning },
@@ -390,11 +397,32 @@ function requestHeapCap() {
       const capBytes = Module.gwonmacHeapCapBytes ?? WASM_HEAP_CAP_BYTES;
       heapCapBytes = capBytes;
       heapWatch = createHeapPressureWatch({ capBytes });
+      const settings = await native().settings.get();
       heapWarning = bindMemoryWarning(
         document,
-        reloadClientSafely,
+        {
+          autoRelogAfterReload: settings.autoRelogAfterReload,
+          async saveAutoRelog(autoRelogAfterReload) {
+            await native().settings.set({ autoRelogAfterReload });
+          },
+          async reload() {
+            try {
+              await native().app.reloadGame('memory-warning');
+            } catch (error) {
+              log(
+                '[err] memory reload failed:',
+                error instanceof Error ? error.message : String(error),
+              );
+              throw error;
+            }
+          },
+        },
         window.gwSurfaces,
       );
+      disposeMemoryWarningSettings();
+      disposeMemoryWarningSettings = native().settings.onChange((updated) => {
+        heapWarning?.setAutoRelog(updated.autoRelogAfterReload);
+      });
     })
     // A failed load retries on the next tick rather than silencing the
     // warning for the whole session.
@@ -421,26 +449,6 @@ const crashTechnicalDetail = (reason: unknown, heapBytes: number): string => {
     `WASM heap at crash: ${Math.round(heapBytes / MIB)} MiB${cap}\n${text}`
   ).slice(0, 8192);
 };
-
-/**
- * Best-effort save sync, then the same page reload the crash overlay's Retry
- * performs; the beforeunload dispose closes this run's game sockets on the
- * way out. The quit path has shown the sync can fail, so the reload never
- * waits on it for more than a beat — IDBFS auto-persist has usually written
- * already.
- */
-function reloadClientSafely() {
-  let reloaded = false;
-  const reload = () => {
-    if (reloaded) return;
-    reloaded = true;
-    window.location.reload();
-  };
-  setTimeout(reload, 1_500);
-  const fs = window.Module?.FS;
-  if (fs) fs.syncfs(false, reload);
-  else reload();
-}
 
 setInterval(() => {
   if (crashRecorded) return;
@@ -582,6 +590,26 @@ async function fetchSnapshotRange(
 // interactive Steam sign-in produced no login. Transient and non-blocking —
 // the login screen itself stays entirely the client's.
 let loginStatusTimer: ReturnType<typeof setTimeout> | null = null;
+let relogStatusRevealTimer: ReturnType<typeof setTimeout> | null = null;
+let relogStatusVisible = false;
+const RELOG_STATUS_REVEAL_DELAY_MS = 350;
+
+function cancelRelogStatusReveal(): void {
+  if (relogStatusRevealTimer === null) return;
+  clearTimeout(relogStatusRevealTimer);
+  relogStatusRevealTimer = null;
+}
+
+function clearRelogStatus(): void {
+  cancelRelogStatusReveal();
+  if (!relogStatusVisible) return;
+  if (loginStatusTimer) clearTimeout(loginStatusTimer);
+  loginStatusTimer = null;
+  relogStatusVisible = false;
+  const status = document.getElementById('login-status');
+  if (status) status.hidden = true;
+}
+
 function showLoginStatus(
   reason: import('../shared/contracts.js').SteamRefusalReason,
 ): void {
@@ -590,13 +618,194 @@ function showLoginStatus(
     const text = describeSteamRefusal(reason);
     const status = document.getElementById('login-status');
     if (!text || !status) return;
+    cancelRelogStatusReveal();
+    relogStatusVisible = false;
     status.textContent = text;
     status.hidden = false;
     if (loginStatusTimer) clearTimeout(loginStatusTimer);
     loginStatusTimer = setTimeout(() => {
       status.hidden = true;
+      loginStatusTimer = null;
     }, 12_000);
   })();
+}
+
+function showRelogStatus(text: string, hideAfterMs?: number): void {
+  cancelRelogStatusReveal();
+  const status = document.getElementById('login-status');
+  if (!status) return;
+  relogStatusVisible = true;
+  status.textContent = text;
+  status.hidden = false;
+  if (loginStatusTimer) clearTimeout(loginStatusTimer);
+  loginStatusTimer = hideAfterMs === undefined ? null : setTimeout(() => {
+    status.hidden = true;
+    relogStatusVisible = false;
+    loginStatusTimer = null;
+  }, hideAfterMs);
+}
+
+function deferRelogStatus(text: string): void {
+  clearRelogStatus();
+  relogStatusRevealTimer = setTimeout(() => {
+    relogStatusRevealTimer = null;
+    showRelogStatus(text);
+  }, RELOG_STATUS_REVEAL_DELAY_MS);
+}
+
+function recordRelogStep(
+  name: Extract<
+    import('../shared/diagnostics.js').RendererMilestone,
+    `relog.${string}`
+  >,
+  step: string,
+  status: string,
+): void {
+  relogLastStep = step;
+  milestone(name);
+  deferRelogStatus(status);
+}
+
+function beginRelogFeedback(): void {
+  recordRelogStep(
+    'relog.intentClaimed',
+    'waiting for saved login',
+    'Reloaded. Waiting for saved login…',
+  );
+  relogDeadlineTimer = setTimeout(() => {
+    milestone('relog.timedOut');
+    milestone('relog.finished', { outcome: 'timed-out' });
+    showRelogStatus(
+      `Automatic return stopped while ${relogLastStep}. Press Return to continue.`,
+    );
+  }, 30_000);
+}
+
+function recordRelogInput(
+  stage: import('../shared/diagnostics.js').RelogInputStage,
+  outcome: AutomaticEnterOutcome,
+): void {
+  milestone('relog.inputSettled', { stage, outcome });
+}
+
+function finishRelogFeedback(outcome: 'restored' | 'outpost'): void {
+  if (relogDeadlineTimer !== null) clearTimeout(relogDeadlineTimer);
+  relogDeadlineTimer = null;
+  clearRelogStatus();
+  milestone('relog.finished', { outcome });
+}
+
+const afterClientPaint = (): Promise<void> => new Promise((resolve) => {
+  requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+});
+
+async function waitForPreGameState(
+  accepted: (state: PreGameState) => boolean,
+): Promise<PreGameState | null> {
+  let previousProbe = "";
+  while (performance.now() <= relogIntentExpiresAt) {
+    const controls = window.gwPreGameControls;
+    const state = controls?.state() ?? 'unknown';
+    const mask = controls?.diagnosticMask() ?? 0;
+    const probe = `${state}:${mask}`;
+    if (probe !== previousProbe) {
+      previousProbe = probe;
+      milestone('relog.preGameProbe', { state, mask });
+    }
+    if (accepted(state)) return state;
+    await new Promise<void>((resolve) => {
+      if (document.visibilityState === 'visible') {
+        requestAnimationFrame(() => resolve());
+      } else {
+        setTimeout(resolve, 25);
+      }
+    });
+  }
+  return null;
+}
+
+async function waitForPlayableRelogState(): Promise<'outpost' | 'explorable' | null> {
+  const { observeRelogPlayableTransition } = await import('./relog-progression.js');
+  let observedNonPlayable = false;
+  while (performance.now() <= relogIntentExpiresAt) {
+    const playable = window.gwPreGameControls?.playable() ?? null;
+    const observation = observeRelogPlayableTransition(
+      observedNonPlayable,
+      playable,
+    );
+    observedNonPlayable = observation.observedNonPlayable;
+    if (observation.outcome !== null) return playable;
+    await new Promise<void>((resolve) => {
+      if (document.visibilityState === 'visible') {
+        requestAnimationFrame(() => resolve());
+      } else {
+        setTimeout(resolve, 25);
+      }
+    });
+  }
+  return null;
+}
+
+const waitForDocumentFocus = (): Promise<boolean> => {
+  if (document.hasFocus()) return Promise.resolve(true);
+  const remaining = relogIntentExpiresAt - performance.now();
+  if (remaining <= 0) return Promise.resolve(false);
+  return new Promise((resolve) => {
+    const focused = () => settle(true);
+    const timer = setTimeout(() => settle(false), remaining);
+    const settle = (value: boolean) => {
+      clearTimeout(timer);
+      window.removeEventListener('focus', focused);
+      resolve(value);
+    };
+    window.addEventListener('focus', focused, { once: true });
+  });
+};
+
+async function sendRelogEnterWhenFocused(
+  send: () => Promise<AutomaticEnterOutcome>,
+): Promise<AutomaticEnterOutcome> {
+  while (performance.now() <= relogIntentExpiresAt) {
+    if (!await waitForDocumentFocus()) return 'unfocused';
+    const outcome = await send();
+    if (outcome !== 'unfocused' && (outcome !== 'cancelled' || document.hasFocus())) {
+      return outcome;
+    }
+  }
+  return 'unfocused';
+}
+
+async function submitSavedLoginForRelog(): Promise<void> {
+  const armed = await relogIntent;
+  if (
+    !armed ||
+    relogIntentConsumed ||
+    relogLoginSubmissionStarted ||
+    performance.now() > relogIntentExpiresAt
+  ) return;
+  relogLoginSubmissionStarted = true;
+  recordRelogStep(
+    'relog.savedCredentialsLoaded',
+    'preparing the login screen',
+    'Saved login loaded. Signing in…',
+  );
+  await afterClientPaint();
+  const loginInput = inputHost;
+  const outcome = loginInput
+    ? await sendRelogEnterWhenFocused(() => loginInput.submitSavedLogin())
+    : 'cancelled';
+  recordRelogInput('login', outcome);
+  if (outcome === 'sent' || outcome === 'physical' || outcome === 'progressed') {
+    recordRelogStep(
+      'relog.loginSubmitted',
+      'waiting for sign-in',
+      'Sign-in submitted. Waiting for Guild Wars…',
+    );
+  } else {
+    relogLastStep = outcome === 'unfocused'
+      ? 'waiting for the game window to regain focus'
+      : 'waiting at the login screen';
+  }
 }
 
 addEventListener('beforeunload', () => {
@@ -608,6 +817,8 @@ addEventListener('beforeunload', () => {
   window.gwVirtualGamepad?.dispose();
   controllerPrompts?.dispose();
   controllerPrompts = null;
+  disposeMemoryWarningSettings();
+  if (relogDeadlineTimer !== null) clearTimeout(relogDeadlineTimer);
   delete window.gwVirtualGamepad;
   delete window.gwControllerPromptTextureStats;
 });
@@ -761,6 +972,7 @@ Module = {
         throw new Error('no stored credentials');
       }
       log('secureStorage: returning saved credentials');
+      void submitSavedLoginForRelog();
       return stored;
     },
     async storeCredentials(username, password) {
@@ -1075,6 +1287,100 @@ function loadGlue(isProxyRouteLabel: (route: string) => boolean) {
         // including when the player chose not to save credentials.
         if (path === '/webgate/my_account/token.xml') {
           inputHost?.expectCharacterSelection();
+          void relogIntent.then((armed) => {
+            if (!armed || relogIntentConsumed) return;
+            recordRelogStep(
+              'relog.tokenRequested',
+              'waiting for sign-in to finish',
+              'Guild Wars is signing in…',
+            );
+          });
+          this.addEventListener('loadend', () => {
+            void relogIntent.then((armed) => {
+              if (
+                !armed ||
+                relogIntentConsumed ||
+                performance.now() > relogIntentExpiresAt ||
+                this.status < 200 ||
+                this.status >= 300
+              ) return;
+              relogIntentConsumed = true;
+              recordRelogStep(
+                'relog.tokenAccepted',
+                'preparing character selection',
+                'Signed in. Returning to your character…',
+              );
+              void (async () => {
+                const {
+                  isRelogCharacterEntryState,
+                  isRelogPostCharacterState,
+                  relogOutcomeForPlayable,
+                } = await import('./relog-progression.js');
+                const characterState = await waitForPreGameState(
+                  isRelogCharacterEntryState,
+                );
+                if (characterState === null) {
+                  relogLastStep = 'waiting for certified character selection';
+                  return;
+                }
+                const characterInput = inputHost;
+                const outcome: AutomaticEnterOutcome = characterState === 'reconnect'
+                  ? 'progressed'
+                  : characterInput
+                    ? await sendRelogEnterWhenFocused(
+                      () => characterInput.playSelectedCharacter(),
+                    )
+                    : 'cancelled';
+                recordRelogInput('character', outcome);
+                if (
+                  outcome !== 'sent'
+                  && outcome !== 'physical'
+                  && outcome !== 'progressed'
+                ) {
+                  relogLastStep = outcome === 'unfocused'
+                    ? 'waiting for the game window to regain focus'
+                    : 'waiting at character selection';
+                  return;
+                }
+                milestone('relog.characterSubmitted');
+                relogLastStep = 'checking for a previous session';
+                deferRelogStatus('Character selected. Restoring your session…');
+                const branch = characterState === 'reconnect'
+                  ? 'reconnect'
+                  : await waitForPreGameState(isRelogPostCharacterState);
+                if (branch === null) {
+                  relogLastStep = 'waiting for a certified reconnect or loading state';
+                  return;
+                }
+                // Only the exact certified reconnect frame receives a second
+                // Return. Loading is a transition, never terminal evidence.
+                const restoreOutcome: AutomaticEnterOutcome = branch === 'loading'
+                  ? 'progressed'
+                  : characterInput
+                    ? await sendRelogEnterWhenFocused(
+                      () => characterInput.acceptReconnect(),
+                    )
+                    : 'cancelled';
+                recordRelogInput('reconnect', restoreOutcome);
+                if (
+                  restoreOutcome !== 'sent'
+                  && restoreOutcome !== 'physical'
+                  && restoreOutcome !== 'progressed'
+                ) {
+                  relogLastStep = restoreOutcome === 'unfocused'
+                    ? 'the reconnect window lost focus'
+                    : 'waiting for session restoration';
+                  return;
+                }
+                relogLastStep = 'waiting for the character to become playable';
+                deferRelogStatus('Guild Wars is loading your character…');
+                const playable = await waitForPlayableRelogState();
+                if (playable === null) return;
+                const finalOutcome = relogOutcomeForPlayable(playable);
+                if (finalOutcome !== null) finishRelogFeedback(finalOutcome);
+              })();
+            });
+          }, { once: true });
         }
         return origOpen.call(this, method, rewritten, ...rest);
       }
@@ -1207,6 +1513,15 @@ function loadGlue(isProxyRouteLabel: (route: string) => boolean) {
     );
     return;
   }
+  relogIntent = native().app.claimRelogIntent()
+    .then((armed) => {
+      // Expiry can only withdraw an explicit one-shot intent. It never grants
+      // authority to send input, so slow or manual login safely falls back.
+      relogIntentExpiresAt = armed ? performance.now() + 30_000 : 0;
+      if (armed) beginRelogFeedback();
+      return armed;
+    })
+    .catch(() => false);
   milestone('renderer.loaded');
   let isProxyRouteLabel: (route: string) => boolean;
   try {

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -177,6 +177,10 @@
       <summary>Details</summary>
       <p id="memory-notice-explanation"></p>
     </details>
+    <label class="memory-notice-relog ui-check">
+      <input type="checkbox" id="memory-notice-auto-relog">
+      <span>Return to my character automatically</span>
+    </label>
   </div>
   <div id="memory-notice-actions">
     <button type="button" id="memory-notice-later" class="ui-button" data-variant="quiet"></button>
@@ -877,6 +881,15 @@
             </p>
             <p id="settings-memory-status" class="settings-memory-status"
                role="status" aria-live="polite"></p>
+          </section>
+          <section class="settings-task" aria-labelledby="settings-relog-title">
+            <label class="settings-check ui-check">
+              <input type="checkbox" name="autoRelogAfterReload">
+              <span id="settings-relog-title">Return to my character after reload</span>
+            </label>
+            <p class="settings-note">
+              After Guild Wars reloads, sign in and return to the selected character automatically when the client supports it. This applies to Command-Q, memory warnings, and Reload Game.
+            </p>
           </section>
           <div class="settings-divider" aria-hidden="true"></div>
           <label class="settings-check ui-check">

--- a/src/renderer/input.ts
+++ b/src/renderer/input.ts
@@ -175,6 +175,10 @@ export const installGameInput = ({
   let providerChooserVisible = false;
   let providerSelection = 0;
   let characterSelectionUntil = 0;
+  let automaticEnter: {
+    timer: ReturnType<typeof setTimeout>;
+    resolve(outcome: AutomaticEnterOutcome): void;
+  } | null = null;
   let virtualCursor: { x: number; y: number } | null = null;
   let pointerWanted = false;
   let modeWatch: ReturnType<typeof setInterval> | null = null;
@@ -361,6 +365,11 @@ export const installGameInput = ({
     releasing = true;
     try {
       resetWheel();
+      if (automaticEnter !== null) {
+        clearTimeout(automaticEnter.timer);
+        automaticEnter.resolve('cancelled');
+        automaticEnter = null;
+      }
       releaseKeys();
       releaseButtons();
     } finally {
@@ -426,6 +435,36 @@ export const installGameInput = ({
     return true;
   };
 
+  const sendCharacterEnter = (init: KeyboardEventInit) => {
+    canvas.dispatchEvent(new globalThis.KeyboardEvent('keydown', init));
+    canvas.dispatchEvent(new globalThis.KeyboardEvent('keyup', init));
+  };
+
+  const scheduleAutomaticEnter = (
+    delayMs = CHARACTER_ENTER_DELAY_MS,
+  ): Promise<AutomaticEnterOutcome> => {
+    if (automaticEnter !== null) return Promise.resolve('cancelled');
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        automaticEnter = null;
+        if (!document.hasFocus()) {
+          resolve('unfocused');
+          return;
+        }
+        canvas.focus();
+        sendCharacterEnter({
+          bubbles: true,
+          cancelable: true,
+          composed: true,
+          key: 'Enter',
+          code: 'Enter',
+        });
+        resolve('sent');
+      }, delayMs);
+      automaticEnter = { timer, resolve };
+    });
+  };
+
   const sendBufferedCharacterEnter = (event: KeyboardEvent) => {
     const init: KeyboardEventInit = {
       bubbles: true,
@@ -435,10 +474,32 @@ export const installGameInput = ({
       code: event.code,
       location: event.location,
     };
-    setTimeout(() => {
-      canvas.dispatchEvent(new globalThis.KeyboardEvent('keydown', init));
-      canvas.dispatchEvent(new globalThis.KeyboardEvent('keyup', init));
-    }, CHARACTER_ENTER_DELAY_MS);
+    setTimeout(() => sendCharacterEnter(init), CHARACTER_ENTER_DELAY_MS);
+  };
+
+  const activatePreGameControl = (
+    expected: 'character-select' | 'reconnect',
+  ): Promise<AutomaticEnterOutcome> => {
+    providerChooserVisible = false;
+    characterSelectionUntil = 0;
+    if (automaticEnter !== null) return Promise.resolve('cancelled');
+    if (!document.hasFocus()) return Promise.resolve('unfocused');
+    canvas.focus();
+    const state = window.gwPreGameControls?.state() ?? 'unknown';
+    if (state !== expected) {
+      const progressed = expected === 'character-select'
+        ? state === 'reconnect' || state === 'loading'
+        : state === 'loading';
+      return Promise.resolve(progressed ? 'progressed' : 'cancelled');
+    }
+    sendCharacterEnter({
+      bubbles: true,
+      cancelable: true,
+      composed: true,
+      key: 'Enter',
+      code: 'Enter',
+    });
+    return Promise.resolve('sent');
   };
 
   const traceOwner = (target: EventTarget | null) => {
@@ -482,6 +543,16 @@ export const installGameInput = ({
     if (handleProviderKey(event)) {
       traceKey(event, 'down', 'suppressed');
       return;
+    }
+    if (
+      event.isTrusted &&
+      event.target === canvas &&
+      event.key === 'Enter' &&
+      automaticEnter !== null
+    ) {
+      clearTimeout(automaticEnter.timer);
+      automaticEnter.resolve('physical');
+      automaticEnter = null;
     }
     if (
       event.target === canvas &&
@@ -873,7 +944,26 @@ export const installGameInput = ({
     },
     expectCharacterSelection() {
       providerChooserVisible = false;
+      // Some saved sessions advance without needing our login-screen Enter.
+      // Cancel it as soon as the token request proves the client moved on, so
+      // it cannot land late on character selection or a reconnect prompt.
+      if (automaticEnter !== null) {
+        clearTimeout(automaticEnter.timer);
+        automaticEnter.resolve('progressed');
+        automaticEnter = null;
+      }
       characterSelectionUntil = performance.now() + CHARACTER_SELECTION_WINDOW_MS;
+    },
+    submitSavedLogin() {
+      providerChooserVisible = false;
+      characterSelectionUntil = 0;
+      return scheduleAutomaticEnter();
+    },
+    playSelectedCharacter() {
+      return activatePreGameControl('character-select');
+    },
+    acceptReconnect() {
+      return activatePreGameControl('reconnect');
     },
   });
 };

--- a/src/renderer/input.ts
+++ b/src/renderer/input.ts
@@ -179,6 +179,12 @@ export const installGameInput = ({
     timer: ReturnType<typeof setTimeout>;
     resolve(outcome: AutomaticEnterOutcome): void;
   } | null = null;
+  const cancelAutomaticEnter = (outcome: AutomaticEnterOutcome = 'cancelled') => {
+    if (automaticEnter === null) return;
+    clearTimeout(automaticEnter.timer);
+    automaticEnter.resolve(outcome);
+    automaticEnter = null;
+  };
   let virtualCursor: { x: number; y: number } | null = null;
   let pointerWanted = false;
   let modeWatch: ReturnType<typeof setInterval> | null = null;
@@ -365,11 +371,7 @@ export const installGameInput = ({
     releasing = true;
     try {
       resetWheel();
-      if (automaticEnter !== null) {
-        clearTimeout(automaticEnter.timer);
-        automaticEnter.resolve('cancelled');
-        automaticEnter = null;
-      }
+      cancelAutomaticEnter();
       releaseKeys();
       releaseButtons();
     } finally {
@@ -442,11 +444,16 @@ export const installGameInput = ({
 
   const scheduleAutomaticEnter = (
     delayMs = CHARACTER_ENTER_DELAY_MS,
+    expiresAt = Number.POSITIVE_INFINITY,
   ): Promise<AutomaticEnterOutcome> => {
     if (automaticEnter !== null) return Promise.resolve('cancelled');
     return new Promise((resolve) => {
       const timer = setTimeout(() => {
         automaticEnter = null;
+        if (performance.now() > expiresAt) {
+          resolve('cancelled');
+          return;
+        }
         if (!document.hasFocus()) {
           resolve('unfocused');
           return;
@@ -546,13 +553,11 @@ export const installGameInput = ({
     }
     if (
       event.isTrusted &&
-      event.target === canvas &&
+      (event.target === canvas || textInputs.has(event.target)) &&
       event.key === 'Enter' &&
       automaticEnter !== null
     ) {
-      clearTimeout(automaticEnter.timer);
-      automaticEnter.resolve('physical');
-      automaticEnter = null;
+      cancelAutomaticEnter('physical');
     }
     if (
       event.target === canvas &&
@@ -930,6 +935,7 @@ export const installGameInput = ({
 
   return Object.freeze({
     releaseAll,
+    cancelAutomaticEnter,
     setLoginProviderChooser(visible: boolean) {
       providerChooserVisible = visible;
       if (!visible) return;
@@ -947,17 +953,13 @@ export const installGameInput = ({
       // Some saved sessions advance without needing our login-screen Enter.
       // Cancel it as soon as the token request proves the client moved on, so
       // it cannot land late on character selection or a reconnect prompt.
-      if (automaticEnter !== null) {
-        clearTimeout(automaticEnter.timer);
-        automaticEnter.resolve('progressed');
-        automaticEnter = null;
-      }
+      cancelAutomaticEnter('progressed');
       characterSelectionUntil = performance.now() + CHARACTER_SELECTION_WINDOW_MS;
     },
-    submitSavedLogin() {
+    submitSavedLogin(expiresAt?: number) {
       providerChooserVisible = false;
       characterSelectionUntil = 0;
-      return scheduleAutomaticEnter();
+      return scheduleAutomaticEnter(CHARACTER_ENTER_DELAY_MS, expiresAt);
     },
     playSelectedCharacter() {
       return activatePreGameControl('character-select');

--- a/src/renderer/loading.ts
+++ b/src/renderer/loading.ts
@@ -235,7 +235,9 @@ window.gwLoading = (function (): LoadingController {
       // at which point this document can safely load it. An active client
       // instead asks main to relaunch and reports `starting`; reloading here
       // would unload the renderer while quit cleanup is still syncing IDBFS.
-      if (progress.phase === 'ready') window.location.reload();
+      if (progress.phase === 'ready') {
+        await window.gwNative.app.reloadGame('crash-retry');
+      }
     } catch {
       if (requestedRecovery === 'filesystem') {
         api.failFilesystem();
@@ -292,10 +294,12 @@ window.gwLoading = (function (): LoadingController {
       { describeLaunchFailure, describeNotice, failureDetail },
       { DownloadDetailLine },
       { launchGateDecision },
+      { launchProgressForSession },
     ] = await Promise.all([
       import('./failure-messages.js'),
       import('./progress-display.js'),
       import('./update-action.js'),
+      import('./client-launch-readiness.js'),
     ]);
 
     return new Promise<boolean>((resolve) => {
@@ -367,6 +371,7 @@ window.gwLoading = (function (): LoadingController {
       };
 
       const apply = (p: DownloadProgress) => {
+        if (settled) return;
         if (p.phase === 'error') {
           api.fail(describeLaunchFailure(p.errorCode), failureDetail(p.errorCode));
           finish(false);
@@ -398,7 +403,15 @@ window.gwLoading = (function (): LoadingController {
       };
 
       const unsub = window.gwNative.progress.onChange(apply);
-      void window.gwNative.progress.current().then(apply);
+      void Promise.all([
+        window.gwNative.progress.current(),
+        window.gwNative.client.session(),
+      ]).then(([progress, session]) => {
+        apply(launchProgressForSession(progress, session));
+      }).catch(() => {
+        // Live progress remains subscribed. A later ready or error event still
+        // settles the launcher if either snapshot read failed during reload.
+      });
     });
   }
 

--- a/src/renderer/memory-warning.ts
+++ b/src/renderer/memory-warning.ts
@@ -42,6 +42,7 @@ export function bindMemoryWarning(
     || !reloadButton || !laterButton || !autoRelog
   ) return null;
   let savedAutoRelog = actions.autoRelogAfterReload;
+  let pendingPreferenceSave = Promise.resolve();
   autoRelog.checked = savedAutoRelog;
 
   let currentLevel: MemoryWarningLevel | null = null;
@@ -69,23 +70,24 @@ export function bindMemoryWarning(
 
   autoRelog.addEventListener("change", () => {
     const selected = autoRelog.checked;
-    void actions.saveAutoRelog(selected).then(() => {
+    pendingPreferenceSave = actions.saveAutoRelog(selected).then(() => {
       savedAutoRelog = selected;
     }).catch(() => {
       if (autoRelog.checked === selected) autoRelog.checked = savedAutoRelog;
+      throw new Error("automatic return preference could not be saved");
     });
+    void pendingPreferenceSave.catch(() => undefined);
   });
 
   reloadButton.addEventListener("click", () => {
     root.hidden = true;
     dismissable?.setOpen(false);
     (reloadButton as HTMLButtonElement).disabled = true;
-    void actions.saveAutoRelog(autoRelog.checked)
-      .then(() => actions.reload())
+    void pendingPreferenceSave.then(() => actions.reload())
       .catch(() => {
-      (reloadButton as HTMLButtonElement).disabled = false;
-      root.hidden = false;
-      dismissable?.setOpen(true);
+        (reloadButton as HTMLButtonElement).disabled = false;
+        root.hidden = false;
+        dismissable?.setOpen(true);
       });
   });
   laterButton.addEventListener("click", dismiss);

--- a/src/renderer/memory-warning.ts
+++ b/src/renderer/memory-warning.ts
@@ -8,13 +8,20 @@ export type MemoryWarningLevel = "low" | "critical";
 
 export interface MemoryWarningPresenter {
   present(level: MemoryWarningLevel, capBytes: number): void;
+  setAutoRelog(enabled: boolean): void;
   hide(): void;
 }
+
+export type MemoryWarningActions = Readonly<{
+  autoRelogAfterReload: boolean;
+  saveAutoRelog(enabled: boolean): Promise<void>;
+  reload(): void | Promise<void>;
+}>;
 
 /** One non-modal warning surface. The estimator owns urgency; this owns DOM. */
 export function bindMemoryWarning(
   document: Document,
-  reload: () => void,
+  actions: MemoryWarningActions,
   surfaces: GwonmacSurfaceController | null = null,
 ): MemoryWarningPresenter | null {
   const root = document.getElementById("memory-notice");
@@ -27,10 +34,15 @@ export function bindMemoryWarning(
     | null;
   const reloadButton = document.getElementById("memory-notice-reload");
   const laterButton = document.getElementById("memory-notice-later");
+  const autoRelog = document.getElementById("memory-notice-auto-relog") as
+    | HTMLInputElement
+    | null;
   if (
     !root || !live || !label || !detail || !explanation || !details
-    || !reloadButton || !laterButton
+    || !reloadButton || !laterButton || !autoRelog
   ) return null;
+  let savedAutoRelog = actions.autoRelogAfterReload;
+  autoRelog.checked = savedAutoRelog;
 
   let currentLevel: MemoryWarningLevel | null = null;
   let dismissedLevel: MemoryWarningLevel | null = null;
@@ -55,10 +67,26 @@ export function bindMemoryWarning(
     root.addEventListener(name, (event) => event.stopPropagation());
   }
 
+  autoRelog.addEventListener("change", () => {
+    const selected = autoRelog.checked;
+    void actions.saveAutoRelog(selected).then(() => {
+      savedAutoRelog = selected;
+    }).catch(() => {
+      if (autoRelog.checked === selected) autoRelog.checked = savedAutoRelog;
+    });
+  });
+
   reloadButton.addEventListener("click", () => {
     root.hidden = true;
     dismissable?.setOpen(false);
-    reload();
+    (reloadButton as HTMLButtonElement).disabled = true;
+    void actions.saveAutoRelog(autoRelog.checked)
+      .then(() => actions.reload())
+      .catch(() => {
+      (reloadButton as HTMLButtonElement).disabled = false;
+      root.hidden = false;
+      dismissable?.setOpen(true);
+      });
   });
   laterButton.addEventListener("click", dismiss);
 
@@ -77,6 +105,10 @@ export function bindMemoryWarning(
       live.setAttribute("aria-live", level === "critical" ? "assertive" : "polite");
       root.hidden = false;
       dismissable?.setOpen(true);
+    },
+    setAutoRelog(enabled) {
+      savedAutoRelog = enabled;
+      autoRelog.checked = enabled;
     },
     hide() {
       root.hidden = true;

--- a/src/renderer/relog-progression.ts
+++ b/src/renderer/relog-progression.ts
@@ -16,19 +16,3 @@ export function relogOutcomeForPlayable(
   if (playable === null) return null;
   return playable === "explorable" ? "restored" : "outpost";
 }
-
-export function observeRelogPlayableTransition(
-  observedNonPlayable: boolean,
-  playable: "outpost" | "explorable" | null,
-): Readonly<{
-  observedNonPlayable: boolean;
-  outcome: "outpost" | "restored" | null;
-}> {
-  if (playable === null) {
-    return { observedNonPlayable: true, outcome: null };
-  }
-  return {
-    observedNonPlayable,
-    outcome: observedNonPlayable ? relogOutcomeForPlayable(playable) : null,
-  };
-}

--- a/src/renderer/relog-progression.ts
+++ b/src/renderer/relog-progression.ts
@@ -1,0 +1,34 @@
+/**
+ * Closed predicates for the observed Guild Wars relog progression.
+ * They keep stale playable publications from completing a new reload.
+ */
+export function isRelogCharacterEntryState(state: PreGameState): boolean {
+  return state === "character-select" || state === "reconnect";
+}
+
+export function isRelogPostCharacterState(state: PreGameState): boolean {
+  return state === "reconnect" || state === "loading";
+}
+
+export function relogOutcomeForPlayable(
+  playable: "outpost" | "explorable" | null,
+): "outpost" | "restored" | null {
+  if (playable === null) return null;
+  return playable === "explorable" ? "restored" : "outpost";
+}
+
+export function observeRelogPlayableTransition(
+  observedNonPlayable: boolean,
+  playable: "outpost" | "explorable" | null,
+): Readonly<{
+  observedNonPlayable: boolean;
+  outcome: "outpost" | "restored" | null;
+}> {
+  if (playable === null) {
+    return { observedNonPlayable: true, outcome: null };
+  }
+  return {
+    observedNonPlayable,
+    outcome: observedNonPlayable ? relogOutcomeForPlayable(playable) : null,
+  };
+}

--- a/src/renderer/settings.ts
+++ b/src/renderer/settings.ts
@@ -37,6 +37,9 @@
   const extendedMemoryEnabled = form.elements.namedItem(
     'extendedMemoryEnabled',
   ) as HTMLInputElement;
+  const autoRelogAfterReload = form.elements.namedItem(
+    'autoRelogAfterReload',
+  ) as HTMLInputElement;
   const diagnosticProfile = form.elements.namedItem(
     'diagnosticProfile',
   ) as HTMLSelectElement;
@@ -502,6 +505,10 @@
         return control instanceof globalThis.HTMLInputElement
           ? { extendedMemoryEnabled: control.checked }
           : null;
+      case 'autoRelogAfterReload':
+        return control instanceof globalThis.HTMLInputElement
+          ? { autoRelogAfterReload: control.checked }
+          : null;
       case 'gwonmacTools':
       case 'teamManagement':
       case 'xunlaiStorage':
@@ -544,6 +551,7 @@
     showAppearanceValues(settings);
     showDiagnostics.checked = settings.showDiagnostics;
     extendedMemoryEnabled.checked = settings.extendedMemoryEnabled;
+    autoRelogAfterReload.checked = settings.autoRelogAfterReload;
     diagnosticProfile.value = selectedDiagnosticProfile;
     gwonmacTools.checked = settings.gwonmacTools;
     teamManagement.checked = settings.teamManagement;

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -406,6 +406,8 @@ export interface AppSettings {
   skillCooldownColor: SkillCooldownColor;
   /** Request the certified 4 GB client module on the next Guild Wars launch. */
   extendedMemoryEnabled: boolean;
+  /** Return toward the current character after an explicit game reload. */
+  autoRelogAfterReload: boolean;
   showDiagnostics: boolean;
   /**
    * Rollback-only storage field. Runtime behavior is always `full`; keeping
@@ -482,6 +484,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   skillCooldownOverlayEnabled: true,
   skillCooldownColor: DEFAULT_SKILL_COOLDOWN_COLOR,
   extendedMemoryEnabled: false,
+  autoRelogAfterReload: false,
   showDiagnostics: false,
   dataStrategy: "full",
   autoCheckUpdates: true,
@@ -659,6 +662,7 @@ export interface ClientCompatibility {
     skillSlotGeometry: OptionalFeatureStatus;
     skillCooldownObservation: OptionalFeatureStatus;
     playRegionObservation: OptionalFeatureStatus;
+    preGameControls: OptionalFeatureStatus;
   }>;
 }
 
@@ -945,6 +949,8 @@ export const IPC = {
   appOpenExternal: "gw:app:openExternal",
   appRevealPath: "gw:app:revealPath",
   appRequestQuit: "gw:app:requestQuit",
+  appReloadGame: "gw:app:reloadGame",
+  appClaimRelogIntent: "gw:app:claimRelogIntent",
   clipboardWriteText: "gw:clipboard:writeText",
   clipboardReadText: "gw:clipboard:readText",
   clipboardEdit: "gw:clipboard:edit",
@@ -1011,6 +1017,14 @@ export type GameTextEditRequest =
   | { command: "selectAll" };
 
 export type GameTextEditCommand = GameTextEditRequest["command"];
+
+export const GAME_RELOAD_CAUSES = [
+  "memory-warning",
+  "menu",
+  "crash-retry",
+  "command-q",
+] as const;
+export type GameReloadCause = (typeof GAME_RELOAD_CAUSES)[number];
 
 // Far above any text a game field holds, low enough that a renderer gone
 // wrong cannot stuff megabytes into the OS pasteboard.
@@ -1155,6 +1169,8 @@ export interface GwNativeApi {
     /** Reveal a named app directory in Finder. */
     reveal(kind: RevealKind): Promise<void>;
     requestQuit(): Promise<void>;
+    reloadGame(cause: GameReloadCause): Promise<void>;
+    claimRelogIntent(): Promise<boolean>;
   };
   clipboard: {
     /**

--- a/src/shared/diagnostics.ts
+++ b/src/shared/diagnostics.ts
@@ -199,7 +199,6 @@ export const RENDERER_MILESTONES = [
   "relog.preGameProbe",
   "relog.inputSettled",
   "relog.finished",
-  "relog.timedOut",
   "wasm.instantiate.begin",
   "wasm.instantiate.end",
   "wasm.streamingFallback",
@@ -239,9 +238,7 @@ export type RelogInputOutcome = (typeof RELOG_INPUT_OUTCOMES)[number];
 export const RELOG_TERMINAL_OUTCOMES = [
   "restored",
   "outpost",
-  "manual",
   "timed-out",
-  "unsupported",
 ] as const;
 export type RelogTerminalOutcome = (typeof RELOG_TERMINAL_OUTCOMES)[number];
 

--- a/src/shared/diagnostics.ts
+++ b/src/shared/diagnostics.ts
@@ -190,6 +190,16 @@ export interface RendererFrameBatch {
 
 export const RENDERER_MILESTONES = [
   "renderer.loaded",
+  "relog.intentClaimed",
+  "relog.savedCredentialsLoaded",
+  "relog.loginSubmitted",
+  "relog.tokenRequested",
+  "relog.tokenAccepted",
+  "relog.characterSubmitted",
+  "relog.preGameProbe",
+  "relog.inputSettled",
+  "relog.finished",
+  "relog.timedOut",
   "wasm.instantiate.begin",
   "wasm.instantiate.end",
   "wasm.streamingFallback",
@@ -213,6 +223,27 @@ export const RENDERER_MILESTONES = [
 ] as const;
 
 export type RendererMilestone = (typeof RENDERER_MILESTONES)[number];
+
+export const RELOG_INPUT_STAGES = ["login", "character", "reconnect"] as const;
+export type RelogInputStage = (typeof RELOG_INPUT_STAGES)[number];
+
+export const RELOG_INPUT_OUTCOMES = [
+  "sent",
+  "physical",
+  "progressed",
+  "unfocused",
+  "cancelled",
+] as const;
+export type RelogInputOutcome = (typeof RELOG_INPUT_OUTCOMES)[number];
+
+export const RELOG_TERMINAL_OUTCOMES = [
+  "restored",
+  "outpost",
+  "manual",
+  "timed-out",
+  "unsupported",
+] as const;
+export type RelogTerminalOutcome = (typeof RELOG_TERMINAL_OUTCOMES)[number];
 
 /**
  * The closed vocabulary a WASM abort collapses into before crossing IPC. The
@@ -277,6 +308,15 @@ export type GraphicsVisualProblemFields = TextureMemorySnapshot & {
 };
 
 export interface RendererMilestoneFieldsByName {
+  "relog.preGameProbe": {
+    state: "unknown" | "character-select" | "reconnect" | "loading";
+    mask: number;
+  };
+  "relog.inputSettled": {
+    stage: RelogInputStage;
+    outcome: RelogInputOutcome;
+  };
+  "relog.finished": { outcome: RelogTerminalOutcome };
   "build.info": { programId: string | number; buildId: string | number };
   /**
    * `heapBytes` is the WASM linear-memory size at the moment of death. The

--- a/src/shared/enhancement-contracts.ts
+++ b/src/shared/enhancement-contracts.ts
@@ -108,13 +108,13 @@ const CAPABILITY_DEFINITIONS = Object.freeze([
     hooks: [],
   },
   {
-    // Core reload automation observes only four exact native frames and
+    // Core reload automation observes only five exact native frames and
     // publishes a closed pre-game state. It deliberately has no generic UI
     // hook or frame command surface.
     id: "preGameControls",
     requiresAll: ["playRegionObservation"],
     requiresAny: [],
-    configOwners: ["skill-slots"],
+    configOwners: [],
     hooks: [],
   },
 ] as const);
@@ -263,7 +263,9 @@ export function enhancementCapabilityProfile(
 
 /** Named product/developer choices. Certificates and caches use only bit identities. */
 export const ENHANCEMENT_CAPABILITY_PRESETS = Object.freeze({
-  cursor: capabilitiesFromMask(0x601),
+  cursor: capabilitiesFromMask(0x001),
+  core: capabilitiesFromMask(0x601),
+  reconnect: capabilitiesFromMask(0x601),
   region: capabilitiesFromMask(0x200),
   target: capabilitiesFromMask(0x202),
   party: capabilitiesFromMask(0x284),
@@ -278,7 +280,7 @@ export {
   ENHANCEMENT_LAYOUT_WORD_COUNT,
   ENHANCEMENT_PARTY_DIRTY_MESSAGE_COUNT,
 } from "./enhancement-config.js";
-export const ENHANCEMENT_TRANSFORM_ABI = 44;
+export const ENHANCEMENT_TRANSFORM_ABI = 45;
 
 export function enhancementConfigWordActive(
   capabilities: EnhancementCapabilities,
@@ -307,7 +309,7 @@ export function enhancementCapabilitiesFor(
       return selection.tools
         ? ENHANCEMENT_CAPABILITY_PRESETS.all
         : selection.nativeCursor
-          ? ENHANCEMENT_CAPABILITY_PRESETS.cursor
+          ? ENHANCEMENT_CAPABILITY_PRESETS.core
           : NO_ENHANCEMENT_CAPABILITIES;
     case "cursor-observer": return ENHANCEMENT_CAPABILITY_PRESETS.cursor;
     case "target-observer": return ENHANCEMENT_CAPABILITY_PRESETS.target;
@@ -316,7 +318,7 @@ export function enhancementCapabilitiesFor(
     case "xunlai-storage": return ENHANCEMENT_CAPABILITY_PRESETS.storage;
     // The reload probe needs the same bounded pre-game and play-region readers
     // that required Core installs in production.
-    case "reconnect-probe": return ENHANCEMENT_CAPABILITY_PRESETS.cursor;
+    case "reconnect-probe": return ENHANCEMENT_CAPABILITY_PRESETS.reconnect;
   }
 }
 

--- a/src/shared/enhancement-contracts.ts
+++ b/src/shared/enhancement-contracts.ts
@@ -21,6 +21,7 @@ export const ENHANCEMENT_PROGRAMS = [
   "toolbox-foundation",
   "toolbox-commands",
   "xunlai-storage",
+  "reconnect-probe",
 ] as const;
 
 export type EnhancementProgram = (typeof ENHANCEMENT_PROGRAMS)[number];
@@ -104,6 +105,16 @@ const CAPABILITY_DEFINITIONS = Object.freeze([
     requiresAll: [],
     requiresAny: [],
     configOwners: ["play-region"],
+    hooks: [],
+  },
+  {
+    // Core reload automation observes only four exact native frames and
+    // publishes a closed pre-game state. It deliberately has no generic UI
+    // hook or frame command surface.
+    id: "preGameControls",
+    requiresAll: ["playRegionObservation"],
+    requiresAny: [],
+    configOwners: ["skill-slots"],
     hooks: [],
   },
 ] as const);
@@ -193,6 +204,7 @@ export const NO_ENHANCEMENT_CAPABILITIES: EnhancementCapabilities = Object.freez
   skillSlotGeometry: false,
   skillCooldownObservation: false,
   playRegionObservation: false,
+  preGameControls: false,
 });
 
 function isExactBooleanRecord<Key extends string>(
@@ -227,6 +239,7 @@ export function parseEnhancementCapabilities(
     skillSlotGeometry: value.skillSlotGeometry,
     skillCooldownObservation: value.skillCooldownObservation,
     playRegionObservation: value.playRegionObservation,
+    preGameControls: value.preGameControls,
   });
 }
 
@@ -250,14 +263,14 @@ export function enhancementCapabilityProfile(
 
 /** Named product/developer choices. Certificates and caches use only bit identities. */
 export const ENHANCEMENT_CAPABILITY_PRESETS = Object.freeze({
-  cursor: capabilitiesFromMask(0x01),
+  cursor: capabilitiesFromMask(0x601),
   region: capabilitiesFromMask(0x200),
   target: capabilitiesFromMask(0x202),
   party: capabilitiesFromMask(0x284),
   cursorParty: capabilitiesFromMask(0x285),
   storage: capabilitiesFromMask(0x270),
   partyCommandsStorage: capabilitiesFromMask(0x2fc),
-  all: capabilitiesFromMask(0x3ff),
+  all: capabilitiesFromMask(0x7ff),
 });
 
 export {
@@ -265,7 +278,7 @@ export {
   ENHANCEMENT_LAYOUT_WORD_COUNT,
   ENHANCEMENT_PARTY_DIRTY_MESSAGE_COUNT,
 } from "./enhancement-config.js";
-export const ENHANCEMENT_TRANSFORM_ABI = 42;
+export const ENHANCEMENT_TRANSFORM_ABI = 44;
 
 export function enhancementConfigWordActive(
   capabilities: EnhancementCapabilities,
@@ -301,6 +314,9 @@ export function enhancementCapabilitiesFor(
     case "toolbox-foundation": return ENHANCEMENT_CAPABILITY_PRESETS.party;
     case "toolbox-commands": return ENHANCEMENT_CAPABILITY_PRESETS.partyCommandsStorage;
     case "xunlai-storage": return ENHANCEMENT_CAPABILITY_PRESETS.storage;
+    // The reload probe needs the same bounded pre-game and play-region readers
+    // that required Core installs in production.
+    case "reconnect-probe": return ENHANCEMENT_CAPABILITY_PRESETS.cursor;
   }
 }
 

--- a/tests/client-artifact/template-save-recert.test.ts
+++ b/tests/client-artifact/template-save-recert.test.ts
@@ -176,6 +176,7 @@ test("the template-save verifier makes a fail-closed decision for a real client"
     skillSlotGeometry: true,
     skillCooldownObservation: true,
     playRegionObservation: true,
+    preGameControls: true,
   });
 
   // If this is a statically shipped build, the shape locator must still
@@ -285,6 +286,7 @@ test("the template-save verifier makes a fail-closed decision for a real client"
     skillSlotGeometry: true,
     skillCooldownObservation: false,
     playRegionObservation: true,
+    preGameControls: true,
   });
   assert.deepEqual(addressDecision.reasons, []);
   const addressTemplateBuild = addressDecision.templateSaveBuild;
@@ -304,6 +306,7 @@ test("the template-save verifier makes a fail-closed decision for a real client"
     skillSlotGeometry: true,
     skillCooldownObservation: false,
     playRegionObservation: true,
+    preGameControls: true,
   });
 
   const targetMutations = [
@@ -947,6 +950,19 @@ test("every certified runtime profile reproduces the real client chain", async (
   const template = rewriteTemplateSaveWasm(official, templateBuild);
   const enhancementBuild = verified.enhancementBuild;
   assert.ok(enhancementBuild, "the template output must pass Enhancement proof");
+  const authoredBuild = ENHANCEMENT_BUILDS.find(
+    (candidate) => candidate.sha256 === enhancementBuild.sha256,
+  );
+  assert.ok(authoredBuild, "the exact client must retain its authored build row");
+  for (const profile of enhancementProfilesForBuild(authoredBuild)) {
+    const capabilities = enhancementCapabilitiesForProfile(profile);
+    assert.ok(capabilities, `authored profile ${profile} must be valid`);
+    assert.equal(
+      sha256(transformEnhancementWasm(template, enhancementBuild, capabilities)),
+      enhancementOutputSha256(authoredBuild, capabilities),
+      `authored profile ${profile} must match the current transform ABI`,
+    );
+  }
 
   // The off profile and every optional capability profile feed the same two
   // downstream exact-hash transforms. Reproducing the complete chain here is

--- a/tests/client-artifact/template-save-recert.test.ts
+++ b/tests/client-artifact/template-save-recert.test.ts
@@ -286,7 +286,7 @@ test("the template-save verifier makes a fail-closed decision for a real client"
     skillSlotGeometry: true,
     skillCooldownObservation: false,
     playRegionObservation: true,
-    preGameControls: true,
+    preGameControls: false,
   });
   assert.deepEqual(addressDecision.reasons, []);
   const addressTemplateBuild = addressDecision.templateSaveBuild;
@@ -306,7 +306,7 @@ test("the template-save verifier makes a fail-closed decision for a real client"
     skillSlotGeometry: true,
     skillCooldownObservation: false,
     playRegionObservation: true,
-    preGameControls: true,
+    preGameControls: false,
   });
 
   const targetMutations = [

--- a/tests/electron/client-compatibility.spec.ts
+++ b/tests/electron/client-compatibility.spec.ts
@@ -226,6 +226,7 @@ test.describe("client compatibility", () => {
               gameFileSaving: { status: "unavailable", reason: "game-update" },
               nativeCursor: { status: "unavailable", reason: "game-update" },
               playRegionObservation: { status: "off" },
+        preGameControls: { status: "off" },
               targetObservation: { status: "off" },
               partyObservation: { status: "off" },
               teamApply: { status: "off" },

--- a/tests/electron/input-keyboard.spec.ts
+++ b/tests/electron/input-keyboard.spec.ts
@@ -208,6 +208,168 @@ test.describe("renderer keyboard input", () => {
     }
   });
 
+  test("submits login after its measured delay and certified pre-game input immediately", async () => {
+    const fixture = await launchCachedClient("gw-character-relog-e2e-");
+    try {
+      const { page } = fixture;
+      await startGameInput(page);
+      await page.evaluate(async () => {
+        const moduleUrl: string = "gw://app/input.js";
+        const { installGameInput } = await import(moduleUrl) as
+          typeof import("../../src/renderer/input.js");
+        const canvas = document.createElement("canvas");
+        canvas.tabIndex = 0;
+        document.body.append(canvas);
+        const events: Array<{ trusted: boolean; type: string; afterMs: number }> = [];
+        const started = performance.now();
+        for (const type of ["keydown", "keyup"] as const) {
+          canvas.addEventListener(type, (event) => {
+            if (event.key === "Enter") {
+              events.push({
+                trusted: event.isTrusted,
+                type,
+                afterMs: performance.now() - started,
+              });
+            }
+          });
+        }
+        const input = installGameInput({ canvas, log: () => undefined });
+        canvas.focus();
+        input.submitSavedLogin();
+        Object.assign(window, {
+          __relogInput: input,
+          __relogCanvas: canvas,
+          __relogEvents: events,
+        });
+      });
+
+      await page.waitForTimeout(80);
+      expect(await page.evaluate(() =>
+        (window as typeof window & { __relogEvents?: unknown[] }).__relogEvents,
+      )).toEqual([]);
+      await expect.poll(() => page.evaluate(() =>
+        (window as typeof window & { __relogEvents?: unknown[] }).__relogEvents,
+      )).toHaveLength(2);
+      const automatic = await page.evaluate(() =>
+        (window as typeof window & {
+          __relogEvents?: Array<{ trusted: boolean; type: string; afterMs: number }>;
+        }).__relogEvents ?? [],
+      );
+      expect(automatic.map(({ trusted, type }) => ({ trusted, type }))).toEqual([
+        { trusted: false, type: "keydown" },
+        { trusted: false, type: "keyup" },
+      ]);
+      expect(automatic[0]?.afterMs).toBeGreaterThanOrEqual(140);
+
+      const activation = await page.evaluate(async () => {
+        const testWindow = window as typeof window & {
+          __relogInput?: GameInputController;
+          __relogCanvas?: HTMLCanvasElement;
+          __relogEvents?: unknown[];
+        };
+        testWindow.__relogEvents?.splice(0);
+        testWindow.__relogCanvas?.focus();
+        window.gwPreGameControls = { state: () => 'character-select', playable: () => null, diagnosticMask: () => 0 };
+        const started = performance.now();
+        const outcome = await testWindow.__relogInput
+          ?.playSelectedCharacter();
+        return { outcome, elapsedMs: performance.now() - started };
+      });
+      const restoration = await page.evaluate(() =>
+        (window as typeof window & {
+          __relogEvents?: Array<{ trusted: boolean; type: string; afterMs: number }>;
+        }).__relogEvents ?? [],
+      );
+      expect(restoration.map(({ trusted, type }) => ({ trusted, type }))).toEqual([
+        { trusted: false, type: "keydown" },
+        { trusted: false, type: "keyup" },
+      ]);
+      expect(activation.outcome).toBe('sent');
+      expect(activation.elapsedMs).toBeLessThan(20);
+
+      expect(await page.evaluate(async () => {
+        const testWindow = window as typeof window & {
+          __relogInput?: GameInputController;
+          __relogEvents?: unknown[];
+        };
+        testWindow.__relogEvents?.splice(0);
+        window.gwPreGameControls = { state: () => 'unknown', playable: () => null, diagnosticMask: () => 0 };
+        const outcome = await testWindow.__relogInput
+          ?.playSelectedCharacter();
+        return { outcome, events: testWindow.__relogEvents };
+      })).toEqual({ outcome: 'cancelled', events: [] });
+
+      expect(await page.evaluate(async () => {
+        const testWindow = window as typeof window & {
+          __relogInput?: GameInputController;
+          __relogEvents?: unknown[];
+        };
+        testWindow.__relogEvents?.splice(0);
+        window.gwPreGameControls = { state: () => 'reconnect', playable: () => null, diagnosticMask: () => 0 };
+        const outcome = await testWindow.__relogInput?.acceptReconnect();
+        return { outcome, events: testWindow.__relogEvents };
+      })).toEqual({
+        outcome: 'sent',
+        events: [
+          expect.objectContaining({ trusted: false, type: 'keydown' }),
+          expect.objectContaining({ trusted: false, type: 'keyup' }),
+        ],
+      });
+
+      expect(await page.evaluate(async () => {
+        const testWindow = window as typeof window & {
+          __relogInput?: GameInputController;
+          __relogEvents?: unknown[];
+        };
+        testWindow.__relogEvents?.splice(0);
+        window.gwPreGameControls = { state: () => 'loading', playable: () => null, diagnosticMask: () => 0 };
+        const outcome = await testWindow.__relogInput?.acceptReconnect();
+        return { outcome, events: testWindow.__relogEvents };
+      })).toEqual({ outcome: 'progressed', events: [] });
+
+      await page.evaluate(() => {
+        const testWindow = window as typeof window & {
+          __relogInput?: GameInputController;
+          __relogCanvas?: HTMLCanvasElement;
+          __relogEvents?: unknown[];
+        };
+        testWindow.__relogEvents?.splice(0);
+        testWindow.__relogCanvas?.focus();
+        testWindow.__relogInput?.submitSavedLogin();
+      });
+      await page.keyboard.press("Enter");
+      await page.waitForTimeout(260);
+      expect(await page.evaluate(() =>
+        (window as typeof window & {
+          __relogEvents?: Array<{ trusted: boolean; type: string }>;
+        }).__relogEvents?.map(({ trusted, type }) => ({ trusted, type })),
+      )).toEqual([
+        { trusted: true, type: "keydown" },
+        { trusted: true, type: "keyup" },
+      ]);
+
+      await page.evaluate(() => {
+        const testWindow = window as typeof window & {
+          __relogInput?: GameInputController;
+          __relogCanvas?: HTMLCanvasElement;
+          __relogEvents?: unknown[];
+        };
+        testWindow.__relogEvents?.splice(0);
+        testWindow.__relogCanvas?.focus();
+        testWindow.__relogInput?.expectCharacterSelection();
+      });
+      await page.keyboard.press("Enter");
+      await page.waitForTimeout(420);
+      expect(await page.evaluate(() =>
+        (window as typeof window & {
+          __relogEvents?: Array<{ trusted: boolean; type: string }>;
+        }).__relogEvents?.filter(({ trusted }) => !trusted),
+      )).toHaveLength(2);
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
   test("uses physical main-block keys without changing typed text", async () => {
     const fixture = await launchCachedClient("gw-physical-key-e2e-");
     try {

--- a/tests/electron/input-keyboard.spec.ts
+++ b/tests/electron/input-keyboard.spec.ts
@@ -219,26 +219,34 @@ test.describe("renderer keyboard input", () => {
           typeof import("../../src/renderer/input.js");
         const canvas = document.createElement("canvas");
         canvas.tabIndex = 0;
-        document.body.append(canvas);
+        const loginField = document.createElement("input");
+        document.body.append(canvas, loginField);
         const events: Array<{ trusted: boolean; type: string; afterMs: number }> = [];
         const started = performance.now();
         for (const type of ["keydown", "keyup"] as const) {
-          canvas.addEventListener(type, (event) => {
-            if (event.key === "Enter") {
-              events.push({
-                trusted: event.isTrusted,
-                type,
-                afterMs: performance.now() - started,
-              });
-            }
-          });
+          for (const target of [canvas, loginField]) {
+            target.addEventListener(type, (event) => {
+              if (event instanceof KeyboardEvent && event.key === "Enter") {
+                events.push({
+                  trusted: event.isTrusted,
+                  type,
+                  afterMs: performance.now() - started,
+                });
+              }
+            });
+          }
         }
-        const input = installGameInput({ canvas, log: () => undefined });
+        const input = installGameInput({
+          canvas,
+          textInputs: new Set([loginField]),
+          log: () => undefined,
+        });
         canvas.focus();
         input.submitSavedLogin();
         Object.assign(window, {
           __relogInput: input,
           __relogCanvas: canvas,
+          __relogInputField: loginField,
           __relogEvents: events,
         });
       });
@@ -265,6 +273,7 @@ test.describe("renderer keyboard input", () => {
         const testWindow = window as typeof window & {
           __relogInput?: GameInputController;
           __relogCanvas?: HTMLCanvasElement;
+          __relogInputField?: HTMLInputElement;
           __relogEvents?: unknown[];
         };
         testWindow.__relogEvents?.splice(0);
@@ -331,10 +340,11 @@ test.describe("renderer keyboard input", () => {
         const testWindow = window as typeof window & {
           __relogInput?: GameInputController;
           __relogCanvas?: HTMLCanvasElement;
+          __relogInputField?: HTMLInputElement;
           __relogEvents?: unknown[];
         };
         testWindow.__relogEvents?.splice(0);
-        testWindow.__relogCanvas?.focus();
+        testWindow.__relogInputField?.focus();
         testWindow.__relogInput?.submitSavedLogin();
       });
       await page.keyboard.press("Enter");

--- a/tests/electron/multiple-accounts.spec.ts
+++ b/tests/electron/multiple-accounts.spec.ts
@@ -475,7 +475,7 @@ test("renderer recovery stays with its account and a second crash needs attentio
   }
 });
 
-test("Multi starts at the Hub and isolates two profile windows from Single", async () => {
+test("Multi isolates profile windows and Copy Reload Trace", async () => {
   test.setTimeout(60_000);
   const fixture = await launchOffline("gw-multi-e2e-", {
     GW_BACKGROUND_LAUNCH: "0",
@@ -637,10 +637,26 @@ test("Multi starts at the Hub and isolates two profile windows from Single", asy
       credentials?.username === "first@example.test")?.game;
     if (!altGame || !nonTargetGame) throw new Error("profile pages not found");
 
+    await Promise.all([altGame, nonTargetGame].map((game) => game.evaluate(() => {
+      (window as typeof window & { __memoryReloadProof?: boolean })
+        .__memoryReloadProof = true;
+    })));
     await altGame.evaluate(async () => {
       const moduleUrl: string = "gw://app/memory-warning.js";
       const { bindMemoryWarning } = await import(moduleUrl) as MemoryWarningModule;
-      const presenter = bindMemoryWarning(document, () => undefined, window.gwSurfaces);
+      const presenter = bindMemoryWarning(
+        document,
+        {
+          autoRelogAfterReload: false,
+          async saveAutoRelog(autoRelogAfterReload) {
+            await window.gwNative.settings.set({ autoRelogAfterReload });
+          },
+          async reload() {
+            await window.gwNative.app.reloadGame("memory-warning");
+          },
+        },
+        window.gwSurfaces,
+      );
       if (!presenter) throw new Error("memory warning is unavailable");
       presenter.present("critical", 2_147_483_648);
     });
@@ -648,9 +664,22 @@ test("Multi starts at the Hub and isolates two profile windows from Single", asy
     await expect(altGame.locator("#memory-notice-label"))
       .toHaveText("Guild Wars is almost out of memory.");
     await expect(nonTargetGame.locator("#memory-notice")).toBeHidden();
-    await altGame.locator("#memory-notice-later").evaluate((button) => {
+    const memoryReloaded = altGame.waitForEvent("framenavigated", {
+      predicate: (frame) => frame === altGame.mainFrame(),
+    });
+    await altGame.locator("#memory-notice-reload").evaluate((button) => {
       (button as HTMLButtonElement).click();
     });
+    await memoryReloaded;
+    await altGame.waitForLoadState("domcontentloaded");
+    expect(await altGame.evaluate(() =>
+      (window as typeof window & { __memoryReloadProof?: boolean })
+        .__memoryReloadProof,
+    )).toBeUndefined();
+    expect(await nonTargetGame.evaluate(() =>
+      (window as typeof window & { __memoryReloadProof?: boolean })
+        .__memoryReloadProof,
+    )).toBe(true);
     await expect(altGame.locator("#memory-notice")).toBeHidden();
     await expect(nonTargetGame.locator("#memory-notice")).toBeHidden();
 
@@ -684,6 +713,31 @@ test("Multi starts at the Hub and isolates two profile windows from Single", asy
       if (!item?.click) throw new Error(`${request.id} menu item is unavailable`);
       item.click(item, win, {} as Electron.KeyboardEvent);
     }, { title, id });
+
+    await fixture.app.evaluate(({ BrowserWindow, dialog }) => {
+      Object.defineProperty(dialog, "showMessageBox", {
+        configurable: true,
+        value: async (first: unknown, second?: { buttons?: string[] }) => {
+          globalThis.__runtimeDialogParent = first instanceof BrowserWindow
+            ? first.getTitle()
+            : null;
+          return {
+            response: second?.buttons?.length === 2 ? 0 : 2,
+            checkboxChecked: true,
+          };
+        },
+      });
+      globalThis.__runtimeDialogParent = null;
+    });
+    await clickMenuForGame("Guild Wars Reforged — Alt", "quit-or-reload-game");
+    await expect.poll(() => altGame.evaluate(() =>
+      window.gwNative.settings.get().then((settings) => settings.autoRelogAfterReload),
+    )).toBe(true);
+    expect(await nonTargetGame.evaluate(() =>
+      window.gwNative.settings.get().then((settings) => settings.autoRelogAfterReload),
+    )).toBe(true);
+    expect(await fixture.app.evaluate(() => globalThis.__runtimeDialogParent))
+      .toBe("Guild Wars Reforged — Alt");
 
     await Promise.all([
       altGame.evaluate(() => {
@@ -722,11 +776,15 @@ test("Multi starts at the Hub and isolates two profile windows from Single", asy
     await fixture.app.evaluate(({ BrowserWindow, dialog }) => {
       Object.defineProperty(dialog, "showMessageBox", {
         configurable: true,
-        value: async (first: unknown) => {
+        value: async (first: unknown, second?: { buttons?: string[] }) => {
           globalThis.__runtimeDialogParent = first instanceof BrowserWindow
             ? first.getTitle()
             : null;
-          return { response: 1, checkboxChecked: false };
+          const reload = second?.buttons?.[0] === "Reload Guild Wars";
+          return {
+            response: reload ? 0 : 1,
+            checkboxChecked: reload,
+          };
         },
       });
       globalThis.__runtimeDialogParent = null;
@@ -768,6 +826,35 @@ test("Multi starts at the Hub and isolates two profile windows from Single", asy
       (window as typeof window & { __reloadProof?: boolean }).__reloadProof,
     )).toBe(true);
     const reloadedGame = altGame;
+    await Promise.all([
+      reloadedGame.evaluate(() => window.gwNative.diagnostics.recordRendererMilestone(
+        "relog.preGameProbe",
+        performance.now() * 1_000,
+        {
+          state: "reconnect",
+          mask: 42_424,
+        },
+      )),
+      nonTargetGame.evaluate(() => window.gwNative.diagnostics.recordRendererMilestone(
+        "relog.preGameProbe",
+        performance.now() * 1_000,
+        {
+          state: "unknown",
+          mask: 43_434,
+        },
+      )),
+    ]);
+    await clickMenuForGame("Guild Wars Reforged — Alt", "copy-reload-trace");
+    await expect.poll(() => fixture.app.evaluate(({ clipboard }) => clipboard.readText()))
+      .toContain("gameReload.requested cause=menu");
+    const reloadTrace = await fixture.app.evaluate(({ clipboard }) => clipboard.readText());
+    expect(reloadTrace).toContain("relog.intentClaimed");
+    expect(reloadTrace).toContain("relog.preGameProbe state=reconnect");
+    expect(reloadTrace).not.toContain("relog.preGameProbe state=unknown");
+    await fixture.app.evaluate(
+      ({ clipboard }, text) => clipboard.writeText(text),
+      clipboardBeforeFocusedEdit,
+    );
     await reloadedGame.evaluate(() => window.gwNative.accounts.loadTemplates());
     await reloadedGame.evaluate(() => window.gwNative.accounts.saveTemplates([
       {

--- a/tests/electron/profile-close.spec.ts
+++ b/tests/electron/profile-close.spec.ts
@@ -39,6 +39,22 @@ test("keeps an account open until an incomplete save is resolved explicitly", as
       [FIRST, SECOND] as const,
     );
     await expect.poll(() => fixture.app.windows().length).toBe(3);
+    await fixture.app.evaluate(async ({ BrowserWindow }) => {
+      const win = BrowserWindow.getAllWindows().find((candidate) =>
+        candidate.getTitle().endsWith("Primary"));
+      if (!win) throw new Error("Primary window not found");
+      await win.webContents.executeJavaScript(`
+        window.Module ??= {};
+        Object.defineProperty(window.Module, "FS", {
+          configurable: true,
+          get() { throw new Error("'FS' was not exported"); },
+        });
+        Object.assign(globalThis, {
+          FS: { syncfs: (_populate, callback) => callback() },
+        });
+        true;
+      `);
+    });
     await fixture.app.evaluate(({ BrowserWindow, dialog }) => {
       globalThis.__profileCloseDialogs = {
         parents: [],

--- a/tests/electron/settings-tools-updates.spec.ts
+++ b/tests/electron/settings-tools-updates.spec.ts
@@ -647,12 +647,18 @@ test.describe("tools and update settings", () => {
       });
       await page.evaluate(() => {
         window.Module ??= {};
-        window.Module.FS = {
-          syncfs: (_populate, callback) => {
+        Object.defineProperty(window.Module, "FS", {
+          configurable: true,
+          get() {
+            throw new Error("'FS' was not exported");
+          },
+        });
+        Object.assign(globalThis, { FS: {
+          syncfs: (_populate: boolean, callback: (error?: unknown) => void) => {
             document.documentElement.dataset.updateFsSynced = "yes";
             callback();
           },
-        };
+        } });
         globalThis.dispatchEvent(new globalThis.CustomEvent("gw:settings", {
           detail: { pane: "updates" },
         }));

--- a/tests/fixtures/enhancement-transform.ts
+++ b/tests/fixtures/enhancement-transform.ts
@@ -15,6 +15,7 @@ import {
 export const UNSUPPORTED_ALL_CAPABILITIES: EnhancementCapabilities = Object.freeze({
   nativeCursor: true,
   playRegionObservation: true,
+    preGameControls: false,
   targetObservation: true,
   partyObservation: true,
   teamApply: false,
@@ -27,6 +28,7 @@ export const UNSUPPORTED_ALL_CAPABILITIES: EnhancementCapabilities = Object.free
 export const CURSOR_ONLY: EnhancementCapabilities = Object.freeze({
   nativeCursor: true,
   playRegionObservation: false,
+    preGameControls: false,
   targetObservation: false,
   partyObservation: false,
   teamApply: false,
@@ -39,6 +41,7 @@ export const CURSOR_ONLY: EnhancementCapabilities = Object.freeze({
 export const CURSOR_TARGET: EnhancementCapabilities = Object.freeze({
   nativeCursor: true,
   playRegionObservation: true,
+    preGameControls: false,
   targetObservation: true,
   partyObservation: false,
   teamApply: false,
@@ -51,6 +54,7 @@ export const CURSOR_TARGET: EnhancementCapabilities = Object.freeze({
 export const TARGET_ONLY: EnhancementCapabilities = Object.freeze({
   nativeCursor: false,
   playRegionObservation: true,
+    preGameControls: false,
   targetObservation: true,
   partyObservation: false,
   teamApply: false,
@@ -63,6 +67,7 @@ export const TARGET_ONLY: EnhancementCapabilities = Object.freeze({
 export const STORAGE_ONLY: EnhancementCapabilities = Object.freeze({
   nativeCursor: false,
   playRegionObservation: true,
+    preGameControls: false,
   targetObservation: false,
   partyObservation: false,
   teamApply: false,
@@ -75,6 +80,7 @@ export const STORAGE_ONLY: EnhancementCapabilities = Object.freeze({
 export const CURSOR_TOOLBOX: EnhancementCapabilities = Object.freeze({
   nativeCursor: true,
   playRegionObservation: true,
+    preGameControls: false,
   targetObservation: false,
   partyObservation: true,
   teamApply: false,
@@ -87,6 +93,7 @@ export const CURSOR_TOOLBOX: EnhancementCapabilities = Object.freeze({
 export const NO_CAPABILITIES: EnhancementCapabilities = Object.freeze({
   nativeCursor: false,
   playRegionObservation: false,
+    preGameControls: false,
   targetObservation: false,
   partyObservation: false,
   teamApply: false,
@@ -99,6 +106,7 @@ export const NO_CAPABILITIES: EnhancementCapabilities = Object.freeze({
 export const CURSOR_TOOLBOX_COMMANDS: EnhancementCapabilities = Object.freeze({
   nativeCursor: true,
   playRegionObservation: true,
+    preGameControls: false,
   targetObservation: false,
   partyObservation: true,
   teamApply: true,
@@ -111,6 +119,7 @@ export const CURSOR_TOOLBOX_COMMANDS: EnhancementCapabilities = Object.freeze({
 export const CURSOR_TARGET_TOOLBOX_COMMANDS: EnhancementCapabilities = Object.freeze({
   nativeCursor: true,
   playRegionObservation: true,
+    preGameControls: false,
   targetObservation: true,
   partyObservation: true,
   teamApply: true,
@@ -123,6 +132,7 @@ export const CURSOR_TARGET_TOOLBOX_COMMANDS: EnhancementCapabilities = Object.fr
 export const CURSOR_TOOLBOX_STORAGE: EnhancementCapabilities = Object.freeze({
   nativeCursor: true,
   playRegionObservation: true,
+    preGameControls: false,
   targetObservation: false,
   partyObservation: true,
   teamApply: false,

--- a/tests/helpers/packaged-enhancement-fixture.ts
+++ b/tests/helpers/packaged-enhancement-fixture.ts
@@ -128,6 +128,7 @@ export const ENHANCEMENT_BUILD =
 export const TARGET_ONLY: EnhancementCapabilities = Object.freeze({
   nativeCursor: false,
   playRegionObservation: true,
+    preGameControls: false,
   targetObservation: true,
   partyObservation: false,
   teamApply: false,
@@ -140,6 +141,7 @@ export const TARGET_ONLY: EnhancementCapabilities = Object.freeze({
 export const TOOLBOX_PROGRAM_CAPABILITIES: EnhancementCapabilities = Object.freeze({
   nativeCursor: true,
   playRegionObservation: true,
+    preGameControls: false,
   targetObservation: false,
   partyObservation: true,
   teamApply: false,
@@ -152,6 +154,7 @@ export const TOOLBOX_PROGRAM_CAPABILITIES: EnhancementCapabilities = Object.free
 export const PRODUCT_TOOLS_CAPABILITIES: EnhancementCapabilities = Object.freeze({
   nativeCursor: true,
   playRegionObservation: true,
+    preGameControls: false,
   targetObservation: true,
   partyObservation: true,
   teamApply: true,
@@ -164,6 +167,7 @@ export const PRODUCT_TOOLS_CAPABILITIES: EnhancementCapabilities = Object.freeze
 export const TARGET_OFF_PRODUCT_CAPABILITIES: EnhancementCapabilities = Object.freeze({
   nativeCursor: true,
   playRegionObservation: true,
+    preGameControls: false,
   targetObservation: false,
   partyObservation: true,
   teamApply: true,

--- a/tests/release/preload-behaviour.test.ts
+++ b/tests/release/preload-behaviour.test.ts
@@ -371,6 +371,16 @@ const INVOCATIONS: Invocation[] = [
   { path: "app.reveal", args: ["gameData"], channel: IPC.appRevealPath },
   { path: "app.requestQuit", args: [], channel: IPC.appRequestQuit },
   {
+    path: "app.reloadGame",
+    args: ["memory-warning"],
+    channel: IPC.appReloadGame,
+  },
+  {
+    path: "app.claimRelogIntent",
+    args: [],
+    channel: IPC.appClaimRelogIntent,
+  },
+  {
     path: "clipboard.writeText",
     args: ["copied text"],
     channel: IPC.clipboardWriteText,

--- a/tests/unit/active-client.test.ts
+++ b/tests/unit/active-client.test.ts
@@ -18,6 +18,7 @@ function generation(wasmPath: string, size: number): ClientGeneration {
         gameFileSaving: supported ? available : unavailable,
         nativeCursor: supported ? available : unavailable,
         playRegionObservation: { status: "off" },
+        preGameControls: { status: "off" },
         targetObservation: { status: "off" },
         partyObservation: { status: "off" },
         teamApply: { status: "off" },

--- a/tests/unit/automatic-character-return.test.ts
+++ b/tests/unit/automatic-character-return.test.ts
@@ -1,0 +1,101 @@
+/** The automatic-return owner must not miss a fast character-select transition. */
+import assert from "node:assert/strict";
+import test from "node:test";
+import { installAutomaticCharacterReturn } from "../../src/renderer/automatic-character-return.js";
+import type { RendererMilestone } from "../../src/shared/diagnostics.js";
+
+test("transient loading cannot skip character selection", async () => {
+  const originalDocument = globalThis.document;
+  const originalWindow = globalThis.window;
+  const originalAnimationFrame = globalThis.requestAnimationFrame;
+  const status = { hidden: true, textContent: "" };
+  let screen: "loading" | "character" | "playable" = "loading";
+  let characterSubmissions = 0;
+  const records: Array<{ name: RendererMilestone; fields: unknown }> = [];
+  const browserWindow = new EventTarget() as EventTarget & {
+    gwPreGameControls: PreGameControls;
+  };
+  browserWindow.gwPreGameControls = {
+    state: () => screen === "loading"
+      ? "loading"
+      : screen === "character"
+        ? "character-select"
+        : "unknown",
+    playable: () => screen === "playable" ? "outpost" : null,
+    diagnosticMask: () => 1,
+  };
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: browserWindow,
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      visibilityState: "visible",
+      hasFocus: () => true,
+      getElementById: (id: string) => id === "login-status" ? status : null,
+    },
+  });
+  globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+    queueMicrotask(() => callback(performance.now()));
+    return 1;
+  });
+
+  const input: GameInputController = {
+    releaseAll() {},
+    cancelAutomaticEnter() {},
+    setLoginProviderChooser() {},
+    expectCharacterSelection() {},
+    submitSavedLogin: async () => "progressed",
+    playSelectedCharacter: async () => {
+      characterSubmissions += 1;
+      screen = "playable";
+      return "sent";
+    },
+    acceptReconnect: async () => "sent",
+  };
+  const controller = installAutomaticCharacterReturn({
+    claimIntent: async () => true,
+    input: () => input,
+    record(name, ...fields) {
+      records.push({ name, fields: fields[0] });
+    },
+  });
+
+  try {
+    await Promise.resolve();
+    controller.savedCredentialsLoaded();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    const request = new EventTarget() as XMLHttpRequest;
+    Object.defineProperty(request, "status", { value: 200 });
+    controller.tokenRequested(request);
+    await Promise.resolve();
+    request.dispatchEvent(new Event("loadend"));
+    assert.equal(characterSubmissions, 0);
+    screen = "character";
+    for (let index = 0; index < 12; index += 1) await Promise.resolve();
+
+    assert.equal(characterSubmissions, 1);
+    assert.equal(
+      records.filter(({ name }) => name === "relog.finished").length,
+      1,
+    );
+    assert.deepEqual(records.find(({ name }) => name === "relog.finished"), {
+      name: "relog.finished",
+      fields: { outcome: "outpost" },
+    });
+  } finally {
+    controller.dispose();
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: originalDocument,
+    });
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow,
+    });
+    globalThis.requestAnimationFrame = originalAnimationFrame;
+  }
+});

--- a/tests/unit/client-certification.test.ts
+++ b/tests/unit/client-certification.test.ts
@@ -25,6 +25,7 @@ const ALL_CAPABILITIES = Object.freeze({
   skillSlotGeometry: false,
   skillCooldownObservation: false,
   playRegionObservation: true,
+    preGameControls: false,
 });
 
 function localVerification(

--- a/tests/unit/client-compatibility-notice.test.ts
+++ b/tests/unit/client-compatibility-notice.test.ts
@@ -22,13 +22,14 @@ const unavailable = (reason: "game-update" | "preparation-failed") =>
 function compatibility(
   overrides: Partial<ClientCompatibility["features"]> = {},
 ): ClientCompatibility {
-  const { playRegionObservation = off, ...visibleOverrides } = overrides;
+  const { playRegionObservation = off, preGameControls = off, ...visibleOverrides } = overrides;
   return {
     clientSha256: "a".repeat(64),
     features: {
       gameFileSaving: available,
       nativeCursor: off,
       playRegionObservation,
+      preGameControls,
       targetObservation: off,
       partyObservation: off,
       teamApply: off,
@@ -200,6 +201,7 @@ describe("client compatibility notice", () => {
                       gameFileSaving,
                       nativeCursor,
                       playRegionObservation: off,
+                      preGameControls: off,
                       targetObservation,
                       partyObservation,
                       teamApply,

--- a/tests/unit/client-launch-readiness.test.ts
+++ b/tests/unit/client-launch-readiness.test.ts
@@ -52,4 +52,8 @@ test("preparation and failure remain launch gates", () => {
   );
   const failure: DownloadProgress = { phase: "error", errorCode: "not_ready" };
   assert.equal(launchProgressForSession(failure, active), failure);
+  for (const phase of ["checking", "client"] as const) {
+    const preparation: DownloadProgress = { ...backgroundDownload, phase };
+    assert.equal(launchProgressForSession(preparation, active), preparation);
+  }
 });

--- a/tests/unit/client-launch-readiness.test.ts
+++ b/tests/unit/client-launch-readiness.test.ts
@@ -1,0 +1,55 @@
+/** Replacement renderers must not confuse background data download with boot. */
+import assert from "node:assert/strict";
+import test from "node:test";
+import type {
+  ClientSession,
+  DownloadProgress,
+} from "../../src/shared/contracts.js";
+import { launchProgressForSession } from "../../src/renderer/client-launch-readiness.js";
+
+const preparing: ClientSession = {
+  appVersion: "test",
+  compatibility: null,
+  extendedMemory: null,
+  healthToken: null,
+};
+const active: ClientSession = {
+  appVersion: "test",
+  compatibility: null,
+  extendedMemory: {
+    requestedAtLaunch: false,
+    status: "standard",
+    effectiveCapBytes: 2_147_483_648,
+    fallbackReason: null,
+  },
+  healthToken: null,
+};
+const backgroundDownload: DownloadProgress = {
+  phase: "image",
+  label: "Downloading full game",
+  received: 16,
+  total: 64,
+  bytesPerSecond: 8,
+  secondsRemaining: 6,
+  fullDownload: { status: "running" },
+};
+
+test("an active client boots while its complete data downloads", () => {
+  assert.deepEqual(
+    launchProgressForSession(backgroundDownload, active),
+    {
+      ...backgroundDownload,
+      phase: "ready",
+      label: "Starting Guild Wars",
+    },
+  );
+});
+
+test("preparation and failure remain launch gates", () => {
+  assert.equal(
+    launchProgressForSession(backgroundDownload, preparing),
+    backgroundDownload,
+  );
+  const failure: DownloadProgress = { phase: "error", errorCode: "not_ready" };
+  assert.equal(launchProgressForSession(failure, active), failure);
+});

--- a/tests/unit/client-module.test.ts
+++ b/tests/unit/client-module.test.ts
@@ -58,6 +58,7 @@ const CURSOR_TOOLBOX: EnhancementCapabilities = Object.freeze({
   skillSlotGeometry: false,
   skillCooldownObservation: false,
   playRegionObservation: true,
+    preGameControls: false,
 });
 const CURSOR_ONLY: EnhancementCapabilities = Object.freeze({
   nativeCursor: true,
@@ -70,6 +71,7 @@ const CURSOR_ONLY: EnhancementCapabilities = Object.freeze({
   skillSlotGeometry: false,
   skillCooldownObservation: false,
   playRegionObservation: false,
+    preGameControls: false,
 });
 const CURSOR_TARGET: EnhancementCapabilities = Object.freeze({
   nativeCursor: true,
@@ -82,6 +84,7 @@ const CURSOR_TARGET: EnhancementCapabilities = Object.freeze({
   skillSlotGeometry: false,
   skillCooldownObservation: false,
   playRegionObservation: true,
+    preGameControls: false,
 });
 const NO_CAPABILITIES: EnhancementCapabilities = Object.freeze({
   nativeCursor: false,
@@ -94,6 +97,7 @@ const NO_CAPABILITIES: EnhancementCapabilities = Object.freeze({
   skillSlotGeometry: false,
   skillCooldownObservation: false,
   playRegionObservation: false,
+    preGameControls: false,
 });
 
 const scratchDirs: string[] = [];

--- a/tests/unit/effective-enhancement-capabilities.test.ts
+++ b/tests/unit/effective-enhancement-capabilities.test.ts
@@ -38,6 +38,7 @@ function session(capabilities: EnhancementCapabilities): ClientSession {
       skillSlotGeometry: selected(capabilities.skillSlotGeometry),
       skillCooldownObservation: selected(capabilities.skillCooldownObservation),
       playRegionObservation: selected(capabilities.playRegionObservation),
+      preGameControls: selected(capabilities.preGameControls),
     },
   };
   return {
@@ -80,6 +81,7 @@ describe("effective Enhancement capability boundary", () => {
           skillSlotGeometry: off,
           skillCooldownObservation: off,
           playRegionObservation: off,
+          preGameControls: off,
         },
       },
     };
@@ -95,6 +97,7 @@ describe("effective Enhancement capability boundary", () => {
       skillSlotGeometry: false,
       skillCooldownObservation: false,
       playRegionObservation: false,
+      preGameControls: false,
     });
   });
 

--- a/tests/unit/enhancement-client-chain.test.ts
+++ b/tests/unit/enhancement-client-chain.test.ts
@@ -19,6 +19,7 @@ import { TEMPLATE_SAVE_BUILDS } from "../../src/main/certification/template-save
 const NO_CAPABILITIES = Object.freeze({
   nativeCursor: false,
   playRegionObservation: false,
+    preGameControls: false,
   targetObservation: false,
   partyObservation: false,
   teamApply: false,
@@ -66,6 +67,7 @@ describe("Enhancement client chain", () => {
       {
         nativeCursor: false,
         playRegionObservation: false,
+    preGameControls: false,
         targetObservation: false,
         partyObservation: false,
         teamApply: true,

--- a/tests/unit/enhancement-command-transform.test.ts
+++ b/tests/unit/enhancement-command-transform.test.ts
@@ -218,6 +218,7 @@ describe("Enhancement command transform", () => {
     const aliasesOnly = {
       nativeCursor: false,
       playRegionObservation: false,
+    preGameControls: false,
       targetObservation: false,
       partyObservation: false,
       teamApply: false,
@@ -240,6 +241,7 @@ describe("Enhancement command transform", () => {
       const capabilities = {
         ...aliasesOnly,
         playRegionObservation: true,
+    preGameControls: false,
         [action]: true,
       };
       const effective = intersectEnhancementCapabilities(capabilities, capabilities);

--- a/tests/unit/enhancement-pre-game-transform.test.ts
+++ b/tests/unit/enhancement-pre-game-transform.test.ts
@@ -16,13 +16,18 @@ import {
 
 const certificate = {
   labels: { play: 101, selector: 102, yes: 103, no: 104, reconnectDialog: 105 },
-  labelHashes: { play: 101, selector: 102, yes: 103, no: 104 },
+  labelHashes: {
+    play: 101,
+    selector: 102,
+    yes: 103,
+    no: 104,
+    reconnectDialog: 105,
+  },
   layout: {
     frameArray: 0,
     frameCount: 4,
     frameBytes: 0x80,
     frameId: 0x04,
-    frameRelation: 0x10,
     frameHashId: 0x1c,
     frameState: 0x20,
     contextRoot: 8,
@@ -83,11 +88,12 @@ test("pre-game state scans exact live label hashes and loading context", async (
   const abi = ENHANCEMENT_TRANSFORM_ABI << 24;
 
   view.setUint32(certificate.layout.frameArray, 32, true);
-  view.setUint32(certificate.layout.frameCount, 5, true);
-  const frames = [0, 128, 256, 384, 512];
+  view.setUint32(certificate.layout.frameCount, 6, true);
+  const frames = [0, 128, 256, 384, 512, 640];
   const hashes = [0, certificate.labels.play, certificate.labels.selector,
-    certificate.labels.yes, certificate.labels.no];
-  for (let id = 1; id <= 4; id += 1) {
+    certificate.labels.yes, certificate.labels.no,
+    certificate.labels.reconnectDialog];
+  for (let id = 1; id <= 5; id += 1) {
     const frame = frames[id]!;
     view.setUint32(32 + id * 4, frame, true);
     view.setUint32(frame + certificate.layout.frameId, id, true);
@@ -95,7 +101,7 @@ test("pre-game state scans exact live label hashes and loading context", async (
     view.setUint32(frame + certificate.layout.frameState, 0x204, true);
   }
 
-  assert.equal(diagnostic(), abi | 0x7c0ff);
+  assert.equal(diagnostic(), abi | 0x1fc0ff);
   assert.equal(state(), 0);
 
   view.setUint32(32 + 4 * 4, 70_000, true);
@@ -104,23 +110,26 @@ test("pre-game state scans exact live label hashes and loading context", async (
 
   view.setUint32(frames[1]! + certificate.layout.frameState, 4, true);
   view.setUint32(frames[2]! + certificate.layout.frameState, 4, true);
-  assert.equal(diagnostic(), abi | 0x7e3ff);
+  assert.equal(diagnostic(), abi | 0x1fe3ff);
   assert.equal(state(), 1);
 
   view.setUint32(frames[1]! + certificate.layout.frameState, 0x204, true);
   view.setUint32(frames[2]! + certificate.layout.frameState, 0x204, true);
   view.setUint32(frames[3]! + certificate.layout.frameState, 4, true);
   view.setUint32(frames[4]! + certificate.layout.frameState, 4, true);
-  assert.equal(diagnostic(), abi | 0x7dcff);
+  assert.equal(diagnostic(), abi | 0x1fdcff);
+  assert.equal(state(), 0, "generic Yes/No buttons are not reconnect authority");
+  view.setUint32(frames[5]! + certificate.layout.frameState, 4, true);
+  assert.equal(diagnostic(), abi | 0x7fdcff);
   assert.equal(state(), 2);
 
   // A stale table slot is rejected even if its hash and visible state match.
   view.setUint32(frames[3]! + certificate.layout.frameId, 99, true);
-  assert.equal(diagnostic(), abi | 0x7c8bf);
+  assert.equal(diagnostic(), abi | 0x3fc8bf);
   assert.equal(state(), 0);
   view.setUint32(frames[3]! + certificate.layout.frameId, 3, true);
 
-  for (let id = 1; id <= 4; id += 1) {
+  for (let id = 1; id <= 5; id += 1) {
     view.setUint32(frames[id]! + certificate.layout.frameState, 0x204, true);
   }
   view.setUint32(certificate.layout.contextRoot, 700, true);

--- a/tests/unit/enhancement-pre-game-transform.test.ts
+++ b/tests/unit/enhancement-pre-game-transform.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { KnownEnhancementBuild } from "../../src/main/certification/enhancement-builds.js";
+import { ENHANCEMENT_TRANSFORM_ABI } from "../../src/shared/enhancement-contracts.js";
+import {
+  preGameDiagnosticReader,
+  preGameStateReader,
+} from "../../src/main/certification/enhancement-pre-game-transform.js";
+import {
+  concat,
+  encodeCode,
+  encodeSection,
+  uleb,
+  WASM_HEADER,
+} from "../../src/main/core/wasm-binary.js";
+
+const certificate = {
+  labels: { play: 101, selector: 102, yes: 103, no: 104, reconnectDialog: 105 },
+  labelHashes: { play: 101, selector: 102, yes: 103, no: 104 },
+  layout: {
+    frameArray: 0,
+    frameCount: 4,
+    frameBytes: 0x80,
+    frameId: 0x04,
+    frameRelation: 0x10,
+    frameHashId: 0x1c,
+    frameState: 0x20,
+    contextRoot: 8,
+    gameContextSlot: 1,
+    characterContext: 0x08,
+    currentInstanceType: 0x0c,
+  },
+} as NonNullable<KnownEnhancementBuild["preGameControls"]>;
+
+function section(id: number, body: Uint8Array): Uint8Array {
+  return encodeSection({ id, body });
+}
+
+function moduleBytes(): Uint8Array {
+  const typeSection = concat(
+    uleb(2),
+    Uint8Array.of(0x60), uleb(2), Uint8Array.of(0x7f, 0x7f),
+    uleb(1), Uint8Array.of(0x7f),
+    Uint8Array.of(0x60), uleb(0), uleb(1), Uint8Array.of(0x7f),
+  );
+  const name = (value: string) => {
+    const bytes = new TextEncoder().encode(value);
+    return concat(uleb(bytes.length), bytes);
+  };
+  return concat(
+    WASM_HEADER,
+    section(1, typeSection),
+    section(3, concat(uleb(3), uleb(0), uleb(1), uleb(1))),
+    section(5, concat(uleb(1), Uint8Array.of(0x00), uleb(1))),
+    section(7, concat(
+      uleb(3),
+      name("memory"), Uint8Array.of(0x02), uleb(0),
+      name("diagnostic"), Uint8Array.of(0x00), uleb(1),
+      name("state"), Uint8Array.of(0x00), uleb(2),
+    )),
+    section(10, encodeCode([
+      // Kept as an unrelated function to prove the reader needs no runtime
+      // callback to compute its already-certified label hashes.
+      concat(uleb(0), Uint8Array.of(0x20), uleb(0), Uint8Array.of(0x0b)),
+      preGameDiagnosticReader(certificate),
+      preGameStateReader(certificate, 1),
+    ])),
+  );
+}
+
+test("pre-game state scans exact live label hashes and loading context", async () => {
+  const bytes = moduleBytes();
+  const buffer = bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength,
+  ) as ArrayBuffer;
+  assert.equal(WebAssembly.validate(buffer), true);
+  const instance = await WebAssembly.instantiate(await WebAssembly.compile(buffer));
+  const memory = instance.exports.memory as WebAssembly.Memory;
+  const state = instance.exports.state as () => number;
+  const diagnostic = instance.exports.diagnostic as () => number;
+  const view = new DataView(memory.buffer);
+  const abi = ENHANCEMENT_TRANSFORM_ABI << 24;
+
+  view.setUint32(certificate.layout.frameArray, 32, true);
+  view.setUint32(certificate.layout.frameCount, 5, true);
+  const frames = [0, 128, 256, 384, 512];
+  const hashes = [0, certificate.labels.play, certificate.labels.selector,
+    certificate.labels.yes, certificate.labels.no];
+  for (let id = 1; id <= 4; id += 1) {
+    const frame = frames[id]!;
+    view.setUint32(32 + id * 4, frame, true);
+    view.setUint32(frame + certificate.layout.frameId, id, true);
+    view.setUint32(frame + certificate.layout.frameHashId, hashes[id]!, true);
+    view.setUint32(frame + certificate.layout.frameState, 0x204, true);
+  }
+
+  assert.equal(diagnostic(), abi | 0x7c0ff);
+  assert.equal(state(), 0);
+
+  view.setUint32(32 + 4 * 4, 70_000, true);
+  assert.equal(diagnostic() & 0x8000_0000, 0);
+  view.setUint32(32 + 4 * 4, frames[4]!, true);
+
+  view.setUint32(frames[1]! + certificate.layout.frameState, 4, true);
+  view.setUint32(frames[2]! + certificate.layout.frameState, 4, true);
+  assert.equal(diagnostic(), abi | 0x7e3ff);
+  assert.equal(state(), 1);
+
+  view.setUint32(frames[1]! + certificate.layout.frameState, 0x204, true);
+  view.setUint32(frames[2]! + certificate.layout.frameState, 0x204, true);
+  view.setUint32(frames[3]! + certificate.layout.frameState, 4, true);
+  view.setUint32(frames[4]! + certificate.layout.frameState, 4, true);
+  assert.equal(diagnostic(), abi | 0x7dcff);
+  assert.equal(state(), 2);
+
+  // A stale table slot is rejected even if its hash and visible state match.
+  view.setUint32(frames[3]! + certificate.layout.frameId, 99, true);
+  assert.equal(diagnostic(), abi | 0x7c8bf);
+  assert.equal(state(), 0);
+  view.setUint32(frames[3]! + certificate.layout.frameId, 3, true);
+
+  for (let id = 1; id <= 4; id += 1) {
+    view.setUint32(frames[id]! + certificate.layout.frameState, 0x204, true);
+  }
+  view.setUint32(certificate.layout.contextRoot, 700, true);
+  view.setUint32(700 + certificate.layout.gameContextSlot * 4, 720, true);
+  view.setUint32(720 + certificate.layout.characterContext, 760, true);
+  view.setUint32(760 + certificate.layout.currentInstanceType, 2, true);
+  assert.equal(state(), 3);
+});

--- a/tests/unit/enhancement-skill-transform.test.ts
+++ b/tests/unit/enhancement-skill-transform.test.ts
@@ -20,6 +20,7 @@ const capabilities: EnhancementCapabilities = Object.freeze({
   skillSlotGeometry: true,
   skillCooldownObservation: true,
   playRegionObservation: true,
+    preGameControls: false,
 });
 
 const hash = (body: Uint8Array) =>

--- a/tests/unit/enhancement-transform.test.ts
+++ b/tests/unit/enhancement-transform.test.ts
@@ -37,6 +37,7 @@ import {
 const PARTY_ONLY: EnhancementCapabilities = Object.freeze({
   nativeCursor: false,
   playRegionObservation: true,
+    preGameControls: false,
   targetObservation: false,
   partyObservation: true,
   teamApply: false,
@@ -290,6 +291,7 @@ describe("targeted Enhancement WebAssembly transform", () => {
         {
           nativeCursor: true,
           playRegionObservation: false,
+    preGameControls: false,
           targetObservation: true,
           partyObservation: false,
           teamApply: true,

--- a/tests/unit/enhancements-are-derived-from-their-registry.test.ts
+++ b/tests/unit/enhancements-are-derived-from-their-registry.test.ts
@@ -118,7 +118,7 @@ test("one capability plan derives hooks without losing feature identity", () => 
   ]) {
     assert.deepEqual(
       enhancementCapabilitiesFor(selection, "cursor-observer"),
-      { nativeCursor: true, targetObservation: false, partyObservation: false, teamApply: false, travelAction: false, xunlaiAction: false, chatAliases: false, skillSlotGeometry: false, skillCooldownObservation: false, playRegionObservation: true, preGameControls: true },
+      { nativeCursor: true, targetObservation: false, partyObservation: false, teamApply: false, travelAction: false, xunlaiAction: false, chatAliases: false, skillSlotGeometry: false, skillCooldownObservation: false, playRegionObservation: false, preGameControls: false },
     );
     assert.deepEqual(
       enhancementCapabilitiesFor(selection, "target-observer"),
@@ -146,7 +146,7 @@ test("launch intent resolves to the canonical frozen capability profiles", () =>
   const cases = [
     [{ nativeCursor: true, tools: false }, "none", "features-601"],
     [{ nativeCursor: true, tools: true }, "none", "features-7ff"],
-    [{ nativeCursor: false, tools: false }, "cursor-observer", "features-601"],
+    [{ nativeCursor: false, tools: false }, "cursor-observer", "features-01"],
     [{ nativeCursor: true, tools: false }, "target-observer", "features-202"],
     [{ nativeCursor: false, tools: false }, "toolbox-foundation", "features-284"],
     [{ nativeCursor: false, tools: false }, "xunlai-storage", "features-270"],

--- a/tests/unit/enhancements-are-derived-from-their-registry.test.ts
+++ b/tests/unit/enhancements-are-derived-from-their-registry.test.ts
@@ -118,38 +118,39 @@ test("one capability plan derives hooks without losing feature identity", () => 
   ]) {
     assert.deepEqual(
       enhancementCapabilitiesFor(selection, "cursor-observer"),
-      { nativeCursor: true, targetObservation: false, partyObservation: false, teamApply: false, travelAction: false, xunlaiAction: false, chatAliases: false, skillSlotGeometry: false, skillCooldownObservation: false, playRegionObservation: false },
+      { nativeCursor: true, targetObservation: false, partyObservation: false, teamApply: false, travelAction: false, xunlaiAction: false, chatAliases: false, skillSlotGeometry: false, skillCooldownObservation: false, playRegionObservation: true, preGameControls: true },
     );
     assert.deepEqual(
       enhancementCapabilitiesFor(selection, "target-observer"),
-      { nativeCursor: false, targetObservation: true, partyObservation: false, teamApply: false, travelAction: false, xunlaiAction: false, chatAliases: false, skillSlotGeometry: false, skillCooldownObservation: false, playRegionObservation: true },
+      { nativeCursor: false, targetObservation: true, partyObservation: false, teamApply: false, travelAction: false, xunlaiAction: false, chatAliases: false, skillSlotGeometry: false, skillCooldownObservation: false, playRegionObservation: true, preGameControls: false },
     );
     assert.deepEqual(
       enhancementCapabilitiesFor(selection, "toolbox-foundation"),
-      { nativeCursor: false, targetObservation: false, partyObservation: true, teamApply: false, travelAction: false, xunlaiAction: false, chatAliases: false, skillSlotGeometry: true, skillCooldownObservation: false, playRegionObservation: true },
+      { nativeCursor: false, targetObservation: false, partyObservation: true, teamApply: false, travelAction: false, xunlaiAction: false, chatAliases: false, skillSlotGeometry: true, skillCooldownObservation: false, playRegionObservation: true, preGameControls: false },
     );
     // The read foundation and the write program differ by exactly this bit,
     // and no saved setting reaches the second: choosing the panel can never
     // carry the ability to send a packet in with it.
     assert.deepEqual(
       enhancementCapabilitiesFor(selection, "toolbox-commands"),
-      { nativeCursor: false, targetObservation: false, partyObservation: true, teamApply: true, travelAction: true, xunlaiAction: true, chatAliases: true, skillSlotGeometry: true, skillCooldownObservation: false, playRegionObservation: true },
+      { nativeCursor: false, targetObservation: false, partyObservation: true, teamApply: true, travelAction: true, xunlaiAction: true, chatAliases: true, skillSlotGeometry: true, skillCooldownObservation: false, playRegionObservation: true, preGameControls: false },
     );
     assert.deepEqual(
       enhancementCapabilitiesFor(selection, "xunlai-storage"),
-      { nativeCursor: false, targetObservation: false, partyObservation: false, teamApply: false, travelAction: true, xunlaiAction: true, chatAliases: true, skillSlotGeometry: false, skillCooldownObservation: false, playRegionObservation: true },
+      { nativeCursor: false, targetObservation: false, partyObservation: false, teamApply: false, travelAction: true, xunlaiAction: true, chatAliases: true, skillSlotGeometry: false, skillCooldownObservation: false, playRegionObservation: true, preGameControls: false },
     );
   }
 });
 
 test("launch intent resolves to the canonical frozen capability profiles", () => {
   const cases = [
-    [{ nativeCursor: true, tools: false }, "none", "features-01"],
-    [{ nativeCursor: true, tools: true }, "none", "features-3ff"],
-    [{ nativeCursor: false, tools: false }, "cursor-observer", "features-01"],
+    [{ nativeCursor: true, tools: false }, "none", "features-601"],
+    [{ nativeCursor: true, tools: true }, "none", "features-7ff"],
+    [{ nativeCursor: false, tools: false }, "cursor-observer", "features-601"],
     [{ nativeCursor: true, tools: false }, "target-observer", "features-202"],
     [{ nativeCursor: false, tools: false }, "toolbox-foundation", "features-284"],
     [{ nativeCursor: false, tools: false }, "xunlai-storage", "features-270"],
+    [{ nativeCursor: false, tools: false }, "reconnect-probe", "features-601"],
   ] as const;
   for (const [selection, program, profile] of cases) {
     const resolved = enhancementCapabilitiesFor(selection, program);
@@ -185,6 +186,7 @@ test("the capability wire contract is exact and has one empty value", () => {
     skillSlotGeometry: true,
     skillCooldownObservation: true,
     playRegionObservation: true,
+    preGameControls: true,
   });
   assert.ok(all);
   assert.equal(Object.isFrozen(all), true);
@@ -213,6 +215,7 @@ test("the capability wire contract is exact and has one empty value", () => {
     skillSlotGeometry: false,
     skillCooldownObservation: false,
     playRegionObservation: false,
+    preGameControls: false,
   });
 
   assert.equal(parseEnhancementCapabilities({ ...all, extra: false }), null);
@@ -277,6 +280,7 @@ test("renderer consumes main's effective subset instead of launch intent", () =>
         nativeCursor: available,
         targetObservation: available,
         playRegionObservation: available,
+        preGameControls: available,
         partyObservation: available,
         teamApply: unavailable,
         travelAction: unavailable,
@@ -286,5 +290,5 @@ test("renderer consumes main's effective subset instead of launch intent", () =>
         skillCooldownObservation: { status: "off" },
       },
     },
-  }), enhancementCapabilitiesForProfile("features-207"));
+  }), enhancementCapabilitiesForProfile("features-607"));
 });

--- a/tests/unit/failure-codes-become-sentences-in-the-renderer.test.ts
+++ b/tests/unit/failure-codes-become-sentences-in-the-renderer.test.ts
@@ -216,9 +216,10 @@ describe("renderer failure messages", () => {
     assert.match(memoryWarningCopy("low", 4_294_901_760).explanation, /4 GB/);
   });
 
-  it("states measured recovery without overpromising", () => {
+  it("explains optional automatic return without overpromising", () => {
     const explanation = memoryWarningCopy("critical", 4_294_901_760).explanation;
-    assert.match(explanation, /puts you back where you were/);
+    assert.match(explanation, /With automatic return enabled/);
+    assert.match(explanation, /returns to the selected character/);
     assert.match(explanation, /cannot stop continued memory growth/);
     assert.doesNotMatch(explanation, /\b(guarantee\w*|never lose|always works?)\b/i);
   });

--- a/tests/unit/feature-contracts.test.ts
+++ b/tests/unit/feature-contracts.test.ts
@@ -103,7 +103,7 @@ test("the capability registry is the ordered wire vocabulary", () => {
       id: "preGameControls",
       requiresAll: ["playRegionObservation"],
       requiresAny: [],
-      configOwners: ["skill-slots"],
+      configOwners: [],
       hooks: [],
     },
   ]);

--- a/tests/unit/feature-contracts.test.ts
+++ b/tests/unit/feature-contracts.test.ts
@@ -99,12 +99,19 @@ test("the capability registry is the ordered wire vocabulary", () => {
       configOwners: ["play-region"],
       hooks: [],
     },
+    {
+      id: "preGameControls",
+      requiresAll: ["playRegionObservation"],
+      requiresAny: [],
+      configOwners: ["skill-slots"],
+      hooks: [],
+    },
   ]);
   assert.deepEqual(
     ENHANCEMENT_CAPABILITY_CONTRACTS.map(({ id }) => id),
     ENHANCEMENT_CAPABILITY_FIELDS,
   );
-  assert.equal(new Set(ENHANCEMENT_CAPABILITY_FIELDS).size, 10);
+  assert.equal(new Set(ENHANCEMENT_CAPABILITY_FIELDS).size, 11);
   for (const contract of ENHANCEMENT_CAPABILITY_CONTRACTS) {
     assert.equal(Object.isFrozen(contract), true, contract.id);
     assert.equal(Object.isFrozen(contract.requiresAll), true, contract.id);

--- a/tests/unit/game-reload.test.ts
+++ b/tests/unit/game-reload.test.ts
@@ -1,0 +1,73 @@
+/** Main's reload owner must bind automatic-return intent to one new document. */
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { BrowserWindow } from "electron";
+import { GameReloader } from "../../src/main/game-reload.js";
+import { DEFAULT_SETTINGS } from "../../src/shared/contracts.js";
+
+function fixture(options: Readonly<{
+  autoRelog?: boolean;
+  settingsError?: Error;
+}> = {}) {
+  let routingId = 10;
+  let loads = 0;
+  let socketCloses = 0;
+  const events: string[] = [];
+  const win = {
+    isDestroyed: () => false,
+    webContents: {
+      id: 7,
+      isDestroyed: () => false,
+      mainFrame: {
+        get routingId() { return routingId; },
+      },
+    },
+  } as unknown as BrowserWindow;
+  const reloader = new GameReloader({
+    sockets: { closeAll() { socketCloses += 1; } },
+    async getSettings() {
+      if (options.settingsError) throw options.settingsError;
+      return {
+        ...DEFAULT_SETTINGS,
+        autoRelogAfterReload: options.autoRelog ?? true,
+      };
+    },
+    diagnosticOwner: () => 3,
+    record(event) { events.push(event.k); },
+    sync: async () => "completed",
+    async load() {
+      loads += 1;
+      routingId += 1;
+    },
+    rendererUrl: "gw://app/renderer/",
+  });
+  return {
+    win,
+    reloader,
+    events,
+    loads: () => loads,
+    socketCloses: () => socketCloses,
+  };
+}
+
+test("automatic-return intent is refused to the source and consumed by its replacement", async () => {
+  const { reloader, win, loads, socketCloses } = fixture();
+  const reload = reloader.reload(win, "menu");
+  assert.equal(reloader.claimRelogIntent(win), false);
+  await reload;
+  assert.equal(loads(), 1);
+  assert.equal(socketCloses(), 1);
+  assert.equal(reloader.claimRelogIntent(win), true);
+  assert.equal(reloader.claimRelogIntent(win), false);
+});
+
+test("a settings read failure performs no partial reload", async () => {
+  const { reloader, win, loads, socketCloses, events } = fixture({
+    settingsError: new Error("unreadable settings"),
+  });
+  await assert.rejects(reloader.reload(win, "command-q"), /unreadable settings/);
+  assert.equal(loads(), 0);
+  assert.equal(socketCloses(), 0);
+  assert.deepEqual(events, []);
+  assert.equal(reloader.claimRelogIntent(win), false);
+});

--- a/tests/unit/local-client-verifier.test.ts
+++ b/tests/unit/local-client-verifier.test.ts
@@ -29,6 +29,7 @@ const NONE: EnhancementCapabilities = Object.freeze({
   skillSlotGeometry: false,
   skillCooldownObservation: false,
   playRegionObservation: false,
+    preGameControls: false,
 });
 const ALL: EnhancementCapabilities = Object.freeze({
   ...NONE,
@@ -42,6 +43,7 @@ const ALL: EnhancementCapabilities = Object.freeze({
   skillSlotGeometry: true,
   skillCooldownObservation: true,
   playRegionObservation: true,
+  preGameControls: true,
 });
 const CURSOR: EnhancementCapabilities = Object.freeze({
   ...NONE,
@@ -50,15 +52,18 @@ const CURSOR: EnhancementCapabilities = Object.freeze({
 const REGION: EnhancementCapabilities = Object.freeze({
   ...NONE,
   playRegionObservation: true,
+    preGameControls: false,
 });
 const TARGET: EnhancementCapabilities = Object.freeze({
   ...NONE,
   playRegionObservation: true,
+    preGameControls: false,
   targetObservation: true,
 });
 const STORAGE: EnhancementCapabilities = Object.freeze({
   ...NONE,
   playRegionObservation: true,
+    preGameControls: false,
   travelAction: true,
   xunlaiAction: true,
   chatAliases: true,
@@ -68,17 +73,20 @@ const STORAGE: EnhancementCapabilities = Object.freeze({
 const PARTY_TEAM: EnhancementCapabilities = Object.freeze({
   ...NONE,
   playRegionObservation: true,
+    preGameControls: false,
   partyObservation: true,
   teamApply: true,
 });
 const SKILL_SLOTS: EnhancementCapabilities = Object.freeze({
   ...NONE,
   playRegionObservation: true,
+    preGameControls: false,
   skillSlotGeometry: true,
 });
 const COOLDOWN: EnhancementCapabilities = Object.freeze({
   ...NONE,
   playRegionObservation: true,
+    preGameControls: false,
   skillCooldownObservation: true,
 });
 type ProvedVerification = Extract<LocalClientVerification, { status: "proved" }>;
@@ -106,7 +114,7 @@ function valid(): ProvedVerification {
   return verificationFor({
     ...ENHANCEMENT,
     outputSha256: {
-      "features-3ff": ENHANCEMENT.outputSha256["features-3ff"]!,
+      "features-7ff": ENHANCEMENT.outputSha256["features-7ff"]!,
     },
   }, ALL);
 }
@@ -403,7 +411,7 @@ describe("local client verification boundary", () => {
     const relocated = verificationFor(
       {
         ...ENHANCEMENT,
-        outputSha256: { "features-3ff": ENHANCEMENT.outputSha256["features-3ff"]! },
+        outputSha256: { "features-7ff": ENHANCEMENT.outputSha256["features-7ff"]! },
         hookFunction: ENHANCEMENT.hookFunction + 1,
       },
       ALL,

--- a/tests/unit/local-client-verifier.test.ts
+++ b/tests/unit/local-client-verifier.test.ts
@@ -570,7 +570,6 @@ describe("local client verification boundary", () => {
       (proof) => { proof.layout.frameScreenBottom = Number(proof.layout.frameScreenBottom) + 4; },
       (proof) => { proof.layout.frameScreenRight = Number(proof.layout.frameScreenRight) + 4; },
       (proof) => { proof.layout.frameScreenTop = Number(proof.layout.frameScreenTop) + 4; },
-      (proof) => { proof.layout.frameRelation = Number(proof.layout.frameRelation) + 4; },
       (proof) => { proof.layout.frameState = Number(proof.layout.frameState) + 4; },
     ];
     for (const mutate of mutations) {

--- a/tests/unit/memory-warning.test.ts
+++ b/tests/unit/memory-warning.test.ts
@@ -20,6 +20,8 @@ class FakeElement {
   readonly attributes = new Map<string, string>();
   readonly listeners = new Map<string, Array<() => void>>();
   focused = false;
+  checked = false;
+  disabled = false;
   addEventListener(name: string, listener: () => void): void {
     const listeners = this.listeners.get(name) ?? [];
     listeners.push(listener);
@@ -27,6 +29,9 @@ class FakeElement {
   }
   click(): void {
     for (const listener of this.listeners.get("click") ?? []) listener();
+  }
+  change(): void {
+    for (const listener of this.listeners.get("change") ?? []) listener();
   }
   focus(): void { this.focused = true; }
   setAttribute(name: string, value: string): void { this.attributes.set(name, value); }
@@ -42,6 +47,7 @@ function memoryDom(complete = true) {
     "memory-notice-details",
     "memory-notice-reload",
     "memory-notice-later",
+    "memory-notice-auto-relog",
     "canvas",
   ];
   const elements = new Map(ids.map((id) => [id, new FakeElement()]));
@@ -54,14 +60,26 @@ function memoryDom(complete = true) {
   };
 }
 
+const warningActions = (
+  autoRelogAfterReload = false,
+  reload: () => void | Promise<void> = () => {},
+) => ({
+  autoRelogAfterReload,
+  async saveAutoRelog() {},
+  reload,
+});
+
 describe("memory warning presenter", () => {
   it("does nothing when the single warning surface is incomplete", () => {
-    assert.equal(bindMemoryWarning(memoryDom(false).document, () => {}), null);
+    assert.equal(
+      bindMemoryWarning(memoryDom(false).document, warningActions()),
+      null,
+    );
   });
 
   it("keeps Low dismissed until Critical reopens the same notice", () => {
     const dom = memoryDom();
-    const presenter = bindMemoryWarning(dom.document, () => {});
+    const presenter = bindMemoryWarning(dom.document, warningActions());
     assert.ok(presenter);
     presenter.present("low", 2_147_483_648);
     assert.equal(dom.element("memory-notice").hidden, false);
@@ -79,13 +97,18 @@ describe("memory warning presenter", () => {
     assert.match(dom.element("memory-notice-explanation").textContent, /4 GB/);
   });
 
-  it("reloads without adding another warning state", () => {
+  it("reloads without adding another warning state", async () => {
     const dom = memoryDom();
     let reloads = 0;
-    const presenter = bindMemoryWarning(dom.document, () => { reloads += 1; });
+    const presenter = bindMemoryWarning(
+      dom.document,
+      warningActions(true, () => { reloads += 1; }),
+    );
     assert.ok(presenter);
     presenter.present("critical", 2_147_483_648);
     dom.element("memory-notice-reload").click();
+    await Promise.resolve();
+    await Promise.resolve();
     assert.equal(reloads, 1);
     assert.equal(dom.element("memory-notice").hidden, true);
   });
@@ -104,7 +127,7 @@ describe("memory warning presenter", () => {
         };
       },
     };
-    const presenter = bindMemoryWarning(dom.document, () => {}, surfaces);
+    const presenter = bindMemoryWarning(dom.document, warningActions(), surfaces);
     assert.ok(presenter);
 
     presenter.present("low", 2_147_483_648);
@@ -113,5 +136,33 @@ describe("memory warning presenter", () => {
     assert.equal(dom.element("memory-notice").hidden, true);
     assert.equal(dom.element("canvas").focused, true);
     assert.deepEqual(open, [true, false]);
+  });
+
+  it("shares and saves the automatic-return preference", async () => {
+    const dom = memoryDom();
+    const saved: boolean[] = [];
+    let reloads = 0;
+    const presenter = bindMemoryWarning(
+      dom.document,
+      {
+        autoRelogAfterReload: false,
+        async saveAutoRelog(enabled) { saved.push(enabled); },
+        reload() { reloads += 1; },
+      },
+    );
+    assert.ok(presenter);
+    const checkbox = dom.element("memory-notice-auto-relog");
+    checkbox.checked = true;
+    checkbox.change();
+    await Promise.resolve();
+    assert.deepEqual(saved, [true]);
+    presenter.setAutoRelog(true);
+    assert.equal(dom.element("memory-notice-auto-relog").checked, true);
+    presenter.present("low", 2_147_483_648);
+    dom.element("memory-notice-reload").click();
+    await Promise.resolve();
+    await Promise.resolve();
+    assert.deepEqual(saved, [true, true]);
+    assert.equal(reloads, 1);
   });
 });

--- a/tests/unit/memory-warning.test.ts
+++ b/tests/unit/memory-warning.test.ts
@@ -162,7 +162,7 @@ describe("memory warning presenter", () => {
     dom.element("memory-notice-reload").click();
     await Promise.resolve();
     await Promise.resolve();
-    assert.deepEqual(saved, [true, true]);
+    assert.deepEqual(saved, [true]);
     assert.equal(reloads, 1);
   });
 });

--- a/tests/unit/relog-progression.test.ts
+++ b/tests/unit/relog-progression.test.ts
@@ -3,7 +3,6 @@ import test from "node:test";
 import {
   isRelogCharacterEntryState,
   isRelogPostCharacterState,
-  observeRelogPlayableTransition,
   relogOutcomeForPlayable,
 } from "../../src/renderer/relog-progression.js";
 
@@ -21,18 +20,4 @@ test("loading cannot impersonate character selection or playable completion", ()
 test("only a certified playable instance completes relog", () => {
   assert.equal(relogOutcomeForPlayable("outpost"), "outpost");
   assert.equal(relogOutcomeForPlayable("explorable"), "restored");
-});
-
-test("a stale playable publication cannot complete a new relog", () => {
-  const stale = observeRelogPlayableTransition(false, "outpost");
-  assert.deepEqual(stale, { observedNonPlayable: false, outcome: null });
-  const loading = observeRelogPlayableTransition(
-    stale.observedNonPlayable,
-    null,
-  );
-  assert.deepEqual(loading, { observedNonPlayable: true, outcome: null });
-  assert.deepEqual(
-    observeRelogPlayableTransition(loading.observedNonPlayable, "explorable"),
-    { observedNonPlayable: true, outcome: "restored" },
-  );
 });

--- a/tests/unit/relog-progression.test.ts
+++ b/tests/unit/relog-progression.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  isRelogCharacterEntryState,
+  isRelogPostCharacterState,
+  observeRelogPlayableTransition,
+  relogOutcomeForPlayable,
+} from "../../src/renderer/relog-progression.js";
+
+test("loading cannot impersonate character selection or playable completion", () => {
+  assert.equal(isRelogCharacterEntryState("character-select"), true);
+  assert.equal(isRelogCharacterEntryState("reconnect"), true);
+  assert.equal(isRelogCharacterEntryState("loading"), false);
+  assert.equal(isRelogCharacterEntryState("unknown"), false);
+
+  assert.equal(isRelogPostCharacterState("reconnect"), true);
+  assert.equal(isRelogPostCharacterState("loading"), true);
+  assert.equal(relogOutcomeForPlayable(null), null);
+});
+
+test("only a certified playable instance completes relog", () => {
+  assert.equal(relogOutcomeForPlayable("outpost"), "outpost");
+  assert.equal(relogOutcomeForPlayable("explorable"), "restored");
+});
+
+test("a stale playable publication cannot complete a new relog", () => {
+  const stale = observeRelogPlayableTransition(false, "outpost");
+  assert.deepEqual(stale, { observedNonPlayable: false, outcome: null });
+  const loading = observeRelogPlayableTransition(
+    stale.observedNonPlayable,
+    null,
+  );
+  assert.deepEqual(loading, { observedNonPlayable: true, outcome: null });
+  assert.deepEqual(
+    observeRelogPlayableTransition(loading.observedNonPlayable, "explorable"),
+    { observedNonPlayable: true, outcome: "restored" },
+  );
+});

--- a/tests/unit/relog-transcript.test.ts
+++ b/tests/unit/relog-transcript.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { formatRelogTranscript } from "../../src/main/diagnostics/relog-transcript.ts";
+import type { LogRecord } from "../../src/main/diagnostics/flight-recorder.ts";
+
+function event(
+  seq: number,
+  ownerId: number | undefined,
+  name: string,
+  fields: LogRecord["fields"] = {},
+): LogRecord {
+  return {
+    seq,
+    tsUs: seq * 1_250,
+    wallTime: "2026-08-25T00:00:00.000Z",
+    level: "info",
+    subsystem: name.startsWith("commandQ") || name.startsWith("quitReload")
+      ? "app" : "renderer",
+    name,
+    ...(ownerId === undefined ? {} : { ownerId }),
+    fields,
+  };
+}
+
+describe("reload transcript", () => {
+  it("joins main and replacement-renderer events for exactly one owner", () => {
+    const text = formatRelogTranscript({
+      ownerId: 4,
+      completeFromStart: true,
+      records: [
+        event(0, 4, "relog.finished", { outcome: "outpost" }),
+        event(1, 4, "commandQ.shortcut", { phase: "claimed", reason: "none" }),
+        event(2, 9, "quitReloadDialog.lifecycle", {
+          phase: "settled", action: "reload", autoRelog: true,
+        }),
+        event(3, 4, "quitReloadDialog.lifecycle", {
+          phase: "settled", action: "reload", autoRelog: true,
+        }),
+        event(4, undefined, "app.ready"),
+        event(5, 4, "gameReload.requested", { cause: "command-q" }),
+        event(6, 4, "gameReload.loaded", { cause: "command-q" }),
+        event(7, 4, "relog.intentClaimed", { clockSynchronized: true }),
+        event(8, 4, "relog.inputSettled", {
+          stage: "login", outcome: "sent", clockSynchronized: true,
+        }),
+        event(10, 4, "relog.finished", {
+          outcome: "restored", clockSynchronized: true,
+        }),
+      ],
+    });
+    assert.match(text, /status: complete/);
+    assert.match(text, /outside-current=1; omitted=0/);
+    assert.match(text, /commandQ\.shortcut claimed none/);
+    assert.match(text, /gameReload\.loaded cause=command-q/);
+    assert.doesNotMatch(text, /app\.ready/);
+    assert.equal((text.match(/quitReloadDialog/g) ?? []).length, 1);
+  });
+
+  it("reports an incomplete or missing boundary truthfully", () => {
+    const incomplete = formatRelogTranscript({
+      ownerId: 1,
+      completeFromStart: false,
+      records: [
+        event(1, 1, "gameReload.requested", { cause: "menu" }),
+        event(2, 1, "relog.tokenRequested", { clockSynchronized: false }),
+      ],
+    });
+    assert.match(incomplete, /status: incomplete; recorder-start=truncated/);
+    const absent = formatRelogTranscript({
+      ownerId: 1,
+      completeFromStart: true,
+      records: [event(1, 1, "renderer.loaded")],
+    });
+    assert.match(absent, /no reload boundary/);
+  });
+
+  it("stays below the clipboard ceiling by retaining newest complete rows", () => {
+    const records = [event(1, 2, "gameReload.requested", { cause: "menu" })];
+    for (let seq = 2; seq < 300; seq += 1) {
+      records.push(event(seq, 2, "relog.preGameProbe", {
+        state: "unknown", mask: seq, clockSynchronized: true,
+      }));
+    }
+    records.push(event(300, 2, "relog.finished", {
+      outcome: "restored", clockSynchronized: true,
+    }));
+    const text = formatRelogTranscript({
+      ownerId: 2,
+      completeFromStart: true,
+      records,
+      ceiling: 1_500,
+    });
+    assert.ok(text.length <= 1_500);
+    assert.match(text, /omitted=[1-9]\d*/);
+    assert.match(text, /relog\.finished/);
+  });
+});

--- a/tests/unit/relog-transcript.test.ts
+++ b/tests/unit/relog-transcript.test.ts
@@ -15,6 +15,7 @@ function event(
     wallTime: "2026-08-25T00:00:00.000Z",
     level: "info",
     subsystem: name.startsWith("commandQ") || name.startsWith("quitReload")
+      || name.startsWith("gameReload")
       ? "app" : "renderer",
     name,
     ...(ownerId === undefined ? {} : { ownerId }),
@@ -72,6 +73,24 @@ describe("reload transcript", () => {
       records: [event(1, 1, "renderer.loaded")],
     });
     assert.match(absent, /no reload boundary/);
+  });
+
+  it("starts a menu trace at its own reload after an older Command-Q run", () => {
+    const text = formatRelogTranscript({
+      ownerId: 1,
+      completeFromStart: true,
+      records: [
+        event(1, 1, "commandQ.shortcut", { phase: "claimed", reason: "none" }),
+        event(2, 1, "gameReload.requested", { cause: "command-q" }),
+        event(3, 1, "relog.finished", { outcome: "restored" }),
+        event(4, 1, "gameReload.requested", { cause: "menu" }),
+        event(5, 1, "relog.finished", { outcome: "outpost" }),
+      ],
+    });
+    assert.doesNotMatch(text, /commandQ\.shortcut/);
+    assert.doesNotMatch(text, /outcome=restored/);
+    assert.match(text, /gameReload\.requested cause=menu/);
+    assert.match(text, /relog\.finished outcome=outpost/);
   });
 
   it("stays below the clipboard ceiling by retaining newest complete rows", () => {

--- a/tests/unit/renderer-client-sessions.test.ts
+++ b/tests/unit/renderer-client-sessions.test.ts
@@ -19,6 +19,7 @@ const base: ClientSession = {
       skillSlotGeometry: { status: "available" },
       skillCooldownObservation: { status: "off" },
       playRegionObservation: { status: "off" },
+        preGameControls: { status: "off" },
     },
   },
   extendedMemory: {

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -37,6 +37,7 @@ describe("settings", () => {
       skillCooldownOverlayEnabled: true,
       skillCooldownColor: { kind: "preset", preset: "red" },
       extendedMemoryEnabled: false,
+      autoRelogAfterReload: false,
       showDiagnostics: false,
       dataStrategy: "full",
       // Automatic app-update checks remain a separate preference from the
@@ -84,6 +85,7 @@ describe("settings", () => {
       skillCooldownOverlayEnabled: true,
       skillCooldownColor: { kind: "preset", preset: "red" },
       extendedMemoryEnabled: false,
+      autoRelogAfterReload: false,
       showDiagnostics: true,
       dataStrategy: "full",
       autoCheckUpdates: true,
@@ -301,6 +303,9 @@ describe("settings", () => {
     assert.deepEqual(parseSettingsPatch({ extendedMemoryEnabled: true }), {
       extendedMemoryEnabled: true,
     });
+    assert.deepEqual(parseSettingsPatch({ autoRelogAfterReload: true }), {
+      autoRelogAfterReload: true,
+    });
     assert.deepEqual(parseSettingsPatch({ uiStyle: "obsidian" }), {
       uiStyle: "obsidian",
     });
@@ -351,6 +356,7 @@ describe("settings", () => {
     const saved = await saveSettings(path, {
       ...DEFAULT_SETTINGS,
       showDiagnostics: true,
+      autoRelogAfterReload: true,
       renderScale: 1.5,
       gwonmacTools: false,
       teamManagement: true,
@@ -360,9 +366,12 @@ describe("settings", () => {
       targetReadout: false,
     });
     assert.equal(saved.showDiagnostics, true);
+    assert.equal(saved.autoRelogAfterReload, true);
+    assert.equal((await loadSettings(path)).autoRelogAfterReload, true);
     const disk = JSON.parse(await readFile(path, "utf8"));
     assert.deepEqual(Object.keys(disk).sort(), [
       "autoCheckUpdates",
+      "autoRelogAfterReload",
       "compatibilityNoticeSeenFor",
       "controllerPromptStyle",
       "dataStrategy",
@@ -431,6 +440,7 @@ describe("settings", () => {
       skillCooldownOverlayEnabled: true,
       skillCooldownColor: { kind: "preset", preset: "red" },
       extendedMemoryEnabled: false,
+      autoRelogAfterReload: false,
       showDiagnostics: true,
       dataStrategy: "full",
       // Fields that alpha never wrote arrive at their defaults — deliberately

--- a/tests/unit/wasm-abort-reason.test.ts
+++ b/tests/unit/wasm-abort-reason.test.ts
@@ -260,3 +260,25 @@ describe("the recorded visual problem", () => {
     );
   });
 });
+
+describe("the relog pre-game probe", () => {
+  it("preserves the complete uint32 diagnostic mask", () => {
+    const fields = { state: "reconnect", mask: 0xff00_4242 } as const;
+    assert.deepEqual(
+      parseRendererMilestoneArgs(["relog.preGameProbe", 12_000, fields]),
+      {
+        name: "relog.preGameProbe",
+        rendererTimestampUs: 12_000,
+        fields,
+      },
+    );
+    assert.throws(
+      () => parseRendererMilestoneArgs([
+        "relog.preGameProbe",
+        12_000,
+        { state: "reconnect", mask: 0x1_0000_0000 },
+      ]),
+      /invalid renderer milestone/,
+    );
+  });
+});

--- a/tests/unit/window-shortcuts.test.ts
+++ b/tests/unit/window-shortcuts.test.ts
@@ -34,9 +34,17 @@ describe("window shortcut input", () => {
     } as unknown as BrowserWindow;
     const actions: string[] = [];
     const edits: string[] = [];
+    let quitOrReload = 0;
+    const commandQ: string[] = [];
+    const settleQuitDialogs: Array<() => void> = [];
     installWindowShortcuts(win, {
       run: (action) => actions.push(action),
       edit: (command) => edits.push(command),
+      quitOrReload: () => {
+        quitOrReload += 1;
+        return new Promise<void>((resolve) => settleQuitDialogs.push(resolve));
+      },
+      recordCommandQ: (phase, reason) => commandQ.push(`${phase}:${reason}`),
     });
     updateWindowShortcuts(win, {});
 
@@ -102,6 +110,27 @@ describe("window shortcut input", () => {
     assert.deepEqual(edits, ["cut", "selectAll"]);
     releaseWindowShortcutKey(win, "KeyA");
     assert.deepEqual(edits, ["cut", "selectAll"]);
+
+    assert.equal(dispatch(keyDown("KeyQ", "q")), true);
+    assert.equal(dispatch(keyDown("KeyQ", "q", { isAutoRepeat: true })), true);
+    assert.equal(quitOrReload, 1);
+    settleQuitDialogs.shift()?.();
+    await Promise.resolve();
+    assert.deepEqual(commandQ, [
+      "claimed:none",
+      "repeat-contained:none",
+      "rearmed:dialog-settled",
+    ]);
+    // A native sheet consumes the first physical key-up. Settling Cancel must
+    // still re-arm Q for the very next press.
+    assert.equal(dispatch(keyDown("KeyQ", "q")), true);
+    assert.equal(quitOrReload, 2);
+    settleQuitDialogs.shift()?.();
+    await Promise.resolve();
+    assert.equal(commandQ.at(-1), "rearmed:dialog-settled");
+    assert.equal(dispatch({
+      ...keyDown("KeyQ", "q"), type: "keyUp", meta: false,
+    }), false);
 
     const capture = captureWindowShortcut(win);
     assert.equal(dispatch(keyDown("KeyK", "k", { shift: true })), true);


### PR DESCRIPTION
Reloading Guild Wars after a memory warning was inconsistent. Command-Q could miss repeated shortcuts, one account reload could affect other windows, and automatic return could stop at login or character selection.

This change gives every reload entry point one account-local lifecycle. Command-Q, the Reload Guild Wars menu action, and memory warnings use the same saved “Return to my character automatically” preference. When enabled, the replacement client signs in, selects the current character, accepts a previous-session reconnect when offered, and otherwise enters the selected outpost.

The automatic flow uses certified client state instead of fixed navigation delays. It requires the exact character-selection or reconnect state before sending input. A transient loading state cannot skip character selection, and playable state cannot complete the flow while pre-game UI is still present.

The code-quality pass moved this lifecycle out of the general renderer harness into one focused owner. It also made client certification fail closed, requires the exact reconnect dialog with its Yes and No controls, prevents partial reload after settings failure, and makes completion and timeout one-shot outcomes.

The branch is based on `main` after #289. Its memory-warning checkbox and actions use the shared UI system introduced there.

## User experience

- Command-Q always opens a native Quit or Reload sheet for the active account.
- Reloading closes only that account's sockets and keeps other accounts open.
- The automatic-return choice is shared by Command-Q, the menu, and memory warnings.
- The choice persists across account windows and future app launches.
- Memory warnings expose the same choice before reloading.
- Help → Diagnostics → Copy Reload Trace provides a bounded feedback loop when a future client build behaves differently.

## Verification

- `pnpm verify`
  - type checking, lint, and documentation links
  - unit and policy suites
  - 111 Tools unit tests
  - 66 integration tests
  - 25 release tests
  - 42 Tools browser tests
  - 158 Electron tests, with the opt-in live-client download test skipped
  - packaged application smoke and packaged Enhancement runtime
- Companion kernel ABI and reproducible build verification
- Every certified runtime profile reproduced against the locally installed Guild Wars client
- Live automatic return completed after rebuilding the corrected renderer
- `git diff --check`

Implemented and investigated with Codex. Live Guild Wars qualification was performed by Matthias using the privacy-bounded reload trace.
