### PR TITLE
chore(certification): record Hotfix 2 client proof

### DIFF
--- a/certificates/certified-client.json
+++ b/certificates/certified-client.json
@@ -1,4 +1,4 @@
 {
   "formatVersion": 1,
-  "codeGeneration": "e017ae15a4b46743a8a1a57bcd7c28a14894dbeeaf7a1c1775473f32c8df369e"
+  "codeGeneration": "03f51c96dc26187c6f440f0a49bfec02c339dca85f6f2867c7aaa45febcb6dfd"
 }


### PR DESCRIPTION
Issues #306 and #307 reported that consecutive ArenaNet generations refused every protected capability. Those reports ran against the pre-hardening verifier. Current `main` now proves the published Hotfix 2 generation locally without an exact-build allowlist.

This PR records the exact reviewed JSPI code generation so the repository marker matches the client we qualified. Runtime authority remains with the isolated semantic verifier; this digest cannot enable a capability.

## Exact Hotfix 2 evidence

- ArenaNet code generation: `03f51c96dc26187c6f440f0a49bfec02c339dca85f6f2867c7aaa45febcb6dfd`
- Official WASM: `3cd87bf15df6812073b558e9f365c8fb8e2a54b1b4c37028e5d3a6cbaf5e6f9e`
- Official JS: `e5fd0f1233243d7ba0dfb8432cf4a45f157af6632fad6ea39442428f5280070f`
- File compatibility and all 11 requested Core/Tools capabilities proved
- Complete native double-click route proved for file-compatible, Core, and Tools chains
- Production cache-chain and adversarial current-client suite passed
- All supported 4 GB profiles passed and safely crossed 3 GiB

## Verification

- `pnpm verify`
- `GW_CLIENT_JS=<official-js> GW_CLIENT_WASM=<official-wasm> pnpm test:client-artifact`
- `node build/tools/certification.js verify <official-wasm>`
- `node build/tools/certification.js double-click <official-wasm>`
- `pnpm memory:qualify:4gb <official-js> <official-wasm>`
- `git diff --check`

The logged-in live Xunlai scenario was launched but could not proceed because no account window was opened. No live-behavior claim is based on the offline proof.

Prepared with Codex using the repository's production verifier and test harness.

Closes #306.
Closes #307.
