### PR TITLE
fix(input): prevent movement keys from sticking

### DIFF
--- a/docs/enhancement-development.md
+++ b/docs/enhancement-development.md
@@ -183,7 +183,10 @@ For an input or Xunlai interaction failure, also open
 **Help → Diagnostics → Show Input Trace**. Clear it, then open Xunlai once,
 close the native storage window with Escape, click empty ground, hold both
 mouse buttons briefly, and interact with one merchant. Pause and copy the
-trace. Pointer rows name only `canvas`, `surface`, `text`, `secret`, or `other`.
+trace. The pause row names any physical canvas keys that remain held. A
+normalized release reports `released` when it found the matching held key and
+`missing` when it did not. Pointer rows name only `canvas`, `surface`, `text`,
+`secret`, or `other`.
 `canvas` proves the event reached Guild Wars; it does not prove the client
 accepted the world action. This distinction separates a hidden GWonMac surface
 from a stuck native game UI state without copying coordinates or UI text.

--- a/docs/process-model.md
+++ b/docs/process-model.md
@@ -160,10 +160,19 @@ On macOS, AppKit consumes ordinary key-up events while Command remains down.
 The app-local native monitor forwards that physical key position to the focused
 game renderer. The renderer releases only the matching entry from its existing
 held-key map and clears that physical code from renderer-owned suppression.
+The monitor remembers each physical key that crosses a Command transition.
+It forwards that key's release even when the release no longer reports Command,
+without consuming the native event. If Chromium delivers the release too, the
+renderer lets it reach the client because key-up is idempotent.
 Bare Command transitions stay outside Guild Wars, which has no
 Command modifier, so pressing or releasing Command cannot interrupt another
 key that is still physically held. A real focus loss remains the final cleanup
 for interrupted input.
+
+When Guild Wars moves focus from the canvas into one of its hidden text proxies,
+the renderer releases canvas-owned W, A, S, and D at that boundary. This keeps
+movement state out of chat without changing later text input or releasing any
+other game key.
 
 Moving focus from the game canvas into a control in the same renderer does not
 blur Guild Wars. Settings, Tools, Travel, warnings, and game text fields remain

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -416,10 +416,12 @@ opens its GitHub issue form immediately. GitHub issues are public.
 - Use **Show Input Trace** for keyboard, text, pointer, shortcut, or gamepad
   problems. Drag its header to move it away from the Guild Wars control you
   need to test. Reproduce the problem, pause the bounded timeline, then copy
-  it into the issue. It omits text, secrets, field lengths, coordinates, account
-  identifiers, and controller identifiers. Pointer rows say only whether the
-  click belonged to the game canvas, a GWonMac surface, a text or secret field,
-  or another element. Closing it discards the trace.
+  it into the issue. Pausing records which physical game-canvas keys remain
+  held. A normalized release says whether the renderer released its matching
+  key or found no held key. The trace omits text, secrets, field lengths,
+  coordinates, account identifiers, and controller identifiers. Pointer rows
+  say only whether the click belonged to the game canvas, a GWonMac surface, a
+  text or secret field, or another element. Closing it discards the trace.
 - Use **Copy Reload Trace** after a reload or failed automatic return. It joins
   Command-Q, the quit/reload dialog, reload, login, character selection, and
   reconnect timing for this game window without copying account or UI text.

--- a/src/main/native-host.ts
+++ b/src/main/native-host.ts
@@ -11,9 +11,9 @@ import { unpackedPath, type BundleLayout } from "./core/paths.js";
 
 export interface NativeHost extends NativeKeychain {
   /**
-   * Observe app-local key releases that AppKit consumes while Command stays
-   * down. Returning true consumes that native release after the renderer owns
-   * its replacement.
+   * Observe app-local key releases owned by a Command chord. Returning true
+   * consumes that release only while Command remains down, after the renderer
+   * owns its replacement.
    */
   monitorCommandKeyUps(handler: (keyCode: number) => boolean): () => void;
 }

--- a/src/native/host/host.mm
+++ b/src/native/host/host.mm
@@ -15,6 +15,7 @@
 #include <exception>
 #include <new>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 namespace {
