### PR TITLE
fix(travel): keep history aligned with active character

### DIFF
--- a/apps/tools/src/components/TravelPalette.test.ts
+++ b/apps/tools/src/components/TravelPalette.test.ts
@@ -13,14 +13,19 @@ import type {
 } from "../travel-host";
 import TravelDestinationPicker from "./TravelDestinationPicker.vue";
 import TravelPalette from "./TravelPalette.vue";
-import { EMPTY_TRAVEL_HISTORY } from "../../../../src/shared/travel-history";
+import {
+  EMPTY_TRAVEL_HISTORY,
+  travelCharacterKey,
+} from "../../../../src/shared/travel-history";
 
 function fixture(options: Readonly<{
   shortcuts?: TravelShortcuts;
   synonyms?: TravelSynonyms;
   history?: readonly number[];
 }> = {}, attachTo?: Element) {
-  const state = ref<TravelHost["state"]["value"]>({ status: "ready", mapId: 55 });
+  const state = ref<TravelHost["state"]["value"]>({
+    status: "ready", mapId: 55, characterKey: null, unlockedMapWords: null,
+  });
   let preferences: TravelPreferences = Object.freeze({
     shortcuts: options.shortcuts ?? DEFAULT_TRAVEL_SHORTCUTS,
     synonyms: options.synonyms ?? Object.freeze([]),
@@ -155,7 +160,10 @@ describe("TravelPalette", () => {
     const unlockedMapWords = Array.from({ length: 28 }, () => 0);
     unlockedMapWords[Math.floor(55 / 32)] = 1 << (55 % 32);
     state.value = {
-      status: "ready", mapId: 55, characterKey: "0123456789abcdef", unlockedMapWords,
+      status: "ready",
+      mapId: 55,
+      characterKey: travelCharacterKey("0123456789abcdef"),
+      unlockedMapWords,
     };
     await wrapper.get("#travel-search-input").setValue("Kamadan");
     expect(wrapper.findAll('[role="option"]')).toHaveLength(0);

--- a/apps/tools/src/travel-history-observation.ts
+++ b/apps/tools/src/travel-history-observation.ts
@@ -1,0 +1,107 @@
+/** Keeps durable Travel history aligned with the currently certified character. */
+import { computed, shallowRef, type Ref } from "vue";
+import type { GwNativeApi } from "../../../src/shared/contracts";
+import type { TravelGameState } from "../../../src/shared/travel-command";
+import { travelDestination } from "../../../src/shared/travel";
+import {
+  EMPTY_TRAVEL_HISTORY,
+  type TravelCharacterKey,
+  type TravelHistory,
+} from "../../../src/shared/travel-history";
+
+type Observation = Readonly<{
+  characterKey: TravelCharacterKey;
+  mapId: number;
+}>;
+type PublishedHistory = Readonly<{
+  characterKey: TravelCharacterKey;
+  maps: TravelHistory;
+}>;
+
+function observation(state: TravelGameState): Observation | null {
+  return state.status === "ready" && state.characterKey !== null
+    ? Object.freeze({ characterKey: state.characterKey, mapId: state.mapId })
+    : null;
+}
+
+function sameObservation(left: Observation | null, right: Observation): boolean {
+  return left?.characterKey === right.characterKey && left.mapId === right.mapId;
+}
+
+export function createTravelHistoryObservation(
+  api: GwNativeApi["travelHistory"],
+  state: Ref<TravelGameState>,
+  development: boolean,
+) {
+  const published = shallowRef<PublishedHistory | null>(null);
+  const history = computed<TravelHistory>(() => {
+    const current = observation(state.value);
+    return current !== null && published.value?.characterKey === current.characterKey
+      ? published.value.maps
+      : EMPTY_TRAVEL_HISTORY;
+  });
+  let tail: Promise<void> = Promise.resolve();
+  let lastObservation: Observation | null = null;
+  let inFlight: Readonly<{ observation: Observation; promise: Promise<TravelHistory> }> | null = null;
+  let disposed = false;
+
+  const synchronize = (next: Observation): Promise<TravelHistory> => {
+    if (inFlight !== null && sameObservation(inFlight.observation, next)) {
+      return inFlight.promise;
+    }
+    const operation = travelDestination(next.mapId) === null
+      ? () => api.get({ characterKey: next.characterKey })
+      : () => api.record(next);
+    const result = tail.then(operation).then((maps) => {
+      if (!disposed && observation(state.value)?.characterKey === next.characterKey) {
+        published.value = Object.freeze({ characterKey: next.characterKey, maps });
+      }
+      return maps;
+    });
+    tail = result.then(() => undefined, () => undefined);
+    inFlight = Object.freeze({ observation: next, promise: result });
+    void result.then(
+      () => {
+        if (inFlight?.promise === result) inFlight = null;
+      },
+      () => {
+        if (inFlight?.promise === result) inFlight = null;
+      },
+    );
+    return result;
+  };
+
+  const reportFailure = (next: Observation, error: unknown): void => {
+    if (sameObservation(lastObservation, next)) lastObservation = null;
+    if (!development) return;
+    console.debug(`[tools:dev] travel.history.refused ${JSON.stringify({
+      mapId: next.mapId,
+      reason: error instanceof Error ? error.message : "unknown history error",
+    })}`);
+  };
+
+  return Object.freeze({
+    history,
+    load(): Promise<TravelHistory> {
+      const current = observation(state.value);
+      if (current === null) return Promise.resolve(EMPTY_TRAVEL_HISTORY);
+      if (inFlight !== null && sameObservation(inFlight.observation, current)) {
+        return inFlight.promise;
+      }
+      if (published.value?.characterKey === current.characterKey) {
+        return Promise.resolve(published.value.maps);
+      }
+      return synchronize(current);
+    },
+    update(nextState: TravelGameState): void {
+      const next = observation(nextState);
+      if (next === null || sameObservation(lastObservation, next)) return;
+      lastObservation = next;
+      void synchronize(next).catch((error: unknown) => reportFailure(next, error));
+    },
+    dispose(): void {
+      disposed = true;
+      published.value = null;
+    },
+  });
+}

--- a/apps/tools/src/travel-host.test.ts
+++ b/apps/tools/src/travel-host.test.ts
@@ -4,6 +4,7 @@ import {
 } from "../../../src/shared/contracts";
 import type { TravelCommand } from "../../../src/shared/travel-command";
 import { DEFAULT_TRAVEL_SHORTCUTS, replaceTravelShortcut } from "../../../src/shared/travel";
+import { travelCharacterKey } from "../../../src/shared/travel-history";
 import {
   createNativeTravelHost,
   type TravelHost,
@@ -29,32 +30,42 @@ function fixture() {
     return save(patch);
   });
   const histories = new Map<string, readonly number[]>();
+  let nextHistoryFailure: Error | null = null;
   const recordHistory = vi.fn(async ({ characterKey, mapId }: {
     characterKey: string; mapId: number;
   }) => {
+    if (nextHistoryFailure !== null) {
+      const failure = nextHistoryFailure;
+      nextHistoryFailure = null;
+      throw failure;
+    }
     const current = histories.get(characterKey) ?? [];
     const next = [mapId, ...current.filter((candidate) => candidate !== mapId)].slice(0, 10);
     histories.set(characterKey, next);
     return next;
   });
+  const getHistory = vi.fn(async ({ characterKey }: { characterKey: string }) =>
+    histories.get(characterKey) ?? []);
   const api = {
     travelPreferences: {
       async get() { return travel; },
       set: setTravel,
     },
     travelHistory: {
-      async get({ characterKey }: { characterKey: string }) {
-        return histories.get(characterKey) ?? [];
-      },
+      get: getHistory,
       record: recordHistory,
-      async clear({ characterKey }: { characterKey: string }) {
-        histories.delete(characterKey);
-        return [];
-      },
     },
   } as unknown as GwNativeApi;
   const command: TravelCommand = { travel: vi.fn(), unavailable: () => null };
-  return { host: createNativeTravelHost(api, command), setTravel, recordHistory };
+  return {
+    host: createNativeTravelHost(api, command),
+    setTravel,
+    recordHistory,
+    getHistory,
+    failNextHistoryWrite(error = new Error("history unavailable")) {
+      nextHistoryFailure = error;
+    },
+  };
 }
 
 afterEach(() => vi.useRealTimers());
@@ -75,7 +86,9 @@ describe("native Travel host", () => {
 
     await host.travel({ mapId: 449 });
     host.updateGameState({ status: "waiting", reason: "loading" });
-    host.updateGameState({ status: "ready", mapId: 449 });
+    host.updateGameState({
+      status: "ready", mapId: 449, characterKey: null, unlockedMapWords: null,
+    });
     await vi.runAllTimersAsync();
 
     expect(host.attempt.value).toEqual({ status: "idle" });
@@ -98,16 +111,18 @@ describe("native Travel host", () => {
   });
 
   it("records observed destinations independently for each character", async () => {
-    const { host, recordHistory } = fixture();
+    const { host, recordHistory, getHistory } = fixture();
     const unlockedMapWords = Array.from({ length: 28 }, () => 0xffff_ffff);
+    const characterA = travelCharacterKey("0123456789abcdef");
+    const characterB = travelCharacterKey("fedcba9876543210");
     host.updateGameState({
-      status: "ready", mapId: 55, characterKey: "0123456789abcdef", unlockedMapWords,
+      status: "ready", mapId: 55, characterKey: characterA, unlockedMapWords,
     });
     host.updateGameState({
-      status: "ready", mapId: 449, characterKey: "0123456789abcdef", unlockedMapWords,
+      status: "ready", mapId: 449, characterKey: characterA, unlockedMapWords,
     });
     host.updateGameState({
-      status: "ready", mapId: 81, characterKey: "fedcba9876543210", unlockedMapWords,
+      status: "ready", mapId: 81, characterKey: characterB, unlockedMapWords,
     });
 
     await vi.waitFor(() => expect(recordHistory).toHaveBeenCalledTimes(3));
@@ -117,5 +132,49 @@ describe("native Travel host", () => {
       { characterKey: "fedcba9876543210", mapId: 81 },
     ]);
     expect(host.history.value).toEqual([81]);
+    expect(getHistory).not.toHaveBeenCalled();
+  });
+
+  it("switches histories when characters share the same map and hides unidentified history", async () => {
+    const { host, recordHistory } = fixture();
+    const characterA = travelCharacterKey("0123456789abcdef");
+    const characterB = travelCharacterKey("fedcba9876543210");
+    const unlockedMapWords = Array.from({ length: 28 }, () => 0xffff_ffff);
+    host.updateGameState({
+      status: "ready", mapId: 55, characterKey: characterA, unlockedMapWords,
+    });
+    await vi.waitFor(() => expect(host.history.value).toEqual([55]));
+
+    host.updateGameState({ status: "waiting", reason: "loading" });
+    expect(host.history.value).toEqual([]);
+    host.updateGameState({
+      status: "ready", mapId: 55, characterKey: null, unlockedMapWords,
+    });
+    expect(host.history.value).toEqual([]);
+    host.updateGameState({
+      status: "ready", mapId: 55, characterKey: characterB, unlockedMapWords,
+    });
+
+    await vi.waitFor(() => expect(host.history.value).toEqual([55]));
+    expect(recordHistory.mock.calls.map(([value]) => value.characterKey)).toEqual([
+      characterA,
+      characterB,
+    ]);
+  });
+
+  it("contains background history failures and retries when history is requested", async () => {
+    const test = fixture();
+    const characterKey = travelCharacterKey("0123456789abcdef");
+    test.failNextHistoryWrite();
+    test.host.updateGameState({
+      status: "ready",
+      mapId: 55,
+      characterKey,
+      unlockedMapWords: Array.from({ length: 28 }, () => 0xffff_ffff),
+    });
+    await vi.waitFor(() => expect(test.recordHistory).toHaveBeenCalledTimes(1));
+
+    await expect(test.host.loadHistory()).resolves.toEqual([55]);
+    expect(test.recordHistory).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/tools/src/travel-host.ts
+++ b/apps/tools/src/travel-host.ts
@@ -18,11 +18,11 @@ import {
   type TravelUserPreferencesPatch,
 } from "../../../src/shared/travel";
 import {
-  EMPTY_TRAVEL_HISTORY,
   recordVisitedTravel,
-  type TravelCharacterKey,
+  travelCharacterKey,
   type TravelHistory,
 } from "../../../src/shared/travel-history";
+import { createTravelHistoryObservation } from "./travel-history-observation";
 
 export type TravelAttempt =
   | Readonly<{ status: "idle" }>
@@ -58,7 +58,11 @@ export function createNativeTravelHost(
   const state = ref<TravelGameState>({ status: "waiting", reason: "game" });
   const attempt = ref<TravelAttempt>({ status: "idle" });
   const notice = ref<TravelNotice | null>(null);
-  const history = ref<TravelHistory>(EMPTY_TRAVEL_HISTORY);
+  const historyObservation = createTravelHistoryObservation(
+    api.travelHistory,
+    state,
+    development,
+  );
   let attemptTimer = 0;
   const clearAttempt = () => {
     window.clearTimeout(attemptTimer);
@@ -72,55 +76,11 @@ export function createNativeTravelHost(
   };
   const loadPreferences = async (): Promise<TravelPreferences> =>
     remember(await api.travelPreferences.get());
-  let historyTail: Promise<void> = Promise.resolve();
-  let activeCharacter: TravelCharacterKey | null = null;
-  let lastObservedMapId: number | null = null;
-  let disposed = false;
-  const enqueueHistory = (
-    characterKey: TravelCharacterKey,
-    operation: () => Promise<TravelHistory>,
-  ): Promise<TravelHistory> => {
-    const result = historyTail.then(operation);
-    historyTail = result.then(() => undefined, () => undefined);
-    return result.then((next) => {
-      if (!disposed && activeCharacter === characterKey) history.value = next;
-      return next;
-    });
-  };
-  const loadHistory = (): Promise<TravelHistory> => {
-    const characterKey = activeCharacter;
-    return characterKey === null
-      ? Promise.resolve(EMPTY_TRAVEL_HISTORY)
-      : enqueueHistory(characterKey, () => api.travelHistory.get({ characterKey }));
-  };
-  const observeMap = (next: TravelGameState): void => {
-    if (next.status !== "ready" || typeof next.characterKey !== "string") return;
-    const key = next.characterKey as TravelCharacterKey;
-    const characterChanged = key !== activeCharacter;
-    if (characterChanged) {
-      activeCharacter = key;
-      lastObservedMapId = null;
-      history.value = EMPTY_TRAVEL_HISTORY;
-      void enqueueHistory(key, () => api.travelHistory.get({ characterKey: key }));
-    }
-    if (next.mapId === lastObservedMapId) return;
-    lastObservedMapId = next.mapId;
-    if (travelDestination(next.mapId) === null) return;
-    void enqueueHistory(key, () => api.travelHistory.record({
-      characterKey: key,
-      mapId: next.mapId,
-    })).catch((error) => {
-      if (development) console.debug(`[tools:dev] travel.history.refused ${JSON.stringify({
-        mapId: next.mapId,
-        reason: error instanceof Error ? error.message : "unknown history error",
-      })}`);
-    });
-  };
   return {
     state,
     attempt,
     notice,
-    history,
+    history: historyObservation.history,
     get unavailable() {
       return command.unavailable();
     },
@@ -129,7 +89,7 @@ export function createNativeTravelHost(
       const expected = currentPreferences ?? await loadPreferences();
       return remember(await api.travelPreferences.set({ expected, patch }));
     },
-    loadHistory,
+    loadHistory: historyObservation.load,
     async travel(request) {
       if (attempt.value.status !== "idle") return;
       attempt.value = { status: "queued", mapId: request.mapId };
@@ -167,7 +127,7 @@ export function createNativeTravelHost(
     },
     updateGameState(next) {
       state.value = next;
-      observeMap(next);
+      historyObservation.update(next);
       const current = attempt.value;
       if (current.status === "idle") return;
       if (next.status === "waiting" && next.reason === "loading") {
@@ -197,7 +157,7 @@ export function createNativeTravelHost(
       if (next.mapId !== current.mapId) return;
     },
     dispose() {
-      disposed = true;
+      historyObservation.dispose();
       clearAttempt();
     },
     traceSearch(query, resultMapIds) {
@@ -217,8 +177,9 @@ export function createNativeTravelHost(
 /** Standalone fixture host for visual and interaction development. */
 export function createDemoTravelHost(): TravelHost {
   const unlockedMapWords = Object.freeze(Array.from({ length: 28 }, () => 0xffff_ffff));
+  const characterKey = travelCharacterKey("0123456789abcdef");
   const state = ref<TravelGameState>({
-    status: "ready", mapId: 55, characterKey: "0123456789abcdef", unlockedMapWords,
+    status: "ready", mapId: 55, characterKey, unlockedMapWords,
   });
   const attempt = ref<TravelAttempt>({ status: "idle" });
   const notice = ref<TravelNotice | null>(null);
@@ -255,7 +216,7 @@ export function createDemoTravelHost(): TravelHost {
         history.value = recordVisitedTravel(history.value, request.mapId);
         state.value = {
           status: "ready", mapId: request.mapId,
-          characterKey: "0123456789abcdef", unlockedMapWords,
+          characterKey, unlockedMapWords,
         };
         attempt.value = { status: "idle" };
       }, 600);

--- a/scripts/companion-kernel-contract.mjs
+++ b/scripts/companion-kernel-contract.mjs
@@ -38,7 +38,7 @@ export const COMPANION_KERNEL_EXPORT_VALUES = Object.freeze({
 });
 
 export const COMPANION_KERNEL_DYLINK0 = Object.freeze([
-  // Memory footprint 2209 bytes (0xa1 0x11 as LEB128). Documented moves:
+  // Memory footprint 2212 bytes (0xa4 0x11 as LEB128). Documented moves:
   //   309 ->  310  the Toolbox observer gained PARTY_OBSERVED, the byte that
   //                separates "you have no heroes" from "nobody read the party";
   //   310 ->  410  Layout grew by the 25 party-detail address words, at 4 bytes
@@ -84,10 +84,12 @@ export const COMPANION_KERNEL_DYLINK0 = Object.freeze([
   //   2201 -> 2209 Travel adds one character-key layout word and bounded
   //                play-region publication state; its larger record remains
   //                in host-owned memory outside this footprint.
+  //   2209 -> 2212 the Travel unlock observer moves beside its play-region
+  //                publisher, keeping feature-specific memory reads together.
   // This constant exists so a kernel whose footprint moves cannot ship without
   // someone saying why. One page is still the ceiling, and this remains far
   // under it.
-  0x01, 0x05, 0xa1, 0x11, 0x02, 0x00, 0x00,
+  0x01, 0x05, 0xa4, 0x11, 0x02, 0x00, 0x00,
 ]);
 
 const WASM_PAGE_BYTES = 65_536;

--- a/src/companion-kernel/lib.rs
+++ b/src/companion-kernel/lib.rs
@@ -178,37 +178,6 @@ impl State {
     }
 }
 
-/** Reads the certified WorldContext Array<u32>; `None` publishes unknown. */
-pub(crate) unsafe fn observe_travel_unlocks(
-    layout: Layout,
-    game: u32,
-) -> Option<[u32; TRAVEL_UNLOCK_WORDS]> {
-    if game == 0 || layout.world_context == 0 || layout.world_unlocked_maps == 0 {
-        return None;
-    }
-    let world_required = checked_add(layout.world_unlocked_maps, 12)?;
-    let world =
-        offset(game, layout.world_context).and_then(|at| unsafe { pointer(at, world_required) })?;
-    let array = offset(world, layout.world_unlocked_maps)?;
-    let buffer = unsafe { read_u32(array) }?;
-    let capacity = offset(array, 4).and_then(|at| unsafe { read_u32(at) })?;
-    let size = offset(array, 8).and_then(|at| unsafe { read_u32(at) })?;
-    if buffer == 0
-        || buffer & 3 != 0
-        || size < TRAVEL_UNLOCK_WORDS as u32
-        || size > capacity
-        || capacity > 64
-        || !contains(buffer, checked_mul(size, 4)?)
-    {
-        return None;
-    }
-    let mut words = [0; TRAVEL_UNLOCK_WORDS];
-    for (index, word) in words.iter_mut().enumerate() {
-        *word = unsafe { read_u32(indexed(buffer, index as u32, 4)?)? };
-    }
-    Some(words)
-}
-
 /**
  * The Tools safety region derived from the client-owned map policy.
  *

--- a/src/companion-kernel/play_region.rs
+++ b/src/companion-kernel/play_region.rs
@@ -7,8 +7,8 @@
 use core::ptr::write_volatile;
 
 use crate::abi::*;
-use crate::memory::{checked_add, contains, offset, pointer, read_u32};
-use crate::{observe_travel_unlocks, resolve_game, GameState};
+use crate::memory::{checked_add, checked_mul, contains, indexed, offset, pointer, read_u32};
+use crate::{resolve_game, GameState};
 
 static mut POINTER: u32 = 0;
 static mut SEQUENCE: u32 = 0;
@@ -55,13 +55,41 @@ pub(crate) unsafe fn initialize(pointer: u32) {
     unsafe { publish(0, 0, 0, 0, 0, [0; TRAVEL_UNLOCK_WORDS]) };
 }
 
+/** Reads the certified WorldContext Array<u32>; `None` publishes unknown. */
+unsafe fn observe_travel_unlocks(layout: Layout, game: u32) -> Option<[u32; TRAVEL_UNLOCK_WORDS]> {
+    if game == 0 || layout.world_context == 0 || layout.world_unlocked_maps == 0 {
+        return None;
+    }
+    let world_required = checked_add(layout.world_unlocked_maps, 12)?;
+    let world =
+        offset(game, layout.world_context).and_then(|at| unsafe { pointer(at, world_required) })?;
+    let array = offset(world, layout.world_unlocked_maps)?;
+    let buffer = unsafe { read_u32(array) }?;
+    let capacity = offset(array, 4).and_then(|at| unsafe { read_u32(at) })?;
+    let size = offset(array, 8).and_then(|at| unsafe { read_u32(at) })?;
+    if buffer == 0
+        || buffer & 3 != 0
+        || size < TRAVEL_UNLOCK_WORDS as u32
+        || size > capacity
+        || capacity > 64
+        || !contains(buffer, checked_mul(size, 4)?)
+    {
+        return None;
+    }
+    let mut words = [0; TRAVEL_UNLOCK_WORDS];
+    for (index, word) in words.iter_mut().enumerate() {
+        *word = unsafe { read_u32(indexed(buffer, index as u32, 4)?)? };
+    }
+    Some(words)
+}
+
 unsafe fn character_key(layout: Layout, game: u32) -> Option<u64> {
     if layout.character_uuid == 0 {
         return None;
     }
     let required = checked_add(layout.character_uuid, 16)?;
-    let character = offset(game, layout.character_context)
-        .and_then(|at| unsafe { pointer(at, required) })?;
+    let character =
+        offset(game, layout.character_context).and_then(|at| unsafe { pointer(at, required) })?;
     let uuid = offset(character, layout.character_uuid)?;
     if !contains(uuid, 16) {
         return None;

--- a/src/renderer/companion-play-region-snapshot.ts
+++ b/src/renderer/companion-play-region-snapshot.ts
@@ -91,13 +91,4 @@ export function readCompanionPlayRegion(buffer: ArrayBuffer, pointer: number) {
 
 export type CompanionPlayRegionState =
   | ReturnType<typeof readCompanionPlayRegion>
-  | Readonly<{
-    status: "ready";
-    sequence: number;
-    mapId: number;
-    instanceType: number;
-    playRegion: "pve" | "pvp";
-    characterKey?: string | null;
-    unlockedMapWords?: readonly number[] | null;
-  }>
   | Readonly<{ status: "waiting"; reason: "stale" }>;

--- a/src/renderer/companion-policy-source.ts
+++ b/src/renderer/companion-policy-source.ts
@@ -28,9 +28,15 @@ type PolicyUpdate<Settings extends OptionalToolSettings> = Readonly<{
 }>;
 
 function projectPlayRegion(state: CompanionPlayRegionState): string {
-  return state.status === "ready"
-    ? `ready:${state.playRegion}:${state.mapId}:${state.instanceType}`
-    : `waiting:${state.reason}`;
+  if (state.status !== "ready") return `waiting:${state.reason}`;
+  return [
+    "ready",
+    state.playRegion,
+    state.mapId,
+    state.instanceType,
+    state.characterKey ?? "unknown-character",
+    state.unlockedMapWords?.join(",") ?? "unknown-unlocks",
+  ].join(":");
 }
 
 export function createCompanionPolicySource<Settings extends OptionalToolSettings>(

--- a/src/shared/travel-command.ts
+++ b/src/shared/travel-command.ts
@@ -3,6 +3,10 @@
  * destination request and exposes availability; no generic UI message crosses.
  */
 import type { TravelRequest } from "./travel.js";
+import {
+  isTravelCharacterKey,
+  type TravelCharacterKey,
+} from "./travel-history.js";
 
 export const TRAVEL_WAITING_REASONS = [
   "game", "loading", "memory", "writing", "snapshot", "corrupt", "cursor", "stale",
@@ -13,8 +17,8 @@ export type TravelGameState =
   | Readonly<{
     status: "ready";
     mapId: number;
-    characterKey?: string | null;
-    unlockedMapWords?: readonly number[] | null;
+    characterKey: TravelCharacterKey | null;
+    unlockedMapWords: readonly number[] | null;
   }>;
 
 export const TRAVEL_UNLOCK_WORDS = 28;
@@ -39,10 +43,7 @@ export function travelGameState(value: unknown): TravelGameState {
       return Object.freeze({
         status: "ready",
         mapId: Number(input.mapId),
-        characterKey: typeof input.characterKey === "string"
-          && /^[0-9a-f]{16}$/u.test(input.characterKey)
-          ? input.characterKey
-          : null,
+        characterKey: isTravelCharacterKey(input.characterKey) ? input.characterKey : null,
         unlockedMapWords,
       });
     }

--- a/src/shared/travel-history.ts
+++ b/src/shared/travel-history.ts
@@ -26,8 +26,12 @@ export const DEFAULT_TRAVEL_HISTORY: TravelHistoryDocument = Object.freeze({
   characters: Object.freeze({}) as Readonly<Record<TravelCharacterKey, TravelHistory>>,
 });
 
+export function isTravelCharacterKey(value: unknown): value is TravelCharacterKey {
+  return typeof value === "string" && CHARACTER_KEY_PATTERN.test(value);
+}
+
 export function travelCharacterKey(value: unknown): TravelCharacterKey {
-  if (typeof value !== "string" || !CHARACTER_KEY_PATTERN.test(value)) {
+  if (!isTravelCharacterKey(value)) {
     throw new TypeError("Travel character key is invalid");
   }
   return value as TravelCharacterKey;

--- a/tests/electron/input-travel.spec.ts
+++ b/tests/electron/input-travel.spec.ts
@@ -38,6 +38,7 @@ test.describe("renderer Travel input", () => {
           state: {
             status: "ready",
             mapId: 133,
+            characterKey: null,
             unlockedMapWords: Array.from({ length: 28 }, () => 0xffff_ffff),
           },
         });

--- a/tests/unit/companion-policy-source.test.ts
+++ b/tests/unit/companion-policy-source.test.ts
@@ -94,6 +94,8 @@ describe("companion policy source", () => {
       mapId: 42,
       instanceType: 0,
       playRegion: "pve" as const,
+      characterKey: null,
+      unlockedMapWords: null,
     });
     test.publishRegion(pve);
     test.publishRegion({ ...pve, sequence: 4 });
@@ -104,6 +106,44 @@ describe("companion policy source", () => {
       { reason: "region", region: "pve" },
       { reason: "region", region: "unknown" },
     ]);
+  });
+
+  it("publishes same-map character and unlock changes", () => {
+    const test = fixture();
+    const keys: Array<string | null> = [];
+    const unlocks: Array<number | null> = [];
+    test.source.subscribe(({ snapshot }) => {
+      if (snapshot.playRegionState.status !== "ready") return;
+      keys.push(snapshot.playRegionState.characterKey);
+      unlocks.push(snapshot.playRegionState.unlockedMapWords?.[1] ?? null);
+    });
+    const ready = {
+      status: "ready" as const,
+      mapId: 55,
+      instanceType: 0,
+      playRegion: "pve" as const,
+    };
+    test.publishRegion(Object.freeze({
+      ...ready,
+      sequence: 2,
+      characterKey: "0123456789abcdef",
+      unlockedMapWords: Object.freeze([0, 1]),
+    }));
+    test.publishRegion(Object.freeze({
+      ...ready,
+      sequence: 4,
+      characterKey: "fedcba9876543210",
+      unlockedMapWords: Object.freeze([0, 1]),
+    }));
+    test.publishRegion(Object.freeze({
+      ...ready,
+      sequence: 6,
+      characterKey: "fedcba9876543210",
+      unlockedMapWords: Object.freeze([0, 3]),
+    }));
+
+    assert.deepEqual(keys, ["0123456789abcdef", "fedcba9876543210", "fedcba9876543210"]);
+    assert.deepEqual(unlocks, [1, 1, 3]);
   });
 
   it("withdraws local Tools only for positively identified active PvP play", () => {
@@ -119,6 +159,8 @@ describe("companion policy source", () => {
       mapId: 188,
       instanceType: 0,
       playRegion: "pvp",
+      characterKey: null,
+      unlockedMapWords: null,
     }));
     test.publishRegion(Object.freeze({ status: "waiting", reason: "loading" }));
 
@@ -139,6 +181,8 @@ describe("companion policy source", () => {
       mapId: 42,
       instanceType: 0,
       playRegion: "pve",
+      characterKey: null,
+      unlockedMapWords: null,
     }));
 
     assert.equal(publications, 1);

--- a/tests/unit/play-region-observation-installation.test.ts
+++ b/tests/unit/play-region-observation-installation.test.ts
@@ -8,6 +8,8 @@ const ready = (sequence: number, mapId = 81) => Object.freeze({
   mapId,
   instanceType: 0,
   playRegion: "pve" as const,
+  characterKey: null,
+  unlockedMapWords: null,
 });
 
 test("play-region authority withdraws on staleness and requires a newer publication to recover", (context) => {


### PR DESCRIPTION
Quick Travel could keep showing the previous character's recent destinations while the game was loading, unidentified, or switching characters on the same map. The canonical play-region publisher also treated character and unlock-only changes as duplicates, so the Tools UI never received them.

This fix publishes every semantic play-region change and moves durable history synchronization behind one focused observer. History is now displayed only when it belongs to the currently certified character, map observations perform one serialized history operation, failures are contained and retryable, and the ready-state contract no longer admits incomplete test-only shapes. The Travel unlock memory observer also lives beside the play-region publisher that owns it.

## Verification

- `pnpm run check` (1,323 unit, 181 policy, and 116 Tools tests)
- `pnpm run build`
- `pnpm test:integration` (67 tests)
- `pnpm test:release` (25 tests)
- Focused Travel and companion-kernel regression suites (68 tests)
- `git diff --check`

Implemented with Codex after a full nuclear code-quality review.
