### PR TITLE
fix(travel): preserve the first recent location

### DIFF
--- a/apps/tools/src/travel-history-observation.ts
+++ b/apps/tools/src/travel-history-observation.ts
@@ -82,6 +82,9 @@ export function createTravelHistoryObservation(
 
   return Object.freeze({
     history,
+    record(next: Observation): void {
+      void synchronize(next).catch((error: unknown) => reportFailure(next, error));
+    },
     load(): Promise<TravelHistory> {
       const current = observation(state.value);
       if (current === null) return Promise.resolve(EMPTY_TRAVEL_HISTORY);

--- a/apps/tools/src/travel-host.test.ts
+++ b/apps/tools/src/travel-host.test.ts
@@ -135,6 +135,28 @@ describe("native Travel host", () => {
     expect(getHistory).not.toHaveBeenCalled();
   });
 
+  it("records the unidentified starting map after the first confirmed travel", async () => {
+    const { host, recordHistory } = fixture();
+    const characterKey = travelCharacterKey("0123456789abcdef");
+    const unlockedMapWords = Array.from({ length: 28 }, () => 0xffff_ffff);
+    host.updateGameState({
+      status: "ready", mapId: 55, characterKey: null, unlockedMapWords,
+    });
+
+    await host.travel({ mapId: 449 });
+    host.updateGameState({ status: "waiting", reason: "loading" });
+    host.updateGameState({
+      status: "ready", mapId: 449, characterKey, unlockedMapWords,
+    });
+
+    await vi.waitFor(() => expect(recordHistory).toHaveBeenCalledTimes(2));
+    expect(recordHistory.mock.calls.map(([value]) => value)).toEqual([
+      { characterKey, mapId: 55 },
+      { characterKey, mapId: 449 },
+    ]);
+    expect(host.history.value).toEqual([449, 55]);
+  });
+
   it("switches histories when characters share the same map and hides unidentified history", async () => {
     const { host, recordHistory } = fixture();
     const characterA = travelCharacterKey("0123456789abcdef");

--- a/apps/tools/src/travel-host.ts
+++ b/apps/tools/src/travel-host.ts
@@ -64,9 +64,11 @@ export function createNativeTravelHost(
     development,
   );
   let attemptTimer = 0;
+  let unidentifiedOriginMapId: number | null = null;
   const clearAttempt = () => {
     window.clearTimeout(attemptTimer);
     attemptTimer = 0;
+    unidentifiedOriginMapId = null;
     attempt.value = { status: "idle" };
   };
   let currentPreferences: TravelPreferences | null = null;
@@ -92,6 +94,10 @@ export function createNativeTravelHost(
     loadHistory: historyObservation.load,
     async travel(request) {
       if (attempt.value.status !== "idle") return;
+      unidentifiedOriginMapId = state.value.status === "ready"
+        && state.value.characterKey === null
+        ? state.value.mapId
+        : null;
       attempt.value = { status: "queued", mapId: request.mapId };
       notice.value = {
         message: `Travelling to ${travelDestination(request.mapId)?.name ?? "destination"}…`,
@@ -127,8 +133,18 @@ export function createNativeTravelHost(
     },
     updateGameState(next) {
       state.value = next;
-      historyObservation.update(next);
       const current = attempt.value;
+      if (current.status === "loading"
+        && next.status === "ready"
+        && next.mapId === current.mapId
+        && next.characterKey !== null
+        && unidentifiedOriginMapId !== null) {
+        historyObservation.record({
+          characterKey: next.characterKey,
+          mapId: unidentifiedOriginMapId,
+        });
+      }
+      historyObservation.update(next);
       if (current.status === "idle") return;
       if (next.status === "waiting" && next.reason === "loading") {
         window.clearTimeout(attemptTimer);


### PR DESCRIPTION
## What changed\n\nThe first location after spawning was missing from Recent because it could be observed before the character key was available. A GWonMac travel attempt now carries that unidentified starting map until the exact requested arrival is confirmed with a character key, then records the origin before the destination.\n\n## Why\n\nThis preserves the initial outpost without weakening per-character history isolation. An ordinary loading screen or character switch cannot attribute an unidentified map to another character.\n\n## Invariant\n\nOnly a named Travel command followed by its exact confirmed destination may attach an unidentified origin to the arriving certified character key.\n\n## Verification\n\n- [x] Scope: all 3 workspace projects
✓ Lockfile passes supply-chain policies (verified 20h ago)
Lockfile is up to date, resolution step is skipped
Progress: resolved 1, reused 0, downloaded 0, added 0
Packages: +1374
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Progress: resolved 1374, reused 1355, downloaded 0, added 90
Progress: resolved 1374, reused 1355, downloaded 0, added 270
Progress: resolved 1374, reused 1355, downloaded 0, added 381
Progress: resolved 1374, reused 1355, downloaded 0, added 485
Progress: resolved 1374, reused 1355, downloaded 0, added 549
Progress: resolved 1374, reused 1355, downloaded 0, added 645
Progress: resolved 1374, reused 1355, downloaded 0, added 754
Progress: resolved 1374, reused 1355, downloaded 0, added 867
Progress: resolved 1374, reused 1355, downloaded 0, added 924
Progress: resolved 1374, reused 1355, downloaded 0, added 1016
Progress: resolved 1374, reused 1355, downloaded 0, added 1088
Progress: resolved 1374, reused 1355, downloaded 0, added 1185
Progress: resolved 1374, reused 1355, downloaded 0, added 1303
Progress: resolved 1374, reused 1355, downloaded 0, added 1373, done
.../node_modules/vue-demi postinstall$ node -e "try{require('./scripts/postinstall.js')}catch(e){}"
.../node_modules/vue-demi postinstall: Done

. postinstall$ install-electron
apps/website prepare$ vp exec nuxt prepare
. postinstall: Done
apps/website prepare: ℹ Nuxt Icon server bundle mode is set to local
apps/website prepare: [nuxt:icon] ✔ Nuxt Icon loaded local collection lucide with 1817 icons
apps/website prepare: [nuxt:icon] ✔ Nuxt Icon loaded local collection circle-flags with 2 icons
apps/website prepare: [nuxt:icon] ✔ Nuxt Icon loaded local collection logos with 7 icons
apps/website prepare: ℹ Nuxt Icon client bundle consist of 96 icons with 38.17KB(uncompressed) in size
apps/website prepare: │
apps/website prepare: ◆  Types generated in .nuxt.
apps/website prepare: Done
Done in 19.4s using pnpm v11.13.1
✔ two builds with the same content are zero apart, however they were written (1.83775ms)
✔ a single skill change is reported as a named swap, not as a slot number (3.082625ms)
✔ the summary's verb agrees with what differs, at none, one and two (0.215875ms)
✔ a build that only re-spends its attributes still reports a difference (0.135916ms)
✔ a profession change is one difference and carries both pairs (0.087292ms)
✔ nearestBuild answers with the closest build inside its ceiling, or with nothing (0.196334ms)
✔ nearestBuild never matches a build against itself, nor across primary professions (0.092417ms)
✔ droppedByTeam names the working heroes a team has no place for, once each (0.240209ms)
✔ a stored record short of eight slots is compared rather than thrown over (0.115375ms)
✔ a bar is eight slots, and a ninth cannot be written (22.700875ms)
✔ the slot list every module iterates is as long as the bar it walks (41.328ms)
✔ a team slot references a build and cannot carry one (0.173458ms)
✔ an attribute rank outside what a character can invest is unspellable (0.098583ms)
✔ variantsOf returns direct children, and nothing else (0.125125ms)
✔ parentOf resolves a link, and answers null when there is nothing to resolve (0.085958ms)
✔ usedBy names teams once each, and says nothing about builds nobody uses (0.114625ms)
✔ forking a variant keeps the root, so lineage never grows a second level (0.135375ms)
✔ a clean verdict has nothing to explain, and a broken one cannot be silent (4.951458ms)
✔ a legal build reports clean, spending exactly the level-20 budget (12.486709ms)
✔ PvE availability is intrinsic while player-only eligibility belongs to assignment (0.26325ms)
✔ a secondary profession may not repeat the primary (0.127375ms)
✔ a bar may hold one elite, and the second is reported against the first (0.10525ms)
✔ the same skill cannot occupy two slots (0.107292ms)
✔ a stored record short of eight slots is validated, not accused of duplicates (0.102375ms)
✔ the last two bar positions are checked like the first six (0.101917ms)
✔ a duplicated elite reports both rules, because fixing one need not fix the other (0.092417ms)
✔ a skill must belong to one of the build's two professions, or to none (0.147875ms)
✔ a skill the catalogue cannot resolve is reported, never assumed clean (0.126208ms)
✔ an attribute must belong to one of the build's two professions (0.083083ms)
✔ a rank of 0 on an attribute the build cannot have is not a problem (0.058416ms)
✔ a primary attribute needs the profession as the primary, not the secondary (0.418792ms)
✔ a rank above the cap is rejected rather than clamped (16.327666ms)
✔ the ranks together may not cost more than a level-20 character has (0.151708ms)
✔ the whole problem list is ordered: professions, bar slots, attributes, budget (0.105791ms)
✔ a slot pointing at a build that is gone empties, and nothing else changes (1.363292ms)
✔ a slot pointing at a build that exists is left alone (5.899625ms)
✔ two builds sharing an id refuse the file rather than lose one quietly (0.915208ms)
✔ a bar that is not eight slots long is not a build to store (14.615709ms)
✔ a value the model has no name for is refused, not coerced (3.886042ms)
✔ a version this build cannot read is refused rather than reinterpreted (0.160333ms)
✔ a missing file is a new profile, and says nothing happened (12.28425ms)
✔ an unreadable library is moved aside, never overwritten (151.806292ms)
✔ a readable file that the model refuses is recovered the same way (3.407959ms)
✔ what a save returns is what the next load will hand back (28.253375ms)
✔ a save applies the same repair a load would, so the two cannot disagree (19.727541ms)
✔ the library is owner-only on disk (28.875375ms)
✔ a team code preserves every team field, shared slot, build and parent (7.349542ms)
✔ import remints identities and remaps repeated slots and lineage atomically (1.088666ms)
✔ future, malformed, dangling, duplicate and oversized codes are refused (4.433833ms)
✔ every worked example decodes to what the specification says it holds (2.13825ms)
✔ every worked example re-encodes to the byte-identical code (0.61975ms)
✔ a template file is the bare code, with nothing wrapped around it (0.178583ms)
✔ a real code decodes to what its publisher says it holds (0.165625ms)
✔ a real code re-encodes to the byte-identical string the client wrote (2.051958ms)
✔ the short padding a stranger's tool may write still decodes (0.289292ms)
✔ nothing in the adversarial corpus throws, and all of it is null (0.345959ms)
✔ each of this codec's own rejections has a valid twin one field away (0.163583ms)
✔ an empty slot round-trips as an empty slot and never as skill 0 (0.31675ms)
✔ a skill id this client build has never heard of decodes rather than fails (0.173542ms)
✔ a code the client would not have written re-encodes to the one it would (0.457917ms)
✔ the encoder refuses what the format cannot spell rather than truncating it (0.315083ms)
✔ a rank that is not a whole number is refused, not rounded into the field (0.129375ms)
✔ a bar that is not eight slots long is refused rather than padded or cut (0.096833ms)
✔ a twelve-attribute template still round-trips, at the edge of the count (0.112208ms)
✔ a captured team resolves through the same door every other team does (1.956333ms)
✔ heroes are compacted, because a henchman between two of them is a gap (0.226792ms)
✔ the player's own slot stays empty, which is the only shape it may have (0.121084ms)
✔ a fully observed player is saved into slot zero (0.946458ms)
✔ a captured build carries the ranks that were read, by name (0.131917ms)
✔ a bar read without its ranks is not a build (0.119625ms)
✔ nothing invested is an empty build, not a missing one (0.109833ms)
✔ a rank against an attribute the table cannot name is dropped (1.169417ms)
✔ a hero whose bar was not read keeps their place and gets no build (0.165666ms)
✔ a stored player build is admitted for the certified player setter (0.195125ms)
✔ behaviour is carried, never defaulted to Guard (0.180375ms)
✔ capture preserves unknown, Normal, and Hard Mode observations (0.079541ms)
✔ there is nothing to capture without a party, and capture says no (0.065292ms)
✔ counted heroes nobody could name are reported, not quietly missing (0.092125ms)
✔ more heroes than a team has positions is refused for the surplus, not silently (0.100333ms)
✔ every gap is written into the team's notes, so the notice is not the record (0.084209ms)
▶ the stored team roster
  ✔ compacts complete member records without moving the player (1.793042ms)
  ✔ preserves repairable legacy records while compacting (0.1155ms)
  ✔ removes the whole member and closes the gap (0.129333ms)
  ✔ moves configured members up, down, and to the last configured position (0.15075ms)
  ✔ does not move the player or an empty source (0.098292ms)
✔ the stored team roster (3.508459ms)
▶ Multiple Accounts profile creation
  ✔ validates every Single Account source before creating destinations (139.831166ms)
  ✔ rolls back both imported libraries when workspace publication fails (171.102708ms)
  ✔ rolls back after each library publication boundary (191.424084ms)
  ✔ refuses a requested destination without changing its existing bytes (48.192167ms)
  ✔ refuses pre-existing profile roots and template destinations (146.076625ms)
  ✔ loses a publication race without replacing the competing file (52.91475ms)
  ✔ treats a workspace rename followed by an error as committed (134.832292ms)
  ✔ removes a later account root when its workspace write fails (95.351958ms)
  ✔ preserves created resources when the workspace commit is ambiguous (101.368209ms)
  ✔ continues reverse cleanup and keeps the primary failure (170.186ms)
✔ Multiple Accounts profile creation (1252.764916ms)
✔ merges unrelated shared-template edits (272.336291ms)
✔ a stale deletion cannot discard a concurrent edit (0.147042ms)
✔ two concurrent edits to one path preserve both contents (0.728875ms)
✔ one window's duplicate close cannot delete another window's addition (1.986792ms)
✔ an identical duplicate uses the merge path's case-insensitive identity (0.269416ms)
✔ shared save requires a load and one generation refuses changed resubmission (0.524625ms)
✔ a failure before publication leaves the generation retryable (0.194208ms)
✔ an unconfirmed publication permits only an identical preserving retry (0.199666ms)
✔ renderer replacement and reload own independent merge generations (0.23225ms)
▶ atomic active client publication
  ✔ publishes the selected module and its complete effective feature map together (1.690042ms)
✔ atomic active client publication (2.226292ms)
▶ allowlists
  ✔ allows approved domain suffixes (0.886459ms)
  ✔ rejects lookalike and empty names (0.099333ms)
  ✔ classifies public vs private addresses (0.478667ms)
  ✔ parses IPv4 destinations only (9.150042ms)
  ✔ allowlists the game ports (0.127125ms)
✔ allowlists (11.449833ms)
✔ no hostile name reaches a path outside the two template directories (2.965458ms)
{"checkpoint":"waiting-for-enhancement","please":"bring the client to a playable character"}
▶ an observation live run cannot reach the automation tier
  ✔ gives every scenario exactly one tier (0.970667ms)
  ✔ declares readiness independently from automation permission (0.1505ms)
  ✔ launches the app with the automation gate off, whatever the caller exports (0.087834ms)
  ✔ opens no parent-process command channel for an observation run (4.172167ms)
  ✔ keeps the rest of the launch decision unchanged (0.478875ms)
  ✔ keeps developer-program preflight independent from saved cursor settings (0.468333ms)
  ✔ hands an observation scenario no handle that can act on the player (0.418042ms)
  ✔ lets an observation scenario read only the fixed cursor projection (0.117875ms)
  ✔ synthesizes no bootstrap input when the client is not yet playable (0.713625ms)
  ✔ still nudges an automation run, so the double above would have caught it (0.293875ms)
  ✔ does not require target-state evidence from a cursor-only observation (0.20775ms)
  ✔ does not pretend a program-free boot smoke installed Enhancement (0.087958ms)
  ✔ accepts the target-readout run only when the real surface matches its snapshot (0.185209ms)
✔ an observation live run cannot reach the automation tier (9.909208ms)
✔ the one live-certified agent pattern keeps its name (1.06375ms)
✔ an uncertified agent pattern publishes its bits, not a guess (0.141625ms)
✔ a living target keeps its name when uncertified bits ride along (0.085ms)
✔ a type word the kernel would never publish is still rejected (0.155958ms)
✔ no target means no bits and no kind (0.42625ms)
✔ an observation that is not ready is a party nobody can draw (4.363125ms)
✔ a well-formed record nobody took a reading for is not an empty party (0.233792ms)
✔ a counted but unnamed hero is counted, not invented (0.09175ms)
✔ every field the companion has not published reads as not observed (0.098583ms)
✔ account and instance facts stay unknown rather than defaulting to false (0.074416ms)
✔ a hero the table cannot name is dropped rather than published as a number (0.133334ms)
✔ the flag says available or the hero is not listed, whatever the id says (0.064792ms)
✔ a fully named party is not partial (0.082542ms)
✔ a nonsense count is floored rather than trusted (0.117417ms)
✔ profession ids become acronyms, and None is a secondary rather than a refusal (0.146917ms)
✔ the full roster wins over the summary, and carries what was read (0.387875ms)
✔ a region whose walk was rejected is not an empty party (0.068875ms)
native update installation refused Error: install refused
    at Object.quitAndInstall (file:///Users/matthias/Git/games/guild-wars-mac/gwonmac-travel-party-close/tests/unit/app-updater.test.ts:178:47)
    at Object.quitAndInstall (file:///Users/matthias/Git/games/guild-wars-mac/gwonmac-travel-party-close/tests/unit/app-updater.test.ts:74:41)
    at AppUpdater.quitAndInstall (file:///Users/matthias/Git/games/guild-wars-mac/gwonmac-travel-party-close/src/main/app-updater.ts:150:34)
    at TestContext.<anonymous> (file:///Users/matthias/Git/games/guild-wars-mac/gwonmac-travel-party-close/tests/unit/app-updater.test.ts:182:28)
    at async Test.run (node:internal/test_runner/test:1332:7)
    at async Suite.processPendingSubtests (node:internal/test_runner/test:911:7)
Update check failed at feed: feed-invalid
Update check failed at feed: feed-invalid
Update check failed at feed: feed-invalid
Update check failed at feed: feed-invalid
Update check failed at feed: feed-invalid
Update check failed at feed: feed-invalid
Update check failed at feed: feed-invalid
Update check failed at feed: offline Error: offline
Update check failed at feed: unreadable SyntaxError: Unexpected token 'o', "not json" is not valid JSON
▶ application updater
  ✔ reads exactly one static manifest for the selected channel (504.860792ms)
  ✔ makes no request and reports unavailable without the signed marker (0.220375ms)
  ✔ validates before asking Squirrel to download and installs once (0.36475ms)
  ✔ closes synchronous native feed and download refusals (0.43925ms)
  ✔ does not start a download after a synchronous native event closes it (0.394667ms)
  ✔ reports a refused terminal install once (4.116583ms)
  ✔ coalesces concurrent checks into one static request (0.816333ms)
  ✔ captures the selected track for an in-flight check (0.4275ms)
  ✔ keeps Stable off prereleases and Beta off alpha (0.553959ms)
  ✔ offers Stable, Beta, and RC through their admitted tracks (2.45275ms)
  ✔ returns from a newer beta to an older Stable only by manual install (0.19825ms)
  ✔ reports the selected channel version when already current (0.161791ms)
  ✔ fails closed for malformed or retargeted channel documents (8.621708ms)
  ✔ never presents transport or parse failure as up to date (113.872417ms)
  ✔ records and times out the static feed request (11.269875ms)
  ✔ does not duplicate work while downloading or ready (0.254458ms)
  ✔ treats Squirrel refusing a prevalidated upgrade as a feed failure (0.1245ms)
✔ application updater (652.304083ms)
▶ automatic check policy
  ✔ refuses incapable, opted-out, and active-game checks (0.096875ms)
  ✔ checks a fresh profile and honors the persisted six-hour boundary (0.044458ms)
  ✔ recovers from a clock moved backwards instead of waiting indefinitely (0.0395ms)
  ✔ keeps 30-minute ticks inside the six-hour due window (0.036083ms)
✔ automatic check policy (0.285125ms)
Update check failed at feed: timeout Error: aborted
▶ appearance settings
  ✔ derives the complete public token override from canonical settings (6.806125ms)
  ✔ projects untouched custom palettes exactly like their built-in material (6.528625ms)
  ✔ sets independent style and font markers and removes their defaults (0.354125ms)
  ✔ derives readable custom tokens and removes them when switching away (23.312625ms)
  ✔ activates a generation-keyed game font only after it loads (3.620708ms)
✔ appearance settings (42.271959ms)
✔ signing evidence accepts each channel's exact Apple identity (1.3175ms)
✔ signing evidence fails closed on every identity boundary (0.515792ms)
✔ signing target classification applies only the required entitlements (1.010833ms)
✔ redundant framework resources are the only ignored signing targets (0.195833ms)
✔ Hard Mode is changed and confirmed before any team command (43.803459ms)
✔ the player's build is applied before hero work and confirmed field by field (20.381542ms)
✔ a wrong player primary refuses before changing difficulty (0.51025ms)
✔ missing player, partial roster and known-locked hero all send zero commands (0.296333ms)
✔ a partial roster does not invent hero-specific verification failures (0.150792ms)
✔ a rejected roster does not multiply into unknown region and mode failures (0.095916ms)
✔ known permanent policy blockers outrank an incomplete roster (0.116667ms)
✔ an absent hero's known primary mismatch refuses before roster mutation (0.14625ms)
✔ a known-locked assigned skill refuses before the first command (0.293166ms)
✔ behavior-only work is part of the canonical preview (0.174292ms)
✔ roster order is a canonical Apply change (0.10875ms)
✔ canonical preflight reports each logical change once (0.142709ms)
✔ a hero the game never adds is a refusal, however cheerful the command (25.571417ms)
✔ a hero that appears without an agent id is not yet added (40.893875ms)
✔ a full apply reports only the changes the roster confirmed (2.374167ms)
✔ attributes the game never applies are a refusal too (0.976291ms)
✔ an ordinary attribute publication just after one second is not a false refusal (14.204792ms)
✔ an empty attribute plan clears the player's invested ranks (0.32975ms)
✔ an empty attribute plan clears a hero's invested ranks (0.27125ms)
✔ a new secondary profession is set, and set before the bar (0.963541ms)
✔ a bar waits for the client's profession rebuild after confirmation (0.645333ms)
✔ a live secondary transition may exceed the ordinary command deadline (5.060375ms)
✔ a profession first published on the deadline receives its stability grace (4.632584ms)
✔ a deadline candidate that disappears is refused without extending the operation (4.781042ms)
✔ a profession must remain observed for a full stable interval (0.841458ms)
✔ cancelling during confirmation sends no dependent command (0.339167ms)
✔ a monoclass build clears the secondary rather than leaving it (0.455833ms)
✔ a secondary the game never changes is a refusal, not a bar written anyway (74.752792ms)
✔ unobserved professions refuse before the first command (1.89325ms)
✔ a wrong primary profession refuses before changing difficulty (0.150666ms)
✔ a bar the game only partly equips is applied, and says what it dropped (0.48925ms)
✔ a progressively published bar is not mistaken for a stable partial bar (0.44025ms)
✔ an omitted reportedly unlocked skill is an inconsistency, not a skip (4.698167ms)
✔ skipped skill names accumulate across the whole team (0.936583ms)
✔ a bar that never moves is still a refusal (0.904208ms)
✔ a bar and ranks already in place send nothing at all (0.790375ms)
▶ atomic-file
  ✔ replaces the target only after a complete write (127.575458ms)
  ✔ writes JSON atomically (63.907375ms)
  ✔ creates parent directories (18.342334ms)
  ✔ applies the requested mode to the published file (16.061625ms)
  ✔ creates a complete file without replacing an existing target (44.493458ms)
  ✔ writes large payloads through writeAtomicInDir (34.604583ms)
✔ atomic-file (318.787916ms)
▶ atomic-file writeAll
  ✔ keeps writing until the buffer is consumed (0.209291ms)
  ✔ resumes from the offset the sink reached, not from zero (0.1395ms)
  ✔ fails loudly when the sink stops making progress (0.158875ms)
  ✔ writes every byte to a real file handle (11.771625ms)
✔ atomic-file writeAll (12.549291ms)
▶ atomic-file durability
  ✔ syncs the temp file before the rename and the directory after it (30.599834ms)
  ✔ syncs a create-only temp before publishing its final name (55.116167ms)
  ✔ leaves no temp file behind when the rename fails (22.004375ms)
✔ atomic-file durability (108.280458ms)
▶ atomic-file orphan sweep
  ✔ removes temp files left by dead processes and keeps everything else (23.806083ms)
  ✔ sweeps a temp file a crashed writer really left behind (24.805375ms)
  ✔ sweeps the orphan a SIGKILLed writer left, with the old document intact (1131.756083ms)
  ✔ reports zero for a directory that does not exist (0.742708ms)
  ✔ reaches every directory the profile publishes documents into (34.944375ms)
✔ atomic-file orphan sweep (1216.51275ms)
✔ transient loading cannot skip character selection (3.976541ms)
▶ build authoring rules
  ✔ uses the exact nonlinear 200-point Guild Wars budget (1.82375ms)
  ✔ offers both professions but never a secondary primary attribute (0.158833ms)
  ✔ stores rank zero as no investment (0.911292ms)
  ✔ resolves every catalogue placement without creating an invalid bar (0.347209ms)
✔ build authoring rules (4.395167ms)
✔ rejects a stale write from another window (183.615042ms)
✔ requires a baseline read before the first write (1.890333ms)
▶ patch-day carry-forward report
  ✔ fails closed when no capability can be located (3.477542ms)
✔ patch-day carry-forward report (4.0055ms)
▶ chunk cache pruning
  ✔ preserves current and rollback data and removes only stale hashes (144.675542ms)
  ✔ fails closed when the current or rollback manifest is corrupt (81.58775ms)
✔ chunk cache pruning (227.1185ms)
▶ chunk-store
  ✔ coalesces concurrent fetches of the same hash (54.795291ms)
  ✔ reads across chunk boundaries and short final chunks (156.05725ms)
  ✔ rejects hash mismatches without publishing (8.351292ms)
  ✔ replaces a corrupt resident chunk before returning it (75.624583ms)
  ✔ verifies and repairs resident chunks before full-download completion (56.80225ms)
  ✔ allows pause and sleep to interrupt resident-cache verification (10.60625ms)
  ✔ full-image resume downloads only missing hashes (40.350042ms)
  ✔ fails before downloading when the full image does not fit (8.271167ms)
  ✔ fails fast and classifies a fatal local write, keeping its cause (7.016375ms)
  ✔ bounds exhausted network work and resumes with verified chunks (366.070917ms)
  ✔ preserves completed chunks when a full download is stopped and resumed (143.252542ms)
  ✔ caps native fetches at eight and promotes queued demand (138.294958ms)
  ✔ serves fetched and first-process resident bytes without a second read (65.396208ms)
  ✔ releases a failed slot and allows the same chunk to retry (191.65ms)
  ✔ stops queued background work while allowing new demand (143.862625ms)
✔ chunk-store (1625.280917ms)
✔ proved documentation and website-only changes use the fast gate (1.018959ms)
✔ website certification follows only its real inputs (0.170375ms)
✔ runtime, packaging, dependency, and unknown changes use the full gate (0.113875ms)
✔ malformed paths fail closed (0.071042ms)
▶ client cache projection
  ✔ reports an empty cache without an active generation (5.429417ms)
  ✔ projects exact residency and the pessimistic capacity shortfall (0.164709ms)
  ✔ does not invent a shortfall when capacity is unknown (0.113ms)
✔ client cache projection (6.347375ms)
▶ client certification
  ✔ maps isolated verifier results without recreating a coarse state (1.830292ms)
✔ client certification (2.373709ms)
▶ client compatibility notice
  ✔ does not interrupt when every selected feature is available (1.818125ms)
  ✔ uses the exact single-feature copy (0.243458ms)
  ✔ groups target and party observation without implementation language (0.156458ms)
  ✔ names only the unavailable observation (17.2955ms)
  ✔ keeps update and restart recovery distinct when reasons are mixed (1.109ms)
  ✔ lists several unavailable features and preserves safe local work (0.229459ms)
  ✔ makes preparation failures retry each launch (0.350625ms)
  ✔ keeps forbidden player-facing terms out of every report (0.347417ms)
  ✔ keeps every feature and reason combination internally consistent (683.654458ms)
  ✔ renders one report into launcher and Settings (0.481833ms)
  ✔ reports cooldown presentation unavailable when slot geometry is unavailable (0.138417ms)
  ✔ keeps the complete cooldown presentation available without party observation (0.107291ms)
  ✔ dismisses the launcher even when acknowledgement cannot persist (0.345ms)
✔ client compatibility notice (716.9355ms)
▶ client compatibility
  ✔ fingerprints only the complete executable client contract (1.861125ms)
  ✔ rejects a failed candidate once and records its fingerprint (454.155583ms)
  ✔ keeps a valid untested candidate pending across an ordinary restart (90.103542ms)
  ✔ clears only the rejection record for an explicit retry (63.837ms)
  ✔ promotes a rendered candidate and removes rollback state (97.431333ms)
  ✔ refuses to confirm a candidate marker that changed (104.848458ms)
  ✔ does not interpret unknown persisted record versions (33.374084ms)
  ✔ prefers the previous complete client when the marker is corrupt (90.141916ms)
✔ client compatibility (937.388083ms)
▶ client clean-exit adapter
  ✔ recognizes the real exported function stored in a WebAssembly table (1.181959ms)
  ✔ delegates timers and callbacks that are not the exported main loop (1.295667ms)
  ✔ keeps running while the main loop schedules a successor (0.219541ms)
  ✔ reports a successful final tick as one clean exit (0.114792ms)
  ✔ reports a rejected main-loop tick as a failure, not a clean exit (0.566333ms)
✔ client clean-exit adapter (4.1425ms)
▶ client health confirmation
  ✔ waits for both signals and retries one rejection without duplicating success (17.092625ms)
  ✔ stops after three permanent failures (3.520875ms)
  ✔ cancels a pending retry when the renderer unloads (11.163625ms)
✔ client health confirmation (33.403708ms)
✔ an active client boots while its complete data downloads (9.091167ms)
✔ preparation and failure remain launch gates (0.239958ms)
▶ client module preparation
  ✔ composes both certified transforms in order (339.898125ms)
  ✔ prepares only templates for a template-only certification (192.605375ms)
  ✔ uses an isolated derived native record through the complete cache path (261.138667ms)
  ✔ requires local native proof and keeps the preceding module untouched on refusal (346.943ms)
  ✔ serves official bytes and drops both caches when uncertified (208.542917ms)
  ✔ closes native double-click preparation when its input disappears (19.963667ms)
  ✔ falls back to the ordinary module when a requested 4 GB pair is unknown (106.70425ms)
  ✔ keeps an earlier transform failure separate from 4 GB preparation failure (142.989916ms)
  ✔ drops the Enhancement cache when the certified tool is disabled (92.836125ms)
  ✔ falls back at the failed stage without serving an invalid module (532.863ms)
  ✔ rebuilds stale compatibility and Enhancement cache entries (663.052375ms)
  ✔ rejects a replacement module even when writable metadata matches it (335.054875ms)
  ✔ selects the largest safe subset when one profile fails validation (229.683708ms)
  ✔ replaces the cache when capabilities change but hooks do not (255.279417ms)
✔ client module preparation (3737.247333ms)
▶ companion core memory installation
  ✔ owns aligned runtime, exact config, and explicit kernel regions (3.025625ms)
  ✔ allocates no observer or command memory when it is not needed (0.278792ms)
  ✔ rolls back every partial allocation in reverse order (0.512083ms)
  ✔ rolls back when the completed layout does not fit memory (0.137ms)
  ✔ does not write runtime or config bytes before explicit initialization (0.201791ms)
  ✔ rolls back a reused allocation pointer exactly once (0.378458ms)
  ✔ reports both allocation and rollback failures (0.361291ms)
  ✔ releases the observer and callback safety groups once (1.105666ms)
  ✔ cannot initialize after either release group runs (0.35275ms)
  ✔ continues a release after one free refuses (0.293916ms)
  ✔ composes with child-region overlap validation (0.179166ms)
✔ companion core memory installation (9.735667ms)
▶ companion kernel loader
  ✔ verifies, initializes, and projects only the canonical kernel (48.092833ms)
  ✔ refuses extra and missing imports and exports (98.576583ms)
  ✔ refuses a canonical name with the wrong function signature (4.761459ms)
  ✔ refuses every mismatched ABI scalar (40.485708ms)
  ✔ does not expose dispatch authority when initialization refuses (0.675333ms)
  ✔ uses the canonical allocation validator before compilation (0.400375ms)
✔ companion kernel loader (212.195583ms)
▶ companion kernel build contract
  ✔ states the exact reviewed import and function vocabulary once (3.773959ms)
  ✔ accepts exactly the fixed side-module surface (6.724875ms)
  ✔ rejects invalid Wasm, a start function, and a changed dylink footprint (6.333458ms)
  ✔ rejects extra imports and exports rather than allow-listing by prefix (2.553917ms)
  ✔ rejects a named export with the wrong exact function type (1.420416ms)
  ✔ states region sizes the decoder and the config ABI already fix (0.153792ms)
  ✔ rejects active data writes outside the declared private footprint (4.639584ms)
✔ companion kernel build contract (26.413792ms)
▶ companion kernel build seal
  ✔ publishes validated bytes and checks their sealed hash before compile (118.780958ms)
  ✔ removes a stale artifact without rewriting when validation fails (16.323375ms)
  ✔ removes the artifact and restores the renderer if final publication fails (7.900375ms)
✔ companion kernel build seal (144.561459ms)
✔ frame pollers run on every observer frame without an observation change (2.343041ms)
✔ party rows refuse payload for optional fields whose presence flag is absent (22.968541ms)
✔ an observed zero-filled player and a present all-zero skillbar remain valid (0.233917ms)
▶ companion policy source
  ✔ publishes one canonical launch snapshot (14.42ms)
  ✔ rereads settings instead of trusting the event payload (0.281375ms)
  ✔ deduplicates equal region values and withdraws policy on waiting (0.155208ms)
  ✔ publishes same-map character and unlock changes (0.155875ms)
  ✔ withdraws local Tools only for positively identified active PvP play (0.133042ms)
  ✔ detaches both inputs and stops publication on disposal (0.123875ms)
  ✔ rolls back a settings listener when region subscription fails (0.281083ms)
  ✔ does not retain a subscriber whose launch callback throws (0.130916ms)
  ✔ stops an individually unsubscribed consumer (0.105042ms)
  ✔ withdraws every reachable listener when input disposal refuses (0.267209ms)
✔ companion policy source (17.651208ms)
✔ a bounded region owns allocation and ignores observations while inactive (5.897917ms)
✔ a withdrawn sequence accepts only a newer uint32 publication (0.241167ms)
✔ malformed ready sequences fail closed (0.108459ms)
✔ an event-driven region keeps a stable accepted publication (0.098625ms)
✔ region descriptors require non-ready withdrawal sentinels (0.261084ms)
✔ teardown withdraws ready state even when freeing fails (0.137792ms)
✔ freshness duration rejects non-finite and negative values (0.101333ms)
✔ sequence ordering accepts uint32 wrap and suppresses duplicate publications (0.13175ms)
✔ an equivalent heartbeat refreshes freshness without notifying listeners (0.169625ms)
▶ controller prompt texture
  ✔ implements the uMod hash for every bounded atlas orientation (8.572625ms)
  ✔ refuses arbitrary data instead of matching dimensions alone (4.363417ms)
  ✔ pins the current WebGL fingerprint to the exact certified client (0.099042ms)
  ✔ substitutes synchronously and restores the client's heap (56.7675ms)
  ✔ passes mismatches, malformed pointers, and unrelated textures unchanged (2.581ms)
  ✔ preserves call receiver, result, and restoration when the upload throws (130.346916ms)
  ✔ also handles an exact full-atlas sub-image upload (12.749291ms)
  ✔ withdraws a match after every non-certified level-zero mutation and reset (7.1355ms)
  ✔ bounds texture deletion bookkeeping and never blocks malformed client calls (31.895417ms)
  ✔ fails closed when the required texture import is absent (2.071292ms)
✔ controller prompt texture (257.607167ms)
▶ corrupt document quarantine
  ✔ preserves the new bytes, retains three backups, and touches no neighbour (437.717625ms)
  ✔ returns null when another owner already moved the document (1.44925ms)
✔ corrupt document quarantine (440.034375ms)
Keychain operation failed arenaNetCredentials unclassified Error
▶ credentials
  ✔ round-trips the fixed credentials slot and clears it (116.176792ms)
  ✔ keeps a Multi profile out of the fixed Single slot (4.474958ms)
  ✔ maps native failure to the credential vocabulary (1.149459ms)
  ✔ retains unreadable Keychain bytes (0.201083ms)
  ✔ rejects invalid saves before replacing stored credentials (0.173791ms)
✔ credentials (123.187ms)
▶ hidden-cursor retry
  ✔ asks on the poll after the hide, then paces by the interval (0.979083ms)
  ✔ asks once per interval, not once per poll (0.101583ms)
  ✔ stops at the deadline and stays stopped until the cursor resolves (0.10575ms)
  ✔ is not expired before the loop has seen anything (0.073167ms)
  ✔ expires at the deadline and resets on resolution (0.077375ms)
  ✔ records the resolved gap and only for a valid resolution (0.075208ms)
  ✔ counts only re-tests the dispatcher accepted (0.099625ms)
  ✔ does nothing while the consumer has no valid state (0.092709ms)
✔ hidden-cursor retry (2.317709ms)
▶ derived wasm cache
  ✔ publishes once and reuses the published module (82.352333ms)
  ✔ keeps only the current input, so an update cannot leak a directory (531.241709ms)
  ✔ keeps only the current transform ABI (304.791666ms)
  ✔ rebuilds when the certified build entry changes (238.081041ms)
  ✔ rejects a cached module whose bytes were altered after publication (198.346333ms)
  ✔ will not let cache metadata certify a module the pinned hash rejects (109.966416ms)
  ✔ publishes nothing when the output misses the pinned hash (2.02675ms)
  ✔ keeps the last good module when a rebuild's transform throws (145.19425ms)
✔ derived wasm cache (1613.472458ms)
▶ diagnostic profile storage
  ✔ defaults to standard and persists every closed profile (494.580625ms)
  ✔ refuses malformed persisted state instead of guessing (57.962125ms)
✔ diagnostic profile storage (557.606042ms)
▶ diagnostic profile policy
  ✔ keeps each isolation profile explicit and internally consistent (1.133958ms)
✔ diagnostic profile policy (1.244708ms)
▶ diagnostic report
  ✔ selects the newest abnormal prior session and tolerates a torn tail (167.057083ms)
  ✔ treats a game-client abort as abnormal even after a clean app quit (123.902917ms)
  ✔ reports no abnormal session when the previous run was clean (64.493917ms)
  ✔ derives startup, capture, and performance fields from canonical data (1.104417ms)
✔ diagnostic report (362.045125ms)
▶ the closed diagnostics schema
  ✔ reports every prohibited field shape in one compiler program (10380.997875ms)
  ✔ still accepts the field kinds the schema is built from (6426.379958ms)
✔ the closed diagnostics schema (16808.056ms)
▶ diagnosticEventRecord
  ✔ classifies account evidence at the same canonical definition as its fields (0.883042ms)
  ✔ owns the subsystem and level of an event, so a call site cannot disagree (0.923917ms)
  ✔ keeps the discriminant out of the recorded fields (0.0985ms)
  ✔ carries every field of a multi-field event (0.125125ms)
  ✔ records a phase as a field rather than as part of the event name (0.087041ms)
  ✔ names the durable action whose relaunch was refused (0.08175ms)
  ✔ keeps the socket event name closed and the payload declared (0.092292ms)
  ✔ records which proxy route failed (0.062834ms)
  ✔ passes a digest and an absent digest through unchanged (0.131291ms)
  ✔ produces only scalars, so no nested value can smuggle text out (70.291667ms)
✔ diagnosticEventRecord (73.643292ms)
▶ asDigest
  ✔ accepts a 64-character lower-case hex digest (0.136375ms)
  ✔ rejects anything else, without quoting it (0.39875ms)
  ✔ has a predicate that agrees with it (0.050959ms)
✔ asDigest (0.687916ms)
▶ asAppVersion
  ✔ accepts the CalVer surface and its release stages (0.328917ms)
  ✔ rejects free text and invalid leading-zero variants (0.121542ms)
✔ asAppVersion (4.226584ms)
▶ renderer diagnostics boundary
  ✔ accepts the complete bounded aggregate (1.474625ms)
  ✔ rejects missing, negative, and non-finite values (0.512875ms)
✔ renderer diagnostics boundary (2.601084ms)
▶ frame capture analysis
  ✔ uses exact visible intervals and resets across hidden records (0.463833ms)
✔ frame capture analysis (0.527625ms)
▶ capture validation, format 2
  ✔ reproduces the manifest's redaction result from events.jsonl (86.649417ms)
  ✔ refuses a manifest whose redaction result the event log does not support (0.244583ms)
  ✔ rejects an event log carrying a field the schema does not declare (0.227833ms)
  ✔ does not require histograms.json, and does require the rest (0.188792ms)
  ✔ refuses a trace scan the included files do not corroborate (0.119292ms)
  ✔ requires explicit consent and a valid PNG for visual evidence (178.279208ms)
✔ capture validation, format 2 (265.9385ms)
▶ capture validation, format 3 visual evidence
  ✔ accepts a complete self-consistent visual capture (0.453292ms)
  ✔ requires one unique declaration and dimension record per image (0.250625ms)
  ✔ rejects dimension mismatches and dimensions without an image (0.127417ms)
  ✔ requires valid runtime state and a visual declaration for format 3 (0.996083ms)
✔ capture validation, format 3 visual evidence (21.562459ms)
▶ capture validation, format 1
  ✔ accepts a complete redacted capture and rejects dropped records (0.181375ms)
  ✔ refuses to call a Level 2 capture complete without its Chromium trace (0.0805ms)
  ✔ validates the machine-readable report without requiring it in old captures (0.104916ms)
  ✔ warns for same-session overlapping captures and mixed levels (0.29225ms)
✔ capture validation, format 1 (0.74325ms)
✔ distribution channels derive the complete capability matrix (4.197208ms)
✔ distribution markers accept only the closed canonical shape (0.655ms)
✔ provisioned channels have distinct application identities (0.188958ms)
▶ dns suffix matching
  ✔ normalizes case and a trailing dot (2.763958ms)
  ✔ matches whole suffix labels only (0.238792ms)
  ✔ rejects IP literals passed as DNS names (0.785792ms)
  ✔ rejects names outside the allowlist without contacting the network (3.520125ms)
✔ dns suffix matching (8.300708ms)
▶ effective Enhancement capability boundary
  ✔ reproduces every served profile from Main's session, independent of request (22.709083ms)
  ✔ does not revive off or unavailable features (0.510834ms)
  ✔ refuses to invent a profile before Main publishes a session (0.107708ms)
✔ effective Enhancement capability boundary (24.082459ms)
▶ Enhancement client chain
  ✔ source-pins every executable capability profile (172.7055ms)
  ✔ certifies the Enhancement transform against the template-save output (0.117417ms)
  ✔ requires all and only the hashes implied by optional capability facts (1.080333ms)
✔ Enhancement client chain (174.568167ms)
▶ Enhancement command transform
  ✔ emits Team Apply and local action authority independently (138.992709ms)
  ✔ derives local actions without installing the party dispatcher hook (13.062792ms)
  ✔ never advertises aliases without an effective named action (3.777417ms)
  ✔ queues the named storage action and drains DataWindow on the game thread (1.462167ms)
  ✔ queues one bounded Travel request and dispatches it on the game thread (1.555709ms)
  ✔ consumes /trade, /tp and exact storage commands at their named boundaries (1.541125ms)
  ✔ dispatches queued commands only from the certified game-thread callback (1.504791ms)
  ✔ distinguishes native and GWonMac command packets without changing them (1.274625ms)
  ✔ refuses a command whose function is not the one certified (0.730959ms)
  ✔ refuses an uncertified or shared command drain boundary (0.899875ms)
  ✔ refuses an uncertified or shared traced packet sender (0.616708ms)
  ✔ refuses an uncertified storage slash parser (0.43175ms)
  ✔ refuses an uncertified Xunlai access reader (0.417125ms)
  ✔ refuses a travel producer that aliases a selected dispatch hook (0.434541ms)
✔ Enhancement command transform (167.73375ms)
✔ pre-game state scans exact live label hashes and loading context (13.053167ms)
▶ Enhancement re-certification input
  ✔ fails closed without inspecting raw official bytes (1.460458ms)
  ✔ nests structural candidates as review evidence without promoting them (1.541834ms)
✔ Enhancement re-certification input (3.605125ms)
✔ developer programs replace saved optional-tool selection in PvE (6.824708ms)
✔ unknown regions keep local Tools while live PvE features fail closed (0.1115ms)
✔ confirmed active PvP play disables every product and developer tool (0.131125ms)
✔ product tool settings remain live once the capability is present (0.080625ms)
✔ skill feature selection distinguishes labels from cooldowns (0.107458ms)
✔ runtime policy projects every registered feature exactly once (0.087958ms)
✔ local Tools require their setting or developer program and only active PvP blocks them (0.422084ms)
✔ skill transform resolves and verifies only its four certified functions (7.984209ms)
✔ unselected skill facts stay absent and selected missing facts fail clearly (2.682792ms)
✔ skill transform refuses changed bodies and changed certified call operands (0.6465ms)
✔ SkillBar capture rewrites only the certified operand and preserves wrapper bytes (0.472542ms)
✔ the storage controller owns policy, events, deduplication, and teardown (3.429167ms)
✔ storage fails closed without a confirmed character access proof (0.226417ms)
✔ storage development traces identify the live refusal without account data (0.189375ms)
▶ review-only Enhancement structural evidence
  ✔ recovers all three boundaries deterministically without a build certificate (6.255875ms)
  ✔ recovers shifted function indices instead of relying on known numbers (0.495917ms)
  ✔ uses the caller's immutable message anchors instead of fixed IDs (0.35875ms)
  ✔ rejects changed tick, dispatcher, and cursor signatures independently (2.782666ms)
  ✔ rejects changed player message and exact-site cardinality evidence (2.270292ms)
  ✔ rejects a changed direct-call target even when both signatures match (0.320542ms)
  ✔ reports duplicate dispatcher and cursor candidates as ambiguous (1.967875ms)
  ✔ distinguishes missing and non-unique active-table relationships (2.909333ms)
  ✔ does not let an exact input hash replace cursor field witnesses (0.710833ms)
  ✔ rejects every changed cursor anchor and duplicate candidate (3.169458ms)
  ✔ fails closed with a deterministic data report for malformed input (1.83975ms)
  ✔ keeps independent tick evidence but rejects an unsupported opcode set (1.33375ms)
✔ review-only Enhancement structural evidence (25.749625ms)
✔ the closed team surface selects only its reviewed opcodes and payloads (2.793083ms)
✔ the storage command owns one fixed DataWindow payload and refuses unsafe sends (0.378209ms)
✔ invalid values are refused before the command queue (0.194625ms)
✔ hero identity is resolved again for every packet and rejected packets throw (0.176041ms)
▶ targeted Enhancement WebAssembly transform
  ✔ is deterministic, valid, and exports only the hook contract (9.412708ms)
  ✔ reports the semantic loop signature and reusable empty slots (0.718584ms)
  ✔ preserves every argument and calls each relocated original once (1.489208ms)
  ✔ rejects a non-terminal slot, hash mismatch, and signature mismatch (5.369042ms)
  ✔ uses only selected hook evidence in deterministic hook order (2.753209ms)
  ✔ rejects nonzero configuration for inactive capabilities (4.175208ms)
  ✔ zeroes only Xunlai proof words when Travel has no access certificate (0.581792ms)
  ✔ binds the exact party-dirty set to the Toolbox manifest and config (2.83225ms)
  ✔ starts the message words exactly where the layout words end (0.133959ms)
  ✔ gives party observation shared agent state without target selection (2.18ms)
  ✔ checks the existing cursor table relation only when cursor is selected (84.959959ms)
✔ targeted Enhancement WebAssembly transform (115.787834ms)
▶ Enhancement workspace doctor
  ✔ fails closed for a missing profile (72.368042ms)
  ✔ reports snapshot residency without reading chunk contents (170.881167ms)
  ✔ reports required Core without writing to the profile (14.454125ms)
✔ Enhancement workspace doctor (258.56225ms)
✔ a packaged build refuses GW_ENHANCEMENT_AUTOMATION=1, so the tools decide alone (5.127334ms)
✔ the launch selection carries required Core and no setting can disable it (1.14125ms)
✔ one capability plan derives hooks without losing feature identity (0.3475ms)
✔ launch intent resolves to the canonical frozen capability profiles (0.266125ms)
✔ the capability wire contract is exact and has one empty value (0.345959ms)
✔ Tools prepares every certified capability independent of child toggles (0.095ms)
✔ renderer consumes main's effective subset instead of launch intent (0.135584ms)
▶ error catalogue
  ✔ has no duplicate codes (0.918167ms)
  ✔ recognises its own members and nothing else (0.142541ms)
✔ error catalogue (28.511625ms)
▶ errorCode
  ✔ returns the code of an AppError (0.143625ms)
  ✔ returns the code of every AppError subclass (0.141375ms)
  ✔ does not republish the code of a foreign error (0.070583ms)
  ✔ survives anything that is not an Error at all (0.059959ms)
  ✔ keeps the message on the error and out of the code (0.093958ms)
  ✔ preserves the cause chain, which never reaches a code (0.080167ms)
✔ errorCode (0.766375ms)
▶ the macOS build number derived from a release version
  ✔ rises at every rung of a release ladder (1.239875ms)
  ✔ orders releases the same way the app's own comparison does (0.345458ms)
  ✔ maps the calendar and the channel onto Apple's 4/2/2 digits (0.910083ms)
  ✔ refuses anything that is not a calendar release in SemVer syntax (3.994083ms)
  ✔ accepts the version this repository would release right now (0.454333ms)
✔ the macOS build number derived from a release version (7.648292ms)
▶ export detector
  ✔ accepts every declared event built through the schema (33.8585ms)
  ✔ accepts only a nonnegative ephemeral window owner (0.428625ms)
  ✔ rejects a declared event that carries a field the schema does not declare (0.116167ms)
  ✔ rejects a value outside the field's declared vocabulary (0.225333ms)
  ✔ rejects text a redactor would have called clean (0.108834ms)
  ✔ rejects a malformed envelope rather than trusting the record (0.230542ms)
  ✔ rejects a declared event under another subsystem or level (7.689167ms)
  ✔ rejects every undeclared event and former free-text producer field (0.217625ms)
  ✔ rejects a nested field on any record, declared or not (0.153833ms)
  ✔ skips the blank lines a JSONL document ends with (0.158542ms)
✔ export detector (44.223792ms)
▶ extended memory runtime result
  ✔ keeps unresolved selection outside the result and maps standard mode (1.657375ms)
  ✔ reports the certified active profile and cap (0.098ms)
  ✔ falls back truthfully after unsupported-client (0.086417ms)
  ✔ falls back truthfully after preparation-failed (0.054875ms)
✔ extended memory runtime result (2.499ms)
▶ extended memory Settings projection
  ✔ distinguishes unresolved intent from the active standard cap (0.848083ms)
  ✔ reports restart only when saved intent differs from this launch (0.124334ms)
  ✔ keeps unsupported and preparation failures visibly distinct (0.100667ms)
✔ extended memory Settings projection (1.696875ms)
▶ certified extended memory transform
  ✔ stops one page short of 4 GiB (0.812833ms)
  ✔ accepts only canonical valid runtime feature profiles (0.216333ms)
  ✔ normalizes only all 59 ASM_CONSTS keys (0.415ms)
  ✔ refuses changed JavaScript semantics and a changed memory shape (0.519917ms)
  ✔ changes only the sole memory maximum and validates the result (0.930042ms)
  ✔ records the effective mode and cap with a closed profile (0.137625ms)
✔ certified extended memory transform (3.730917ms)
▶ renderer failure messages
  ✔ answers every code in the catalogue with a sentence, on every surface (3.552958ms)
  ✔ carries the disk shortfall into the sentence when the caller knows it (0.181292ms)
  ✔ gives the same fault a different action on each surface (0.132417ms)
  ✔ keeps the sentences the two probe and recovery paths used to send (0.065541ms)
  ✔ falls back to one default rather than inventing a sentence per code (0.065166ms)
  ✔ answers every notice code with a sentence (0.144917ms)
  ✔ explains a failed Steam sign-in and stays silent on a plain cancel (0.104291ms)
  ✔ tells offline apart from a server fault, on both transfer surfaces (0.088458ms)
  ✔ suggests a bug report only when the fault may be the app's (0.123792ms)
  ✔ tells a locked Keychain apart from a build that may not use one (0.1305ms)
  ✔ stops promising a retry once the client crashes twice in one run (0.945792ms)
  ✔ escalates memory wording while keeping one action model (0.134583ms)
  ✔ prints the effective cap but no unreliable countdown (0.106417ms)
  ✔ explains optional automatic return without overpromising (0.120958ms)
✔ renderer failure messages (7.413917ms)
✔ the capability registry is the ordered wire vocabulary (1.973334ms)
✔ dependency pruning is derived from capability contracts (0.336959ms)
✔ cooldown owns the reusable player skillbar core without Party (1.624ms)
✔ feature selection policies are deeply immutable (0.099709ms)
✔ shared activation and area policy cover required, setting, and content features (0.123375ms)
▶ frame attribution
  ✔ reads only visible records and rejects a bad header (2.537ms)
  ✔ blames composition loss when the window changed state (0.466083ms)
  ✔ blames the main process only when its event loop actually blocked (0.190916ms)
  ✔ refuses to blame anything when the capture predates the instrumentation (0.098417ms)
  ✔ ignores gaps under the threshold and events outside the window (0.135334ms)
  ✔ rejects a non-positive threshold (0.088ms)
✔ frame attribution (4.368875ms)
✔ automatic-return intent is refused to the source and consumed by its replacement (1.311625ms)
✔ a settings read failure performs no partial reload (6.811ms)
✔ a completed program is answered without another round trip (2.141834ms)
✔ an incomplete program is never frozen, however often it is polled (0.145084ms)
✔ relinking makes a completed program incomplete again (0.132791ms)
✔ a recycled program name never inherits the deleted program's completion (0.114917ms)
✔ a name the host never saw created always reaches the client (0.103334ms)
✔ every pname except completion reaches the client every time (0.171ms)
✔ null and misaligned out-pointers pass through and record nothing (0.08575ms)
✔ losing the GL context drops every memoized program (0.125333ms)
✔ a missing invalidator leaves every import untouched (0.175625ms)
✔ programs beyond the ceiling stay correct by passing through (0.346334ms)
✔ hits and misses both return the client's void result (0.083834ms)
✔ a grown WASM heap is followed on both the miss and the hit (0.096167ms)
✔ reconnaissance counts the queries that still reach the client (0.123083ms)
✔ completion polls the cache cannot serve stay visible (0.074292ms)
✔ graphics diagnostics read immutable context facts only once (3.996542ms)
✔ the Guild Wars nibble stream decodes every printable ASCII glyph (4.2455ms)
✔ alternating runs cannot overrun a glyph (0.451708ms)
✔ the converted result is a complete checksummed TrueType font (238.415083ms)
✔ the original display strike builds as a separate browser family (1.353959ms)
✔ the measured contour remains the default and calibration inputs are bounded (94.961ms)
✔ a narrow numeral gets balanced proportional spacing (2.197916ms)
✔ an unsupported font is refused once for its immutable client generation (0.329667ms)
✔ a compact oversized strike is refused before outline tracing (0.119542ms)
✔ the shared UI offers the local Guild Wars font independently of Inter (34.982875ms)
▶ Guild Wars archive decoder process boundary
  ✔ settles and stops the child when writing stdin throws (5.496458ms)
  ✔ contains an early stdin close and reports the decoder refusal (568.423166ms)
  ✔ settles once when an output refusal closes stdin (326.283208ms)
✔ Guild Wars archive decoder process boundary (926.084583ms)
▶ renderer image source
  ✔ answers fileSize synchronously, before any read, and only for open snapshot handles (1.299583ms)
  ✔ coalesces concurrent reads of the same range into one fetch (48.078584ms)
  ✔ batches adjacent queued demand chunks without fetching across a gap (40.7945ms)
  ✔ counts batched demand chunks toward the shared eight-chunk ceiling (55.75975ms)
  ✔ coalesces a demand read onto an already active prefetch instead of promoting it (31.988084ms)
  ✔ runs one multi-chunk cacheAsync seven-wide, keeping the demand slot free (23.301ms)
  ✔ runs demand work before queued prefetch, and promotes the queued chunk a read needs (36.564708ms)
  ✔ releases the slot a failed fetch held, and reports the failure until a retry succeeds (11.345958ms)
  ✔ releases every slot after a batched failure (13.826417ms)
  ✔ rejects every affected chunk when a batched response is truncated (12.3215ms)
  ✔ assembles a range across a chunk boundary and into the short final chunk (0.532667ms)
  ✔ evicts the least recently used chunk at the 256 MiB budget (0.42425ms)
  ✔ counts native residency in isCached, which memory eviction does not erase (0.273041ms)
  ✔ stops background work at unload and fails what was still queued (1.563958ms)
✔ renderer image source (287.573417ms)
✔ main input trace emits only while its renderer harness is enabled (1.796167ms)
✔ main trace state changes only after renderer acknowledgement (0.194917ms)
▶ the JSONL reader
  ✔ keeps every complete record when the last one is torn (16.191333ms)
  ✔ survives a tear at the only record, and at no record at all (0.168541ms)
  ✔ survives a final torn record that is still valid JSON (0.196167ms)
  ✔ rejects malformed or incomplete records before the final line (0.364917ms)
  ✔ allows trailing line endings but not blank records between events (0.104458ms)
  ✔ orders by sequence number, so rolled files may arrive in any order (0.086916ms)
  ✔ preserves the fields the export and the report both read (0.092083ms)
✔ the JSONL reader (17.962125ms)
▶ keyboard shortcuts
  ✔ uses defaults until a player replaces or clears one action (1.619708ms)
  ✔ stores only differences from defaults (0.115667ms)
  ✔ matches only Command and keeps Control chords in the game (0.172167ms)
  ✔ normalizes physical Command chords across Option-modified layouts (0.096ms)
  ✔ protects editing and lifecycle shortcuts and finds action conflicts (0.111208ms)
  ✔ formats the same binding for Electron and for players (0.094125ms)
  ✔ refuses unknown actions, keys, fields, and modifier types (0.140416ms)
✔ keyboard shortcuts (3.016375ms)
Keychain operation failed arenaNetCredentials unclassified Error
Keychain operation failed arenaNetCredentials keychain_locked Error
Keychain operation failed arenaNetCredentials keychain_locked Error
Keychain operation failed arenaNetCredentials keychain_locked Error
Keychain operation failed arenaNetCredentials keychain_unentitled Error
Keychain operation failed arenaNetCredentials keychain_unentitled Error
Keychain operation failed arenaNetCredentials keychain_unentitled Error
Keychain operation failed arenaNetCredentials unclassified Error
Keychain operation failed arenaNetCredentials unclassified Error
Keychain operation failed arenaNetCredentials unclassified Error
Keychain operation failed arenaNetCredentials unclassified Error
Keychain operation failed arenaNetCredentials unclassified Error
Keychain operation failed arenaNetCredentials unclassified Error
Keychain operation failed arenaNetCredentials unclassified Error
▶ KeychainJsonStore
  ✔ serializes overlapping writes and recovers its queue after failure (3.897917ms)
  ✔ keeps the native classification of a refusal instead of collapsing it (0.954041ms)
  ✔ zeroes native save buffers on success and failure (0.19025ms)
  ✔ zeroes loaded native buffers after valid and corrupt payloads (0.222042ms)
✔ KeychainJsonStore (6.023208ms)
▶ legacy secret cleanup
  ✔ removes only the two retired files and is idempotent (224.437208ms)
  ✔ unlinks a retired-name symlink without touching its target (55.224208ms)
  ✔ does not recursively remove a directory with a retired filename (6.608958ms)
  ✔ attempts both exact files and returns bounded failures (0.915667ms)
✔ legacy secret cleanup (288.039542ms)
✔ skillbar diagnostics preserve feature-local failure precedence (9.815792ms)
✔ shared module failures override skillbar-specific diagnostics (0.112583ms)
✔ the build fragment keeps cooldown independent from Party UI authority (0.20575ms)
✔ the build fragment refuses inconsistent include flags (0.085125ms)
▶ local client verification boundary
  ✔ certifies play region directly from the exact observation base (6.407666ms)
  ✔ accepts the verifier's complete baseline proof (34.376375ms)
  ✔ rejects an exact authored row that did not cross semantic proof (0.202875ms)
  ✔ rejects a proof for any other official client (0.090416ms)
  ✔ rejects an unconstrained enhancement layout (0.137708ms)
  ✔ accepts a relocated hook but rejects an incompatible signature (1.894417ms)
  ✔ accepts a structurally derived cursor proof and rejects malformed layouts (0.31725ms)
  ✔ accepts a field-complete Target proof and rejects one bad relocation (0.313375ms)
  ✔ accepts independent local-action proofs and rejects one bad Xunlai field (0.368ms)
  ✔ accepts complete Party and Team proofs and rejects each independently (13.10225ms)
  ✔ validates the complete skill-slot geometry proof at the process boundary (27.60325ms)
  ✔ certifies cooldown from the player skillbar without Party or UI authority (0.293625ms)
  ✔ accepts a template-only proof and requires no enhancement behind failure (0.183041ms)
  ✔ represents an unrequested enhancement as a proved template, not a refusal (0.091875ms)
  ✔ rejects a stale verifier ABI at either boundary (0.23775ms)
  ✔ binds each verdict to the post-template hash and requested feature (0.141042ms)
  ✔ carries anchor-specific changed and ambiguous evidence across IPC (2.36125ms)
✔ local client verification boundary (116.287292ms)
▶ macOS Command-held key releases
  ✔ consumes only mapped releases routed to the focused game (56.542875ms)
✔ macOS Command-held key releases (57.095417ms)
✔ macOS key positions cover movement and player-bindable keys (51.704542ms)
✔ launch configuration arrives as a preload argument, not as a URL (5.034709ms)
✔ a renderer with no readable init argument gets the production posture (4.353792ms)
✔ menu commands reach the renderer as events and are acknowledged (3.015083ms)
✔ one physical key release crosses preload and is acknowledged (1.713209ms)
✔ ordinary renderer text editing declines to the main-process fallback (1.838417ms)
✔ input harness state crosses as an explicit value and is acknowledged (2.961708ms)
✔ the Tools shortcut is refused when there is no Toolbox to toggle (6.322209ms)
✔ a capture level crosses as a number, not as interpolated source (1.724917ms)
✔ the acknowledgement waits for the renderer's own promise (1.200083ms)
✔ a renderer that cannot act reports failure (134.10275ms)
▶ manifest
  ✔ accepts flat files and finds by basename (3.356042ms)
  ✔ rebuilds nested paths via parentIndex (0.281542ms)
  ✔ rejects chunk count mismatch (0.359291ms)
  ✔ rejects unknown compression (0.101833ms)
  ✔ rejects cycles and invalid parent indexes (0.141666ms)
  ✔ treats an explicitly null parentIndex as the root (0.144542ms)
  ✔ rejects unsafe names, duplicate paths, and invalid sizes (0.248458ms)
  ✔ rejects conflicting lengths for one content hash (0.224208ms)
  ✔ requires exactly one copy of each product basename (0.251416ms)
✔ manifest (7.138875ms)
▶ memory warning presenter
  ✔ does nothing when the single warning surface is incomplete (0.948417ms)
  ✔ keeps Low dismissed until Critical reopens the same notice (0.331709ms)
  ✔ reloads without adding another warning state (0.150042ms)
  ✔ registers as a dismissible keyboard surface while visible (0.953667ms)
  ✔ shares and saves the automatic-return preference (0.203084ms)
✔ memory warning presenter (3.26875ms)
▶ Multiple Accounts documents
  ✔ keeps a missing mode and workspace on the legacy Single path (23.054042ms)
  ✔ publishes a workspace before an explicit Multi selection (206.918333ms)
  ✔ fails closed for corrupt or future documents (114.017208ms)
  ✔ quarantines a damaged document without rewriting its bytes (48.120959ms)
  ✔ accepts only lowercase UUID v4 identifiers (0.221208ms)
  ✔ rejects duplicate labels after normalization and case folding (0.1175ms)
  ✔ accepts an empty onboarding workspace but rejects an all-archived workspace (0.119833ms)
  ✔ requires valid binary sharing choices (0.085208ms)
  ✔ adds, updates, and archives profiles without changing stable IDs (0.34425ms)
✔ Multiple Accounts documents (393.934708ms)
▶ generation mutex
  ✔ serialises real generation-directory moves (423.684541ms)
  ✔ tears the same tree when the moves are not serialised (129.305583ms)
  ✔ does not wedge the queue when a task rejects (0.7665ms)
  ✔ gives each caller its own task's result, in queue order (110.290167ms)
✔ generation mutex (665.340042ms)
▶ queue drain
  ✔ waits for the work already queued, failure included (4.656959ms)
✔ queue drain (4.980125ms)
▶ settings write queue
  ✔ keeps both patches when the writes are serialised (94.232ms)
  ✔ drops a patch when the same writes are not serialised (111.488125ms)
  ✔ writes the next patch after a write fails (80.736333ms)
✔ settings write queue (286.776875ms)
✔ appends one exported mutable global and writes it into the record (13.096416ms)
✔ locates an unchanged callback without a predecessor hash (0.734666ms)
✔ refuses malformed input and ambiguous callback candidates (0.173792ms)
✔ rejects malformed or over-broad isolated verifier records (0.239958ms)
✔ refuses a callback whose body is not the certified one (0.314833ms)
✔ rechecks the isolated record's callback signature during production (0.121834ms)
✔ refuses a table slot that no longer holds the certified function (12.732791ms)
✔ refuses duplicate active table slots instead of accepting the last mapping (0.198083ms)
✔ refuses to insert past the end of the body (0.158666ms)
✔ refuses a module that already carries the flag export (0.275333ms)
✔ the shipped baseline states its own offsets and keeps valid historic fixtures (0.166959ms)
▶ native Keychain boundary
  ✔ has exactly the two product-owned slots (1.631584ms)
  ✔ resolves the one development and one packaged binary path (0.161084ms)
  ✔ accepts an asynchronous in-memory fake without another interface (0.206083ms)
✔ native Keychain boundary (2.640417ms)
▶ no game traffic is uploaded: the only reachable destination
  ✔ refuses every destination that is not a public ArenaNet-shaped address (5.737041ms)
  ✔ refuses loopback through the constructor's own defaults (0.196042ms)
  ✔ opens an allowed destination at exactly the address it was given (0.333167ms)
  ✔ resolves no name outside ArenaNet's, including this project's own (0.157583ms)
✔ no game traffic is uploaded: the only reachable destination (7.420916ms)
▶ no game traffic is uploaded: what the recorder may hear
  ✔ publishes payload bytes to the game and to nothing else (0.581083ms)
  ✔ exports a socket's lifetime with no trace of what it carried (13.086042ms)
  ✔ stops the export if a socket record carries the bytes anyway (0.841709ms)
✔ no game traffic is uploaded: what the recorder may hear (15.280958ms)
▶ the published code generation
  ✔ is the identity of the two JSPI artifacts and nothing else (2.264208ms)
  ✔ refuses a manifest that names no code artifact (0.315791ms)
✔ the published code generation (3.624125ms)
▶ the command line
  ✔ reads the three things this script does (18.227417ms)
  ✔ refuses a record it was not handed a generation for (0.242ms)
  ✔ refuses to fetch and record in the same run (0.113833ms)
  ✔ refuses a download with nowhere to put the bytes (0.107917ms)
✔ the command line (18.854916ms)
▶ the recorded client generation
  ✔ round-trips through its own serializer (0.196375ms)
  ✔ refuses everything it cannot read exactly (0.144625ms)
  ✔ is a tracked file the detector can read today (96.852291ms)
✔ the recorded client generation (97.500792ms)
✔ packaging accepts only the four complete supported intents (196.425542ms)
▶ patch-client update
  ✔ publishes a generation whose artifacts match the manifest beside them (549.441041ms)
  ✔ leaves an alpha-published generation installed instead of re-staging it (406.499834ms)
  ✔ promotes nothing when assembly silently truncates an artifact (408.567417ms)
  ✔ keeps the installed generation when a staged artifact changes under it (477.959333ms)
  ✔ aborts a slow preparation without moving the installed generation (352.498209ms)
  ✔ still swaps in a verified replacement and keeps the rollback target (673.653125ms)
✔ patch-client update (2870.8375ms)
▶ patch transport
  ✔ owns patch identity, redirect policy, caller abort, and response bounds (358.913083ms)
  ✔ accepts only HTTP 200 and never follows redirects through retries (0.310042ms)
  ✔ classifies a request that never got an HTTP answer as net_offline (0.213167ms)
  ✔ rejects a materialized body above its declared call-site limit (0.134875ms)
  ✔ interrupts retry backoff without starting another request (48.761792ms)
  ✔ bounds streamed bodies with and without content-length (28.972708ms)
  ✔ enforces exact decoded chunk lengths and gzip output bounds (68.467333ms)
✔ patch transport (506.693167ms)
▶ resolved profile paths
  ✔ pins the whole profile layout as literals (2.440416ms)
  ✔ sweeps every directory the profile publishes documents into (0.321792ms)
  ✔ derives profile paths only beneath the Multi namespace (0.414042ms)
  ✔ keeps the downloaded chunk cache exactly where the alpha put it (0.160958ms)
  ✔ pins the files published inside a client generation (0.094334ms)
  ✔ resolves an unpacked executable in development and when packaged (0.107459ms)
  ✔ pins the diagnostics frame log name (0.069834ms)
  ✔ resolves a staged generation without escaping the game directory (1.970791ms)
✔ resolved profile paths (7.038792ms)
▶ ArenaNet unavailable platform capabilities
  ✔ exposes only the two namespaces required by defective client guards (1.728791ms)
  ✔ returns promises with explicit unavailable outcomes (0.451833ms)
  ✔ preserves the four callback assignments made by the glue (0.0865ms)
✔ ArenaNet unavailable platform capabilities (2.984292ms)
✔ play-region authority withdraws on staleness and requires a newer publication to recover (3.755542ms)
▶ PreferencesCoordinator
  ✔ publishes shortcut commits and the active result of an ambiguous write (356.150875ms)
  ✔ keeps the released district-bearing shortcut shape (92.63725ms)
  ✔ refuses a stale second window instead of losing the first write (73.37275ms)
  ✔ serializes ordinary settings writes with shortcut writes (74.471583ms)
  ✔ reports a post-rename failure as unconfirmed, then reloads the active value (47.384875ms)
  ✔ returns an ordinary settings update that became active before fsync failed (51.36775ms)
  ✔ returns a settings reset that became active before fsync failed (79.135792ms)
  ✔ resets settings and Travel preferences completely (236.219042ms)
  ✔ does not attempt Travel when the settings reset definitively fails (172.523084ms)
  ✔ skips the Travel write when its document is already default (105.511708ms)
  ✔ returns a partial result when the Travel write definitively fails (64.116334ms)
  ✔ reconciles a Travel reset published before directory fsync failed (97.356916ms)
  ✔ returns partial when Travel cannot be read after settings commit (58.736333ms)
  ✔ returns partial when an unconfirmed Travel publication cannot be reread (134.347458ms)
  ✔ completes an idempotent retry after a partial Travel reset (159.2995ms)
  ✔ runs the next queued mutation after a partial reset (206.7245ms)
✔ PreferencesCoordinator (2010.974791ms)
✔ the command trace publishes exact profession and skill payloads (5.008042ms)
✔ a drained attribute opcode does not invent an observed target (0.297542ms)
▶ Multiple Accounts runtime state
  ✔ tracks honest batch transitions without changing already-open accounts (0.895958ms)
  ✔ releases the untouched queue after canary failure (88.139083ms)
  ✔ maps every failure stage to bounded player-safe vocabulary (0.115375ms)
✔ Multiple Accounts runtime state (89.820167ms)
▶ download progress
  ✔ warms up, then smooths bursty chunk completion rates (25.648625ms)
  ✔ moves the displayed minutes only at the hysteresis edges (0.17225ms)
  ✔ throttles the detail line but renders clearing events immediately (0.155708ms)
  ✔ ignores duplicate and regressing samples instead of producing spikes (0.07425ms)
  ✔ drives Dock progress and sleep blocking only for a full download (0.90775ms)
✔ download progress (27.677542ms)
▶ proxy-routes
  ✔ maps only the explicit ArenaNet/NCSoft route labels (1.093ms)
  ✔ keeps redirects inside the custom protocol and exact upstream host (0.233458ms)
  ✔ applies redirect and stateless-header policy as one response boundary (459.930958ms)
  ✔ permits proxy routes only for fetch/XHR destinations (0.146917ms)
  ✔ keeps the proxy stateless in both directions (0.077959ms)
✔ proxy-routes (462.198292ms)
▶ published client manifest
  ✔ returns a canonical detached manifest (65.744208ms)
  ✔ reads a manifest the alpha published with no format version (0.174667ms)
  ✔ refuses a manifest from a format this build cannot read (3.709792ms)
  ✔ publishes the format marker when it seals a legacy generation (270.1625ms)
  ✔ verifies every persisted executable artifact (165.730334ms)
  ✔ atomically seals a legacy generation before it can be replaced (90.812333ms)
  ✔ rejects invalid snapshot identity, dimensions, and chunk count (0.407583ms)
✔ published client manifest (598.159958ms)
✔ neither a stuck cleanup task nor a stuck final flush can hold the quit (2.269041ms)
▶ ranges
  ✔ parses closed, open-ended, and suffix ranges (2.287125ms)
  ✔ returns null without a usable Range header (0.120375ms)
  ✔ marks unsatisfiable ranges (0.071084ms)
✔ ranges (3.10025ms)
▶ Squirrel.Mac release manifest
  ✔ contains exactly one immutable release asset (3.329ms)
  ✔ refuses mismatched tags and non-file ZIP names (0.200208ms)
  ✔ uses one closed reader for generated and downloaded manifests (0.133375ms)
✔ Squirrel.Mac release manifest (4.28725ms)
▶ the one marked release Verification record
  ✔ stages Pending evidence without changing generated notes (7.696375ms)
  ✔ replaces only the marked block (3.850292ms)
  ✔ preserves a passed result only for the same immutable evidence (0.671125ms)
  ✔ refuses duplicate markers, changed checksum rows, and Pending results (0.201458ms)
✔ the one marked release Verification record (13.585875ms)
▶ release version parsing
  ✔ accepts every shape the release workflow publishes, tagged or not (3.393542ms)
  ✔ rejects 2026.07.01 and every other non-SemVer numeric identifier (0.139167ms)
  ✔ rejects anything that is not exactly a published release shape (0.095917ms)
  ✔ rejects digit runs too long to compare exactly (0.099583ms)
  ✔ round-trips through canonical text without the tag prefix (0.139875ms)
✔ release version parsing (4.575417ms)
▶ release version ordering
  ✔ orders numerically first, then prerelease before its own release (0.329125ms)
  ✔ does not read a prerelease as equal to the release it leads to (0.106334ms)
  ✔ reports which versions are prereleases (0.09175ms)
✔ release version ordering (0.668167ms)
▶ public release tracks
  ✔ keeps Stable as the default and never makes alpha public (0.17ms)
  ✔ requires GitHub prerelease metadata to match the tag (0.122166ms)
✔ public release tracks (0.374084ms)
✔ loading cannot impersonate character selection or playable completion (0.959417ms)
✔ only a certified playable instance completes relog (0.083208ms)
▶ reload transcript
  ✔ joins main and replacement-renderer events for exactly one owner (1.190209ms)
  ✔ reports an incomplete or missing boundary truthfully (0.128125ms)
  ✔ starts a menu trace at its own reload after an older Command-Q run (0.111625ms)
  ✔ stays below the clipboard ceiling by retaining newest complete rows (93.895084ms)
✔ reload transcript (95.996291ms)
✔ renderer failures stay with one document and client generation (41.5365ms)
✔ a renderer handler may complete before the final load event (1.104958ms)
✔ mounts, restores, prepares, and persists the game filesystem before main (6.816208ms)
✔ reuses an existing mount while restoring every required invariant (0.177625ms)
✔ normalizes Guild Wars desktop template paths at the filesystem boundary (0.287584ms)
✔ blocks game startup and reports an IndexedDB restore failure (0.130833ms)
✔ blocks game startup when the directory invariant cannot be persisted (0.107ms)
✔ blocks game startup when IndexedDB synchronization stalls (0.14275ms)
✔ every host module exports exactly one installer (1.423666ms)
✔ merging the host modules loses no installer (0.863083ms)
▶ canonical renderer URL
  ✔ allows the launcher document and nothing else (6.025125ms)
  ✔ rejects every query string, including the ones it used to carry (0.122709ms)
  ✔ rejects proxy, subresource, ambiguous, and malformed URLs (0.109583ms)
  ✔ gives the accounts Hub its own document boundary (0.094583ms)
✔ canonical renderer URL (7.047791ms)
✔ runtime states admit only their complete valid phases (4.133708ms)
▶ semantic proof primitives
  ✔ binds every verdict to one input and verifier ABI (0.799333ms)
  ✔ requires an exact, non-empty witness ledger (1.133ms)
  ✔ canonicalizes only explicit relocation operands (1.426833ms)
  ✔ fails closed at the analysis ceiling (0.143291ms)
✔ semantic proof primitives (4.156167ms)
▶ the sensitive-key vocabulary
  ✔ treats a field named pass as sensitive (1.04325ms)
  ✔ treats a field named auth as sensitive (0.075ms)
  ✔ treats a field named cookie as sensitive (0.053958ms)
  ✔ treats a field named token as sensitive (0.05075ms)
  ✔ treats a field named secret as sensitive (0.055625ms)
  ✔ treats a field named credential as sensitive (0.047792ms)
  ✔ treats a field named username as sensitive (0.064583ms)
  ✔ treats a field named email as sensitive (0.046917ms)
  ✔ treats a field named account as sensitive (0.064958ms)
  ✔ treats a field named login as sensitive (0.113042ms)
  ✔ leaves the field names the schema already declares alone (0.090375ms)
  ✔ scans text for every sensitive key stem (0.62325ms)
✔ the sensitive-key vocabulary (3.111667ms)
✔ ENOENT means no destructive startup action is pending (2.602584ms)
✔ marker inspection failures other than ENOENT remain visible (15.925667ms)
✔ a failed shortcut write reconciles through Settings and leaves capture mode (10.549ms)
✔ cooldown settings render the canonical choice and shared preview (2.852583ms)
✔ cooldown settings reject malformed custom colors and persist valid colors (37.932667ms)
✔ cooldown settings recover the active state after a failed write (11.443417ms)
✔ cooldown settings do not repaint a custom color while it is being edited (0.239917ms)
✔ skill-key previews expose the same canonical label as their visual plate (6.287458ms)
✔ blur cancels recording and a captured chord persists only the display setting (2.791583ms)
▶ settings
  ✔ exposes the documented defaults (1.797708ms)
  ✔ drops retired cursor fields from an alpha profile (0.282875ms)
  ✔ fills missing fields and ignores unknown keys on read (0.07725ms)
  ✔ preserves every explicit supported render scale (0.082167ms)
  ✔ accepts only supported interface styles (0.258334ms)
  ✔ normalises and validates the permanent custom theme contract (0.3165ms)
  ✔ accepts only the supported interface fonts (0.103167ms)
  ✔ accepts only the two supported controller prompt styles (0.108375ms)
  ✔ rejects unknown types (0.187083ms)
  ✔ takes the update fields only in the shapes the renderer can produce (0.223375ms)
  ✔ accepts only bounded shortcut overrides (0.243041ms)
  ✔ accepts exactly eight display-only skill bindings (0.364458ms)
  ✔ takes the acknowledged client build only as a client hash (0.191083ms)
  ✔ accepts one canonical cooldown switch and color (0.229666ms)
  ✔ validates patches without filling fields from defaults (0.208875ms)
  ✔ keeps Travel shortcuts off the generic renderer settings channel (0.093625ms)
  ✔ loads defaults for missing or corrupt files (267.874208ms)
  ✔ saves only known fields (15.245125ms)
  ✔ loads an alpha-written bare-JSON file with every value intact (17.516666ms)
  ✔ preserves released district shortcuts for Stable rollback compatibility (1.474125ms)
  ✔ keeps the three newest corrupt backups and drops the rest (10.161167ms)
  ✔ moves aside a settings format this build cannot read (3.816791ms)
✔ settings (322.059209ms)
✔ catalogue and icon refusals are retryable without restarting (18.932959ms)
✔ the skill catalogue has one complete cross-process parser (2.00525ms)
✔ one malformed skill refuses the whole catalogue (0.241958ms)
✔ the presentation joins complete geometry and cooldown state without touching keys (3.033542ms)
✔ ready skills, stale state, disabled Tools, and incomplete publications hide everything (0.334125ms)
✔ sub-frame timer changes that keep the same label cause no presentation update (0.197958ms)
✔ equal cooldown labels skip projection while resize refreshes it (0.253208ms)
✔ either accepted feed withdrawing hides the complete cooldown HUD (0.18975ms)
✔ the minimal cooldown profile needs play-region policy but no Party or UI hook (1.907083ms)
✔ the minimal cooldown profile activates only its shared read substrate (0.393708ms)
✔ withdraws a cooldown publication whose sequence stops advancing (1.935833ms)
✔ cooldown formatting rounds active values upward without showing zero (57.228417ms)
✔ cooldown colors accept only the closed presets or exact six-digit RGB (1.361875ms)
✔ formats modifiers in one fixed order before the main key (2.384334ms)
✔ formats mouse buttons and wheel directions without stored labels (0.169708ms)
✔ requires exactly eight closed, bounded bindings (0.393208ms)
✔ clone and update return deeply frozen independent tuples (0.152542ms)
✔ clone and update reject malformed values at the runtime boundary (0.270875ms)
✔ a custom projection adds only the changed key label (13.537292ms)
✔ a malformed or absent custom binding hides the complete overlay (0.2965ms)
✔ an unchanged frame performs no text write (0.886583ms)
✔ the consumer maps only slot eight's custom C binding (31.360125ms)
✔ a viewport resize refreshes projected key geometry (0.27975ms)
✔ the consumer withdraws geometry whose publisher stopped advancing (0.304458ms)
✔ the surface never takes input or enters the accessibility tree (0.105375ms)
✔ disposing removes the complete surface (0.08525ms)
✔ skill policy activates and withdraws only the observation regions it needs (4.396583ms)
✔ geometry listeners ignore heartbeat-only publications but receive moved bars (3.377209ms)
▶ client language-file table
  ✔ finds all 18 language rows by their complete pointer/hash shape (7.908833ms)
✔ client language-file table (8.468333ms)
▶ client language shards
  ✔ parses exactly 1,024 bounded UTF-16 records and ignores the trailer (11.343791ms)
  ✔ keeps unrelated context-keyed records opaque without losing the shard (39.4065ms)
  ✔ maps string ids across shard boundaries (1.112875ms)
  ✔ substitutes all three skill ranges without interpreting markup as HTML (0.09825ms)
✔ client language shards (52.246167ms)
▶ socket events carry no error text
  ✔ publishes a declared failure code, not libuv's message (2.059125ms)
  ✔ collapses an unrecognised errno rather than passing it through (0.156917ms)
  ✔ classifies each errno the allowlist names, and nothing else (0.095417ms)
  ✔ names why a socket closed, from a closed vocabulary (0.285209ms)
  ✔ reports a connect timeout as a timeout, not as an error (0.161208ms)
✔ socket events carry no error text (4.160875ms)
▶ renderer socket host
  ✔ uses one subscription and demultiplexes sockets by native ID (63.3165ms)
  ✔ honors close requested before connect resolves and closes once (5.310791ms)
  ✔ rejects pre-open sends asynchronously and compacts opened payloads (12.668208ms)
  ✔ waits for close after an error instead of retaining the close forever (3.360458ms)
✔ renderer socket host (87.626291ms)
▶ main-process socket queue budget
  ✔ holds the aggregate owner ceiling across 64 sockets (3.017833ms)
  ✔ refuses a write past the per-socket ceiling while the owner still has room (0.502792ms)
  ✔ keeps one owner's budget and sockets out of another owner's reach (0.587875ms)
  ✔ reclaims a dead socket's bytes once, not again when its callbacks arrive late (0.608083ms)
  ✔ releases callback and synchronous write failures without exposing native details (0.50125ms)
  ✔ leaves no owner queued after close, failure, reload and quit (18.549708ms)
✔ main-process socket queue budget (24.930125ms)
▶ the Steam authorize URL
  ✔ carries the config read out of the official client (26.695375ms)
  ✔ is built from whichever config it is handed (0.231292ms)
✔ the Steam authorize URL (28.041125ms)
▶ the sign-in origin allowlist
  ✔ admits the configured Steam-owned https hosts and their subdomains (0.22225ms)
  ✔ admits the configured authorize origin itself (0.083042ms)
  ✔ rejects non-Steam hosts, plaintext, and suffix look-alikes (0.142541ms)
  ✔ rejects a trailing-dot host rather than resolving it to the same name (0.066ms)
  ✔ answers from the config it is given, not a module-level list (0.068375ms)
✔ the sign-in origin allowlist (0.746458ms)
▶ reading the token back
  ✔ accepts a fragment token whose state matches (1.067792ms)
  ✔ accepts a query token as well as a fragment token (0.135542ms)
  ✔ accepts a bare `token` key as well as `access_token` (0.175458ms)
  ✔ prefers access_token when a response carries both (0.095792ms)
  ✔ rejects a response whose state does not match the attempt (0.071375ms)
  ✔ rejects a response carrying no state at all (0.057916ms)
  ✔ rejects a matching-state response that carries no token (0.084666ms)
  ✔ rejects a matching-state response whose token is empty (0.067334ms)
  ✔ does not treat a matching state on another URL as the redirect (31.065792ms)
✔ reading the token back (43.870542ms)
▶ the state nonce
  ✔ is unguessable and fresh per attempt (1.244334ms)
✔ the state nonce (1.318542ms)
Keychain operation failed steamSession unclassified Error
▶ the Steam session store
  ✔ round-trips the fixed Steam slot and clears it (8.732292ms)
  ✔ keeps a record whose expiry the account service has not supplied (0.247041ms)
  ✔ reports an absent store as absent, not as a failure (0.12225ms)
  ✔ maps native failure to the Steam session vocabulary (1.05575ms)
  ✔ refuses invalid bytes without destroying them (0.191167ms)
  ✔ rejects an invalid record before replacing a stored one (0.201875ms)
✔ the Steam session store (17.951917ms)
▶ the Steam session shape check
  ✔ accepts a token with a numeric expiry or none yet (0.108ms)
  ✔ keeps only the two fields it models (0.078208ms)
  ✔ rejects anything that cannot be replayed at a login screen (0.231458ms)
✔ the Steam session shape check (0.546833ms)
▶ deciding which Steam token to vend
  ✔ replays a stored token that has not expired, without opening a window (8.330667ms)
  ✔ replays a stored token whose expiry is not known yet (0.099042ms)
  ✔ answers a silent request with nothing rather than opening a window (0.09925ms)
  ✔ acquires on a non-silent request and stores what it got (0.116792ms)
  ✔ replaces a locally valid token on an explicit request (0.089792ms)
  ✔ does not replay a rejected token when explicit reauthentication is cancelled (0.059375ms)
  ✔ refuses an implausibly long token instead of handing it to the client (0.067125ms)
  ✔ reports a sign-in that did not complete without storing anything (0.057959ms)
  ✔ carries the sign-in refusal reason through to the caller (0.1565ms)
  ✔ treats an expired token as absent and discards it (3.678333ms)
  ✔ re-acquires when the expired token is met with a real request (0.115416ms)
  ✔ treats an unreadable store as absent and keeps the file (0.103042ms)
  ✔ still vends an acquired token when storing it fails (0.12825ms)
✔ deciding which Steam token to vend (13.308ms)
▶ keeping its promise never to throw
  ✔ reports an acquisition that threw instead of letting it escape (0.087583ms)
  ✔ reports an acquisition that rejected asynchronously (0.084541ms)
✔ keeping its promise never to throw (0.214ms)
▶ ordering complete Steam session operations
  ✔ makes clear final when acquisition was already in flight (3.535458ms)
  ✔ makes clear final when storeback was already in flight (86.120959ms)
  ✔ does not let an older storeback overwrite a newer resolution (0.212208ms)
  ✔ continues after a queued operation rejects (0.117125ms)
  ✔ lets quit wait for the last queued secret write (0.119666ms)
  ✔ coalesces concurrent interactive resolutions (0.084875ms)
✔ ordering complete Steam session operations (96.403292ms)
▶ how a resolution reads in diagnostics
  ✔ separates a replayed token from a freshly acquired one (0.076375ms)
  ✔ still calls it acquired when only persisting the token failed (0.037ms)
  ✔ calls a failed acquisition absent, not acquired (0.032375ms)
  ✔ reads an expired-then-replaced token as acquired (0.032667ms)
✔ how a resolution reads in diagnostics (0.234958ms)
▶ the client handing a token back
  ✔ refreshes the expiry of the token it already holds (0.100875ms)
  ✔ refuses an expiry that has already passed (0.086333ms)
  ✔ still accepts an expiry in the future (0.050583ms)
  ✔ never extends persistence beyond the OAuth lifetime (0.074375ms)
  ✔ keeps an expiry exactly at the maximum boundary (0.045625ms)
  ✔ rejects an expiry at the current instant (0.040875ms)
  ✔ refuses to turn a known expiry back into an unknown one (0.038583ms)
  ✔ accepts no-expiry-yet when none is known either way (0.037208ms)
  ✔ ignores a storeback that is not the token it holds (0.050875ms)
  ✔ ignores a storeback when nothing is stored at all (0.047708ms)
  ✔ reports a refresh it could not write (0.080334ms)
  ✔ reports an unreadable store rather than overwriting it (0.05575ms)
✔ the client handing a token back (0.818916ms)
✔ tests/unit/team-apply-fixture.ts (994.872791ms)
✔ primary-mismatch facts carry exact professions (0.93375ms)
✔ a behaviour already set is not sent again (48.929458ms)
✔ heroes that are not in the team leave before the ones that are arrive (13.749833ms)
✔ a changed hero order rebuilds the roster in the saved order (20.44375ms)
✔ a roster rebuild adds nobody until each removal is confirmed (45.088125ms)
✔ a concurrent roster addition cannot turn into a false Apply success (1.664417ms)
✔ Devona is removed through the current build's observed hero-id command (15.933334ms)
✔ applying outside an outpost is refused before anything is sent (0.522833ms)
✔ a party that stops publishing mid-apply stops the apply (1.056667ms)
✔ the count in a refusal is the work that landed, not the work attempted (31.932583ms)
✔ is dormant unless the renderer init payload asks for the trace (1.890125ms)
✔ captures the real template open, write, and close result without a path (0.7235ms)
✔ records an open errno and ignores unrelated filesystem traffic (0.272416ms)
✔ recognises the two template kinds and nothing else (1.112666ms)
✔ reads the file the game itself writes (1.20275ms)
✔ every import lands where the client will actually look (0.2435ms)
✔ a trailing newline does not change the file's meaning (0.082083ms)
✔ reads every form a shared build arrives in (0.19075ms)
✔ codes with no name are named after the file they came from (0.118584ms)
✔ text with no origin still names what it imports (0.078375ms)
✔ keeps a profession pair readable and refuses what the client refuses (0.071084ms)
✔ a name is never long enough to vanish from the client's listing (0.107625ms)
✔ one name has one spelling (0.133042ms)
✔ counts the names it had to adjust (0.08625ms)
✔ decodes a file however Windows wrote it (0.25425ms)
✔ a byte order mark never reaches the code (0.082875ms)
✔ lands the same templates wherever the player started the picker (0.091125ms)
✔ a picked path cannot name a folder outside the mount (0.154459ms)
✔ bounds one gesture rather than one file (1.082583ms)
✔ a Windows collection keeps its organisation in the only place the client shows (0.065291ms)
✔ writes the layout it reads (0.070458ms)
✔ an export round-trips through the importer unchanged (0.158458ms)
✔ counts what is saved, in whichever kinds exist (0.993584ms)
✔ says what an import would do before it does it (0.123167ms)
✔ explains a difference between what was picked and what will land (0.248875ms)
✔ a zero bucket contributes no clause (0.07225ms)
✔ a finished import names the in-game action that reveals it (0.11125ms)
✔ names the state the game offers no way out of (0.079916ms)
✔ a rescue reports what moved, what did not, and how to see it (0.111ms)
✔ an export says what it wrote, and a cancel says nothing at all (0.092958ms)
▶ template-save WASM compatibility transform
  ✔ routes the certified call site to the host behind a dirfd marker (2.810167ms)
  ✔ keeps the stub itself intact so uncertified callers are unaffected (0.450625ms)
  ✔ rejects input, stub, call-site, and derived-output drift (0.486917ms)
  ✔ never writes into the caller's input, Buffer or not (1.746708ms)
✔ template-save WASM compatibility transform (6.549334ms)
✔ passes ordinary stat calls through untouched (1.996542ms)
✔ creates the directory the client asks for, separator and all (0.356125ms)
✔ refuses to leave the mount (0.121833ms)
✔ collapses the client's doubled separator instead of rejecting it (0.134083ms)
✔ lists the files a wildcard matches, sorted, and hands over a block (0.472041ms)
✔ honours the wildcard instead of listing the whole directory (0.1535ms)
✔ leaves the list empty for a missing or unreadable directory (0.168042ms)
✔ stays silent unless the trace is explicitly requested (0.255208ms)
✔ hands back the client's internal template path (0.170875ms)
✔ keeps the last character the client's own trimmer would eat (0.162208ms)
✔ truncates a display name to the destination the client offered (0.082542ms)
✔ separates the file and directory requests by flag (0.190666ms)
✔ deletes a template and reports the outcome the caller expects (0.086584ms)
✔ answers whether a file exists without creating it (0.121708ms)
✔ accepts every path shape the client actually emits (0.120417ms)
▶ template-save re-certification
  ✔ builds a valid fixture module (36.705792ms)
  ✔ derives every target and call site past its decoys (24.548333ms)
  ✔ excludes the callers that must keep the original behaviour (1.402292ms)
  ✔ reads the delete stub's own assertion rather than guessing (205.597875ms)
  ✔ round-trips the derived entry through the production transform (2.047833ms)
  ✔ binds one production rewrite to its derived build and exact bytes (2.078792ms)
  ✔ feeds certified and structurally-derived builds through identical rewrites (15.022291ms)
  ✔ fingerprints complete caller semantics, not only call offsets (2.56475ms)
  ✔ reports a build with no create-directory stub as not applicable (1.1625ms)
  ✔ keeps the negative fixtures valid, so the throw is the locator's (7.1825ms)
  ✔ refuses to guess when a predicate matches more than once (15.221917ms)
  ✔ fails loudly when a call site is not padded to the repointable width (0.668625ms)
✔ template-save re-certification (315.440167ms)
▶ adding a derived entry to the authoring table
  ✔ appends the formatted entry to the end of the real table (64.884417ms)
  ✔ refuses to restate a build somebody already certified (0.777416ms)
  ✔ refuses a source with no table to extend (0.37775ms)
✔ adding a derived entry to the authoring table (66.287541ms)
✔ reads both kinds and one level of subfolder (18.242292ms)
✔ ignores what the game would not list (0.173917ms)
✔ addresses an export the way an export folder is addressed (0.152ms)
✔ replaces a profile projection with the canonical snapshot (0.452292ms)
✔ re-importing the same folder does nothing at all (0.210458ms)
✔ a name taken by a different build is refused, or replaced when asked (0.114417ms)
✔ two incoming templates cannot claim one name (0.074916ms)
✔ the game's own root limit is reached before a write, not during one (2.401208ms)
✔ writes what it planned and creates the folder it needs (0.28525ms)
✔ a template is only reported saved once the mount has been synchronised (0.1965ms)
✔ a second import cannot overlap the one already running (0.40575ms)
✔ a failed synchronisation does not strand the guard (0.13125ms)
✔ finds only the templates the game has no way to reach (0.126875ms)
✔ moves a stranded template up, keeping its folder in the name (0.417667ms)
✔ a rescue that would overwrite a different build leaves both alone (0.163208ms)
✔ a stranded copy of a build already at the top level is just removed (4.743375ms)
✔ a rescue cannot push the top level past the game's own limit (4.506041ms)
✔ a folder holding something else is left standing (0.179042ms)
✔ refuses any name that would not stay inside the two directories (0.077833ms)
▶ temporary exact-draft testing
  ✔ compares macOS bundle versions numerically (1.027083ms)
  ✔ accepts Stable, Beta, and RC but refuses Alpha (1.089958ms)
  ✔ requires GitHub prerelease metadata to match the tag (0.16825ms)
  ✔ refuses non-drafts and changed asset inventories (0.12075ms)
  ✔ launches, records Passed, and removes the temporary candidate (80.492584ms)
  ✔ removes complete downloads after a pre-launch checksum failure (6.536083ms)
  ✔ removes complete downloads after a pre-launch attestation failure (6.518958ms)
  ✔ removes complete downloads after a pre-launch signature failure (4.157625ms)
  ✔ removes complete downloads after a pre-launch launch failure (4.10575ms)
  ✔ creates no temporary download when GitHub authentication fails (2.860084ms)
  ✔ retains a launched candidate when it is still running (3.5965ms)
  ✔ retains a launched candidate when release-note recording fails (5.187792ms)
✔ temporary exact-draft testing (117.453583ms)
▶ LEB128 as the snapshots spell it
  ✔ decodes every non-canonical width of the same unsigned value (6.20875ms)
  ✔ round-trips signed values and refuses what will not fit (9.542834ms)
✔ LEB128 as the snapshots spell it (16.95275ms)
▶ the chunk format against generated input
  ✔ accepts exactly the digest shapes, and lower-cases what it accepts (2.775625ms)
  ✔ verifies a chunk against its own digest and no other (5.7225ms)
  ✔ never yields a decoded chunk of a length the manifest did not declare (956.645125ms)
✔ the chunk format against generated input (966.828083ms)
▶ the patch manifest against generated input
  ✔ either refuses, or yields paths that may be joined onto a real directory (15.163ms)
✔ the patch manifest against generated input (15.622042ms)
▶ the WebAssembly section walk against generated input
  ✔ re-encodes what it split, byte for byte (33.603334ms)
  ✔ round-trips index vectors and code bodies (33.711916ms)
  ✔ refuses a corrupted module as a structural fault, never as a surprise (197.755041ms)
✔ the WebAssembly section walk against generated input (265.265292ms)
✔ the independent TypeScript and Rust companion contracts match exactly (27.8955ms)
✔ same-size field swaps, bit drift, opcode drift, and new names are rejected (17.900292ms)
▶ scripts/copy-renderer.mjs only copies assets
  ✔ succeeds without a Rust toolchain (0.826125ms)
  ✔ still produces the renderer tree and its static media (0.472125ms)
  ✔ copies no code, because Rollup emits build/renderer's JavaScript (0.4705ms)
  ✔ copies only declared package inputs (32.895209ms)
  ✔ emits no WebAssembly (0.513791ms)
✔ scripts/copy-renderer.mjs only copies assets (35.965084ms)
▶ scripts/build.mjs is the one caller of rustc
  ✔ compiles the kernel exactly once per build (0.089208ms)
  ✔ writes only an unserved candidate (0.076333ms)
  ✔ publishes it through one immediate build-time sealing step (0.108042ms)
✔ scripts/build.mjs is the one caller of rustc (0.40875ms)
▶ scripts/build.mjs orders the producers of build/renderer
  ✔ copies the assets before the renderer is compiled into the same directory (0.091041ms)
  ✔ compiles and seals the kernel after both of them (0.103792ms)
✔ scripts/build.mjs orders the producers of build/renderer (0.270917ms)
▶ renderer typechecking does not emit runtime files
  ✔ leaves build/shared to the main compiler (0.094375ms)
  ✔ has one explicit renderer runtime producer (0.064542ms)
✔ renderer typechecking does not emit runtime files (0.215791ms)
✔ no second declaration of the ceiling exists (30.38ms)
✔ the renderer's scheduler imports the module that declares it (0.354666ms)
✔ eight is what ArenaNet's shared infrastructure is owed (0.081834ms)
✔ the header's offset and size are not read backwards (2.811209ms)
✔ something that is not a Guild Wars archive is refused (0.296125ms)
✔ a file table without its magic is refused rather than parsed as slots (0.126959ms)
✔ a file id resolves through the index, not by being a slot number (0.215292ms)
✔ a file's streams are followed as a chain (0.134208ms)
✔ a chain that loops terminates instead of hanging on a 4 GB file (0.288125ms)
✔ an empty base slot carries no payload and is not a hit (0.08825ms)
✔ the table holds the 39 real heroes and neither sentinel (1.839084ms)
✔ HERO_BY_ID answers for every hero and for nothing else (0.173542ms)
✔ panel order is a permutation of the 39 places after the player's own (0.1345ms)
✔ no hero carries a profession or a display name, because the source has neither (0.138334ms)
✔ the eight mercenaries are the only heroes no campaign unlocks (0.115625ms)
✔ Razah is player-chosen too, and is the only non-mercenary that is (0.0785ms)
✔ the ten professions carry ids 1-10, and None is not one of them (0.109875ms)
✔ attribute ids skip the unnamed 26-28 gap and never spell the None sentinel (0.148792ms)
✔ every attribute names a profession the table defines (0.171166ms)
✔ a profession row states its wire id and its English name, and nothing else (0.142875ms)
✔ the cost table has one entry per rank and rises with every one (0.097625ms)
✔ the module exports nothing the source could not supply (0.058083ms)
▶ the memory warning counts time, not bytes
  ✔ warns an open-world session with the headroom it claims (2.165291ms)
  ✔ gives a texture-dense mission a real warning, not ninety seconds (2.336542ms)
  ✔ reads the rate that was actually spent, not the shape of the staircase (0.9595ms)
  ✔ puts the levels of a real crash where they belong (0.897208ms)
  ✔ does not read the cost of starting the game as the cost of playing it (0.662083ms)
  ✔ survives a first run whose download outlasts the warm-up (0.630583ms)
  ✔ starts measuring when the player starts playing, not when they log in (1.929416ms)
  ✔ does not let one map load latch a warning that cannot be taken back (1.102084ms)
  ✔ says nothing through an hour with only one growth step in it (1.034167ms)
  ✔ shows the span behind every rate it reports (0.842375ms)
  ✔ falls back to bytes only while there is no rate to read (0.108791ms)
  ✔ keeps warning a stalled heap that is nearly full (0.091625ms)
  ✔ lets a rate go stale rather than believing it forever (2.290917ms)
  ✔ never lowers a warning it has already raised (0.111208ms)
  ✔ rounds the estimate without ever flattering it by much (0.577667ms)
  ✔ produces no NaN, no infinity and no negative minutes (0.136334ms)
✔ the memory warning counts time, not bytes (17.023416ms)
✔ the exposed method invokes the channel the contracts name (4.600292ms)
✔ renaming a canonical channel moves the call, with no edit to the body (1.306167ms)
✔ the derived client's bridge markers cross unchanged, and follow an edit (1.552583ms)
✔ the launch argument prefix comes from the contracts too (1.459042ms)
✔ every canonical Enhancement tool crosses without another field list (0.977458ms)
✔ a contracts export the body needs but does not have fails the build (0.267458ms)
✔ the whole table is read, from record zero (1.828833ms)
✔ energy-cost sentinels are normalized at the parsing boundary (0.08825ms)
✔ the table is found even when the scan lands in the middle of it (0.591292ms)
✔ each weak field of the signature rejects its own near miss (0.131125ms)
✔ ids that do not ascend end the run (0.078833ms)
✔ a binary with no table says so instead of guessing (3.586833ms)
✔ availability separates what a player may actually equip (0.109916ms)
✔ a decoded icon becomes a bottom-up BMP without swapping its channels (1.264166ms)
✔ an icon the decoder could not have produced is refused (0.308542ms)
✔ a decompressed shard is unwrapped only when its length agrees (0.255209ms)
✔ a selected target shows its distance and its range band (2.663667ms)
✔ every band the snapshot can carry has a name to show (0.282208ms)
✔ nothing is shown until the snapshot says a target is selected (0.178042ms)
✔ dropping the target hides the readout again (0.11575ms)
✔ an unchanged target costs no DOM write, however many frames pass (3.275625ms)
✔ a state missing the fields it claims renders nothing (0.170125ms)
✔ the readout takes the page back with it (0.116708ms)
✔ the overlay never takes a click and is never announced (0.124917ms)
✔ the store writes to the directories the mount creates (5.611541ms)
✔ the store addresses the mount absolutely (0.27375ms)
✔ no component decides a colour for itself (13.749417ms)
✔ no component decides a corner for itself (2.14125ms)
✔ no consumer invents a stacking order (1.47675ms)
✔ style projections stay in tokens and consumers do not branch (0.6015ms)
✔ persistent interaction states do not leak into neutral controls (0.698375ms)
✔ shared interaction feedback owns disabled, active, and error presentation (0.461042ms)
✔ every token a stylesheet uses is actually declared (1.564542ms)
✔ every token declared is actually read (0.81225ms)
✔ no token reference carries a leftover alpha suffix (32.424375ms)
✔ the measured Guild Wars radii are fixed in the token source (37.615917ms)
✔ a not-yet-tokenised surface is still not tokenised (40.435291ms)
▶ Chromium stall attribution
  ✔ joins long frame marks, snapshot boundaries, CPU stacks, and renderer tasks (2.265458ms)
  ✔ reports captures without new frame marks and rejects invalid thresholds (0.276083ms)
✔ Chromium stall attribution (3.12925ms)
▶ Chromium trace scanner
  ✔ redacts an absolute path that is the entire value (1.475625ms)
  ✔ redacts a file: URL (0.077917ms)
  ✔ redacts a multiline stack trace (0.061958ms)
  ✔ redacts account and username identifiers in free text (0.057083ms)
  ✔ redacts the JSON spelling a trace actually uses (0.062542ms)
  ✔ redacts a sensitive value containing an escaped quote (0.067833ms)
  ✔ redacts punctuation in a sensitive key and commas and escapes in its value (0.05025ms)
  ✔ redacts a query string carrying credentials (0.059542ms)
  ✔ redacts an OAuth token in a redirect fragment (0.072292ms)
  ✔ redacts an OAuth token in a redirect query (0.113ms)
  ✔ redacts a bearer token (0.072833ms)
  ✔ redacts an email address (0.050584ms)
  ✔ redacts unicode and right-to-left text around a path (0.401042ms)
  ✔ redacts the user's home directory (0.043958ms)
  ✔ redacts a path under the exporting user's own home directory (0.048709ms)
  ✔ keeps the trace parseable as JSON (0.091917ms)
  ✔ keeps a value with an escaped quote in it parseable (0.075083ms)
  ✔ fully redacts a sensitive quoted value containing commas and escapes (0.06875ms)
  ✔ redacts a value that straddles a streaming chunk boundary (9.947917ms)
  ✔ gives the same answer at every split point, for every corpus case (47.4435ms)
  ✔ fails closed when commas inside a JSON string cannot bound the carry (1232.22675ms)
  ✔ streams a large trace when structural commas keep the carry bounded (549.4965ms)
✔ Chromium trace scanner (1843.114333ms)
▶ trade chat contracts
  ✔ accepts numeric and numeric-string timestamps plus replacements (1.768583ms)
  ✔ bounds, validates, deduplicates and orders search results (0.200083ms)
  ✔ rejects malformed payloads and invalid searches (0.229709ms)
  ✔ validates bounded saved offers and players without accepting duplicates (0.22125ms)
  ✔ normalizes bounded trader quotes and price history (0.334625ms)
  ✔ persists saved trade state in one private atomic document (207.69675ms)
✔ trade chat contracts (215.599167ms)
▶ trade chat service
  ✔ fetches and caches current quotes while requesting exact history ranges (65.645916ms)
  ✔ coalesces in-flight history and caches nearby ranges by minute (44.970417ms)
  ✔ classifies an upstream history rate limit without throwing (0.410166ms)
  ✔ rejects oversized trader history while the body is still streaming (0.816959ms)
  ✔ shares one connection and coalesces semantic offer and player searches (0.833458ms)
  ✔ bounds live history, applies replacements, and stops after the last subscriber (5.902042ms)
  ✔ times out unanswered searches and reconnects while subscribed (133.750875ms)
✔ trade chat service (252.709792ms)
▶ Travel history
  ✔ keeps ten unique reviewed destinations in most-recent order (2.021375ms)
  ✔ persists histories independently per character across store instances (242.831042ms)
  ✔ quarantines an unreadable document instead of sharing invented history (3.131541ms)
✔ Travel history (249.194875ms)
▶ Travel preferences
  ✔ preserves corrupt bytes before returning defaults and reports the backup (55.681625ms)
  ✔ stores the Travel-only document without adding Stable-owned settings keys (19.35075ms)
  ✔ projects the released shape and clears withdrawn history on first load (21.348375ms)
  ✔ rejects ambiguous synonyms and unknown document fields (0.70225ms)
✔ Travel preferences (99.4675ms)
▶ Travel
  ✔ contains the complete reviewed direct-travel catalogue (1.844083ms)
  ✔ ranks exact aliases and useful partial names first (12.324375ms)
  ✔ bounds search work before normalization or scoring (2.061917ms)
  ✔ keeps the numbered shortcut list bounded and typed (0.187541ms)
  ✔ keeps Stable-readable shortcut fields on disk while runtime stays map-only (0.243084ms)
  ✔ resolves only catalogue map ids (0.08225ms)
  ✔ rejects one request that would write both preference files (0.68725ms)
✔ Travel (18.135833ms)
▶ custom UI theme contract
  ✔ has the durable v1 defaults (1.5625ms)
  ✔ restores one canonical palette for each material (0.1065ms)
  ✔ strictly parses and normalises six-digit colours (0.156208ms)
  ✔ normalises only the complete semantic theme shape (0.168708ms)
  ✔ round trips the versioned share format and rejects malformed input (0.20575ms)
✔ custom UI theme contract (2.87475ms)
▶ update action
  ✔ formats persisted check times without claiming a future time (1.480708ms)
  ✔ gates a launch on exactly the in-flight and ready updater states (0.146125ms)
  ✔ rehydrates and follows the one main-process state (0.518208ms)
  ✔ makes a downgrade a truthful manual Stable return (0.258625ms)
  ✔ renders closed failure reasons and never says up to date (0.132792ms)
✔ update action (5.000833ms)
▶ static update feed publication
  ✔ selects the highest eligible release independently for each channel (1.274792ms)
  ✔ lets a newer Stable lead both channels and downloads its manifest once (259.780875ms)
  ✔ publishes distinct Stable and Beta manifests when Beta is ahead (0.5525ms)
  ✔ refuses duplicate versions, inconsistent metadata, and missing assets (1.175166ms)
  ✔ refuses unreadable, missing-channel, unavailable, and inconsistent input (0.474ms)
  ✔ allows an unchanged or advancing pair and refuses either rollback (0.284042ms)
  ✔ allows absent published feeds only during explicit bootstrap (0.625125ms)
  ✔ refuses a partial published pair even during bootstrap (0.45175ms)
  ✔ cache-busts both published feeds and disables fetch caching (0.610416ms)
✔ static update feed publication (266.047166ms)
▶ development virtual gamepad
  ✔ starts disconnected, preserves physical pads, and restores Navigator (3.071ms)
  ✔ supports the standard face buttons and a right-stick activation pulse (0.310709ms)
✔ development virtual gamepad (4.003292ms)
▶ wasm abort reasons collapse into the closed vocabulary
  ✔ names the failure class of each known Emscripten abort shape (4.815791ms)
  ✔ classifies an Error by its name and message (0.562416ms)
  ✔ never invents a kind outside the declared union (0.203417ms)
✔ wasm abort reasons collapse into the closed vocabulary (6.304542ms)
▶ wasm abort fingerprints
  ✔ always satisfy the boundary validator, whatever the reason was (1.330875ms)
  ✔ cluster identical causes and separate different ones (3.552125ms)
✔ wasm abort fingerprints (5.06925ms)
▶ the recorded abort event
  ✔ is an error-level renderer event carrying kind, fingerprint, and heap (1.143125ms)
✔ the recorded abort event (1.296792ms)
▶ the recorded heap staircase
  ✔ records whether heap-growth observation is active (0.175584ms)
  ✔ is an info-level renderer event carrying both sides of a growth step (0.080541ms)
  ✔ records the growth trigger as a separate closed event (26.240792ms)
✔ the recorded heap staircase (29.3115ms)
▶ the recorded visual problem
  ✔ contains only bounded graphics and texture state (0.282375ms)
  ✔ preserves unavailable WebGL and program probes at the IPC boundary (0.559083ms)
✔ the recorded visual problem (0.916209ms)
▶ the relog pre-game probe
  ✔ preserves the complete uint32 diagnostic mask (0.121292ms)
✔ the relog pre-game probe (0.154875ms)
▶ wasm binary codec
  ✔ round-trips unsigned LEB128 (1.8605ms)
  ✔ round-trips signed LEB128, including the client's dirfd markers (0.149584ms)
  ✔ emits fixed-width indices and refuses ones that do not fit (0.135375ms)
  ✔ refuses an oversized LEB rather than truncating it (0.092917ms)
  ✔ round-trips sections (0.203958ms)
  ✔ round-trips code bodies and index vectors (0.167375ms)
  ✔ parses function types by resolved signature (0.157917ms)
  ✔ counts and names function imports, skipping the other kinds (0.268ms)
✔ wasm binary codec (3.737417ms)
▶ WASM growth provenance
  ✔ can retain heap evidence without intercepting GL calls (1.245292ms)
  ✔ keeps only the first four numeric WASM frames (8.579209ms)
  ✔ records the request, result, call stack, and current texture state (0.667583ms)
  ✔ distinguishes a refused resize from one that throws (0.346958ms)
  ✔ preserves the allocator contract when observation itself fails (0.155958ms)
  ✔ does not alter imports when the shipped client lacks the resize boundary (0.089458ms)
  ✔ stops retaining texture identities at the documented bound (4.81675ms)
  ✔ drops dead-context residency before texture ids can be reused (0.248459ms)
✔ WASM growth provenance (94.241333ms)
▶ texture storage estimates
  ✔ covers direct and block-compressed formats without guessing unknown ones (0.204459ms)
✔ texture storage estimates (0.327833ms)
▶ window registry
  ✔ resolves immutable context from the native sender id (1.945459ms)
  ✔ retains one process-local account owner across renderer replacement (0.19825ms)
  ✔ attributes a renderer process only to its exact account owner (0.117792ms)
  ✔ refuses to assign a renderer process shared by different owners (0.074292ms)
  ✔ enforces one live game window for a profile (0.2645ms)
  ✔ unregisters only the exact native window (0.099959ms)
  ✔ unregisters after Electron has made webContents unreadable (0.121292ms)
  ✔ does not return destroyed windows (0.150875ms)
  ✔ owns the one Single game window and the one Multiple Accounts Hub (0.1355ms)
  ✔ resolves only registered senders and the focused game (0.188625ms)
  ✔ refuses an ambiguous game selection (0.086375ms)
✔ window registry (4.173666ms)
▶ window shortcut input
  ✔ runs one Command action, preserves Control, and contains capture repeats (3.089917ms)
✔ window shortcut input (3.72175ms)
▶ window state
  ✔ validates and round-trips owner-only state (37.402292ms)
  ✔ restores an alpha window written without a format version (34.926834ms)
  ✔ discards a window-state format this build cannot read (5.118542ms)
  ✔ removes corrupt state and falls back cleanly (6.3305ms)
  ✔ keeps visible windows on their display and clamps oversized bounds (0.197917ms)
  ✔ centers state on the primary display when its monitor disappeared (0.118917ms)
  ✔ keeps the default window distinct from a constrained work area (0.063125ms)
  ✔ restores relative geometry on an unchanged work area (0.077666ms)
  ✔ restores relative geometry on a larger work area (0.065ms)
  ✔ restores relative geometry on a smaller work area constrained by minimum window size (0.101667ms)
  ✔ restores relative geometry on a missing display (0.051708ms)
  ✔ restores relative geometry on the matching display in a multi-display layout (0.048958ms)
  ✔ cascades new account windows by 32px and clamps them (0.096583ms)
✔ window state (85.585666ms)
ℹ tests 1323
ℹ suites 154
ℹ pass 1323
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 35369.615709
✔ every workflow action is pinned to a full commit SHA (11.890334ms)
✔ the pinning scan rejects a floating tag (0.195167ms)
✔ the PlayStation prompt atlas is the reviewed 256×512 CC0 composition (43.626375ms)
✔ the controller prompt lifecycle resets on WebGL context replacement (8.984584ms)
✔ each channel has an exact minimal and isolated entitlement file (1.460792ms)
✔ bug and feature intake stays short, structured, and issue-backed (21.364333ms)
✔ public bug and feature links name issue templates that exist (1.047708ms)
✔ the bundled fonts are pinned and carry their OFL licenses (8.334834ms)
✔ no downloaded game artifacts or generated output are tracked (2.505583ms)
✔ no tracked symlink resolves outside the repository (42.070834ms)
✔ the application does not collect process-memory crash dumps (1.37175ms)
✔ no second production runtime remains (0.131834ms)
✔ no private key material is tracked (1407.571417ms)
✔ only public identifiers and explicit profile-id fixtures are UUID-shaped (2831.109209ms)
✔ release fuses keep Node, inspection and file-protocol privileges disabled (1.470875ms)
✔ no fuse is left to its default (1.020958ms)
✔ lint rejects: src/main/core imports electron (3668.682666ms)
✔ lint rejects: src/main/core type-imports electron (60.960333ms)
✔ lint rejects: src/main/core dynamically imports electron (133.807875ms)
✔ lint rejects: src/main/core imports a submodule of electron (6.3105ms)
✔ lint rejects: src/main/core requires electron through createRequire (19.039875ms)
✔ lint rejects: src/main/core requires electron through an aliased createRequire binding (3.577875ms)
✔ lint rejects: src/main/core dynamically imports electron, spelled with a template literal (2.686166ms)
✔ lint rejects: src/main/core imports upward from src/main (11.077708ms)
✔ lint rejects: src/main/core imports upward from src/main, spelled through src/main (19.500417ms)
✔ lint rejects: src/main/core imports upward from src/main, spelled from the repository root (34.617583ms)
✔ lint rejects: a subdirectory of src/main/core imports upward from src/main (261.854917ms)
✔ lint rejects: src/main/core imports upward through a subdirectory of src/main (20.147416ms)
✔ lint rejects: src/main/core dynamically imports upward from src/main (2.23875ms)
✔ lint rejects: src/main/core dynamically imports upward through a subdirectory of src/main (3.592916ms)
✔ lint rejects: src/main/core dynamically imports upward, spelled through src/main (1.830584ms)
✔ lint rejects: src/main/core dynamically imports upward, spelled with a template literal (2.002833ms)
✔ lint rejects: src/main/core requires upward through createRequire (2.105542ms)
✔ lint rejects: src/main/core imports one level up into a sibling of src/main/core named shared (11.492083ms)
✔ lint rejects: src/main/certification imports electron (40.578041ms)
✔ lint rejects: src/main/certification dynamically imports electron (2.190167ms)
✔ lint rejects: src/main/certification imports upward from src/main (33.558334ms)
✔ lint rejects: src/main/certification imports upward from src/main, spelled through src/main (4.251042ms)
✔ lint rejects: src/main/certification imports upward from src/main, spelled from the repository root (1.850625ms)
✔ lint rejects: src/main/certification dynamically imports upward from src/main (1.489167ms)
✔ lint rejects: src/main/certification dynamically imports upward, spelled with a template literal (1.439958ms)
✔ lint rejects: src/main/certification imports one level up into a sibling of src/main/certification named shared (1.587583ms)
✔ lint rejects: src/main/certification imports the exempt verifier host (1.873042ms)
✔ lint rejects: src/main/certification imports the exempt enhancement policy (4.457375ms)
✔ lint rejects: src/main/certification dynamically imports the exempt enhancement policy (22.457083ms)
✔ lint rejects: src/renderer imports src/main (15.626834ms)
✔ lint rejects: a subdirectory of src/renderer imports src/main (6.155583ms)
✔ lint rejects: a src/renderer TypeScript declaration imports src/main (7.084916ms)
✔ lint rejects: a src/renderer module imports src/main (2.706375ms)
✔ lint rejects: src/renderer dynamically imports src/main (3.47525ms)
✔ lint rejects: src/renderer dynamically imports src/main, spelled with a template literal (2.546042ms)
✔ lint rejects: src/renderer requires src/main through createRequire (2.699334ms)
✔ lint rejects: an apps/website .vue SFC imports src/main (71.57875ms)
✔ lint rejects: an apps/website .vue SFC dynamically imports src/renderer (6.389625ms)
✔ lint rejects: apps/website imports src/main (8.995292ms)
✔ lint rejects: apps/website dynamically imports src/main (2.362333ms)
✔ lint rejects: apps/website dynamically imports src/main, spelled with a template literal (1.730709ms)
✔ lint rejects: apps/website requires src/main through createRequire (1.64625ms)
✔ lint rejects: apps/website imports developer tooling under src/tools (1.441167ms)
✔ lint rejects: an apps/website .vue SFC imports developer tooling under src/tools (12.220708ms)
✔ lint allows: src/main/core imports src/shared (5.845084ms)
✔ lint allows: src/main/core imports a sibling (1.954125ms)
✔ lint allows: src/main/core dynamically imports a sibling (5.734333ms)
✔ lint allows: a subdirectory of src/main/core imports src/shared (21.50975ms)
✔ lint allows: src/main/core requires a node builtin through createRequire (6.2885ms)
✔ lint allows: src/main imports electron (30.181958ms)
✔ lint allows: the certification host imports electron (1.899167ms)
✔ lint allows: src/main/certification imports the codec that stayed in src/main/core (1.311167ms)
✔ lint allows: src/main/certification imports src/shared (4.769125ms)
✔ lint allows: src/main/certification imports a sibling that is not an Electron caller (2.451875ms)
✔ lint allows: src/renderer imports src/shared (3.191625ms)
✔ lint allows: an apps/website .vue SFC imports src/shared (4.434167ms)
✔ lint allows: apps/website imports src/shared (1.614167ms)
✔ the .vue sources this boundary covers still exist (87.932333ms)
✔ ESLint covers the packaging config and every website source (4634.063541ms)
✔ every website .vue source is linted, not just the one named above (46.819125ms)
✔ ESLint still skips derived output and developer-only tooling (3.840291ms)
✔ main-process runtime imports are acyclic (1848.7085ms)
✔ the graph check distinguishes runtime cycles from erased type edges (1.02375ms)
✔ a link to NOPE.md in README.md exits non-zero and names the line (979.886792ms)
✔ a repository whose links all resolve exits zero and says nothing (1566.972042ms)
✔ targets are resolved relative to the file that contains them (50.690375ms)
✔ percent-encoded, titled and fragment-suffixed targets resolve to the real path (33.712167ms)
✔ an unbracketed destination containing a space is not a link (0.129458ms)
✔ link syntaxes that carry a target are all extracted (0.148833ms)
✔ a badge link reports the outer destination, not only the image it wraps (62.040125ms)
✔ a tracked file deleted from the working tree is skipped, not fatal (1198.150084ms)
✔ an existing target outside the repository is broken (120.595375ms)
✔ an ignored target is broken even while it exists locally (107.843958ms)
✔ a repository directory target has at least one durable child (120.701042ms)
✔ code blocks, code spans, URLs and bare anchors are not treated as links (0.140667ms)
✔ the file list covers tracked docs and excludes gitignored scratch (41.439208ms)
✔ the bundled application icon carries every representation macOS renders (2.882834ms)
✔ release workflow stages and publishes one tested, attested package version (49.805125ms)
✔ cooldown presentation has no gameplay input or command dependency (11.875917ms)
▶ the macOS input policy
  ✔ has no selectable or persisted touch mode (891.817791ms)
  ✔ sets the bundle-specific repeat preference before the first window (3.631042ms)
✔ the macOS input policy (897.339333ms)
✔ IPC still refuses a sender that is not the main frame at the canonical URL (1.738292ms)
✔ production resolves native windows only through the window registry (57.04925ms)
✔ runtime error dialogs keep their owning game window (0.287875ms)
✔ the proxy still answers only fetches (0.1015ms)
✔ the proxy response still crosses the canonical header boundary (0.354083ms)
✔ every source module opens with a block doc comment (44.53075ms)
✔ every KNOWN_UNHEADERED entry still names a file that still lacks one (0.106625ms)
✔ the native boundary uses only ABI-stable Node-API (1.118333ms)
✔ Command-held releases use one app-local macOS monitor (0.133958ms)
✔ the native host does not own the app key-repeat preference (0.109ms)
✔ the native boundary owns two fixed Data Protection Keychain items (1.129375ms)
✔ the canonical build emits one host-only Node-API 8 addon (0.251042ms)
✔ Forge unpacks only the two executables from ASAR (0.229542ms)
✔ the hand-written preload body contains no channel literal (5.428ms)
✔ the body declares nothing the generator is meant to supply (453.001917ms)
✔ macOS identity uses the Reforged name and configured application icon (3.37725ms)
✔ the public rename keeps the existing profile as its one data home (1.5865ms)
✔ package metadata identifies the GPL project and canonical repository (0.322417ms)
✔ packaged releases carry the project and third-party license notices (0.65075ms)
✔ the packaged bundle takes its version numbers from the package version (0.181541ms)
✔ the host has one native automatic application replacement path (1.493458ms)
✔ distribution channels use preflighted signing and a scoped marker (1.263083ms)
✔ release entitlements are an exact three-key allowlist (0.289667ms)
✔ the Stable rollback proof establishes its write generation before saving (1.007834ms)
✔ application verification routes conservatively through one required result (6.734041ms)
✔ developer builds are exact, ad-hoc, bounded, and isolated from releases (1.870625ms)
✔ runtime package entries and audit exceptions stay explicit (9.395792ms)
✔ packaging cleans its output first, and builds the renderer runtime (0.429625ms)
✔ the default gate is deterministic and certifies every shipped test layer (2.962875ms)
✔ release verification tells the player to check, never to disable a check (0.890417ms)
✔ the maintainer tests a temporary exact draft without replacing Applications (1.590959ms)
✔ the required application gate owns website certification (311.525666ms)
✔ Vercel Previews are explicit, exact-head, and collaborator-only (0.578542ms)
✔ client recertification reports evidence but cannot grant authority (1.400584ms)
✔ the scheduled canary exercises the latest ArenaNet client conservatively (0.156541ms)
✔ saved login has exactly two Data Protection Keychain items (211.872666ms)
✔ only provisioned distribution channels enable persistent secrets (1.178875ms)
✔ no build seeds the Steam token from the environment (47.634333ms)
✔ Settings exposes two built-ins and one semantic custom theme (10.36375ms)
✔ Settings exposes the independent interface fonts (26.929ms)
✔ Settings exposes the two controller prompt styles (72.686208ms)
✔ panel opacity uses the canonical bounds (11.484959ms)
✔ Tools features consume Reka behavior through the shared Vue UI layer (61.862625ms)
✔ feature styles cannot reintroduce the retired selection recipes (1.374ms)
✔ shared motion transitions only transform or opacity (1.564375ms)
✔ the single-weight Guild Wars face is never synthetically emboldened (0.372667ms)
✔ the scripts index.html loads with a plain tag emit no ES module (109.92425ms)
✔ the official gamepad imports stay wired without a production WASM hook (1.482875ms)
✔ persistent game files are prepared through supported Emscripten startup hooks (2.802958ms)
✔ production diagnostics do not patch Web Audio prototypes (4.228459ms)
✔ the live harness persists no raw addresses or Toolbox screenshots (1.799041ms)
✔ stall attribution markers are fixed-name and Level 2 only (0.800084ms)
✔ template file tracing is explicit, bounded, and attached only at the import boundary (2.091792ms)
✔ the GL program cache memoizes only shader-completion state, and only once it is true (3.744958ms)
✔ template saving uses one exact-build derived WASM and a restricted mkdir bridge (1.084583ms)
✔ a new client build can be re-certified without hand-derivation (2.058458ms)
✔ Enhancement re-certification inspects only post-template bytes (1.26325ms)
✔ only strict feature locators may turn structural evidence into launch authority (3.163375ms)
✔ native double-click and 4 GB use bounded local proof as sole runtime authority (1.841834ms)
✔ the WASM section codec has exactly one home (2.621625ms)
✔ the served module decides whether Enhancement imports (1.672792ms)
✔ a completed client main loop closes the host application (1.551042ms)
✔ the memory warning measures time and keeps its one contract import (1.552834ms)
✔ the memory warning measures a staircase step to step (2.035375ms)
▶ the benchmark measures each arm in both orders
  ✔ mirrors the arms so every arm sits at the same mean position (1.90425ms)
  ✔ recognises a biased order for what it is (0.115417ms)
  ✔ warms every phase the same way and records the order it ran (0.869542ms)
  ✔ reports no regression for a drift the old order would have blamed on the Enhancement (0.461375ms)
  ✔ still reports a real cost the arm actually has (0.312583ms)
  ✔ refuses a phase that measured nothing (0.165417ms)
  ✔ averages an arm's phases instead of pooling their samples (0.250292ms)
✔ the benchmark measures each arm in both orders (4.800916ms)
▶ the performance acceptance gate reads the record the benchmark writes
  ✔ accepts the record a mirrored run produces (25.617ms)
  ✔ refuses a run that measured each arm once (0.38075ms)
  ✔ refuses a record whose arms it cannot find (0.159125ms)
  ✔ keeps every budget the two-phase gate held (52.407ms)
✔ the performance acceptance gate reads the record the benchmark writes (78.744416ms)
✔ rust-toolchain.toml pins the channel, its components, and the wasm target (1.195417ms)
✔ every script name is a literal the build scan can match (0.16025ms)
✔ every workflow that compiles the kernel installs the pinned toolchain first (84.247583ms)
✔ the toolchain scan rejects a build on the runner's own toolchain (0.275166ms)
✔ the Node floor is declared once and enforced before anything is built (0.338417ms)
✔ every workflow pins a Node version the floor accepts (8.290292ms)
✔ every source file the repository owns is an input to a tsconfig project (4.236292ms)
✔ every KNOWN_UNCHECKED entry still names a file that is still unchecked (0.182375ms)
✔ no hand-written declaration shadows the implementation it describes (0.5055ms)
ℹ tests 181
ℹ suites 3
ℹ pass 181
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 8452.446125

 RUN  v4.1.10 /Users/matthias/Git/games/guild-wars-mac/gwonmac-travel-party-close/apps/tools


 Test Files  16 passed (16)
      Tests  120 passed (120)
   Start at  14:58:07
   Duration  11.64s (transform 16.50s, setup 0ms, import 28.80s, tests 14.94s, environment 19.58s)\n- [x] Tools tests: 120 passed\n- [x] Added a focused first-travel sequence test\n- [x] Kept this pull request focused\n- [x] Added no game binaries, credentials, diagnostics, or private traffic