### PR TITLE
test(relog): wait for reload intent before trace assertions

### DIFF
--- a/tests/electron/multiple-accounts.spec.ts
+++ b/tests/electron/multiple-accounts.spec.ts
@@ -844,10 +844,12 @@ test("Multi isolates profile windows and Copy Reload Trace", async () => {
         },
       )),
     ]);
-    await clickMenuForGame("Guild Wars Reforged — Alt", "copy-reload-trace");
-    await expect.poll(() => fixture.app.evaluate(({ clipboard }) => clipboard.readText()))
-      .toContain("gameReload.requested cause=menu");
+    await expect.poll(async () => {
+      await clickMenuForGame("Guild Wars Reforged — Alt", "copy-reload-trace");
+      return fixture.app.evaluate(({ clipboard }) => clipboard.readText());
+    }).toContain("relog.intentClaimed");
     const reloadTrace = await fixture.app.evaluate(({ clipboard }) => clipboard.readText());
+    expect(reloadTrace).toContain("gameReload.requested cause=menu");
     expect(reloadTrace).toContain("relog.intentClaimed");
     expect(reloadTrace).toContain("relog.preGameProbe state=reconnect");
     expect(reloadTrace).not.toContain("relog.preGameProbe state=unknown");


### PR DESCRIPTION
Application verification on `main` could fail after a successful game reload because the Electron test copied the diagnostic trace before the replacement renderer had finished its asynchronous relog-intent claim.

This makes the test wait on the event it needs to verify. Each poll refreshes the copied trace, then the existing assertions still confirm the menu reload, account-local reconnect probe, and absence of the other account's probe.

## Verification

- `pnpm check`
- `pnpm build`
- Focused Electron test repeated five times: 5 passed
- `git diff --check`

Implemented and investigated with Codex.
