### PR TITLE
fix(trade): preserve floating window placement

### DIFF
--- a/apps/tools/src/TradeChatApp.vue
+++ b/apps/tools/src/TradeChatApp.vue
@@ -90,6 +90,7 @@ const { panel, resizeGrip, panelStyle, startDrag } = useFloatingWindow({
   minWidth: 520,
   minHeight: 400,
   viewportMargin: 32,
+  placementStorageKey: "gwonmac.trade-window-placement",
 });
 
 const current = computed(() => states[source.value]);

--- a/apps/tools/src/floating-window-placement.test.ts
+++ b/apps/tools/src/floating-window-placement.test.ts
@@ -1,0 +1,65 @@
+/** Unit coverage for normalized floating-window persistence and validation. */
+import { describe, expect, it } from "vitest";
+import {
+  restoreFloatingWindowPlacement,
+  serializeFloatingWindowPlacement,
+} from "./floating-window-placement";
+
+const viewport = { width: 1_600, height: 1_000, margin: 32 };
+const minimum = { width: 520, height: 400 };
+
+describe("floating window placement", () => {
+  it("round-trips a window in the same viewport", () => {
+    const box = { left: 200, top: 100, width: 900, height: 600 };
+
+    expect(restoreFloatingWindowPlacement(
+      serializeFloatingWindowPlacement(box, viewport),
+      viewport,
+      minimum,
+    )).toEqual(box);
+  });
+
+  it("preserves relative size and position when the viewport changes", () => {
+    const stored = serializeFloatingWindowPlacement(
+      { left: 416, top: 266, width: 768, height: 468 },
+      viewport,
+    );
+
+    expect(restoreFloatingWindowPlacement(
+      stored,
+      { width: 2_368, height: 1_452, margin: 32 },
+      minimum,
+    )).toEqual({ left: 608, top: 379, width: 1_152, height: 694 });
+  });
+
+  it("clamps a restored window into a smaller viewport", () => {
+    const stored = serializeFloatingWindowPlacement(
+      { left: 900, top: 500, width: 600, height: 430 },
+      viewport,
+    );
+
+    expect(restoreFloatingWindowPlacement(
+      stored,
+      { width: 600, height: 460, margin: 32 },
+      minimum,
+    )).toEqual({ left: 47, top: 32, width: 520, height: 396 });
+  });
+
+  it.each([
+    null,
+    "not-json",
+    "{}",
+    JSON.stringify({ formatVersion: 2, left: 0, top: 0, width: 1, height: 1 }),
+    JSON.stringify({ formatVersion: 1, left: -1, top: 0, width: 1, height: 1 }),
+    JSON.stringify({ formatVersion: 1, left: 0, top: 0, width: 0, height: 1 }),
+  ])("rejects invalid stored placement %s", (stored) => {
+    expect(restoreFloatingWindowPlacement(stored, viewport, minimum)).toBeNull();
+  });
+
+  it("does not serialize an unmeasured window", () => {
+    expect(serializeFloatingWindowPlacement(
+      { left: 32, top: 32, width: 0, height: 0 },
+      viewport,
+    )).toBeNull();
+  });
+});