@@ -25,6 +26,9 @@ struct CommandKeyUpMonitor {
   napi_async_context async_context = nullptr;
   id token = nil;
   bool active = false;
+  bool commandHeld = false;
+  std::unordered_set<unsigned short> downKeys;
+  std::unordered_set<unsigned short> commandKeys;
 };
 
 CommandKeyUpMonitor *gCommandKeyUpMonitor = nullptr;
@@ -86,6 +90,34 @@ bool DispatchCommandKeyUp(CommandKeyUpMonitor *monitor, unsigned short keyCode) 
   return handled;
 }
 
+bool IsCommandOwnedKeyUp(CommandKeyUpMonitor *monitor, NSEvent *event,
+                         bool commandHeld) {
+  if (event.type == NSEventTypeFlagsChanged) {
+    if (commandHeld && !monitor->commandHeld) {
+      monitor->commandKeys.insert(monitor->downKeys.begin(),
+                                  monitor->downKeys.end());
+    }
+    monitor->commandHeld = commandHeld;
+    return false;
+  }
+  if (event.type == NSEventTypeKeyDown) {
+    if (!event.isARepeat) {
+      monitor->downKeys.insert(event.keyCode);
+      monitor->commandKeys.erase(event.keyCode);
+    }
+    if (commandHeld) {
+      monitor->commandKeys.insert(event.keyCode);
+    }
+    monitor->commandHeld = commandHeld;
+    return false;
+  }
+  monitor->downKeys.erase(event.keyCode);
+  const bool commandOwned =
+      commandHeld || monitor->commandKeys.erase(event.keyCode) != 0;
+  monitor->commandHeld = commandHeld;
+  return commandOwned;
+}
+
 napi_value StopCommandKeyUpsCallback(napi_env env, napi_callback_info info) {
   size_t argc = 0;
   void *data = nullptr;
@@ -142,15 +174,22 @@ napi_value MonitorCommandKeyUpsCallback(napi_env env, napi_callback_info info) {
   monitor->active = true;
   gCommandKeyUpMonitor = monitor;
   monitor->token = [NSEvent
-      addLocalMonitorForEventsMatchingMask:NSEventMaskKeyUp
+      addLocalMonitorForEventsMatchingMask:NSEventMaskKeyDown |
+                                            NSEventMaskKeyUp |
+                                            NSEventMaskFlagsChanged
                                   handler:^NSEvent *(NSEvent *event) {
     const NSEventModifierFlags modifiers =
         event.modifierFlags & NSEventModifierFlagDeviceIndependentFlagsMask;
-    if (!monitor->active ||
-        (modifiers & NSEventModifierFlagCommand) == 0) {
+    if (!monitor->active) {
       return event;
     }
-    return DispatchCommandKeyUp(monitor, event.keyCode) ? nil : event;
+    const bool commandHeld =
+        (modifiers & NSEventModifierFlagCommand) != 0;
+    if (!IsCommandOwnedKeyUp(monitor, event, commandHeld)) {
+      return event;
+    }
+    const bool handled = DispatchCommandKeyUp(monitor, event.keyCode);
+    return commandHeld && handled ? nil : event;
   }];
   if (monitor->token == nil) {
     StopCommandKeyUps(monitor);

--- a/src/renderer/gw-native.d.ts
+++ b/src/renderer/gw-native.d.ts
@@ -54,6 +54,7 @@ declare global {
 
   interface GameInputController {
     releaseAll(): void;
+    traceState(): void;
     cancelAutomaticEnter(): void;
     setLoginProviderChooser(visible: boolean): void;
     expectCharacterSelection(): void;

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -1117,6 +1117,7 @@ function loadGlue(isProxyRouteLabel: (route: string) => boolean) {
   inputTrace = host.createInputTrace(
     document.body,
     (text) => native().clipboard.writeText(text),
+    () => inputHost?.traceState(),
   );
   gamepadTrace = host.installGamepadTrace(inputTrace);
   // Install before game input so a key claimed by the topmost GWonMac surface

--- a/src/renderer/held-keys.ts
+++ b/src/renderer/held-keys.ts
@@ -1,0 +1,136 @@
+/**
+ * The renderer keyboard ledger. It owns exact synthetic releases and the
+ * privacy-safe evidence that a release found, or did not find, a held press.
+ */
+import type {
+  InputTrace,
+  InputTraceKeyKind,
+  InputTraceOwner,
+} from '../shared/input-trace.js';
+
+/** A trusted press retained exactly for a synthetic release at its target. */
+export type HeldKey = {
+  target: EventTarget | null;
+  key: string;
+  code: string;
+  location: number;
+  charCode: number;
+  keyCode: number;
+  which: number;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  metaKey: boolean;
+};
+
+export const isMovementKey = (code: string): boolean =>
+  /^Key[WASD]$/u.test(code);
+
+const tracedKeyKind = (code: string): InputTraceKeyKind => {
+  if (isMovementKey(code)) return 'movement';
+  if (/^(?:Meta|Control|Shift|Alt)(?:Left|Right)$/u.test(code)) return 'modifier';
+  if (/^(?:ArrowUp|ArrowDown|ArrowLeft|ArrowRight|Tab)$/u.test(code)) {
+    return 'navigation';
+  }
+  if (/^(?:Backspace|Delete|Enter|Escape)$/u.test(code)) return 'editing';
+  if (/^(?:Key[A-Z]|Digit[0-9])$/u.test(code)) return 'printable';
+  return 'other';
+};
+
+export const dispatchHeldKeyRelease = (input: HeldKey) => {
+  const release = new globalThis.KeyboardEvent('keyup', {
+    bubbles: true,
+    cancelable: true,
+    key: input.key,
+    code: input.code,
+    location: input.location,
+    ctrlKey: input.ctrlKey,
+    shiftKey: input.shiftKey,
+    altKey: input.altKey,
+    metaKey: input.metaKey,
+  });
+  // ArenaNet's Emscripten bridge still marshals these read-only legacy fields.
+  // Shadow their prototype getters with the exact values from the press.
+  Object.defineProperties(release, {
+    charCode: { value: input.charCode },
+    keyCode: { value: input.keyCode },
+    which: { value: input.which },
+  });
+  input.target?.dispatchEvent(release);
+};
+
+export class HeldKeys {
+  readonly #inputs = new Map<string, HeldKey>();
+  readonly #trace: InputTrace | undefined;
+  readonly #owner: (target: EventTarget | null) => InputTraceOwner;
+
+  constructor(
+    trace: InputTrace | undefined,
+    owner: (target: EventTarget | null) => InputTraceOwner,
+  ) {
+    this.#trace = trace;
+    this.#owner = owner;
+  }
+
+  get hasInputs(): boolean {
+    return this.#inputs.size > 0;
+  }
+
+  get(code: string): HeldKey | undefined {
+    return this.#inputs.get(code);
+  }
+
+  hold(input: HeldKey): void {
+    this.#inputs.set(input.code, input);
+  }
+
+  take(code: string): HeldKey | undefined {
+    const input = this.#inputs.get(code);
+    this.#inputs.delete(code);
+    return input;
+  }
+
+  release(
+    matches: (code: string, input: HeldKey) => boolean = () => true,
+  ): void {
+    const inputs = [...this.#inputs.entries()].filter(([code, input]) =>
+      matches(code, input));
+    for (const [code] of inputs) this.#inputs.delete(code);
+    for (const [, input] of inputs) dispatchHeldKeyRelease(input);
+  }
+
+  releaseNormalized(code: string): void {
+    const input = this.take(code);
+    if (!input) {
+      this.#trace?.record({
+        source: 'renderer', kind: 'normalized-release',
+        key: tracedKeyKind(code), released: false,
+      });
+      return;
+    }
+    const owner = this.#owner(input.target);
+    this.#trace?.record(owner === 'canvas'
+      ? {
+          source: 'renderer', kind: 'normalized-release', owner,
+          code, key: tracedKeyKind(code), released: true,
+        }
+      : {
+          source: 'renderer', kind: 'normalized-release', owner,
+          key: tracedKeyKind(code), released: true,
+        });
+    dispatchHeldKeyRelease(input);
+  }
+
+  traceState(): void {
+    if (!this.hasInputs) {
+      this.#trace?.record({ source: 'renderer', kind: 'held-state', owner: 'none' });
+      return;
+    }
+    for (const [code, input] of this.#inputs) {
+      const owner = this.#owner(input.target);
+      this.#trace?.record(owner === 'canvas'
+        ? { source: 'renderer', kind: 'held-state', owner, code }
+        : { source: 'renderer', kind: 'held-state', owner });
+    }
+  }
+}

--- a/src/renderer/input-trace.ts
+++ b/src/renderer/input-trace.ts
@@ -63,6 +63,20 @@ const label = (record: InputTraceRecord): { text: string; tone: string } => {
           + `${record.repeat ? ' repeat' : ''}`
           + ` trusted=${record.trusted} → ${record.decision}`,
       };
+    case 'normalized-release':
+      return {
+        tone: record.released ? 'decision' : 'refused',
+        text: `${prefix} normalized ${record.key} release`
+          + `${record.owner ? ` ${record.owner}` : ''}`
+          + `${record.code ? ` ${record.code}` : ''}`
+          + ` → ${record.released ? 'released' : 'missing'}`,
+      };
+    case 'held-state':
+      return {
+        tone: record.owner === 'none' ? 'event' : 'refused',
+        text: `${prefix} held-state ${record.owner}`
+          + `${record.code ? ` ${record.code}` : ''}`,
+      };
     case 'text':
       return {
         tone: 'event',
@@ -103,6 +117,7 @@ const label = (record: InputTraceRecord): { text: string; tone: string } => {
 export function createInputTrace(
   parent: HTMLElement,
   writeText: (text: string) => Promise<void>,
+  snapshot: () => void = () => undefined,
 ): InputTrace {
   const style = document.createElement('style');
   style.textContent = OVERLAY_CSS;
@@ -207,11 +222,13 @@ export function createInputTrace(
   };
 
   pauseButton.addEventListener('click', () => {
+    if (!isPaused) snapshot();
     isPaused = !isPaused;
     pauseButton.textContent = isPaused ? 'Resume' : 'Pause';
   });
   clearButton.addEventListener('click', clear);
   copyButton.addEventListener('click', () => {
+    snapshot();
     void writeText(inputTraceTranscript(entries)).then(
       () => { copyButton.textContent = 'Copied'; },
       () => { copyButton.textContent = 'Copy failed'; },

--- a/src/renderer/input.ts
+++ b/src/renderer/input.ts
@@ -2,6 +2,11 @@
  * Renderer-owned game input. The Emscripten host installs this once before its
  * glue loads; native interruptions all converge on releaseAll().
  */
+import {
+  dispatchHeldKeyRelease,
+  HeldKeys,
+  isMovementKey,
+} from './held-keys.js';
 
 // Canvases a held drag may wander from the one it started on. The client keeps
 // integrating mouse moves whose coordinates fall outside the canvas, so a drag
@@ -78,25 +83,6 @@ const physicalKey = (code: string, fallback: string): string => {
 };
 
 /**
- * What a trusted press recorded, so the synthetic release can restate it
- * exactly. `target` is the node the press reached, which is where its release
- * has to be dispatched.
- */
-type HeldKey = {
-  target: EventTarget | null;
-  key: string;
-  code: string;
-  location: number;
-  charCode: number;
-  keyCode: number;
-  which: number;
-  ctrlKey: boolean;
-  shiftKey: boolean;
-  altKey: boolean;
-  metaKey: boolean;
-};
-
-/**
  * The same for a held mouse button. The coordinates and modifiers are updated
  * by every trusted mousemove, so a release lands where the pointer now is.
  */
@@ -169,7 +155,19 @@ export const installGameInput = ({
   clientCursorHidden,
   log,
 }: GameInputOptions): GameInputController => {
-  const heldKeys = new Map<string, HeldKey>();
+  const traceOwner = (target: EventTarget | null) => {
+    if (target === canvas) return 'canvas' as const;
+    if (textInputs.has(target)) {
+      return target instanceof HTMLInputElement &&
+        (target.type === 'password' || target.type === 'email')
+        ? 'secret' as const
+        : 'text' as const;
+    }
+    return target instanceof Element && target.closest('[data-gwonmac-surface]')
+      ? 'surface' as const
+      : 'other' as const;
+  };
+  const heldKeys = new HeldKeys(trace, traceOwner);
   const heldButtons = new Map<number, HeldButton>();
   const suppressedKeyUps = new Set<string>();
   let providerChooserVisible = false;
@@ -305,35 +303,6 @@ export const installGameInput = ({
     if (document.pointerLockElement === canvas) document.exitPointerLock();
   }
 
-  function dispatchKeyRelease(input: HeldKey) {
-    const release = new globalThis.KeyboardEvent('keyup', {
-      bubbles: true,
-      cancelable: true,
-      key: input.key,
-      code: input.code,
-      location: input.location,
-      ctrlKey: input.ctrlKey,
-      shiftKey: input.shiftKey,
-      altKey: input.altKey,
-      metaKey: input.metaKey,
-    });
-    // KeyboardEvent's legacy numeric fields are read-only constructor
-    // outputs. ArenaNet's Emscripten bridge still marshals them, so shadow
-    // the prototype getters with the exact values from the trusted press.
-    Object.defineProperties(release, {
-      charCode: { value: input.charCode },
-      keyCode: { value: input.keyCode },
-      which: { value: input.which },
-    });
-    input.target?.dispatchEvent(release);
-  }
-
-  function releaseKeys(matches: (code: string) => boolean = () => true) {
-    const inputs = [...heldKeys.entries()].filter(([code]) => matches(code));
-    for (const [code] of inputs) heldKeys.delete(code);
-    for (const [, input] of inputs) dispatchKeyRelease(input);
-  }
-
   function dispatchButtonRelease(input: HeldButton, buttons: number) {
     input.target?.dispatchEvent(new MouseEvent('mouseup', {
       bubbles: true,
@@ -372,7 +341,7 @@ export const installGameInput = ({
     try {
       resetWheel();
       cancelAutomaticEnter();
-      releaseKeys();
+      heldKeys.release();
       releaseButtons();
     } finally {
       releasing = false;
@@ -509,19 +478,6 @@ export const installGameInput = ({
     return Promise.resolve('sent');
   };
 
-  const traceOwner = (target: EventTarget | null) => {
-    if (target === canvas) return 'canvas' as const;
-    if (textInputs.has(target)) {
-      return target instanceof HTMLInputElement &&
-        (target.type === 'password' || target.type === 'email')
-        ? 'secret' as const
-        : 'text' as const;
-    }
-    return target instanceof Element && target.closest('[data-gwonmac-surface]')
-      ? 'surface' as const
-      : 'other' as const;
-  };
-
   const traceKey = (
     event: KeyboardEvent,
     phase: 'down' | 'up',
@@ -586,9 +542,9 @@ export const installGameInput = ({
       // hidden proxy forwards the native repeat to the canvas, but the game
       // ignores that keydown while the first press is still held. Restate the
       // missing release before each AppKit repeat. The physical key remains in
-      // heldKeys, so interruption cleanup and the final trusted keyup still
+      // the ledger, so interruption cleanup and the final trusted keyup still
       // release it normally. AppKit remains the only repeat clock.
-      if (REPEATED_ARROW_KEYS.has(key)) dispatchKeyRelease(held);
+      if (REPEATED_ARROW_KEYS.has(key)) dispatchHeldKeyRelease(held);
       traceKey(event, 'down', 'observed');
       return;
     }
@@ -596,7 +552,7 @@ export const installGameInput = ({
     if (modifier) trace?.record({
       source: 'renderer', kind: 'modifier', key: modifier, down: true,
     });
-    heldKeys.set(event.code, {
+    heldKeys.hold({
       target: event.target,
       key,
       code: event.code,
@@ -624,20 +580,19 @@ export const installGameInput = ({
       event.stopImmediatePropagation();
       return;
     }
-    const held = heldKeys.get(event.code);
+    const held = heldKeys.take(event.code);
     const key = clientKey(event, held?.key);
     const modifier = TRACED_MODIFIERS[key];
     if (modifier) trace?.record({
       source: 'renderer', kind: 'modifier', key: modifier, down: false,
     });
-    heldKeys.delete(event.code);
     traceKey(event, 'up', 'released');
     // A release landing on renderer UI (the Tools palette) never bubbles back
     // to the client's canvas listeners, so a press the canvas received would
     // stay held forever. Replay exactly those releases at the press target;
     // presses the UI itself received stay inside its event boundary.
     if (held && held.target === canvas && event.target !== canvas) {
-      dispatchKeyRelease(held);
+      dispatchHeldKeyRelease(held);
     }
   }, true);
   window.addEventListener('mousedown', (event) => {
@@ -703,11 +658,23 @@ export const installGameInput = ({
     }
   }, true);
 
+  // Guild Wars moves keyboard focus from the canvas into a hidden proxy when
+  // chat opens. A movement key released after that boundary may update the
+  // proxy without clearing the canvas state that started the movement. End
+  // only movement presses owned by the canvas at the boundary; subsequent
+  // W/A/S/D presses belong to the text field and type normally.
+  for (const input of textInputs) {
+    input?.addEventListener('focus', () => {
+      heldKeys.release((code, held) =>
+        held.target === canvas && isMovementKey(code));
+    });
+  }
+
   const releaseFor = (cause: 'blur' | 'hidden' | 'command' | 'pagehide') => () => {
     // Only the causes are named, not a new reason to release: every one of
     // these already released everything, and the trace exists to say which
     // native interruption ended a drag the player thought they still had.
-    if (heldKeys.size || heldButtons.size) {
+    if (heldKeys.hasInputs || heldButtons.size) {
       trace?.record({ source: 'renderer', kind: 'release-all', cause });
     }
     suppressedKeyUps.clear();
@@ -719,7 +686,7 @@ export const installGameInput = ({
   window.addEventListener('gw:input-release', (event) => {
     if (!(event instanceof CustomEvent) || typeof event.detail !== 'string') return;
     suppressedKeyUps.delete(event.detail);
-    releaseKeys((code) => code === event.detail);
+    heldKeys.releaseNormalized(event.detail);
   });
   document.addEventListener('visibilitychange', () => {
     if (document.visibilityState === 'hidden') releaseFor('hidden')();
@@ -935,6 +902,7 @@ export const installGameInput = ({
 
   return Object.freeze({
     releaseAll,
+    traceState: () => heldKeys.traceState(),
     cancelAutomaticEnter,
     setLoginProviderChooser(visible: boolean) {
       providerChooserVisible = visible;

--- a/src/shared/input-trace.ts
+++ b/src/shared/input-trace.ts
@@ -28,6 +28,13 @@ export type InputTraceInputType =
   | 'other'
   | 'none';
 export type InputTraceModifier = 'ctrl' | 'shift' | 'alt' | 'cmd';
+export type InputTraceKeyKind =
+  | 'movement'
+  | 'modifier'
+  | 'navigation'
+  | 'editing'
+  | 'printable'
+  | 'other';
 export type InputTraceEntry =
   | {
       source: 'appkit' | 'main';
@@ -46,6 +53,42 @@ export type InputTraceEntry =
       repeat: boolean;
       trusted: boolean;
       decision: 'observed' | 'held' | 'released' | 'suppressed' | 'command';
+    }
+  | {
+      source: 'renderer';
+      kind: 'normalized-release';
+      owner: 'canvas';
+      code: string;
+      key: InputTraceKeyKind;
+      released: true;
+    }
+  | {
+      source: 'renderer';
+      kind: 'normalized-release';
+      owner: Exclude<InputTraceOwner, 'canvas'>;
+      code?: never;
+      key: InputTraceKeyKind;
+      released: true;
+    }
+  | {
+      source: 'renderer';
+      kind: 'normalized-release';
+      owner?: never;
+      code?: never;
+      key: InputTraceKeyKind;
+      released: false;
+    }
+  | {
+      source: 'renderer';
+      kind: 'held-state';
+      owner: 'canvas';
+      code: string;
+    }
+  | {
+      source: 'renderer';
+      kind: 'held-state';
+      owner: Exclude<InputTraceOwner, 'canvas'> | 'none';
+      code?: never;
     }
   | {
       source: 'renderer';

--- a/tests/electron/input-keyboard.spec.ts
+++ b/tests/electron/input-keyboard.spec.ts
@@ -635,6 +635,60 @@ test.describe("renderer keyboard input", () => {
     }
   });
 
+  test("ends canvas movement when Guild Wars opens a text proxy", async () => {
+    const fixture = await launchCachedClient("gw-chat-movement-release-e2e-");
+    try {
+      const { page } = fixture;
+      await startGameInput(page);
+      await page.evaluate(() => {
+        const canvas = document.getElementById("canvas");
+        if (!(canvas instanceof HTMLCanvasElement)) throw new Error("canvas is missing");
+        const testWindow = window as KeyboardInputWindow;
+        testWindow.__gameKeys = [];
+        for (const type of ["keydown", "keyup"] as const) {
+          canvas.addEventListener(type, (event) => {
+            testWindow.__gameKeys.push(`${event.type}:${event.code}`);
+          });
+        }
+        canvas.focus();
+      });
+
+      const cdp = await fixture.app.context().newCDPSession(page);
+      const sendKeyDown = (code: string, key: string, virtualKeyCode: number) =>
+        cdp.send("Input.dispatchKeyEvent", {
+          type: "keyDown",
+          key,
+          code,
+          windowsVirtualKeyCode: virtualKeyCode,
+          nativeVirtualKeyCode: virtualKeyCode,
+        });
+      await sendKeyDown("KeyA", "a", 65);
+      await sendKeyDown("KeyD", "d", 68);
+      await sendKeyDown("KeyX", "x", 88);
+
+      await page.evaluate(() => {
+        const text = document.getElementById("osk-input-text");
+        if (!(text instanceof HTMLInputElement)) throw new Error("text input is missing");
+        const gameModule = window.Module as OskModuleHost | undefined;
+        if (!gameModule) throw new Error("window.Module is not installed");
+        gameModule.oskActiveInput = text;
+        text.focus();
+      });
+
+      expect(await page.evaluate(() => (
+        window as KeyboardInputWindow
+      ).__gameKeys)).toEqual([
+        "keydown:KeyA",
+        "keydown:KeyD",
+        "keydown:KeyX",
+        "keyup:KeyA",
+        "keyup:KeyD",
+      ]);
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
   test("forgets a surface-claimed key after its Command-held release", async () => {
     const fixture = await launchCachedClient("gw-command-surface-release-e2e-");
     try {

--- a/tests/electron/input-trace.spec.ts
+++ b/tests/electron/input-trace.spec.ts
@@ -6,6 +6,10 @@ import {
 import { closeOffline, launchCachedClient } from "./fixtures.mjs";
 import { boxOf, startGameInput } from "./input-helpers.js";
 
+type OskModuleHost = NonNullable<Window["Module"]> & {
+  oskActiveInput?: EventTarget | null;
+};
+
 /**
  * The trace is the instrument a bug report is built from, so what it must be
  * proved to do is: cost nothing until it is switched on, name the decision
@@ -49,6 +53,74 @@ const announceLock = (page: import("@playwright/test").Page, locked: boolean) =>
   }, locked);
 
 test.describe("input trace", () => {
+  test("keeps a real release after a normalized text-to-canvas release", async () => {
+    const fixture = await launchCachedClient("gw-input-trace-held-keys-");
+    try {
+      const { page } = fixture;
+      await startGameInput(page);
+      await toggleTrace(page);
+      await page.evaluate(() => {
+        const text = document.getElementById("osk-input-text");
+        if (!(text instanceof HTMLInputElement)) throw new Error("text input is missing");
+        const gameModule = window.Module as OskModuleHost | undefined;
+        if (!gameModule) throw new Error("window.Module is not installed");
+        gameModule.oskActiveInput = text;
+        text.focus();
+      });
+
+      const cdp = await fixture.app.context().newCDPSession(page);
+      const keyDown = () => cdp.send("Input.dispatchKeyEvent", {
+        type: "keyDown",
+        key: "w",
+        code: "KeyW",
+        windowsVirtualKeyCode: 87,
+        nativeVirtualKeyCode: 87,
+        modifiers: 4,
+      });
+
+      await keyDown();
+      await page.evaluate(() => window.dispatchEvent(
+        new CustomEvent("gw:input-release", { detail: "KeyW" }),
+      ));
+      await page.evaluate(() => {
+        const canvas = document.getElementById("canvas");
+        if (!(canvas instanceof HTMLCanvasElement)) throw new Error("canvas is missing");
+        const gameModule = window.Module as OskModuleHost | undefined;
+        if (!gameModule) throw new Error("window.Module is not installed");
+        gameModule.oskActiveInput = null;
+        canvas.focus();
+      });
+      await cdp.send("Input.dispatchKeyEvent", {
+        type: "keyUp",
+        key: "w",
+        code: "KeyW",
+        windowsVirtualKeyCode: 87,
+        nativeVirtualKeyCode: 87,
+        modifiers: 0,
+      });
+      await page.evaluate(() => window.dispatchEvent(
+        new CustomEvent("gw:input-release", { detail: "KeyW" }),
+      ));
+      await expectTrace(page).toContain(
+        "normalized movement release text → released",
+      );
+      await expectTrace(page).toContain(
+        "normalized movement release → missing",
+      );
+      await expectTrace(page).toContain(
+        "key up canvas KeyW trusted=true → released",
+      );
+
+      await keyDown();
+      await page.locator('#input-trace [data-role="pause"]').evaluate((button) => {
+        (button as HTMLButtonElement).click();
+      });
+      await expectTrace(page).toContain("held-state canvas KeyW");
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
   test("stays dormant, names double-click decisions, and copies no coordinates", async () => {
     const fixture = await launchCachedClient("gw-input-trace-on-");
     try {

--- a/tests/policy/source-native-keychain.test.ts
+++ b/tests/policy/source-native-keychain.test.ts
@@ -31,9 +31,17 @@ test("the native boundary uses only ABI-stable Node-API", () => {
 
 test("Command-held releases use one app-local macOS monitor", () => {
   assert.match(source, /#import <AppKit\/AppKit\.h>/u);
-  assert.match(source, /addLocalMonitorForEventsMatchingMask:NSEventMaskKeyUp/u);
+  assert.match(source, /addLocalMonitorForEventsMatchingMask:/u);
+  assert.match(source, /NSEventMaskKeyUp/u);
+  assert.match(source, /NSEventMaskKeyDown/u);
+  assert.match(source, /NSEventMaskFlagsChanged/u);
   assert.match(source, /NSEventModifierFlagCommand/u);
-  assert.match(source, /DispatchCommandKeyUp\(monitor, event\.keyCode\) \? nil : event/u);
+  assert.match(source, /commandKeys\.insert\(monitor->downKeys\.begin\(\)/u);
+  assert.match(source, /const bool commandOwned =\s+commandHeld \|\|/u);
+  assert.match(
+    source,
+    /return commandHeld && handled \? nil : event/u,
+  );
   assert.doesNotMatch(source, /CGEventTap|IOHID|AXIsProcessTrusted/u);
 });
 

--- a/tests/unit/automatic-character-return.test.ts
+++ b/tests/unit/automatic-character-return.test.ts
@@ -43,6 +43,7 @@ test("transient loading cannot skip character selection", async () => {
 
   const input: GameInputController = {
     releaseAll() {},
+    traceState() {},
     cancelAutomaticEnter() {},
     setLoginProviderChooser() {},
     expectCharacterSelection() {},


### PR DESCRIPTION
Movement could remain active when Guild Wars transferred keyboard focus from the game canvas into chat, or when AppKit swallowed a key release around a Command shortcut. This caused intermittent continued running or spinning after the physical movement key was released.

The renderer now releases only canvas-owned W, A, S, and D presses when Guild Wars opens its hidden text proxy, so later chat input remains untouched. The native monitor also remembers physical keys that cross a Command transition and normalizes their late release without consuming an ordinary release after Command is lifted.

The keyboard ledger is now one focused renderer module that owns held-key state, exact synthetic releases, and privacy-safe diagnostic snapshots. This removes the broad release branch from the main process and keeps the input controller below the repository's file-size limit.

## Verification

- `pnpm verify`
- `pnpm check` after rebasing onto the latest `main`
- Electron regressions cover chat focus releasing canvas-owned movement while preserving other keys.
- Input-trace regressions cover normalized releases, later trusted releases, and held-key snapshots.
- Native policy tests enforce the app-local Command chord monitor and prohibit global input hooks.
- Matthias confirmed the original stuck-running scenario no longer reproduced before the final cleanup.

Implemented and nuclear-reviewed with Codex using the privacy-safe input harness, Playwright Electron tests, and the repository's complete verification gate.
