### PR TITLE
feat(window): preserve placement across display changes

### DIFF
--- a/docs/process-model.md
+++ b/docs/process-model.md
@@ -295,6 +295,11 @@ The main process owns these native stores:
 - Single Account and profile-scoped saved-login items in Apple's Data
   Protection Keychain.
 
+Each game window stores its normal bounds, mode, and display work area in its
+window-state document. Restore keeps the window's relative size and position
+when display resolution, scaling, or usable space changes. A missing display
+falls back to the primary display. Restore never opens a window off-screen.
+
 Each game renderer owns one Guild Wars IDBFS mount under its isolated
 `gw://app` session. The mount contains game preferences, templates,
 screenshots, and chat logs. Two renderers do not mount the same browser store.

--- a/scripts/verify-stable-beta-roundtrip.ts
+++ b/scripts/verify-stable-beta-roundtrip.ts
@@ -289,6 +289,9 @@ const publishWindowSize = (width: number, height: number): Promise<void> =>
   saveWindowState(windowStatePath, {
     bounds: { x: 100, y: 100, width, height },
     mode: "normal",
+    // The rollback Stable ignores this additive field. The candidate requires
+    // it whenever it writes the same format-1 document.
+    displayWorkArea: { x: 0, y: 0, width: 1_920, height: 1_080 },
   });
 
 async function windowSize(page: Page): Promise<{ width: number; height: number }> {

--- a/src/main/core/window-state.ts
+++ b/src/main/core/window-state.ts
@@ -1,6 +1,8 @@
 /**
  * The persisted window placement: what counts as a valid one, and how a stored
- * one is fitted back onto the displays that exist right now.
+ * one is fitted back onto the displays that exist right now. The saved display
+ * work area keeps the window's relative size and position when that display's
+ * resolution or usable area changes.
  *
  * `mode` is three values and minimized is not among them — a window is never
  * restored into a state the player cannot see. Placement is re-validated
@@ -24,10 +26,20 @@ export interface WindowBounds {
   height: number;
 }
 
+type WindowMode = "normal" | "maximized" | "fullscreen";
+
 export interface WindowState {
   bounds: WindowBounds;
-  mode: "normal" | "maximized" | "fullscreen";
+  mode: WindowMode;
+  displayWorkArea: WindowBounds;
 }
+
+export interface LegacyWindowState {
+  bounds: WindowBounds;
+  mode: WindowMode;
+}
+
+export type RestorableWindowState = WindowState | LegacyWindowState;
 
 export const DEFAULT_WINDOW_SIZE = {
   width: 1280,
@@ -37,66 +49,81 @@ export const DEFAULT_WINDOW_SIZE = {
 const DEFAULT_WINDOW_MARGIN = 64;
 const WINDOW_STATE_FORMAT = 1;
 
-const MODES = new Set<WindowState["mode"]>([
-  "normal",
-  "maximized",
-  "fullscreen",
-]);
-
 function integer(value: unknown, name: string): number {
-  if (!Number.isSafeInteger(value)) {
+  if (typeof value !== "number" || !Number.isSafeInteger(value)) {
     throw new AppError("bad_window_state", `windowState.${name} must be an integer`);
   }
-  return value as number;
+  return value;
+}
+
+function parseMode(value: unknown): WindowMode {
+  if (value === "normal" || value === "maximized" || value === "fullscreen") {
+    return value;
+  }
+  throw new AppError("bad_window_state", "window state mode is invalid");
+}
+
+function parseBounds(value: unknown, name: string): WindowBounds {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new AppError("bad_window_state", `windowState.${name} is invalid`);
+  }
+  const bounds = value as Record<string, unknown>;
+  const parsed = {
+    x: integer(bounds.x, `${name}.x`),
+    y: integer(bounds.y, `${name}.y`),
+    width: integer(bounds.width, `${name}.width`),
+    height: integer(bounds.height, `${name}.height`),
+  };
+  if (
+    parsed.width < 1 ||
+    parsed.height < 1 ||
+    parsed.width > 32_768 ||
+    parsed.height > 32_768
+  ) {
+    throw new AppError("bad_window_state", `windowState.${name} values are invalid`);
+  }
+  return parsed;
 }
 
 /**
- * A file with no `formatVersion` is what the public alpha wrote: v0 and v1 are
- * the same `{ bounds, mode }` shape, so an alpha window comes back where the
- * player left it. A version this build does not know is refused, and
- * `loadWindowState` falls back to a default window rather than placing one
- * from a shape it cannot read.
+ * A file with no `formatVersion` is what the public alpha wrote. Early version
+ * 1 files also contain only `{ bounds, mode }`. Both restore in absolute pixels
+ * once and gain their display work area on the next save. The additive field
+ * keeps the document readable by the supported Stable rollback baseline.
  */
-export function parseWindowState(value: unknown): WindowState {
+export function parseWindowState(value: unknown): RestorableWindowState {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     throw new AppError("bad_window_state", "window state must be an object");
   }
   const record = value as Record<string, unknown>;
-  if (
-    record.formatVersion !== undefined &&
-    record.formatVersion !== WINDOW_STATE_FORMAT
-  ) {
+  const version = record.formatVersion;
+  if (version !== undefined && version !== WINDOW_STATE_FORMAT) {
     throw new AppError(
       "bad_window_state",
       `windowState.formatVersion ${JSON.stringify(record.formatVersion)} is not readable`,
     );
   }
-  if (!record.bounds || typeof record.bounds !== "object" || Array.isArray(record.bounds)) {
-    throw new AppError("bad_window_state", "window state bounds are invalid");
-  }
-  const bounds = record.bounds as Record<string, unknown>;
-  const parsed: WindowBounds = {
-    x: integer(bounds.x, "bounds.x"),
-    y: integer(bounds.y, "bounds.y"),
-    width: integer(bounds.width, "bounds.width"),
-    height: integer(bounds.height, "bounds.height"),
-  };
-  if (
-    parsed.width < 320 ||
-    parsed.height < 240 ||
-    parsed.width > 32_768 ||
-    parsed.height > 32_768 ||
-    !MODES.has(record.mode as WindowState["mode"])
-  ) {
+  const parsed = parseBounds(record.bounds, "bounds");
+  if (parsed.width < 320 || parsed.height < 240) {
     throw new AppError("bad_window_state", "window state values are invalid");
   }
-  return { bounds: parsed, mode: record.mode as WindowState["mode"] };
+  const state: LegacyWindowState = {
+    bounds: parsed,
+    mode: parseMode(record.mode),
+  };
+  if (record.displayWorkArea !== undefined) {
+    return {
+      ...state,
+      displayWorkArea: parseBounds(record.displayWorkArea, "displayWorkArea"),
+    };
+  }
+  return state;
 }
 
 export async function loadWindowState(
   path: string,
   onInvalid?: () => void | Promise<void>,
-): Promise<WindowState | null> {
+): Promise<RestorableWindowState | null> {
   let text: string;
   try {
     text = await readFile(path, "utf8");
@@ -117,9 +144,13 @@ export async function saveWindowState(
   path: string,
   value: WindowState,
 ): Promise<void> {
+  const parsed = parseWindowState({
+    formatVersion: WINDOW_STATE_FORMAT,
+    ...value,
+  });
   await writeAtomicJson(
     path,
-    { formatVersion: WINDOW_STATE_FORMAT, ...parseWindowState(value) },
+    { formatVersion: WINDOW_STATE_FORMAT, ...parsed },
     0o600,
   );
 }
@@ -148,27 +179,77 @@ function clamp(value: number, minimum: number, maximum: number): number {
   return Math.min(maximum, Math.max(minimum, value));
 }
 
+function scaledSize(
+  bounds: WindowBounds,
+  savedArea: WindowBounds,
+  currentArea: WindowBounds,
+): Pick<WindowBounds, "width" | "height"> {
+  const requestedWidth = Math.round(bounds.width / savedArea.width * currentArea.width);
+  const requestedHeight = Math.round(bounds.height / savedArea.height * currentArea.height);
+  return {
+    width: Math.min(Math.max(800, requestedWidth), currentArea.width),
+    height: Math.min(Math.max(600, requestedHeight), currentArea.height),
+  };
+}
+
+function restoreBounds(
+  bounds: WindowBounds,
+  savedArea: WindowBounds,
+  currentArea: WindowBounds,
+): WindowBounds {
+  const size = scaledSize(bounds, savedArea, currentArea);
+  const savedHorizontalRange = savedArea.width - bounds.width;
+  const savedVerticalRange = savedArea.height - bounds.height;
+  const horizontalRatio = savedHorizontalRange > 0
+    ? clamp((bounds.x - savedArea.x) / savedHorizontalRange, 0, 1)
+    : 0;
+  const verticalRatio = savedVerticalRange > 0
+    ? clamp((bounds.y - savedArea.y) / savedVerticalRange, 0, 1)
+    : 0;
+  return {
+    x: currentArea.x + Math.round(
+      horizontalRatio * (currentArea.width - size.width),
+    ),
+    y: currentArea.y + Math.round(
+      verticalRatio * (currentArea.height - size.height),
+    ),
+    ...size,
+  };
+}
+
+function centeredBounds(
+  size: Pick<WindowBounds, "width" | "height">,
+  area: WindowBounds,
+): WindowBounds {
+  return {
+    x: Math.round(area.x + (area.width - size.width) / 2),
+    y: Math.round(area.y + (area.height - size.height) / 2),
+    ...size,
+  };
+}
+
 export function fitWindowStateToDisplays(
-  state: WindowState,
+  state: RestorableWindowState,
   workAreas: WindowBounds[],
   primaryWorkArea: WindowBounds,
 ): WindowState {
+  const savedArea = "displayWorkArea" in state
+    ? state.displayWorkArea
+    : null;
+  const reference = savedArea ?? state.bounds;
   const target = workAreas
-    .map((area) => ({ area, overlap: intersectionArea(state.bounds, area) }))
+    .map((area) => ({ area, overlap: intersectionArea(reference, area) }))
     .sort((a, b) => b.overlap - a.overlap)[0];
-  const area = target && target.overlap > 0 ? target.area : primaryWorkArea;
-  const width = Math.min(Math.max(800, state.bounds.width), area.width);
-  const height = Math.min(Math.max(600, state.bounds.height), area.height);
-  const hasVisibleIntersection = !!target && target.overlap > 0;
-  const x = hasVisibleIntersection
-    ? clamp(state.bounds.x, area.x, area.x + area.width - width)
-    : Math.round(area.x + (area.width - width) / 2);
-  const y = hasVisibleIntersection
-    ? clamp(state.bounds.y, area.y, area.y + area.height - height)
-    : Math.round(area.y + (area.height - height) / 2);
+  const hasTarget = !!target && target.overlap > 0;
+  const area = hasTarget ? target.area : primaryWorkArea;
+  const sourceArea = savedArea ?? area;
+  const bounds = hasTarget
+    ? restoreBounds(state.bounds, sourceArea, area)
+    : centeredBounds(scaledSize(state.bounds, sourceArea, area), area);
   return {
-    bounds: { x, y, width, height },
+    bounds,
     mode: state.mode,
+    displayWorkArea: area,
   };
 }
 
@@ -195,6 +276,7 @@ export function defaultWindowState(primaryWorkArea: WindowBounds): WindowState {
       height,
     },
     mode: "normal",
+    displayWorkArea: primaryWorkArea,
   };
 }
 

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -135,6 +135,10 @@ function primaryWorkArea(): WindowBounds {
   return { ...screen.getPrimaryDisplay().workArea };
 }
 
+function displayWorkAreaFor(bounds: WindowBounds): WindowBounds {
+  return { ...screen.getDisplayMatching(bounds).workArea };
+}
+
 export async function prepareWindowState(
   diagnosticOwnerId: number,
   statePath = gamePaths().windowState,
@@ -175,15 +179,15 @@ function currentWindowState(win: BrowserWindow, owner: WindowStateOwner): Window
   if (mode === "normal") {
     owner.lastNormalBounds = { ...win.getBounds() };
   }
+  const bounds = owner.lastNormalBounds ?? fitWindowStateToDisplays(
+    defaultWindowState(primaryWorkArea()),
+    workAreas(),
+    primaryWorkArea(),
+  ).bounds;
   return {
-    bounds:
-      owner.lastNormalBounds ??
-      fitWindowStateToDisplays(
-        defaultWindowState(primaryWorkArea()),
-        workAreas(),
-        primaryWorkArea(),
-      ).bounds,
+    bounds,
     mode,
+    displayWorkArea: displayWorkAreaFor(bounds),
   };
 }
 
@@ -274,7 +278,11 @@ export function resetWindowState(win: BrowserWindow): Promise<void> {
           });
         }
         win.setBounds(requested.bounds);
-        settled = { bounds: { ...win.getBounds() }, mode: "normal" };
+        settled = {
+          bounds: { ...win.getBounds() },
+          mode: "normal",
+          displayWorkArea: displayWorkAreaFor(win.getBounds()),
+        };
       }
       owner.restored = settled;
       owner.lastNormalBounds = settled.bounds;

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -92,8 +92,7 @@ export function resetRendererRecovery(statePath: string): void {
 interface WindowStateOwner {
   readonly path: string;
   readonly diagnosticOwnerId: number;
-  restored: WindowState | null;
-  lastNormalBounds: WindowBounds | null;
+  lastNormalPlacement: Pick<WindowState, "bounds" | "displayWorkArea"> | null;
   timer: ReturnType<typeof setTimeout> | null;
   write: Promise<void>;
   reset: Promise<void>;
@@ -177,17 +176,19 @@ function currentWindowState(win: BrowserWindow, owner: WindowStateOwner): Window
       ? "maximized"
       : "normal";
   if (mode === "normal") {
-    owner.lastNormalBounds = { ...win.getBounds() };
+    const bounds = { ...win.getBounds() };
+    owner.lastNormalPlacement = {
+      bounds,
+      displayWorkArea: displayWorkAreaFor(bounds),
+    };
   }
-  const bounds = owner.lastNormalBounds ?? fitWindowStateToDisplays(
-    defaultWindowState(primaryWorkArea()),
-    workAreas(),
+  const placement = owner.lastNormalPlacement ?? defaultWindowState(
     primaryWorkArea(),
-  ).bounds;
+  );
   return {
-    bounds,
+    bounds: placement.bounds,
     mode,
-    displayWorkArea: displayWorkAreaFor(bounds),
+    displayWorkArea: placement.displayWorkArea,
   };
 }
 
@@ -195,7 +196,6 @@ async function persistWindowState(win: BrowserWindow): Promise<void> {
   const owner = windowStateOwners.get(win);
   if (win.isDestroyed() || !owner) return;
   const state = currentWindowState(win, owner);
-  owner.restored = state;
   const write = owner.write.then(() =>
     saveWindowState(owner.path, state),
   );
@@ -284,8 +284,10 @@ export function resetWindowState(win: BrowserWindow): Promise<void> {
           displayWorkArea: displayWorkAreaFor(win.getBounds()),
         };
       }
-      owner.restored = settled;
-      owner.lastNormalBounds = settled.bounds;
+      owner.lastNormalPlacement = {
+        bounds: settled.bounds,
+        displayWorkArea: settled.displayWorkArea,
+      };
       const write = owner.write.then(() =>
         saveWindowState(owner.path, settled),
       );
@@ -445,8 +447,12 @@ export function createMainWindow(
   const stateOwner: WindowStateOwner = {
     path: statePath,
     diagnosticOwnerId: options.diagnosticOwnerId,
-    restored: initialState,
-    lastNormalBounds: initialState?.bounds ?? null,
+    lastNormalPlacement: initialState
+      ? {
+          bounds: initialState.bounds,
+          displayWorkArea: initialState.displayWorkArea,
+        }
+      : null,
     timer: null,
     write: Promise.resolve(),
     reset: Promise.resolve(),
@@ -481,7 +487,11 @@ export function createMainWindow(
       win.isFullScreen() ||
       win.isMaximized()
     ) return;
-    stateOwner.lastNormalBounds = { ...win.getBounds() };
+    const bounds = { ...win.getBounds() };
+    stateOwner.lastNormalPlacement = {
+      bounds,
+      displayWorkArea: displayWorkAreaFor(bounds),
+    };
     scheduleWindowStateSave(win);
   };
   win.on("move", rememberNormalBounds);

--- a/tests/electron/app.spec.ts
+++ b/tests/electron/app.spec.ts
@@ -294,6 +294,12 @@ test.describe("Electron application", () => {
         formatVersion: 1,
         bounds: normalBounds,
         mode: "fullscreen",
+        displayWorkArea: {
+          x: expect.any(Number),
+          y: expect.any(Number),
+          width: expect.any(Number),
+          height: expect.any(Number),
+        },
       });
       expect((await stat(statePath)).mode & 0o777).toBe(0o600);
 
@@ -337,26 +343,35 @@ test.describe("Electron application", () => {
         )
         .not.toBeNull();
       const resetHasSettled = async () => {
-        const bounds = await app.evaluate(({ BrowserWindow }) => {
+        const placement = await app.evaluate(({ BrowserWindow, screen }) => {
           const win = BrowserWindow.getAllWindows()[0];
           if (!win) throw new Error("window missing");
-          return win.getBounds();
+          const bounds = win.getBounds();
+          return {
+            bounds,
+            displayWorkArea: { ...screen.getDisplayMatching(bounds).workArea },
+          };
         });
         const saved = JSON.parse(await readFile(statePath, "utf8")) as {
           formatVersion?: unknown;
-          bounds?: Partial<typeof bounds>;
+          bounds?: Partial<typeof placement.bounds>;
+          displayWorkArea?: Partial<typeof placement.displayWorkArea>;
           mode?: unknown;
         };
         return {
-          bounds,
+          ...placement,
           saved,
           converged:
             saved.formatVersion === 1
             && saved.mode === "normal"
-            && saved.bounds?.x === bounds.x
-            && saved.bounds?.y === bounds.y
-            && saved.bounds?.width === bounds.width
-            && saved.bounds?.height === bounds.height,
+            && saved.bounds?.x === placement.bounds.x
+            && saved.bounds?.y === placement.bounds.y
+            && saved.bounds?.width === placement.bounds.width
+            && saved.bounds?.height === placement.bounds.height
+            && saved.displayWorkArea?.x === placement.displayWorkArea.x
+            && saved.displayWorkArea?.y === placement.displayWorkArea.y
+            && saved.displayWorkArea?.width === placement.displayWorkArea.width
+            && saved.displayWorkArea?.height === placement.displayWorkArea.height,
         };
       };
       await expect
@@ -364,7 +379,7 @@ test.describe("Electron application", () => {
           timeout: 15_000,
         })
         .toBe(true);
-      const { bounds: actualReset, saved: savedReset } =
+      const { bounds: actualReset, displayWorkArea, saved: savedReset } =
         await resetHasSettled();
       expect(
         await app.evaluate(({ screen }, bounds) =>
@@ -379,6 +394,7 @@ test.describe("Electron application", () => {
         formatVersion: 1,
         bounds: actualReset,
         mode: "normal",
+        displayWorkArea,
       });
       await closeCleanly(app);
     } finally {

--- a/tests/unit/window-state.test.ts
+++ b/tests/unit/window-state.test.ts
@@ -20,6 +20,7 @@ describe("window state", () => {
     const value = {
       bounds: { x: -1200, y: 40, width: 1280, height: 800 },
       mode: "fullscreen" as const,
+      displayWorkArea: { x: -1440, y: 0, width: 1440, height: 900 },
     };
     await saveWindowState(path, value);
     assert.deepEqual(await loadWindowState(path), value);
@@ -44,14 +45,26 @@ describe("window state", () => {
       invalid = true;
     });
     assert.equal(invalid, false, "an alpha window must not be discarded");
+    assert.ok(loaded);
     assert.deepEqual(loaded, alpha);
+    assert.deepEqual(parseWindowState({ formatVersion: 1, ...alpha }), alpha);
+    assert.throws(
+      () => parseWindowState({
+        formatVersion: 1,
+        ...alpha,
+        displayWorkArea: { x: 0, y: 0, width: 0, height: 900 },
+      }),
+      AppError,
+    );
 
-    await saveWindowState(path, loaded!);
+    const workArea = { x: 0, y: 25, width: 1728, height: 1080 };
+    const migrated = fitWindowStateToDisplays(loaded, [workArea], workArea);
+    await saveWindowState(path, migrated);
     assert.deepEqual(JSON.parse(await readFile(path, "utf8")), {
       formatVersion: 1,
-      ...alpha,
+      ...migrated,
     });
-    assert.deepEqual(await loadWindowState(path), alpha);
+    assert.deepEqual(await loadWindowState(path), migrated);
   });
 
   it("discards a window-state format this build cannot read", async () => {
@@ -95,6 +108,7 @@ describe("window state", () => {
       {
         bounds: { x: -1440, y: 0, width: 1440, height: 900 },
         mode: "maximized",
+        displayWorkArea: secondary,
       },
     );
   });
@@ -110,11 +124,13 @@ describe("window state", () => {
       {
         bounds: { x: 224, y: 165, width: 1280, height: 800 },
         mode: "normal",
+        displayWorkArea: primary,
       },
     );
     assert.deepEqual(defaultWindowState(primary), {
       bounds: { x: 224, y: 165, width: 1280, height: 800 },
       mode: "normal",
+      displayWorkArea: primary,
     });
   });
 
@@ -123,8 +139,81 @@ describe("window state", () => {
     assert.deepEqual(defaultWindowState(primary), {
       bounds: { x: 32, y: 57, width: 960, height: 620 },
       mode: "normal",
+      displayWorkArea: primary,
     });
   });
+
+  const proportionalCases = [
+    {
+      name: "an unchanged work area",
+      savedArea: { x: 0, y: 25, width: 1920, height: 1055 },
+      bounds: { x: 576, y: 236, width: 960, height: 633 },
+      workAreas: [{ x: 0, y: 25, width: 1920, height: 1055 }],
+      primary: { x: 0, y: 25, width: 1920, height: 1055 },
+      expectedArea: { x: 0, y: 25, width: 1920, height: 1055 },
+      expectedBounds: { x: 576, y: 236, width: 960, height: 633 },
+    },
+    {
+      name: "a larger work area",
+      savedArea: { x: 0, y: 25, width: 1920, height: 1055 },
+      bounds: { x: 576, y: 236, width: 960, height: 633 },
+      workAreas: [{ x: 0, y: 25, width: 2560, height: 1400 }],
+      primary: { x: 0, y: 25, width: 2560, height: 1400 },
+      expectedArea: { x: 0, y: 25, width: 2560, height: 1400 },
+      expectedBounds: { x: 768, y: 305, width: 1280, height: 840 },
+    },
+    {
+      name: "a smaller work area constrained by minimum window size",
+      savedArea: { x: 0, y: 25, width: 1920, height: 1055 },
+      bounds: { x: 576, y: 236, width: 960, height: 633 },
+      workAreas: [{ x: 0, y: 25, width: 1024, height: 684 }],
+      primary: { x: 0, y: 25, width: 1024, height: 684 },
+      expectedArea: { x: 0, y: 25, width: 1024, height: 684 },
+      expectedBounds: { x: 134, y: 67, width: 800, height: 600 },
+    },
+    {
+      name: "a missing display",
+      savedArea: { x: 2000, y: 25, width: 1920, height: 1055 },
+      bounds: { x: 2576, y: 236, width: 960, height: 633 },
+      workAreas: [{ x: 0, y: 25, width: 1728, height: 1080 }],
+      primary: { x: 0, y: 25, width: 1728, height: 1080 },
+      expectedArea: { x: 0, y: 25, width: 1728, height: 1080 },
+      expectedBounds: { x: 432, y: 241, width: 864, height: 648 },
+    },
+    {
+      name: "the matching display in a multi-display layout",
+      savedArea: { x: 1728, y: 25, width: 1920, height: 1055 },
+      bounds: { x: 2304, y: 236, width: 960, height: 633 },
+      workAreas: [
+        { x: 0, y: 25, width: 1728, height: 1080 },
+        { x: 1728, y: 25, width: 2560, height: 1400 },
+      ],
+      primary: { x: 0, y: 25, width: 1728, height: 1080 },
+      expectedArea: { x: 1728, y: 25, width: 2560, height: 1400 },
+      expectedBounds: { x: 2496, y: 305, width: 1280, height: 840 },
+    },
+  ] as const;
+
+  for (const testCase of proportionalCases) {
+    it(`restores relative geometry on ${testCase.name}`, () => {
+      assert.deepEqual(
+        fitWindowStateToDisplays(
+          {
+            bounds: testCase.bounds,
+            mode: "normal",
+            displayWorkArea: testCase.savedArea,
+          },
+          [...testCase.workAreas],
+          testCase.primary,
+        ),
+        {
+          bounds: testCase.expectedBounds,
+          mode: "normal",
+          displayWorkArea: testCase.expectedArea,
+        },
+      );
+    });
+  }
 
   it("cascades new account windows by 32px and clamps them", () => {
     const workArea = { x: 0, y: 24, width: 1600, height: 1000 };


### PR DESCRIPTION
Game windows could reopen with placement that no longer matched the player’s screen after its resolution, scaling, Dock space, or monitor layout changed.

This change saves the display work area with each game window and restores its normal size and position proportionally. Existing window-state files migrate on their next save, missing displays fall back safely to the primary display, and the additive format remains readable by the supported Stable rollback baseline.

The window-state model now separates legacy input from canonical writable state. The geometry policy is covered for unchanged, larger, smaller, missing, and multi-display work areas.

## Verification

- `pnpm run check`
  - 1,319 unit tests
  - 181 policy tests
  - 111 Tools tests
- Focused Electron fullscreen, restore, and reset lifecycle test
- `git diff --check`

Implemented and reviewed with Codex.
