### PR TITLE
feat(travel): keep six recents above the fold

### DIFF
--- a/apps/tools/src/components/TravelPalette.test.ts
+++ b/apps/tools/src/components/TravelPalette.test.ts
@@ -146,12 +146,15 @@ describe("TravelPalette", () => {
     wrapper.unmount();
   });
 
-  it("shows per-character recents without repeating the current map", async () => {
-    const { wrapper } = fixture({ history: [55, 449, 81] });
+  it("shows at most six per-character recents without repeating the current map", async () => {
+    const { wrapper } = fixture({ history: [55, 449, 81, 194, 642, 857, 248, 15] });
     await flushPromises();
+    expect(wrapper.findAll(".travel-recent")).toHaveLength(6);
     expect(wrapper.get(".travel-history").text()).toContain("Kamadan");
     expect(wrapper.get(".travel-history").text()).toContain("Ascalon City");
     expect(wrapper.get(".travel-history").text()).not.toContain("Lion's Arch");
+    expect(wrapper.get(".travel-history").text()).toContain("Great Temple of Balthazar");
+    expect(wrapper.get(".travel-history").text()).not.toContain("D'Alessio Seaboard");
     wrapper.unmount();
   });
 

--- a/apps/tools/src/components/TravelPalette.vue
+++ b/apps/tools/src/components/TravelPalette.vue
@@ -379,7 +379,7 @@ onBeforeUnmount(() => window.clearTimeout(closeTimer));
 
     <section v-else-if="mode === 'travel'" id="travel-panel" class="ui-scroll travel-body" role="region" aria-label="Travel">
       <section v-if="recentDestinations.length" class="travel-section travel-history" aria-labelledby="travel-history-title">
-        <header class="travel-section-head"><h2 id="travel-history-title">Recent</h2><span>Observed in Guild Wars</span></header>
+        <header class="travel-section-head"><h2 id="travel-history-title">Recent</h2></header>
         <div class="travel-recent-grid">
           <button v-for="destination in recentDestinations" :key="destination.mapId" type="button" class="travel-recent ui-row" :disabled="travelPending || host.unavailable !== null" :aria-label="`Travel to recent destination ${destination.name}`" @click="travel({ mapId: destination.mapId })"><span><strong>{{ destination.name }}</strong><small>{{ destination.campaign }}</small></span><svg viewBox="0 0 20 20" aria-hidden="true"><path d="m7 4 6 6-6 6" /></svg></button>
         </div>

--- a/apps/tools/src/styles.css
+++ b/apps/tools/src/styles.css
@@ -174,14 +174,18 @@
   gap: 3px;
 }
 
-.travel-recent-grid { display: grid; gap: 3px; }
+.travel-recent-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 3px var(--ui-space-2);
+}
 .travel-recent {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: center;
   gap: var(--ui-space-3);
-  min-height: 46px;
-  padding: var(--ui-space-2) var(--ui-space-3);
+  min-height: 42px;
+  padding: var(--ui-space-1) var(--ui-space-2);
   border: 1px solid transparent;
   border-radius: var(--ui-radius-sm);
   background: transparent;
@@ -191,10 +195,17 @@
   cursor: pointer;
 }
 .travel-recent:hover:not(:disabled) { background: var(--ui-hover); }
+.travel-recent > span { min-width: 0; }
 .travel-recent strong,
 .travel-recent small { display: block; }
-.travel-recent small { color: var(--ui-text-faint); }
+.travel-recent strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.travel-recent small { color: var(--ui-text-faint); font-size: var(--ui-font-size-sm); line-height: 1.2; }
 .travel-recent svg { width: 16px; height: 16px; fill: none; stroke: currentColor; stroke-width: 1.5; }
+
+.travel-history + .travel-favorites {
+  margin-top: var(--ui-space-3);
+  padding-top: var(--ui-space-3);
+}
 
 .travel-result strong,
 .travel-result small {
@@ -443,6 +454,7 @@
   .travel-search { min-height: 54px; padding-inline: var(--ui-space-3); }
   .travel-notice { margin-inline: var(--ui-space-3); }
   .travel-body { padding: var(--ui-space-3); }
+  .travel-recent-grid { grid-template-columns: 1fr; }
   .travel-favorite-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
   .travel-customize-shortcuts { grid-template-columns: repeat(5, minmax(0, 1fr)); }
   .travel-phrase-row,

--- a/apps/tools/src/travel-host.ts
+++ b/apps/tools/src/travel-host.ts
@@ -183,7 +183,7 @@ export function createDemoTravelHost(): TravelHost {
   });
   const attempt = ref<TravelAttempt>({ status: "idle" });
   const notice = ref<TravelNotice | null>(null);
-  const history = ref<TravelHistory>(Object.freeze([55, 449, 194, 642, 857]));
+  const history = ref<TravelHistory>(Object.freeze([449, 194, 642, 857, 81, 248]));
   let current: TravelPreferences = Object.freeze({
     shortcuts: DEFAULT_TRAVEL_SHORTCUTS,
     synonyms: Object.freeze([]),

--- a/src/shared/travel-history.ts
+++ b/src/shared/travel-history.ts
@@ -6,7 +6,7 @@ import { travelDestination } from "./travel-destinations.js";
 
 export const TRAVEL_HISTORY_FORMAT = 2;
 export const TRAVEL_HISTORY_LIMIT = 10;
-export const TRAVEL_HISTORY_VISIBLE_LIMIT = 5;
+export const TRAVEL_HISTORY_VISIBLE_LIMIT = 6;
 export const TRAVEL_HISTORY_CHARACTER_LIMIT = 32;
 
 declare const TRAVEL_CHARACTER_KEY: unique symbol;


### PR DESCRIPTION
Quick Travel showed recent destinations as a tall single-column list, which pushed Favorites below the visible area and forced players to scroll for routine travel.

This change presents the six newest eligible destinations as three compact two-column rows. Each destination keeps a full desktop hit target and campaign context, narrow windows fall back to one column, and the redundant “Observed in Guild Wars” label is removed. The durable per-character history still retains up to ten entries; only the visible palette limit changes.

## Verification

- `pnpm run check` (1,323 unit, 181 policy, and 116 Tools tests)
- `pnpm --filter @gwonmac/tools-ui build`
- Production Travel fixture: six recents, `308px` client/scroll height, no scrollbar
- `git diff --check`

Implemented and visually verified with Codex.