--- a/apps/tools/src/floating-window-placement.ts
+++ b/apps/tools/src/floating-window-placement.ts
@@ -1,0 +1,111 @@
+/** Normalized persistence for an embedded Tools window across viewport sizes. */
+
+export type FloatingWindowViewport = Readonly<{
+  width: number;
+  height: number;
+  margin: number;
+}>;
+
+export type FloatingWindowBox = Readonly<{
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}>;
+
+type StoredFloatingWindowPlacement = Readonly<{
+  formatVersion: 1;
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}>;
+
+const ratio = (value: unknown): value is number =>
+  typeof value === "number" && Number.isFinite(value) && value >= 0 && value <= 1;
+
+const clamp = (value: number, minimum: number, maximum: number) =>
+  Math.min(maximum, Math.max(Math.min(minimum, maximum), value));
+
+function usable(viewport: FloatingWindowViewport) {
+  return {
+    width: Math.max(0, viewport.width - viewport.margin * 2),
+    height: Math.max(0, viewport.height - viewport.margin * 2),
+  };
+}
+
+export function restoreFloatingWindowPlacement(
+  serialized: string | null,
+  viewport: FloatingWindowViewport,
+  minimum: Readonly<{ width: number; height: number }>,
+): FloatingWindowBox | null {
+  if (serialized === null) return null;
+  let value: unknown;
+  try {
+    value = JSON.parse(serialized);
+  } catch {
+    return null;
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const stored = value as Partial<StoredFloatingWindowPlacement>;
+  if (
+    stored.formatVersion !== 1
+    || !ratio(stored.left)
+    || !ratio(stored.top)
+    || !ratio(stored.width)
+    || !ratio(stored.height)
+    || stored.width === 0
+    || stored.height === 0
+  ) return null;
+
+  const available = usable(viewport);
+  if (available.width === 0 || available.height === 0) return null;
+  const width = clamp(
+    Math.round(stored.width * available.width),
+    minimum.width,
+    available.width,
+  );
+  const height = clamp(
+    Math.round(stored.height * available.height),
+    minimum.height,
+    available.height,
+  );
+  return {
+    left: viewport.margin + Math.round(
+      stored.left * Math.max(0, available.width - width),
+    ),
+    top: viewport.margin + Math.round(
+      stored.top * Math.max(0, available.height - height),
+    ),
+    width,
+    height,
+  };
+}
+
+export function serializeFloatingWindowPlacement(
+  box: FloatingWindowBox,
+  viewport: FloatingWindowViewport,
+): string | null {
+  const available = usable(viewport);
+  if (
+    available.width === 0
+    || available.height === 0
+    || box.width <= 0
+    || box.height <= 0
+  ) return null;
+  const width = clamp(box.width, 1, available.width);
+  const height = clamp(box.height, 1, available.height);
+  const horizontalRange = Math.max(0, available.width - width);
+  const verticalRange = Math.max(0, available.height - height);
+  return JSON.stringify({
+    formatVersion: 1,
+    left: horizontalRange === 0
+      ? 0
+      : clamp((box.left - viewport.margin) / horizontalRange, 0, 1),
+    top: verticalRange === 0
+      ? 0
+      : clamp((box.top - viewport.margin) / verticalRange, 0, 1),
+    width: width / available.width,
+    height: height / available.height,
+  } satisfies StoredFloatingWindowPlacement);
+}

--- a/apps/tools/src/floating-window-placement.ts
+++ b/apps/tools/src/floating-window-placement.ts
@@ -47,7 +47,7 @@ export function restoreFloatingWindowPlacement(
     return null;
   }
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-  const stored = value as Partial<StoredFloatingWindowPlacement>;
+  const stored = value as Record<string, unknown>;
   if (
     stored.formatVersion !== 1
     || !ratio(stored.left)

--- a/apps/tools/src/use-floating-window.test.ts
+++ b/apps/tools/src/use-floating-window.test.ts
@@ -1,0 +1,95 @@
+/** Lifecycle regression coverage for persistent embedded Tools geometry. */
+import { mount } from "@vue/test-utils";
+import { defineComponent, h, ref } from "vue";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useFloatingWindow } from "./use-floating-window";
+
+const storageKey = "test.floating-window-placement";
+
+function mountWindow() {
+  return mount(defineComponent({
+    setup() {
+      const floating = useFloatingWindow({
+        mode: "embedded",
+        visible: ref(true),
+        initialPosition: { left: 64, top: 54 },
+        minWidth: 520,
+        minHeight: 400,
+        viewportMargin: 32,
+        placementStorageKey: storageKey,
+      });
+      return () => h("section", {
+        ref: floating.panel,
+        style: floating.panelStyle.value,
+      }, [
+        h("header", { onPointerdown: floating.startDrag }),
+        h("button", { ref: floating.resizeGrip }),
+      ]);
+    },
+  }), { attachTo: document.body });
+}
+
+function giveWindowGeometry(element: HTMLElement) {
+  Object.defineProperty(element, "offsetWidth", {
+    configurable: true,
+    get: () => Number.parseFloat(element.style.width) || 800,
+  });
+  Object.defineProperty(element, "offsetHeight", {
+    configurable: true,
+    get: () => Number.parseFloat(element.style.height) || 600,
+  });
+  element.getBoundingClientRect = () => ({
+    x: Number.parseFloat(element.style.left),
+    y: Number.parseFloat(element.style.top),
+    left: Number.parseFloat(element.style.left),
+    top: Number.parseFloat(element.style.top),
+    right: Number.parseFloat(element.style.left) + element.offsetWidth,
+    bottom: Number.parseFloat(element.style.top) + element.offsetHeight,
+    width: element.offsetWidth,
+    height: element.offsetHeight,
+    toJSON: () => ({}),
+  });
+}
+
+afterEach(() => {
+  localStorage.clear();
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+describe("useFloatingWindow", () => {
+  it("restores resized and moved geometry after the document unloads", async () => {
+    vi.spyOn(window, "requestAnimationFrame").mockReturnValue(1);
+    const wrapper = mountWindow();
+    const panel = wrapper.get("section").element as HTMLElement;
+    giveWindowGeometry(panel);
+
+    await wrapper.get("button").trigger("keydown", { key: "ArrowLeft" });
+
+    const header = wrapper.get("header").element as HTMLElement;
+    Object.defineProperty(header, "setPointerCapture", { value: vi.fn() });
+    header.dispatchEvent(new PointerEvent("pointerdown", {
+      bubbles: true,
+      clientX: 100,
+      clientY: 70,
+      pointerId: 1,
+    }));
+    header.dispatchEvent(new PointerEvent("pointermove", {
+      clientX: 236,
+      clientY: 140,
+      pointerId: 1,
+    }));
+    header.dispatchEvent(new PointerEvent("pointerup", { pointerId: 1 }));
+    window.dispatchEvent(new PageTransitionEvent("pagehide"));
+    wrapper.unmount();
+
+    expect(localStorage.getItem(storageKey)).not.toBeNull();
+
+    const restored = mountWindow();
+    expect(restored.get("section").attributes("style")).toContain("left: 200px");
+    expect(restored.get("section").attributes("style")).toContain("top: 124px");
+    expect(restored.get("section").attributes("style")).toContain("width: 784px");
+    expect(restored.get("section").attributes("style")).toContain("height: 600px");
+    restored.unmount();
+  });
+});

--- a/apps/tools/src/use-floating-window.test.ts
+++ b/apps/tools/src/use-floating-window.test.ts
@@ -80,10 +80,10 @@ describe("useFloatingWindow", () => {
       pointerId: 1,
     }));
     header.dispatchEvent(new PointerEvent("pointerup", { pointerId: 1 }));
+    expect(localStorage.getItem(storageKey)).toBeNull();
     window.dispatchEvent(new PageTransitionEvent("pagehide"));
-    wrapper.unmount();
-
     expect(localStorage.getItem(storageKey)).not.toBeNull();
+    wrapper.unmount();
 
     const restored = mountWindow();
     expect(restored.get("section").attributes("style")).toContain("left: 200px");

--- a/apps/tools/src/use-floating-window.ts
+++ b/apps/tools/src/use-floating-window.ts
@@ -25,11 +25,14 @@ export function useFloatingWindow(options: {
   const panel = ref<HTMLElement | null>(null);
   const resizeGrip = ref<HTMLButtonElement | null>(null);
   const margin = options.viewportMargin ?? 0;
+  const storageKey = options.mode === "embedded"
+    ? options.placementStorageKey
+    : undefined;
   const viewport = () => ({ width: window.innerWidth, height: window.innerHeight, margin });
   let serialized: string | null = null;
-  if (options.mode === "embedded" && options.placementStorageKey) {
+  if (storageKey) {
     try {
-      serialized = window.localStorage.getItem(options.placementStorageKey);
+      serialized = window.localStorage.getItem(storageKey);
     } catch {
       // Browser storage refusal leaves the window at its ordinary default.
     }
@@ -108,11 +111,7 @@ export function useFloatingWindow(options: {
   let disposeResize: (() => void) | null = null;
   let persistTimer: ReturnType<typeof setTimeout> | null = null;
   const persistPlacement = () => {
-    if (
-      options.mode !== "embedded"
-      || !options.placementStorageKey
-      || !panel.value
-    ) return;
+    if (!storageKey || !panel.value) return;
     const value = serializeFloatingWindowPlacement({
       ...position.value,
       width: size.value?.width ?? panel.value.offsetWidth,
@@ -120,24 +119,25 @@ export function useFloatingWindow(options: {
     }, viewport());
     if (value === null) return;
     try {
-      window.localStorage.setItem(options.placementStorageKey, value);
+      window.localStorage.setItem(storageKey, value);
     } catch {
       // A UI preference must not make the surface unusable when storage fails.
     }
   };
   const schedulePersistence = () => {
-    if (!options.placementStorageKey || options.mode !== "embedded") return;
     if (persistTimer) clearTimeout(persistTimer);
     persistTimer = setTimeout(() => {
       persistTimer = null;
       persistPlacement();
     }, 150);
   };
-  watch(position, schedulePersistence);
-  watch(size, schedulePersistence);
+  if (storageKey) {
+    watch(position, schedulePersistence);
+    watch(size, schedulePersistence);
+  }
   onMounted(() => {
     window.addEventListener("resize", fitToViewport);
-    window.addEventListener("pagehide", persistPlacement);
+    if (storageKey) window.addEventListener("pagehide", persistPlacement);
     requestAnimationFrame(fitToViewport);
     if (options.mode !== "embedded" || !panel.value || !resizeGrip.value) return;
     disposeResize = installResizeGrip(resizeGrip.value, {
@@ -161,9 +161,11 @@ export function useFloatingWindow(options: {
   });
   onBeforeUnmount(() => {
     window.removeEventListener("resize", fitToViewport);
-    window.removeEventListener("pagehide", persistPlacement);
-    if (persistTimer) clearTimeout(persistTimer);
-    persistPlacement();
+    if (storageKey) {
+      window.removeEventListener("pagehide", persistPlacement);
+      if (persistTimer) clearTimeout(persistTimer);
+      persistPlacement();
+    }
     disposeResize?.();
   });
   watch(options.visible, (visible) => {

--- a/apps/tools/src/use-floating-window.ts
+++ b/apps/tools/src/use-floating-window.ts
@@ -8,6 +8,10 @@ import {
   type Ref,
 } from "vue";
 import { installResizeGrip } from "../../../src/shared/ui/resize";
+import {
+  restoreFloatingWindowPlacement,
+  serializeFloatingWindowPlacement,
+} from "./floating-window-placement";
 
 export function useFloatingWindow(options: {
   mode: "standalone" | "embedded";
@@ -16,12 +20,31 @@ export function useFloatingWindow(options: {
   minWidth: number;
   minHeight: number;
   viewportMargin?: number;
+  placementStorageKey?: string;
 }) {
   const panel = ref<HTMLElement | null>(null);
   const resizeGrip = ref<HTMLButtonElement | null>(null);
-  const position = ref({ ...options.initialPosition });
-  const size = ref<{ width: number; height: number } | null>(null);
   const margin = options.viewportMargin ?? 0;
+  const viewport = () => ({ width: window.innerWidth, height: window.innerHeight, margin });
+  let serialized: string | null = null;
+  if (options.mode === "embedded" && options.placementStorageKey) {
+    try {
+      serialized = window.localStorage.getItem(options.placementStorageKey);
+    } catch {
+      // Browser storage refusal leaves the window at its ordinary default.
+    }
+  }
+  const restored = restoreFloatingWindowPlacement(
+    serialized,
+    viewport(),
+    { width: options.minWidth, height: options.minHeight },
+  );
+  const position = ref(restored
+    ? { left: restored.left, top: restored.top }
+    : { ...options.initialPosition });
+  const size = ref(restored
+    ? { width: restored.width, height: restored.height }
+    : null);
   const panelStyle = computed(() => options.mode === "embedded"
     ? {
         left: `${position.value.left}px`,
@@ -83,8 +106,38 @@ export function useFloatingWindow(options: {
   };
 
   let disposeResize: (() => void) | null = null;
+  let persistTimer: ReturnType<typeof setTimeout> | null = null;
+  const persistPlacement = () => {
+    if (
+      options.mode !== "embedded"
+      || !options.placementStorageKey
+      || !panel.value
+    ) return;
+    const value = serializeFloatingWindowPlacement({
+      ...position.value,
+      width: size.value?.width ?? panel.value.offsetWidth,
+      height: size.value?.height ?? panel.value.offsetHeight,
+    }, viewport());
+    if (value === null) return;
+    try {
+      window.localStorage.setItem(options.placementStorageKey, value);
+    } catch {
+      // A UI preference must not make the surface unusable when storage fails.
+    }
+  };
+  const schedulePersistence = () => {
+    if (!options.placementStorageKey || options.mode !== "embedded") return;
+    if (persistTimer) clearTimeout(persistTimer);
+    persistTimer = setTimeout(() => {
+      persistTimer = null;
+      persistPlacement();
+    }, 150);
+  };
+  watch(position, schedulePersistence);
+  watch(size, schedulePersistence);
   onMounted(() => {
     window.addEventListener("resize", fitToViewport);
+    window.addEventListener("pagehide", persistPlacement);
     requestAnimationFrame(fitToViewport);
     if (options.mode !== "embedded" || !panel.value || !resizeGrip.value) return;
     disposeResize = installResizeGrip(resizeGrip.value, {
@@ -108,6 +161,9 @@ export function useFloatingWindow(options: {
   });
   onBeforeUnmount(() => {
     window.removeEventListener("resize", fitToViewport);
+    window.removeEventListener("pagehide", persistPlacement);
+    if (persistTimer) clearTimeout(persistTimer);
+    persistPlacement();
     disposeResize?.();
   });
   watch(options.visible, (visible) => {


### PR DESCRIPTION
The Kamadan Trade panel returned to its default size and position whenever the game renderer reloaded. This made Multi-client reloads especially frustrating because each client lost the layout the player had just arranged.

The panel now stores its geometry in the existing per-profile browser partition. Position and size are normalized against the usable viewport, so the layout remains proportional when the game window or display size changes, and restoration clamps it safely on smaller screens. Reload flushes the current placement before navigation.

## Verification

- `pnpm check`
- `pnpm build`
- `pnpm test:policy`
- `pnpm --filter @gwonmac/tools-ui test`
- `pnpm --filter @gwonmac/tools-ui typecheck`
- Regression harness covers resize, drag, `pagehide`, component destruction, and remount.
- Manually confirmed in Multi: resize and move Kamadan Trade, Reload, then reopen with the same geometry.

Implemented and reviewed with Codex using the repository's Electron and Vitest harnesses.
