### PR TITLE
fix(travel): recognize shorter unlock sets

### DIFF
--- a/src/companion-kernel/play_region.rs
+++ b/src/companion-kernel/play_region.rs
@@ -69,7 +69,6 @@ unsafe fn observe_travel_unlocks(layout: Layout, game: u32) -> Option<[u32; TRAV
     let size = offset(array, 8).and_then(|at| unsafe { read_u32(at) })?;
     if buffer == 0
         || buffer & 3 != 0
-        || size < TRAVEL_UNLOCK_WORDS as u32
         || size > capacity
         || capacity > 64
         || !contains(buffer, checked_mul(size, 4)?)
@@ -77,7 +76,12 @@ unsafe fn observe_travel_unlocks(layout: Layout, game: u32) -> Option<[u32; TRAV
         return None;
     }
     let mut words = [0; TRAVEL_UNLOCK_WORDS];
-    for (index, word) in words.iter_mut().enumerate() {
+    // Native arrays may be shorter on new accounts. Missing words mean locked.
+    for (index, word) in words
+        .iter_mut()
+        .take(core::cmp::min(size as usize, TRAVEL_UNLOCK_WORDS))
+        .enumerate()
+    {
         *word = unsafe { read_u32(indexed(buffer, index as u32, 4)?)? };
     }
     Some(words)

--- a/tests/integration/enhancements-kernel.test.ts
+++ b/tests/integration/enhancements-kernel.test.ts
@@ -233,6 +233,42 @@ describe("Companion kernel", () => {
     );
   });
 
+  it("treats missing words in a shorter Travel unlock set as locked", async () => {
+    const kernel = await createKernel({ partyDetail: true });
+    installGameGraph(kernel.view);
+    kernel.view.setUint32(ADDRESSES.world + 0x614, 5, true);
+    kernel.view.setUint32(
+      ADDRESSES.travelUnlockBuffer + 5 * 4,
+      0xffff_ffff,
+      true,
+    );
+    assert.equal(kernel.init({ features: FEATURE_PLAY_REGION_OBSERVATION }), 1);
+    kernel.tick();
+
+    const state = kernel.playRegion();
+    assert.equal(state.status, "ready");
+    if (state.status !== "ready") return;
+    assert.equal(state.unlockedMapWords?.length, 28);
+    assert.equal(
+      (state.unlockedMapWords?.[Math.floor(133 / 32)] ?? 0) >>> (133 % 32) & 1,
+      1,
+    );
+    assert.deepEqual(state.unlockedMapWords?.slice(5), Array(23).fill(0));
+  });
+
+  it("rejects a Travel unlock set whose size exceeds its capacity", async () => {
+    const kernel = await createKernel({ partyDetail: true });
+    installGameGraph(kernel.view);
+    kernel.view.setUint32(ADDRESSES.world + 0x614, 29, true);
+    assert.equal(kernel.init({ features: FEATURE_PLAY_REGION_OBSERVATION }), 1);
+    kernel.tick();
+
+    const state = kernel.playRegion();
+    assert.equal(state.status, "ready");
+    if (state.status !== "ready") return;
+    assert.equal(state.unlockedMapWords, null);
+  });
+
   it("requires UI message configuration only for the Toolbox capability", async () => {
     const cursorOnly = await createKernel();
     cursorOnly.config.fill(0, MESSAGE_CONFIG_START);


### PR DESCRIPTION
## What changed\n\nFresh characters could expose every Travel destination because Guild Wars may publish an unlock bitset shorter than GWonMac's fixed 28-word snapshot. This accepts valid shorter native arrays and fills absent words with zero, so maps outside the published range remain locked.\n\n## Why\n\nThe previous observer treated a short array as unknown. The palette intentionally stays usable when unlock state is unknown, which made every outpost visible on a fresh Nightfall character.\n\n## Invariant\n\nA valid native array may be shorter than the snapshot. Missing words mean locked. Malformed arrays, including size greater than capacity, still fail closed as unknown.\n\n## Verification\n\n- [x] Scope: all 3 workspace projects
✓ Lockfile passes supply-chain policies (verified 20h ago)
Lockfile is up to date, resolution step is skipped
Progress: resolved 1, reused 0, downloaded 0, added 0
Packages: +1374
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Progress: resolved 1374, reused 1355, downloaded 0, added 46
Progress: resolved 1374, reused 1355, downloaded 0, added 204
Progress: resolved 1374, reused 1355, downloaded 0, added 372
Progress: resolved 1374, reused 1355, downloaded 0, added 406
Progress: resolved 1374, reused 1355, downloaded 0, added 535
Progress: resolved 1374, reused 1355, downloaded 0, added 618
Progress: resolved 1374, reused 1355, downloaded 0, added 737
Progress: resolved 1374, reused 1355, downloaded 0, added 863
Progress: resolved 1374, reused 1355, downloaded 0, added 932
Progress: resolved 1374, reused 1355, downloaded 0, added 980
Progress: resolved 1374, reused 1355, downloaded 0, added 1044
Progress: resolved 1374, reused 1355, downloaded 0, added 1175
Progress: resolved 1374, reused 1355, downloaded 0, added 1278
Progress: resolved 1374, reused 1355, downloaded 0, added 1373, done
.../node_modules/vue-demi postinstall$ node -e "try{require('./scripts/postinstall.js')}catch(e){}"
.../node_modules/vue-demi postinstall: Done

. postinstall$ install-electron
apps/website prepare$ vp exec nuxt prepare
. postinstall: Done
apps/website prepare: ℹ Nuxt Icon server bundle mode is set to local
apps/website prepare: [nuxt:icon] ✔ Nuxt Icon loaded local collection lucide with 1817 icons
apps/website prepare: [nuxt:icon] ✔ Nuxt Icon loaded local collection circle-flags with 2 icons
apps/website prepare: [nuxt:icon] ✔ Nuxt Icon loaded local collection logos with 7 icons
apps/website prepare: ℹ Nuxt Icon client bundle consist of 96 icons with 38.17KB(uncompressed) in size
apps/website prepare: │
apps/website prepare: ◆  Types generated in .nuxt.
apps/website prepare: Done
Done in 19.3s using pnpm v11.13.1
✔ two builds with the same content are zero apart, however they were written (10.593292ms)
✔ a single skill change is reported as a named swap, not as a slot number (0.2865ms)
✔ the summary's verb agrees with what differs, at none, one and two (0.163542ms)
✔ a build that only re-spends its attributes still reports a difference (0.114625ms)
✔ a profession change is one difference and carries both pairs (0.084958ms)
✔ nearestBuild answers with the closest build inside its ceiling, or with nothing (0.186792ms)
✔ nearestBuild never matches a build against itself, nor across primary professions (0.093625ms)
✔ droppedByTeam names the working heroes a team has no place for, once each (6.651541ms)
✔ a stored record short of eight slots is compared rather than thrown over (0.231125ms)
✔ a bar is eight slots, and a ninth cannot be written (15.223792ms)
✔ the slot list every module iterates is as long as the bar it walks (0.9735ms)
✔ a team slot references a build and cannot carry one (29.069375ms)
✔ an attribute rank outside what a character can invest is unspellable (0.128042ms)
✔ variantsOf returns direct children, and nothing else (0.14975ms)
✔ parentOf resolves a link, and answers null when there is nothing to resolve (4.224292ms)
✔ usedBy names teams once each, and says nothing about builds nobody uses (0.169125ms)
✔ forking a variant keeps the root, so lineage never grows a second level (0.114167ms)
✔ a clean verdict has nothing to explain, and a broken one cannot be silent (33.46475ms)
✔ a legal build reports clean, spending exactly the level-20 budget (1.151542ms)
✔ PvE availability is intrinsic while player-only eligibility belongs to assignment (0.240958ms)
✔ a secondary profession may not repeat the primary (0.12275ms)
✔ a bar may hold one elite, and the second is reported against the first (0.109458ms)
✔ the same skill cannot occupy two slots (0.112333ms)
✔ a stored record short of eight slots is validated, not accused of duplicates (0.106375ms)
✔ the last two bar positions are checked like the first six (0.102875ms)
✔ a duplicated elite reports both rules, because fixing one need not fix the other (0.08775ms)
✔ a skill must belong to one of the build's two professions, or to none (0.163833ms)
✔ a skill the catalogue cannot resolve is reported, never assumed clean (0.137208ms)
✔ an attribute must belong to one of the build's two professions (0.0895ms)
✔ a rank of 0 on an attribute the build cannot have is not a problem (0.063959ms)
✔ a primary attribute needs the profession as the primary, not the secondary (0.407459ms)
✔ a rank above the cap is rejected rather than clamped (29.750458ms)
✔ the ranks together may not cost more than a level-20 character has (0.121334ms)
✔ the whole problem list is ordered: professions, bar slots, attributes, budget (0.09525ms)
✔ a slot pointing at a build that is gone empties, and nothing else changes (1.583625ms)
✔ a slot pointing at a build that exists is left alone (9.821167ms)
✔ two builds sharing an id refuse the file rather than lose one quietly (34.728541ms)
✔ a bar that is not eight slots long is not a build to store (34.200708ms)
✔ a value the model has no name for is refused, not coerced (0.298875ms)
✔ a version this build cannot read is refused rather than reinterpreted (0.12725ms)
✔ a missing file is a new profile, and says nothing happened (31.559208ms)
✔ an unreadable library is moved aside, never overwritten (10.246666ms)
✔ a readable file that the model refuses is recovered the same way (3.411125ms)
✔ what a save returns is what the next load will hand back (69.770125ms)
✔ a save applies the same repair a load would, so the two cannot disagree (69.676ms)
✔ the library is owner-only on disk (23.513375ms)
✔ a team code preserves every team field, shared slot, build and parent (8.716792ms)
✔ import remints identities and remaps repeated slots and lineage atomically (0.56125ms)
✔ future, malformed, dangling, duplicate and oversized codes are refused (2.353375ms)
✔ every worked example decodes to what the specification says it holds (3.300625ms)
✔ every worked example re-encodes to the byte-identical code (0.954ms)
✔ a template file is the bare code, with nothing wrapped around it (0.230125ms)
✔ a real code decodes to what its publisher says it holds (0.168792ms)
✔ a real code re-encodes to the byte-identical string the client wrote (2.811583ms)
✔ the short padding a stranger's tool may write still decodes (0.551959ms)
✔ nothing in the adversarial corpus throws, and all of it is null (0.402042ms)
✔ each of this codec's own rejections has a valid twin one field away (0.188375ms)
✔ an empty slot round-trips as an empty slot and never as skill 0 (0.20125ms)
✔ a skill id this client build has never heard of decodes rather than fails (0.15575ms)
✔ a code the client would not have written re-encodes to the one it would (0.1395ms)
✔ the encoder refuses what the format cannot spell rather than truncating it (0.261167ms)
✔ a rank that is not a whole number is refused, not rounded into the field (0.119417ms)
✔ a bar that is not eight slots long is refused rather than padded or cut (0.108125ms)
✔ a twelve-attribute template still round-trips, at the edge of the count (0.482792ms)
✔ a captured team resolves through the same door every other team does (3.4345ms)
✔ heroes are compacted, because a henchman between two of them is a gap (0.266958ms)
✔ the player's own slot stays empty, which is the only shape it may have (0.124125ms)
✔ a fully observed player is saved into slot zero (5.86775ms)
✔ a captured build carries the ranks that were read, by name (0.184292ms)
✔ a bar read without its ranks is not a build (0.125ms)
✔ nothing invested is an empty build, not a missing one (0.104834ms)
✔ a rank against an attribute the table cannot name is dropped (0.091833ms)
✔ a hero whose bar was not read keeps their place and gets no build (13.745084ms)
✔ a stored player build is admitted for the certified player setter (0.246375ms)
✔ behaviour is carried, never defaulted to Guard (0.1725ms)
✔ capture preserves unknown, Normal, and Hard Mode observations (0.077666ms)
✔ there is nothing to capture without a party, and capture says no (7.442375ms)
✔ counted heroes nobody could name are reported, not quietly missing (0.229791ms)
✔ more heroes than a team has positions is refused for the surplus, not silently (0.1205ms)
✔ every gap is written into the team's notes, so the notice is not the record (0.101ms)
▶ the stored team roster
  ✔ compacts complete member records without moving the player (1.686417ms)
  ✔ preserves repairable legacy records while compacting (0.109291ms)
  ✔ removes the whole member and closes the gap (0.141666ms)
  ✔ moves configured members up, down, and to the last configured position (0.147125ms)
  ✔ does not move the player or an empty source (0.084041ms)
✔ the stored team roster (2.82625ms)
▶ Multiple Accounts profile creation
  ✔ validates every Single Account source before creating destinations (136.147208ms)
  ✔ rolls back both imported libraries when workspace publication fails (172.555958ms)
  ✔ rolls back after each library publication boundary (223.08075ms)
  ✔ refuses a requested destination without changing its existing bytes (44.240625ms)
  ✔ refuses pre-existing profile roots and template destinations (134.176875ms)
  ✔ loses a publication race without replacing the competing file (66.229834ms)
  ✔ treats a workspace rename followed by an error as committed (135.697167ms)
  ✔ removes a later account root when its workspace write fails (86.692042ms)
  ✔ preserves created resources when the workspace commit is ambiguous (101.814667ms)
  ✔ continues reverse cleanup and keeps the primary failure (248.744041ms)
✔ Multiple Accounts profile creation (1355.524417ms)
✔ merges unrelated shared-template edits (102.174041ms)
✔ a stale deletion cannot discard a concurrent edit (0.17425ms)
✔ two concurrent edits to one path preserve both contents (0.15725ms)
✔ one window's duplicate close cannot delete another window's addition (0.316416ms)
✔ an identical duplicate uses the merge path's case-insensitive identity (0.477459ms)
✔ shared save requires a load and one generation refuses changed resubmission (0.748667ms)
✔ a failure before publication leaves the generation retryable (0.186042ms)
✔ an unconfirmed publication permits only an identical preserving retry (0.207333ms)
✔ renderer replacement and reload own independent merge generations (0.222959ms)
▶ atomic active client publication
  ✔ publishes the selected module and its complete effective feature map together (11.346667ms)
✔ atomic active client publication (11.894417ms)
▶ allowlists
  ✔ allows approved domain suffixes (0.879083ms)
  ✔ rejects lookalike and empty names (0.092666ms)
  ✔ classifies public vs private addresses (0.513792ms)
  ✔ parses IPv4 destinations only (1.339833ms)
  ✔ allowlists the game ports (0.097583ms)
✔ allowlists (3.606541ms)
✔ no hostile name reaches a path outside the two template directories (4.835208ms)
{"checkpoint":"waiting-for-enhancement","please":"bring the client to a playable character"}
▶ an observation live run cannot reach the automation tier
  ✔ gives every scenario exactly one tier (35.871166ms)
  ✔ declares readiness independently from automation permission (1.24375ms)
  ✔ launches the app with the automation gate off, whatever the caller exports (2.595709ms)
  ✔ opens no parent-process command channel for an observation run (1.024917ms)
  ✔ keeps the rest of the launch decision unchanged (0.255459ms)
  ✔ keeps developer-program preflight independent from saved cursor settings (0.147917ms)
  ✔ hands an observation scenario no handle that can act on the player (0.377542ms)
  ✔ lets an observation scenario read only the fixed cursor projection (0.159542ms)
  ✔ synthesizes no bootstrap input when the client is not yet playable (0.742ms)
  ✔ still nudges an automation run, so the double above would have caught it (0.280625ms)
  ✔ does not require target-state evidence from a cursor-only observation (0.206792ms)
  ✔ does not pretend a program-free boot smoke installed Enhancement (0.087ms)
  ✔ accepts the target-readout run only when the real surface matches its snapshot (0.187417ms)
✔ an observation live run cannot reach the automation tier (45.763167ms)
✔ the one live-certified agent pattern keeps its name (1.146875ms)
✔ an uncertified agent pattern publishes its bits, not a guess (0.152167ms)
✔ a living target keeps its name when uncertified bits ride along (0.086667ms)
✔ a type word the kernel would never publish is still rejected (0.118167ms)
✔ no target means no bits and no kind (0.105209ms)
✔ an observation that is not ready is a party nobody can draw (5.38675ms)
✔ a well-formed record nobody took a reading for is not an empty party (0.279959ms)
✔ a counted but unnamed hero is counted, not invented (0.096792ms)
✔ every field the companion has not published reads as not observed (0.10775ms)
✔ account and instance facts stay unknown rather than defaulting to false (0.085834ms)
✔ a hero the table cannot name is dropped rather than published as a number (0.130458ms)
✔ the flag says available or the hero is not listed, whatever the id says (0.682542ms)
✔ a fully named party is not partial (0.130833ms)
✔ a nonsense count is floored rather than trusted (0.136666ms)
✔ profession ids become acronyms, and None is a secondary rather than a refusal (0.177167ms)
✔ the full roster wins over the summary, and carries what was read (0.422ms)
✔ a region whose walk was rejected is not an empty party (0.072458ms)
native update installation refused Error: install refused
    at Object.quitAndInstall (file:///Users/matthias/Git/games/guild-wars-mac/gwonmac-travel-party-close/tests/unit/app-updater.test.ts:178:47)
    at Object.quitAndInstall (file:///Users/matthias/Git/games/guild-wars-mac/gwonmac-travel-party-close/tests/unit/app-updater.test.ts:74:41)
    at AppUpdater.quitAndInstall (file:///Users/matthias/Git/games/guild-wars-mac/gwonmac-travel-party-close/src/main/app-updater.ts:150:34)
    at TestContext.<anonymous> (file:///Users/matthias/Git/games/guild-wars-mac/gwonmac-travel-party-close/tests/unit/app-updater.test.ts:182:28)
    at async Test.run (node:internal/test_runner/test:1332:7)
    at async Suite.processPendingSubtests (node:internal/test_runner/test:911:7)
Update check failed at feed: feed-invalid
Update check failed at feed: feed-invalid
Update check failed at feed: feed-invalid
Update check failed at feed: feed-invalid
Update check failed at feed: feed-invalid
Update check failed at feed: feed-invalid
Update check failed at feed: feed-invalid
Update check failed at feed: offline Error: offline
Update check failed at feed: unreadable SyntaxError: Unexpected token 'o', "not json" is not valid JSON
▶ application updater
  ✔ reads exactly one static manifest for the selected channel (957.824083ms)
  ✔ makes no request and reports unavailable without the signed marker (0.24775ms)
  ✔ validates before asking Squirrel to download and installs once (0.410625ms)
  ✔ closes synchronous native feed and download refusals (0.475166ms)
  ✔ does not start a download after a synchronous native event closes it (0.4325ms)
  ✔ reports a refused terminal install once (1.633792ms)
  ✔ coalesces concurrent checks into one static request (0.303ms)
  ✔ captures the selected track for an in-flight check (0.348875ms)
  ✔ keeps Stable off prereleases and Beta off alpha (0.3245ms)
  ✔ offers Stable, Beta, and RC through their admitted tracks (0.43325ms)
  ✔ returns from a newer beta to an older Stable only by manual install (0.164334ms)
  ✔ reports the selected channel version when already current (0.183792ms)
  ✔ fails closed for malformed or retargeted channel documents (0.407125ms)
  ✔ never presents transport or parse failure as up to date (1.240708ms)
Update check failed at feed: timeout Error: aborted
  ✔ records and times out the static feed request (131.973666ms)
  ✔ does not duplicate work while downloading or ready (13.626916ms)
  ✔ treats Squirrel refusing a prevalidated upgrade as a feed failure (0.272709ms)
✔ application updater (1111.280292ms)
▶ automatic check policy
  ✔ refuses incapable, opted-out, and active-game checks (0.120541ms)
  ✔ checks a fresh profile and honors the persisted six-hour boundary (0.051208ms)
  ✔ recovers from a clock moved backwards instead of waiting indefinitely (0.048583ms)
  ✔ keeps 30-minute ticks inside the six-hour due window (0.046541ms)
✔ automatic check policy (0.347125ms)
▶ appearance settings
  ✔ derives the complete public token override from canonical settings (1.874833ms)
  ✔ projects untouched custom palettes exactly like their built-in material (7.168458ms)
  ✔ sets independent style and font markers and removes their defaults (9.180333ms)
  ✔ derives readable custom tokens and removes them when switching away (2.922333ms)
  ✔ activates a generation-keyed game font only after it loads (27.008458ms)
✔ appearance settings (49.292209ms)
✔ signing evidence accepts each channel's exact Apple identity (1.414916ms)
✔ signing evidence fails closed on every identity boundary (0.492167ms)
✔ signing target classification applies only the required entitlements (3.47275ms)
✔ redundant framework resources are the only ignored signing targets (0.244ms)
✔ Hard Mode is changed and confirmed before any team command (18.154583ms)
✔ the player's build is applied before hero work and confirmed field by field (74.702125ms)
✔ a wrong player primary refuses before changing difficulty (0.558292ms)
✔ missing player, partial roster and known-locked hero all send zero commands (0.314792ms)
✔ a partial roster does not invent hero-specific verification failures (30.411958ms)
✔ a rejected roster does not multiply into unknown region and mode failures (0.151208ms)
✔ known permanent policy blockers outrank an incomplete roster (0.138833ms)
✔ an absent hero's known primary mismatch refuses before roster mutation (0.193708ms)
✔ a known-locked assigned skill refuses before the first command (0.326667ms)
✔ behavior-only work is part of the canonical preview (0.191958ms)
✔ roster order is a canonical Apply change (0.128375ms)
✔ canonical preflight reports each logical change once (16.884417ms)
✔ a hero the game never adds is a refusal, however cheerful the command (3.678916ms)
✔ a hero that appears without an agent id is not yet added (58.344291ms)
✔ a full apply reports only the changes the roster confirmed (1.62475ms)
✔ attributes the game never applies are a refusal too (19.179334ms)
✔ an ordinary attribute publication just after one second is not a false refusal (0.859667ms)
✔ an empty attribute plan clears the player's invested ranks (0.241958ms)
✔ an empty attribute plan clears a hero's invested ranks (6.037417ms)
✔ a new secondary profession is set, and set before the bar (1.683084ms)
✔ a bar waits for the client's profession rebuild after confirmation (0.731875ms)
✔ a live secondary transition may exceed the ordinary command deadline (52.379416ms)
✔ a profession first published on the deadline receives its stability grace (19.119667ms)
✔ a deadline candidate that disappears is refused without extending the operation (51.241875ms)
✔ a profession must remain observed for a full stable interval (0.794708ms)
✔ cancelling during confirmation sends no dependent command (0.337834ms)
✔ a monoclass build clears the secondary rather than leaving it (3.821958ms)
✔ a secondary the game never changes is a refusal, not a bar written anyway (34.532292ms)
✔ unobserved professions refuse before the first command (0.176125ms)
✔ a wrong primary profession refuses before changing difficulty (0.111125ms)
✔ a bar the game only partly equips is applied, and says what it dropped (0.467042ms)
✔ a progressively published bar is not mistaken for a stable partial bar (0.399417ms)
✔ an omitted reportedly unlocked skill is an inconsistency, not a skip (0.540083ms)
✔ skipped skill names accumulate across the whole team (33.454875ms)
✔ a bar that never moves is still a refusal (6.014ms)
✔ a bar and ranks already in place send nothing at all (3.463625ms)
▶ atomic-file
  ✔ replaces the target only after a complete write (290.533708ms)
  ✔ writes JSON atomically (33.071ms)
  ✔ creates parent directories (23.167584ms)
  ✔ applies the requested mode to the published file (66.53975ms)
  ✔ creates a complete file without replacing an existing target (63.904709ms)
  ✔ writes large payloads through writeAtomicInDir (55.393958ms)
✔ atomic-file (534.10775ms)
▶ atomic-file writeAll
  ✔ keeps writing until the buffer is consumed (0.493125ms)
  ✔ resumes from the offset the sink reached, not from zero (0.150459ms)
  ✔ fails loudly when the sink stops making progress (0.152834ms)
  ✔ writes every byte to a real file handle (9.365542ms)
✔ atomic-file writeAll (10.452292ms)
▶ atomic-file durability
  ✔ syncs the temp file before the rename and the directory after it (30.083125ms)
  ✔ syncs a create-only temp before publishing its final name (20.038625ms)
  ✔ leaves no temp file behind when the rename fails (47.853542ms)
✔ atomic-file durability (98.978292ms)
▶ atomic-file orphan sweep
  ✔ removes temp files left by dead processes and keeps everything else (41.832417ms)
  ✔ sweeps a temp file a crashed writer really left behind (39.802209ms)
  ✔ sweeps the orphan a SIGKILLed writer left, with the old document intact (931.759458ms)
  ✔ reports zero for a directory that does not exist (1.737041ms)
  ✔ reaches every directory the profile publishes documents into (43.108625ms)
✔ atomic-file orphan sweep (1058.816916ms)
✔ transient loading cannot skip character selection (7.088084ms)
▶ build authoring rules
  ✔ uses the exact nonlinear 200-point Guild Wars budget (0.849291ms)
  ✔ offers both professions but never a secondary primary attribute (0.112041ms)
  ✔ stores rank zero as no investment (0.839875ms)
  ✔ resolves every catalogue placement without creating an invalid bar (0.307709ms)
✔ build authoring rules (2.765125ms)
✔ rejects a stale write from another window (40.009042ms)
✔ requires a baseline read before the first write (5.557458ms)
▶ patch-day carry-forward report
  ✔ fails closed when no capability can be located (45.33775ms)
✔ patch-day carry-forward report (47.218375ms)
▶ chunk cache pruning
  ✔ preserves current and rollback data and removes only stale hashes (332.920541ms)
  ✔ fails closed when the current or rollback manifest is corrupt (5.4075ms)
✔ chunk cache pruning (340.7065ms)
▶ chunk-store
  ✔ coalesces concurrent fetches of the same hash (228.232792ms)
  ✔ reads across chunk boundaries and short final chunks (102.675042ms)
  ✔ rejects hash mismatches without publishing (27.853583ms)
  ✔ replaces a corrupt resident chunk before returning it (52.065125ms)
  ✔ verifies and repairs resident chunks before full-download completion (51.387291ms)
  ✔ allows pause and sleep to interrupt resident-cache verification (47.2195ms)
  ✔ full-image resume downloads only missing hashes (90.41475ms)
  ✔ fails before downloading when the full image does not fit (3.23025ms)
  ✔ fails fast and classifies a fatal local write, keeping its cause (8.217667ms)
  ✔ bounds exhausted network work and resumes with verified chunks (338.290333ms)
  ✔ preserves completed chunks when a full download is stopped and resumed (181.173541ms)
  ✔ caps native fetches at eight and promotes queued demand (146.546459ms)
  ✔ serves fetched and first-process resident bytes without a second read (37.914084ms)
  ✔ releases a failed slot and allows the same chunk to retry (179.3165ms)
  ✔ stops queued background work while allowing new demand (104.253792ms)
✔ chunk-store (1686.5845ms)
✔ proved documentation and website-only changes use the fast gate (1.322834ms)
✔ website certification follows only its real inputs (0.153708ms)
✔ runtime, packaging, dependency, and unknown changes use the full gate (0.095792ms)
✔ malformed paths fail closed (0.071ms)
▶ client cache projection
  ✔ reports an empty cache without an active generation (1.65025ms)
  ✔ projects exact residency and the pessimistic capacity shortfall (0.129209ms)
  ✔ does not invent a shortfall when capacity is unknown (0.101125ms)
✔ client cache projection (2.482291ms)
▶ client certification
  ✔ maps isolated verifier results without recreating a coarse state (210.287834ms)
✔ client certification (211.0995ms)
▶ client compatibility notice
  ✔ does not interrupt when every selected feature is available (2.391791ms)
  ✔ uses the exact single-feature copy (0.188791ms)
  ✔ groups target and party observation without implementation language (0.156167ms)
  ✔ names only the unavailable observation (0.18825ms)
  ✔ keeps update and restart recovery distinct when reasons are mixed (0.091708ms)
  ✔ lists several unavailable features and preserves safe local work (0.100125ms)
  ✔ makes preparation failures retry each launch (0.090125ms)
  ✔ keeps forbidden player-facing terms out of every report (0.245166ms)
  ✔ keeps every feature and reason combination internally consistent (821.601916ms)
  ✔ renders one report into launcher and Settings (0.429916ms)
  ✔ reports cooldown presentation unavailable when slot geometry is unavailable (0.127875ms)
  ✔ keeps the complete cooldown presentation available without party observation (0.090583ms)
  ✔ dismisses the launcher even when acknowledgement cannot persist (0.313542ms)
✔ client compatibility notice (827.006167ms)
▶ client compatibility
  ✔ fingerprints only the complete executable client contract (56.775167ms)
  ✔ rejects a failed candidate once and records its fingerprint (229.265917ms)
  ✔ keeps a valid untested candidate pending across an ordinary restart (67.949416ms)
  ✔ clears only the rejection record for an explicit retry (139.102334ms)
  ✔ promotes a rendered candidate and removes rollback state (157.707291ms)
  ✔ refuses to confirm a candidate marker that changed (92.544125ms)
  ✔ does not interpret unknown persisted record versions (53.03025ms)
  ✔ prefers the previous complete client when the marker is corrupt (94.299875ms)
✔ client compatibility (912.984208ms)
▶ client clean-exit adapter
  ✔ recognizes the real exported function stored in a WebAssembly table (3.278ms)
  ✔ delegates timers and callbacks that are not the exported main loop (1.033834ms)
  ✔ keeps running while the main loop schedules a successor (0.189709ms)
  ✔ reports a successful final tick as one clean exit (0.112375ms)
  ✔ reports a rejected main-loop tick as a failure, not a clean exit (0.38825ms)
✔ client clean-exit adapter (5.999667ms)
▶ client health confirmation
  ✔ waits for both signals and retries one rejection without duplicating success (6.151834ms)
  ✔ stops after three permanent failures (1.339208ms)
  ✔ cancels a pending retry when the renderer unloads (0.795917ms)
✔ client health confirmation (9.363125ms)
✔ an active client boots while its complete data downloads (5.613542ms)
✔ preparation and failure remain launch gates (0.134583ms)
▶ client module preparation
  ✔ composes both certified transforms in order (439.579459ms)
  ✔ prepares only templates for a template-only certification (264.676542ms)
  ✔ uses an isolated derived native record through the complete cache path (132.549458ms)
  ✔ requires local native proof and keeps the preceding module untouched on refusal (139.0585ms)
  ✔ serves official bytes and drops both caches when uncertified (39.200666ms)
  ✔ closes native double-click preparation when its input disappears (142.707291ms)
  ✔ falls back to the ordinary module when a requested 4 GB pair is unknown (57.213042ms)
  ✔ keeps an earlier transform failure separate from 4 GB preparation failure (305.398333ms)
  ✔ drops the Enhancement cache when the certified tool is disabled (380.282916ms)
  ✔ falls back at the failed stage without serving an invalid module (333.085334ms)
  ✔ rebuilds stale compatibility and Enhancement cache entries (711.958416ms)
  ✔ rejects a replacement module even when writable metadata matches it (531.973916ms)
  ✔ selects the largest safe subset when one profile fails validation (309.330292ms)
  ✔ replaces the cache when capabilities change but hooks do not (229.336708ms)
✔ client module preparation (4018.037042ms)
▶ companion core memory installation
  ✔ owns aligned runtime, exact config, and explicit kernel regions (6.160042ms)
  ✔ allocates no observer or command memory when it is not needed (0.358417ms)
  ✔ rolls back every partial allocation in reverse order (0.803ms)
  ✔ rolls back when the completed layout does not fit memory (0.265417ms)
  ✔ does not write runtime or config bytes before explicit initialization (0.587959ms)
  ✔ rolls back a reused allocation pointer exactly once (0.473125ms)
  ✔ reports both allocation and rollback failures (0.361666ms)
  ✔ releases the observer and callback safety groups once (0.565ms)
  ✔ cannot initialize after either release group runs (1.162875ms)
  ✔ continues a release after one free refuses (0.838792ms)
  ✔ composes with child-region overlap validation (0.223583ms)
✔ companion core memory installation (12.900584ms)
▶ companion kernel loader
  ✔ verifies, initializes, and projects only the canonical kernel (66.423333ms)
  ✔ refuses extra and missing imports and exports (8.14575ms)
  ✔ refuses a canonical name with the wrong function signature (0.755958ms)
  ✔ refuses every mismatched ABI scalar (96.0055ms)
  ✔ does not expose dispatch authority when initialization refuses (0.775708ms)
  ✔ uses the canonical allocation validator before compilation (0.485416ms)
✔ companion kernel loader (177.133708ms)
▶ companion kernel build contract
  ✔ states the exact reviewed import and function vocabulary once (1.69875ms)
  ✔ accepts exactly the fixed side-module surface (4.072625ms)
  ✔ rejects invalid Wasm, a start function, and a changed dylink footprint (46.705458ms)
  ✔ rejects extra imports and exports rather than allow-listing by prefix (64.527125ms)
  ✔ rejects a named export with the wrong exact function type (0.456125ms)
  ✔ states region sizes the decoder and the config ABI already fix (0.123167ms)
  ✔ rejects active data writes outside the declared private footprint (35.215375ms)
✔ companion kernel build contract (153.557292ms)
▶ companion kernel build seal
  ✔ publishes validated bytes and checks their sealed hash before compile (23.77575ms)
  ✔ removes a stale artifact without rewriting when validation fails (0.997917ms)
  ✔ removes the artifact and restores the renderer if final publication fails (4.574708ms)
✔ companion kernel build seal (29.518417ms)
✔ frame pollers run on every observer frame without an observation change (2.33675ms)
✔ party rows refuse payload for optional fields whose presence flag is absent (3.28075ms)
✔ an observed zero-filled player and a present all-zero skillbar remain valid (0.26175ms)
▶ companion policy source
  ✔ publishes one canonical launch snapshot (3.0825ms)
  ✔ rereads settings instead of trusting the event payload (0.2825ms)
  ✔ deduplicates equal region values and withdraws policy on waiting (0.173083ms)
  ✔ publishes same-map character and unlock changes (0.154625ms)
  ✔ withdraws local Tools only for positively identified active PvP play (0.123958ms)
  ✔ detaches both inputs and stops publication on disposal (0.117375ms)
  ✔ rolls back a settings listener when region subscription fails (0.295459ms)
  ✔ does not retain a subscriber whose launch callback throws (0.13425ms)
  ✔ stops an individually unsubscribed consumer (0.105458ms)
  ✔ withdraws every reachable listener when input disposal refuses (0.287208ms)
✔ companion policy source (5.590625ms)
✔ a bounded region owns allocation and ignores observations while inactive (5.649417ms)
✔ a withdrawn sequence accepts only a newer uint32 publication (0.2065ms)
✔ malformed ready sequences fail closed (0.104333ms)
✔ an event-driven region keeps a stable accepted publication (0.093708ms)
✔ region descriptors require non-ready withdrawal sentinels (0.259375ms)
✔ teardown withdraws ready state even when freeing fails (0.149292ms)
✔ freshness duration rejects non-finite and negative values (0.115875ms)
✔ sequence ordering accepts uint32 wrap and suppresses duplicate publications (0.133292ms)
✔ an equivalent heartbeat refreshes freshness without notifying listeners (0.200458ms)
▶ controller prompt texture
  ✔ implements the uMod hash for every bounded atlas orientation (49.793584ms)
  ✔ refuses arbitrary data instead of matching dimensions alone (24.669583ms)
  ✔ pins the current WebGL fingerprint to the exact certified client (0.125667ms)
  ✔ substitutes synchronously and restores the client's heap (311.98625ms)
  ✔ passes mismatches, malformed pointers, and unrelated textures unchanged (2.669834ms)
  ✔ preserves call receiver, result, and restoration when the upload throws (7.612209ms)
  ✔ also handles an exact full-atlas sub-image upload (3.849917ms)
  ✔ withdraws a match after every non-certified level-zero mutation and reset (7.600208ms)
  ✔ bounds texture deletion bookkeeping and never blocks malformed client calls (3.886209ms)
  ✔ fails closed when the required texture import is absent (17.586125ms)
✔ controller prompt texture (431.665333ms)
▶ corrupt document quarantine
  ✔ preserves the new bytes, retains three backups, and touches no neighbour (313.628709ms)
  ✔ returns null when another owner already moved the document (4.146125ms)
✔ corrupt document quarantine (319.671583ms)
Keychain operation failed arenaNetCredentials unclassified Error
▶ credentials
  ✔ round-trips the fixed credentials slot and clears it (2.345916ms)
  ✔ keeps a Multi profile out of the fixed Single slot (0.242125ms)
  ✔ maps native failure to the credential vocabulary (1.745792ms)
  ✔ retains unreadable Keychain bytes (0.202083ms)
  ✔ rejects invalid saves before replacing stored credentials (0.328292ms)
✔ credentials (34.453417ms)
▶ hidden-cursor retry
  ✔ asks on the poll after the hide, then paces by the interval (1.277667ms)
  ✔ asks once per interval, not once per poll (0.149917ms)
  ✔ stops at the deadline and stays stopped until the cursor resolves (0.110125ms)
  ✔ is not expired before the loop has seen anything (0.070667ms)
  ✔ expires at the deadline and resets on resolution (0.145041ms)
  ✔ records the resolved gap and only for a valid resolution (0.099709ms)
  ✔ counts only re-tests the dispatcher accepted (0.08325ms)
  ✔ does nothing while the consumer has no valid state (0.087542ms)
✔ hidden-cursor retry (4.419708ms)
▶ derived wasm cache
  ✔ publishes once and reuses the published module (405.28125ms)
  ✔ keeps only the current input, so an update cannot leak a directory (190.508041ms)
  ✔ keeps only the current transform ABI (237.900958ms)
  ✔ rebuilds when the certified build entry changes (222.743417ms)
  ✔ rejects a cached module whose bytes were altered after publication (194.618583ms)
  ✔ will not let cache metadata certify a module the pinned hash rejects (168.405834ms)
  ✔ publishes nothing when the output misses the pinned hash (9.597541ms)
  ✔ keeps the last good module when a rebuild's transform throws (114.645709ms)
✔ derived wasm cache (1547.523416ms)
▶ diagnostic profile storage
  ✔ defaults to standard and persists every closed profile (353.690708ms)
  ✔ refuses malformed persisted state instead of guessing (56.755ms)
✔ diagnostic profile storage (412.474416ms)
▶ diagnostic profile policy
  ✔ keeps each isolation profile explicit and internally consistent (0.99ms)
✔ diagnostic profile policy (1.064625ms)
▶ diagnostic report
  ✔ selects the newest abnormal prior session and tolerates a torn tail (233.956333ms)
  ✔ treats a game-client abort as abnormal even after a clean app quit (113.944583ms)
  ✔ reports no abnormal session when the previous run was clean (19.200917ms)
  ✔ derives startup, capture, and performance fields from canonical data (0.7385ms)
✔ diagnostic report (369.261541ms)
▶ the closed diagnostics schema
  ✔ reports every prohibited field shape in one compiler program (8168.741334ms)
  ✔ still accepts the field kinds the schema is built from (6821.863625ms)
✔ the closed diagnostics schema (14991.310542ms)
▶ diagnosticEventRecord
  ✔ classifies account evidence at the same canonical definition as its fields (0.946167ms)
  ✔ owns the subsystem and level of an event, so a call site cannot disagree (0.9835ms)
  ✔ keeps the discriminant out of the recorded fields (0.288959ms)
  ✔ carries every field of a multi-field event (0.138166ms)
  ✔ records a phase as a field rather than as part of the event name (0.095083ms)
  ✔ names the durable action whose relaunch was refused (0.0835ms)
  ✔ keeps the socket event name closed and the payload declared (0.089958ms)
  ✔ records which proxy route failed (0.061417ms)
  ✔ passes a digest and an absent digest through unchanged (0.221917ms)
  ✔ produces only scalars, so no nested value can smuggle text out (0.2565ms)
✔ diagnosticEventRecord (4.075167ms)
▶ asDigest
  ✔ accepts a 64-character lower-case hex digest (0.106334ms)
  ✔ rejects anything else, without quoting it (0.366083ms)
  ✔ has a predicate that agrees with it (0.057792ms)
✔ asDigest (0.621083ms)
▶ asAppVersion
  ✔ accepts the CalVer surface and its release stages (0.3165ms)
  ✔ rejects free text and invalid leading-zero variants (0.121375ms)
✔ asAppVersion (0.481125ms)
▶ renderer diagnostics boundary
  ✔ accepts the complete bounded aggregate (1.247541ms)
  ✔ rejects missing, negative, and non-finite values (4.807375ms)
✔ renderer diagnostics boundary (6.698166ms)
▶ frame capture analysis
  ✔ uses exact visible intervals and resets across hidden records (3.531042ms)
✔ frame capture analysis (5.539792ms)
▶ capture validation, format 2
  ✔ reproduces the manifest's redaction result from events.jsonl (5.426916ms)
  ✔ refuses a manifest whose redaction result the event log does not support (0.251959ms)
  ✔ rejects an event log carrying a field the schema does not declare (0.223125ms)
  ✔ does not require histograms.json, and does require the rest (0.163666ms)
  ✔ refuses a trace scan the included files do not corroborate (0.112084ms)
  ✔ requires explicit consent and a valid PNG for visual evidence (1.028292ms)
✔ capture validation, format 2 (7.450958ms)
▶ capture validation, format 3 visual evidence
  ✔ accepts a complete self-consistent visual capture (1.947ms)
  ✔ requires one unique declaration and dimension record per image (0.210708ms)
  ✔ rejects dimension mismatches and dimensions without an image (0.133042ms)
  ✔ requires valid runtime state and a visual declaration for format 3 (1.980792ms)
✔ capture validation, format 3 visual evidence (4.513375ms)
▶ capture validation, format 1
  ✔ accepts a complete redacted capture and rejects dropped records (0.210917ms)
  ✔ refuses to call a Level 2 capture complete without its Chromium trace (0.08675ms)
  ✔ validates the machine-readable report without requiring it in old captures (0.102666ms)
  ✔ warns for same-session overlapping captures and mixed levels (0.316042ms)
✔ capture validation, format 1 (0.813208ms)
✔ distribution channels derive the complete capability matrix (1.721041ms)
✔ distribution markers accept only the closed canonical shape (0.1715ms)
✔ provisioned channels have distinct application identities (0.107791ms)
▶ dns suffix matching
  ✔ normalizes case and a trailing dot (0.871375ms)
  ✔ matches whole suffix labels only (0.141083ms)
  ✔ rejects IP literals passed as DNS names (0.744291ms)
  ✔ rejects names outside the allowlist without contacting the network (200.839083ms)
✔ dns suffix matching (203.315375ms)
▶ effective Enhancement capability boundary
  ✔ reproduces every served profile from Main's session, independent of request (7.457792ms)
  ✔ does not revive off or unavailable features (0.164958ms)
  ✔ refuses to invent a profile before Main publishes a session (0.079875ms)
✔ effective Enhancement capability boundary (8.734333ms)
▶ Enhancement client chain
  ✔ source-pins every executable capability profile (84.658167ms)
  ✔ certifies the Enhancement transform against the template-save output (0.130958ms)
  ✔ requires all and only the hashes implied by optional capability facts (1.172833ms)
✔ Enhancement client chain (86.621375ms)
▶ Enhancement command transform
  ✔ emits Team Apply and local action authority independently (97.818458ms)
  ✔ derives local actions without installing the party dispatcher hook (4.075667ms)
  ✔ never advertises aliases without an effective named action (1.903959ms)
  ✔ queues the named storage action and drains DataWindow on the game thread (1.724875ms)
  ✔ queues one bounded Travel request and dispatches it on the game thread (2.188542ms)
  ✔ consumes /trade, /tp and exact storage commands at their named boundaries (2.119417ms)
  ✔ dispatches queued commands only from the certified game-thread callback (2.643917ms)
  ✔ distinguishes native and GWonMac command packets without changing them (92.114708ms)
  ✔ refuses a command whose function is not the one certified (0.67925ms)
  ✔ refuses an uncertified or shared command drain boundary (0.822959ms)
  ✔ refuses an uncertified or shared traced packet sender (0.559209ms)
  ✔ refuses an uncertified storage slash parser (0.40525ms)
  ✔ refuses an uncertified Xunlai access reader (12.7665ms)
  ✔ refuses a travel producer that aliases a selected dispatch hook (1.337834ms)
✔ Enhancement command transform (222.251167ms)
✔ pre-game state scans exact live label hashes and loading context (20.129042ms)
▶ Enhancement re-certification input
  ✔ fails closed without inspecting raw official bytes (1.585875ms)
  ✔ nests structural candidates as review evidence without promoting them (34.683833ms)
✔ Enhancement re-certification input (36.957667ms)
✔ developer programs replace saved optional-tool selection in PvE (1.78525ms)
✔ unknown regions keep local Tools while live PvE features fail closed (0.098042ms)
✔ confirmed active PvP play disables every product and developer tool (0.116083ms)
✔ product tool settings remain live once the capability is present (0.1175ms)
✔ skill feature selection distinguishes labels from cooldowns (0.10375ms)
✔ runtime policy projects every registered feature exactly once (0.083625ms)
✔ local Tools require their setting or developer program and only active PvP blocks them (0.414333ms)
✔ skill transform resolves and verifies only its four certified functions (2.741583ms)
✔ unselected skill facts stay absent and selected missing facts fail clearly (0.341ms)
✔ skill transform refuses changed bodies and changed certified call operands (0.168875ms)
✔ SkillBar capture rewrites only the certified operand and preserves wrapper bytes (0.291708ms)
✔ the storage controller owns policy, events, deduplication, and teardown (3.356125ms)
✔ storage fails closed without a confirmed character access proof (0.20925ms)
✔ storage development traces identify the live refusal without account data (0.189125ms)
▶ review-only Enhancement structural evidence
  ✔ recovers all three boundaries deterministically without a build certificate (96.980333ms)
  ✔ recovers shifted function indices instead of relying on known numbers (0.529583ms)
  ✔ uses the caller's immutable message anchors instead of fixed IDs (0.354667ms)
  ✔ rejects changed tick, dispatcher, and cursor signatures independently (2.948667ms)
  ✔ rejects changed player message and exact-site cardinality evidence (9.5585ms)
  ✔ rejects a changed direct-call target even when both signatures match (0.297166ms)
  ✔ reports duplicate dispatcher and cursor candidates as ambiguous (0.449666ms)
  ✔ distinguishes missing and non-unique active-table relationships (0.461083ms)
  ✔ does not let an exact input hash replace cursor field witnesses (0.55475ms)
  ✔ rejects every changed cursor anchor and duplicate candidate (0.521417ms)
  ✔ fails closed with a deterministic data report for malformed input (0.510458ms)
  ✔ keeps independent tick evidence but rejects an unsupported opcode set (0.36325ms)
✔ review-only Enhancement structural evidence (114.504958ms)
✔ the closed team surface selects only its reviewed opcodes and payloads (29.0335ms)
✔ the storage command owns one fixed DataWindow payload and refuses unsafe sends (0.391792ms)
✔ invalid values are refused before the command queue (0.197333ms)
✔ hero identity is resolved again for every packet and rejected packets throw (0.177708ms)
▶ targeted Enhancement WebAssembly transform
  ✔ is deterministic, valid, and exports only the hook contract (25.55425ms)
  ✔ reports the semantic loop signature and reusable empty slots (0.581125ms)
  ✔ preserves every argument and calls each relocated original once (1.492417ms)
  ✔ rejects a non-terminal slot, hash mismatch, and signature mismatch (7.315375ms)
  ✔ uses only selected hook evidence in deterministic hook order (16.907084ms)
  ✔ rejects nonzero configuration for inactive capabilities (10.856583ms)
  ✔ zeroes only Xunlai proof words when Travel has no access certificate (3.277083ms)
  ✔ binds the exact party-dirty set to the Toolbox manifest and config (4.058209ms)
  ✔ starts the message words exactly where the layout words end (1.085417ms)
  ✔ gives party observation shared agent state without target selection (9.1275ms)
  ✔ checks the existing cursor table relation only when cursor is selected (7.576792ms)
✔ targeted Enhancement WebAssembly transform (89.610083ms)
▶ Enhancement workspace doctor
  ✔ fails closed for a missing profile (8.06275ms)
  ✔ reports snapshot residency without reading chunk contents (30.4255ms)
  ✔ reports required Core without writing to the profile (8.788042ms)
✔ Enhancement workspace doctor (49.028542ms)
✔ a packaged build refuses GW_ENHANCEMENT_AUTOMATION=1, so the tools decide alone (0.90675ms)
✔ the launch selection carries required Core and no setting can disable it (2.15875ms)
✔ one capability plan derives hooks without losing feature identity (0.392583ms)
✔ launch intent resolves to the canonical frozen capability profiles (0.426083ms)
✔ the capability wire contract is exact and has one empty value (0.35825ms)
✔ Tools prepares every certified capability independent of child toggles (0.096666ms)
✔ renderer consumes main's effective subset instead of launch intent (0.132916ms)
▶ error catalogue
  ✔ has no duplicate codes (0.784958ms)
  ✔ recognises its own members and nothing else (18.811334ms)
✔ error catalogue (20.256625ms)
▶ errorCode
  ✔ returns the code of an AppError (0.21625ms)
  ✔ returns the code of every AppError subclass (0.228708ms)
  ✔ does not republish the code of a foreign error (0.081958ms)
  ✔ survives anything that is not an Error at all (0.064084ms)
  ✔ keeps the message on the error and out of the code (0.098791ms)
  ✔ preserves the cause chain, which never reaches a code (0.083792ms)
✔ errorCode (0.973458ms)
▶ the macOS build number derived from a release version
  ✔ rises at every rung of a release ladder (1.116542ms)
  ✔ orders releases the same way the app's own comparison does (0.333ms)
  ✔ maps the calendar and the channel onto Apple's 4/2/2 digits (0.917375ms)
  ✔ refuses anything that is not a calendar release in SemVer syntax (12.227334ms)
  ✔ accepts the version this repository would release right now (0.97425ms)
✔ the macOS build number derived from a release version (61.521ms)
▶ export detector
  ✔ accepts every declared event built through the schema (5.062208ms)
  ✔ accepts only a nonnegative ephemeral window owner (0.425917ms)
  ✔ rejects a declared event that carries a field the schema does not declare (0.1365ms)
  ✔ rejects a value outside the field's declared vocabulary (0.251792ms)
  ✔ rejects text a redactor would have called clean (0.128292ms)
  ✔ rejects a malformed envelope rather than trusting the record (0.256167ms)
  ✔ rejects a declared event under another subsystem or level (0.112459ms)
  ✔ rejects every undeclared event and former free-text producer field (0.151875ms)
  ✔ rejects a nested field on any record, declared or not (0.15675ms)
  ✔ skips the blank lines a JSONL document ends with (0.140917ms)
✔ export detector (7.623166ms)
▶ extended memory runtime result
  ✔ keeps unresolved selection outside the result and maps standard mode (1.7855ms)
  ✔ reports the certified active profile and cap (0.114292ms)
  ✔ falls back truthfully after unsupported-client (0.08875ms)
  ✔ falls back truthfully after preparation-failed (0.055667ms)
✔ extended memory runtime result (2.742167ms)
▶ extended memory Settings projection
  ✔ distinguishes unresolved intent from the active standard cap (0.880125ms)
  ✔ reports restart only when saved intent differs from this launch (0.162167ms)
  ✔ keeps unsupported and preparation failures visibly distinct (0.102417ms)
✔ extended memory Settings projection (1.795875ms)
▶ certified extended memory transform
  ✔ stops one page short of 4 GiB (0.839625ms)
  ✔ accepts only canonical valid runtime feature profiles (0.236667ms)
  ✔ normalizes only all 59 ASM_CONSTS keys (0.413667ms)
  ✔ refuses changed JavaScript semantics and a changed memory shape (0.531041ms)
  ✔ changes only the sole memory maximum and validates the result (0.933833ms)
  ✔ records the effective mode and cap with a closed profile (0.140208ms)
✔ certified extended memory transform (4.221625ms)
▶ renderer failure messages
  ✔ answers every code in the catalogue with a sentence, on every surface (6.964125ms)
  ✔ carries the disk shortfall into the sentence when the caller knows it (0.430417ms)
  ✔ gives the same fault a different action on each surface (0.474292ms)
  ✔ keeps the sentences the two probe and recovery paths used to send (0.902667ms)
  ✔ falls back to one default rather than inventing a sentence per code (1.815667ms)
  ✔ answers every notice code with a sentence (0.633083ms)
  ✔ explains a failed Steam sign-in and stays silent on a plain cancel (0.150083ms)
  ✔ tells offline apart from a server fault, on both transfer surfaces (0.111708ms)
  ✔ suggests a bug report only when the fault may be the app's (0.163208ms)
  ✔ tells a locked Keychain apart from a build that may not use one (0.138375ms)
  ✔ stops promising a retry once the client crashes twice in one run (0.983375ms)
  ✔ escalates memory wording while keeping one action model (0.143584ms)
  ✔ prints the effective cap but no unreliable countdown (0.102375ms)
  ✔ explains optional automatic return without overpromising (0.105542ms)
✔ renderer failure messages (14.230916ms)
✔ the capability registry is the ordered wire vocabulary (1.94475ms)
✔ dependency pruning is derived from capability contracts (0.353416ms)
✔ cooldown owns the reusable player skillbar core without Party (20.797583ms)
✔ feature selection policies are deeply immutable (0.118083ms)
✔ shared activation and area policy cover required, setting, and content features (0.144333ms)
▶ frame attribution
  ✔ reads only visible records and rejects a bad header (1.992833ms)
  ✔ blames composition loss when the window changed state (0.425125ms)
  ✔ blames the main process only when its event loop actually blocked (0.177875ms)
  ✔ refuses to blame anything when the capture predates the instrumentation (0.092125ms)
  ✔ ignores gaps under the threshold and events outside the window (0.126375ms)
  ✔ rejects a non-positive threshold (0.081917ms)
✔ frame attribution (3.548709ms)
✔ automatic-return intent is refused to the source and consumed by its replacement (1.189416ms)
✔ a settings read failure performs no partial reload (1.107458ms)
✔ a completed program is answered without another round trip (7.013375ms)
✔ an incomplete program is never frozen, however often it is polled (0.20825ms)
✔ relinking makes a completed program incomplete again (0.138417ms)
✔ a recycled program name never inherits the deleted program's completion (0.115959ms)
✔ a name the host never saw created always reaches the client (0.108833ms)
✔ every pname except completion reaches the client every time (0.183584ms)
✔ null and misaligned out-pointers pass through and record nothing (0.083709ms)
✔ losing the GL context drops every memoized program (0.131208ms)
✔ a missing invalidator leaves every import untouched (0.176125ms)
✔ programs beyond the ceiling stay correct by passing through (0.344041ms)
✔ hits and misses both return the client's void result (0.075583ms)
✔ a grown WASM heap is followed on both the miss and the hit (0.094ms)
✔ reconnaissance counts the queries that still reach the client (0.119542ms)
✔ completion polls the cache cannot serve stay visible (0.070416ms)
✔ graphics diagnostics read immutable context facts only once (84.445791ms)
✔ the Guild Wars nibble stream decodes every printable ASCII glyph (2.150083ms)
✔ alternating runs cannot overrun a glyph (0.466167ms)
✔ the converted result is a complete checksummed TrueType font (17.435958ms)
✔ the original display strike builds as a separate browser family (18.502375ms)
✔ the measured contour remains the default and calibration inputs are bounded (194.844167ms)
✔ a narrow numeral gets balanced proportional spacing (9.451583ms)
✔ an unsupported font is refused once for its immutable client generation (0.342375ms)
✔ a compact oversized strike is refused before outline tracing (9.767792ms)
✔ the shared UI offers the local Guild Wars font independently of Inter (8.598416ms)
▶ Guild Wars archive decoder process boundary
  ✔ settles and stops the child when writing stdin throws (3.068167ms)
  ✔ contains an early stdin close and reports the decoder refusal (424.176458ms)
  ✔ settles once when an output refusal closes stdin (365.122083ms)
✔ Guild Wars archive decoder process boundary (793.626042ms)
▶ renderer image source
  ✔ answers fileSize synchronously, before any read, and only for open snapshot handles (1.2745ms)
  ✔ coalesces concurrent reads of the same range into one fetch (22.153667ms)
  ✔ batches adjacent queued demand chunks without fetching across a gap (0.751041ms)
  ✔ counts batched demand chunks toward the shared eight-chunk ceiling (2.065333ms)
  ✔ coalesces a demand read onto an already active prefetch instead of promoting it (30.572792ms)
  ✔ runs one multi-chunk cacheAsync seven-wide, keeping the demand slot free (24.357084ms)
  ✔ runs demand work before queued prefetch, and promotes the queued chunk a read needs (48.575083ms)
  ✔ releases the slot a failed fetch held, and reports the failure until a retry succeeds (15.4195ms)
  ✔ releases every slot after a batched failure (20.736459ms)
  ✔ rejects every affected chunk when a batched response is truncated (6.3345ms)
  ✔ assembles a range across a chunk boundary and into the short final chunk (0.37725ms)
  ✔ evicts the least recently used chunk at the 256 MiB budget (0.40125ms)
  ✔ counts native residency in isCached, which memory eviction does not erase (0.274ms)
  ✔ stops background work at unload and fails what was still queued (1.559208ms)
✔ renderer image source (176.545792ms)
✔ main input trace emits only while its renderer harness is enabled (113.334875ms)
✔ main trace state changes only after renderer acknowledgement (0.23825ms)
▶ the JSONL reader
  ✔ keeps every complete record when the last one is torn (17.245666ms)
  ✔ survives a tear at the only record, and at no record at all (0.154542ms)
  ✔ survives a final torn record that is still valid JSON (0.18075ms)
  ✔ rejects malformed or incomplete records before the final line (0.377917ms)
  ✔ allows trailing line endings but not blank records between events (0.107709ms)
  ✔ orders by sequence number, so rolled files may arrive in any order (0.085625ms)
  ✔ preserves the fields the export and the report both read (0.088417ms)
✔ the JSONL reader (18.9535ms)
▶ keyboard shortcuts
  ✔ uses defaults until a player replaces or clears one action (13.145291ms)
  ✔ stores only differences from defaults (0.397042ms)
  ✔ matches only Command and keeps Control chords in the game (55.737917ms)
  ✔ normalizes physical Command chords across Option-modified layouts (5.108625ms)
  ✔ protects editing and lifecycle shortcuts and finds action conflicts (0.207375ms)
  ✔ formats the same binding for Electron and for players (0.114417ms)
  ✔ refuses unknown actions, keys, fields, and modifier types (0.202ms)
✔ keyboard shortcuts (91.934958ms)
Keychain operation failed arenaNetCredentials unclassified Error
Keychain operation failed arenaNetCredentials keychain_locked Error
Keychain operation failed arenaNetCredentials keychain_locked Error
Keychain operation failed arenaNetCredentials keychain_locked Error
Keychain operation failed arenaNetCredentials keychain_unentitled Error
Keychain operation failed arenaNetCredentials keychain_unentitled Error
Keychain operation failed arenaNetCredentials keychain_unentitled Error
Keychain operation failed arenaNetCredentials unclassified Error
Keychain operation failed arenaNetCredentials unclassified Error
Keychain operation failed arenaNetCredentials unclassified Error
Keychain operation failed arenaNetCredentials unclassified Error
Keychain operation failed arenaNetCredentials unclassified Error
Keychain operation failed arenaNetCredentials unclassified Error
Keychain operation failed arenaNetCredentials unclassified Error
▶ KeychainJsonStore
  ✔ serializes overlapping writes and recovers its queue after failure (15.900959ms)
  ✔ keeps the native classification of a refusal instead of collapsing it (1.086458ms)
  ✔ zeroes native save buffers on success and failure (0.237958ms)
  ✔ zeroes loaded native buffers after valid and corrupt payloads (0.26125ms)
✔ KeychainJsonStore (18.467917ms)
▶ legacy secret cleanup
  ✔ removes only the two retired files and is idempotent (34.90525ms)
  ✔ unlinks a retired-name symlink without touching its target (4.1465ms)
  ✔ does not recursively remove a directory with a retired filename (5.076958ms)
  ✔ attempts both exact files and returns bounded failures (0.614583ms)
✔ legacy secret cleanup (48.942292ms)
✔ skillbar diagnostics preserve feature-local failure precedence (1.757083ms)
✔ shared module failures override skillbar-specific diagnostics (0.10525ms)
✔ the build fragment keeps cooldown independent from Party UI authority (0.199833ms)
✔ the build fragment refuses inconsistent include flags (0.08375ms)
▶ local client verification boundary
  ✔ certifies play region directly from the exact observation base (1.131583ms)
  ✔ accepts the verifier's complete baseline proof (2.24125ms)
  ✔ rejects an exact authored row that did not cross semantic proof (0.160833ms)
  ✔ rejects a proof for any other official client (0.090417ms)
  ✔ rejects an unconstrained enhancement layout (0.134417ms)
  ✔ accepts a relocated hook but rejects an incompatible signature (0.404333ms)
  ✔ accepts a structurally derived cursor proof and rejects malformed layouts (0.251042ms)
  ✔ accepts a field-complete Target proof and rejects one bad relocation (0.286792ms)
  ✔ accepts independent local-action proofs and rejects one bad Xunlai field (0.377792ms)
  ✔ accepts complete Party and Team proofs and rejects each independently (71.03675ms)
  ✔ validates the complete skill-slot geometry proof at the process boundary (35.019167ms)
  ✔ certifies cooldown from the player skillbar without Party or UI authority (0.305042ms)
  ✔ accepts a template-only proof and requires no enhancement behind failure (0.170625ms)
  ✔ represents an unrequested enhancement as a proved template, not a refusal (0.089458ms)
  ✔ rejects a stale verifier ABI at either boundary (0.19975ms)
  ✔ binds each verdict to the post-template hash and requested feature (0.1975ms)
  ✔ carries anchor-specific changed and ambiguous evidence across IPC (1.426916ms)
✔ local client verification boundary (114.484292ms)
▶ macOS Command-held key releases
  ✔ consumes only mapped releases routed to the focused game (1.840375ms)
✔ macOS Command-held key releases (3.071042ms)
✔ macOS key positions cover movement and player-bindable keys (2.899958ms)
✔ launch configuration arrives as a preload argument, not as a URL (9.082042ms)
✔ a renderer with no readable init argument gets the production posture (3.157875ms)
✔ menu commands reach the renderer as events and are acknowledged (2.76775ms)
✔ one physical key release crosses preload and is acknowledged (3.419834ms)
✔ ordinary renderer text editing declines to the main-process fallback (4.422167ms)
✔ input harness state crosses as an explicit value and is acknowledged (3.119958ms)
✔ the Tools shortcut is refused when there is no Toolbox to toggle (4.786834ms)
✔ a capture level crosses as a number, not as interpolated source (3.901125ms)
✔ the acknowledgement waits for the renderer's own promise (64.843333ms)
✔ a renderer that cannot act reports failure (49.520625ms)
▶ manifest
  ✔ accepts flat files and finds by basename (1.169875ms)
  ✔ rebuilds nested paths via parentIndex (0.146375ms)
  ✔ rejects chunk count mismatch (0.27225ms)
  ✔ rejects unknown compression (0.087709ms)
  ✔ rejects cycles and invalid parent indexes (0.123875ms)
  ✔ treats an explicitly null parentIndex as the root (0.108791ms)
  ✔ rejects unsafe names, duplicate paths, and invalid sizes (0.22525ms)
  ✔ rejects conflicting lengths for one content hash (0.103541ms)
  ✔ requires exactly one copy of each product basename (0.186459ms)
✔ manifest (3.219583ms)
▶ memory warning presenter
  ✔ does nothing when the single warning surface is incomplete (0.9555ms)
  ✔ keeps Low dismissed until Critical reopens the same notice (0.477833ms)
  ✔ reloads without adding another warning state (0.170333ms)
  ✔ registers as a dismissible keyboard surface while visible (2.061375ms)
  ✔ shares and saves the automatic-return preference (0.58425ms)
✔ memory warning presenter (6.427792ms)
▶ Multiple Accounts documents
  ✔ keeps a missing mode and workspace on the legacy Single path (12.073375ms)
  ✔ publishes a workspace before an explicit Multi selection (167.130958ms)
  ✔ fails closed for corrupt or future documents (23.11725ms)
  ✔ quarantines a damaged document without rewriting its bytes (5.546875ms)
  ✔ accepts only lowercase UUID v4 identifiers (0.23525ms)
  ✔ rejects duplicate labels after normalization and case folding (0.123ms)
  ✔ accepts an empty onboarding workspace but rejects an all-archived workspace (0.891666ms)
  ✔ requires valid binary sharing choices (0.233417ms)
  ✔ adds, updates, and archives profiles without changing stable IDs (0.64375ms)
✔ Multiple Accounts documents (211.6335ms)
▶ generation mutex
  ✔ serialises real generation-directory moves (668.584ms)
  ✔ tears the same tree when the moves are not serialised (122.071166ms)
  ✔ does not wedge the queue when a task rejects (1.047666ms)
  ✔ gives each caller its own task's result, in queue order (63.677958ms)
✔ generation mutex (856.516291ms)
▶ queue drain
  ✔ waits for the work already queued, failure included (0.715125ms)
✔ queue drain (0.829792ms)
▶ settings write queue
  ✔ keeps both patches when the writes are serialised (106.601542ms)
  ✔ drops a patch when the same writes are not serialised (105.931083ms)
  ✔ writes the next patch after a write fails (18.93225ms)
✔ settings write queue (232.108125ms)
✔ appends one exported mutable global and writes it into the record (2.942ms)
✔ locates an unchanged callback without a predecessor hash (0.853375ms)
✔ refuses malformed input and ambiguous callback candidates (0.168334ms)
✔ rejects malformed or over-broad isolated verifier records (0.220542ms)
✔ refuses a callback whose body is not the certified one (0.298125ms)
✔ rechecks the isolated record's callback signature during production (0.12675ms)
✔ refuses a table slot that no longer holds the certified function (59.608167ms)
✔ refuses duplicate active table slots instead of accepting the last mapping (0.169333ms)
✔ refuses to insert past the end of the body (0.16975ms)
✔ refuses a module that already carries the flag export (0.258625ms)
✔ the shipped baseline states its own offsets and keeps valid historic fixtures (0.172416ms)
▶ native Keychain boundary
  ✔ has exactly the two product-owned slots (1.888ms)
  ✔ resolves the one development and one packaged binary path (6.671291ms)
  ✔ accepts an asynchronous in-memory fake without another interface (0.259958ms)
✔ native Keychain boundary (185.990209ms)
▶ no game traffic is uploaded: the only reachable destination
  ✔ refuses every destination that is not a public ArenaNet-shaped address (33.141583ms)
  ✔ refuses loopback through the constructor's own defaults (0.177375ms)
  ✔ opens an allowed destination at exactly the address it was given (1.115875ms)
  ✔ resolves no name outside ArenaNet's, including this project's own (0.180459ms)
✔ no game traffic is uploaded: the only reachable destination (36.794541ms)
▶ no game traffic is uploaded: what the recorder may hear
  ✔ publishes payload bytes to the game and to nothing else (0.5355ms)
  ✔ exports a socket's lifetime with no trace of what it carried (10.438542ms)
  ✔ stops the export if a socket record carries the bytes anyway (0.607125ms)
✔ no game traffic is uploaded: what the recorder may hear (11.748958ms)
▶ the published code generation
  ✔ is the identity of the two JSPI artifacts and nothing else (10.162584ms)
  ✔ refuses a manifest that names no code artifact (5.958625ms)
✔ the published code generation (28.318709ms)
▶ the command line
  ✔ reads the three things this script does (0.992542ms)
  ✔ refuses a record it was not handed a generation for (0.126667ms)
  ✔ refuses to fetch and record in the same run (0.078542ms)
  ✔ refuses a download with nowhere to put the bytes (0.0805ms)
✔ the command line (1.416458ms)
▶ the recorded client generation
  ✔ round-trips through its own serializer (0.171792ms)
  ✔ refuses everything it cannot read exactly (0.126542ms)
  ✔ is a tracked file the detector can read today (149.984125ms)
✔ the recorded client generation (150.82475ms)
✔ packaging accepts only the four complete supported intents (1.95375ms)
▶ patch-client update
  ✔ publishes a generation whose artifacts match the manifest beside them (508.227791ms)
  ✔ leaves an alpha-published generation installed instead of re-staging it (441.470708ms)
  ✔ promotes nothing when assembly silently truncates an artifact (332.541625ms)
  ✔ keeps the installed generation when a staged artifact changes under it (423.592333ms)
  ✔ aborts a slow preparation without moving the installed generation (362.285667ms)
  ✔ still swaps in a verified replacement and keeps the rollback target (505.594334ms)
✔ patch-client update (2575.754917ms)
▶ patch transport
  ✔ owns patch identity, redirect policy, caller abort, and response bounds (204.425917ms)
  ✔ accepts only HTTP 200 and never follows redirects through retries (1.139667ms)
  ✔ classifies a request that never got an HTTP answer as net_offline (0.638291ms)
  ✔ rejects a materialized body above its declared call-site limit (1.182333ms)
  ✔ interrupts retry backoff without starting another request (17.594291ms)
  ✔ bounds streamed bodies with and without content-length (2.751833ms)
  ✔ enforces exact decoded chunk lengths and gzip output bounds (255.589459ms)
✔ patch transport (490.320667ms)
▶ resolved profile paths
  ✔ pins the whole profile layout as literals (6.066417ms)
  ✔ sweeps every directory the profile publishes documents into (0.196916ms)
  ✔ derives profile paths only beneath the Multi namespace (0.2425ms)
  ✔ keeps the downloaded chunk cache exactly where the alpha put it (0.157333ms)
  ✔ pins the files published inside a client generation (0.098042ms)
  ✔ resolves an unpacked executable in development and when packaged (0.097541ms)
  ✔ pins the diagnostics frame log name (0.067666ms)
  ✔ resolves a staged generation without escaping the game directory (49.518ms)
✔ resolved profile paths (67.973208ms)
▶ ArenaNet unavailable platform capabilities
  ✔ exposes only the two namespaces required by defective client guards (6.375792ms)
  ✔ returns promises with explicit unavailable outcomes (1.257583ms)
  ✔ preserves the four callback assignments made by the glue (0.105166ms)
✔ ArenaNet unavailable platform capabilities (58.76275ms)
✔ play-region authority withdraws on staleness and requires a newer publication to recover (3.896916ms)
▶ PreferencesCoordinator
  ✔ publishes shortcut commits and the active result of an ambiguous write (204.447375ms)
  ✔ keeps the released district-bearing shortcut shape (68.467167ms)
  ✔ refuses a stale second window instead of losing the first write (37.953625ms)
  ✔ serializes ordinary settings writes with shortcut writes (75.115ms)
  ✔ reports a post-rename failure as unconfirmed, then reloads the active value (57.933584ms)
  ✔ returns an ordinary settings update that became active before fsync failed (19.807208ms)
  ✔ returns a settings reset that became active before fsync failed (68.5845ms)
  ✔ resets settings and Travel preferences completely (147.557875ms)
  ✔ does not attempt Travel when the settings reset definitively fails (161.5645ms)
  ✔ skips the Travel write when its document is already default (152.095333ms)
  ✔ returns a partial result when the Travel write definitively fails (132.517833ms)
  ✔ reconciles a Travel reset published before directory fsync failed (120.588834ms)
  ✔ returns partial when Travel cannot be read after settings commit (116.836291ms)
  ✔ returns partial when an unconfirmed Travel publication cannot be reread (195.689959ms)
  ✔ completes an idempotent retry after a partial Travel reset (278.772667ms)
  ✔ runs the next queued mutation after a partial reset (193.049ms)
✔ PreferencesCoordinator (2036.67075ms)
✔ the command trace publishes exact profession and skill payloads (25.352666ms)
✔ a drained attribute opcode does not invent an observed target (0.234042ms)
▶ Multiple Accounts runtime state
  ✔ tracks honest batch transitions without changing already-open accounts (1.789833ms)
  ✔ releases the untouched queue after canary failure (25.28625ms)
  ✔ maps every failure stage to bounded player-safe vocabulary (0.110417ms)
✔ Multiple Accounts runtime state (37.364125ms)
▶ download progress
  ✔ warms up, then smooths bursty chunk completion rates (5.079833ms)
  ✔ moves the displayed minutes only at the hysteresis edges (0.188042ms)
  ✔ throttles the detail line but renders clearing events immediately (0.178334ms)
  ✔ ignores duplicate and regressing samples instead of producing spikes (0.079875ms)
  ✔ drives Dock progress and sleep blocking only for a full download (1.494333ms)
✔ download progress (16.326208ms)
▶ proxy-routes
  ✔ maps only the explicit ArenaNet/NCSoft route labels (1.06525ms)
  ✔ keeps redirects inside the custom protocol and exact upstream host (0.202833ms)
  ✔ applies redirect and stateless-header policy as one response boundary (139.934958ms)
  ✔ permits proxy routes only for fetch/XHR destinations (0.128042ms)
  ✔ keeps the proxy stateless in both directions (0.075ms)
✔ proxy-routes (142.394708ms)
▶ published client manifest
  ✔ returns a canonical detached manifest (194.87475ms)
  ✔ reads a manifest the alpha published with no format version (0.2005ms)
  ✔ refuses a manifest from a format this build cannot read (1.071792ms)
  ✔ publishes the format marker when it seals a legacy generation (218.651ms)
  ✔ verifies every persisted executable artifact (149.443791ms)
  ✔ atomically seals a legacy generation before it can be replaced (79.136958ms)
  ✔ rejects invalid snapshot identity, dimensions, and chunk count (0.385375ms)
✔ published client manifest (645.055083ms)
✔ neither a stuck cleanup task nor a stuck final flush can hold the quit (2.269542ms)
▶ ranges
  ✔ parses closed, open-ended, and suffix ranges (90.488333ms)
  ✔ returns null without a usable Range header (9.42775ms)
  ✔ marks unsatisfiable ranges (0.590958ms)
✔ ranges (101.455875ms)
▶ Squirrel.Mac release manifest
  ✔ contains exactly one immutable release asset (8.173333ms)
  ✔ refuses mismatched tags and non-file ZIP names (0.2735ms)
  ✔ uses one closed reader for generated and downloaded manifests (0.145875ms)
✔ Squirrel.Mac release manifest (9.398958ms)
▶ the one marked release Verification record
  ✔ stages Pending evidence without changing generated notes (2.727083ms)
  ✔ replaces only the marked block (1.653375ms)
  ✔ preserves a passed result only for the same immutable evidence (0.509084ms)
  ✔ refuses duplicate markers, changed checksum rows, and Pending results (0.192375ms)
✔ the one marked release Verification record (5.759417ms)
▶ release version parsing
  ✔ accepts every shape the release workflow publishes, tagged or not (4.361958ms)
  ✔ rejects 2026.07.01 and every other non-SemVer numeric identifier (16.125792ms)
  ✔ rejects anything that is not exactly a published release shape (0.176042ms)
  ✔ rejects digit runs too long to compare exactly (0.098542ms)
  ✔ round-trips through canonical text without the tag prefix (0.176167ms)
✔ release version parsing (50.44075ms)
▶ release version ordering
  ✔ orders numerically first, then prerelease before its own release (0.182291ms)
  ✔ does not read a prerelease as equal to the release it leads to (0.0765ms)
  ✔ reports which versions are prereleases (0.093625ms)
✔ release version ordering (0.462292ms)
▶ public release tracks
  ✔ keeps Stable as the default and never makes alpha public (0.146042ms)
  ✔ requires GitHub prerelease metadata to match the tag (0.115875ms)
✔ public release tracks (0.34075ms)
✔ loading cannot impersonate character selection or playable completion (0.882166ms)
✔ only a certified playable instance completes relog (0.131583ms)
▶ reload transcript
  ✔ joins main and replacement-renderer events for exactly one owner (1.240875ms)
  ✔ reports an incomplete or missing boundary truthfully (0.127083ms)
  ✔ starts a menu trace at its own reload after an older Command-Q run (0.108917ms)
  ✔ stays below the clipboard ceiling by retaining newest complete rows (26.360167ms)
✔ reload transcript (29.661917ms)
✔ renderer failures stay with one document and client generation (1.896708ms)
✔ a renderer handler may complete before the final load event (1.159209ms)
✔ mounts, restores, prepares, and persists the game filesystem before main (2.220583ms)
✔ reuses an existing mount while restoring every required invariant (0.195167ms)
✔ normalizes Guild Wars desktop template paths at the filesystem boundary (0.296291ms)
✔ blocks game startup and reports an IndexedDB restore failure (0.128292ms)
✔ blocks game startup when the directory invariant cannot be persisted (0.109333ms)
✔ blocks game startup when IndexedDB synchronization stalls (0.139958ms)
✔ every host module exports exactly one installer (1.49075ms)
✔ merging the host modules loses no installer (0.360541ms)
▶ canonical renderer URL
  ✔ allows the launcher document and nothing else (34.042959ms)
  ✔ rejects every query string, including the ones it used to carry (0.189583ms)
  ✔ rejects proxy, subresource, ambiguous, and malformed URLs (0.136042ms)
  ✔ gives the accounts Hub its own document boundary (0.100334ms)
✔ canonical renderer URL (35.814125ms)
✔ runtime states admit only their complete valid phases (5.115584ms)
▶ semantic proof primitives
  ✔ binds every verdict to one input and verifier ABI (47.196667ms)
  ✔ requires an exact, non-empty witness ledger (1.230584ms)
  ✔ canonicalizes only explicit relocation operands (0.686667ms)
  ✔ fails closed at the analysis ceiling (0.107917ms)
✔ semantic proof primitives (81.122334ms)
▶ the sensitive-key vocabulary
  ✔ treats a field named pass as sensitive (1.115125ms)
  ✔ treats a field named auth as sensitive (0.113458ms)
  ✔ treats a field named cookie as sensitive (0.059875ms)
  ✔ treats a field named token as sensitive (0.05375ms)
  ✔ treats a field named secret as sensitive (1.645042ms)
  ✔ treats a field named credential as sensitive (0.471458ms)
  ✔ treats a field named username as sensitive (0.091ms)
  ✔ treats a field named email as sensitive (0.068833ms)
  ✔ treats a field named account as sensitive (0.078167ms)
  ✔ treats a field named login as sensitive (0.110583ms)
  ✔ leaves the field names the schema already declares alone (0.090125ms)
  ✔ scans text for every sensitive key stem (0.638584ms)
✔ the sensitive-key vocabulary (5.665917ms)
✔ ENOENT means no destructive startup action is pending (3.195209ms)
✔ marker inspection failures other than ENOENT remain visible (3.72375ms)
✔ a failed shortcut write reconciles through Settings and leaves capture mode (10.099708ms)
✔ cooldown settings render the canonical choice and shared preview (168.890708ms)
✔ cooldown settings reject malformed custom colors and persist valid colors (7.026709ms)
✔ cooldown settings recover the active state after a failed write (0.663333ms)
✔ cooldown settings do not repaint a custom color while it is being edited (0.224708ms)
✔ skill-key previews expose the same canonical label as their visual plate (3.613625ms)
✔ blur cancels recording and a captured chord persists only the display setting (16.380833ms)
▶ settings
  ✔ exposes the documented defaults (1.752666ms)
  ✔ drops retired cursor fields from an alpha profile (0.269875ms)
  ✔ fills missing fields and ignores unknown keys on read (0.076042ms)
  ✔ preserves every explicit supported render scale (0.081292ms)
  ✔ accepts only supported interface styles (0.262917ms)
  ✔ normalises and validates the permanent custom theme contract (0.330375ms)
  ✔ accepts only the supported interface fonts (0.102833ms)
  ✔ accepts only the two supported controller prompt styles (0.100833ms)
  ✔ rejects unknown types (0.191083ms)
  ✔ takes the update fields only in the shapes the renderer can produce (0.252625ms)
  ✔ accepts only bounded shortcut overrides (0.236542ms)
  ✔ accepts exactly eight display-only skill bindings (0.321333ms)
  ✔ takes the acknowledged client build only as a client hash (0.153833ms)
  ✔ accepts one canonical cooldown switch and color (0.167875ms)
  ✔ validates patches without filling fields from defaults (0.18225ms)
  ✔ keeps Travel shortcuts off the generic renderer settings channel (0.091041ms)
  ✔ loads defaults for missing or corrupt files (176.039417ms)
  ✔ saves only known fields (37.159333ms)
  ✔ loads an alpha-written bare-JSON file with every value intact (22.670375ms)
  ✔ preserves released district shortcuts for Stable rollback compatibility (4.197792ms)
  ✔ keeps the three newest corrupt backups and drops the rest (16.337125ms)
  ✔ moves aside a settings format this build cannot read (3.166875ms)
✔ settings (268.109625ms)
✔ catalogue and icon refusals are retryable without restarting (46.351667ms)
✔ the skill catalogue has one complete cross-process parser (2.03825ms)
✔ one malformed skill refuses the whole catalogue (0.248583ms)
✔ the presentation joins complete geometry and cooldown state without touching keys (2.459083ms)
✔ ready skills, stale state, disabled Tools, and incomplete publications hide everything (0.248417ms)
✔ sub-frame timer changes that keep the same label cause no presentation update (0.185292ms)
✔ equal cooldown labels skip projection while resize refreshes it (0.234334ms)
✔ either accepted feed withdrawing hides the complete cooldown HUD (0.382208ms)
✔ the minimal cooldown profile needs play-region policy but no Party or UI hook (1.895833ms)
✔ the minimal cooldown profile activates only its shared read substrate (0.3935ms)
✔ withdraws a cooldown publication whose sequence stops advancing (1.958375ms)
✔ cooldown formatting rounds active values upward without showing zero (0.954833ms)
✔ cooldown colors accept only the closed presets or exact six-digit RGB (1.197375ms)
✔ formats modifiers in one fixed order before the main key (2.233041ms)
✔ formats mouse buttons and wheel directions without stored labels (0.171084ms)
✔ requires exactly eight closed, bounded bindings (0.368041ms)
✔ clone and update return deeply frozen independent tuples (0.149ms)
✔ clone and update reject malformed values at the runtime boundary (0.265542ms)
✔ a custom projection adds only the changed key label (2.622625ms)
✔ a malformed or absent custom binding hides the complete overlay (2.651875ms)
✔ an unchanged frame performs no text write (12.898125ms)
✔ the consumer maps only slot eight's custom C binding (6.025083ms)
✔ a viewport resize refreshes projected key geometry (28.985959ms)
✔ the consumer withdraws geometry whose publisher stopped advancing (0.434291ms)
✔ the surface never takes input or enters the accessibility tree (0.119167ms)
✔ disposing removes the complete surface (0.082542ms)
✔ skill policy activates and withdraws only the observation regions it needs (8.204042ms)
✔ geometry listeners ignore heartbeat-only publications but receive moved bars (6.783ms)
▶ client language-file table
  ✔ finds all 18 language rows by their complete pointer/hash shape (7.534667ms)
✔ client language-file table (8.083375ms)
▶ client language shards
  ✔ parses exactly 1,024 bounded UTF-16 records and ignores the trailer (1.43775ms)
  ✔ keeps unrelated context-keyed records opaque without losing the shard (0.639458ms)
  ✔ maps string ids across shard boundaries (1.127958ms)
  ✔ substitutes all three skill ranges without interpreting markup as HTML (0.092958ms)
✔ client language shards (3.458666ms)
▶ socket events carry no error text
  ✔ publishes a declared failure code, not libuv's message (2.130208ms)
  ✔ collapses an unrecognised errno rather than passing it through (0.150875ms)
  ✔ classifies each errno the allowlist names, and nothing else (0.093ms)
  ✔ names why a socket closed, from a closed vocabulary (0.300459ms)
  ✔ reports a connect timeout as a timeout, not as an error (0.156333ms)
✔ socket events carry no error text (5.270833ms)
▶ renderer socket host
  ✔ uses one subscription and demultiplexes sockets by native ID (8.625125ms)
  ✔ honors close requested before connect resolves and closes once (20.582917ms)
  ✔ rejects pre-open sends asynchronously and compacts opened payloads (12.846084ms)
  ✔ waits for close after an error instead of retaining the close forever (3.262792ms)
✔ renderer socket host (70.880333ms)
▶ main-process socket queue budget
  ✔ holds the aggregate owner ceiling across 64 sockets (8.3775ms)
  ✔ refuses a write past the per-socket ceiling while the owner still has room (0.456625ms)
  ✔ keeps one owner's budget and sockets out of another owner's reach (0.824209ms)
  ✔ reclaims a dead socket's bytes once, not again when its callbacks arrive late (0.916792ms)
  ✔ releases callback and synchronous write failures without exposing native details (0.464416ms)
  ✔ leaves no owner queued after close, failure, reload and quit (0.813208ms)
✔ main-process socket queue budget (12.2205ms)
▶ the Steam authorize URL
  ✔ carries the config read out of the official client (1.295833ms)
  ✔ is built from whichever config it is handed (0.149542ms)
✔ the Steam authorize URL (2.061041ms)
▶ the sign-in origin allowlist
  ✔ admits the configured Steam-owned https hosts and their subdomains (0.2115ms)
  ✔ admits the configured authorize origin itself (0.079917ms)
  ✔ rejects non-Steam hosts, plaintext, and suffix look-alikes (0.148083ms)
  ✔ rejects a trailing-dot host rather than resolving it to the same name (0.072875ms)
  ✔ answers from the config it is given, not a module-level list (0.07375ms)
✔ the sign-in origin allowlist (0.743708ms)
▶ reading the token back
  ✔ accepts a fragment token whose state matches (27.463166ms)
  ✔ accepts a query token as well as a fragment token (0.277ms)
  ✔ accepts a bare `token` key as well as `access_token` (0.701291ms)
  ✔ prefers access_token when a response carries both (0.1535ms)
  ✔ rejects a response whose state does not match the attempt (0.087459ms)
  ✔ rejects a response carrying no state at all (0.058375ms)
  ✔ rejects a matching-state response that carries no token (0.070208ms)
  ✔ rejects a matching-state response whose token is empty (8.367917ms)
  ✔ does not treat a matching state on another URL as the redirect (0.200791ms)
✔ reading the token back (37.732375ms)
▶ the state nonce
  ✔ is unguessable and fresh per attempt (0.414833ms)
✔ the state nonce (0.455708ms)
Keychain operation failed steamSession unclassified Error
▶ the Steam session store
  ✔ round-trips the fixed Steam slot and clears it (2.086708ms)
  ✔ keeps a record whose expiry the account service has not supplied (0.149625ms)
  ✔ reports an absent store as absent, not as a failure (0.095ms)
  ✔ maps native failure to the Steam session vocabulary (0.9605ms)
  ✔ refuses invalid bytes without destroying them (0.170625ms)
  ✔ rejects an invalid record before replacing a stored one (0.181667ms)
✔ the Steam session store (4.377417ms)
▶ the Steam session shape check
  ✔ accepts a token with a numeric expiry or none yet (0.099167ms)
  ✔ keeps only the two fields it models (0.072542ms)
  ✔ rejects anything that cannot be replayed at a login screen (20.139375ms)
✔ the Steam session shape check (20.470875ms)
▶ deciding which Steam token to vend
  ✔ replays a stored token that has not expired, without opening a window (1.549875ms)
  ✔ replays a stored token whose expiry is not known yet (0.078833ms)
  ✔ answers a silent request with nothing rather than opening a window (0.062166ms)
  ✔ acquires on a non-silent request and stores what it got (0.103417ms)
  ✔ replaces a locally valid token on an explicit request (0.09425ms)
  ✔ does not replay a rejected token when explicit reauthentication is cancelled (0.049541ms)
  ✔ refuses an implausibly long token instead of handing it to the client (0.056166ms)
  ✔ reports a sign-in that did not complete without storing anything (0.04625ms)
  ✔ carries the sign-in refusal reason through to the caller (0.13225ms)
  ✔ treats an expired token as absent and discards it (0.060041ms)
  ✔ re-acquires when the expired token is met with a real request (0.05725ms)
  ✔ treats an unreadable store as absent and keeps the file (0.065209ms)
  ✔ still vends an acquired token when storing it fails (0.08825ms)
✔ deciding which Steam token to vend (2.599542ms)
▶ keeping its promise never to throw
  ✔ reports an acquisition that threw instead of letting it escape (0.070375ms)
  ✔ reports an acquisition that rejected asynchronously (0.069333ms)
✔ keeping its promise never to throw (0.176208ms)
▶ ordering complete Steam session operations
  ✔ makes clear final when acquisition was already in flight (0.162875ms)
  ✔ makes clear final when storeback was already in flight (0.141625ms)
  ✔ does not let an older storeback overwrite a newer resolution (0.11ms)
  ✔ continues after a queued operation rejects (0.087334ms)
  ✔ lets quit wait for the last queued secret write (0.10925ms)
  ✔ coalesces concurrent interactive resolutions (0.06975ms)
✔ ordering complete Steam session operations (0.76275ms)
▶ how a resolution reads in diagnostics
  ✔ separates a replayed token from a freshly acquired one (0.065959ms)
  ✔ still calls it acquired when only persisting the token failed (0.03225ms)
  ✔ calls a failed acquisition absent, not acquired (0.034042ms)
  ✔ reads an expired-then-replaced token as acquired (0.03025ms)
✔ how a resolution reads in diagnostics (0.213375ms)
▶ the client handing a token back
  ✔ refreshes the expiry of the token it already holds (0.088042ms)
  ✔ refuses an expiry that has already passed (0.087792ms)
  ✔ still accepts an expiry in the future (0.046916ms)
  ✔ never extends persistence beyond the OAuth lifetime (0.067792ms)
  ✔ keeps an expiry exactly at the maximum boundary (0.042083ms)
  ✔ rejects an expiry at the current instant (0.036959ms)
  ✔ refuses to turn a known expiry back into an unknown one (0.038583ms)
  ✔ accepts no-expiry-yet when none is known either way (0.038ms)
  ✔ ignores a storeback that is not the token it holds (0.056208ms)
  ✔ ignores a storeback when nothing is stored at all (0.045958ms)
  ✔ reports a refresh it could not write (0.064542ms)
  ✔ reports an unreadable store rather than overwriting it (0.048125ms)
✔ the client handing a token back (0.77225ms)
✔ tests/unit/team-apply-fixture.ts (688.251833ms)
✔ primary-mismatch facts carry exact professions (1.032291ms)
✔ a behaviour already set is not sent again (2.144125ms)
✔ heroes that are not in the team leave before the ones that are arrive (38.185292ms)
✔ a changed hero order rebuilds the roster in the saved order (0.52625ms)
✔ a roster rebuild adds nobody until each removal is confirmed (1.12ms)
✔ a concurrent roster addition cannot turn into a false Apply success (0.340791ms)
✔ Devona is removed through the current build's observed hero-id command (0.35725ms)
✔ applying outside an outpost is refused before anything is sent (0.372833ms)
✔ a party that stops publishing mid-apply stops the apply (0.222167ms)
✔ the count in a refusal is the work that landed, not the work attempted (1.195333ms)
✔ is dormant unless the renderer init payload asks for the trace (2.911625ms)
✔ captures the real template open, write, and close result without a path (0.805792ms)
✔ records an open errno and ignores unrelated filesystem traffic (0.246416ms)
✔ recognises the two template kinds and nothing else (10.899959ms)
✔ reads the file the game itself writes (1.640167ms)
✔ every import lands where the client will actually look (0.30525ms)
✔ a trailing newline does not change the file's meaning (0.086041ms)
✔ reads every form a shared build arrives in (0.208875ms)
✔ codes with no name are named after the file they came from (0.123042ms)
✔ text with no origin still names what it imports (0.091166ms)
✔ keeps a profession pair readable and refuses what the client refuses (0.252875ms)
✔ a name is never long enough to vanish from the client's listing (0.203709ms)
✔ one name has one spelling (0.162708ms)
✔ counts the names it had to adjust (0.202792ms)
✔ decodes a file however Windows wrote it (0.332875ms)
✔ a byte order mark never reaches the code (0.085333ms)
✔ lands the same templates wherever the player started the picker (0.093708ms)
✔ a picked path cannot name a folder outside the mount (1.330542ms)
✔ bounds one gesture rather than one file (4.205375ms)
✔ a Windows collection keeps its organisation in the only place the client shows (1.0625ms)
✔ writes the layout it reads (0.097417ms)
✔ an export round-trips through the importer unchanged (0.230125ms)
✔ counts what is saved, in whichever kinds exist (1.049541ms)
✔ says what an import would do before it does it (0.132916ms)
✔ explains a difference between what was picked and what will land (0.244875ms)
✔ a zero bucket contributes no clause (0.0635ms)
✔ a finished import names the in-game action that reveals it (0.10025ms)
✔ names the state the game offers no way out of (0.075125ms)
✔ a rescue reports what moved, what did not, and how to see it (0.116ms)
✔ an export says what it wrote, and a cancel says nothing at all (0.101916ms)
▶ template-save WASM compatibility transform
  ✔ routes the certified call site to the host behind a dirfd marker (2.80375ms)
  ✔ keeps the stub itself intact so uncertified callers are unaffected (0.423959ms)
  ✔ rejects input, stub, call-site, and derived-output drift (0.492875ms)
  ✔ never writes into the caller's input, Buffer or not (0.275917ms)
✔ template-save WASM compatibility transform (4.673666ms)
✔ passes ordinary stat calls through untouched (3.152458ms)
✔ creates the directory the client asks for, separator and all (2.556791ms)
✔ refuses to leave the mount (0.236875ms)
✔ collapses the client's doubled separator instead of rejecting it (0.169833ms)
✔ lists the files a wildcard matches, sorted, and hands over a block (0.538709ms)
✔ honours the wildcard instead of listing the whole directory (0.150125ms)
✔ leaves the list empty for a missing or unreadable directory (4.672125ms)
✔ stays silent unless the trace is explicitly requested (0.378291ms)
✔ hands back the client's internal template path (0.223709ms)
✔ keeps the last character the client's own trimmer would eat (0.174375ms)
✔ truncates a display name to the destination the client offered (0.085292ms)
✔ separates the file and directory requests by flag (0.194125ms)
✔ deletes a template and reports the outcome the caller expects (0.090667ms)
✔ answers whether a file exists without creating it (0.112625ms)
✔ accepts every path shape the client actually emits (2.180916ms)
▶ template-save re-certification
  ✔ builds a valid fixture module (9.368584ms)
  ✔ derives every target and call site past its decoys (20.216709ms)
  ✔ excludes the callers that must keep the original behaviour (1.442583ms)
  ✔ reads the delete stub's own assertion rather than guessing (139.757292ms)
  ✔ round-trips the derived entry through the production transform (1.970833ms)
  ✔ binds one production rewrite to its derived build and exact bytes (16.245ms)
  ✔ feeds certified and structurally-derived builds through identical rewrites (4.649125ms)
  ✔ fingerprints complete caller semantics, not only call offsets (38.848916ms)
  ✔ reports a build with no create-directory stub as not applicable (13.00725ms)
  ✔ keeps the negative fixtures valid, so the throw is the locator's (24.400042ms)
  ✔ refuses to guess when a predicate matches more than once (2.202208ms)
  ✔ fails loudly when a call site is not padded to the repointable width (0.625625ms)
✔ template-save re-certification (277.462042ms)
▶ adding a derived entry to the authoring table
  ✔ appends the formatted entry to the end of the real table (35.771833ms)
  ✔ refuses to restate a build somebody already certified (1.155625ms)
  ✔ refuses a source with no table to extend (0.162333ms)
✔ adding a derived entry to the authoring table (37.240875ms)
✔ reads both kinds and one level of subfolder (75.663792ms)
✔ ignores what the game would not list (0.170791ms)
✔ addresses an export the way an export folder is addressed (0.156917ms)
✔ replaces a profile projection with the canonical snapshot (0.442292ms)
✔ re-importing the same folder does nothing at all (0.199708ms)
✔ a name taken by a different build is refused, or replaced when asked (0.1195ms)
✔ two incoming templates cannot claim one name (0.358416ms)
✔ the game's own root limit is reached before a write, not during one (1.670375ms)
✔ writes what it planned and creates the folder it needs (0.256167ms)
✔ a template is only reported saved once the mount has been synchronised (0.1985ms)
✔ a second import cannot overlap the one already running (0.415459ms)
✔ a failed synchronisation does not strand the guard (0.1385ms)
✔ finds only the templates the game has no way to reach (0.126416ms)
✔ moves a stranded template up, keeping its folder in the name (0.413833ms)
✔ a rescue that would overwrite a different build leaves both alone (0.162834ms)
✔ a stranded copy of a build already at the top level is just removed (0.099417ms)
✔ a rescue cannot push the top level past the game's own limit (4.576333ms)
✔ a folder holding something else is left standing (2.986875ms)
✔ refuses any name that would not stay inside the two directories (0.113209ms)
▶ temporary exact-draft testing
  ✔ compares macOS bundle versions numerically (1.064125ms)
  ✔ accepts Stable, Beta, and RC but refuses Alpha (1.101166ms)
  ✔ requires GitHub prerelease metadata to match the tag (0.154334ms)
  ✔ refuses non-drafts and changed asset inventories (0.117833ms)
  ✔ launches, records Passed, and removes the temporary candidate (11.032709ms)
  ✔ removes complete downloads after a pre-launch checksum failure (6.631458ms)
  ✔ removes complete downloads after a pre-launch attestation failure (4.295833ms)
  ✔ removes complete downloads after a pre-launch signature failure (5.17475ms)
  ✔ removes complete downloads after a pre-launch launch failure (3.409209ms)
  ✔ creates no temporary download when GitHub authentication fails (40.20475ms)
  ✔ retains a launched candidate when it is still running (16.15775ms)
  ✔ retains a launched candidate when release-note recording fails (4.368125ms)
✔ temporary exact-draft testing (95.186083ms)
▶ LEB128 as the snapshots spell it
  ✔ decodes every non-canonical width of the same unsigned value (9.135292ms)
  ✔ round-trips signed values and refuses what will not fit (2.495708ms)
✔ LEB128 as the snapshots spell it (12.288458ms)
▶ the chunk format against generated input
  ✔ accepts exactly the digest shapes, and lower-cases what it accepts (1.780917ms)
  ✔ verifies a chunk against its own digest and no other (3.699ms)
  ✔ never yields a decoded chunk of a length the manifest did not declare (870.269875ms)
✔ the chunk format against generated input (876.150042ms)
▶ the patch manifest against generated input
  ✔ either refuses, or yields paths that may be joined onto a real directory (16.767042ms)
✔ the patch manifest against generated input (17.15425ms)
▶ the WebAssembly section walk against generated input
  ✔ re-encodes what it split, byte for byte (4.382583ms)
  ✔ round-trips index vectors and code bodies (2.853833ms)
  ✔ refuses a corrupted module as a structural fault, never as a surprise (181.401833ms)
✔ the WebAssembly section walk against generated input (188.997292ms)
✔ the independent TypeScript and Rust companion contracts match exactly (2.945125ms)
✔ same-size field swaps, bit drift, opcode drift, and new names are rejected (15.666584ms)
▶ scripts/copy-renderer.mjs only copies assets
  ✔ succeeds without a Rust toolchain (0.820708ms)
  ✔ still produces the renderer tree and its static media (0.48025ms)
  ✔ copies no code, because Rollup emits build/renderer's JavaScript (0.450584ms)
  ✔ copies only declared package inputs (0.761459ms)
  ✔ emits no WebAssembly (0.330417ms)
✔ scripts/copy-renderer.mjs only copies assets (3.500042ms)
▶ scripts/build.mjs is the one caller of rustc
  ✔ compiles the kernel exactly once per build (0.105083ms)
  ✔ writes only an unserved candidate (0.076875ms)
  ✔ publishes it through one immediate build-time sealing step (0.108875ms)
✔ scripts/build.mjs is the one caller of rustc (0.419708ms)
▶ scripts/build.mjs orders the producers of build/renderer
  ✔ copies the assets before the renderer is compiled into the same directory (0.0965ms)
  ✔ compiles and seals the kernel after both of them (0.106166ms)
✔ scripts/build.mjs orders the producers of build/renderer (0.278625ms)
▶ renderer typechecking does not emit runtime files
  ✔ leaves build/shared to the main compiler (0.092334ms)
  ✔ has one explicit renderer runtime producer (0.063625ms)
✔ renderer typechecking does not emit runtime files (0.211459ms)
✔ no second declaration of the ceiling exists (71.887542ms)
✔ the renderer's scheduler imports the module that declares it (0.33625ms)
✔ eight is what ArenaNet's shared infrastructure is owed (0.08425ms)
✔ the header's offset and size are not read backwards (1.187375ms)
✔ something that is not a Guild Wars archive is refused (0.307792ms)
✔ a file table without its magic is refused rather than parsed as slots (0.139875ms)
✔ a file id resolves through the index, not by being a slot number (0.222209ms)
✔ a file's streams are followed as a chain (0.129208ms)
✔ a chain that loops terminates instead of hanging on a 4 GB file (0.307667ms)
✔ an empty base slot carries no payload and is not a hit (0.097166ms)
✔ the table holds the 39 real heroes and neither sentinel (1.864375ms)
✔ HERO_BY_ID answers for every hero and for nothing else (0.102208ms)
✔ panel order is a permutation of the 39 places after the player's own (0.137583ms)
✔ no hero carries a profession or a display name, because the source has neither (0.133333ms)
✔ the eight mercenaries are the only heroes no campaign unlocks (0.120833ms)
✔ Razah is player-chosen too, and is the only non-mercenary that is (0.086917ms)
✔ the ten professions carry ids 1-10, and None is not one of them (0.115625ms)
✔ attribute ids skip the unnamed 26-28 gap and never spell the None sentinel (0.162041ms)
✔ every attribute names a profession the table defines (0.164167ms)
✔ a profession row states its wire id and its English name, and nothing else (0.152167ms)
✔ the cost table has one entry per rank and rises with every one (0.103375ms)
✔ the module exports nothing the source could not supply (0.060667ms)
▶ the memory warning counts time, not bytes
  ✔ warns an open-world session with the headroom it claims (2.218792ms)
  ✔ gives a texture-dense mission a real warning, not ninety seconds (1.413416ms)
  ✔ reads the rate that was actually spent, not the shape of the staircase (1.951416ms)
  ✔ puts the levels of a real crash where they belong (0.857709ms)
  ✔ does not read the cost of starting the game as the cost of playing it (0.6695ms)
  ✔ survives a first run whose download outlasts the warm-up (0.7315ms)
  ✔ starts measuring when the player starts playing, not when they log in (40.804166ms)
  ✔ does not let one map load latch a warning that cannot be taken back (0.48975ms)
  ✔ says nothing through an hour with only one growth step in it (0.80775ms)
  ✔ shows the span behind every rate it reports (0.702ms)
  ✔ falls back to bytes only while there is no rate to read (0.092958ms)
  ✔ keeps warning a stalled heap that is nearly full (0.08775ms)
  ✔ lets a rate go stale rather than believing it forever (32.117208ms)
  ✔ never lowers a warning it has already raised (0.1725ms)
  ✔ rounds the estimate without ever flattering it by much (0.513917ms)
  ✔ produces no NaN, no infinity and no negative minutes (0.103167ms)
✔ the memory warning counts time, not bytes (84.707ms)
✔ the exposed method invokes the channel the contracts name (4.342959ms)
✔ renaming a canonical channel moves the call, with no edit to the body (1.061708ms)
✔ the derived client's bridge markers cross unchanged, and follow an edit (1.464667ms)
✔ the launch argument prefix comes from the contracts too (1.42575ms)
✔ every canonical Enhancement tool crosses without another field list (1.961583ms)
✔ a contracts export the body needs but does not have fails the build (0.290042ms)
✔ the whole table is read, from record zero (2.039542ms)
✔ energy-cost sentinels are normalized at the parsing boundary (0.088916ms)
✔ the table is found even when the scan lands in the middle of it (0.592166ms)
✔ each weak field of the signature rejects its own near miss (0.408083ms)
✔ ids that do not ascend end the run (0.124208ms)
✔ a binary with no table says so instead of guessing (1.3815ms)
✔ availability separates what a player may actually equip (0.137667ms)
✔ a decoded icon becomes a bottom-up BMP without swapping its channels (1.355ms)
✔ an icon the decoder could not have produced is refused (0.344541ms)
✔ a decompressed shard is unwrapped only when its length agrees (0.265209ms)
✔ a selected target shows its distance and its range band (4.364292ms)
✔ every band the snapshot can carry has a name to show (0.544292ms)
✔ nothing is shown until the snapshot says a target is selected (0.192041ms)
✔ dropping the target hides the readout again (0.122375ms)
✔ an unchanged target costs no DOM write, however many frames pass (1.670709ms)
✔ a state missing the fields it claims renders nothing (0.211708ms)
✔ the readout takes the page back with it (0.124625ms)
✔ the overlay never takes a click and is never announced (0.138916ms)
✔ the store writes to the directories the mount creates (5.153167ms)
✔ the store addresses the mount absolutely (0.193125ms)
✔ no component decides a colour for itself (4.832084ms)
✔ no component decides a corner for itself (1.914375ms)
✔ no consumer invents a stacking order (0.947875ms)
✔ style projections stay in tokens and consumers do not branch (0.540125ms)
✔ persistent interaction states do not leak into neutral controls (127.763125ms)
✔ shared interaction feedback owns disabled, active, and error presentation (31.886833ms)
✔ every token a stylesheet uses is actually declared (15.273542ms)
✔ every token declared is actually read (1.598833ms)
✔ no token reference carries a leftover alpha suffix (0.491209ms)
✔ the measured Guild Wars radii are fixed in the token source (0.329834ms)
✔ a not-yet-tokenised surface is still not tokenised (0.203584ms)
▶ Chromium stall attribution
  ✔ joins long frame marks, snapshot boundaries, CPU stacks, and renderer tasks (2.246375ms)
  ✔ reports captures without new frame marks and rejects invalid thresholds (0.260583ms)
✔ Chromium stall attribution (3.107334ms)
▶ Chromium trace scanner
  ✔ redacts an absolute path that is the entire value (1.503292ms)
  ✔ redacts a file: URL (0.083875ms)
  ✔ redacts a multiline stack trace (0.063959ms)
  ✔ redacts account and username identifiers in free text (0.057375ms)
  ✔ redacts the JSON spelling a trace actually uses (0.060833ms)
  ✔ redacts a sensitive value containing an escaped quote (0.068167ms)
  ✔ redacts punctuation in a sensitive key and commas and escapes in its value (0.051041ms)
  ✔ redacts a query string carrying credentials (0.063541ms)
  ✔ redacts an OAuth token in a redirect fragment (0.072666ms)
  ✔ redacts an OAuth token in a redirect query (0.114833ms)
  ✔ redacts a bearer token (0.074666ms)
  ✔ redacts an email address (0.048459ms)
  ✔ redacts unicode and right-to-left text around a path (0.413666ms)
  ✔ redacts the user's home directory (0.046542ms)
  ✔ redacts a path under the exporting user's own home directory (0.054875ms)
  ✔ keeps the trace parseable as JSON (0.089833ms)
  ✔ keeps a value with an escaped quote in it parseable (0.074125ms)
  ✔ fully redacts a sensitive quoted value containing commas and escapes (0.073333ms)
  ✔ redacts a value that straddles a streaming chunk boundary (151.661ms)
  ✔ gives the same answer at every split point, for every corpus case (153.730333ms)
  ✔ fails closed when commas inside a JSON string cannot bound the carry (1145.98825ms)
  ✔ streams a large trace when structural commas keep the carry bounded (1037.09925ms)
✔ Chromium trace scanner (2492.782709ms)
▶ trade chat contracts
  ✔ accepts numeric and numeric-string timestamps plus replacements (1.757917ms)
  ✔ bounds, validates, deduplicates and orders search results (0.211583ms)
  ✔ rejects malformed payloads and invalid searches (0.236708ms)
  ✔ validates bounded saved offers and players without accepting duplicates (0.210208ms)
  ✔ normalizes bounded trader quotes and price history (0.318583ms)
  ✔ persists saved trade state in one private atomic document (81.6705ms)
✔ trade chat contracts (85.270791ms)
▶ trade chat service
  ✔ fetches and caches current quotes while requesting exact history ranges (218.541792ms)
  ✔ coalesces in-flight history and caches nearby ranges by minute (27.546667ms)
  ✔ classifies an upstream history rate limit without throwing (20.064583ms)
  ✔ rejects oversized trader history while the body is still streaming (1.017375ms)
  ✔ shares one connection and coalesces semantic offer and player searches (1.213167ms)
  ✔ bounds live history, applies replacements, and stops after the last subscriber (2.755291ms)
  ✔ times out unanswered searches and reconnects while subscribed (22.746333ms)
✔ trade chat service (338.254625ms)
▶ Travel history
  ✔ keeps ten unique reviewed destinations in most-recent order (1.780208ms)
  ✔ persists histories independently per character across store instances (253.396583ms)
  ✔ quarantines an unreadable document instead of sharing invented history (4.621542ms)
✔ Travel history (260.665459ms)
▶ Travel preferences
  ✔ preserves corrupt bytes before returning defaults and reports the backup (66.532875ms)
  ✔ stores the Travel-only document without adding Stable-owned settings keys (113.796292ms)
  ✔ projects the released shape and clears withdrawn history on first load (61.927125ms)
  ✔ rejects ambiguous synonyms and unknown document fields (8.713417ms)
✔ Travel preferences (282.503041ms)
▶ Travel
  ✔ contains the complete reviewed direct-travel catalogue (2.809542ms)
  ✔ ranks exact aliases and useful partial names first (7.892542ms)
  ✔ bounds search work before normalization or scoring (2.460958ms)
  ✔ keeps the numbered shortcut list bounded and typed (0.18ms)
  ✔ keeps Stable-readable shortcut fields on disk while runtime stays map-only (14.15825ms)
  ✔ resolves only catalogue map ids (0.132291ms)
  ✔ rejects one request that would write both preference files (0.725916ms)
✔ Travel (30.734958ms)
▶ custom UI theme contract
  ✔ has the durable v1 defaults (5.234916ms)
  ✔ restores one canonical palette for each material (0.122291ms)
  ✔ strictly parses and normalises six-digit colours (0.15975ms)
  ✔ normalises only the complete semantic theme shape (0.183125ms)
  ✔ round trips the versioned share format and rejects malformed input (2.986667ms)
✔ custom UI theme contract (9.559542ms)
▶ update action
  ✔ formats persisted check times without claiming a future time (1.030791ms)
  ✔ gates a launch on exactly the in-flight and ready updater states (0.114416ms)
  ✔ rehydrates and follows the one main-process state (2.277292ms)
  ✔ makes a downgrade a truthful manual Stable return (0.298292ms)
  ✔ renders closed failure reasons and never says up to date (0.136208ms)
✔ update action (4.538042ms)
▶ static update feed publication
  ✔ selects the highest eligible release independently for each channel (1.262291ms)
  ✔ lets a newer Stable lead both channels and downloads its manifest once (460.644125ms)
  ✔ publishes distinct Stable and Beta manifests when Beta is ahead (0.54025ms)
  ✔ refuses duplicate versions, inconsistent metadata, and missing assets (0.490791ms)
  ✔ refuses unreadable, missing-channel, unavailable, and inconsistent input (0.415166ms)
  ✔ allows an unchanged or advancing pair and refuses either rollback (0.293625ms)
  ✔ allows absent published feeds only during explicit bootstrap (0.619583ms)
  ✔ refuses a partial published pair even during bootstrap (0.486083ms)
  ✔ cache-busts both published feeds and disables fetch caching (0.392416ms)
✔ static update feed publication (465.9275ms)
▶ development virtual gamepad
  ✔ starts disconnected, preserves physical pads, and restores Navigator (8.685542ms)
  ✔ supports the standard face buttons and a right-stick activation pulse (0.348625ms)
✔ development virtual gamepad (14.278833ms)
▶ wasm abort reasons collapse into the closed vocabulary
  ✔ names the failure class of each known Emscripten abort shape (0.898417ms)
  ✔ classifies an Error by its name and message (2.804833ms)
  ✔ never invents a kind outside the declared union (0.144167ms)
✔ wasm abort reasons collapse into the closed vocabulary (4.502833ms)
▶ wasm abort fingerprints
  ✔ always satisfy the boundary validator, whatever the reason was (0.868625ms)
  ✔ cluster identical causes and separate different ones (0.093416ms)
✔ wasm abort fingerprints (1.044334ms)
▶ the recorded abort event
  ✔ is an error-level renderer event carrying kind, fingerprint, and heap (0.927209ms)
✔ the recorded abort event (1.003959ms)
▶ the recorded heap staircase
  ✔ records whether heap-growth observation is active (0.119292ms)
  ✔ is an info-level renderer event carrying both sides of a growth step (0.06975ms)
  ✔ records the growth trigger as a separate closed event (0.138ms)
✔ the recorded heap staircase (0.433042ms)
▶ the recorded visual problem
  ✔ contains only bounded graphics and texture state (0.1805ms)
  ✔ preserves unavailable WebGL and program probes at the IPC boundary (0.497625ms)
✔ the recorded visual problem (0.731875ms)
▶ the relog pre-game probe
  ✔ preserves the complete uint32 diagnostic mask (0.123875ms)
✔ the relog pre-game probe (0.160291ms)
▶ wasm binary codec
  ✔ round-trips unsigned LEB128 (14.7535ms)
  ✔ round-trips signed LEB128, including the client's dirfd markers (0.156166ms)
  ✔ emits fixed-width indices and refuses ones that do not fit (0.1305ms)
  ✔ refuses an oversized LEB rather than truncating it (0.095708ms)
  ✔ round-trips sections (0.221834ms)
  ✔ round-trips code bodies and index vectors (13.509208ms)
  ✔ parses function types by resolved signature (0.46825ms)
  ✔ counts and names function imports, skipping the other kinds (5.690917ms)
✔ wasm binary codec (50.020625ms)
▶ WASM growth provenance
  ✔ can retain heap evidence without intercepting GL calls (1.485958ms)
  ✔ keeps only the first four numeric WASM frames (47.021ms)
  ✔ records the request, result, call stack, and current texture state (14.793958ms)
  ✔ distinguishes a refused resize from one that throws (0.373584ms)
  ✔ preserves the allocator contract when observation itself fails (0.148375ms)
  ✔ does not alter imports when the shipped client lacks the resize boundary (0.095792ms)
  ✔ stops retaining texture identities at the documented bound (27.572959ms)
  ✔ drops dead-context residency before texture ids can be reused (0.271042ms)
✔ WASM growth provenance (130.882875ms)
▶ texture storage estimates
  ✔ covers direct and block-compressed formats without guessing unknown ones (16.139791ms)
✔ texture storage estimates (16.266292ms)
▶ window registry
  ✔ resolves immutable context from the native sender id (1.912834ms)
  ✔ retains one process-local account owner across renderer replacement (0.172709ms)
  ✔ attributes a renderer process only to its exact account owner (0.115375ms)
  ✔ refuses to assign a renderer process shared by different owners (0.071917ms)
  ✔ enforces one live game window for a profile (0.261583ms)
  ✔ unregisters only the exact native window (0.090125ms)
  ✔ unregisters after Electron has made webContents unreadable (0.118791ms)
  ✔ does not return destroyed windows (0.133708ms)
  ✔ owns the one Single game window and the one Multiple Accounts Hub (0.123042ms)
  ✔ resolves only registered senders and the focused game (0.1875ms)
  ✔ refuses an ambiguous game selection (0.088541ms)
✔ window registry (4.070416ms)
▶ window shortcut input
  ✔ runs one Command action, preserves Control, and contains capture repeats (9.664792ms)
✔ window shortcut input (10.234125ms)
▶ window state
  ✔ validates and round-trips owner-only state (27.478291ms)
  ✔ restores an alpha window written without a format version (27.689542ms)
  ✔ discards a window-state format this build cannot read (87.951792ms)
  ✔ removes corrupt state and falls back cleanly (16.98075ms)
  ✔ keeps visible windows on their display and clamps oversized bounds (0.20725ms)
  ✔ centers state on the primary display when its monitor disappeared (0.124375ms)
  ✔ keeps the default window distinct from a constrained work area (0.063166ms)
  ✔ restores relative geometry on an unchanged work area (0.07775ms)
  ✔ restores relative geometry on a larger work area (0.064084ms)
  ✔ restores relative geometry on a smaller work area constrained by minimum window size (0.099042ms)
  ✔ restores relative geometry on a missing display (1.268958ms)
  ✔ restores relative geometry on the matching display in a multi-display layout (0.092083ms)
  ✔ cascades new account windows by 32px and clamps them (0.152334ms)
✔ window state (163.257167ms)
ℹ tests 1323
ℹ suites 154
ℹ pass 1323
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 35182.950541
✔ every workflow action is pinned to a full commit SHA (7.08925ms)
✔ the pinning scan rejects a floating tag (0.177583ms)
✔ the PlayStation prompt atlas is the reviewed 256×512 CC0 composition (34.257875ms)
✔ the controller prompt lifecycle resets on WebGL context replacement (2.402541ms)
✔ each channel has an exact minimal and isolated entitlement file (3.452041ms)
✔ bug and feature intake stays short, structured, and issue-backed (2.384541ms)
✔ public bug and feature links name issue templates that exist (2.98025ms)
✔ the bundled fonts are pinned and carry their OFL licenses (26.029709ms)
✔ no downloaded game artifacts or generated output are tracked (3.282792ms)
✔ no tracked symlink resolves outside the repository (45.146166ms)
✔ the application does not collect process-memory crash dumps (4.538667ms)
✔ no second production runtime remains (0.146084ms)
✔ no private key material is tracked (1130.024666ms)
✔ only public identifiers and explicit profile-id fixtures are UUID-shaped (2879.670125ms)
✔ release fuses keep Node, inspection and file-protocol privileges disabled (2.601958ms)
✔ no fuse is left to its default (1.036666ms)
✔ lint rejects: src/main/core imports electron (5071.021792ms)
✔ lint rejects: src/main/core type-imports electron (40.083625ms)
✔ lint rejects: src/main/core dynamically imports electron (6.798916ms)
✔ lint rejects: src/main/core imports a submodule of electron (5.345625ms)
✔ lint rejects: src/main/core requires electron through createRequire (4.705625ms)
✔ lint rejects: src/main/core requires electron through an aliased createRequire binding (24.441791ms)
✔ lint rejects: src/main/core dynamically imports electron, spelled with a template literal (2.930125ms)
✔ lint rejects: src/main/core imports upward from src/main (2.447041ms)
✔ lint rejects: src/main/core imports upward from src/main, spelled through src/main (2.925167ms)
✔ lint rejects: src/main/core imports upward from src/main, spelled from the repository root (2.686334ms)
✔ lint rejects: a subdirectory of src/main/core imports upward from src/main (13.63975ms)
✔ lint rejects: src/main/core imports upward through a subdirectory of src/main (1.558459ms)
✔ lint rejects: src/main/core dynamically imports upward from src/main (1.441833ms)
✔ lint rejects: src/main/core dynamically imports upward through a subdirectory of src/main (2.538416ms)
✔ lint rejects: src/main/core dynamically imports upward, spelled through src/main (1.54ms)
✔ lint rejects: src/main/core dynamically imports upward, spelled with a template literal (1.219083ms)
✔ lint rejects: src/main/core requires upward through createRequire (1.688917ms)
✔ lint rejects: src/main/core imports one level up into a sibling of src/main/core named shared (1.752583ms)
✔ lint rejects: src/main/certification imports electron (19.235875ms)
✔ lint rejects: src/main/certification dynamically imports electron (1.729083ms)
✔ lint rejects: src/main/certification imports upward from src/main (1.966083ms)
✔ lint rejects: src/main/certification imports upward from src/main, spelled through src/main (1.388083ms)
✔ lint rejects: src/main/certification imports upward from src/main, spelled from the repository root (28.562041ms)
✔ lint rejects: src/main/certification dynamically imports upward from src/main (3.584625ms)
✔ lint rejects: src/main/certification dynamically imports upward, spelled with a template literal (2.944791ms)
✔ lint rejects: src/main/certification imports one level up into a sibling of src/main/certification named shared (2.21925ms)
✔ lint rejects: src/main/certification imports the exempt verifier host (1.658042ms)
✔ lint rejects: src/main/certification imports the exempt enhancement policy (1.575ms)
✔ lint rejects: src/main/certification dynamically imports the exempt enhancement policy (1.532916ms)
✔ lint rejects: src/renderer imports src/main (36.796917ms)
✔ lint rejects: a subdirectory of src/renderer imports src/main (14.541084ms)
✔ lint rejects: a src/renderer TypeScript declaration imports src/main (5.616083ms)
✔ lint rejects: a src/renderer module imports src/main (3.617625ms)
✔ lint rejects: src/renderer dynamically imports src/main (2.258375ms)
✔ lint rejects: src/renderer dynamically imports src/main, spelled with a template literal (1.628791ms)
✔ lint rejects: src/renderer requires src/main through createRequire (1.731083ms)
✔ lint rejects: an apps/website .vue SFC imports src/main (53.497375ms)
✔ lint rejects: an apps/website .vue SFC dynamically imports src/renderer (6.929ms)
✔ lint rejects: apps/website imports src/main (17.859541ms)
✔ lint rejects: apps/website dynamically imports src/main (2.926625ms)
✔ lint rejects: apps/website dynamically imports src/main, spelled with a template literal (4.829084ms)
✔ lint rejects: apps/website requires src/main through createRequire (3.380041ms)
✔ lint rejects: apps/website imports developer tooling under src/tools (1.504625ms)
✔ lint rejects: an apps/website .vue SFC imports developer tooling under src/tools (3.746083ms)
✔ lint allows: src/main/core imports src/shared (2.290167ms)
✔ lint allows: src/main/core imports a sibling (1.358833ms)
✔ lint allows: src/main/core dynamically imports a sibling (1.110042ms)
✔ lint allows: a subdirectory of src/main/core imports src/shared (1.098541ms)
✔ lint allows: src/main/core requires a node builtin through createRequire (1.194084ms)
✔ lint allows: src/main imports electron (15.94125ms)
✔ lint allows: the certification host imports electron (1.930583ms)
✔ lint allows: src/main/certification imports the codec that stayed in src/main/core (1.321ms)
✔ lint allows: src/main/certification imports src/shared (1.41575ms)
✔ lint allows: src/main/certification imports a sibling that is not an Electron caller (1.251666ms)
✔ lint allows: src/renderer imports src/shared (1.468709ms)
✔ lint allows: an apps/website .vue SFC imports src/shared (6.027792ms)
✔ lint allows: apps/website imports src/shared (2.266167ms)
✔ the .vue sources this boundary covers still exist (45.650917ms)
✔ ESLint covers the packaging config and every website source (4720.192125ms)
✔ every website .vue source is linted, not just the one named above (104.437958ms)
✔ ESLint still skips derived output and developer-only tooling (42.675958ms)
✔ main-process runtime imports are acyclic (2102.156125ms)
✔ the graph check distinguishes runtime cycles from erased type edges (128.700417ms)
✔ a link to NOPE.md in README.md exits non-zero and names the line (1029.014041ms)
✔ a repository whose links all resolve exits zero and says nothing (1371.598875ms)
✔ targets are resolved relative to the file that contains them (36.208375ms)
✔ percent-encoded, titled and fragment-suffixed targets resolve to the real path (52.170541ms)
✔ an unbracketed destination containing a space is not a link (0.156584ms)
✔ link syntaxes that carry a target are all extracted (0.222ms)
✔ a badge link reports the outer destination, not only the image it wraps (29.770042ms)
✔ a tracked file deleted from the working tree is skipped, not fatal (1410.622167ms)
✔ an existing target outside the repository is broken (134.843625ms)
✔ an ignored target is broken even while it exists locally (116.309458ms)
✔ a repository directory target has at least one durable child (102.651792ms)
✔ code blocks, code spans, URLs and bare anchors are not treated as links (0.349333ms)
✔ the file list covers tracked docs and excludes gitignored scratch (34.479041ms)
✔ the bundled application icon carries every representation macOS renders (2.1395ms)
✔ release workflow stages and publishes one tested, attested package version (12.648ms)
✔ cooldown presentation has no gameplay input or command dependency (13.186375ms)
▶ the macOS input policy
  ✔ has no selectable or persisted touch mode (845.730916ms)
  ✔ sets the bundle-specific repeat preference before the first window (1.641125ms)
✔ the macOS input policy (848.1465ms)
✔ IPC still refuses a sender that is not the main frame at the canonical URL (1.105042ms)
✔ production resolves native windows only through the window registry (40.775542ms)
✔ runtime error dialogs keep their owning game window (0.346ms)
✔ the proxy still answers only fetches (0.102625ms)
✔ the proxy response still crosses the canonical header boundary (0.168375ms)
✔ every source module opens with a block doc comment (61.806292ms)
✔ every KNOWN_UNHEADERED entry still names a file that still lacks one (0.123958ms)
✔ the native boundary uses only ABI-stable Node-API (1.076541ms)
✔ Command-held releases use one app-local macOS monitor (0.136459ms)
✔ the native host does not own the app key-repeat preference (0.101542ms)
✔ the native boundary owns two fixed Data Protection Keychain items (1.137042ms)
✔ the canonical build emits one host-only Node-API 8 addon (0.2435ms)
✔ Forge unpacks only the two executables from ASAR (0.194208ms)
✔ the hand-written preload body contains no channel literal (119.796416ms)
✔ the body declares nothing the generator is meant to supply (630.742083ms)
✔ macOS identity uses the Reforged name and configured application icon (1.529208ms)
✔ the public rename keeps the existing profile as its one data home (0.208417ms)
✔ package metadata identifies the GPL project and canonical repository (0.149292ms)
✔ packaged releases carry the project and third-party license notices (0.627916ms)
✔ the packaged bundle takes its version numbers from the package version (0.179792ms)
✔ the host has one native automatic application replacement path (1.427417ms)
✔ distribution channels use preflighted signing and a scoped marker (1.204208ms)
✔ release entitlements are an exact three-key allowlist (0.291708ms)
✔ the Stable rollback proof establishes its write generation before saving (0.198041ms)
✔ application verification routes conservatively through one required result (1.568084ms)
✔ developer builds are exact, ad-hoc, bounded, and isolated from releases (1.353041ms)
✔ runtime package entries and audit exceptions stay explicit (1.169375ms)
✔ packaging cleans its output first, and builds the renderer runtime (0.481625ms)
✔ the default gate is deterministic and certifies every shipped test layer (0.437334ms)
✔ release verification tells the player to check, never to disable a check (0.163333ms)
✔ the maintainer tests a temporary exact draft without replacing Applications (0.294125ms)
✔ the required application gate owns website certification (352.232667ms)
✔ Vercel Previews are explicit, exact-head, and collaborator-only (0.376917ms)
✔ client recertification reports evidence but cannot grant authority (1.303125ms)
✔ the scheduled canary exercises the latest ArenaNet client conservatively (0.159708ms)
✔ saved login has exactly two Data Protection Keychain items (405.03425ms)
✔ only provisioned distribution channels enable persistent secrets (1.210666ms)
✔ no build seeds the Steam token from the environment (23.541ms)
✔ Settings exposes two built-ins and one semantic custom theme (64.811208ms)
✔ Settings exposes the independent interface fonts (1.330292ms)
✔ Settings exposes the two controller prompt styles (66.205667ms)
✔ panel opacity uses the canonical bounds (48.781167ms)
✔ Tools features consume Reka behavior through the shared Vue UI layer (103.069333ms)
✔ feature styles cannot reintroduce the retired selection recipes (7.47125ms)
✔ shared motion transitions only transform or opacity (1.83275ms)
✔ the single-weight Guild Wars face is never synthetically emboldened (0.389625ms)
✔ the scripts index.html loads with a plain tag emit no ES module (146.062208ms)
✔ the official gamepad imports stay wired without a production WASM hook (4.242375ms)
✔ persistent game files are prepared through supported Emscripten startup hooks (3.808417ms)
✔ production diagnostics do not patch Web Audio prototypes (7.126792ms)
✔ the live harness persists no raw addresses or Toolbox screenshots (13.917708ms)
✔ stall attribution markers are fixed-name and Level 2 only (4.599042ms)
✔ template file tracing is explicit, bounded, and attached only at the import boundary (3.619792ms)
✔ the GL program cache memoizes only shader-completion state, and only once it is true (4.181708ms)
✔ template saving uses one exact-build derived WASM and a restricted mkdir bridge (1.923042ms)
✔ a new client build can be re-certified without hand-derivation (5.841125ms)
✔ Enhancement re-certification inspects only post-template bytes (0.787416ms)
✔ only strict feature locators may turn structural evidence into launch authority (5.578125ms)
✔ native double-click and 4 GB use bounded local proof as sole runtime authority (5.539167ms)
✔ the WASM section codec has exactly one home (4.422334ms)
✔ the served module decides whether Enhancement imports (1.507833ms)
✔ a completed client main loop closes the host application (5.019ms)
✔ the memory warning measures time and keeps its one contract import (1.959333ms)
✔ the memory warning measures a staircase step to step (0.760584ms)
▶ the benchmark measures each arm in both orders
  ✔ mirrors the arms so every arm sits at the same mean position (1.862375ms)
  ✔ recognises a biased order for what it is (0.107958ms)
  ✔ warms every phase the same way and records the order it ran (0.887417ms)
  ✔ reports no regression for a drift the old order would have blamed on the Enhancement (0.397417ms)
  ✔ still reports a real cost the arm actually has (0.260958ms)
  ✔ refuses a phase that measured nothing (0.167958ms)
  ✔ averages an arm's phases instead of pooling their samples (0.222042ms)
✔ the benchmark measures each arm in both orders (4.603ms)
▶ the performance acceptance gate reads the record the benchmark writes
  ✔ accepts the record a mirrored run produces (0.368833ms)
  ✔ refuses a run that measured each arm once (40.216416ms)
  ✔ refuses a record whose arms it cannot find (0.193291ms)
  ✔ keeps every budget the two-phase gate held (0.918708ms)
✔ the performance acceptance gate reads the record the benchmark writes (41.850833ms)
✔ rust-toolchain.toml pins the channel, its components, and the wasm target (1.578875ms)
✔ every script name is a literal the build scan can match (0.224542ms)
✔ every workflow that compiles the kernel installs the pinned toolchain first (64.244875ms)
✔ the toolchain scan rejects a build on the runner's own toolchain (12.420834ms)
✔ the Node floor is declared once and enforced before anything is built (12.356833ms)
✔ every workflow pins a Node version the floor accepts (42.430875ms)
✔ every source file the repository owns is an input to a tsconfig project (3.630209ms)
✔ every KNOWN_UNCHECKED entry still names a file that is still unchecked (0.100625ms)
✔ no hand-written declaration shadows the implementation it describes (0.415834ms)
ℹ tests 181
ℹ suites 3
ℹ pass 181
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 8650.843

 RUN  v4.1.10 /Users/matthias/Git/games/guild-wars-mac/gwonmac-travel-party-close/apps/tools


 Test Files  16 passed (16)
      Tests  120 passed (120)
   Start at  14:58:07
   Duration  11.83s (transform 19.16s, setup 0ms, import 30.47s, tests 15.16s, environment 20.54s)\n- [x] copied renderer -> /Users/matthias/Git/games/guild-wars-mac/gwonmac-travel-party-close/build/renderer
vite v8.1.5 building client environment for embedded...
[2Ktransforming...✓ 834 modules transformed.
rendering chunks...
computing gzip size...
../../build/renderer/tools/tools-app.css   73.05 kB │ gzip:  12.62 kB
../../build/renderer/tools/tools-app.js   988.38 kB │ gzip: 459.27 kB

✓ built in 451ms
generated preload -> build/preload/preload.cjs
sealed companion kernel artifact and loader hash\n- [x] Companion kernel integration tests: 27 passed\n- [x] Kept this pull request focused\n- [x] Added no game binaries, credentials, diagnostics, or private traffic