### PR TITLE
feat(travel): restore per-character recent destinations

### DIFF
--- a/apps/tools/src/components/TravelPalette.test.ts
+++ b/apps/tools/src/components/TravelPalette.test.ts
@@ -13,10 +13,12 @@ import type {
 } from "../travel-host";
 import TravelDestinationPicker from "./TravelDestinationPicker.vue";
 import TravelPalette from "./TravelPalette.vue";
+import { EMPTY_TRAVEL_HISTORY } from "../../../../src/shared/travel-history";
 
 function fixture(options: Readonly<{
   shortcuts?: TravelShortcuts;
   synonyms?: TravelSynonyms;
+  history?: readonly number[];
 }> = {}, attachTo?: Element) {
   const state = ref<TravelHost["state"]["value"]>({ status: "ready", mapId: 55 });
   let preferences: TravelPreferences = Object.freeze({
@@ -25,6 +27,7 @@ function fixture(options: Readonly<{
   });
   const attempt = ref<TravelHost["attempt"]["value"]>({ status: "idle" });
   const notice = ref<TravelHost["notice"]["value"]>(null);
+  const history = ref(options.history ?? EMPTY_TRAVEL_HISTORY);
   const travel = vi.fn<TravelHost["travel"]>(async (request) => {
     attempt.value = { status: "queued", mapId: request.mapId };
   });
@@ -42,9 +45,11 @@ function fixture(options: Readonly<{
     state,
     attempt,
     notice,
+    history,
     unavailable: null,
     async loadPreferences() { return preferences; },
     savePreferences,
+    async loadHistory() { return history.value; },
     travel,
     updateGameState(next) {
       state.value = next;
@@ -133,6 +138,29 @@ describe("TravelPalette", () => {
     expect(wrapper.get(".travel-match").text()).toBe("Search phrase");
     await wrapper.get('[role="option"]').trigger("click");
     expect(travel).toHaveBeenCalledWith({ mapId: 480 });
+    wrapper.unmount();
+  });
+
+  it("shows per-character recents without repeating the current map", async () => {
+    const { wrapper } = fixture({ history: [55, 449, 81] });
+    await flushPromises();
+    expect(wrapper.get(".travel-history").text()).toContain("Kamadan");
+    expect(wrapper.get(".travel-history").text()).toContain("Ascalon City");
+    expect(wrapper.get(".travel-history").text()).not.toContain("Lion's Arch");
+    wrapper.unmount();
+  });
+
+  it("filters positively locked destinations while unlock observation is available", async () => {
+    const { wrapper, state } = fixture();
+    const unlockedMapWords = Array.from({ length: 28 }, () => 0);
+    unlockedMapWords[Math.floor(55 / 32)] = 1 << (55 % 32);
+    state.value = {
+      status: "ready", mapId: 55, characterKey: "0123456789abcdef", unlockedMapWords,
+    };
+    await wrapper.get("#travel-search-input").setValue("Kamadan");
+    expect(wrapper.findAll('[role="option"]')).toHaveLength(0);
+    await wrapper.get("#travel-search-input").setValue("Lion's Arch");
+    expect(wrapper.findAll('[role="option"]')).toHaveLength(1);
     wrapper.unmount();
   });
 

--- a/apps/tools/src/components/TravelPalette.vue
+++ b/apps/tools/src/components/TravelPalette.vue
@@ -12,6 +12,8 @@ import {
   type TravelRequest,
 } from "../../../../src/shared/travel";
 import type { TravelHost } from "../travel-host";
+import { isTravelMapUnlocked } from "../../../../src/shared/travel-command";
+import { TRAVEL_HISTORY_VISIBLE_LIMIT } from "../../../../src/shared/travel-history";
 import { useTravelPreferences } from "../travel-preferences";
 import TravelDestinationPicker from "./TravelDestinationPicker.vue";
 
@@ -50,15 +52,30 @@ let visibilityLoad = 0;
 
 const hasQuery = computed(() => normaliseTravelTerm(query.value).length > 0);
 const travelPending = computed(() => props.host.attempt.value.status !== "idle");
-const results = computed(() => hasQuery.value
+const catalogueResults = computed(() => hasQuery.value
   ? searchTravelDestinations(query.value, synonyms.value)
   : []
 );
+const isAvailable = (mapId: number) =>
+  isTravelMapUnlocked(props.host.state.value, mapId) !== false;
+const results = computed(() => catalogueResults.value.filter(
+  (destination) => isAvailable(destination.mapId),
+));
 const shortcutRows = computed(() => Array.from({ length: TRAVEL_SHORTCUT_LIMIT }, (_, index) => {
   const request = shortcuts.value[index] ?? null;
   return { index, request, destination: request === null ? null : travelDestination(request.mapId) };
 }));
-const assignedShortcuts = computed(() => shortcutRows.value.filter((row) => row.destination !== null));
+const assignedShortcuts = computed(() => shortcutRows.value.filter(
+  (row) => row.destination !== null && row.request !== null && isAvailable(row.request.mapId),
+));
+const currentMapId = computed(() =>
+  props.host.state.value.status === "ready" ? props.host.state.value.mapId : null
+);
+const recentDestinations = computed(() => props.host.history.value
+  .filter((mapId) => mapId !== currentMapId.value && isAvailable(mapId))
+  .map((mapId) => travelDestination(mapId))
+  .filter((destination): destination is TravelDestination => destination !== null)
+  .slice(0, TRAVEL_HISTORY_VISIBLE_LIMIT));
 const activeDestination = computed(() => results.value[active.value] ?? null);
 const statusText = computed(() => feedback.value || props.host.unavailable || "");
 const statusLevel = computed(() => feedback.value
@@ -110,7 +127,11 @@ watch(() => props.visible, async (visible) => {
   feedback.value = "";
   phraseError.value = "";
   try {
-    if (!await travelPreferences.load() || load !== visibilityLoad) return;
+    const [preferencesLoaded] = await Promise.all([
+      travelPreferences.load(),
+      props.host.loadHistory(),
+    ]);
+    if (!preferencesLoaded || load !== visibilityLoad) return;
   } catch {
     setFeedback("Travel preferences could not be loaded. Reopen Travel to try again.", "danger");
   }
@@ -330,7 +351,7 @@ function onKeydown(event: KeyboardEvent): void {
     event.preventDefault();
     const slot = Number(event.code.slice(5)) - 1;
     const shortcut = shortcuts.value[slot];
-    if (shortcut) void travel(shortcut);
+    if (shortcut && isAvailable(shortcut.mapId)) void travel(shortcut);
     else void openShortcutManager(slot);
   }
 }
@@ -357,6 +378,12 @@ onBeforeUnmount(() => window.clearTimeout(closeTimer));
     </section>
 
     <section v-else-if="mode === 'travel'" id="travel-panel" class="ui-scroll travel-body" role="region" aria-label="Travel">
+      <section v-if="recentDestinations.length" class="travel-section travel-history" aria-labelledby="travel-history-title">
+        <header class="travel-section-head"><h2 id="travel-history-title">Recent</h2><span>Observed in Guild Wars</span></header>
+        <div class="travel-recent-grid">
+          <button v-for="destination in recentDestinations" :key="destination.mapId" type="button" class="travel-recent ui-row" :disabled="travelPending || host.unavailable !== null" :aria-label="`Travel to recent destination ${destination.name}`" @click="travel({ mapId: destination.mapId })"><span><strong>{{ destination.name }}</strong><small>{{ destination.campaign }}</small></span><svg viewBox="0 0 20 20" aria-hidden="true"><path d="m7 4 6 6-6 6" /></svg></button>
+        </div>
+      </section>
       <section class="travel-section travel-favorites" aria-labelledby="travel-favorites-title">
         <header class="travel-section-head"><h2 id="travel-favorites-title">Favorites</h2><span>Press 1–9</span></header>
         <div v-if="assignedShortcuts.length" class="travel-favorite-grid">

--- a/apps/tools/src/styles.css
+++ b/apps/tools/src/styles.css
@@ -174,6 +174,28 @@
   gap: 3px;
 }
 
+.travel-recent-grid { display: grid; gap: 3px; }
+.travel-recent {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: var(--ui-space-3);
+  min-height: 46px;
+  padding: var(--ui-space-2) var(--ui-space-3);
+  border: 1px solid transparent;
+  border-radius: var(--ui-radius-sm);
+  background: transparent;
+  color: var(--ui-text);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.travel-recent:hover:not(:disabled) { background: var(--ui-hover); }
+.travel-recent strong,
+.travel-recent small { display: block; }
+.travel-recent small { color: var(--ui-text-faint); }
+.travel-recent svg { width: 16px; height: 16px; fill: none; stroke: currentColor; stroke-width: 1.5; }
+
 .travel-result strong,
 .travel-result small {
   display: block;

--- a/apps/tools/src/travel-host.test.ts
+++ b/apps/tools/src/travel-host.test.ts
@@ -28,14 +28,33 @@ function fixture() {
     expect(expected).toEqual(travel);
     return save(patch);
   });
+  const histories = new Map<string, readonly number[]>();
+  const recordHistory = vi.fn(async ({ characterKey, mapId }: {
+    characterKey: string; mapId: number;
+  }) => {
+    const current = histories.get(characterKey) ?? [];
+    const next = [mapId, ...current.filter((candidate) => candidate !== mapId)].slice(0, 10);
+    histories.set(characterKey, next);
+    return next;
+  });
   const api = {
     travelPreferences: {
       async get() { return travel; },
       set: setTravel,
     },
+    travelHistory: {
+      async get({ characterKey }: { characterKey: string }) {
+        return histories.get(characterKey) ?? [];
+      },
+      record: recordHistory,
+      async clear({ characterKey }: { characterKey: string }) {
+        histories.delete(characterKey);
+        return [];
+      },
+    },
   } as unknown as GwNativeApi;
   const command: TravelCommand = { travel: vi.fn(), unavailable: () => null };
-  return { host: createNativeTravelHost(api, command), setTravel };
+  return { host: createNativeTravelHost(api, command), setTravel, recordHistory };
 }
 
 afterEach(() => vi.useRealTimers());
@@ -76,5 +95,27 @@ describe("native Travel host", () => {
     await vi.advanceTimersByTimeAsync(30_000);
     expect(expired.attempt.value).toEqual({ status: "idle" });
     expect(expired.notice.value?.message).toContain("ready to try again");
+  });
+
+  it("records observed destinations independently for each character", async () => {
+    const { host, recordHistory } = fixture();
+    const unlockedMapWords = Array.from({ length: 28 }, () => 0xffff_ffff);
+    host.updateGameState({
+      status: "ready", mapId: 55, characterKey: "0123456789abcdef", unlockedMapWords,
+    });
+    host.updateGameState({
+      status: "ready", mapId: 449, characterKey: "0123456789abcdef", unlockedMapWords,
+    });
+    host.updateGameState({
+      status: "ready", mapId: 81, characterKey: "fedcba9876543210", unlockedMapWords,
+    });
+
+    await vi.waitFor(() => expect(recordHistory).toHaveBeenCalledTimes(3));
+    expect(recordHistory.mock.calls.map(([value]) => value)).toEqual([
+      { characterKey: "0123456789abcdef", mapId: 55 },
+      { characterKey: "0123456789abcdef", mapId: 449 },
+      { characterKey: "fedcba9876543210", mapId: 81 },
+    ]);
+    expect(host.history.value).toEqual([81]);
   });
 });

--- a/apps/tools/src/travel-host.ts
+++ b/apps/tools/src/travel-host.ts
@@ -17,6 +17,12 @@ import {
   type TravelUserPreferences,
   type TravelUserPreferencesPatch,
 } from "../../../src/shared/travel";
+import {
+  EMPTY_TRAVEL_HISTORY,
+  recordVisitedTravel,
+  type TravelCharacterKey,
+  type TravelHistory,
+} from "../../../src/shared/travel-history";
 
 export type TravelAttempt =
   | Readonly<{ status: "idle" }>
@@ -33,9 +39,11 @@ export interface TravelHost {
   readonly state: Ref<TravelGameState>;
   readonly attempt: Ref<TravelAttempt>;
   readonly notice: Ref<TravelNotice | null>;
+  readonly history: Ref<TravelHistory>;
   readonly unavailable: string | null;
   loadPreferences(): Promise<TravelPreferences>;
   savePreferences(patch: TravelPreferencePatch): Promise<TravelPreferences>;
+  loadHistory(): Promise<TravelHistory>;
   travel(request: TravelRequest): Promise<void>;
   updateGameState(state: TravelGameState): void;
   dispose(): void;
@@ -50,6 +58,7 @@ export function createNativeTravelHost(
   const state = ref<TravelGameState>({ status: "waiting", reason: "game" });
   const attempt = ref<TravelAttempt>({ status: "idle" });
   const notice = ref<TravelNotice | null>(null);
+  const history = ref<TravelHistory>(EMPTY_TRAVEL_HISTORY);
   let attemptTimer = 0;
   const clearAttempt = () => {
     window.clearTimeout(attemptTimer);
@@ -63,10 +72,55 @@ export function createNativeTravelHost(
   };
   const loadPreferences = async (): Promise<TravelPreferences> =>
     remember(await api.travelPreferences.get());
+  let historyTail: Promise<void> = Promise.resolve();
+  let activeCharacter: TravelCharacterKey | null = null;
+  let lastObservedMapId: number | null = null;
+  let disposed = false;
+  const enqueueHistory = (
+    characterKey: TravelCharacterKey,
+    operation: () => Promise<TravelHistory>,
+  ): Promise<TravelHistory> => {
+    const result = historyTail.then(operation);
+    historyTail = result.then(() => undefined, () => undefined);
+    return result.then((next) => {
+      if (!disposed && activeCharacter === characterKey) history.value = next;
+      return next;
+    });
+  };
+  const loadHistory = (): Promise<TravelHistory> => {
+    const characterKey = activeCharacter;
+    return characterKey === null
+      ? Promise.resolve(EMPTY_TRAVEL_HISTORY)
+      : enqueueHistory(characterKey, () => api.travelHistory.get({ characterKey }));
+  };
+  const observeMap = (next: TravelGameState): void => {
+    if (next.status !== "ready" || typeof next.characterKey !== "string") return;
+    const key = next.characterKey as TravelCharacterKey;
+    const characterChanged = key !== activeCharacter;
+    if (characterChanged) {
+      activeCharacter = key;
+      lastObservedMapId = null;
+      history.value = EMPTY_TRAVEL_HISTORY;
+      void enqueueHistory(key, () => api.travelHistory.get({ characterKey: key }));
+    }
+    if (next.mapId === lastObservedMapId) return;
+    lastObservedMapId = next.mapId;
+    if (travelDestination(next.mapId) === null) return;
+    void enqueueHistory(key, () => api.travelHistory.record({
+      characterKey: key,
+      mapId: next.mapId,
+    })).catch((error) => {
+      if (development) console.debug(`[tools:dev] travel.history.refused ${JSON.stringify({
+        mapId: next.mapId,
+        reason: error instanceof Error ? error.message : "unknown history error",
+      })}`);
+    });
+  };
   return {
     state,
     attempt,
     notice,
+    history,
     get unavailable() {
       return command.unavailable();
     },
@@ -75,6 +129,7 @@ export function createNativeTravelHost(
       const expected = currentPreferences ?? await loadPreferences();
       return remember(await api.travelPreferences.set({ expected, patch }));
     },
+    loadHistory,
     async travel(request) {
       if (attempt.value.status !== "idle") return;
       attempt.value = { status: "queued", mapId: request.mapId };
@@ -112,6 +167,7 @@ export function createNativeTravelHost(
     },
     updateGameState(next) {
       state.value = next;
+      observeMap(next);
       const current = attempt.value;
       if (current.status === "idle") return;
       if (next.status === "waiting" && next.reason === "loading") {
@@ -141,6 +197,7 @@ export function createNativeTravelHost(
       if (next.mapId !== current.mapId) return;
     },
     dispose() {
+      disposed = true;
       clearAttempt();
     },
     traceSearch(query, resultMapIds) {
@@ -159,9 +216,13 @@ export function createNativeTravelHost(
 
 /** Standalone fixture host for visual and interaction development. */
 export function createDemoTravelHost(): TravelHost {
-  const state = ref<TravelGameState>({ status: "ready", mapId: 55 });
+  const unlockedMapWords = Object.freeze(Array.from({ length: 28 }, () => 0xffff_ffff));
+  const state = ref<TravelGameState>({
+    status: "ready", mapId: 55, characterKey: "0123456789abcdef", unlockedMapWords,
+  });
   const attempt = ref<TravelAttempt>({ status: "idle" });
   const notice = ref<TravelNotice | null>(null);
+  const history = ref<TravelHistory>(Object.freeze([55, 449, 194, 642, 857]));
   let current: TravelPreferences = Object.freeze({
     shortcuts: DEFAULT_TRAVEL_SHORTCUTS,
     synonyms: Object.freeze([]),
@@ -177,6 +238,7 @@ export function createDemoTravelHost(): TravelHost {
     state,
     attempt,
     notice,
+    history,
     unavailable: null,
     async loadPreferences() {
       return current;
@@ -184,12 +246,17 @@ export function createDemoTravelHost(): TravelHost {
     async savePreferences(patch) {
       return save(patch);
     },
+    async loadHistory() { return history.value; },
     async travel(request) {
       attempt.value = { status: "queued", mapId: request.mapId };
       state.value = { status: "waiting", reason: "loading" };
       attempt.value = { status: "loading", mapId: request.mapId };
       window.setTimeout(() => {
-        state.value = { status: "ready", mapId: request.mapId };
+        history.value = recordVisitedTravel(history.value, request.mapId);
+        state.value = {
+          status: "ready", mapId: request.mapId,
+          characterKey: "0123456789abcdef", unlockedMapWords,
+        };
         attempt.value = { status: "idle" };
       }, 600);
     },

--- a/docs/enhancement-development.md
+++ b/docs/enhancement-development.md
@@ -29,9 +29,10 @@ current optional features are:
   has a separate Settings opt-in and requires a live snapshot that proves the
   current character can access storage. It does not depend on party observation.
 - **Quick Travel palette**: Command-T or `/tp` opens host-owned destination
-  autocomplete and 1–9 shortcuts. A named, bounded Travel action reaches the
-  certified client dispatcher only from the game-thread drain. It has a separate
-  Settings opt-in.
+  autocomplete and 1–9 shortcuts. Search filters positively locked maps from
+  the current character's bounded unlock set, and Recent persists certified map
+  observations per privacy-safe character key. A named, bounded Travel action
+  rechecks the unlock at the game-thread drain. It has a separate Settings opt-in.
 - **Skill key labels**: show player-authored keyboard, mouse-button, and wheel
   labels over certified skill-slot rectangles. The feature is display-only and
   never changes or forwards game input.
@@ -111,8 +112,9 @@ character names, account data, chat, packet bytes, or Travel search text.
 - Travel emits `travel.search` with query length, token count, catalogue size,
   result count, and bounded result map IDs. It never includes the query itself.
   `travel.queued` or `travel.refused` then identifies the named command result.
-  Search covers the reviewed 199-destination direct-travel catalogue. A zero
-  result means the query did not match that catalogue; passage-scroll locations
+  Search covers the reviewed 199-destination direct-travel catalogue and omits
+  positively locked results. A zero result can mean no match or only locked
+  matches; passage-scroll locations
   such as Urgoz's Warren and The Deep intentionally use their original UI.
 
 For a report, reproduce one operation at a time and copy the lines from its

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -147,9 +147,15 @@ After that restart, these choices update immediately:
   Command-1 through Command-9 while a search
   result is selected. Type any of the 199 reviewed direct-travel destinations,
   an official alias such as `la`, `kama`, or `eotn`, or your own custom synonym,
-  then press Return. Locked destinations remain visible; Guild Wars decides
-  whether the current character can travel there. Travel keeps the current
+  then press Return. Once Guild Wars publishes the active character's unlock
+  data, locked destinations are hidden; the command checks the unlock again
+  immediately before travel. Travel keeps the current
   Guild Wars region and language and uses district Any.
+
+  **Recent** comes from locations Guild Wars actually reports, including world
+  map travel and other in-game paths. It keeps up to ten unique reviewed places
+  per character across game and app restarts, hides the current map, and shows
+  the five newest destinations that character can still travel to.
 
 Open **Trade Chat** from the View menu, with Command-Shift-B, or by typing the
 exact lowercase `/trade` command on a certified client. The Trade window is

--- a/docs/wasm-host.md
+++ b/docs/wasm-host.md
@@ -275,19 +275,30 @@ remains usable; no party-state fallback is allowed.
 Travel accepts only one reviewed map ID from the renderer. The exact `/tp`
 command sets one named, one-shot palette toggle that the renderer takes and
 clears. Search text, aliases, destinations, and numbered shortcuts stay
-in the host-owned Vue interface. At the certified frame drain, the transform
-rechecks the reviewed map list, invokes the independently proved client helper
+in the host-owned Vue interface. The play-region snapshot publishes a fixed
+28-word map-unlock bitset only after the certified `WorldContext` array is read
+completely; unknown evidence stays unknown instead of looking like every map is
+locked. At the certified frame drain, the transform rechecks the reviewed map
+list and live unlock bit, then invokes the independently proved client helper
 that resolves the player's current region and language, validates those values,
 and writes the four-word Travel payload with district Any. It then calls the
-exact client Travel dispatcher with `kTravel`. An unknown map, unresolved live
-context, or changed helper stops only Travel without dispatching another client
-UI message.
+exact client Travel dispatcher with `kTravel`. An unknown or locked map,
+unreadable unlock array, unresolved live context, or changed helper stops only
+Travel without dispatching another client UI message.
 
 The Tools host owns one Travel attempt: `idle`, `queued`, or `loading`. A
 three-second start deadline and a separate thirty-second arrival deadline both
 return it to `idle`; disconnect, corrupt snapshot, and other non-loading states
 also end a loading attempt. The Vue component renders this state but does not
 interpret the game protocol or own its timers.
+
+Recent destinations are independent of attempt state. The host records every
+changed ready map that belongs to the reviewed direct-travel catalogue,
+including arrivals outside the palette. Main serializes at most ten unique map
+IDs per character in atomic `travel-history.json`. The companion hashes the
+official 128-bit character UUID before publication; raw UUIDs and names never
+cross the boundary or reach disk. The palette excludes the current map and any
+positively locked destination. History cannot authorize travel.
 
 Shortcut slots remain in `settings.json` using the district-bearing shape the
 published Stable understands. The current runtime projects those records to

--- a/scripts/companion-kernel-contract.mjs
+++ b/scripts/companion-kernel-contract.mjs
@@ -38,7 +38,7 @@ export const COMPANION_KERNEL_EXPORT_VALUES = Object.freeze({
 });
 
 export const COMPANION_KERNEL_DYLINK0 = Object.freeze([
-  // Memory footprint 2201 bytes (0x99 0x11 as LEB128). Documented moves:
+  // Memory footprint 2209 bytes (0xa1 0x11 as LEB128). Documented moves:
   //   309 ->  310  the Toolbox observer gained PARTY_OBSERVED, the byte that
   //                separates "you have no heroes" from "nobody read the party";
   //   310 ->  410  Layout grew by the 25 party-detail address words, at 4 bytes
@@ -81,10 +81,13 @@ export const COMPANION_KERNEL_DYLINK0 = Object.freeze([
   //                its pointer and sequence; its 28-byte record is host-owned.
   //   2197 -> 2201 cooldown row caching gains a bounded audit-age word so a
   //                later duplicate player row cannot remain hidden indefinitely.
+  //   2201 -> 2209 Travel adds one character-key layout word and bounded
+  //                play-region publication state; its larger record remains
+  //                in host-owned memory outside this footprint.
   // This constant exists so a kernel whose footprint moves cannot ship without
   // someone saying why. One page is still the ceiling, and this remains far
   // under it.
-  0x01, 0x05, 0x99, 0x11, 0x02, 0x00, 0x00,
+  0x01, 0x05, 0xa1, 0x11, 0x02, 0x00, 0x00,
 ]);
 
 const WASM_PAGE_BYTES = 65_536;

--- a/src/companion-kernel/abi.rs
+++ b/src/companion-kernel/abi.rs
@@ -33,16 +33,21 @@ pub(crate) const FEATURE_TARGET_OBSERVATION: u32 = 1 << 3;
 pub(crate) const FEATURE_SKILL_SLOT_GEOMETRY: u32 = 1 << 4;
 pub(crate) const FEATURE_SKILL_COOLDOWN_OBSERVATION: u32 = 1 << 5;
 pub(crate) const FEATURE_PLAY_REGION_OBSERVATION: u32 = 1 << 6;
-pub(crate) const KNOWN_FEATURES: u32 =
-    FEATURE_NATIVE_CURSOR | FEATURE_GAME_SNAPSHOT | FEATURE_TOOLBOX_FOUNDATION
-        | FEATURE_TARGET_OBSERVATION | FEATURE_SKILL_SLOT_GEOMETRY
-        | FEATURE_SKILL_COOLDOWN_OBSERVATION | FEATURE_PLAY_REGION_OBSERVATION;
+pub(crate) const KNOWN_FEATURES: u32 = FEATURE_NATIVE_CURSOR
+    | FEATURE_GAME_SNAPSHOT
+    | FEATURE_TOOLBOX_FOUNDATION
+    | FEATURE_TARGET_OBSERVATION
+    | FEATURE_SKILL_SLOT_GEOMETRY
+    | FEATURE_SKILL_COOLDOWN_OBSERVATION
+    | FEATURE_PLAY_REGION_OBSERVATION;
 
 pub(crate) const PLAY_REGION_BYTES: u32 = size_of::<PlayRegionSnapshot>() as u32;
 pub(crate) const PLAY_REGION_MAGIC: u32 = 0x5250_5747;
-pub(crate) const PLAY_REGION_ABI_AND_SIZE: u32 = (PLAY_REGION_BYTES << 16) | 1;
+pub(crate) const PLAY_REGION_ABI_AND_SIZE: u32 = (PLAY_REGION_BYTES << 16) | 2;
 pub(crate) const FLAG_PLAY_REGION_READY: u32 = 1 << 0;
 pub(crate) const FLAG_PLAY_REGION_LOADING: u32 = 1 << 1;
+pub(crate) const FLAG_PLAY_REGION_CHARACTER: u32 = 1 << 2;
+pub(crate) const FLAG_PLAY_REGION_UNLOCKS: u32 = 1 << 3;
 
 pub(crate) const SKILL_SLOT_BYTES: u32 = size_of::<SkillSlotSnapshot>() as u32;
 pub(crate) const SKILL_SLOT_MAGIC: u32 = 0x534b_5747;
@@ -125,6 +130,8 @@ pub(crate) const SKILL_SLOTS: usize = 8;
 /// The official client currently publishes 70 words, covering skill ids
 /// 0..2239. A fixed bound keeps account data finite and the wire shape closed.
 pub(crate) const SKILL_UNLOCK_WORDS: usize = 70;
+/// Covers map ids 0..895, including every reviewed Quick Travel destination.
+pub(crate) const TRAVEL_UNLOCK_WORDS: usize = 28;
 
 /// The highest attribute id the client defines. The array is walked to here
 /// and no further: the reference struct pads to 54 entries and indices 51-53
@@ -271,6 +278,8 @@ pub(crate) struct Layout {
     pub(crate) frame_state: u32,
     // Appended exact-client field used only by cooldown observation.
     pub(crate) skill_slot_recharge: u32,
+    pub(crate) world_unlocked_maps: u32,
+    pub(crate) character_uuid: u32,
     pub(crate) player_chat_message: u32,
     pub(crate) hide_hero_panel_message: u32,
     pub(crate) show_hero_panel_message: u32,
@@ -377,6 +386,8 @@ impl Layout {
         frame_relation: 0,
         frame_state: 0,
         skill_slot_recharge: 0,
+        world_unlocked_maps: 0,
+        character_uuid: 0,
         player_chat_message: 0,
         hide_hero_panel_message: 0,
         show_hero_panel_message: 0,
@@ -415,6 +426,9 @@ pub(crate) struct PlayRegionSnapshot {
     pub(crate) map_id: u32,
     pub(crate) instance_type: u32,
     pub(crate) play_region: u32,
+    pub(crate) character_key_low: u32,
+    pub(crate) character_key_high: u32,
+    pub(crate) unlocked_maps: [u32; TRAVEL_UNLOCK_WORDS],
 }
 
 #[repr(C)]
@@ -544,13 +558,13 @@ pub(crate) struct PartySnapshot {
     pub(crate) character_skills: [u32; SKILL_UNLOCK_WORDS],
 }
 
-const _: [(); 444] = [(); size_of::<Layout>()];
+const _: [(); 452] = [(); size_of::<Layout>()];
 const _: [(); 96] = [(); size_of::<PartySlot>()];
 const _: [(); 1560] = [(); size_of::<PartySnapshot>()];
 const _: [(); 64] = [(); size_of::<Snapshot>()];
+const _: [(); 148] = [(); size_of::<PlayRegionSnapshot>()];
 const _: [(); 4160] = [(); size_of::<CursorSnapshot>()];
 const _: [(); 64] = [(); size_of::<ToolboxSnapshot>()];
 const _: [(); 16] = [(); size_of::<SkillSlotRect>()];
 const _: [(); 156] = [(); size_of::<SkillSlotSnapshot>()];
 const _: [(); 60] = [(); size_of::<SkillCooldownSnapshot>()];
-const _: [(); 28] = [(); size_of::<PlayRegionSnapshot>()];

--- a/src/companion-kernel/lib.rs
+++ b/src/companion-kernel/lib.rs
@@ -178,6 +178,37 @@ impl State {
     }
 }
 
+/** Reads the certified WorldContext Array<u32>; `None` publishes unknown. */
+pub(crate) unsafe fn observe_travel_unlocks(
+    layout: Layout,
+    game: u32,
+) -> Option<[u32; TRAVEL_UNLOCK_WORDS]> {
+    if game == 0 || layout.world_context == 0 || layout.world_unlocked_maps == 0 {
+        return None;
+    }
+    let world_required = checked_add(layout.world_unlocked_maps, 12)?;
+    let world =
+        offset(game, layout.world_context).and_then(|at| unsafe { pointer(at, world_required) })?;
+    let array = offset(world, layout.world_unlocked_maps)?;
+    let buffer = unsafe { read_u32(array) }?;
+    let capacity = offset(array, 4).and_then(|at| unsafe { read_u32(at) })?;
+    let size = offset(array, 8).and_then(|at| unsafe { read_u32(at) })?;
+    if buffer == 0
+        || buffer & 3 != 0
+        || size < TRAVEL_UNLOCK_WORDS as u32
+        || size > capacity
+        || capacity > 64
+        || !contains(buffer, checked_mul(size, 4)?)
+    {
+        return None;
+    }
+    let mut words = [0; TRAVEL_UNLOCK_WORDS];
+    for (index, word) in words.iter_mut().enumerate() {
+        *word = unsafe { read_u32(indexed(buffer, index as u32, 4)?)? };
+    }
+    Some(words)
+}
+
 /**
  * The Tools safety region derived from the client-owned map policy.
  *
@@ -898,7 +929,7 @@ pub unsafe extern "C" fn companion_dispatch(kind: u32, a: u32, b: u32, c: u32, _
 
 #[no_mangle]
 pub extern "C" fn companion_abi() -> u32 {
-    17
+    18
 }
 
 #[no_mangle]

--- a/src/companion-kernel/play_region.rs
+++ b/src/companion-kernel/play_region.rs
@@ -7,12 +7,20 @@
 use core::ptr::write_volatile;
 
 use crate::abi::*;
-use crate::{resolve_game, GameState};
+use crate::memory::{checked_add, contains, offset, pointer, read_u32};
+use crate::{observe_travel_unlocks, resolve_game, GameState};
 
 static mut POINTER: u32 = 0;
 static mut SEQUENCE: u32 = 0;
 
-unsafe fn publish(flags: u32, map_id: u32, instance_type: u32, play_region: u32) {
+unsafe fn publish(
+    flags: u32,
+    map_id: u32,
+    instance_type: u32,
+    play_region: u32,
+    character_key: u64,
+    unlocked_maps: [u32; TRAVEL_UNLOCK_WORDS],
+) {
     let next = unsafe { SEQUENCE }.wrapping_add(2) & !1;
     let snapshot = unsafe { POINTER as *mut PlayRegionSnapshot };
     unsafe {
@@ -23,6 +31,14 @@ unsafe fn publish(flags: u32, map_id: u32, instance_type: u32, play_region: u32)
         write_volatile(&mut (*snapshot).map_id, map_id);
         write_volatile(&mut (*snapshot).instance_type, instance_type);
         write_volatile(&mut (*snapshot).play_region, play_region);
+        write_volatile(&mut (*snapshot).character_key_low, character_key as u32);
+        write_volatile(
+            &mut (*snapshot).character_key_high,
+            (character_key >> 32) as u32,
+        );
+        for (index, word) in unlocked_maps.iter().enumerate() {
+            write_volatile(&mut (*snapshot).unlocked_maps[index], *word);
+        }
         write_volatile(&mut (*snapshot).sequence, next);
         SEQUENCE = next;
     }
@@ -36,24 +52,76 @@ pub(crate) unsafe fn initialize(pointer: u32) {
     for index in 0..PLAY_REGION_BYTES / 4 {
         unsafe { write_volatile((pointer + index * 4) as *mut u32, 0) };
     }
-    unsafe { publish(0, 0, 0, 0) };
+    unsafe { publish(0, 0, 0, 0, 0, [0; TRAVEL_UNLOCK_WORDS]) };
+}
+
+unsafe fn character_key(layout: Layout, game: u32) -> Option<u64> {
+    if layout.character_uuid == 0 {
+        return None;
+    }
+    let required = checked_add(layout.character_uuid, 16)?;
+    let character = offset(game, layout.character_context)
+        .and_then(|at| unsafe { pointer(at, required) })?;
+    let uuid = offset(character, layout.character_uuid)?;
+    if !contains(uuid, 16) {
+        return None;
+    }
+    let mut hash = 0xcbf2_9ce4_8422_2325_u64;
+    let mut nonzero = 0_u32;
+    for index in 0..4_u32 {
+        let word = unsafe { read_u32(offset(uuid, index * 4)?)? };
+        nonzero |= word;
+        for byte in word.to_le_bytes() {
+            hash ^= byte as u64;
+            hash = hash.wrapping_mul(0x100_0000_01b3);
+        }
+    }
+    (nonzero != 0 && hash != 0).then_some(hash)
 }
 
 pub(crate) unsafe fn tick(layout: Layout) {
     match unsafe { resolve_game(layout) } {
         GameState::Ready {
+            game,
             map_id,
             instance_type,
             play_region,
             ..
         } if play_region == PLAY_REGION_PVE || play_region == PLAY_REGION_PVP => unsafe {
-            publish(FLAG_PLAY_REGION_READY, map_id, instance_type, play_region);
+            let key = character_key(layout, game);
+            let unlocks = observe_travel_unlocks(layout, game);
+            let flags = FLAG_PLAY_REGION_READY
+                | if key.is_some() {
+                    FLAG_PLAY_REGION_CHARACTER
+                } else {
+                    0
+                }
+                | if unlocks.is_some() {
+                    FLAG_PLAY_REGION_UNLOCKS
+                } else {
+                    0
+                };
+            publish(
+                flags,
+                map_id,
+                instance_type,
+                play_region,
+                key.unwrap_or(0),
+                unlocks.unwrap_or([0; TRAVEL_UNLOCK_WORDS]),
+            );
         },
         GameState::Loading => unsafe {
-            publish(FLAG_PLAY_REGION_LOADING, 0, 0, 0);
+            publish(
+                FLAG_PLAY_REGION_LOADING,
+                0,
+                0,
+                0,
+                0,
+                [0; TRAVEL_UNLOCK_WORDS],
+            );
         },
         GameState::Ready { .. } | GameState::Unavailable => unsafe {
-            publish(0, 0, 0, 0);
+            publish(0, 0, 0, 0, 0, [0; TRAVEL_UNLOCK_WORDS]);
         },
     }
 }

--- a/src/main/certification/enhancement-build-model.ts
+++ b/src/main/certification/enhancement-build-model.ts
@@ -32,6 +32,7 @@ import {
   type EnhancementSkillSlotGeometryLayout,
   type EnhancementStorageLayout,
   type EnhancementTargetLayout,
+  type EnhancementTravelLayout,
 } from "../../shared/enhancement-config.js";
 export {
   ENHANCEMENT_LAYOUT_FIELDS,
@@ -131,6 +132,9 @@ export function enhancementConfigWords(
           break;
         case "storage":
           value = build.xunlaiAction?.accessProof?.layout[field.key];
+          break;
+        case "travel":
+          value = build.travelAction?.unlockProof.layout[field.key];
           break;
         case "skill-slots":
           value = build.skillSlotGeometry?.layout[field.key];
@@ -306,6 +310,22 @@ export interface KnownEnhancementBuild {
     configureExport: string;
     toggleExport: string;
     messageId: number;
+    /** Certified client array and official bit-test consumer. */
+    unlockProof: Readonly<{
+      layout: EnhancementTravelLayout;
+      accessor: Readonly<{
+        functionIndex: number;
+        params: readonly [];
+        results: readonly ["i32"];
+        bodySha256: string;
+      }>;
+      consumer: Readonly<{
+        functionIndex: number;
+        params: readonly ["i32"];
+        results: readonly ["i32"];
+        bodySha256: string;
+      }>;
+    }>;
     /** Exact producer that constructs {map, region, language, district}. */
     producer: Readonly<{
       functionIndex: number;
@@ -414,7 +434,7 @@ export function supportedEnhancementCapabilities(
     && build.uiDispatcher !== undefined
     && build.partyObservation !== undefined;
   const gameThread = build.gameThread !== undefined;
-  const travelAction = playRegionObservation && build.uiDispatcher !== undefined
+  const travelAction = observationBase && build.uiDispatcher !== undefined
     && gameThread && build.travelAction !== undefined;
   const xunlaiAction = observationBase && build.uiDispatcher !== undefined
     && gameThread && build.xunlaiAction?.accessProof !== undefined;

--- a/src/main/certification/enhancement-builds.ts
+++ b/src/main/certification/enhancement-builds.ts
@@ -36,9 +36,9 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
       // ENHANCEMENT_TRANSFORM_ABI or any config word changes.
       outputSha256: Object.freeze({
         "features-601":
-          "200341f7bbeb50ab2ab9125a869c7fa61d7b1569d9c760e98acbe026f94ba6bb",
+          "cfdc58bd7a024fe6cdc4ae631e6edfcb23cb54a8885d3f264243c0fcc2ba64cf",
         "features-7ff":
-          "c4b31ca957bf5b8d74e97eb8bd8f816cf448bca5d0b8d56f1037bc7a96c4d638",
+          "74b75630edff0cb9e9b68cc719a43d496b72c1b1aa9720afb40d7c1ed9aac0f5",
       }),
       programId: 1,
       // The verifier derives this bounded identity from the exact module; it is
@@ -59,6 +59,7 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
           agentArray: 0x5a4de8,
           gameContextSlot: 6,
           characterContext: 0x44,
+          characterUuid: 0x64,
           mapId: 0x198,
           isExplorable: 0x19c,
           currentMapId: 0x234,
@@ -85,6 +86,7 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
           contextRoot: 0x5a0e70,
           gameContextSlot: 6,
           characterContext: 0x44,
+          characterUuid: 0x64,
           mapId: 0x198,
           isExplorable: 0x19c,
           currentMapId: 0x234,
@@ -231,6 +233,24 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
         // writes its four scalar arguments to {map, region, language,
         // district} and sends this message through the certified dispatcher.
         messageId: 0x1000_0183,
+        // WorldContext::unlocked_map is not accepted from GWCA's struct.
+        // Accessor #9184 returns the exact Array<u32> at +0x60c, while the
+        // official map consumer #15978 proves word=map/32 and bit=map%32.
+        unlockProof: Object.freeze({
+          layout: Object.freeze({ worldUnlockedMaps: 0x60c }),
+          accessor: Object.freeze({
+            functionIndex: 9184,
+            params: Object.freeze([] as const),
+            results: Object.freeze(["i32"] as const),
+            bodySha256: "24579d9f602bc21a37c0dc8ca88c362a38493c64d101d42081ccd6ed5314f975",
+          }),
+          consumer: Object.freeze({
+            functionIndex: 15978,
+            params: Object.freeze(["i32"] as const),
+            results: Object.freeze(["i32"] as const),
+            bodySha256: "c462fd76a759a90c48dc9298223cf6f571dec8ef11c732177faa14ac4b49fb9f",
+          }),
+        }),
         producer: Object.freeze({
           functionIndex: 16199,
           params: Object.freeze([
@@ -521,6 +541,7 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
           contextRoot: 0x5a0e70,
           gameContextSlot: 6,
           characterContext: 0x44,
+          characterUuid: 0x64,
           currentInstanceType: 0x23c,
         }),
       }),

--- a/src/main/certification/enhancement-local-actions-proof.ts
+++ b/src/main/certification/enhancement-local-actions-proof.ts
@@ -619,6 +619,22 @@ export function locateAutomaticLocalActions(
       const travelContextResolver = travelExpected
         ? deriveTravelContextResolver(module)
         : null;
+      const unlockAccessor = travelExpected
+        ? uniqueExactFunction(
+            module,
+            travelExpected.unlockProof.accessor.bodySha256,
+            travelExpected.unlockProof.accessor.params,
+            travelExpected.unlockProof.accessor.results,
+          )
+        : null;
+      const unlockConsumer = travelExpected
+        ? uniqueExactFunction(
+            module,
+            travelExpected.unlockProof.consumer.bodySha256,
+            travelExpected.unlockProof.consumer.params,
+            travelExpected.unlockProof.consumer.results,
+          )
+        : null;
       const travelAction = uiDispatcher && gameThread && travelExpected && travelBody
         && unsignedOperand(travelBody, 169) === travelExpected.messageId
         && travelValues !== null
@@ -641,6 +657,8 @@ export function locateAutomaticLocalActions(
         && signatureMatches(module, travelPrecheck, [], ["i32"])
         && signatureMatches(module, travelPostcheck, ["i32", "i32", "f32"], [])
         && travelContextResolver !== null
+        && unlockAccessor !== null
+        && unlockConsumer !== null
         ? Object.freeze({
             ...travelExpected,
             producer: Object.freeze({
@@ -649,6 +667,17 @@ export function locateAutomaticLocalActions(
               bodySha256: functionBodySha256(module, travelFunction!),
             }),
             contextResolver: travelContextResolver,
+            unlockProof: Object.freeze({
+              layout: travelExpected.unlockProof.layout,
+              accessor: Object.freeze({
+                ...travelExpected.unlockProof.accessor,
+                functionIndex: unlockAccessor,
+              }),
+              consumer: Object.freeze({
+                ...travelExpected.unlockProof.consumer,
+                functionIndex: unlockConsumer,
+              }),
+            }),
           })
         : null;
 
@@ -693,7 +722,9 @@ export function locateAutomaticLocalActions(
         baseline,
         hookFunction: tick.functionIndex,
         hookBodySha256: tick.bodySha256,
-        observationLayout: xunlaiAction || partyObservation ? observationLayout : null,
+        observationLayout: travelAction || xunlaiAction || partyObservation
+          ? observationLayout
+          : null,
         uiDispatcher,
         gameThread: travelAction || xunlaiAction || teamApply ? gameThread : null,
         travelAction,

--- a/src/main/certification/enhancement-target-proof.ts
+++ b/src/main/certification/enhancement-target-proof.ts
@@ -287,6 +287,9 @@ export function derivePlayRegionLayout(
     contextRoot,
     gameContextSlot: unsignedOperand(contextBody, 17),
     characterContext: unsignedOperand(body("gameCharacter"), 5),
+    // Official CharContext::player_uuid is a fixed 16-byte field. Keeping the
+    // raw UUID inside the kernel lets the renderer receive only a one-way key.
+    characterUuid: 0x64,
     mapId: unsignedOperand(body("mapId"), 39),
     isExplorable: unsignedOperand(body("mapState"), 37),
     currentMapId: unsignedOperand(body("currentMap"), 11),
@@ -313,6 +316,7 @@ export function derivePlayRegionLayout(
     contextRoot: { sourceRole: "context-root-writer", expression: "relocated static store", occurrences: [11] },
     gameContextSlot: { sourceRole: "context-root-writer", expression: "context registration slot", occurrences: [17] },
     characterContext: { sourceRole: "game-context character reader", expression: "i32.load offset", occurrences: [5] },
+    characterUuid: { sourceRole: "official character-context layout", expression: "fixed 16-byte UUID field", occurrences: [0x64] },
     mapId: { sourceRole: "map-id reader", expression: "i32.load offset", occurrences: [39] },
     isExplorable: { sourceRole: "map-state reader", expression: "map availability field", occurrences: [37] },
     currentMapId: { sourceRole: "character-context map reader", expression: "i32.load offset", occurrences: [11] },

--- a/src/main/certification/enhancement-transform-features.ts
+++ b/src/main/certification/enhancement-transform-features.ts
@@ -194,6 +194,7 @@ export function applyFeatureContributions(
             {
             dispatcherFunctionIndex: uiOriginalIndex ?? uiDispatcher.functionIndex,
             contextResolverFunctionIndex: travelAction.contextResolver.functionIndex,
+            unlockAccessorFunctionIndex: travelAction.unlockProof.accessor.functionIndex,
             messageId: travelAction.messageId,
             payloadGlobalIndex: globalIndices.travelPayload,
             reviewedMapIds: REVIEWED_TRAVEL_MAP_IDS,

--- a/src/main/certification/enhancement-transform.ts
+++ b/src/main/certification/enhancement-transform.ts
@@ -519,6 +519,32 @@ function resolveEnhancementTransform(
   ) {
     fail("travel context resolver body does not match its semantic fingerprint");
   }
+  const travelUnlockAccessor = capabilities.travelAction
+    ? resolveHook(
+        "travel unlock array accessor",
+        travelAction.unlockProof.accessor.functionIndex,
+        travelAction.unlockProof.accessor.params,
+        travelAction.unlockProof.accessor.results,
+      )
+    : null;
+  if (
+    travelUnlockAccessor
+    && bodyHash(travelAction.unlockProof.accessor.functionIndex)
+      !== travelAction.unlockProof.accessor.bodySha256
+  ) fail("travel unlock accessor body does not match its certified identity");
+  const travelUnlockConsumer = capabilities.travelAction
+    ? resolveHook(
+        "travel unlock bitset consumer",
+        travelAction.unlockProof.consumer.functionIndex,
+        travelAction.unlockProof.consumer.params,
+        travelAction.unlockProof.consumer.results,
+      )
+    : null;
+  if (
+    travelUnlockConsumer
+    && bodyHash(travelAction.unlockProof.consumer.functionIndex)
+      !== travelAction.unlockProof.consumer.bodySha256
+  ) fail("travel unlock consumer body does not match its certified identity");
   const packetSender = capabilities.teamApply
     ? resolveHook(
         "traced packet sender",

--- a/src/main/certification/enhancement-travel-command-transform.ts
+++ b/src/main/certification/enhancement-travel-command-transform.ts
@@ -17,10 +17,51 @@ const VALID_TRAVEL_LANGUAGES = [0, 1, 2, 3, 4, 5, 6, 8, 9, 10, 17] as const;
 export type TravelDrainConfig = Readonly<{
   dispatcherFunctionIndex: number;
   contextResolverFunctionIndex: number;
+  unlockAccessorFunctionIndex: number;
   messageId: number;
   payloadGlobalIndex: number;
   reviewedMapIds: readonly number[];
 }>;
+
+const TRAVEL_UNLOCK_WORD_LIMIT = 28;
+
+function refuseLockedMap(travel: TravelDrainConfig, mapGlobalIndex: number): Uint8Array {
+  const payload = () => concat(Uint8Array.of(0x23), uleb(travel.payloadGlobalIndex));
+  const array = () => concat(payload(), Uint8Array.of(0x28), uleb(2), uleb(4));
+  const map = () => concat(Uint8Array.of(0x23), uleb(mapGlobalIndex));
+  const word = () => concat(map(), Uint8Array.of(0x41), sleb(5), Uint8Array.of(0x76));
+  const memoryBytes = () => concat(
+    Uint8Array.of(0x3f, 0x00, 0x41), sleb(16), Uint8Array.of(0x74),
+  );
+  const buffer = () => concat(array(), Uint8Array.of(0x28), uleb(2), uleb(0));
+  const wordAddress = () => concat(
+    buffer(), word(), Uint8Array.of(0x41), sleb(2), Uint8Array.of(0x74, 0x6a),
+  );
+  return concat(
+    // The official accessor returns Array<u32>{buffer, capacity, size}.
+    payload(), Uint8Array.of(0x10), uleb(travel.unlockAccessorFunctionIndex),
+    Uint8Array.of(0x36), uleb(2), uleb(4),
+    refuseUnless(concat(array(), Uint8Array.of(0x45, 0x45))),
+    refuseUnless(concat(
+      array(), memoryBytes(), Uint8Array.of(0x41), sleb(12), Uint8Array.of(0x6b, 0x4d),
+    )),
+    refuseUnless(concat(buffer(), Uint8Array.of(0x45, 0x45))),
+    refuseUnless(concat(wordAddress(), buffer(), Uint8Array.of(0x4f))),
+    refuseUnless(concat(
+      wordAddress(), memoryBytes(), Uint8Array.of(0x41), sleb(4), Uint8Array.of(0x6b, 0x4d),
+    )),
+    refuseUnless(concat(
+      array(), Uint8Array.of(0x28), uleb(2), uleb(8),
+      word(), Uint8Array.of(0x4b),
+      array(), Uint8Array.of(0x28), uleb(2), uleb(8),
+      Uint8Array.of(0x41), sleb(TRAVEL_UNLOCK_WORD_LIMIT), Uint8Array.of(0x4d),
+      wordAddress(), Uint8Array.of(0x28), uleb(2), uleb(0),
+      map(), Uint8Array.of(0x76, 0x41), sleb(1), Uint8Array.of(0x71),
+      // The size bound and map bit must both be true.
+      Uint8Array.of(0x71, 0x71),
+    )),
+  );
+}
 
 function valueIsOneOf(load: () => Uint8Array, values: readonly number[]): Uint8Array {
   return concat(...values.map((value, index) => concat(
@@ -129,6 +170,7 @@ export function travelDrain(
     Uint8Array.of(0x41), sleb(TRAVEL_COMMAND), Uint8Array.of(0x46, 0x04, 0x40),
     Uint8Array.of(0x41), sleb(0), Uint8Array.of(0x24), uleb(pendingGlobalIndex),
     refuseUnless(globalValueIsOneOf(argumentGlobalBase, travel.reviewedMapIds)),
+    refuseLockedMap(travel, argumentGlobalBase),
     Uint8Array.of(0x23), uleb(travel.payloadGlobalIndex),
     Uint8Array.of(0x23), uleb(argumentGlobalBase),
     Uint8Array.of(0x36), uleb(2), uleb(TRAVEL_MAP_OFFSET),

--- a/src/main/certification/local-client-verification-boundary.ts
+++ b/src/main/certification/local-client-verification-boundary.ts
@@ -388,6 +388,27 @@ function matchesTravelAction(
     && isDeepStrictEqual(
       candidate.contextResolver.results,
       expected.contextResolver.results,
+    )
+    && isDeepStrictEqual(candidate.unlockProof.layout, expected.unlockProof.layout)
+    && isIndex(candidate.unlockProof.accessor.functionIndex)
+    && isDigest(candidate.unlockProof.accessor.bodySha256)
+    && isDeepStrictEqual(
+      candidate.unlockProof.accessor.params,
+      expected.unlockProof.accessor.params,
+    )
+    && isDeepStrictEqual(
+      candidate.unlockProof.accessor.results,
+      expected.unlockProof.accessor.results,
+    )
+    && isIndex(candidate.unlockProof.consumer.functionIndex)
+    && isDigest(candidate.unlockProof.consumer.bodySha256)
+    && isDeepStrictEqual(
+      candidate.unlockProof.consumer.params,
+      expected.unlockProof.consumer.params,
+    )
+    && isDeepStrictEqual(
+      candidate.unlockProof.consumer.results,
+      expected.unlockProof.consumer.results,
     );
 }
 

--- a/src/main/certification/local-client-verifier.ts
+++ b/src/main/certification/local-client-verifier.ts
@@ -621,7 +621,8 @@ function deriveEnhancementBuild(
     && locatedLocal?.gameThread != null
     && locatedLocal.teamApply != null;
   const includeTravel = requestedCapabilities.travelAction
-    && locatedLocal?.uiDispatcher != null
+    && locatedLocal?.observationLayout != null
+    && locatedLocal.uiDispatcher != null
     && locatedLocal.gameThread != null
     && locatedLocal.travelAction != null;
   const includeXunlai = requestedCapabilities.xunlaiAction

--- a/src/main/core/paths.ts
+++ b/src/main/core/paths.ts
@@ -21,6 +21,7 @@ export interface GamePaths {
   settings: string;
   diagnosticProfile: string;
   travelPreferences: string;
+  travelHistory: string;
   tradeSaved: string;
   buildLibrary: string;
   windowState: string;
@@ -55,6 +56,7 @@ export function gamePaths(userData: string): GamePaths {
     settings: path.join(userData, "settings.json"),
     diagnosticProfile: path.join(userData, "diagnostic-profile.json"),
     travelPreferences: path.join(userData, "travel-preferences.json"),
+    travelHistory: path.join(userData, "travel-history.json"),
     tradeSaved: path.join(userData, "trade-saved.json"),
     buildLibrary: path.join(userData, "build-library.json"),
     windowState: path.join(userData, "window-state.json"),

--- a/src/main/core/travel-history.ts
+++ b/src/main/core/travel-history.ts
@@ -1,0 +1,85 @@
+/**
+ * Serializes atomic per-character Travel history updates. Corrupt convenience
+ * data is quarantined without affecting settings or Travel preferences.
+ */
+import { readFile } from "node:fs/promises";
+import {
+  DEFAULT_TRAVEL_HISTORY,
+  EMPTY_TRAVEL_HISTORY,
+  TRAVEL_HISTORY_CHARACTER_LIMIT,
+  TRAVEL_HISTORY_FORMAT,
+  parseTravelHistoryDocument,
+  recordVisitedTravel,
+  type TravelCharacterKey,
+  type TravelHistory,
+  type TravelHistoryDocument,
+} from "../../shared/travel-history.js";
+import { writeAtomicJson } from "./atomic-file.js";
+import { quarantineCorruptDocument } from "./corrupt-document.js";
+
+async function readDocument(path: string): Promise<TravelHistoryDocument> {
+  let text: string;
+  try {
+    text = await readFile(path, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return DEFAULT_TRAVEL_HISTORY;
+    throw error;
+  }
+  try {
+    return parseTravelHistoryDocument(JSON.parse(text) as unknown);
+  } catch {
+    await quarantineCorruptDocument(path);
+    return DEFAULT_TRAVEL_HISTORY;
+  }
+}
+
+function updateCharacter(
+  document: TravelHistoryDocument,
+  characterKey: TravelCharacterKey,
+  history: TravelHistory,
+): TravelHistoryDocument {
+  const entries = Object.entries(document.characters)
+    .filter(([key]) => key !== characterKey)
+    .slice(-(TRAVEL_HISTORY_CHARACTER_LIMIT - 1));
+  return {
+    formatVersion: TRAVEL_HISTORY_FORMAT,
+    characters: Object.fromEntries([...entries, [characterKey, history]]) as Record<
+      TravelCharacterKey,
+      TravelHistory
+    >,
+  };
+}
+
+export class TravelHistoryStore {
+  readonly #path: string;
+  #tail: Promise<void> = Promise.resolve();
+
+  constructor(path: string) {
+    this.#path = path;
+  }
+
+  #enqueue<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.#tail.then(operation);
+    this.#tail = result.then(() => undefined, () => undefined);
+    return result;
+  }
+
+  get(characterKey: TravelCharacterKey): Promise<TravelHistory> {
+    return this.#enqueue(async () =>
+      (await readDocument(this.#path)).characters[characterKey] ?? EMPTY_TRAVEL_HISTORY
+    );
+  }
+
+  record(characterKey: TravelCharacterKey, mapId: number): Promise<TravelHistory> {
+    return this.#enqueue(async () => {
+      const document = await readDocument(this.#path);
+      const next = recordVisitedTravel(
+        document.characters[characterKey] ?? EMPTY_TRAVEL_HISTORY,
+        mapId,
+      );
+      await writeAtomicJson(this.#path, updateCharacter(document, characterKey, next));
+      return next;
+    });
+  }
+
+}

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -144,6 +144,12 @@ import {
   submitVisualCapture,
 } from "./visual-capture.js";
 import { parseDiagnosticProfile } from "./core/diagnostic-profile.js";
+import {
+  parseTravelHistoryCharacter,
+  parseTravelHistoryRecord,
+  type TravelCharacterKey,
+  type TravelHistory,
+} from "../shared/travel-history.js";
 
 export interface IpcContext extends TradeIpcContext {
   sockets: SocketManager;
@@ -164,6 +170,8 @@ export interface IpcContext extends TradeIpcContext {
   resetSettings: () => Promise<SettingsResetOutcome>;
   getTravelPreferences: () => Promise<TravelUserPreferences>;
   setTravelPreferences: (update: TravelUserPreferencesUpdate) => Promise<TravelUserPreferences>;
+  getTravelHistory: (characterKey: TravelCharacterKey) => Promise<TravelHistory>;
+  recordTravelHistory: (characterKey: TravelCharacterKey, mapId: number) => Promise<TravelHistory>;
   /** Whether this process started with every certified Tools capability prepared. */
   toolsEnabledAtLaunch: boolean;
   downloadFullGame: () => Promise<FullDownloadOutcome>;
@@ -537,6 +545,10 @@ export function registerIpcHandlers(ctx: IpcContext): {
     travelPreferencesGet: channel(nothing, () => ctx.getTravelPreferences()),
     travelPreferencesSet: channel(one(parseTravelUserPreferencesUpdate), (_win, update) =>
       ctx.setTravelPreferences(update)),
+    travelHistoryGet: channel(one(parseTravelHistoryCharacter), (_win, value) =>
+      ctx.getTravelHistory(value.characterKey)),
+    travelHistoryRecord: channel(one(parseTravelHistoryRecord), (_win, value) =>
+      ctx.recordTravelHistory(value.characterKey, value.mapId)),
     shortcutCapture: channel(nothing, (win) => captureWindowShortcut(win)),
     shortcutCaptureCancel: channel(nothing, (win) => {
       cancelWindowShortcutCapture(win);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -48,6 +48,7 @@ import { PreferencesCoordinator } from "./core/preferences-coordinator.js";
 import { SocketManager } from "./core/sockets.js";
 import { TradeChatService } from "./core/trade-chat-service.js";
 import { TradeSavedStore } from "./core/trade-saved-store.js";
+import { TravelHistoryStore } from "./core/travel-history.js";
 import {
   count,
   exportDiagnosticsForWindow,
@@ -611,6 +612,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
   const sockets = buildSocketManager();
   const tradeChat = new TradeChatService();
   const tradeSaved = new TradeSavedStore(paths.tradeSaved);
+  const travelHistory = new TravelHistoryStore(paths.travelHistory);
   appUpdaterController = new AppUpdater({
     currentVersion: HOST_VERSION,
     capable: distribution.automaticUpdates,
@@ -713,6 +715,8 @@ if (primaryInstance) void app.whenReady().then(async () => {
     },
     getTravelPreferences: () => preferences.getTravelPreferences(),
     setTravelPreferences: (update) => preferences.updateTravelPreferences(update),
+    getTravelHistory: (characterKey) => travelHistory.get(characterKey),
+    recordTravelHistory: (characterKey, mapId) => travelHistory.record(characterKey, mapId),
     toolsEnabledAtLaunch: enhancementSelection.tools,
     tradeChat,
     getTradeSaved: () => tradeSaved.get(),

--- a/src/preload/preload.body.cjs
+++ b/src/preload/preload.body.cjs
@@ -202,6 +202,10 @@ const api = {
     get: () => ipcRenderer.invoke(IPC.travelPreferencesGet),
     set: (value) => ipcRenderer.invoke(IPC.travelPreferencesSet, value),
   },
+  travelHistory: {
+    get: (value) => ipcRenderer.invoke(IPC.travelHistoryGet, value),
+    record: (value) => ipcRenderer.invoke(IPC.travelHistoryRecord, value),
+  },
   shortcuts: {
     capture: () => ipcRenderer.invoke(IPC.shortcutCapture),
     cancelCapture: () => ipcRenderer.invoke(IPC.shortcutCaptureCancel),

--- a/src/renderer/companion-play-region-snapshot.ts
+++ b/src/renderer/companion-play-region-snapshot.ts
@@ -8,7 +8,8 @@ export const COMPANION_PLAY_REGION_ABI = COMPANION_ABI.playRegion.abi;
 export const COMPANION_PLAY_REGION_BYTES = COMPANION_ABI.playRegion.bytes;
 
 const MAGIC = 0x5250_5747;
-const FLAGS = Object.freeze({ ready: 1, loading: 2 });
+const FLAGS = Object.freeze({ ready: 1, loading: 2, character: 4, unlocks: 8 });
+const UNLOCK_WORDS = COMPANION_ABI.travelUnlockWords;
 
 export function readCompanionPlayRegion(buffer: ArrayBuffer, pointer: number) {
   if (
@@ -30,6 +31,12 @@ export function readCompanionPlayRegion(buffer: ArrayBuffer, pointer: number) {
   const mapId = view.getUint32(16, true);
   const instanceType = view.getUint32(20, true);
   const encodedRegion = view.getUint32(24, true);
+  const characterLow = view.getUint32(28, true);
+  const characterHigh = view.getUint32(32, true);
+  const unlockedMapWords = Object.freeze(Array.from(
+    { length: UNLOCK_WORDS },
+    (_, index) => view.getUint32(36 + index * 4, true),
+  ));
   const secondSequence = view.getUint32(8, true);
   if (
     magic !== MAGIC
@@ -37,17 +44,22 @@ export function readCompanionPlayRegion(buffer: ArrayBuffer, pointer: number) {
     || bytes !== COMPANION_PLAY_REGION_BYTES
     || firstSequence !== secondSequence
     || (secondSequence & 1) !== 0
-    || (flags & ~(FLAGS.ready | FLAGS.loading)) !== 0
-    || flags === (FLAGS.ready | FLAGS.loading)
+    || (flags & ~(FLAGS.ready | FLAGS.loading | FLAGS.character | FLAGS.unlocks)) !== 0
+    || (flags & FLAGS.loading) !== 0 && flags !== FLAGS.loading
+    || (flags & (FLAGS.character | FLAGS.unlocks)) !== 0 && (flags & FLAGS.ready) === 0
   ) return Object.freeze({ status: "waiting", reason: "snapshot" } as const);
 
   if ((flags & FLAGS.loading) !== 0) {
     return mapId === 0 && instanceType === 0 && encodedRegion === 0
+      && characterLow === 0 && characterHigh === 0
+      && unlockedMapWords.every((word) => word === 0)
       ? Object.freeze({ status: "waiting", reason: "loading" } as const)
       : Object.freeze({ status: "waiting", reason: "corrupt" } as const);
   }
   if ((flags & FLAGS.ready) === 0) {
     return mapId === 0 && instanceType === 0 && encodedRegion === 0
+      && characterLow === 0 && characterHigh === 0
+      && unlockedMapWords.every((word) => word === 0)
       ? Object.freeze({ status: "waiting", reason: "game" } as const)
       : Object.freeze({ status: "waiting", reason: "corrupt" } as const);
   }
@@ -57,6 +69,12 @@ export function readCompanionPlayRegion(buffer: ArrayBuffer, pointer: number) {
     || instanceType > 1
     || (encodedRegion !== 1 && encodedRegion !== 2)
   ) return Object.freeze({ status: "waiting", reason: "corrupt" } as const);
+  const hasCharacter = (flags & FLAGS.character) !== 0;
+  const hasUnlocks = (flags & FLAGS.unlocks) !== 0;
+  if (
+    hasCharacter !== (characterLow !== 0 || characterHigh !== 0)
+    || (!hasUnlocks && unlockedMapWords.some((word) => word !== 0))
+  ) return Object.freeze({ status: "waiting", reason: "corrupt" } as const);
 
   return Object.freeze({
     status: "ready" as const,
@@ -64,9 +82,22 @@ export function readCompanionPlayRegion(buffer: ArrayBuffer, pointer: number) {
     mapId,
     instanceType,
     playRegion: encodedRegion === 1 ? "pve" as const : "pvp" as const,
+    characterKey: hasCharacter
+      ? `${characterHigh.toString(16).padStart(8, "0")}${characterLow.toString(16).padStart(8, "0")}`
+      : null,
+    unlockedMapWords: hasUnlocks ? unlockedMapWords : null,
   });
 }
 
 export type CompanionPlayRegionState =
   | ReturnType<typeof readCompanionPlayRegion>
+  | Readonly<{
+    status: "ready";
+    sequence: number;
+    mapId: number;
+    instanceType: number;
+    playRegion: "pve" | "pvp";
+    characterKey?: string | null;
+    unlockedMapWords?: readonly number[] | null;
+  }>
   | Readonly<{ status: "waiting"; reason: "stale" }>;

--- a/src/shared/companion-abi.ts
+++ b/src/shared/companion-abi.ts
@@ -3,15 +3,16 @@
  * Renderer, scripts, and tests derive their ABI constants from this descriptor.
  */
 export const COMPANION_ABI = Object.freeze({
-  kernel: 17,
-  config: Object.freeze({ bytes: 444 }),
+  kernel: 18,
+  config: Object.freeze({ bytes: 452 }),
   snapshot: Object.freeze({ abi: 3, bytes: 64 }),
+  travelUnlockWords: 28,
   cursor: Object.freeze({ abi: 1, bytes: 4_160 }),
   toolbox: Object.freeze({ abi: 4, bytes: 64 }),
   party: Object.freeze({ abi: 7, bytes: 1_560 }),
   skillSlots: Object.freeze({ abi: 1, bytes: 156 }),
   skillCooldowns: Object.freeze({ abi: 1, bytes: 60 }),
-  playRegion: Object.freeze({ abi: 1, bytes: 28 }),
+  playRegion: Object.freeze({ abi: 2, bytes: 148 }),
 });
 
 export const COMPANION_FEATURE_BITS = Object.freeze({

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -919,6 +919,8 @@ export const IPC = {
   traderPriceHistoryGet: "gw:trader:priceHistory:get",
   travelPreferencesGet: "gw:travelPreferences:get",
   travelPreferencesSet: "gw:travelPreferences:set",
+  travelHistoryGet: "gw:travelHistory:get",
+  travelHistoryRecord: "gw:travelHistory:record",
   shortcutCapture: "gw:shortcuts:capture",
   shortcutCaptureCancel: "gw:shortcuts:captureCancel",
   skillKeyCapture: "gw:skillKeys:capture",
@@ -1092,6 +1094,10 @@ export interface GwNativeApi {
   travelPreferences: {
     get(): Promise<TravelUserPreferences>;
     set(value: TravelUserPreferencesUpdate): Promise<TravelUserPreferences>;
+  };
+  travelHistory: {
+    get(value: { characterKey: string }): Promise<readonly number[]>;
+    record(value: { characterKey: string; mapId: number }): Promise<readonly number[]>;
   };
   shortcuts: {
     capture(): Promise<ShortcutCaptureResult>;

--- a/src/shared/enhancement-config.ts
+++ b/src/shared/enhancement-config.ts
@@ -9,6 +9,7 @@ export interface EnhancementLayout {
   automaticTargetAgentId: number;
   gameContextSlot: number;
   characterContext: number;
+  characterUuid: number;
   mapId: number;
   isExplorable: number;
   currentMapId: number;
@@ -46,6 +47,7 @@ export interface EnhancementLayout {
   accountContextSlot: number;
   accountUnlockedSkills: number;
   worldContext: number;
+  worldUnlockedMaps: number;
   worldHeroFlags: number;
   heroFlagStride: number;
   flagHeroId: number;
@@ -106,6 +108,7 @@ export interface EnhancementLayout {
 export type EnhancementPlayRegionLayout = Pick<EnhancementLayout,
   | "contextRoot" | "gameContextSlot" | "characterContext" | "mapId"
   | "isExplorable" | "currentMapId" | "currentInstanceType" | "playerNumber"
+  | "characterUuid"
   | "areaInfo" | "areaInfoCount" | "areaInfoStride" | "areaInfoFlags"
 >;
 export type EnhancementObservationBaseLayout = EnhancementPlayRegionLayout & Pick<
@@ -127,6 +130,7 @@ export type EnhancementStorageLayout = Pick<EnhancementLayout,
   | "worldPlayers" | "playerRecordStride" | "playerRecordAgentId"
   | "playerRecordAccessFlags" | "playerRecordNumber" | "areaInfoType"
 >;
+export type EnhancementTravelLayout = Pick<EnhancementLayout, "worldUnlockedMaps">;
 export type EnhancementSkillSlotGeometryLayout = Pick<EnhancementLayout,
   | "frameArray" | "frameCount" | "frameBytes" | "frameChildOffsetId"
   | "frameId" | "framePositionFlags" | "frameViewportWidth"
@@ -158,7 +162,7 @@ export type EnhancementPartyLayout = Pick<EnhancementLayout,
 >;
 
 type Owner = "play-region" | "observation" | "target" | "cursor" | "party" | "storage"
-  | "player-skillbar" | "party-skillbar" | "skill-slots" | "skill-cooldown";
+  | "travel" | "player-skillbar" | "party-skillbar" | "skill-slots" | "skill-cooldown";
 type ConfigField =
   | Readonly<{
     source: "layout";
@@ -184,6 +188,7 @@ type ConfigField =
     key: keyof EnhancementPartySkillbarLayout;
   }>
   | Readonly<{ source: "layout"; owner: "storage"; key: keyof EnhancementStorageLayout }>
+  | Readonly<{ source: "layout"; owner: "travel"; key: keyof EnhancementTravelLayout }>
   | Readonly<{
     source: "layout";
     owner: "skill-slots";
@@ -241,6 +246,9 @@ const skillCooldown = (
 ): readonly ConfigField[] => keys.map((key) => ({
   source: "layout", key, owner: "skill-cooldown",
 }));
+const travel = (
+  ...keys: readonly (keyof EnhancementTravelLayout)[]
+): readonly ConfigField[] => keys.map((key) => ({ source: "layout", key, owner: "travel" }));
 
 export const ENHANCEMENT_CONFIG_FIELDS = Object.freeze([
   ...playRegion("contextRoot"),
@@ -273,6 +281,8 @@ export const ENHANCEMENT_CONFIG_FIELDS = Object.freeze([
     "frameRelation", "frameState",
   ),
   ...skillCooldown("skillSlotRecharge"),
+  ...travel("worldUnlockedMaps"),
+  ...playRegion("characterUuid"),
   { source: "dispatcher", key: "playerChatMessage", owner: "party" },
   { source: "dispatcher", key: "hideHeroPanelMessage", owner: "party" },
   { source: "dispatcher", key: "showHeroPanelMessage", owner: "party" },

--- a/src/shared/enhancement-contracts.ts
+++ b/src/shared/enhancement-contracts.ts
@@ -69,7 +69,7 @@ const CAPABILITY_DEFINITIONS = Object.freeze([
     id: "travelAction",
     requiresAll: ["playRegionObservation"],
     requiresAny: [],
-    configOwners: [],
+    configOwners: ["observation", "travel"],
     hooks: [],
   },
   {
@@ -280,7 +280,7 @@ export {
   ENHANCEMENT_LAYOUT_WORD_COUNT,
   ENHANCEMENT_PARTY_DIRTY_MESSAGE_COUNT,
 } from "./enhancement-config.js";
-export const ENHANCEMENT_TRANSFORM_ABI = 45;
+export const ENHANCEMENT_TRANSFORM_ABI = 46;
 
 export function enhancementConfigWordActive(
   capabilities: EnhancementCapabilities,

--- a/src/shared/travel-command.ts
+++ b/src/shared/travel-command.ts
@@ -10,13 +10,41 @@ export const TRAVEL_WAITING_REASONS = [
 export type TravelWaitingReason = (typeof TRAVEL_WAITING_REASONS)[number];
 export type TravelGameState =
   | Readonly<{ status: "waiting"; reason: TravelWaitingReason }>
-  | Readonly<{ status: "ready"; mapId: number }>;
+  | Readonly<{
+    status: "ready";
+    mapId: number;
+    characterKey?: string | null;
+    unlockedMapWords?: readonly number[] | null;
+  }>;
+
+export const TRAVEL_UNLOCK_WORDS = 28;
+
+export function isTravelMapUnlocked(state: TravelGameState, mapId: number): boolean | null {
+  if (state.status !== "ready" || state.unlockedMapWords == null) return null;
+  if (!Number.isSafeInteger(mapId) || mapId < 0) return false;
+  const word = state.unlockedMapWords[Math.floor(mapId / 32)];
+  return word === undefined ? false : ((word >>> (mapId % 32)) & 1) === 1;
+}
 
 export function travelGameState(value: unknown): TravelGameState {
   if (value !== null && typeof value === "object" && !Array.isArray(value)) {
     const input = value as Record<string, unknown>;
     if (input.status === "ready" && Number.isSafeInteger(input.mapId)) {
-      return Object.freeze({ status: "ready", mapId: Number(input.mapId) });
+      const words = input.unlockedMapWords;
+      const unlockedMapWords = Array.isArray(words)
+        && words.length === TRAVEL_UNLOCK_WORDS
+        && words.every((word) => Number.isSafeInteger(word) && word >= 0 && word <= 0xffff_ffff)
+        ? Object.freeze(words.map(Number))
+        : null;
+      return Object.freeze({
+        status: "ready",
+        mapId: Number(input.mapId),
+        characterKey: typeof input.characterKey === "string"
+          && /^[0-9a-f]{16}$/u.test(input.characterKey)
+          ? input.characterKey
+          : null,
+        unlockedMapWords,
+      });
     }
     if (
       input.status === "waiting"

--- a/src/shared/travel-history.ts
+++ b/src/shared/travel-history.ts
@@ -1,0 +1,122 @@
+/**
+ * Durable, bounded Travel history partitioned by a privacy-safe character key.
+ * Character names and raw game UUIDs never cross this contract.
+ */
+import { travelDestination } from "./travel-destinations.js";
+
+export const TRAVEL_HISTORY_FORMAT = 2;
+export const TRAVEL_HISTORY_LIMIT = 10;
+export const TRAVEL_HISTORY_VISIBLE_LIMIT = 5;
+export const TRAVEL_HISTORY_CHARACTER_LIMIT = 32;
+
+declare const TRAVEL_CHARACTER_KEY: unique symbol;
+export type TravelCharacterKey = string & {
+  readonly [TRAVEL_CHARACTER_KEY]: true;
+};
+export type TravelHistory = readonly number[];
+export type TravelHistoryDocument = Readonly<{
+  formatVersion: typeof TRAVEL_HISTORY_FORMAT;
+  characters: Readonly<Record<TravelCharacterKey, TravelHistory>>;
+}>;
+
+const CHARACTER_KEY_PATTERN = /^[0-9a-f]{16}$/u;
+export const EMPTY_TRAVEL_HISTORY: TravelHistory = Object.freeze([]);
+export const DEFAULT_TRAVEL_HISTORY: TravelHistoryDocument = Object.freeze({
+  formatVersion: TRAVEL_HISTORY_FORMAT,
+  characters: Object.freeze({}) as Readonly<Record<TravelCharacterKey, TravelHistory>>,
+});
+
+export function travelCharacterKey(value: unknown): TravelCharacterKey {
+  if (typeof value !== "string" || !CHARACTER_KEY_PATTERN.test(value)) {
+    throw new TypeError("Travel character key is invalid");
+  }
+  return value as TravelCharacterKey;
+}
+
+export function isTravelHistory(value: unknown): value is TravelHistory {
+  return Array.isArray(value)
+    && value.length <= TRAVEL_HISTORY_LIMIT
+    && new Set(value).size === value.length
+    && value.every((mapId) =>
+      Number.isSafeInteger(mapId) && travelDestination(Number(mapId)) !== null
+    );
+}
+
+export function parseTravelHistoryDocument(value: unknown): TravelHistoryDocument {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("Travel history must be an object");
+  }
+  const input = value as Record<string, unknown>;
+  if (
+    Object.keys(input).length !== 2
+    || input.formatVersion !== TRAVEL_HISTORY_FORMAT
+    || input.characters === null
+    || typeof input.characters !== "object"
+    || Array.isArray(input.characters)
+  ) throw new TypeError("Travel history is invalid");
+  const entries = Object.entries(input.characters as Record<string, unknown>);
+  if (
+    entries.length > TRAVEL_HISTORY_CHARACTER_LIMIT
+    || entries.some(([key, history]) => {
+      try {
+        travelCharacterKey(key);
+        return !isTravelHistory(history);
+      } catch {
+        return true;
+      }
+    })
+  ) throw new TypeError("Travel history is invalid");
+  return Object.freeze({
+    formatVersion: TRAVEL_HISTORY_FORMAT,
+    characters: Object.freeze(Object.fromEntries(entries.map(([key, history]) => [
+      travelCharacterKey(key),
+      Object.freeze((history as TravelHistory).map(Number)),
+    ]))) as Readonly<Record<TravelCharacterKey, TravelHistory>>,
+  });
+}
+
+/** Most-recently visited unique destinations, newest first. */
+export function recordVisitedTravel(
+  current: TravelHistory,
+  mapId: number,
+): TravelHistory {
+  if (travelDestination(mapId) === null) {
+    throw new RangeError(`Travel destination ${mapId} is not reviewed`);
+  }
+  return Object.freeze([
+    mapId,
+    ...current.filter((candidate) => candidate !== mapId),
+  ].slice(0, TRAVEL_HISTORY_LIMIT));
+}
+
+export function parseTravelHistoryRecord(value: unknown): Readonly<{
+  characterKey: TravelCharacterKey;
+  mapId: number;
+}> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("Travel history record is invalid");
+  }
+  const input = value as Record<string, unknown>;
+  if (
+    Object.keys(input).length !== 2
+    || !Number.isSafeInteger(input.mapId)
+    || travelDestination(Number(input.mapId)) === null
+  ) throw new TypeError("Travel history record is invalid");
+  return Object.freeze({
+    characterKey: travelCharacterKey(input.characterKey),
+    mapId: Number(input.mapId),
+  });
+}
+
+export function parseTravelHistoryCharacter(value: unknown): Readonly<{
+  characterKey: TravelCharacterKey;
+}> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new TypeError("Travel history character is invalid");
+  }
+  const input = value as Record<string, unknown>;
+  if (Object.keys(input).length !== 1) {
+    throw new TypeError("Travel history character is invalid");
+  }
+  return Object.freeze({ characterKey: travelCharacterKey(input.characterKey) });
+}

--- a/tests/electron/input-travel.spec.ts
+++ b/tests/electron/input-travel.spec.ts
@@ -35,7 +35,11 @@ test.describe("renderer Travel input", () => {
         installation.update({
           enabled: true,
           playRegion: "pve",
-          state: { status: "ready", mapId: 133 },
+          state: {
+            status: "ready",
+            mapId: 133,
+            unlockedMapWords: Array.from({ length: 28 }, () => 0xffff_ffff),
+          },
         });
         installation.poll();
       });

--- a/tests/electron/sandbox.spec.ts
+++ b/tests/electron/sandbox.spec.ts
@@ -68,6 +68,7 @@ test.describe("sandbox boundary", () => {
           "steam",
           "templates",
           "trade",
+          "travelHistory",
           "travelPreferences",
           "wasmBridgeMarkers",
         ],

--- a/tests/fixtures/enhancement-transform.ts
+++ b/tests/fixtures/enhancement-transform.ts
@@ -209,13 +209,14 @@ export function moduleWithManifest(value: unknown): WebAssembly.Module {
 // otherwise.
 export function fixture(hookParamType = 0x7f): Uint8Array {
   const type = section(1, [
-    6,
+    7,
     0x60, 1, hookParamType, 0,
     0x60, 5, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0,
     0x60, 3, 0x7f, 0x7f, 0x7f, 0,
     0x60, 2, 0x7f, 0x7f, 0,
     0x60, 2, 0x7f, 0x7f, 1, 0x7f,
     0x60, 1, 0x7f, 1, 0x7f,
+    0x60, 0, 1, 0x7f,
   ]);
   const env = [3, 101, 110, 118];
   const imports = section(2, [
@@ -224,10 +225,10 @@ export function fixture(hookParamType = 0x7f): Uint8Array {
     ...env, 1, 99, 0, 1,
     ...env, 1, 117, 0, 2,
   ]);
-  // Fourteen defined functions: three hooks, three commands, the recurring
+  // Sixteen defined functions: three hooks, three commands, the recurring
   // game-thread callback, packet sender, DataWindow, slash parser, and Travel
   // producer, plus three exact-signature Xunlai fact readers.
-  const functions = section(3, [14, 0, 1, 2, 0, 2, 3, 3, 2, 0, 4, 1, 5, 5, 5]);
+  const functions = section(3, [16, 0, 1, 2, 0, 2, 3, 3, 2, 0, 4, 1, 5, 5, 5, 6, 5]);
   const table = section(4, [1, 0x70, 1, 5, 5]);
   const memory = section(5, [1, 1, 1, 1]);
   const globals = section(6, [0]);
@@ -293,8 +294,9 @@ export function fixture(hookParamType = 0x7f): Uint8Array {
   const dataWindow = [0, 0x20, 0, 0x10, 0, 0x0b];
   const slash = [0, 0x20, 0, 0x10, 0, 0x41, 0, 0x0b];
   const reader = [0, 0x20, 0, 0x0b];
+  const unlockAccessor = [0, 0x41, ...sleb(256), 0x0b];
   const code = section(10, [
-    14,
+    16,
     ...uleb(tick.length), ...tick,
     ...uleb(cursor.length), ...cursor,
     ...uleb(ui.length), ...ui,
@@ -309,11 +311,23 @@ export function fixture(hookParamType = 0x7f): Uint8Array {
     ...uleb(reader.length), ...reader,
     ...uleb(reader.length), ...reader,
     ...uleb(reader.length), ...reader,
+    ...uleb(unlockAccessor.length), ...unlockAccessor,
+    ...uleb(reader.length), ...reader,
+  ]);
+  const unlockData = [
+    0x20, 0x01, 0, 0,
+    28, 0, 0, 0,
+    28, 0, 0, 0,
+    ...Array.from({ length: 28 * 4 }, () => 0xff),
+  ];
+  const data = section(11, [
+    1, 0, 0x41, ...sleb(256), 0x0b,
+    ...uleb(unlockData.length), ...unlockData,
   ]);
   return Uint8Array.from([
     0, 97, 115, 109, 1, 0, 0, 0,
     ...type, ...imports, ...functions, ...table, ...memory, ...globals, ...exports,
-    ...elements, ...code,
+    ...elements, ...code, ...data,
   ]);
 }
 
@@ -362,6 +376,21 @@ export function manifest(bytes: Uint8Array): KnownEnhancementBuild {
       configureExport: "enhancement_configure_travel",
       toggleExport: "enhancement_take_travel_toggle",
       messageId: 0x1000_0183,
+      unlockProof: {
+        layout: { worldUnlockedMaps: 0x60c },
+        accessor: {
+          functionIndex: 17,
+          params: [],
+          results: ["i32"],
+          bodySha256: createHash("sha256").update(commandBody(bytes, 14)).digest("hex"),
+        },
+        consumer: {
+          functionIndex: 18,
+          params: ["i32"],
+          results: ["i32"],
+          bodySha256: createHash("sha256").update(commandBody(bytes, 15)).digest("hex"),
+        },
+      },
       producer: {
         functionIndex: 13,
         params: ["i32", "i32", "i32", "i32", "i32"],
@@ -471,7 +500,7 @@ export function manifest(bytes: Uint8Array): KnownEnhancementBuild {
     },
     observationBase: { layout: {
       contextRoot: 1, agentArray: 2, gameContextSlot: 6,
-      characterContext: 4, mapId: 5, isExplorable: 6,
+      characterContext: 4, characterUuid: 0x64, mapId: 5, isExplorable: 6,
       currentMapId: 7, currentInstanceType: 8, playerNumber: 9,
       agentId: 10, agentX: 11, agentY: 12, agentType: 13,
       agentPlayerNumber: 14, agentModelType: 15,
@@ -479,7 +508,7 @@ export function manifest(bytes: Uint8Array): KnownEnhancementBuild {
       areaInfo: 72, areaInfoCount: 73, areaInfoStride: 74, areaInfoFlags: 75,
     } },
     playRegionObservation: { layout: {
-      contextRoot: 1, gameContextSlot: 6, characterContext: 4,
+      contextRoot: 1, gameContextSlot: 6, characterContext: 4, characterUuid: 0x64,
       mapId: 5, isExplorable: 6, currentMapId: 7,
       currentInstanceType: 8, playerNumber: 9,
       areaInfo: 72, areaInfoCount: 73, areaInfoStride: 74, areaInfoFlags: 75,

--- a/tests/fixtures/enhancements.ts
+++ b/tests/fixtures/enhancements.ts
@@ -302,6 +302,7 @@ export const ADDRESSES = Object.freeze({
   skillbarBuffer: 0x1_3000,
   attributeBuffer: 0x1_4000,
   playerRecordBuffer: 0x1_5000,
+  travelUnlockBuffer: 0x1_6000,
   areaInfo: 0x20_0000,
   frameArrayGlobal: 0x21_0000,
   frameCountGlobal: 0x21_0004,
@@ -570,6 +571,8 @@ export async function createKernel(
     0x1c8, 0xb8, 0xbc, 0xd8, 0x104, 0x108,
     0x10c, 0x110, 0x114, 0x118, 0x128, 0x18c,
   ], SKILL_CONFIG_START);
+  config[ENHANCEMENT_LAYOUT_FIELDS.indexOf("worldUnlockedMaps")] = 0x60c;
+  config[ENHANCEMENT_LAYOUT_FIELDS.indexOf("characterUuid")] = 0x64;
   // Placed at the boundary rather than appended to the literal above. Written
   // as one flat list, the messages sat directly after the party chain — and
   // when the layout grew they silently stayed there, a full detail block short of
@@ -713,6 +716,10 @@ export function installGameGraph(view: DataView) {
   view.setUint32(ADDRESSES.character + 0x234, 133, true);
   view.setUint32(ADDRESSES.character + 0x23c, 0, true);
   view.setUint32(ADDRESSES.character + 0x2ac, 42, true);
+  view.setUint32(ADDRESSES.character + 0x64, 0x0403_0201, true);
+  view.setUint32(ADDRESSES.character + 0x68, 0x0807_0605, true);
+  view.setUint32(ADDRESSES.character + 0x6c, 0x0c0b_0a09, true);
+  view.setUint32(ADDRESSES.character + 0x70, 0x100f_0e0d, true);
   const area = ADDRESSES.areaInfo + 133 * 0x7c;
   view.setUint32(area + 0x00, 1, true);
   view.setUint32(area + 0x04, 0, true);
@@ -739,6 +746,14 @@ export function installGameGraph(view: DataView) {
   view.setUint32(ADDRESSES.manualTargetId, 9, true);
   view.setUint32(ADDRESSES.game + 0x4c, ADDRESSES.partyContext, true);
   view.setUint32(ADDRESSES.game + DETAIL.worldContext, ADDRESSES.world, true);
+  view.setUint32(ADDRESSES.world + 0x60c, ADDRESSES.travelUnlockBuffer, true);
+  view.setUint32(ADDRESSES.world + 0x610, 28, true);
+  view.setUint32(ADDRESSES.world + 0x614, 28, true);
+  view.setUint32(
+    ADDRESSES.travelUnlockBuffer + Math.floor(133 / 32) * 4,
+    1 << (133 % 32),
+    true,
+  );
   view.setUint32(ADDRESSES.world + DETAIL.players, ADDRESSES.playerRecordBuffer, true);
   view.setUint32(ADDRESSES.world + DETAIL.players + 4, 64, true);
   view.setUint32(ADDRESSES.world + DETAIL.players + 8, PLAYER_RECORD_INDEX + 1, true);

--- a/tests/helpers/packaged-enhancement-scenarios.ts
+++ b/tests/helpers/packaged-enhancement-scenarios.ts
@@ -300,7 +300,7 @@ export async function assertTargetReadoutLifecycle() {
     );
     assert.deepEqual(disposed, {
       // Runtime allocation, target snapshot, config, and policy region.
-      freed: [0x1000, 0x11_010, 0x11_050, 0x11_210],
+      freed: [0x1000, 0x11_010, 0x11_050, 0x11_218],
       hook: 0,
       // Cleanup withdraws the published runtime by writing null over it.
       runtime: null,

--- a/tests/integration/enhancements-kernel.test.ts
+++ b/tests/integration/enhancements-kernel.test.ts
@@ -216,6 +216,23 @@ describe("Companion kernel", () => {
     assert.equal(policy.targetValid, false);
   });
 
+  it("publishes a privacy-safe character key and the bounded Travel unlock set", async () => {
+    const kernel = await createKernel({ partyDetail: true });
+    installGameGraph(kernel.view);
+    assert.equal(kernel.init({ features: FEATURE_PLAY_REGION_OBSERVATION }), 1);
+    kernel.tick();
+
+    const state = kernel.playRegion();
+    assert.equal(state.status, "ready");
+    if (state.status !== "ready") return;
+    assert.equal(state.characterKey, "e7ecfb4f6e006495");
+    assert.equal(state.unlockedMapWords?.length, 28);
+    assert.equal(
+      (state.unlockedMapWords?.[Math.floor(133 / 32)] ?? 0) >>> (133 % 32) & 1,
+      1,
+    );
+  });
+
   it("requires UI message configuration only for the Toolbox capability", async () => {
     const cursorOnly = await createKernel();
     cursorOnly.config.fill(0, MESSAGE_CONFIG_START);

--- a/tests/integration/play-region-kernel.test.ts
+++ b/tests/integration/play-region-kernel.test.ts
@@ -13,6 +13,10 @@ import {
 } from "../fixtures/enhancements.ts";
 
 const AREA_133 = ADDRESSES.areaInfo + 133 * 0x7c;
+const OBSERVED_CHARACTER = Object.freeze({
+  characterKey: "e7ecfb4f6e006495",
+  unlockedMapWords: null,
+});
 
 describe("play-region kernel", () => {
   it("publishes the bounded area policy without traversing the agent array", async () => {
@@ -30,6 +34,7 @@ describe("play-region kernel", () => {
       mapId: 133,
       instanceType: 0,
       playRegion: "pve",
+      ...OBSERVED_CHARACTER,
     });
 
     // Guild halls and PvP outposts carry the PvP area flag, but an outpost is
@@ -42,6 +47,7 @@ describe("play-region kernel", () => {
       mapId: 133,
       instanceType: 0,
       playRegion: "pve",
+      ...OBSERVED_CHARACTER,
     });
 
     kernel.view.setUint32(ADDRESSES.character + 0x19c, 1, true);
@@ -53,6 +59,7 @@ describe("play-region kernel", () => {
       mapId: 133,
       instanceType: 1,
       playRegion: "pvp",
+      ...OBSERVED_CHARACTER,
     });
   });
 

--- a/tests/integration/play-region-snapshot.test.ts
+++ b/tests/integration/play-region-snapshot.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   COMPANION_PLAY_REGION_BYTES,
+  COMPANION_PLAY_REGION_ABI,
   readCompanionPlayRegion,
 } from "../../src/renderer/companion-play-region-snapshot.ts";
 
@@ -14,17 +15,24 @@ function snapshot(overrides: Readonly<{
   mapId?: number;
   instanceType?: number;
   playRegion?: number;
+  characterLow?: number;
+  characterHigh?: number;
+  unlockedMapWords?: readonly number[];
 }> = {}) {
   const buffer = new ArrayBuffer(COMPANION_PLAY_REGION_BYTES);
   const view = new DataView(buffer);
   view.setUint32(0, overrides.magic ?? 0x5250_5747, true);
-  view.setUint16(4, overrides.abi ?? 1, true);
+  view.setUint16(4, overrides.abi ?? COMPANION_PLAY_REGION_ABI, true);
   view.setUint16(6, overrides.bytes ?? COMPANION_PLAY_REGION_BYTES, true);
   view.setUint32(8, overrides.sequence ?? 2, true);
   view.setUint32(12, overrides.flags ?? 1, true);
   view.setUint32(16, overrides.mapId ?? 133, true);
   view.setUint32(20, overrides.instanceType ?? 0, true);
   view.setUint32(24, overrides.playRegion ?? 1, true);
+  view.setUint32(28, overrides.characterLow ?? 0, true);
+  view.setUint32(32, overrides.characterHigh ?? 0, true);
+  overrides.unlockedMapWords?.forEach((word, index) =>
+    view.setUint32(36 + index * 4, word, true));
   return buffer;
 }
 
@@ -36,6 +44,8 @@ describe("play-region snapshot ABI", () => {
       mapId: 133,
       instanceType: 0,
       playRegion: "pve",
+      characterKey: null,
+      unlockedMapWords: null,
     });
     assert.deepEqual(readCompanionPlayRegion(snapshot({
       mapId: 248,
@@ -47,11 +57,13 @@ describe("play-region snapshot ABI", () => {
       mapId: 248,
       instanceType: 1,
       playRegion: "pvp",
+      characterKey: null,
+      unlockedMapWords: null,
     });
   });
 
   it("fails closed for memory, torn headers, contradictory flags, and values", () => {
-    assert.deepEqual(readCompanionPlayRegion(new ArrayBuffer(27), 0), {
+    assert.deepEqual(readCompanionPlayRegion(new ArrayBuffer(COMPANION_PLAY_REGION_BYTES - 1), 0), {
       status: "waiting", reason: "memory",
     });
     assert.deepEqual(readCompanionPlayRegion(snapshot({ sequence: 3 }), 0), {

--- a/tests/release/preload-behaviour.test.ts
+++ b/tests/release/preload-behaviour.test.ts
@@ -198,6 +198,16 @@ const INVOCATIONS: Invocation[] = [
     }],
     channel: IPC.travelPreferencesSet,
   },
+  {
+    path: "travelHistory.get",
+    args: [{ characterKey: "0123456789abcdef" }],
+    channel: IPC.travelHistoryGet,
+  },
+  {
+    path: "travelHistory.record",
+    args: [{ characterKey: "0123456789abcdef", mapId: 55 }],
+    channel: IPC.travelHistoryRecord,
+  },
   { path: "trade.subscribe", args: ["kamadan"], channel: IPC.tradeSubscribe },
   { path: "trade.unsubscribe", args: [], channel: IPC.tradeUnsubscribe },
   {

--- a/tests/unit/client-module.test.ts
+++ b/tests/unit/client-module.test.ts
@@ -142,7 +142,7 @@ const CALL_OFFSET = 5;
  */
 function officialFixture(): Uint8Array {
   const types = section(1, [
-    7,
+    8,
     0x60, 2, 0x7f, 0x7f, 1, 0x7f,
     0x60, 4, 0x7f, 0x7f, 0x7f, 0x7f, 1, 0x7f,
     0x60, 1, 0x7f, 0,
@@ -150,9 +150,10 @@ function officialFixture(): Uint8Array {
     0x60, 3, 0x7f, 0x7f, 0x7f, 0,
     0x60, 2, 0x7f, 0x7f, 0,
     0x60, 1, 0x7f, 1, 0x7f,
+    0x60, 0, 1, 0x7f,
   ]);
   const imports = section(2, [1, 1, 109, 1, 97, 0, 1]);
-  const functions = section(3, [15, 0, 0, 2, 3, 4, 5, 5, 4, 4, 2, 0, 3, 6, 6, 6]);
+  const functions = section(3, [17, 0, 0, 2, 3, 4, 5, 5, 4, 4, 2, 0, 3, 6, 6, 6, 7, 6]);
   const table = section(4, [1, 0x70, 1, 5, 5]);
   const memory = section(5, [1, 1, 1, 1]);
   const globals = section(6, [0]);
@@ -184,8 +185,9 @@ function officialFixture(): Uint8Array {
   const loop = [1, 2, 0x7f, 0x0b];
   const slashParser = [0, 0x41, 0, 0x0b];
   const reader = [0, 0x20, 0, 0x0b];
+  const unlockAccessor = [0, 0x41, ...uleb(256), 0x0b];
   const code = section(10, [
-    15,
+    17,
     ...uleb(STUB_BODY.length), ...STUB_BODY,
     ...uleb(caller.length), ...caller,
     ...uleb(loop.length), ...loop,
@@ -201,6 +203,18 @@ function officialFixture(): Uint8Array {
     ...uleb(reader.length), ...reader,
     ...uleb(reader.length), ...reader,
     ...uleb(reader.length), ...reader,
+    ...uleb(unlockAccessor.length), ...unlockAccessor,
+    ...uleb(reader.length), ...reader,
+  ]);
+  const unlockData = [
+    0x20, 0x01, 0, 0,
+    28, 0, 0, 0,
+    28, 0, 0, 0,
+    ...Array.from({ length: 28 * 4 }, () => 0xff),
+  ];
+  const data = section(11, [
+    1, 0, 0x41, ...uleb(256), 0x0b,
+    ...uleb(unlockData.length), ...unlockData,
   ]);
   return Uint8Array.from([
     0, 97, 115, 109, 1, 0, 0, 0,
@@ -213,6 +227,7 @@ function officialFixture(): Uint8Array {
     ...exports,
     ...elements,
     ...code,
+    ...data,
   ]);
 }
 
@@ -262,7 +277,7 @@ function enhancementBuild(input: Uint8Array): KnownEnhancementBuild {
     tableSlot: 5,
     observationBase: { layout: {
       contextRoot: 1, agentArray: 2, gameContextSlot: 6,
-      characterContext: 4, mapId: 5, isExplorable: 6,
+      characterContext: 4, characterUuid: 0x64, mapId: 5, isExplorable: 6,
       currentMapId: 7, currentInstanceType: 8, playerNumber: 9,
       agentId: 10, agentPlayerNumber: 14, agentModelType: 15,
       agentX: 11, agentY: 12, agentType: 13,
@@ -270,7 +285,7 @@ function enhancementBuild(input: Uint8Array): KnownEnhancementBuild {
       areaInfoStride: 74, areaInfoFlags: 75,
     } },
     playRegionObservation: { layout: {
-      contextRoot: 1, gameContextSlot: 6, characterContext: 4,
+      contextRoot: 1, gameContextSlot: 6, characterContext: 4, characterUuid: 0x64,
       mapId: 5, isExplorable: 6, currentMapId: 7,
       currentInstanceType: 8, playerNumber: 9, areaInfo: 72,
       areaInfoCount: 73, areaInfoStride: 74, areaInfoFlags: 75,
@@ -307,6 +322,17 @@ function enhancementBuild(input: Uint8Array): KnownEnhancementBuild {
       configureExport: "enhancement_configure_travel",
       toggleExport: "enhancement_take_travel_toggle",
       messageId: 0x1000_0183,
+      unlockProof: {
+        layout: { worldUnlockedMaps: 0x60c },
+        accessor: {
+          functionIndex: 16, params: [], results: ["i32"],
+          bodySha256: sha256(parseCode(sectionById(splitSections(input), 10))[15]!),
+        },
+        consumer: {
+          functionIndex: 17, params: ["i32"], results: ["i32"],
+          bodySha256: sha256(parseCode(sectionById(splitSections(input), 10))[16]!),
+        },
+      },
       producer: {
         functionIndex: 12,
         params: ["i32", "i32", "i32", "i32", "i32"],

--- a/tests/unit/feature-contracts.test.ts
+++ b/tests/unit/feature-contracts.test.ts
@@ -61,7 +61,7 @@ test("the capability registry is the ordered wire vocabulary", () => {
       id: "travelAction",
       requiresAll: ["playRegionObservation"],
       requiresAny: [],
-      configOwners: [],
+      configOwners: ["observation", "travel"],
       hooks: [],
     },
     {
@@ -164,8 +164,8 @@ test("dependency pruning is derived from capability contracts", () => {
 });
 
 test("cooldown owns the reusable player skillbar core without Party", () => {
-  assert.equal(ENHANCEMENT_CONFIG_WORD_COUNT * Uint32Array.BYTES_PER_ELEMENT, 444);
-  assert.equal(ENHANCEMENT_LAYOUT_WORD_COUNT, 98);
+  assert.equal(ENHANCEMENT_CONFIG_WORD_COUNT * Uint32Array.BYTES_PER_ELEMENT, 452);
+  assert.equal(ENHANCEMENT_LAYOUT_WORD_COUNT, 100);
   assert.equal(ENHANCEMENT_LAYOUT_OWNERSHIP_IS_EXHAUSTIVE, true);
   assert.equal(
     new Set(ENHANCEMENT_LAYOUT_FIELDS).size,

--- a/tests/unit/paths.test.ts
+++ b/tests/unit/paths.test.ts
@@ -26,6 +26,7 @@ describe("resolved profile paths", () => {
       settings: `${root}/settings.json`,
       diagnosticProfile: `${root}/diagnostic-profile.json`,
       travelPreferences: `${root}/travel-preferences.json`,
+      travelHistory: `${root}/travel-history.json`,
       tradeSaved: `${root}/trade-saved.json`,
       buildLibrary: `${root}/build-library.json`,
       windowState: `${root}/window-state.json`,

--- a/tests/unit/the-companion-abi-is-exact-across-typescript-and-rust.test.ts
+++ b/tests/unit/the-companion-abi-is-exact-across-typescript-and-rust.test.ts
@@ -151,7 +151,7 @@ function replaced(source: string, from: string, to: string): string {
 
 test("the independent TypeScript and Rust companion contracts match exactly", () => {
   assertExactContract(rustSource);
-  assert.equal(typescriptConfigSlots().length, 111);
+  assert.equal(typescriptConfigSlots().length, 113);
 });
 
 test("same-size field swaps, bit drift, opcode drift, and new names are rejected", () => {

--- a/tests/unit/travel-history.test.ts
+++ b/tests/unit/travel-history.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { TravelHistoryStore } from "../../src/main/core/travel-history.js";
+import {
+  parseTravelHistoryDocument,
+  recordVisitedTravel,
+  travelCharacterKey,
+} from "../../src/shared/travel-history.js";
+
+const characterA = travelCharacterKey("0123456789abcdef");
+const characterB = travelCharacterKey("fedcba9876543210");
+
+describe("Travel history", () => {
+  it("keeps ten unique reviewed destinations in most-recent order", () => {
+    const destinations = [148, 164, 165, 166, 163, 778, 81, 55, 20, 49, 109, 81, 85];
+    const history = destinations.reduce(recordVisitedTravel, Object.freeze([]) as readonly number[]);
+    assert.deepEqual(history, [85, 81, 109, 49, 20, 55, 778, 163, 166, 165]);
+    assert.throws(() => recordVisitedTravel(history, 2_000), /not reviewed/u);
+  });
+
+  it("persists histories independently per character across store instances", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "gw-travel-history-"));
+    const path = join(dir, "travel-history.json");
+    const first = new TravelHistoryStore(path);
+    await first.record(characterA, 55);
+    await first.record(characterB, 449);
+    await first.record(characterA, 81);
+
+    const restarted = new TravelHistoryStore(path);
+    assert.deepEqual(await restarted.get(characterA), [81, 55]);
+    assert.deepEqual(await restarted.get(characterB), [449]);
+    assert.deepEqual(parseTravelHistoryDocument(JSON.parse(await readFile(path, "utf8"))), {
+      formatVersion: 2,
+      characters: { [characterB]: [449], [characterA]: [81, 55] },
+    });
+  });
+
+  it("quarantines an unreadable document instead of sharing invented history", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "gw-travel-history-"));
+    const path = join(dir, "travel-history.json");
+    await writeFile(path, "not json");
+    assert.deepEqual(await new TravelHistoryStore(path).get(characterA), []);
+    await assert.rejects(readFile(path, "utf8"), /ENOENT/u);
+  });
+});


### PR DESCRIPTION
Quick Travel lost its previously visited locations when the unlock-aware work was removed, and the history was not scoped to the active character. This restores that useful behavior without reverting the current Spotlight-style search or its single-focus treatment.

The app now observes the current reviewed map and a privacy-safe hash of the active character UUID, then stores a bounded recent list per character in one atomic local document. Raw UUIDs and character names never leave the native kernel. Search results, favorites, number shortcuts, and recent destinations use the observed map-unlock bitset; the game-thread command validates the unlock again and fails closed before travel.

The current Travel layout remains unchanged apart from a compact **Recent** section. The current map is excluded, histories survive app and game restarts, corrupt convenience data is quarantined, and old character entries are bounded.

## Verification

- TypeScript checks for main, renderer, tests, and Tools
- Production build, including sealed companion-kernel artifact
- Companion-kernel live-memory fixture and play-region ABI tests
- Travel history persistence, restart, character isolation, and corruption tests
- Preload/IPC boundary tests
- Focused Travel palette and host tests
- Certification bundle verification
- `git diff --check`
- Visual review of the embedded Travel demo

Implemented with Codex.
