### PR TITLE
fix(travel): close palette and correct focus order

### DIFF
--- a/apps/tools/src/components/TravelPalette.test.ts
+++ b/apps/tools/src/components/TravelPalette.test.ts
@@ -158,6 +158,36 @@ describe("TravelPalette", () => {
     wrapper.unmount();
   });
 
+  it("keeps the palette open when destination submission is refused", async () => {
+    const test = fixture({ synonyms: [{ term: "daily run", mapId: 480 }] });
+    test.travel.mockRejectedValueOnce(new Error("travel refused"));
+    await flushPromises();
+
+    await test.wrapper.get("#travel-search-input").setValue("daily");
+    await test.wrapper.get('[role="option"]').trigger("click");
+    await flushPromises();
+
+    expect(test.wrapper.emitted("close")).toBeUndefined();
+    test.wrapper.unmount();
+  });
+
+  it("tabs from search through recents and favorites before header actions", async () => {
+    const { wrapper } = fixture({ history: [449] });
+    await flushPromises();
+    const controls = wrapper.findAll("input, button").filter(({ element }) =>
+      !(element as HTMLInputElement | HTMLButtonElement).disabled
+      && element.getAttribute("tabindex") !== "-1"
+    );
+
+    expect(controls[0]?.attributes("aria-label")).toBe("Destination or search phrase");
+    expect(controls[1]?.classes()).toContain("travel-recent");
+    expect(controls.slice(2, -2).every((control) =>
+      control.classes().includes("travel-favorite"))).toBe(true);
+    expect(controls.at(-2)?.attributes("aria-label")).toBe("Customize Travel");
+    expect(controls.at(-1)?.attributes("aria-label")).toBe("Close Quick Travel");
+    wrapper.unmount();
+  });
+
   it("shows at most six per-character recents without repeating the current map", async () => {
     const { wrapper } = fixture({ history: [55, 449, 81, 194, 642, 857, 248, 15] });
     await flushPromises();
@@ -357,6 +387,7 @@ describe("TravelPalette", () => {
     expect(rejected.wrapper.text()).toContain(
       "Travel could not start. Check Guild Wars, then try again.",
     );
+    expect(rejected.wrapper.emitted("close")).toBeUndefined();
     rejected.wrapper.unmount();
 
   });

--- a/apps/tools/src/components/TravelPalette.test.ts
+++ b/apps/tools/src/components/TravelPalette.test.ts
@@ -146,6 +146,18 @@ describe("TravelPalette", () => {
     wrapper.unmount();
   });
 
+  it("closes after submitting a destination", async () => {
+    const { wrapper } = fixture({ synonyms: [{ term: "daily run", mapId: 480 }] });
+    await flushPromises();
+
+    await wrapper.get("#travel-search-input").setValue("daily");
+    await wrapper.get('[role="option"]').trigger("click");
+    await flushPromises();
+
+    expect(wrapper.emitted("close")).toHaveLength(1);
+    wrapper.unmount();
+  });
+
   it("shows at most six per-character recents without repeating the current map", async () => {
     const { wrapper } = fixture({ history: [55, 449, 81, 194, 642, 857, 248, 15] });
     await flushPromises();

--- a/apps/tools/src/components/TravelPalette.vue
+++ b/apps/tools/src/components/TravelPalette.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, ref, watch } from "vue";
+import { computed, nextTick, ref, watch } from "vue";
 import {
   TRAVEL_SEARCH_QUERY_LIMIT,
   TRAVEL_SHORTCUT_LIMIT,
@@ -47,7 +47,6 @@ const {
   pending: preferenceWritePending,
   disabled: preferenceControlsDisabled,
 } = travelPreferences;
-let closeTimer = 0;
 let visibilityLoad = 0;
 
 const hasQuery = computed(() => normaliseTravelTerm(query.value).length > 0);
@@ -143,12 +142,6 @@ watch(() => props.host.notice.value, (notice) => {
   if (!notice) return;
   setFeedback(notice.message, notice.level);
 });
-watch(() => props.host.attempt.value.status, (status) => {
-  if (status !== "loading") return;
-  window.clearTimeout(closeTimer);
-  closeTimer = window.setTimeout(() => emit("close"), 350);
-});
-
 async function selectMode(next: PaletteMode, focus: "search" | "settings" = "search"): Promise<void> {
   query.value = "";
   active.value = 0;
@@ -170,6 +163,7 @@ async function travel(request: TravelRequest): Promise<void> {
   if (travelPending.value || !isTravelRequest(request)) return;
   try {
     await props.host.travel(request);
+    emit("close");
   } catch { /* The host owns the refusal notice and resets its transaction. */ }
 }
 
@@ -356,7 +350,6 @@ function onKeydown(event: KeyboardEvent): void {
   }
 }
 
-onBeforeUnmount(() => window.clearTimeout(closeTimer));
 </script>
 
 <template>

--- a/apps/tools/src/components/TravelPalette.vue
+++ b/apps/tools/src/components/TravelPalette.vue
@@ -356,8 +356,6 @@ function onKeydown(event: KeyboardEvent): void {
   <section ref="palette" v-show="visible" class="ui-frame travel-palette" role="dialog" aria-label="Quick Travel" :aria-busy="preferenceWritePending" @keydown="onKeydown">
     <div class="travel-search">
       <label for="travel-search-input"><svg class="travel-search-icon" viewBox="0 0 20 20" aria-hidden="true"><circle cx="8.5" cy="8.5" r="5.25" /><path d="m12.4 12.4 4.1 4.1" /></svg><input id="travel-search-input" ref="input" v-model="query" role="combobox" aria-label="Destination or search phrase" :aria-controls="hasQuery ? 'travel-results' : undefined" aria-autocomplete="list" aria-haspopup="listbox" :aria-activedescendant="activeDestination ? `travel-${activeDestination.mapId}` : undefined" :aria-expanded="results.length > 0" autocomplete="off" spellcheck="false" :maxlength="TRAVEL_SEARCH_QUERY_LIMIT" placeholder="Search destinations or phrases…"></label>
-      <button ref="settingsButton" type="button" class="ui-button travel-close" data-icon aria-label="Customize Travel" title="Customize Travel" :aria-pressed="mode === 'customize'" aria-controls="travel-customize-panel" :disabled="preferenceControlsDisabled" @click="toggleCustomize"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.38a2 2 0 0 0-.73-2.73l-.15-.09a2 2 0 0 1-1-1.74v-.51a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2Z" /><circle cx="12" cy="12" r="3" /></svg></button>
-      <button type="button" class="ui-button travel-close" data-icon aria-label="Close Quick Travel" @click="emit('close')"><svg viewBox="0 0 16 16" aria-hidden="true"><path d="m3 3 10 10M13 3 3 13" /></svg></button>
     </div>
 
     <div v-if="urgentNoticeVisible" class="travel-notice" :data-level="statusLevel" role="status" aria-live="polite">{{ statusText }}</div>
@@ -386,7 +384,7 @@ function onKeydown(event: KeyboardEvent): void {
       </section>
     </section>
 
-    <section v-else id="travel-customize-panel" class="ui-scroll travel-body travel-customize" role="region" aria-label="Customize Travel">
+    <section v-else id="travel-customize-panel" class="ui-scroll travel-body travel-customize" role="region" aria-label="Travel settings">
       <section class="travel-customize-group" aria-labelledby="travel-shortcuts-title">
         <header class="travel-section-head"><h2 id="travel-shortcuts-title">Number shortcuts</h2><span>Press 1–9</span></header>
         <div class="travel-customize-shortcuts">
@@ -404,5 +402,9 @@ function onKeydown(event: KeyboardEvent): void {
       </section>
     </section>
     <footer class="travel-footer"><span v-if="statusText && !urgentNoticeVisible" :data-level="statusLevel" role="status" aria-live="polite">{{ statusText }}</span><span v-if="mode === 'travel' || hasQuery" class="travel-key-hints"><kbd class="ui-kbd">↑↓</kbd> choose <kbd class="ui-kbd">return</kbd> travel <kbd class="ui-kbd">⌘1–9</kbd> save</span><span v-else class="travel-key-hints"><kbd class="ui-kbd">esc</kbd> back</span></footer>
+    <div class="travel-header-actions">
+      <button ref="settingsButton" type="button" class="ui-button travel-close" data-icon aria-label="Customize Travel" title="Customize Travel" :aria-pressed="mode === 'customize'" aria-controls="travel-customize-panel" :disabled="preferenceControlsDisabled" @click="toggleCustomize"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.38a2 2 0 0 0-.73-2.73l-.15-.09a2 2 0 0 1-1-1.74v-.51a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2Z" /><circle cx="12" cy="12" r="3" /></svg></button>
+      <button type="button" class="ui-button travel-close" data-icon aria-label="Close Quick Travel" @click="emit('close')"><svg viewBox="0 0 16 16" aria-hidden="true"><path d="m3 3 10 10M13 3 3 13" /></svg></button>
+    </div>
   </section>
 </template>

--- a/apps/tools/src/styles.css
+++ b/apps/tools/src/styles.css
@@ -33,12 +33,23 @@
 .travel-search {
   display: grid;
   min-height: 56px;
-  grid-template-columns: minmax(0, 1fr) auto auto;
+  grid-template-columns: minmax(0, 1fr);
   flex: none;
   align-items: center;
-  gap: var(--ui-space-2);
-  padding: var(--ui-space-2) var(--ui-space-3);
+  padding: var(--ui-space-2) calc(var(--ui-space-3) + 84px) var(--ui-space-2) var(--ui-space-3);
   border-bottom: 1px solid var(--ui-line);
+}
+
+/* Keep these controls in the visual header while their later DOM position
+ * follows the task's natural keyboard order. */
+.travel-header-actions {
+  position: absolute;
+  top: 0;
+  right: var(--ui-space-3);
+  display: flex;
+  height: 56px;
+  align-items: center;
+  gap: var(--ui-space-2);
 }
 
 .travel-search-icon {
@@ -96,7 +107,7 @@
   box-shadow: none;
 }
 
-.travel-search .travel-close {
+.travel-header-actions .travel-close {
   width: 34px;
   min-width: 34px;
   min-height: 34px;
@@ -106,7 +117,7 @@
   box-shadow: none;
 }
 
-.travel-search .travel-close:hover:not(:disabled) {
+.travel-header-actions .travel-close:hover:not(:disabled) {
   background: var(--ui-hover);
 }
 
@@ -451,7 +462,11 @@
 
 @media (max-width: 560px) {
   .travel-palette { top: 16px; max-height: calc(100vh - 32px); }
-  .travel-search { min-height: 54px; padding-inline: var(--ui-space-3); }
+  .travel-search {
+    min-height: 54px;
+    padding-inline: var(--ui-space-3) calc(var(--ui-space-3) + 84px);
+  }
+  .travel-header-actions { height: 54px; }
   .travel-notice { margin-inline: var(--ui-space-3); }
   .travel-body { padding: var(--ui-space-3); }
   .travel-recent-grid { grid-template-columns: 1fr; }

--- a/apps/tools/src/travel-host.test.ts
+++ b/apps/tools/src/travel-host.test.ts
@@ -80,18 +80,18 @@ describe("native Travel host", () => {
     expect(setTravel.mock.calls[0]?.[0].patch.shortcuts?.[8]).toEqual({ mapId: 642 });
   });
 
-  it("releases a travel attempt after Guild Wars confirms arrival", async () => {
+  it("releases a queued travel attempt when Guild Wars confirms arrival directly", async () => {
     vi.useFakeTimers();
     const { host } = fixture();
 
     await host.travel({ mapId: 449 });
-    host.updateGameState({ status: "waiting", reason: "loading" });
     host.updateGameState({
       status: "ready", mapId: 449, characterKey: null, unlockedMapWords: null,
     });
     await vi.runAllTimersAsync();
 
     expect(host.attempt.value).toEqual({ status: "idle" });
+    expect(host.notice.value?.message).not.toContain("did not start");
   });
 
   it("always releases a loading attempt after interruption or its arrival deadline", async () => {
@@ -144,7 +144,6 @@ describe("native Travel host", () => {
     });
 
     await host.travel({ mapId: 449 });
-    host.updateGameState({ status: "waiting", reason: "loading" });
     host.updateGameState({
       status: "ready", mapId: 449, characterKey, unlockedMapWords,
     });

--- a/apps/tools/src/travel-host.ts
+++ b/apps/tools/src/travel-host.ts
@@ -134,9 +134,10 @@ export function createNativeTravelHost(
     updateGameState(next) {
       state.value = next;
       const current = attempt.value;
-      if (current.status === "loading"
+      const arrived = current.status !== "idle"
         && next.status === "ready"
-        && next.mapId === current.mapId
+        && next.mapId === current.mapId;
+      if (arrived
         && next.characterKey !== null
         && unidentifiedOriginMapId !== null) {
         historyObservation.record({
@@ -146,6 +147,10 @@ export function createNativeTravelHost(
       }
       historyObservation.update(next);
       if (current.status === "idle") return;
+      if (arrived) {
+        clearAttempt();
+        return;
+      }
       if (next.status === "waiting" && next.reason === "loading") {
         window.clearTimeout(attemptTimer);
         attempt.value = { status: "loading", mapId: current.mapId };
@@ -170,7 +175,6 @@ export function createNativeTravelHost(
         return;
       }
       clearAttempt();
-      if (next.mapId !== current.mapId) return;
     },
     dispose() {
       historyObservation.dispose();


### PR DESCRIPTION
## What changed\n\nParty travel left Quick Travel open during the countdown, and Tab reached Settings and Close before the travel choices. The palette now closes as soon as the host accepts a destination, while natural DOM order moves focus through Search, Recent, Favorites, Settings, and Close.\n\n## Why\n\nThe palette should get out of the way once travel is submitted, including during a party countdown. Keyboard focus should follow the visible travel task before reaching secondary header actions.\n\n## Invariant\n\nA successful submission closes immediately. A refused submission stays open and shows the host notice. Focus order uses native DOM order with no positive tabindex values.\n\n## Verification\n\n- [x] Scope: all 3 workspace projects
✓ Lockfile passes supply-chain policies (verified 20h ago)
Lockfile is up to date, resolution step is skipped
Progress: resolved 1, reused 0, downloaded 0, added 0
Packages: +1374
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
Progress: resolved 1374, reused 1355, downloaded 0, added 372
Progress: resolved 1374, reused 1355, downloaded 0, added 746
Progress: resolved 1374, reused 1355, downloaded 0, added 941
Progress: resolved 1374, reused 1355, downloaded 0, added 984
Progress: resolved 1374, reused 1355, downloaded 0, added 1120
Progress: resolved 1374, reused 1355, downloaded 0, added 1212
Progress: resolved 1374, reused 1355, downloaded 0, added 1333
Progress: resolved 1374, reused 1355, downloaded 0, added 1374, done
[WARN] Failed to create bin at /Users/matthias/Git/games/guild-wars-mac/gwonmac-travel-party-close/node_modules/.pnpm/@vitest+mocker@4.1.10_vite@8.1.5_@types+node@24.13.3_esbuild@0.28.1_jiti@2.7.0_terser@5.49.0_yaml@2.9.0_/node_modules/@vitest/mocker/node_modules/.bin/vite. ENOENT: no such file or directory, chmod '/Users/matthias/Git/games/guild-wars-mac/gwonmac-travel-party-close/node_modules/.pnpm/@vitest+mocker@4.1.10_vite@8.1.5_@types+node@24.13.3_esbuild@0.28.1_jiti@2.7.0_terser@5.49.0_yaml@2.9.0_/node_modules/@vitest/mocker/node_modules/.bin/vite'
[WARN] Failed to create bin at /Users/matthias/Git/games/guild-wars-mac/gwonmac-travel-party-close/node_modules/.pnpm/unplugin@3.3.0_esbuild@0.28.1_rolldown@1.2.0_rollup@4.62.2_vite@8.1.5_@types+node@24.13_e94789378f33bcbcbcc0794a399d365e/node_modules/unplugin/node_modules/.bin/esbuild. ENOENT: no such file or directory, chmod '/Users/matthias/Git/games/guild-wars-mac/gwonmac-travel-party-close/node_modules/.pnpm/unplugin@3.3.0_esbuild@0.28.1_rolldown@1.2.0_rollup@4.62.2_vite@8.1.5_@types+node@24.13_e94789378f33bcbcbcc0794a399d365e/node_modules/unplugin/node_modules/.bin/esbuild'
.../node_modules/vue-demi postinstall$ node -e "try{require('./scripts/postinstall.js')}catch(e){}"
.../node_modules/vue-demi postinstall: Done

dependencies:
+ ws 8.21.3

devDependencies:
+ @electron-forge/cli 7.11.2
+ @electron-forge/maker-dmg 7.11.2
+ @electron-forge/maker-zip 7.11.2
+ @electron-forge/shared-types 7.11.2
+ @electron/asar 3.4.1
+ @electron/fuses 2.1.3
+ @electron/osx-sign 1.3.3
+ @eslint/js 10.0.1
+ @fontsource-variable/inter 5.3.0
+ @playwright/test 1.61.1
+ @types/node 24.13.3
+ @types/pngjs 6.0.5
+ @types/ws 8.18.1
+ electron 43.4.1
+ eslint 10.7.0
+ eslint-plugin-vue 10.10.0
+ node-api-headers 1.9.0
+ pixelmatch 7.2.0
+ playwright 1.61.1
+ plist 3.1.1
+ pngjs 7.0.0
+ rollup 4.62.2
+ typescript 5.9.3
+ typescript-eslint 8.65.0
+ vue-eslint-parser 10.4.1

apps/website prepare$ vp exec nuxt prepare
. postinstall$ install-electron
. postinstall: Done
apps/website prepare: ℹ Nuxt Icon server bundle mode is set to local
apps/website prepare: [nuxt:icon] ✔ Nuxt Icon loaded local collection lucide with 1817 icons
apps/website prepare: [nuxt:icon] ✔ Nuxt Icon loaded local collection circle-flags with 2 icons
apps/website prepare: [nuxt:icon] ✔ Nuxt Icon loaded local collection logos with 7 icons
apps/website prepare: ℹ Nuxt Icon client bundle consist of 96 icons with 38.17KB(uncompressed) in size
apps/website prepare: │
apps/website prepare: ◆  Types generated in .nuxt.
apps/website prepare: Done
Done in 19.9s using pnpm v11.13.1
✔ two builds with the same content are zero apart, however they were written (7.2155ms)
✔ a single skill change is reported as a named swap, not as a slot number (0.271041ms)
✔ the summary's verb agrees with what differs, at none, one and two (0.166458ms)
✔ a build that only re-spends its attributes still reports a difference (0.111ms)
✔ a profession change is one difference and carries both pairs (0.087458ms)
✔ nearestBuild answers with the closest build inside its ceiling, or with nothing (7.188541ms)
✔ nearestBuild never matches a build against itself, nor across primary professions (0.143083ms)
✔ droppedByTeam names the working heroes a team has no place for, once each (11.733542ms)
✔ a stored record short of eight slots is compared rather than thrown over (0.1615ms)
✔ a bar is eight slots, and a ninth cannot be written (1.001625ms)
✔ the slot list every module iterates is as long as the bar it walks (0.9015ms)
✔ a team slot references a build and cannot carry one (0.127375ms)
✔ an attribute rank outside what a character can invest is unspellable (0.0875ms)
✔ variantsOf returns direct children, and nothing else (0.10975ms)
✔ parentOf resolves a link, and answers null when there is nothing to resolve (0.075042ms)
✔ usedBy names teams once each, and says nothing about builds nobody uses (0.1015ms)
✔ forking a variant keeps the root, so lineage never grows a second level (0.091834ms)
✔ a clean verdict has nothing to explain, and a broken one cannot be silent (0.996375ms)
✔ a legal build reports clean, spending exactly the level-20 budget (1.049208ms)
✔ PvE availability is intrinsic while player-only eligibility belongs to assignment (0.236458ms)
✔ a secondary profession may not repeat the primary (0.135292ms)
✔ a bar may hold one elite, and the second is reported against the first (0.102375ms)
✔ the same skill cannot occupy two slots (0.121667ms)
✔ a stored record short of eight slots is validated, not accused of duplicates (0.114625ms)
✔ the last two bar positions are checked like the first six (0.102666ms)
✔ a duplicated elite reports both rules, because fixing one need not fix the other (0.100958ms)
✔ a skill must belong to one of the build's two professions, or to none (0.141625ms)
✔ a skill the catalogue cannot resolve is reported, never assumed clean (0.133375ms)
✔ an attribute must belong to one of the build's two professions (0.089333ms)
✔ a rank of 0 on an attribute the build cannot have is not a problem (0.059916ms)
✔ a primary attribute needs the profession as the primary, not the secondary (33.514125ms)
✔ a rank above the cap is rejected rather than clamped (0.1595ms)
✔ the ranks together may not cost more than a level-20 character has (0.107458ms)
✔ the whole problem list is ordered: professions, bar slots, attributes, budget (0.089125ms)
✔ a slot pointing at a build that is gone empties, and nothing else changes (16.8985ms)
✔ a slot pointing at a build that exists is left alone (12.848ms)
✔ two builds sharing an id refuse the file rather than lose one quietly (1.630333ms)
✔ a bar that is not eight slots long is not a build to store (0.14825ms)
✔ a value the model has no name for is refused, not coerced (0.207ms)
✔ a version this build cannot read is refused rather than reinterpreted (0.105166ms)
✔ a missing file is a new profile, and says nothing happened (80.826167ms)
✔ an unreadable library is moved aside, never overwritten (95.957041ms)
✔ a readable file that the model refuses is recovered the same way (31.348625ms)
✔ what a save returns is what the next load will hand back (31.155083ms)
✔ a save applies the same repair a load would, so the two cannot disagree (18.0095ms)
✔ the library is owner-only on disk (15.136833ms)
✔ a team code preserves every team field, shared slot, build and parent (3.100959ms)
✔ import remints identities and remaps repeated slots and lineage atomically (0.541042ms)
✔ future, malformed, dangling, duplicate and oversized codes are refused (2.449ms)
✔ every worked example decodes to what the specification says it holds (2.088167ms)
✔ every worked example re-encodes to the byte-identical code (0.545583ms)
✔ a template file is the bare code, with nothing wrapped around it (0.171084ms)
✔ a real code decodes to what its publisher says it holds (0.143875ms)
✔ a real code re-encodes to the byte-identical string the client wrote (0.25975ms)
✔ the short padding a stranger's tool may write still decodes (1.738833ms)
✔ nothing in the adversarial corpus throws, and all of it is null (0.817625ms)
✔ each of this codec's own rejections has a valid twin one field away (3.667583ms)
✔ an empty slot round-trips as an empty slot and never as skill 0 (0.252167ms)
✔ a skill id this client build has never heard of decodes rather than fails (0.169ms)
✔ a code the client would not have written re-encodes to the one it would (0.129625ms)
✔ the encoder refuses what the format cannot spell rather than truncating it (0.225333ms)
✔ a rank that is not a whole number is refused, not rounded into the field (0.135041ms)
✔ a bar that is not eight slots long is refused rather than padded or cut (0.104ms)
✔ a twelve-attribute template still round-trips, at the edge of the count (0.121583ms)
✔ a captured team resolves through the same door every other team does (2.541166ms)
✔ heroes are compacted, because a henchman between two of them is a gap (0.233833ms)
✔ the player's own slot stays empty, which is the only shape it may have (0.128333ms)
✔ a fully observed player is saved into slot zero (1.0625ms)
✔ a captured build carries the ranks that were read, by name (0.157666ms)
✔ a bar read without its ranks is not a build (0.125583ms)
✔ nothing invested is an empty build, not a missing one (0.142291ms)
✔ a rank against an attribute the table cannot name is dropped (0.096083ms)
✔ a hero whose bar was not read keeps their place and gets no build (1.417833ms)
✔ a stored player build is admitted for the certified player setter (0.285708ms)
✔ behaviour is carried, never defaulted to Guard (0.276ms)
✔ capture preserves unknown, Normal, and Hard Mode observations (0.101709ms)
✔ there is nothing to capture without a party, and capture says no (0.070291ms)
✔ counted heroes nobody could name are reported, not quietly missing (0.111084ms)
✔ more heroes than a team has positions is refused for the surplus, not silently (0.104334ms)
✔ every gap is written into the team's notes, so the notice is not the record (0.07875ms)
▶ the stored team roster
  ✔ compacts complete member records without moving the player (85.276875ms)
  ✔ preserves repairable legacy records while compacting (0.1265ms)
  ✔ removes the whole member and closes the gap (0.135458ms)
  ✔ moves configured members up, down, and to the last configured position (0.154167ms)
  ✔ does not move the player or an empty source (0.099875ms)
✔ the stored team roster (91.031875ms)
▶ Multiple Accounts profile creation
  ✔ validates every Single Account source before creating destinations (23.05175ms)
  ✔ rolls back both imported libraries when workspace publication fails (254.981792ms)
  ✔ rolls back after each library publication boundary (255.564333ms)
  ✔ refuses a requested destination without changing its existing bytes (50.059709ms)
  ✔ refuses pre-existing profile roots and template destinations (188.344ms)
  ✔ loses a publication race without replacing the competing file (66.733833ms)
  ✔ treats a workspace rename followed by an error as committed (148.3335ms)
  ✔ removes a later account root when its workspace write fails (160.204958ms)
  ✔ preserves created resources when the workspace commit is ambiguous (393.454834ms)
  ✔ continues reverse cleanup and keeps the primary failure (151.036417ms)
✔ Multiple Accounts profile creation (1695.068708ms)
✔ merges unrelated shared-template edits (402.856625ms)
✔ a stale deletion cannot discard a concurrent edit (0.371708ms)
✔ two concurrent edits to one path preserve both contents (0.167625ms)
✔ one window's duplicate close cannot delete another window's addition (0.334167ms)
✔ an identical duplicate uses the merge path's case-insensitive identity (0.233542ms)
✔ shared save requires a load and one generation refuses changed resubmission (50.130416ms)
✔ a failure before publication leaves the generation retryable (214.282459ms)
✔ an unconfirmed publication permits only an identical preserving retry (1.388541ms)
✔ renderer replacement and reload own independent merge generations (0.331916ms)
▶ atomic active client publication
  ✔ publishes the selected module and its complete effective feature map together (0.92525ms)
✔ atomic active client publication (1.449625ms)
▶ allowlists
  ✔ allows approved domain suffixes (4.77675ms)
  ✔ rejects lookalike and empty names (0.152708ms)
  ✔ classifies public vs private addresses (0.790292ms)
  ✔ parses IPv4 destinations only (1.300834ms)
  ✔ allowlists the game ports (0.107667ms)
✔ allowlists (7.879584ms)
✔ no hostile name reaches a path outside the two template directories (3.18525ms)
{"checkpoint":"waiting-for-enhancement","please":"bring the client to a playable character"}
▶ an observation live run cannot reach the automation tier
  ✔ gives every scenario exactly one tier (1.194875ms)
  ✔ declares readiness independently from automation permission (0.16225ms)
  ✔ launches the app with the automation gate off, whatever the caller exports (0.097375ms)
  ✔ opens no parent-process command channel for an observation run (2.747791ms)
  ✔ keeps the rest of the launch decision unchanged (0.109583ms)
  ✔ keeps developer-program preflight independent from saved cursor settings (0.096916ms)
  ✔ hands an observation scenario no handle that can act on the player (0.388125ms)
  ✔ lets an observation scenario read only the fixed cursor projection (0.129625ms)
  ✔ synthesizes no bootstrap input when the client is not yet playable (85.005625ms)
  ✔ still nudges an automation run, so the double above would have caught it (0.308041ms)
  ✔ does not require target-state evidence from a cursor-only observation (0.222667ms)
  ✔ does not pretend a program-free boot smoke installed Enhancement (0.069792ms)
  ✔ accepts the target-readout run only when the real surface matches its snapshot (0.167291ms)
✔ an observation live run cannot reach the automation tier (92.337666ms)
✔ the one live-certified agent pattern keeps its name (1.086417ms)
✔ an uncertified agent pattern publishes its bits, not a guess (0.135292ms)
✔ a living target keeps its name when uncertified bits ride along (0.077541ms)
✔ a type word the kernel would never publish is still rejected (0.091958ms)
✔ no target means no bits and no kind (0.102875ms)
✔ an observation that is not ready is a party nobody can draw (1.8105ms)
✔ a well-formed record nobody took a reading for is not an empty party (0.187625ms)
✔ a counted but unnamed hero is counted, not invented (0.089167ms)
✔ every field the companion has not published reads as not observed (0.1005ms)
✔ account and instance facts stay unknown rather than defaulting to false (0.076125ms)
✔ a hero the table cannot name is dropped rather than published as a number (0.111334ms)
✔ the flag says available or the hero is not listed, whatever the id says (0.062167ms)
✔ a fully named party is not partial (0.081458ms)
✔ a nonsense count is floored rather than trusted (0.100167ms)
✔ profession ids become acronyms, and None is a secondary rather than a refusal (1.388834ms)
✔ the full roster wins over the summary, and carries what was read (0.81325ms)
✔ a region whose walk was rejected is not an empty party (0.080708ms)
native update installation refused Error: install refused
    at Object.quitAndInstall (file:///Users/matthias/Git/games/guild-wars-mac/gwonmac-travel-party-close/tests/unit/app-updater.test.ts:178:47)
    at Object.quitAndInstall (file:///Users/matthias/Git/games/guild-wars-mac/gwonmac-travel-party-close/tests/unit/app-updater.test.ts:74:41)
    at AppUpdater.quitAndInstall (file:///Users/matthias/Git/games/guild-wars-mac/gwonmac-travel-party-close/src/main/app-updater.ts:150:34)
    at TestContext.<anonymous> (file:///Users/matthias/Git/games/guild-wars-mac/gwonmac-travel-party-close/tests/unit/app-updater.test.ts:182:28)
    at async Test.run (node:internal/test_runner/test:1332:7)
    at async Suite.processPendingSubtests (node:internal/test_runner/test:911:7)
Update check failed at feed: feed-invalid
Update check failed at feed: feed-invalid
Update check failed at feed: feed-invalid
Update check failed at feed: feed-invalid
Update check failed at feed: feed-invalid
Update check failed at feed: feed-invalid
Update check failed at feed: feed-invalid
Update check failed at feed: offline Error: offline
Update check failed at feed: unreadable SyntaxError: Unexpected token 'o', "not json" is not valid JSON
▶ application updater
  ✔ reads exactly one static manifest for the selected channel (778.559542ms)
  ✔ makes no request and reports unavailable without the signed marker (0.905459ms)
  ✔ validates before asking Squirrel to download and installs once (2.278875ms)
  ✔ closes synchronous native feed and download refusals (4.740459ms)
  ✔ does not start a download after a synchronous native event closes it (1.632542ms)
  ✔ reports a refused terminal install once (4.892542ms)
  ✔ coalesces concurrent checks into one static request (0.841959ms)
  ✔ captures the selected track for an in-flight check (2.346875ms)
  ✔ keeps Stable off prereleases and Beta off alpha (0.793875ms)
  ✔ offers Stable, Beta, and RC through their admitted tracks (0.464667ms)
  ✔ returns from a newer beta to an older Stable only by manual install (0.184125ms)
  ✔ reports the selected channel version when already current (0.155917ms)
  ✔ fails closed for malformed or retargeted channel documents (0.435083ms)
  ✔ never presents transport or parse failure as up to date (3.702334ms)
Update check failed at feed: timeout Error: aborted
  ✔ records and times out the static feed request (60.482375ms)
  ✔ does not duplicate work while downloading or ready (0.291917ms)
  ✔ treats Squirrel refusing a prevalidated upgrade as a feed failure (0.13575ms)
✔ application updater (866.493625ms)
▶ automatic check policy
  ✔ refuses incapable, opted-out, and active-game checks (0.100458ms)
  ✔ checks a fresh profile and honors the persisted six-hour boundary (0.044833ms)
  ✔ recovers from a clock moved backwards instead of waiting indefinitely (0.182666ms)
  ✔ keeps 30-minute ticks inside the six-hour due window (0.852875ms)
✔ automatic check policy (1.287583ms)
▶ appearance settings
  ✔ derives the complete public token override from canonical settings (3.494917ms)
  ✔ projects untouched custom palettes exactly like their built-in material (2.330042ms)
  ✔ sets independent style and font markers and removes their defaults (0.344833ms)
  ✔ derives readable custom tokens and removes them when switching away (2.989125ms)
  ✔ activates a generation-keyed game font only after it loads (3.255458ms)
✔ appearance settings (13.546375ms)
✔ signing evidence accepts each channel's exact Apple identity (1.254541ms)
✔ signing evidence fails closed on every identity boundary (0.496417ms)
✔ signing target classification applies only the required entitlements (1.015ms)
✔ redundant framework resources are the only ignored signing targets (0.184125ms)
✔ Hard Mode is changed and confirmed before any team command (47.178084ms)
✔ the player's build is applied before hero work and confirmed field by field (1.636542ms)
✔ a wrong player primary refuses before changing difficulty (0.514917ms)
✔ missing player, partial roster and known-locked hero all send zero commands (0.29825ms)
✔ a partial roster does not invent hero-specific verification failures (0.135083ms)
✔ a rejected roster does not multiply into unknown region and mode failures (0.12125ms)
✔ known permanent policy blockers outrank an incomplete roster (0.111125ms)
✔ an absent hero's known primary mismatch refuses before roster mutation (0.140584ms)
✔ a known-locked assigned skill refuses before the first command (0.301625ms)
✔ behavior-only work is part of the canonical preview (0.17525ms)
✔ roster order is a canonical Apply change (0.114709ms)
✔ canonical preflight reports each logical change once (0.133209ms)
✔ a hero the game never adds is a refusal, however cheerful the command (1.085083ms)
✔ a hero that appears without an agent id is not yet added (2.837292ms)
✔ a full apply reports only the changes the roster confirmed (0.67925ms)
✔ attributes the game never applies are a refusal too (0.984209ms)
✔ an ordinary attribute publication just after one second is not a false refusal (0.783875ms)
✔ an empty attribute plan clears the player's invested ranks (0.247ms)
✔ an empty attribute plan clears a hero's invested ranks (0.293333ms)
✔ a new secondary profession is set, and set before the bar (1.394625ms)
✔ a bar waits for the client's profession rebuild after confirmation (1.327375ms)
✔ a live secondary transition may exceed the ordinary command deadline (5.633167ms)
✔ a profession first published on the deadline receives its stability grace (164.789125ms)
✔ a deadline candidate that disappears is refused without extending the operation (10.046958ms)
✔ a profession must remain observed for a full stable interval (0.768083ms)
✔ cancelling during confirmation sends no dependent command (0.502625ms)
✔ a monoclass build clears the secondary rather than leaving it (0.450708ms)
✔ a secondary the game never changes is a refusal, not a bar written anyway (50.057ms)
✔ unobserved professions refuse before the first command (0.216542ms)
✔ a wrong primary profession refuses before changing difficulty (0.339416ms)
✔ a bar the game only partly equips is applied, and says what it dropped (0.480375ms)
✔ a progressively published bar is not mistaken for a stable partial bar (0.404708ms)
✔ an omitted reportedly unlocked skill is an inconsistency, not a skip (0.546833ms)
✔ skipped skill names accumulate across the whole team (10.956083ms)
✔ a bar that never moves is still a refusal (6.591791ms)
✔ a bar and ranks already in place send nothing at all (17.089ms)
▶ atomic-file
  ✔ replaces the target only after a complete write (116.601833ms)
  ✔ writes JSON atomically (41.325917ms)
  ✔ creates parent directories (15.707333ms)
  ✔ applies the requested mode to the published file (18.899ms)
  ✔ creates a complete file without replacing an existing target (35.070542ms)
  ✔ writes large payloads through writeAtomicInDir (25.975541ms)
✔ atomic-file (255.371292ms)
▶ atomic-file writeAll
  ✔ keeps writing until the buffer is consumed (0.212292ms)
  ✔ resumes from the offset the sink reached, not from zero (0.1355ms)
  ✔ fails loudly when the sink stops making progress (0.149542ms)
  ✔ writes every byte to a real file handle (5.860125ms)
✔ atomic-file writeAll (6.651333ms)
▶ atomic-file durability
  ✔ syncs the temp file before the rename and the directory after it (42.405917ms)
  ✔ syncs a create-only temp before publishing its final name (95.605583ms)
  ✔ leaves no temp file behind when the rename fails (15.111709ms)
✔ atomic-file durability (153.529417ms)
▶ atomic-file orphan sweep
  ✔ removes temp files left by dead processes and keeps everything else (10.581ms)
  ✔ sweeps a temp file a crashed writer really left behind (17.258667ms)
  ✔ sweeps the orphan a SIGKILLed writer left, with the old document intact (1037.013542ms)
  ✔ reports zero for a directory that does not exist (1.112958ms)
  ✔ reaches every directory the profile publishes documents into (57.670958ms)
✔ atomic-file orphan sweep (1124.112834ms)
✔ transient loading cannot skip character selection (9.064125ms)
▶ build authoring rules
  ✔ uses the exact nonlinear 200-point Guild Wars budget (1.735833ms)
  ✔ offers both professions but never a secondary primary attribute (0.360917ms)
  ✔ stores rank zero as no investment (2.679375ms)
  ✔ resolves every catalogue placement without creating an invalid bar (2.187875ms)
✔ build authoring rules (9.227208ms)
✔ rejects a stale write from another window (42.658333ms)
✔ requires a baseline read before the first write (11.430333ms)
▶ patch-day carry-forward report
  ✔ fails closed when no capability can be located (3.022083ms)
✔ patch-day carry-forward report (3.597084ms)
▶ chunk cache pruning
  ✔ preserves current and rollback data and removes only stale hashes (29.811916ms)
  ✔ fails closed when the current or rollback manifest is corrupt (6.574708ms)
✔ chunk cache pruning (37.319125ms)
▶ chunk-store
  ✔ coalesces concurrent fetches of the same hash (81.289375ms)
  ✔ reads across chunk boundaries and short final chunks (136.075125ms)
  ✔ rejects hash mismatches without publishing (10.625625ms)
  ✔ replaces a corrupt resident chunk before returning it (57.384334ms)
  ✔ verifies and repairs resident chunks before full-download completion (153.561958ms)
  ✔ allows pause and sleep to interrupt resident-cache verification (113.018458ms)
  ✔ full-image resume downloads only missing hashes (97.874583ms)
  ✔ fails before downloading when the full image does not fit (8.781833ms)
  ✔ fails fast and classifies a fatal local write, keeping its cause (15.642875ms)
  ✔ bounds exhausted network work and resumes with verified chunks (234.465209ms)
  ✔ preserves completed chunks when a full download is stopped and resumed (150.160583ms)
  ✔ caps native fetches at eight and promotes queued demand (152.204625ms)
  ✔ serves fetched and first-process resident bytes without a second read (59.159875ms)
  ✔ releases a failed slot and allows the same chunk to retry (125.415541ms)
  ✔ stops queued background work while allowing new demand (93.257292ms)
✔ chunk-store (1531.553708ms)
✔ proved documentation and website-only changes use the fast gate (0.951542ms)
✔ website certification follows only its real inputs (0.258917ms)
✔ runtime, packaging, dependency, and unknown changes use the full gate (0.217333ms)
✔ malformed paths fail closed (0.0855ms)
▶ client cache projection
  ✔ reports an empty cache without an active generation (1.835666ms)
  ✔ projects exact residency and the pessimistic capacity shortfall (0.15175ms)
  ✔ does not invent a shortfall when capacity is unknown (0.225709ms)
✔ client cache projection (2.828083ms)
▶ client certification
  ✔ maps isolated verifier results without recreating a coarse state (2.091083ms)
✔ client certification (2.6185ms)
▶ client compatibility notice
  ✔ does not interrupt when every selected feature is available (2.451542ms)
  ✔ uses the exact single-feature copy (0.188416ms)
  ✔ groups target and party observation without implementation language (0.14525ms)
  ✔ names only the unavailable observation (0.19ms)
  ✔ keeps update and restart recovery distinct when reasons are mixed (0.093917ms)
  ✔ lists several unavailable features and preserves safe local work (0.116125ms)
  ✔ makes preparation failures retry each launch (0.098208ms)
  ✔ keeps forbidden player-facing terms out of every report (0.270167ms)
  ✔ keeps every feature and reason combination internally consistent (897.639208ms)
  ✔ renders one report into launcher and Settings (0.437709ms)
  ✔ reports cooldown presentation unavailable when slot geometry is unavailable (0.179042ms)
  ✔ keeps the complete cooldown presentation available without party observation (0.114083ms)
  ✔ dismisses the launcher even when acknowledgement cannot persist (0.551416ms)
✔ client compatibility notice (919.2995ms)
▶ client compatibility
  ✔ fingerprints only the complete executable client contract (2.453875ms)
  ✔ rejects a failed candidate once and records its fingerprint (541.634125ms)
  ✔ keeps a valid untested candidate pending across an ordinary restart (59.254166ms)
  ✔ clears only the rejection record for an explicit retry (102.116958ms)
  ✔ promotes a rendered candidate and removes rollback state (89.686ms)
  ✔ refuses to confirm a candidate marker that changed (98.332166ms)
  ✔ does not interpret unknown persisted record versions (24.19125ms)
  ✔ prefers the previous complete client when the marker is corrupt (137.124417ms)
✔ client compatibility (1057.167958ms)
▶ client clean-exit adapter
  ✔ recognizes the real exported function stored in a WebAssembly table (1.209583ms)
  ✔ delegates timers and callbacks that are not the exported main loop (1.021875ms)
  ✔ keeps running while the main loop schedules a successor (0.284167ms)
  ✔ reports a successful final tick as one clean exit (0.1535ms)
  ✔ reports a rejected main-loop tick as a failure, not a clean exit (0.256709ms)
✔ client clean-exit adapter (3.61125ms)
▶ client health confirmation
  ✔ waits for both signals and retries one rejection without duplicating success (32.488125ms)
  ✔ stops after three permanent failures (18.855083ms)
  ✔ cancels a pending retry when the renderer unloads (6.6815ms)
✔ client health confirmation (94.723875ms)
✔ an active client boots while its complete data downloads (5.679208ms)
✔ preparation and failure remain launch gates (0.9085ms)
▶ client module preparation
  ✔ composes both certified transforms in order (387.182708ms)
  ✔ prepares only templates for a template-only certification (67.815708ms)
  ✔ uses an isolated derived native record through the complete cache path (255.559334ms)
  ✔ requires local native proof and keeps the preceding module untouched on refusal (94.552583ms)
  ✔ serves official bytes and drops both caches when uncertified (20.795917ms)
  ✔ closes native double-click preparation when its input disappears (40.91125ms)
  ✔ falls back to the ordinary module when a requested 4 GB pair is unknown (535.099166ms)
  ✔ keeps an earlier transform failure separate from 4 GB preparation failure (148.675125ms)
  ✔ drops the Enhancement cache when the certified tool is disabled (257.493792ms)
  ✔ falls back at the failed stage without serving an invalid module (385.784125ms)
  ✔ rebuilds stale compatibility and Enhancement cache entries (702.361458ms)
  ✔ rejects a replacement module even when writable metadata matches it (406.54ms)
  ✔ selects the largest safe subset when one profile fails validation (234.337541ms)
  ✔ replaces the cache when capabilities change but hooks do not (324.592041ms)
✔ client module preparation (3869.131584ms)
▶ companion core memory installation
  ✔ owns aligned runtime, exact config, and explicit kernel regions (3.161083ms)
  ✔ allocates no observer or command memory when it is not needed (0.27075ms)
  ✔ rolls back every partial allocation in reverse order (0.484167ms)
  ✔ rolls back when the completed layout does not fit memory (0.14075ms)
  ✔ does not write runtime or config bytes before explicit initialization (0.207208ms)
  ✔ rolls back a reused allocation pointer exactly once (0.123167ms)
  ✔ reports both allocation and rollback failures (0.274459ms)
  ✔ releases the observer and callback safety groups once (0.197542ms)
  ✔ cannot initialize after either release group runs (0.251208ms)
  ✔ continues a release after one free refuses (10.344042ms)
  ✔ composes with child-region overlap validation (8.844334ms)
✔ companion core memory installation (25.285333ms)
▶ companion kernel loader
  ✔ verifies, initializes, and projects only the canonical kernel (53.460625ms)
  ✔ refuses extra and missing imports and exports (23.504375ms)
  ✔ refuses a canonical name with the wrong function signature (0.914042ms)
  ✔ refuses every mismatched ABI scalar (149.597417ms)
  ✔ does not expose dispatch authority when initialization refuses (1.534416ms)
  ✔ uses the canonical allocation validator before compilation (0.373041ms)
✔ companion kernel loader (230.279125ms)
▶ companion kernel build contract
  ✔ states the exact reviewed import and function vocabulary once (1.666292ms)
  ✔ accepts exactly the fixed side-module surface (16.347708ms)
  ✔ rejects invalid Wasm, a start function, and a changed dylink footprint (2.205083ms)
  ✔ rejects extra imports and exports rather than allow-listing by prefix (0.808375ms)
  ✔ rejects a named export with the wrong exact function type (0.440416ms)
  ✔ states region sizes the decoder and the config ABI already fix (0.114041ms)
  ✔ rejects active data writes outside the declared private footprint (11.262084ms)
✔ companion kernel build contract (33.653334ms)
▶ companion kernel build seal
  ✔ publishes validated bytes and checks their sealed hash before compile (18.1875ms)
  ✔ removes a stale artifact without rewriting when validation fails (1.4265ms)
  ✔ removes the artifact and restores the renderer if final publication fails (10.966167ms)
✔ companion kernel build seal (30.763292ms)
✔ frame pollers run on every observer frame without an observation change (2.320958ms)
✔ party rows refuse payload for optional fields whose presence flag is absent (2.194208ms)
✔ an observed zero-filled player and a present all-zero skillbar remain valid (0.217542ms)
▶ companion policy source
  ✔ publishes one canonical launch snapshot (44.706333ms)
  ✔ rereads settings instead of trusting the event payload (1.031792ms)
  ✔ deduplicates equal region values and withdraws policy on waiting (0.185875ms)
  ✔ publishes same-map character and unlock changes (0.168125ms)
  ✔ withdraws local Tools only for positively identified active PvP play (0.20825ms)
  ✔ detaches both inputs and stops publication on disposal (0.152208ms)
  ✔ rolls back a settings listener when region subscription fails (0.314333ms)
  ✔ does not retain a subscriber whose launch callback throws (0.14675ms)
  ✔ stops an individually unsubscribed consumer (0.114083ms)
  ✔ withdraws every reachable listener when input disposal refuses (0.397125ms)
✔ companion policy source (50.1075ms)
✔ a bounded region owns allocation and ignores observations while inactive (7.490208ms)
✔ a withdrawn sequence accepts only a newer uint32 publication (0.223125ms)
✔ malformed ready sequences fail closed (0.101625ms)
✔ an event-driven region keeps a stable accepted publication (0.096458ms)
✔ region descriptors require non-ready withdrawal sentinels (0.251542ms)
✔ teardown withdraws ready state even when freeing fails (0.139875ms)
✔ freshness duration rejects non-finite and negative values (0.103458ms)
✔ sequence ordering accepts uint32 wrap and suppresses duplicate publications (0.131375ms)
✔ an equivalent heartbeat refreshes freshness without notifying listeners (0.177708ms)
▶ controller prompt texture
  ✔ implements the uMod hash for every bounded atlas orientation (3.918292ms)
  ✔ refuses arbitrary data instead of matching dimensions alone (66.254084ms)
  ✔ pins the current WebGL fingerprint to the exact certified client (0.301583ms)
  ✔ substitutes synchronously and restores the client's heap (11.440041ms)
  ✔ passes mismatches, malformed pointers, and unrelated textures unchanged (10.944667ms)
  ✔ preserves call receiver, result, and restoration when the upload throws (2.886166ms)
  ✔ also handles an exact full-atlas sub-image upload (4.237917ms)
  ✔ withdraws a match after every non-certified level-zero mutation and reset (4.664125ms)
  ✔ bounds texture deletion bookkeeping and never blocks malformed client calls (408.1935ms)
  ✔ fails closed when the required texture import is absent (18.108667ms)
✔ controller prompt texture (536.4905ms)
▶ corrupt document quarantine
  ✔ preserves the new bytes, retains three backups, and touches no neighbour (376.673958ms)
  ✔ returns null when another owner already moved the document (1.578625ms)
✔ corrupt document quarantine (379.297583ms)
Keychain operation failed arenaNetCredentials unclassified Error
▶ credentials
  ✔ round-trips the fixed credentials slot and clears it (17.09775ms)
  ✔ keeps a Multi profile out of the fixed Single slot (0.253084ms)
  ✔ maps native failure to the credential vocabulary (0.979375ms)
  ✔ retains unreadable Keychain bytes (0.172708ms)
  ✔ rejects invalid saves before replacing stored credentials (37.4915ms)
✔ credentials (78.605041ms)
▶ hidden-cursor retry
  ✔ asks on the poll after the hide, then paces by the interval (1.122167ms)
  ✔ asks once per interval, not once per poll (0.666791ms)
  ✔ stops at the deadline and stays stopped until the cursor resolves (0.356375ms)
  ✔ is not expired before the loop has seen anything (0.120917ms)
  ✔ expires at the deadline and resets on resolution (0.193833ms)
  ✔ records the resolved gap and only for a valid resolution (20.66725ms)
  ✔ counts only re-tests the dispatcher accepted (0.164875ms)
  ✔ does nothing while the consumer has no valid state (0.097375ms)
✔ hidden-cursor retry (27.259125ms)
▶ derived wasm cache
  ✔ publishes once and reuses the published module (246.1645ms)
  ✔ keeps only the current input, so an update cannot leak a directory (365.514916ms)
  ✔ keeps only the current transform ABI (266.185667ms)
  ✔ rebuilds when the certified build entry changes (168.018333ms)
  ✔ rejects a cached module whose bytes were altered after publication (180.739833ms)
  ✔ will not let cache metadata certify a module the pinned hash rejects (132.688708ms)
  ✔ publishes nothing when the output misses the pinned hash (5.86575ms)
  ✔ keeps the last good module when a rebuild's transform throws (83.446333ms)
✔ derived wasm cache (1451.580541ms)
▶ diagnostic profile storage
  ✔ defaults to standard and persists every closed profile (237.447625ms)
  ✔ refuses malformed persisted state instead of guessing (106.433125ms)
✔ diagnostic profile storage (344.75025ms)
▶ diagnostic profile policy
  ✔ keeps each isolation profile explicit and internally consistent (2.506916ms)
✔ diagnostic profile policy (2.604208ms)
▶ diagnostic report
  ✔ selects the newest abnormal prior session and tolerates a torn tail (145.603208ms)
  ✔ treats a game-client abort as abnormal even after a clean app quit (395.148791ms)
  ✔ reports no abnormal session when the previous run was clean (33.171417ms)
  ✔ derives startup, capture, and performance fields from canonical data (0.49ms)
✔ diagnostic report (575.297958ms)
▶ the closed diagnostics schema
  ✔ reports every prohibited field shape in one compiler program (10211.740458ms)
  ✔ still accepts the field kinds the schema is built from (6083.325ms)
✔ the closed diagnostics schema (16295.765083ms)
▶ diagnosticEventRecord
  ✔ classifies account evidence at the same canonical definition as its fields (0.963542ms)
  ✔ owns the subsystem and level of an event, so a call site cannot disagree (1.274ms)
  ✔ keeps the discriminant out of the recorded fields (0.12125ms)
  ✔ carries every field of a multi-field event (0.130666ms)
  ✔ records a phase as a field rather than as part of the event name (0.091958ms)
  ✔ names the durable action whose relaunch was refused (0.083791ms)
  ✔ keeps the socket event name closed and the payload declared (0.111625ms)
  ✔ records which proxy route failed (0.066291ms)
  ✔ passes a digest and an absent digest through unchanged (0.154417ms)
  ✔ produces only scalars, so no nested value can smuggle text out (0.230167ms)
✔ diagnosticEventRecord (4.157084ms)
▶ asDigest
  ✔ accepts a 64-character lower-case hex digest (0.094292ms)
  ✔ rejects anything else, without quoting it (14.901ms)
  ✔ has a predicate that agrees with it (0.085792ms)
✔ asDigest (15.195708ms)
▶ asAppVersion
  ✔ accepts the CalVer surface and its release stages (36.204667ms)
  ✔ rejects free text and invalid leading-zero variants (0.207208ms)
✔ asAppVersion (36.504666ms)
▶ renderer diagnostics boundary
  ✔ accepts the complete bounded aggregate (1.595625ms)
  ✔ rejects missing, negative, and non-finite values (0.776375ms)
✔ renderer diagnostics boundary (3.355083ms)
▶ frame capture analysis
  ✔ uses exact visible intervals and resets across hidden records (2.568667ms)
✔ frame capture analysis (2.6725ms)
▶ capture validation, format 2
  ✔ reproduces the manifest's redaction result from events.jsonl (157.830375ms)
  ✔ refuses a manifest whose redaction result the event log does not support (7.173375ms)
  ✔ rejects an event log carrying a field the schema does not declare (14.628833ms)
  ✔ does not require histograms.json, and does require the rest (15.906709ms)
  ✔ refuses a trace scan the included files do not corroborate (0.245708ms)
  ✔ requires explicit consent and a valid PNG for visual evidence (0.368208ms)
✔ capture validation, format 2 (196.743ms)
▶ capture validation, format 3 visual evidence
  ✔ accepts a complete self-consistent visual capture (0.354083ms)
  ✔ requires one unique declaration and dimension record per image (0.14125ms)
  ✔ rejects dimension mismatches and dimensions without an image (0.117167ms)
  ✔ requires valid runtime state and a visual declaration for format 3 (0.130625ms)
✔ capture validation, format 3 visual evidence (0.832375ms)
▶ capture validation, format 1
  ✔ accepts a complete redacted capture and rejects dropped records (0.773ms)
  ✔ refuses to call a Level 2 capture complete without its Chromium trace (0.163167ms)
  ✔ validates the machine-readable report without requiring it in old captures (0.118333ms)
  ✔ warns for same-session overlapping captures and mixed levels (0.263917ms)
✔ capture validation, format 1 (1.405917ms)
✔ distribution channels derive the complete capability matrix (8.175875ms)
✔ distribution markers accept only the closed canonical shape (0.1675ms)
✔ provisioned channels have distinct application identities (0.126125ms)
▶ dns suffix matching
  ✔ normalizes case and a trailing dot (0.827625ms)
  ✔ matches whole suffix labels only (0.151875ms)
  ✔ rejects IP literals passed as DNS names (0.875042ms)
  ✔ rejects names outside the allowlist without contacting the network (2.211458ms)
✔ dns suffix matching (4.733ms)
▶ effective Enhancement capability boundary
  ✔ reproduces every served profile from Main's session, independent of request (7.395125ms)
  ✔ does not revive off or unavailable features (0.1595ms)
  ✔ refuses to invent a profile before Main publishes a session (0.086083ms)
✔ effective Enhancement capability boundary (8.29325ms)
▶ Enhancement client chain
  ✔ source-pins every executable capability profile (35.604375ms)
  ✔ certifies the Enhancement transform against the template-save output (0.647042ms)
  ✔ requires all and only the hashes implied by optional capability facts (13.686416ms)
✔ Enhancement client chain (50.9185ms)
▶ Enhancement command transform
  ✔ emits Team Apply and local action authority independently (30.900541ms)
  ✔ derives local actions without installing the party dispatcher hook (2.557083ms)
  ✔ never advertises aliases without an effective named action (3.213833ms)
  ✔ queues the named storage action and drains DataWindow on the game thread (1.710375ms)
  ✔ queues one bounded Travel request and dispatches it on the game thread (1.401084ms)
  ✔ consumes /trade, /tp and exact storage commands at their named boundaries (3.305916ms)
  ✔ dispatches queued commands only from the certified game-thread callback (1.933125ms)
  ✔ distinguishes native and GWonMac command packets without changing them (8.195458ms)
  ✔ refuses a command whose function is not the one certified (0.72175ms)
  ✔ refuses an uncertified or shared command drain boundary (36.365708ms)
  ✔ refuses an uncertified or shared traced packet sender (111.687375ms)
  ✔ refuses an uncertified storage slash parser (0.438834ms)
  ✔ refuses an uncertified Xunlai access reader (3.663583ms)
  ✔ refuses a travel producer that aliases a selected dispatch hook (0.427958ms)
✔ Enhancement command transform (216.995459ms)
✔ pre-game state scans exact live label hashes and loading context (31.463417ms)
▶ Enhancement re-certification input
  ✔ fails closed without inspecting raw official bytes (2.3505ms)
  ✔ nests structural candidates as review evidence without promoting them (86.919084ms)
✔ Enhancement re-certification input (89.96275ms)
✔ developer programs replace saved optional-tool selection in PvE (1.756ms)
✔ unknown regions keep local Tools while live PvE features fail closed (0.099416ms)
✔ confirmed active PvP play disables every product and developer tool (0.123958ms)
✔ product tool settings remain live once the capability is present (0.080834ms)
✔ skill feature selection distinguishes labels from cooldowns (0.107834ms)
✔ runtime policy projects every registered feature exactly once (0.07875ms)
✔ local Tools require their setting or developer program and only active PvP blocks them (0.490458ms)
✔ skill transform resolves and verifies only its four certified functions (2.158417ms)
✔ unselected skill facts stay absent and selected missing facts fail clearly (0.331666ms)
✔ skill transform refuses changed bodies and changed certified call operands (0.166166ms)
✔ SkillBar capture rewrites only the certified operand and preserves wrapper bytes (0.308458ms)
✔ the storage controller owns policy, events, deduplication, and teardown (8.670417ms)
✔ storage fails closed without a confirmed character access proof (0.255458ms)
✔ storage development traces identify the live refusal without account data (0.197208ms)
▶ review-only Enhancement structural evidence
  ✔ recovers all three boundaries deterministically without a build certificate (18.020542ms)
  ✔ recovers shifted function indices instead of relying on known numbers (11.775375ms)
  ✔ uses the caller's immutable message anchors instead of fixed IDs (0.374791ms)
  ✔ rejects changed tick, dispatcher, and cursor signatures independently (0.650666ms)
  ✔ rejects changed player message and exact-site cardinality evidence (25.703542ms)
  ✔ rejects a changed direct-call target even when both signatures match (8.513708ms)
  ✔ reports duplicate dispatcher and cursor candidates as ambiguous (0.619583ms)
  ✔ distinguishes missing and non-unique active-table relationships (1.368625ms)
  ✔ does not let an exact input hash replace cursor field witnesses (1.271458ms)
  ✔ rejects every changed cursor anchor and duplicate candidate (0.616208ms)
  ✔ fails closed with a deterministic data report for malformed input (0.153542ms)
  ✔ keeps independent tick evidence but rejects an unsupported opcode set (0.242792ms)
✔ review-only Enhancement structural evidence (157.237166ms)
✔ the closed team surface selects only its reviewed opcodes and payloads (4.617375ms)
✔ the storage command owns one fixed DataWindow payload and refuses unsafe sends (37.104625ms)
✔ invalid values are refused before the command queue (0.257875ms)
✔ hero identity is resolved again for every packet and rejected packets throw (0.211ms)
▶ targeted Enhancement WebAssembly transform
  ✔ is deterministic, valid, and exports only the hook contract (139.439209ms)
  ✔ reports the semantic loop signature and reusable empty slots (8.344417ms)
  ✔ preserves every argument and calls each relocated original once (48.511291ms)
  ✔ rejects a non-terminal slot, hash mismatch, and signature mismatch (17.378375ms)
  ✔ uses only selected hook evidence in deterministic hook order (35.923208ms)
  ✔ rejects nonzero configuration for inactive capabilities (6.173666ms)
  ✔ zeroes only Xunlai proof words when Travel has no access certificate (1.538542ms)
  ✔ binds the exact party-dirty set to the Toolbox manifest and config (2.311167ms)
  ✔ starts the message words exactly where the layout words end (0.128917ms)
  ✔ gives party observation shared agent state without target selection (1.642542ms)
  ✔ checks the existing cursor table relation only when cursor is selected (1.113834ms)
✔ targeted Enhancement WebAssembly transform (280.546625ms)
▶ Enhancement workspace doctor
  ✔ fails closed for a missing profile (73.825958ms)
  ✔ reports snapshot residency without reading chunk contents (243.179334ms)
  ✔ reports required Core without writing to the profile (269.88425ms)
✔ Enhancement workspace doctor (588.296541ms)
✔ a packaged build refuses GW_ENHANCEMENT_AUTOMATION=1, so the tools decide alone (0.930125ms)
✔ the launch selection carries required Core and no setting can disable it (0.920667ms)
✔ one capability plan derives hooks without losing feature identity (0.458792ms)
✔ launch intent resolves to the canonical frozen capability profiles (0.268833ms)
✔ the capability wire contract is exact and has one empty value (0.342917ms)
✔ Tools prepares every certified capability independent of child toggles (0.089125ms)
✔ renderer consumes main's effective subset instead of launch intent (0.122209ms)
▶ error catalogue
  ✔ has no duplicate codes (0.735833ms)
  ✔ recognises its own members and nothing else (0.138417ms)
✔ error catalogue (1.448833ms)
▶ errorCode
  ✔ returns the code of an AppError (0.145333ms)
  ✔ returns the code of every AppError subclass (0.146459ms)
  ✔ does not republish the code of a foreign error (0.075333ms)
  ✔ survives anything that is not an Error at all (0.069209ms)
  ✔ keeps the message on the error and out of the code (0.10925ms)
  ✔ preserves the cause chain, which never reaches a code (0.082834ms)
✔ errorCode (0.801458ms)
▶ the macOS build number derived from a release version
  ✔ rises at every rung of a release ladder (1.24375ms)
  ✔ orders releases the same way the app's own comparison does (0.516458ms)
  ✔ maps the calendar and the channel onto Apple's 4/2/2 digits (1.027583ms)
  ✔ refuses anything that is not a calendar release in SemVer syntax (0.298834ms)
  ✔ accepts the version this repository would release right now (0.546458ms)
✔ the macOS build number derived from a release version (4.355458ms)
▶ export detector
  ✔ accepts every declared event built through the schema (5.772416ms)
  ✔ accepts only a nonnegative ephemeral window owner (0.414333ms)
  ✔ rejects a declared event that carries a field the schema does not declare (0.148333ms)
  ✔ rejects a value outside the field's declared vocabulary (0.233708ms)
  ✔ rejects text a redactor would have called clean (0.122959ms)
  ✔ rejects a malformed envelope rather than trusting the record (0.25025ms)
  ✔ rejects a declared event under another subsystem or level (0.68175ms)
  ✔ rejects every undeclared event and former free-text producer field (0.179834ms)
  ✔ rejects a nested field on any record, declared or not (0.147ms)
  ✔ skips the blank lines a JSONL document ends with (0.143875ms)
✔ export detector (8.89175ms)
▶ extended memory runtime result
  ✔ keeps unresolved selection outside the result and maps standard mode (1.702542ms)
  ✔ reports the certified active profile and cap (0.098583ms)
  ✔ falls back truthfully after unsupported-client (0.084209ms)
  ✔ falls back truthfully after preparation-failed (0.066333ms)
✔ extended memory runtime result (3.40425ms)
▶ extended memory Settings projection
  ✔ distinguishes unresolved intent from the active standard cap (1.18875ms)
  ✔ reports restart only when saved intent differs from this launch (0.184541ms)
  ✔ keeps unsupported and preparation failures visibly distinct (0.105375ms)
✔ extended memory Settings projection (2.186416ms)
▶ certified extended memory transform
  ✔ stops one page short of 4 GiB (0.824958ms)
  ✔ accepts only canonical valid runtime feature profiles (0.225959ms)
  ✔ normalizes only all 59 ASM_CONSTS keys (0.422125ms)
  ✔ refuses changed JavaScript semantics and a changed memory shape (0.5175ms)
  ✔ changes only the sole memory maximum and validates the result (0.944125ms)
  ✔ records the effective mode and cap with a closed profile (0.152958ms)
✔ certified extended memory transform (3.762458ms)
▶ renderer failure messages
  ✔ answers every code in the catalogue with a sentence, on every surface (2.445875ms)
  ✔ carries the disk shortfall into the sentence when the caller knows it (0.170334ms)
  ✔ gives the same fault a different action on each surface (0.131542ms)
  ✔ keeps the sentences the two probe and recovery paths used to send (0.066208ms)
  ✔ falls back to one default rather than inventing a sentence per code (0.06275ms)
  ✔ answers every notice code with a sentence (0.135166ms)
  ✔ explains a failed Steam sign-in and stays silent on a plain cancel (0.09025ms)
  ✔ tells offline apart from a server fault, on both transfer surfaces (0.082292ms)
  ✔ suggests a bug report only when the fault may be the app's (0.134834ms)
  ✔ tells a locked Keychain apart from a build that may not use one (0.125458ms)
  ✔ stops promising a retry once the client crashes twice in one run (0.931917ms)
  ✔ escalates memory wording while keeping one action model (0.14ms)
  ✔ prints the effective cap but no unreliable countdown (0.10175ms)
  ✔ explains optional automatic return without overpromising (0.11175ms)
✔ renderer failure messages (5.55575ms)
✔ the capability registry is the ordered wire vocabulary (3.091875ms)
✔ dependency pruning is derived from capability contracts (0.424667ms)
✔ cooldown owns the reusable player skillbar core without Party (1.762333ms)
✔ feature selection policies are deeply immutable (0.119792ms)
✔ shared activation and area policy cover required, setting, and content features (0.150042ms)
▶ frame attribution
  ✔ reads only visible records and rejects a bad header (2.076042ms)
  ✔ blames composition loss when the window changed state (8.721166ms)
  ✔ blames the main process only when its event loop actually blocked (0.619583ms)
  ✔ refuses to blame anything when the capture predates the instrumentation (0.3015ms)
  ✔ ignores gaps under the threshold and events outside the window (0.412042ms)
  ✔ rejects a non-positive threshold (0.142625ms)
✔ frame attribution (13.910417ms)
✔ automatic-return intent is refused to the source and consumed by its replacement (1.253375ms)
✔ a settings read failure performs no partial reload (61.710166ms)
✔ a completed program is answered without another round trip (19.8905ms)
✔ an incomplete program is never frozen, however often it is polled (0.213875ms)
✔ relinking makes a completed program incomplete again (0.140584ms)
✔ a recycled program name never inherits the deleted program's completion (0.117833ms)
✔ a name the host never saw created always reaches the client (0.103417ms)
✔ every pname except completion reaches the client every time (0.175ms)
✔ null and misaligned out-pointers pass through and record nothing (0.085791ms)
✔ losing the GL context drops every memoized program (0.133375ms)
✔ a missing invalidator leaves every import untouched (0.164291ms)
✔ programs beyond the ceiling stay correct by passing through (0.331541ms)
✔ hits and misses both return the client's void result (0.078167ms)
✔ a grown WASM heap is followed on both the miss and the hit (0.088042ms)
✔ reconnaissance counts the queries that still reach the client (0.118584ms)
✔ completion polls the cache cannot serve stay visible (0.072958ms)
✔ graphics diagnostics read immutable context facts only once (3.937125ms)
✔ the Guild Wars nibble stream decodes every printable ASCII glyph (2.090041ms)
✔ alternating runs cannot overrun a glyph (1.017834ms)
✔ the converted result is a complete checksummed TrueType font (13.737875ms)
✔ the original display strike builds as a separate browser family (150.457167ms)
✔ the measured contour remains the default and calibration inputs are bounded (31.445209ms)
✔ a narrow numeral gets balanced proportional spacing (24.2435ms)
✔ an unsupported font is refused once for its immutable client generation (0.339625ms)
✔ a compact oversized strike is refused before outline tracing (0.12925ms)
✔ the shared UI offers the local Guild Wars font independently of Inter (0.792208ms)
▶ Guild Wars archive decoder process boundary
  ✔ settles and stops the child when writing stdin throws (3.186125ms)
  ✔ contains an early stdin close and reports the decoder refusal (409.864333ms)
  ✔ settles once when an output refusal closes stdin (428.407708ms)
✔ Guild Wars archive decoder process boundary (842.782875ms)
▶ renderer image source
  ✔ answers fileSize synchronously, before any read, and only for open snapshot handles (1.307209ms)
  ✔ coalesces concurrent reads of the same range into one fetch (9.022334ms)
  ✔ batches adjacent queued demand chunks without fetching across a gap (0.748417ms)
  ✔ counts batched demand chunks toward the shared eight-chunk ceiling (0.904875ms)
  ✔ coalesces a demand read onto an already active prefetch instead of promoting it (5.780375ms)
  ✔ runs one multi-chunk cacheAsync seven-wide, keeping the demand slot free (1.254875ms)
  ✔ runs demand work before queued prefetch, and promotes the queued chunk a read needs (5.515208ms)
  ✔ releases the slot a failed fetch held, and reports the failure until a retry succeeds (1.126583ms)
  ✔ releases every slot after a batched failure (0.950959ms)
  ✔ rejects every affected chunk when a batched response is truncated (0.561041ms)
  ✔ assembles a range across a chunk boundary and into the short final chunk (0.313334ms)
  ✔ evicts the least recently used chunk at the 256 MiB budget (0.452167ms)
  ✔ counts native residency in isCached, which memory eviction does not erase (0.251875ms)
  ✔ stops background work at unload and fails what was still queued (2.439292ms)
✔ renderer image source (31.8775ms)
✔ main input trace emits only while its renderer harness is enabled (2.859334ms)
✔ main trace state changes only after renderer acknowledgement (0.209875ms)
▶ the JSONL reader
  ✔ keeps every complete record when the last one is torn (10.414834ms)
  ✔ survives a tear at the only record, and at no record at all (0.114708ms)
  ✔ survives a final torn record that is still valid JSON (0.163917ms)
  ✔ rejects malformed or incomplete records before the final line (0.335667ms)
  ✔ allows trailing line endings but not blank records between events (0.096167ms)
  ✔ orders by sequence number, so rolled files may arrive in any order (0.081708ms)
  ✔ preserves the fields the export and the report both read (0.083125ms)
✔ the JSONL reader (12.014666ms)
▶ keyboard shortcuts
  ✔ uses defaults until a player replaces or clears one action (1.67875ms)
  ✔ stores only differences from defaults (0.138541ms)
  ✔ matches only Command and keeps Control chords in the game (0.2ms)
  ✔ normalizes physical Command chords across Option-modified layouts (0.1005ms)
  ✔ protects editing and lifecycle shortcuts and finds action conflicts (0.116042ms)
  ✔ formats the same binding for Electron and for players (0.091459ms)
  ✔ refuses unknown actions, keys, fields, and modifier types (0.150875ms)
✔ keyboard shortcuts (3.185625ms)
Keychain operation failed arenaNetCredentials unclassified Error
Keychain operation failed arenaNetCredentials keychain_locked Error
Keychain operation failed arenaNetCredentials keychain_locked Error
Keychain operation failed arenaNetCredentials keychain_locked Error
Keychain operation failed arenaNetCredentials keychain_unentitled Error
Keychain operation failed arenaNetCredentials keychain_unentitled Error
Keychain operation failed arenaNetCredentials keychain_unentitled Error
Keychain operation failed arenaNetCredentials unclassified Error
Keychain operation failed arenaNetCredentials unclassified Error
Keychain operation failed arenaNetCredentials unclassified Error
Keychain operation failed arenaNetCredentials unclassified Error
Keychain operation failed arenaNetCredentials unclassified Error
Keychain operation failed arenaNetCredentials unclassified Error
Keychain operation failed arenaNetCredentials unclassified Error
▶ KeychainJsonStore
  ✔ serializes overlapping writes and recovers its queue after failure (15.867ms)
  ✔ keeps the native classification of a refusal instead of collapsing it (5.203167ms)
  ✔ zeroes native save buffers on success and failure (0.238042ms)
  ✔ zeroes loaded native buffers after valid and corrupt payloads (0.249208ms)
✔ KeychainJsonStore (22.253292ms)
▶ legacy secret cleanup
  ✔ removes only the two retired files and is idempotent (306.154458ms)
  ✔ unlinks a retired-name symlink without touching its target (10.812167ms)
  ✔ does not recursively remove a directory with a retired filename (42.771125ms)
  ✔ attempts both exact files and returns bounded failures (0.264625ms)
✔ legacy secret cleanup (361.036417ms)
✔ skillbar diagnostics preserve feature-local failure precedence (7.585541ms)
✔ shared module failures override skillbar-specific diagnostics (0.172334ms)
✔ the build fragment keeps cooldown independent from Party UI authority (0.236458ms)
✔ the build fragment refuses inconsistent include flags (0.08825ms)
▶ local client verification boundary
  ✔ certifies play region directly from the exact observation base (1.142541ms)
  ✔ accepts the verifier's complete baseline proof (3.705292ms)
  ✔ rejects an exact authored row that did not cross semantic proof (0.177709ms)
  ✔ rejects a proof for any other official client (0.100875ms)
  ✔ rejects an unconstrained enhancement layout (53.915125ms)
  ✔ accepts a relocated hook but rejects an incompatible signature (0.51075ms)
  ✔ accepts a structurally derived cursor proof and rejects malformed layouts (3.528542ms)
  ✔ accepts a field-complete Target proof and rejects one bad relocation (0.47025ms)
  ✔ accepts independent local-action proofs and rejects one bad Xunlai field (0.402458ms)
  ✔ accepts complete Party and Team proofs and rejects each independently (0.525042ms)
  ✔ validates the complete skill-slot geometry proof at the process boundary (60.432958ms)
  ✔ certifies cooldown from the player skillbar without Party or UI authority (0.40525ms)
  ✔ accepts a template-only proof and requires no enhancement behind failure (63.137458ms)
  ✔ represents an unrequested enhancement as a proved template, not a refusal (0.140708ms)
  ✔ rejects a stale verifier ABI at either boundary (0.404542ms)
  ✔ binds each verdict to the post-template hash and requested feature (0.176542ms)
  ✔ carries anchor-specific changed and ambiguous evidence across IPC (0.359584ms)
✔ local client verification boundary (195.231042ms)
▶ macOS Command-held key releases
  ✔ consumes only mapped releases routed to the focused game (1.722208ms)
✔ macOS Command-held key releases (7.513042ms)
✔ macOS key positions cover movement and player-bindable keys (1.948583ms)
✔ launch configuration arrives as a preload argument, not as a URL (3.534625ms)
✔ a renderer with no readable init argument gets the production posture (4.697083ms)
✔ menu commands reach the renderer as events and are acknowledged (2.891166ms)
✔ one physical key release crosses preload and is acknowledged (1.60825ms)
✔ ordinary renderer text editing declines to the main-process fallback (1.329875ms)
✔ input harness state crosses as an explicit value and is acknowledged (2.5395ms)
✔ the Tools shortcut is refused when there is no Toolbox to toggle (1.402583ms)
✔ a capture level crosses as a number, not as interpolated source (1.678667ms)
✔ the acknowledgement waits for the renderer's own promise (1.606875ms)
✔ a renderer that cannot act reports failure (1.829291ms)
▶ manifest
  ✔ accepts flat files and finds by basename (1.1675ms)
  ✔ rebuilds nested paths via parentIndex (0.152792ms)
  ✔ rejects chunk count mismatch (1.299958ms)
  ✔ rejects unknown compression (0.13625ms)
  ✔ rejects cycles and invalid parent indexes (0.155833ms)
  ✔ treats an explicitly null parentIndex as the root (0.12375ms)
  ✔ rejects unsafe names, duplicate paths, and invalid sizes (0.721375ms)
  ✔ rejects conflicting lengths for one content hash (0.164209ms)
  ✔ requires exactly one copy of each product basename (0.260208ms)
✔ manifest (5.197875ms)
▶ memory warning presenter
  ✔ does nothing when the single warning surface is incomplete (2.306083ms)
  ✔ keeps Low dismissed until Critical reopens the same notice (0.404458ms)
  ✔ reloads without adding another warning state (0.235583ms)
  ✔ registers as a dismissible keyboard surface while visible (3.6715ms)
  ✔ shares and saves the automatic-return preference (0.36375ms)
✔ memory warning presenter (7.776083ms)
▶ Multiple Accounts documents
  ✔ keeps a missing mode and workspace on the legacy Single path (307.299583ms)
  ✔ publishes a workspace before an explicit Multi selection (270.040875ms)
  ✔ fails closed for corrupt or future documents (34.672792ms)
  ✔ quarantines a damaged document without rewriting its bytes (52.866584ms)
  ✔ accepts only lowercase UUID v4 identifiers (16.044917ms)
  ✔ rejects duplicate labels after normalization and case folding (0.181167ms)
  ✔ accepts an empty onboarding workspace but rejects an all-archived workspace (12.2325ms)
  ✔ requires valid binary sharing choices (0.213583ms)
  ✔ adds, updates, and archives profiles without changing stable IDs (0.371667ms)
✔ Multiple Accounts documents (698.722125ms)
▶ generation mutex
  ✔ serialises real generation-directory moves (608.885667ms)
  ✔ tears the same tree when the moves are not serialised (114.6295ms)
  ✔ does not wedge the queue when a task rejects (0.616375ms)
  ✔ gives each caller its own task's result, in queue order (148.40775ms)
✔ generation mutex (873.782709ms)
▶ queue drain
  ✔ waits for the work already queued, failure included (2.3015ms)
✔ queue drain (2.476542ms)
▶ settings write queue
  ✔ keeps both patches when the writes are serialised (154.179083ms)
  ✔ drops a patch when the same writes are not serialised (59.629209ms)
  ✔ writes the next patch after a write fails (21.304041ms)
✔ settings write queue (235.511792ms)
✔ appends one exported mutable global and writes it into the record (2.114375ms)
✔ locates an unchanged callback without a predecessor hash (0.765458ms)
✔ refuses malformed input and ambiguous callback candidates (0.158625ms)
✔ rejects malformed or over-broad isolated verifier records (0.21925ms)
✔ refuses a callback whose body is not the certified one (0.294583ms)
✔ rechecks the isolated record's callback signature during production (0.120959ms)
✔ refuses a table slot that no longer holds the certified function (1.377667ms)
✔ refuses duplicate active table slots instead of accepting the last mapping (0.114917ms)
✔ refuses to insert past the end of the body (0.121209ms)
✔ refuses a module that already carries the flag export (0.255334ms)
✔ the shipped baseline states its own offsets and keeps valid historic fixtures (110.316208ms)
▶ native Keychain boundary
  ✔ has exactly the two product-owned slots (2.913708ms)
  ✔ resolves the one development and one packaged binary path (0.174667ms)
  ✔ accepts an asynchronous in-memory fake without another interface (0.193625ms)
✔ native Keychain boundary (3.927209ms)
▶ no game traffic is uploaded: the only reachable destination
  ✔ refuses every destination that is not a public ArenaNet-shaped address (3.651333ms)
  ✔ refuses loopback through the constructor's own defaults (68.929792ms)
  ✔ opens an allowed destination at exactly the address it was given (151.995708ms)
  ✔ resolves no name outside ArenaNet's, including this project's own (0.247625ms)
✔ no game traffic is uploaded: the only reachable destination (225.580708ms)
▶ no game traffic is uploaded: what the recorder may hear
  ✔ publishes payload bytes to the game and to nothing else (0.598792ms)
  ✔ exports a socket's lifetime with no trace of what it carried (76.288416ms)
  ✔ stops the export if a socket record carries the bytes anyway (0.537291ms)
✔ no game traffic is uploaded: what the recorder may hear (77.658167ms)
▶ the published code generation
  ✔ is the identity of the two JSPI artifacts and nothing else (2.206167ms)
  ✔ refuses a manifest that names no code artifact (0.307458ms)
✔ the published code generation (3.120208ms)
▶ the command line
  ✔ reads the three things this script does (1.647875ms)
  ✔ refuses a record it was not handed a generation for (0.17375ms)
  ✔ refuses to fetch and record in the same run (0.092375ms)
  ✔ refuses a download with nowhere to put the bytes (0.098042ms)
✔ the command line (2.167ms)
▶ the recorded client generation
  ✔ round-trips through its own serializer (80.886125ms)
  ✔ refuses everything it cannot read exactly (0.461958ms)
  ✔ is a tracked file the detector can read today (18.819542ms)
✔ the recorded client generation (101.296625ms)
✔ packaging accepts only the four complete supported intents (37.274875ms)
▶ patch-client update
  ✔ publishes a generation whose artifacts match the manifest beside them (280.732667ms)
  ✔ leaves an alpha-published generation installed instead of re-staging it (373.572083ms)
  ✔ promotes nothing when assembly silently truncates an artifact (332.811458ms)
  ✔ keeps the installed generation when a staged artifact changes under it (460.968875ms)
  ✔ aborts a slow preparation without moving the installed generation (335.352125ms)
  ✔ still swaps in a verified replacement and keeps the rollback target (546.59625ms)
✔ patch-client update (2343.562083ms)
▶ patch transport
  ✔ owns patch identity, redirect policy, caller abort, and response bounds (50.683625ms)
  ✔ accepts only HTTP 200 and never follows redirects through retries (0.241708ms)
  ✔ classifies a request that never got an HTTP answer as net_offline (0.173375ms)
  ✔ rejects a materialized body above its declared call-site limit (0.115333ms)
  ✔ interrupts retry backoff without starting another request (144.360542ms)
  ✔ bounds streamed bodies with and without content-length (1.035667ms)
  ✔ enforces exact decoded chunk lengths and gzip output bounds (122.105042ms)
✔ patch transport (319.617375ms)
▶ resolved profile paths
  ✔ pins the whole profile layout as literals (1.882667ms)
  ✔ sweeps every directory the profile publishes documents into (0.166917ms)
  ✔ derives profile paths only beneath the Multi namespace (0.232167ms)
  ✔ keeps the downloaded chunk cache exactly where the alpha put it (0.126875ms)
  ✔ pins the files published inside a client generation (0.095ms)
  ✔ resolves an unpacked executable in development and when packaged (0.094875ms)
  ✔ pins the diagnostics frame log name (0.068959ms)
  ✔ resolves a staged generation without escaping the game directory (2.767834ms)
✔ resolved profile paths (6.81625ms)
▶ ArenaNet unavailable platform capabilities
  ✔ exposes only the two namespaces required by defective client guards (3.851917ms)
  ✔ returns promises with explicit unavailable outcomes (0.507916ms)
  ✔ preserves the four callback assignments made by the glue (0.089ms)
✔ ArenaNet unavailable platform capabilities (17.473ms)
✔ play-region authority withdraws on staleness and requires a newer publication to recover (3.910791ms)
▶ PreferencesCoordinator
  ✔ publishes shortcut commits and the active result of an ambiguous write (309.233708ms)
  ✔ keeps the released district-bearing shortcut shape (78.458584ms)
  ✔ refuses a stale second window instead of losing the first write (95.958375ms)
  ✔ serializes ordinary settings writes with shortcut writes (137.568958ms)
  ✔ reports a post-rename failure as unconfirmed, then reloads the active value (66.415333ms)
  ✔ returns an ordinary settings update that became active before fsync failed (42.406584ms)
  ✔ returns a settings reset that became active before fsync failed (79.030583ms)
  ✔ resets settings and Travel preferences completely (256.591042ms)
  ✔ does not attempt Travel when the settings reset definitively fails (116.477416ms)
  ✔ skips the Travel write when its document is already default (41.753459ms)
  ✔ returns a partial result when the Travel write definitively fails (115.146542ms)
  ✔ reconciles a Travel reset published before directory fsync failed (106.495917ms)
  ✔ returns partial when Travel cannot be read after settings commit (81.95775ms)
  ✔ returns partial when an unconfirmed Travel publication cannot be reread (133.932167ms)
  ✔ completes an idempotent retry after a partial Travel reset (109.477917ms)
  ✔ runs the next queued mutation after a partial reset (153.619791ms)
✔ PreferencesCoordinator (1927.449958ms)
✔ the command trace publishes exact profession and skill payloads (2.495375ms)
✔ a drained attribute opcode does not invent an observed target (0.190291ms)
▶ Multiple Accounts runtime state
  ✔ tracks honest batch transitions without changing already-open accounts (4.575583ms)
  ✔ releases the untouched queue after canary failure (1.334833ms)
  ✔ maps every failure stage to bounded player-safe vocabulary (0.11275ms)
✔ Multiple Accounts runtime state (9.556167ms)
▶ download progress
  ✔ warms up, then smooths bursty chunk completion rates (0.940417ms)
  ✔ moves the displayed minutes only at the hysteresis edges (0.125583ms)
  ✔ throttles the detail line but renders clearing events immediately (0.148875ms)
  ✔ ignores duplicate and regressing samples instead of producing spikes (0.069917ms)
  ✔ drives Dock progress and sleep blocking only for a full download (0.939042ms)
✔ download progress (2.916083ms)
▶ proxy-routes
  ✔ maps only the explicit ArenaNet/NCSoft route labels (1.244584ms)
  ✔ keeps redirects inside the custom protocol and exact upstream host (0.222542ms)
  ✔ applies redirect and stateless-header policy as one response boundary (349.435875ms)
  ✔ permits proxy routes only for fetch/XHR destinations (0.111917ms)
  ✔ keeps the proxy stateless in both directions (0.072666ms)
✔ proxy-routes (351.830959ms)
▶ published client manifest
  ✔ returns a canonical detached manifest (2.360167ms)
  ✔ reads a manifest the alpha published with no format version (3.869709ms)
  ✔ refuses a manifest from a format this build cannot read (0.410583ms)
  ✔ publishes the format marker when it seals a legacy generation (275.878333ms)
  ✔ verifies every persisted executable artifact (80.685792ms)
  ✔ atomically seals a legacy generation before it can be replaced (61.148167ms)
  ✔ rejects invalid snapshot identity, dimensions, and chunk count (0.357042ms)
✔ published client manifest (425.907666ms)
✔ neither a stuck cleanup task nor a stuck final flush can hold the quit (2.205959ms)
▶ ranges
  ✔ parses closed, open-ended, and suffix ranges (6.677333ms)
  ✔ returns null without a usable Range header (0.396042ms)
  ✔ marks unsatisfiable ranges (0.179167ms)
✔ ranges (8.523583ms)
▶ Squirrel.Mac release manifest
  ✔ contains exactly one immutable release asset (3.851208ms)
  ✔ refuses mismatched tags and non-file ZIP names (0.224167ms)
  ✔ uses one closed reader for generated and downloaded manifests (0.238209ms)
✔ Squirrel.Mac release manifest (6.016333ms)
▶ the one marked release Verification record
  ✔ stages Pending evidence without changing generated notes (25.5855ms)
  ✔ replaces only the marked block (3.123375ms)
  ✔ preserves a passed result only for the same immutable evidence (29.30975ms)
  ✔ refuses duplicate markers, changed checksum rows, and Pending results (0.230417ms)
✔ the one marked release Verification record (66.386833ms)
▶ release version parsing
  ✔ accepts every shape the release workflow publishes, tagged or not (1.900709ms)
  ✔ rejects 2026.07.01 and every other non-SemVer numeric identifier (0.097208ms)
  ✔ rejects anything that is not exactly a published release shape (0.093834ms)
  ✔ rejects digit runs too long to compare exactly (0.093542ms)
  ✔ round-trips through canonical text without the tag prefix (0.139292ms)
✔ release version parsing (2.971375ms)
▶ release version ordering
  ✔ orders numerically first, then prerelease before its own release (0.170375ms)
  ✔ does not read a prerelease as equal to the release it leads to (0.069959ms)
  ✔ reports which versions are prereleases (18.8835ms)
✔ release version ordering (38.86425ms)
▶ public release tracks
  ✔ keeps Stable as the default and never makes alpha public (0.297ms)
  ✔ requires GitHub prerelease metadata to match the tag (0.131625ms)
✔ public release tracks (4.64225ms)
✔ loading cannot impersonate character selection or playable completion (0.909083ms)
✔ only a certified playable instance completes relog (0.977916ms)
▶ reload transcript
  ✔ joins main and replacement-renderer events for exactly one owner (1.205375ms)
  ✔ reports an incomplete or missing boundary truthfully (0.115042ms)
  ✔ starts a menu trace at its own reload after an older Command-Q run (0.111917ms)
  ✔ stays below the clipboard ceiling by retaining newest complete rows (46.067833ms)
✔ reload transcript (65.485167ms)
✔ renderer failures stay with one document and client generation (3.420458ms)
✔ a renderer handler may complete before the final load event (1.176084ms)
✔ mounts, restores, prepares, and persists the game filesystem before main (2.13825ms)
✔ reuses an existing mount while restoring every required invariant (0.162959ms)
✔ normalizes Guild Wars desktop template paths at the filesystem boundary (0.273958ms)
✔ blocks game startup and reports an IndexedDB restore failure (0.124292ms)
✔ blocks game startup when the directory invariant cannot be persisted (0.104292ms)
✔ blocks game startup when IndexedDB synchronization stalls (0.141916ms)
✔ every host module exports exactly one installer (2.959375ms)
✔ merging the host modules loses no installer (0.413459ms)
▶ canonical renderer URL
  ✔ allows the launcher document and nothing else (4.776416ms)
  ✔ rejects every query string, including the ones it used to carry (0.159167ms)
  ✔ rejects proxy, subresource, ambiguous, and malformed URLs (0.127042ms)
  ✔ gives the accounts Hub its own document boundary (0.101708ms)
✔ canonical renderer URL (5.816625ms)
✔ runtime states admit only their complete valid phases (1.684583ms)
▶ semantic proof primitives
  ✔ binds every verdict to one input and verifier ABI (0.834083ms)
  ✔ requires an exact, non-empty witness ledger (1.223959ms)
  ✔ canonicalizes only explicit relocation operands (1.276958ms)
  ✔ fails closed at the analysis ceiling (0.222542ms)
✔ semantic proof primitives (4.312667ms)
▶ the sensitive-key vocabulary
  ✔ treats a field named pass as sensitive (0.996459ms)
  ✔ treats a field named auth as sensitive (0.066ms)
  ✔ treats a field named cookie as sensitive (0.055875ms)
  ✔ treats a field named token as sensitive (0.05025ms)
  ✔ treats a field named secret as sensitive (0.053292ms)
  ✔ treats a field named credential as sensitive (0.045667ms)
  ✔ treats a field named username as sensitive (0.057834ms)
  ✔ treats a field named email as sensitive (0.046375ms)
  ✔ treats a field named account as sensitive (0.065583ms)
  ✔ treats a field named login as sensitive (0.107875ms)
  ✔ leaves the field names the schema already declares alone (0.085292ms)
  ✔ scans text for every sensitive key stem (0.611041ms)
✔ the sensitive-key vocabulary (2.9965ms)
✔ ENOENT means no destructive startup action is pending (8.085166ms)
✔ marker inspection failures other than ENOENT remain visible (5.176416ms)
✔ a failed shortcut write reconciles through Settings and leaves capture mode (4.169167ms)
✔ cooldown settings render the canonical choice and shared preview (3.391666ms)
✔ cooldown settings reject malformed custom colors and persist valid colors (3.287292ms)
✔ cooldown settings recover the active state after a failed write (0.653916ms)
✔ cooldown settings do not repaint a custom color while it is being edited (0.229042ms)
✔ skill-key previews expose the same canonical label as their visual plate (3.501834ms)
✔ blur cancels recording and a captured chord persists only the display setting (2.223042ms)
▶ settings
  ✔ exposes the documented defaults (1.821209ms)
  ✔ drops retired cursor fields from an alpha profile (0.271458ms)
  ✔ fills missing fields and ignores unknown keys on read (0.075708ms)
  ✔ preserves every explicit supported render scale (0.097917ms)
  ✔ accepts only supported interface styles (0.262375ms)
  ✔ normalises and validates the permanent custom theme contract (0.31125ms)
  ✔ accepts only the supported interface fonts (0.101792ms)
  ✔ accepts only the two supported controller prompt styles (0.094584ms)
  ✔ rejects unknown types (0.194291ms)
  ✔ takes the update fields only in the shapes the renderer can produce (0.249792ms)
  ✔ accepts only bounded shortcut overrides (0.263916ms)
  ✔ accepts exactly eight display-only skill bindings (0.348833ms)
  ✔ takes the acknowledged client build only as a client hash (0.177209ms)
  ✔ accepts one canonical cooldown switch and color (0.208375ms)
  ✔ validates patches without filling fields from defaults (0.232333ms)
  ✔ keeps Travel shortcuts off the generic renderer settings channel (0.110166ms)
  ✔ loads defaults for missing or corrupt files (14.57975ms)
  ✔ saves only known fields (165.244042ms)
  ✔ loads an alpha-written bare-JSON file with every value intact (78.239208ms)
  ✔ preserves released district shortcuts for Stable rollback compatibility (4.151541ms)
  ✔ keeps the three newest corrupt backups and drops the rest (30.262084ms)
  ✔ moves aside a settings format this build cannot read (9.937042ms)
✔ settings (310.982375ms)
✔ catalogue and icon refusals are retryable without restarting (72.947458ms)
✔ the skill catalogue has one complete cross-process parser (2.027334ms)
✔ one malformed skill refuses the whole catalogue (0.251083ms)
✔ the presentation joins complete geometry and cooldown state without touching keys (4.22975ms)
✔ ready skills, stale state, disabled Tools, and incomplete publications hide everything (0.293625ms)
✔ sub-frame timer changes that keep the same label cause no presentation update (0.186291ms)
✔ equal cooldown labels skip projection while resize refreshes it (0.23225ms)
✔ either accepted feed withdrawing hides the complete cooldown HUD (0.180708ms)
✔ the minimal cooldown profile needs play-region policy but no Party or UI hook (2.222167ms)
✔ the minimal cooldown profile activates only its shared read substrate (0.483834ms)
✔ withdraws a cooldown publication whose sequence stops advancing (2.034416ms)
✔ cooldown formatting rounds active values upward without showing zero (0.928583ms)
✔ cooldown colors accept only the closed presets or exact six-digit RGB (1.208541ms)
✔ formats modifiers in one fixed order before the main key (15.711792ms)
✔ formats mouse buttons and wheel directions without stored labels (2.614458ms)
✔ requires exactly eight closed, bounded bindings (1.401ms)
✔ clone and update return deeply frozen independent tuples (0.8905ms)
✔ clone and update reject malformed values at the runtime boundary (6.816375ms)
✔ a custom projection adds only the changed key label (4.017ms)
✔ a malformed or absent custom binding hides the complete overlay (0.35875ms)
✔ an unchanged frame performs no text write (1.465042ms)
✔ the consumer maps only slot eight's custom C binding (14.664416ms)
✔ a viewport resize refreshes projected key geometry (0.2895ms)
✔ the consumer withdraws geometry whose publisher stopped advancing (0.359583ms)
✔ the surface never takes input or enters the accessibility tree (0.108083ms)
✔ disposing removes the complete surface (0.089708ms)
✔ skill policy activates and withdraws only the observation regions it needs (3.513042ms)
✔ geometry listeners ignore heartbeat-only publications but receive moved bars (4.0385ms)
▶ client language-file table
  ✔ finds all 18 language rows by their complete pointer/hash shape (25.589208ms)
✔ client language-file table (26.27475ms)
▶ client language shards
  ✔ parses exactly 1,024 bounded UTF-16 records and ignores the trailer (6.001709ms)
  ✔ keeps unrelated context-keyed records opaque without losing the shard (1.987209ms)
  ✔ maps string ids across shard boundaries (3.007583ms)
  ✔ substitutes all three skill ranges without interpreting markup as HTML (0.136541ms)
✔ client language shards (11.681334ms)
▶ socket events carry no error text
  ✔ publishes a declared failure code, not libuv's message (19.5365ms)
  ✔ collapses an unrecognised errno rather than passing it through (0.222167ms)
  ✔ classifies each errno the allowlist names, and nothing else (0.095084ms)
  ✔ names why a socket closed, from a closed vocabulary (0.278083ms)
  ✔ reports a connect timeout as a timeout, not as an error (0.1525ms)
✔ socket events carry no error text (21.135834ms)
▶ renderer socket host
  ✔ uses one subscription and demultiplexes sockets by native ID (3.37925ms)
  ✔ honors close requested before connect resolves and closes once (0.624959ms)
  ✔ rejects pre-open sends asynchronously and compacts opened payloads (2.88025ms)
  ✔ waits for close after an error instead of retaining the close forever (0.436417ms)
✔ renderer socket host (8.120042ms)
▶ main-process socket queue budget
  ✔ holds the aggregate owner ceiling across 64 sockets (26.679ms)
  ✔ refuses a write past the per-socket ceiling while the owner still has room (0.416084ms)
  ✔ keeps one owner's budget and sockets out of another owner's reach (5.374417ms)
  ✔ reclaims a dead socket's bytes once, not again when its callbacks arrive late (14.31125ms)
  ✔ releases callback and synchronous write failures without exposing native details (14.745041ms)
  ✔ leaves no owner queued after close, failure, reload and quit (23.179542ms)
✔ main-process socket queue budget (88.9815ms)
▶ the Steam authorize URL
  ✔ carries the config read out of the official client (1.243ms)
  ✔ is built from whichever config it is handed (0.135083ms)
✔ the Steam authorize URL (1.963083ms)
▶ the sign-in origin allowlist
  ✔ admits the configured Steam-owned https hosts and their subdomains (0.207541ms)
  ✔ admits the configured authorize origin itself (0.087542ms)
  ✔ rejects non-Steam hosts, plaintext, and suffix look-alikes (0.142416ms)
  ✔ rejects a trailing-dot host rather than resolving it to the same name (0.064875ms)
  ✔ answers from the config it is given, not a module-level list (0.084458ms)
✔ the sign-in origin allowlist (0.756833ms)
▶ reading the token back
  ✔ accepts a fragment token whose state matches (1.057791ms)
  ✔ accepts a query token as well as a fragment token (0.135584ms)
  ✔ accepts a bare `token` key as well as `access_token` (0.164ms)
  ✔ prefers access_token when a response carries both (0.102375ms)
  ✔ rejects a response whose state does not match the attempt (0.086542ms)
  ✔ rejects a response carrying no state at all (6.478ms)
  ✔ rejects a matching-state response that carries no token (0.205916ms)
  ✔ rejects a matching-state response whose token is empty (0.082542ms)
  ✔ does not treat a matching state on another URL as the redirect (0.209666ms)
✔ reading the token back (8.713125ms)
▶ the state nonce
  ✔ is unguessable and fresh per attempt (0.3625ms)
✔ the state nonce (0.399292ms)
Keychain operation failed steamSession unclassified Error
▶ the Steam session store
  ✔ round-trips the fixed Steam slot and clears it (2.075166ms)
  ✔ keeps a record whose expiry the account service has not supplied (0.17575ms)
  ✔ reports an absent store as absent, not as a failure (1.744625ms)
  ✔ maps native failure to the Steam session vocabulary (134.808541ms)
  ✔ refuses invalid bytes without destroying them (22.719292ms)
  ✔ rejects an invalid record before replacing a stored one (0.914042ms)
✔ the Steam session store (163.660792ms)
▶ the Steam session shape check
  ✔ accepts a token with a numeric expiry or none yet (23.998542ms)
  ✔ keeps only the two fields it models (0.137375ms)
  ✔ rejects anything that cannot be replayed at a login screen (4.151083ms)
✔ the Steam session shape check (28.833167ms)
▶ deciding which Steam token to vend
  ✔ replays a stored token that has not expired, without opening a window (54.392375ms)
  ✔ replays a stored token whose expiry is not known yet (0.114083ms)
  ✔ answers a silent request with nothing rather than opening a window (0.080875ms)
  ✔ acquires on a non-silent request and stores what it got (0.12325ms)
  ✔ replaces a locally valid token on an explicit request (0.087834ms)
  ✔ does not replay a rejected token when explicit reauthentication is cancelled (0.055125ms)
  ✔ refuses an implausibly long token instead of handing it to the client (0.060791ms)
  ✔ reports a sign-in that did not complete without storing anything (0.0605ms)
  ✔ carries the sign-in refusal reason through to the caller (0.143875ms)
  ✔ treats an expired token as absent and discards it (0.207209ms)
  ✔ re-acquires when the expired token is met with a real request (0.061083ms)
  ✔ treats an unreadable store as absent and keeps the file (0.080625ms)
  ✔ still vends an acquired token when storing it fails (2.607167ms)
✔ deciding which Steam token to vend (58.350708ms)
▶ keeping its promise never to throw
  ✔ reports an acquisition that threw instead of letting it escape (0.212167ms)
  ✔ reports an acquisition that rejected asynchronously (0.232791ms)
✔ keeping its promise never to throw (0.517958ms)
▶ ordering complete Steam session operations
  ✔ makes clear final when acquisition was already in flight (0.255875ms)
  ✔ makes clear final when storeback was already in flight (0.288708ms)
  ✔ does not let an older storeback overwrite a newer resolution (0.145416ms)
  ✔ continues after a queued operation rejects (0.42225ms)
  ✔ lets quit wait for the last queued secret write (2.277917ms)
  ✔ coalesces concurrent interactive resolutions (0.120042ms)
✔ ordering complete Steam session operations (3.654875ms)
▶ how a resolution reads in diagnostics
  ✔ separates a replayed token from a freshly acquired one (0.085ms)
  ✔ still calls it acquired when only persisting the token failed (0.044208ms)
  ✔ calls a failed acquisition absent, not acquired (0.044917ms)
  ✔ reads an expired-then-replaced token as acquired (0.043417ms)
✔ how a resolution reads in diagnostics (0.272375ms)
▶ the client handing a token back
  ✔ refreshes the expiry of the token it already holds (0.093167ms)
  ✔ refuses an expiry that has already passed (0.074208ms)
  ✔ still accepts an expiry in the future (0.047334ms)
  ✔ never extends persistence beyond the OAuth lifetime (0.07275ms)
  ✔ keeps an expiry exactly at the maximum boundary (0.043708ms)
  ✔ rejects an expiry at the current instant (0.041542ms)
  ✔ refuses to turn a known expiry back into an unknown one (0.038666ms)
  ✔ accepts no-expiry-yet when none is known either way (3.928083ms)
  ✔ ignores a storeback that is not the token it holds (0.192041ms)
  ✔ ignores a storeback when nothing is stored at all (0.516583ms)
  ✔ reports a refresh it could not write (0.1575ms)
  ✔ reports an unreadable store rather than overwriting it (0.160875ms)
✔ the client handing a token back (32.953917ms)
✔ tests/unit/team-apply-fixture.ts (1029.992875ms)
✔ primary-mismatch facts carry exact professions (0.98025ms)
✔ a behaviour already set is not sent again (2.081917ms)
✔ heroes that are not in the team leave before the ones that are arrive (6.820708ms)
✔ a changed hero order rebuilds the roster in the saved order (0.621833ms)
✔ a roster rebuild adds nobody until each removal is confirmed (1.489208ms)
✔ a concurrent roster addition cannot turn into a false Apply success (0.334125ms)
✔ Devona is removed through the current build's observed hero-id command (0.330917ms)
✔ applying outside an outpost is refused before anything is sent (0.347959ms)
✔ a party that stops publishing mid-apply stops the apply (0.183542ms)
✔ the count in a refusal is the work that landed, not the work attempted (26.832792ms)
✔ is dormant unless the renderer init payload asks for the trace (1.926875ms)
✔ captures the real template open, write, and close result without a path (0.698625ms)
✔ records an open errno and ignores unrelated filesystem traffic (0.246708ms)
✔ recognises the two template kinds and nothing else (1.540333ms)
✔ reads the file the game itself writes (1.394959ms)
✔ every import lands where the client will actually look (0.280458ms)
✔ a trailing newline does not change the file's meaning (0.085834ms)
✔ reads every form a shared build arrives in (0.207084ms)
✔ codes with no name are named after the file they came from (0.117542ms)
✔ text with no origin still names what it imports (0.083542ms)
✔ keeps a profession pair readable and refuses what the client refuses (0.076167ms)
✔ a name is never long enough to vanish from the client's listing (0.115167ms)
✔ one name has one spelling (0.144084ms)
✔ counts the names it had to adjust (0.093375ms)
✔ decodes a file however Windows wrote it (0.340292ms)
✔ a byte order mark never reaches the code (0.101833ms)
✔ lands the same templates wherever the player started the picker (0.107666ms)
✔ a picked path cannot name a folder outside the mount (0.343708ms)
✔ bounds one gesture rather than one file (1.156959ms)
✔ a Windows collection keeps its organisation in the only place the client shows (0.083458ms)
✔ writes the layout it reads (0.075292ms)
✔ an export round-trips through the importer unchanged (0.167625ms)
✔ counts what is saved, in whichever kinds exist (0.949792ms)
✔ says what an import would do before it does it (0.116ms)
✔ explains a difference between what was picked and what will land (0.223625ms)
✔ a zero bucket contributes no clause (0.060209ms)
✔ a finished import names the in-game action that reveals it (0.101959ms)
✔ names the state the game offers no way out of (0.072875ms)
✔ a rescue reports what moved, what did not, and how to see it (0.111834ms)
✔ an export says what it wrote, and a cancel says nothing at all (0.099917ms)
▶ template-save WASM compatibility transform
  ✔ routes the certified call site to the host behind a dirfd marker (3.312542ms)
  ✔ keeps the stub itself intact so uncertified callers are unaffected (0.43675ms)
  ✔ rejects input, stub, call-site, and derived-output drift (0.497458ms)
  ✔ never writes into the caller's input, Buffer or not (0.280583ms)
✔ template-save WASM compatibility transform (9.75375ms)
✔ passes ordinary stat calls through untouched (1.938833ms)
✔ creates the directory the client asks for, separator and all (13.456917ms)
✔ refuses to leave the mount (0.21425ms)
✔ collapses the client's doubled separator instead of rejecting it (0.188209ms)
✔ lists the files a wildcard matches, sorted, and hands over a block (0.522625ms)
✔ honours the wildcard instead of listing the whole directory (0.243584ms)
✔ leaves the list empty for a missing or unreadable directory (0.27375ms)
✔ stays silent unless the trace is explicitly requested (0.301125ms)
✔ hands back the client's internal template path (0.202ms)
✔ keeps the last character the client's own trimmer would eat (0.248375ms)
✔ truncates a display name to the destination the client offered (0.129166ms)
✔ separates the file and directory requests by flag (0.223459ms)
✔ deletes a template and reports the outcome the caller expects (0.098375ms)
✔ answers whether a file exists without creating it (0.113166ms)
✔ accepts every path shape the client actually emits (0.167042ms)
▶ template-save re-certification
  ✔ builds a valid fixture module (11.328375ms)
  ✔ derives every target and call site past its decoys (10.998125ms)
  ✔ excludes the callers that must keep the original behaviour (1.441ms)
  ✔ reads the delete stub's own assertion rather than guessing (34.329209ms)
  ✔ round-trips the derived entry through the production transform (2.549541ms)
  ✔ binds one production rewrite to its derived build and exact bytes (1.8825ms)
  ✔ feeds certified and structurally-derived builds through identical rewrites (3.923458ms)
  ✔ fingerprints complete caller semantics, not only call offsets (3.074334ms)
  ✔ reports a build with no create-directory stub as not applicable (6.890917ms)
  ✔ keeps the negative fixtures valid, so the throw is the locator's (17.91775ms)
  ✔ refuses to guess when a predicate matches more than once (2.431458ms)
  ✔ fails loudly when a call site is not padded to the repointable width (2.473167ms)
✔ template-save re-certification (100.319459ms)
▶ adding a derived entry to the authoring table
  ✔ appends the formatted entry to the end of the real table (5.274666ms)
  ✔ refuses to restate a build somebody already certified (0.51175ms)
  ✔ refuses a source with no table to extend (0.122292ms)
✔ adding a derived entry to the authoring table (6.117709ms)
✔ reads both kinds and one level of subfolder (57.096292ms)
✔ ignores what the game would not list (0.161084ms)
✔ addresses an export the way an export folder is addressed (0.150083ms)
✔ replaces a profile projection with the canonical snapshot (0.457917ms)
✔ re-importing the same folder does nothing at all (0.200042ms)
✔ a name taken by a different build is refused, or replaced when asked (0.11675ms)
✔ two incoming templates cannot claim one name (0.08025ms)
✔ the game's own root limit is reached before a write, not during one (1.446958ms)
✔ writes what it planned and creates the folder it needs (0.207791ms)
✔ a template is only reported saved once the mount has been synchronised (0.17125ms)
✔ a second import cannot overlap the one already running (0.370042ms)
✔ a failed synchronisation does not strand the guard (0.124458ms)
✔ finds only the templates the game has no way to reach (0.11875ms)
✔ moves a stranded template up, keeping its folder in the name (0.387167ms)
✔ a rescue that would overwrite a different build leaves both alone (0.157583ms)
✔ a stranded copy of a build already at the top level is just removed (0.101959ms)
✔ a rescue cannot push the top level past the game's own limit (16.956792ms)
✔ a folder holding something else is left standing (12.709458ms)
✔ refuses any name that would not stay inside the two directories (0.12075ms)
▶ temporary exact-draft testing
  ✔ compares macOS bundle versions numerically (1.065083ms)
  ✔ accepts Stable, Beta, and RC but refuses Alpha (1.271792ms)
  ✔ requires GitHub prerelease metadata to match the tag (0.15625ms)
  ✔ refuses non-drafts and changed asset inventories (0.121333ms)
  ✔ launches, records Passed, and removes the temporary candidate (17.195166ms)
  ✔ removes complete downloads after a pre-launch checksum failure (3.511333ms)
  ✔ removes complete downloads after a pre-launch attestation failure (9.160541ms)
  ✔ removes complete downloads after a pre-launch signature failure (9.177708ms)
  ✔ removes complete downloads after a pre-launch launch failure (66.965042ms)
  ✔ creates no temporary download when GitHub authentication fails (6.503084ms)
  ✔ retains a launched candidate when it is still running (5.960958ms)
  ✔ retains a launched candidate when release-note recording fails (5.529833ms)
✔ temporary exact-draft testing (128.400833ms)
▶ LEB128 as the snapshots spell it
  ✔ decodes every non-canonical width of the same unsigned value (10.876459ms)
  ✔ round-trips signed values and refuses what will not fit (2.485875ms)
✔ LEB128 as the snapshots spell it (14.003458ms)
▶ the chunk format against generated input
  ✔ accepts exactly the digest shapes, and lower-cases what it accepts (11.552375ms)
  ✔ verifies a chunk against its own digest and no other (5.439875ms)
  ✔ never yields a decoded chunk of a length the manifest did not declare (979.811917ms)
✔ the chunk format against generated input (1000.195083ms)
▶ the patch manifest against generated input
  ✔ either refuses, or yields paths that may be joined onto a real directory (13.483833ms)
✔ the patch manifest against generated input (13.598208ms)
▶ the WebAssembly section walk against generated input
  ✔ re-encodes what it split, byte for byte (4.575125ms)
  ✔ round-trips index vectors and code bodies (10.206542ms)
  ✔ refuses a corrupted module as a structural fault, never as a surprise (168.591959ms)
✔ the WebAssembly section walk against generated input (183.554333ms)
✔ the independent TypeScript and Rust companion contracts match exactly (9.112125ms)
✔ same-size field swaps, bit drift, opcode drift, and new names are rejected (104.541042ms)
▶ scripts/copy-renderer.mjs only copies assets
  ✔ succeeds without a Rust toolchain (0.80725ms)
  ✔ still produces the renderer tree and its static media (0.485875ms)
  ✔ copies no code, because Rollup emits build/renderer's JavaScript (0.519125ms)
  ✔ copies only declared package inputs (0.780667ms)
  ✔ emits no WebAssembly (0.338292ms)
✔ scripts/copy-renderer.mjs only copies assets (3.552416ms)
▶ scripts/build.mjs is the one caller of rustc
  ✔ compiles the kernel exactly once per build (0.0755ms)
  ✔ writes only an unserved candidate (0.069334ms)
  ✔ publishes it through one immediate build-time sealing step (0.105791ms)
✔ scripts/build.mjs is the one caller of rustc (0.364209ms)
▶ scripts/build.mjs orders the producers of build/renderer
  ✔ copies the assets before the renderer is compiled into the same directory (0.100541ms)
  ✔ compiles and seals the kernel after both of them (0.105209ms)
✔ scripts/build.mjs orders the producers of build/renderer (0.281417ms)
▶ renderer typechecking does not emit runtime files
  ✔ leaves build/shared to the main compiler (0.105833ms)
  ✔ has one explicit renderer runtime producer (0.068042ms)
✔ renderer typechecking does not emit runtime files (0.231167ms)
✔ no second declaration of the ceiling exists (27.932208ms)
✔ the renderer's scheduler imports the module that declares it (0.290292ms)
✔ eight is what ArenaNet's shared infrastructure is owed (0.076542ms)
✔ the header's offset and size are not read backwards (1.68275ms)
✔ something that is not a Guild Wars archive is refused (0.282ms)
✔ a file table without its magic is refused rather than parsed as slots (0.157958ms)
✔ a file id resolves through the index, not by being a slot number (0.232417ms)
✔ a file's streams are followed as a chain (0.14125ms)
✔ a chain that loops terminates instead of hanging on a 4 GB file (0.3225ms)
✔ an empty base slot carries no payload and is not a hit (0.1025ms)
✔ the table holds the 39 real heroes and neither sentinel (1.963208ms)
✔ HERO_BY_ID answers for every hero and for nothing else (0.113ms)
✔ panel order is a permutation of the 39 places after the player's own (0.139041ms)
✔ no hero carries a profession or a display name, because the source has neither (0.42725ms)
✔ the eight mercenaries are the only heroes no campaign unlocks (0.189292ms)
✔ Razah is player-chosen too, and is the only non-mercenary that is (0.091958ms)
✔ the ten professions carry ids 1-10, and None is not one of them (0.121083ms)
✔ attribute ids skip the unnamed 26-28 gap and never spell the None sentinel (0.151083ms)
✔ every attribute names a profession the table defines (0.174792ms)
✔ a profession row states its wire id and its English name, and nothing else (0.247917ms)
✔ the cost table has one entry per rank and rises with every one (0.122333ms)
✔ the module exports nothing the source could not supply (0.0665ms)
▶ the memory warning counts time, not bytes
  ✔ warns an open-world session with the headroom it claims (10.765667ms)
  ✔ gives a texture-dense mission a real warning, not ninety seconds (25.866666ms)
  ✔ reads the rate that was actually spent, not the shape of the staircase (0.858708ms)
  ✔ puts the levels of a real crash where they belong (4.044167ms)
  ✔ does not read the cost of starting the game as the cost of playing it (2.542833ms)
  ✔ survives a first run whose download outlasts the warm-up (1.8525ms)
  ✔ starts measuring when the player starts playing, not when they log in (1.107959ms)
  ✔ does not let one map load latch a warning that cannot be taken back (0.466125ms)
  ✔ says nothing through an hour with only one growth step in it (0.769542ms)
  ✔ shows the span behind every rate it reports (0.749ms)
  ✔ falls back to bytes only while there is no rate to read (0.116916ms)
  ✔ keeps warning a stalled heap that is nearly full (0.095333ms)
  ✔ lets a rate go stale rather than believing it forever (4.239625ms)
  ✔ never lowers a warning it has already raised (0.347125ms)
  ✔ rounds the estimate without ever flattering it by much (0.787625ms)
  ✔ produces no NaN, no infinity and no negative minutes (0.1465ms)
✔ the memory warning counts time, not bytes (56.0685ms)
✔ the exposed method invokes the channel the contracts name (9.85825ms)
✔ renaming a canonical channel moves the call, with no edit to the body (1.149084ms)
✔ the derived client's bridge markers cross unchanged, and follow an edit (17.656667ms)
✔ the launch argument prefix comes from the contracts too (1.514459ms)
✔ every canonical Enhancement tool crosses without another field list (0.936208ms)
✔ a contracts export the body needs but does not have fails the build (50.11625ms)
✔ the whole table is read, from record zero (1.814334ms)
✔ energy-cost sentinels are normalized at the parsing boundary (0.077125ms)
✔ the table is found even when the scan lands in the middle of it (0.60125ms)
✔ each weak field of the signature rejects its own near miss (0.163292ms)
✔ ids that do not ascend end the run (0.087125ms)
✔ a binary with no table says so instead of guessing (1.982542ms)
✔ availability separates what a player may actually equip (0.101083ms)
✔ a decoded icon becomes a bottom-up BMP without swapping its channels (1.307916ms)
✔ an icon the decoder could not have produced is refused (0.320375ms)
✔ a decompressed shard is unwrapped only when its length agrees (0.257833ms)
✔ a selected target shows its distance and its range band (16.714083ms)
✔ every band the snapshot can carry has a name to show (0.290125ms)
✔ nothing is shown until the snapshot says a target is selected (2.295ms)
✔ dropping the target hides the readout again (0.148ms)
✔ an unchanged target costs no DOM write, however many frames pass (0.799333ms)
✔ a state missing the fields it claims renders nothing (0.133625ms)
✔ the readout takes the page back with it (0.10325ms)
✔ the overlay never takes a click and is never announced (0.125083ms)
✔ the store writes to the directories the mount creates (70.705292ms)
✔ the store addresses the mount absolutely (0.220125ms)
✔ no component decides a colour for itself (116.8415ms)
✔ no component decides a corner for itself (66.68325ms)
✔ no consumer invents a stacking order (1.002584ms)
✔ style projections stay in tokens and consumers do not branch (0.51325ms)
✔ persistent interaction states do not leak into neutral controls (1.094125ms)
✔ shared interaction feedback owns disabled, active, and error presentation (1.006834ms)
✔ every token a stylesheet uses is actually declared (2.087791ms)
✔ every token declared is actually read (0.876667ms)
✔ no token reference carries a leftover alpha suffix (0.42775ms)
✔ the measured Guild Wars radii are fixed in the token source (0.286292ms)
✔ a not-yet-tokenised surface is still not tokenised (0.170333ms)
▶ Chromium stall attribution
  ✔ joins long frame marks, snapshot boundaries, CPU stacks, and renderer tasks (2.218625ms)
  ✔ reports captures without new frame marks and rejects invalid thresholds (0.266334ms)
✔ Chromium stall attribution (3.091209ms)
▶ Chromium trace scanner
  ✔ redacts an absolute path that is the entire value (1.497042ms)
  ✔ redacts a file: URL (0.079417ms)
  ✔ redacts a multiline stack trace (0.062333ms)
  ✔ redacts account and username identifiers in free text (0.056292ms)
  ✔ redacts the JSON spelling a trace actually uses (0.06475ms)
  ✔ redacts a sensitive value containing an escaped quote (0.068958ms)
  ✔ redacts punctuation in a sensitive key and commas and escapes in its value (0.071333ms)
  ✔ redacts a query string carrying credentials (0.066292ms)
  ✔ redacts an OAuth token in a redirect fragment (0.074375ms)
  ✔ redacts an OAuth token in a redirect query (0.115125ms)
  ✔ redacts a bearer token (0.077709ms)
  ✔ redacts an email address (0.046042ms)
  ✔ redacts unicode and right-to-left text around a path (1.792083ms)
  ✔ redacts the user's home directory (0.0715ms)
  ✔ redacts a path under the exporting user's own home directory (6.9765ms)
  ✔ keeps the trace parseable as JSON (4.411ms)
  ✔ keeps a value with an escaped quote in it parseable (0.106875ms)
  ✔ fully redacts a sensitive quoted value containing commas and escapes (0.076958ms)
  ✔ redacts a value that straddles a streaming chunk boundary (3.373542ms)
  ✔ gives the same answer at every split point, for every corpus case (207.861542ms)
  ✔ fails closed when commas inside a JSON string cannot bound the carry (1014.736375ms)
  ✔ streams a large trace when structural commas keep the carry bounded (458.352459ms)
✔ Chromium trace scanner (1701.121583ms)
▶ trade chat contracts
  ✔ accepts numeric and numeric-string timestamps plus replacements (34.936292ms)
  ✔ bounds, validates, deduplicates and orders search results (0.471042ms)
  ✔ rejects malformed payloads and invalid searches (0.265125ms)
  ✔ validates bounded saved offers and players without accepting duplicates (0.225459ms)
  ✔ normalizes bounded trader quotes and price history (0.350458ms)
  ✔ persists saved trade state in one private atomic document (34.265083ms)
✔ trade chat contracts (85.829292ms)
▶ trade chat service
  ✔ fetches and caches current quotes while requesting exact history ranges (248.020083ms)
  ✔ coalesces in-flight history and caches nearby ranges by minute (22.5495ms)
  ✔ classifies an upstream history rate limit without throwing (0.363042ms)
  ✔ rejects oversized trader history while the body is still streaming (15.041708ms)
  ✔ shares one connection and coalesces semantic offer and player searches (0.886625ms)
  ✔ bounds live history, applies replacements, and stops after the last subscriber (1.349417ms)
  ✔ times out unanswered searches and reconnects while subscribed (67.215875ms)
✔ trade chat service (355.98175ms)
▶ Travel history
  ✔ keeps ten unique reviewed destinations in most-recent order (1.842791ms)
  ✔ persists histories independently per character across store instances (149.081208ms)
  ✔ quarantines an unreadable document instead of sharing invented history (14.982875ms)
✔ Travel history (168.884834ms)
▶ Travel preferences
  ✔ preserves corrupt bytes before returning defaults and reports the backup (50.991417ms)
  ✔ stores the Travel-only document without adding Stable-owned settings keys (20.938833ms)
  ✔ projects the released shape and clears withdrawn history on first load (24.600417ms)
  ✔ rejects ambiguous synonyms and unknown document fields (0.615916ms)
✔ Travel preferences (98.3705ms)
▶ Travel
  ✔ contains the complete reviewed direct-travel catalogue (1.939042ms)
  ✔ ranks exact aliases and useful partial names first (9.007375ms)
  ✔ bounds search work before normalization or scoring (4.799667ms)
  ✔ keeps the numbered shortcut list bounded and typed (0.206084ms)
  ✔ keeps Stable-readable shortcut fields on disk while runtime stays map-only (0.221458ms)
  ✔ resolves only catalogue map ids (0.080625ms)
  ✔ rejects one request that would write both preference files (0.683333ms)
✔ Travel (17.687667ms)
▶ custom UI theme contract
  ✔ has the durable v1 defaults (8.415875ms)
  ✔ restores one canonical palette for each material (0.143167ms)
  ✔ strictly parses and normalises six-digit colours (0.163042ms)
  ✔ normalises only the complete semantic theme shape (0.176458ms)
  ✔ round trips the versioned share format and rejects malformed input (0.199625ms)
✔ custom UI theme contract (9.815334ms)
▶ update action
  ✔ formats persisted check times without claiming a future time (1.062875ms)
  ✔ gates a launch on exactly the in-flight and ready updater states (0.156333ms)
  ✔ rehydrates and follows the one main-process state (0.690417ms)
  ✔ makes a downgrade a truthful manual Stable return (0.3145ms)
  ✔ renders closed failure reasons and never says up to date (0.14625ms)
✔ update action (3.115333ms)
▶ static update feed publication
  ✔ selects the highest eligible release independently for each channel (1.675416ms)
  ✔ lets a newer Stable lead both channels and downloads its manifest once (188.500916ms)
  ✔ publishes distinct Stable and Beta manifests when Beta is ahead (0.54ms)
  ✔ refuses duplicate versions, inconsistent metadata, and missing assets (0.500875ms)
  ✔ refuses unreadable, missing-channel, unavailable, and inconsistent input (0.423416ms)
  ✔ allows an unchanged or advancing pair and refuses either rollback (0.294ms)
  ✔ allows absent published feeds only during explicit bootstrap (0.64725ms)
  ✔ refuses a partial published pair even during bootstrap (0.474625ms)
  ✔ cache-busts both published feeds and disables fetch caching (0.41475ms)
✔ static update feed publication (194.283958ms)
▶ development virtual gamepad
  ✔ starts disconnected, preserves physical pads, and restores Navigator (5.489875ms)
  ✔ supports the standard face buttons and a right-stick activation pulse (0.354ms)
✔ development virtual gamepad (6.584458ms)
▶ wasm abort reasons collapse into the closed vocabulary
  ✔ names the failure class of each known Emscripten abort shape (0.995291ms)
  ✔ classifies an Error by its name and message (0.098084ms)
  ✔ never invents a kind outside the declared union (0.107375ms)
✔ wasm abort reasons collapse into the closed vocabulary (1.880542ms)
▶ wasm abort fingerprints
  ✔ always satisfy the boundary validator, whatever the reason was (2.199209ms)
  ✔ cluster identical causes and separate different ones (0.13675ms)
✔ wasm abort fingerprints (2.459667ms)
▶ the recorded abort event
  ✔ is an error-level renderer event carrying kind, fingerprint, and heap (0.95ms)
✔ the recorded abort event (1.028208ms)
▶ the recorded heap staircase
  ✔ records whether heap-growth observation is active (0.123209ms)
  ✔ is an info-level renderer event carrying both sides of a growth step (0.087208ms)
  ✔ records the growth trigger as a separate closed event (0.153916ms)
✔ the recorded heap staircase (0.470166ms)
▶ the recorded visual problem
  ✔ contains only bounded graphics and texture state (0.178958ms)
  ✔ preserves unavailable WebGL and program probes at the IPC boundary (0.531542ms)
✔ the recorded visual problem (0.75925ms)
▶ the relog pre-game probe
  ✔ preserves the complete uint32 diagnostic mask (0.098667ms)
✔ the relog pre-game probe (0.128042ms)
▶ wasm binary codec
  ✔ round-trips unsigned LEB128 (1.933209ms)
  ✔ round-trips signed LEB128, including the client's dirfd markers (0.151417ms)
  ✔ emits fixed-width indices and refuses ones that do not fit (0.137291ms)
  ✔ refuses an oversized LEB rather than truncating it (0.235084ms)
  ✔ round-trips sections (0.293666ms)
  ✔ round-trips code bodies and index vectors (0.196542ms)
  ✔ parses function types by resolved signature (0.172625ms)
  ✔ counts and names function imports, skipping the other kinds (0.269125ms)
✔ wasm binary codec (4.155209ms)
▶ WASM growth provenance
  ✔ can retain heap evidence without intercepting GL calls (1.246708ms)
  ✔ keeps only the first four numeric WASM frames (0.950666ms)
  ✔ records the request, result, call stack, and current texture state (2.117416ms)
  ✔ distinguishes a refused resize from one that throws (0.37625ms)
  ✔ preserves the allocator contract when observation itself fails (0.150084ms)
  ✔ does not alter imports when the shipped client lacks the resize boundary (0.084292ms)
  ✔ stops retaining texture identities at the documented bound (5.0615ms)
  ✔ drops dead-context residency before texture ids can be reused (0.327666ms)
✔ WASM growth provenance (11.100583ms)
▶ texture storage estimates
  ✔ covers direct and block-compressed formats without guessing unknown ones (0.133125ms)
✔ texture storage estimates (0.226167ms)
▶ window registry
  ✔ resolves immutable context from the native sender id (2.462583ms)
  ✔ retains one process-local account owner across renderer replacement (0.199291ms)
  ✔ attributes a renderer process only to its exact account owner (0.119875ms)
  ✔ refuses to assign a renderer process shared by different owners (0.073167ms)
  ✔ enforces one live game window for a profile (0.269667ms)
  ✔ unregisters only the exact native window (0.105917ms)
  ✔ unregisters after Electron has made webContents unreadable (0.125833ms)
  ✔ does not return destroyed windows (0.143917ms)
  ✔ owns the one Single game window and the one Multiple Accounts Hub (0.142125ms)
  ✔ resolves only registered senders and the focused game (0.203625ms)
  ✔ refuses an ambiguous game selection (0.0925ms)
✔ window registry (4.728667ms)
▶ window shortcut input
  ✔ runs one Command action, preserves Control, and contains capture repeats (3.265209ms)
✔ window shortcut input (3.788333ms)
▶ window state
  ✔ validates and round-trips owner-only state (43.47475ms)
  ✔ restores an alpha window written without a format version (19.259833ms)
  ✔ discards a window-state format this build cannot read (5.731125ms)
  ✔ removes corrupt state and falls back cleanly (2.882166ms)
  ✔ keeps visible windows on their display and clamps oversized bounds (0.206708ms)
  ✔ centers state on the primary display when its monitor disappeared (0.124709ms)
  ✔ keeps the default window distinct from a constrained work area (0.068875ms)
  ✔ restores relative geometry on an unchanged work area (0.076958ms)
  ✔ restores relative geometry on a larger work area (0.076875ms)
  ✔ restores relative geometry on a smaller work area constrained by minimum window size (0.096625ms)
  ✔ restores relative geometry on a missing display (0.050708ms)
  ✔ restores relative geometry on the matching display in a multi-display layout (0.045667ms)
  ✔ cascades new account windows by 32px and clamps them (0.102083ms)
✔ window state (74.499833ms)
ℹ tests 1323
ℹ suites 154
ℹ pass 1323
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 35338.61425
✔ every workflow action is pinned to a full commit SHA (8.302333ms)
✔ the pinning scan rejects a floating tag (0.237542ms)
✔ the PlayStation prompt atlas is the reviewed 256×512 CC0 composition (6.190125ms)
✔ the controller prompt lifecycle resets on WebGL context replacement (4.82025ms)
✔ each channel has an exact minimal and isolated entitlement file (5.620584ms)
✔ bug and feature intake stays short, structured, and issue-backed (25.386792ms)
✔ public bug and feature links name issue templates that exist (5.4485ms)
✔ the bundled fonts are pinned and carry their OFL licenses (19.310291ms)
✔ no downloaded game artifacts or generated output are tracked (2.628542ms)
✔ no tracked symlink resolves outside the repository (76.268959ms)
✔ the application does not collect process-memory crash dumps (17.233083ms)
✔ no second production runtime remains (0.150375ms)
✔ no private key material is tracked (1673.8655ms)
✔ only public identifiers and explicit profile-id fixtures are UUID-shaped (2803.925084ms)
✔ release fuses keep Node, inspection and file-protocol privileges disabled (1.672666ms)
✔ no fuse is left to its default (0.944667ms)
✔ lint rejects: src/main/core imports electron (4167.949541ms)
✔ lint rejects: src/main/core type-imports electron (4.455458ms)
✔ lint rejects: src/main/core dynamically imports electron (6.320958ms)
✔ lint rejects: src/main/core imports a submodule of electron (2.531458ms)
✔ lint rejects: src/main/core requires electron through createRequire (4.285333ms)
✔ lint rejects: src/main/core requires electron through an aliased createRequire binding (3.254542ms)
✔ lint rejects: src/main/core dynamically imports electron, spelled with a template literal (13.1025ms)
✔ lint rejects: src/main/core imports upward from src/main (2.532417ms)
✔ lint rejects: src/main/core imports upward from src/main, spelled through src/main (4.006292ms)
✔ lint rejects: src/main/core imports upward from src/main, spelled from the repository root (20.797292ms)
✔ lint rejects: a subdirectory of src/main/core imports upward from src/main (23.746166ms)
✔ lint rejects: src/main/core imports upward through a subdirectory of src/main (2.170125ms)
✔ lint rejects: src/main/core dynamically imports upward from src/main (2.240542ms)
✔ lint rejects: src/main/core dynamically imports upward through a subdirectory of src/main (2.394292ms)
✔ lint rejects: src/main/core dynamically imports upward, spelled through src/main (1.69275ms)
✔ lint rejects: src/main/core dynamically imports upward, spelled with a template literal (1.416375ms)
✔ lint rejects: src/main/core requires upward through createRequire (15.725125ms)
✔ lint rejects: src/main/core imports one level up into a sibling of src/main/core named shared (16.04675ms)
✔ lint rejects: src/main/certification imports electron (12.2775ms)
✔ lint rejects: src/main/certification dynamically imports electron (5.478792ms)
✔ lint rejects: src/main/certification imports upward from src/main (2.24125ms)
✔ lint rejects: src/main/certification imports upward from src/main, spelled through src/main (1.497083ms)
✔ lint rejects: src/main/certification imports upward from src/main, spelled from the repository root (1.272125ms)
✔ lint rejects: src/main/certification dynamically imports upward from src/main (1.555833ms)
✔ lint rejects: src/main/certification dynamically imports upward, spelled with a template literal (1.418208ms)
✔ lint rejects: src/main/certification imports one level up into a sibling of src/main/certification named shared (1.377708ms)
✔ lint rejects: src/main/certification imports the exempt verifier host (5.115125ms)
✔ lint rejects: src/main/certification imports the exempt enhancement policy (5.34875ms)
✔ lint rejects: src/main/certification dynamically imports the exempt enhancement policy (4.307167ms)
✔ lint rejects: src/renderer imports src/main (13.935542ms)
✔ lint rejects: a subdirectory of src/renderer imports src/main (11.764958ms)
✔ lint rejects: a src/renderer TypeScript declaration imports src/main (8.899167ms)
✔ lint rejects: a src/renderer module imports src/main (1.982708ms)
✔ lint rejects: src/renderer dynamically imports src/main (5.353292ms)
✔ lint rejects: src/renderer dynamically imports src/main, spelled with a template literal (2.012416ms)
✔ lint rejects: src/renderer requires src/main through createRequire (2.085583ms)
✔ lint rejects: an apps/website .vue SFC imports src/main (41.384917ms)
✔ lint rejects: an apps/website .vue SFC dynamically imports src/renderer (4.910667ms)
✔ lint rejects: apps/website imports src/main (21.209ms)
✔ lint rejects: apps/website dynamically imports src/main (1.495ms)
✔ lint rejects: apps/website dynamically imports src/main, spelled with a template literal (1.468209ms)
✔ lint rejects: apps/website requires src/main through createRequire (4.361541ms)
✔ lint rejects: apps/website imports developer tooling under src/tools (1.624625ms)
✔ lint rejects: an apps/website .vue SFC imports developer tooling under src/tools (2.600791ms)
✔ lint allows: src/main/core imports src/shared (15.449042ms)
✔ lint allows: src/main/core imports a sibling (1.781833ms)
✔ lint allows: src/main/core dynamically imports a sibling (4.209958ms)
✔ lint allows: a subdirectory of src/main/core imports src/shared (4.101125ms)
✔ lint allows: src/main/core requires a node builtin through createRequire (4.177583ms)
✔ lint allows: src/main imports electron (7.345875ms)
✔ lint allows: the certification host imports electron (1.752625ms)
✔ lint allows: src/main/certification imports the codec that stayed in src/main/core (1.172292ms)
✔ lint allows: src/main/certification imports src/shared (1.287667ms)
✔ lint allows: src/main/certification imports a sibling that is not an Electron caller (3.417083ms)
✔ lint allows: src/renderer imports src/shared (1.836209ms)
✔ lint allows: an apps/website .vue SFC imports src/shared (2.427625ms)
✔ lint allows: apps/website imports src/shared (1.111167ms)
✔ the .vue sources this boundary covers still exist (25.680042ms)
✔ ESLint covers the packaging config and every website source (4412.214792ms)
✔ every website .vue source is linted, not just the one named above (30.545ms)
✔ ESLint still skips derived output and developer-only tooling (2.076333ms)
✔ main-process runtime imports are acyclic (1650.831792ms)
✔ the graph check distinguishes runtime cycles from erased type edges (1.043375ms)
✔ a link to NOPE.md in README.md exits non-zero and names the line (1083.159083ms)
✔ a repository whose links all resolve exits zero and says nothing (1548.117125ms)
✔ targets are resolved relative to the file that contains them (57.248625ms)
✔ percent-encoded, titled and fragment-suffixed targets resolve to the real path (31.907875ms)
✔ an unbracketed destination containing a space is not a link (0.114167ms)
✔ link syntaxes that carry a target are all extracted (0.154083ms)
✔ a badge link reports the outer destination, not only the image it wraps (40.117875ms)
✔ a tracked file deleted from the working tree is skipped, not fatal (1262.173208ms)
✔ an existing target outside the repository is broken (124.514625ms)
✔ an ignored target is broken even while it exists locally (108.734625ms)
✔ a repository directory target has at least one durable child (96.198833ms)
✔ code blocks, code spans, URLs and bare anchors are not treated as links (0.142333ms)
✔ the file list covers tracked docs and excludes gitignored scratch (35.773458ms)
✔ the bundled application icon carries every representation macOS renders (3.380083ms)
✔ release workflow stages and publishes one tested, attested package version (43.669417ms)
✔ cooldown presentation has no gameplay input or command dependency (46.528875ms)
▶ the macOS input policy
  ✔ has no selectable or persisted touch mode (915.143625ms)
  ✔ sets the bundle-specific repeat preference before the first window (3.97ms)
✔ the macOS input policy (919.928083ms)
✔ IPC still refuses a sender that is not the main frame at the canonical URL (20.942792ms)
✔ production resolves native windows only through the window registry (13.269709ms)
✔ runtime error dialogs keep their owning game window (0.336292ms)
✔ the proxy still answers only fetches (0.111375ms)
✔ the proxy response still crosses the canonical header boundary (0.187166ms)
✔ every source module opens with a block doc comment (62.056958ms)
✔ every KNOWN_UNHEADERED entry still names a file that still lacks one (0.56675ms)
✔ the native boundary uses only ABI-stable Node-API (11.289708ms)
✔ Command-held releases use one app-local macOS monitor (0.230666ms)
✔ the native host does not own the app key-repeat preference (0.121958ms)
✔ the native boundary owns two fixed Data Protection Keychain items (1.194292ms)
✔ the canonical build emits one host-only Node-API 8 addon (0.265917ms)
✔ Forge unpacks only the two executables from ASAR (0.212666ms)
✔ the hand-written preload body contains no channel literal (5.61ms)
✔ the body declares nothing the generator is meant to supply (324.991875ms)
✔ macOS identity uses the Reforged name and configured application icon (3.672083ms)
✔ the public rename keeps the existing profile as its one data home (0.285625ms)
✔ package metadata identifies the GPL project and canonical repository (0.147083ms)
✔ packaged releases carry the project and third-party license notices (3.158083ms)
✔ the packaged bundle takes its version numbers from the package version (0.206208ms)
✔ the host has one native automatic application replacement path (1.428375ms)
✔ distribution channels use preflighted signing and a scoped marker (6.435ms)
✔ release entitlements are an exact three-key allowlist (0.374375ms)
✔ the Stable rollback proof establishes its write generation before saving (0.228084ms)
✔ application verification routes conservatively through one required result (0.779334ms)
✔ developer builds are exact, ad-hoc, bounded, and isolated from releases (13.260041ms)
✔ runtime package entries and audit exceptions stay explicit (1.207875ms)
✔ packaging cleans its output first, and builds the renderer runtime (0.301ms)
✔ the default gate is deterministic and certifies every shipped test layer (0.298458ms)
✔ release verification tells the player to check, never to disable a check (0.14725ms)
✔ the maintainer tests a temporary exact draft without replacing Applications (0.261417ms)
✔ the required application gate owns website certification (348.094042ms)
✔ Vercel Previews are explicit, exact-head, and collaborator-only (0.427583ms)
✔ client recertification reports evidence but cannot grant authority (1.6635ms)
✔ the scheduled canary exercises the latest ArenaNet client conservatively (0.159417ms)
✔ saved login has exactly two Data Protection Keychain items (329.5615ms)
✔ only provisioned distribution channels enable persistent secrets (1.213958ms)
✔ no build seeds the Steam token from the environment (20.847125ms)
✔ Settings exposes two built-ins and one semantic custom theme (18.143667ms)
✔ Settings exposes the independent interface fonts (172.113917ms)
✔ Settings exposes the two controller prompt styles (16.185292ms)
✔ panel opacity uses the canonical bounds (52.245875ms)
✔ Tools features consume Reka behavior through the shared Vue UI layer (18.217875ms)
✔ feature styles cannot reintroduce the retired selection recipes (5.950958ms)
✔ shared motion transitions only transform or opacity (4.886209ms)
✔ the single-weight Guild Wars face is never synthetically emboldened (3.096292ms)
✔ the scripts index.html loads with a plain tag emit no ES module (140.696417ms)
✔ the official gamepad imports stay wired without a production WASM hook (3.829792ms)
✔ persistent game files are prepared through supported Emscripten startup hooks (5.147833ms)
✔ production diagnostics do not patch Web Audio prototypes (4.064417ms)
✔ the live harness persists no raw addresses or Toolbox screenshots (3.112041ms)
✔ stall attribution markers are fixed-name and Level 2 only (4.675375ms)
✔ template file tracing is explicit, bounded, and attached only at the import boundary (10.552791ms)
✔ the GL program cache memoizes only shader-completion state, and only once it is true (7.452125ms)
✔ template saving uses one exact-build derived WASM and a restricted mkdir bridge (2.145167ms)
✔ a new client build can be re-certified without hand-derivation (3.602792ms)
✔ Enhancement re-certification inspects only post-template bytes (0.572042ms)
✔ only strict feature locators may turn structural evidence into launch authority (4.085917ms)
✔ native double-click and 4 GB use bounded local proof as sole runtime authority (6.465833ms)
✔ the WASM section codec has exactly one home (17.976792ms)
✔ the served module decides whether Enhancement imports (2.809125ms)
✔ a completed client main loop closes the host application (7.2585ms)
✔ the memory warning measures time and keeps its one contract import (6.018334ms)
✔ the memory warning measures a staircase step to step (0.679791ms)
▶ the benchmark measures each arm in both orders
  ✔ mirrors the arms so every arm sits at the same mean position (1.843041ms)
  ✔ recognises a biased order for what it is (0.107417ms)
  ✔ warms every phase the same way and records the order it ran (2.702792ms)
  ✔ reports no regression for a drift the old order would have blamed on the Enhancement (0.441ms)
  ✔ still reports a real cost the arm actually has (0.288791ms)
  ✔ refuses a phase that measured nothing (0.188125ms)
  ✔ averages an arm's phases instead of pooling their samples (0.219209ms)
✔ the benchmark measures each arm in both orders (6.500375ms)
▶ the performance acceptance gate reads the record the benchmark writes
  ✔ accepts the record a mirrored run produces (0.303875ms)
  ✔ refuses a run that measured each arm once (1.768375ms)
  ✔ refuses a record whose arms it cannot find (0.18175ms)
  ✔ keeps every budget the two-phase gate held (0.903292ms)
✔ the performance acceptance gate reads the record the benchmark writes (3.305917ms)
✔ rust-toolchain.toml pins the channel, its components, and the wasm target (1.613292ms)
✔ every script name is a literal the build scan can match (0.169833ms)
✔ every workflow that compiles the kernel installs the pinned toolchain first (44.690375ms)
✔ the toolchain scan rejects a build on the runner's own toolchain (0.758375ms)
✔ the Node floor is declared once and enforced before anything is built (2.457ms)
✔ every workflow pins a Node version the floor accepts (1.864708ms)
✔ every source file the repository owns is an input to a tsconfig project (2.750708ms)
✔ every KNOWN_UNCHECKED entry still names a file that is still unchecked (0.158542ms)
✔ no hand-written declaration shadows the implementation it describes (0.468458ms)
ℹ tests 181
ℹ suites 3
ℹ pass 181
ℹ fail 0
ℹ cancelled 0
ℹ skipped 0
ℹ todo 0
ℹ duration_ms 8337.314375

 RUN  v4.1.10 /Users/matthias/Git/games/guild-wars-mac/gwonmac-travel-party-close/apps/tools


 Test Files  16 passed (16)
      Tests  120 passed (120)
   Start at  14:58:07
   Duration  11.67s (transform 17.30s, setup 0ms, import 30.14s, tests 14.84s, environment 20.56s)\n- [x] copied renderer -> /Users/matthias/Git/games/guild-wars-mac/gwonmac-travel-party-close/build/renderer
vite v8.1.5 building client environment for embedded...
[2Ktransforming...✓ 834 modules transformed.
rendering chunks...
computing gzip size...
../../build/renderer/tools/tools-app.css   73.05 kB │ gzip:  12.62 kB
../../build/renderer/tools/tools-app.js   988.38 kB │ gzip: 459.27 kB

✓ built in 451ms
generated preload -> build/preload/preload.cjs
[ELIFECYCLE] Command failed with exit code 1.\n- [x] TravelPalette tests: 17 passed\n- [x] Tools tests: 120 passed\n- [x] Kept this pull request focused\n- [x] Added no game binaries, credentials, diagnostics, or private traffic