### PR TITLE
fix(release): make 2026.8.10 failures diagnosable

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -31,6 +31,25 @@ sampling.
 The shared startup timeline records application and renderer milestones. It
 also records the official client identity used by the session.
 
+For optional Core and Tools behavior, read the evidence in this order:
+
+`launch selection → requested profile → verifier verdict → effective profile → consumer signal`
+
+The launch event identifies release or development build kind, the developer
+program, whether Tools were enabled, and the diagnostic profile. The verifier
+then records one closed verdict for every capability: off, proved,
+changed at a named invariant, or ambiguous with a candidate count. The active
+runtime retains the requested and effective profiles plus any preparation
+failure stage. Finally, observer-backed consumers record installation and their
+first valid observation separately for cursor, region, target, party, skill
+geometry, and cooldowns. A missing first observation is not itself a failure:
+some observations depend on game state or on a player setting.
+
+Developer programs are accepted only by an unpackaged launch with
+`GW_LIVE_SMOKE=1`. Such a launch has a persistent warning and title prefix.
+Ordinary development and every packaged build use program `none` even if a
+stray developer-program environment variable exists.
+
 The recorder includes window focus, visibility, minimize, and resize state.
 This context is required. macOS can stop frame callbacks for an occluded or
 moving window without a renderer defect.
@@ -79,6 +98,11 @@ means the clipboard size limit removed events from this trace.
 and accepted once, followed by a certified playable explorable instance.
 `outcome=outpost` means the character reached a certified playable outpost.
 Loading is transition evidence only and can never complete the workflow.
+When automatic return does not run, `relog.skipped` is the terminal row. Its
+reason is one of `disabled`, `saved-login-unavailable`,
+`pre-game-controls-unavailable`, or `intent-expired`. A plain reload still
+records `gameReload.loaded`, which proves that the replacement renderer loaded
+even when automatic return is disabled.
 
 The trace contains only closed stages, outcomes, and bounded native-control
 state. It contains no Guild Wars UI text, dispatcher parameters, pointers,

--- a/src/main/active-client.ts
+++ b/src/main/active-client.ts
@@ -11,6 +11,7 @@ import type {
   ClientTransforms,
   ClientCompatibility,
   ExtendedMemoryRuntimeStatus,
+  RuntimeEnhancementVerification,
 } from "../shared/contracts.js";
 import type { ChunkStore } from "./core/chunk-store.js";
 
@@ -23,6 +24,7 @@ export interface ActiveClient {
   readonly compatibility: ClientCompatibility | null;
   readonly extendedMemory: ExtendedMemoryRuntimeStatus;
   readonly transforms: ClientTransforms;
+  readonly enhancementVerification: RuntimeEnhancementVerification;
 }
 
 export type ClientGeneration = Omit<ActiveClient, "generation">;

--- a/src/main/certification/enhancement-policy.ts
+++ b/src/main/certification/enhancement-policy.ts
@@ -23,7 +23,9 @@ import {
 } from "../../shared/enhancement-contracts.js";
 
 export const ENHANCEMENT_AUTOMATION_ENABLED =
-  !app.isPackaged && process.env.GW_ENHANCEMENT_AUTOMATION === "1";
+  !app.isPackaged
+  && process.env.GW_LIVE_SMOKE === "1"
+  && process.env.GW_ENHANCEMENT_AUTOMATION === "1";
 
 const requestedProgram = process.env.GW_ENHANCEMENT_PROGRAM;
 
@@ -34,6 +36,7 @@ const requestedProgram = process.env.GW_ENHANCEMENT_PROGRAM;
  */
 export const DEVELOPER_ENHANCEMENT_PROGRAM: EnhancementProgram =
   !app.isPackaged
+  && process.env.GW_LIVE_SMOKE === "1"
   && ENHANCEMENT_PROGRAMS.some((program) => program === requestedProgram)
     ? requestedProgram as EnhancementProgram
     : "none";

--- a/src/main/certification/local-client-verification-contract.ts
+++ b/src/main/certification/local-client-verification-contract.ts
@@ -126,6 +126,10 @@ export const LOCAL_FEATURE_INVARIANTS = Object.freeze({
 export type LocalFeatureInvariant<Feature extends LocalClientFeature> =
   (typeof LOCAL_FEATURE_INVARIANTS)[Feature][number];
 
+export type AnyLocalFeatureInvariant = {
+  [Feature in LocalClientFeature]: LocalFeatureInvariant<Feature>;
+}[LocalClientFeature];
+
 export type LocalFeatureFailure<Feature extends LocalClientFeature> =
   | Readonly<{
       status: "changed";

--- a/src/main/client-runtime-diagnostics.ts
+++ b/src/main/client-runtime-diagnostics.ts
@@ -6,7 +6,10 @@ import type {
   DiagnosticProfile,
   RuntimeDiagnosticState,
 } from "../shared/contracts.js";
-import type { EnhancementCapabilities } from "../shared/enhancement-contracts.js";
+import type {
+  EnhancementCapabilities,
+  EnhancementProgram,
+} from "../shared/enhancement-contracts.js";
 import { diagnosticProfilePolicy } from "../shared/diagnostic-profile.js";
 import type { ActiveClient } from "./active-client.js";
 import { clientArtifactPath, type GamePaths } from "./core/paths.js";
@@ -18,6 +21,7 @@ export async function readClientRuntimeDiagnosticState(options: Readonly<{
   diagnosticProfile: DiagnosticProfile;
   extendedMemoryEnabled: boolean;
   enhancementCapabilities: EnhancementCapabilities;
+  enhancementProgram: EnhancementProgram;
 }>): Promise<RuntimeDiagnosticState> {
   const {
     active,
@@ -25,11 +29,13 @@ export async function readClientRuntimeDiagnosticState(options: Readonly<{
     diagnosticProfile,
     extendedMemoryEnabled,
     enhancementCapabilities,
+    enhancementProgram,
   } = options;
   if (!active) {
     return {
       status: "preparing",
       diagnosticProfile,
+      enhancementProgram,
       extendedMemoryRequested: extendedMemoryEnabled,
       enhancementCapabilitiesRequested: enhancementCapabilities,
     };
@@ -50,6 +56,7 @@ export async function readClientRuntimeDiagnosticState(options: Readonly<{
     status: "active",
     generation: active.generation,
     diagnosticProfile,
+    enhancementProgram,
     presentationPath: policy.presentationPath === "direct"
       ? "direct-canvas"
       : "offscreen-imagebitmap",
@@ -63,6 +70,7 @@ export async function readClientRuntimeDiagnosticState(options: Readonly<{
     extendedMemoryEffective: active.extendedMemory,
     enhancementCapabilitiesRequested: enhancementCapabilities,
     enhancementFeaturesEffective: active.compatibility?.features ?? null,
+    enhancementVerification: active.enhancementVerification,
     transforms: active.transforms,
     observers: {
       heapGrowth: true,

--- a/src/main/client-runtime-values.ts
+++ b/src/main/client-runtime-values.ts
@@ -2,8 +2,14 @@
  * Small boundary projections shared by client selection and rollback paths.
  * They turn verified runtime facts into closed diagnostics values.
  */
-import type { OptionalFeatureStatus } from "../shared/contracts.js";
+import type {
+  OptionalFeatureStatus,
+  RuntimeEnhancementVerification,
+} from "../shared/contracts.js";
+import { ENHANCEMENT_CAPABILITY_FIELDS } from "../shared/enhancement-contracts.js";
 import { isDigest, type Digest } from "../shared/digest.js";
+import type { LocalFeatureVerdicts } from
+  "./certification/local-client-verification-contract.js";
 
 /** Convert a verified client fingerprint into the diagnostics schema safely. */
 export function diagnosticDigest(
@@ -27,4 +33,21 @@ export function optionalFeatureStatus(
       ? "preparation-failed"
       : "game-update",
   };
+}
+
+/** Retain one bounded, closed verdict per capability for the active generation. */
+export function runtimeFeatureVerdicts(
+  verdicts: LocalFeatureVerdicts | null,
+): RuntimeEnhancementVerification["featureVerdicts"] {
+  if (!verdicts) return null;
+  return Object.freeze(Object.fromEntries(
+    ENHANCEMENT_CAPABILITY_FIELDS.map((feature) => {
+      const verdict = verdicts[feature];
+      return [feature, Object.freeze({
+        status: verdict.status === "not-requested" ? "off" : verdict.status,
+        invariant: "invariant" in verdict ? verdict.invariant : null,
+        candidates: verdict.status === "ambiguous" ? verdict.candidates : null,
+      })];
+    }),
+  )) as RuntimeEnhancementVerification["featureVerdicts"];
 }

--- a/src/main/client-runtime.ts
+++ b/src/main/client-runtime.ts
@@ -37,10 +37,13 @@ import {
   type SnapshotMetadata,
 } from "../shared/contracts.js";
 import {
+  enhancementCapabilityProfile,
   enhancementCapabilitiesRequested,
   ENHANCEMENT_TRANSFORM_ABI,
+  ENHANCEMENT_CAPABILITY_FIELDS,
   NO_ENHANCEMENT_CAPABILITIES,
   type EnhancementCapabilities,
+  type EnhancementProgram,
 } from "../shared/enhancement-contracts.js";
 import { AppError, NotReadyError, errorCode } from "../shared/errors.js";
 import { INITIAL_PROGRESS } from "../shared/progress.js";
@@ -96,6 +99,10 @@ import {
   verifyExtendedMemoryLocally,
   verifyNativeDoubleClickLocally,
 } from "./certification/local-client-verifier-host.js";
+import type {
+  AnyLocalFeatureInvariant,
+  LocalFeatureVerdicts,
+} from "./certification/local-client-verification-contract.js";
 import { extendedMemoryRuntimeStatus } from "./extended-memory-runtime.js";
 import { supportedEnhancementCapabilities } from "./certification/enhancement-builds.js";
 import { readClientRuntimeDiagnosticState } from "./client-runtime-diagnostics.js";
@@ -103,6 +110,7 @@ import { selectOfficialDiagnosticClient } from "./client-diagnostic-selection.js
 import {
   diagnosticDigest,
   optionalFeatureStatus,
+  runtimeFeatureVerdicts,
 } from "./client-runtime-values.js";
 
 export type { ActiveClient } from "./active-client.js";
@@ -112,6 +120,7 @@ interface ClientRuntimeOptions {
   hostVersion: string;
   cachedOnly: boolean;
   enhancementCapabilities: EnhancementCapabilities;
+  enhancementProgram?: EnhancementProgram;
   extendedMemoryEnabled: boolean;
   diagnosticProfile: DiagnosticProfile;
   onProgress: (progress: DownloadProgress) => void;
@@ -200,6 +209,7 @@ export class ClientRuntime {
       diagnosticProfile: this.options.diagnosticProfile,
       extendedMemoryEnabled: this.options.extendedMemoryEnabled,
       enhancementCapabilities: this.options.enhancementCapabilities,
+      enhancementProgram: this.options.enhancementProgram ?? "none",
     });
   }
 
@@ -278,6 +288,7 @@ export class ClientRuntime {
     compatibility: ClientCompatibility | null;
     extendedMemory: ExtendedMemoryRuntimeStatus;
     transforms: ActiveClient["transforms"];
+    enhancementVerification: ActiveClient["enhancementVerification"];
   }> {
     const officialWasm = clientArtifactPath(
       this.options.paths.artifacts,
@@ -304,6 +315,12 @@ export class ClientRuntime {
         compatibility: null,
         extendedMemory,
         transforms: { templateSave: false, nativeDoubleClick: false },
+        enhancementVerification: {
+          requestedProfile: enhancementCapabilityProfile(this.options.enhancementCapabilities),
+          effectiveProfile: null,
+          preparationFailureStage: null,
+          featureVerdicts: null,
+        },
       };
     }
 
@@ -312,7 +329,17 @@ export class ClientRuntime {
       profile: this.options.diagnosticProfile,
       extendedMemoryEnabled: this.options.extendedMemoryEnabled,
     });
-    if (officialDiagnosticClient) return officialDiagnosticClient;
+    if (officialDiagnosticClient) {
+      return {
+        ...officialDiagnosticClient,
+        enhancementVerification: {
+          requestedProfile: enhancementCapabilityProfile(this.options.enhancementCapabilities),
+          effectiveProfile: null,
+          preparationFailureStage: null,
+          featureVerdicts: null,
+        },
+      };
+    }
 
     let certification: ClientCertification = {
       templateSaveBuild: null,
@@ -325,6 +352,7 @@ export class ClientRuntime {
     });
     if (local) {
       certification = certificationFromLocalVerification(local);
+      recordFeatureVerdicts(local.featureVerdicts);
       logEvent({ k: "wasm.localVerificationCompleted" });
     } else {
       logEvent({ k: "wasm.localVerificationUnavailable" });
@@ -508,6 +536,14 @@ export class ClientRuntime {
         templateSave: prepared.gameFileSaving.status === "available",
         nativeDoubleClick: prepared.nativeDoubleClick,
       },
+      enhancementVerification: {
+        requestedProfile: enhancementCapabilityProfile(requested),
+        effectiveProfile: enhancementCapabilityProfile(effective),
+        preparationFailureStage: prepared.failure?.stage
+          ?? (local?.status === "template-refused" ? "template-save"
+            : local?.status === "enhancement-refused" ? "enhancement" : null),
+        featureVerdicts: runtimeFeatureVerdicts(local?.featureVerdicts ?? null),
+      },
     };
   }
 
@@ -548,6 +584,7 @@ export class ClientRuntime {
       compatibility: enhancement.compatibility,
       extendedMemory: enhancement.extendedMemory,
       transforms: enhancement.transforms,
+      enhancementVerification: enhancement.enhancementVerification,
     });
     this.candidateHealthToken = candidateFingerprint
       ? Object.freeze({
@@ -1008,5 +1045,21 @@ export class ClientRuntime {
     await update?.catch(() => undefined);
     const active = this.activeSlot.current;
     active?.store.stop();
+  }
+}
+
+function recordFeatureVerdicts(verdicts: LocalFeatureVerdicts | null): void {
+  if (!verdicts) return;
+  for (const feature of ENHANCEMENT_CAPABILITY_FIELDS) {
+    const verdict = verdicts[feature];
+    logEvent({
+      k: "enhancement.featureVerdict",
+      feature,
+      status: verdict.status === "not-requested" ? "off" : verdict.status,
+      invariant: "invariant" in verdict
+        ? verdict.invariant as AnyLocalFeatureInvariant
+        : null,
+      candidates: verdict.status === "ambiguous" ? verdict.candidates : null,
+    });
   }
 }

--- a/src/main/diagnostics/relog-transcript.ts
+++ b/src/main/diagnostics/relog-transcript.ts
@@ -19,10 +19,11 @@ const RELOG_EVENTS = new Set([
   "relog.characterSubmitted",
   "relog.preGameProbe",
   "relog.inputSettled",
+  "relog.skipped",
   "relog.finished",
 ]);
 
-const TERMINAL_EVENTS = new Set(["relog.finished"]);
+const TERMINAL_EVENTS = new Set(["relog.finished", "relog.skipped"]);
 
 function scalar(fields: LogRecord["fields"], key: string): string | null {
   const value = fields[key];
@@ -70,6 +71,8 @@ function details(
     }
     case "relog.finished":
       return `outcome=${scalar(fields, "outcome") ?? "unknown"}`;
+    case "relog.skipped":
+      return `reason=${scalar(fields, "reason") ?? "unknown"}`;
     default:
       return "";
   }

--- a/src/main/diagnostics/renderer.ts
+++ b/src/main/diagnostics/renderer.ts
@@ -409,6 +409,20 @@ export function recordRendererMilestone(
     );
     return;
   }
+  if (name === "relog.skipped") {
+    if (!fields || !("reason" in fields)) return;
+    recordEvent({ k: "relog.skipped", reason: fields.reason }, { timestampUs }, ownerId);
+    return;
+  }
+  if (name === "enhancement.consumerSignal") {
+    if (!fields || !("consumer" in fields)) return;
+    recordEvent({
+      k: "enhancement.consumerSignal",
+      consumer: fields.consumer,
+      signal: fields.signal,
+    }, { timestampUs }, ownerId);
+    return;
+  }
   if (name === "wasm.abort") {
     // IPC validation guarantees these fields for this name; a call without
     // them is unreachable and recording a reasonless abort would be a lie.

--- a/src/main/diagnostics/schema-app-update.ts
+++ b/src/main/diagnostics/schema-app-update.ts
@@ -4,9 +4,25 @@
  */
 import type { EventSpec } from "./schema-fields.js";
 import {
+  DIAGNOSTIC_PROFILES,
+  type DiagnosticProfile,
+} from "../../shared/contracts.js";
+import {
+  ENHANCEMENT_CAPABILITY_FIELDS,
+  ENHANCEMENT_PROGRAMS,
+  isEnhancementCapabilityProfile,
+  type EnhancementCapability,
+  type EnhancementCapabilityProfile,
+  type EnhancementProgram,
+} from "../../shared/enhancement-contracts.js";
+import {
   isExtendedMemoryProfile,
   type ExtendedMemoryProfile,
 } from "../certification/extended-memory.js";
+import {
+  LOCAL_FEATURE_INVARIANTS,
+  type AnyLocalFeatureInvariant,
+} from "../certification/local-client-verification-contract.js";
 import {
   appPhase,
   appUpdateErrorCode,
@@ -35,6 +51,16 @@ const extendedMemoryProfile: FieldGuard<"none" | ExtendedMemoryProfile> = (
   value,
 ): value is "none" | ExtendedMemoryProfile =>
   value === "none" || isExtendedMemoryProfile(value);
+const localFeatureInvariants = new Set<AnyLocalFeatureInvariant>(
+  Object.values(LOCAL_FEATURE_INVARIANTS).flat(),
+);
+const localFeatureInvariant: FieldGuard<AnyLocalFeatureInvariant> = (
+  value,
+): value is AnyLocalFeatureInvariant =>
+  typeof value === "string"
+  && localFeatureInvariants.has(value as AnyLocalFeatureInvariant);
+const enhancementCapabilityProfile: FieldGuard<EnhancementCapabilityProfile> =
+  isEnhancementCapabilityProfile;
 
 export const APP_AND_UPDATE_EVENT_SCHEMA = {
   "app.uncaughtException": {
@@ -643,6 +669,29 @@ export const APP_AND_UPDATE_EVENT_SCHEMA = {
   },
 
   // Client certification, transformation, and update.
+  "enhancement.launchSelected": {
+    scope: "app",
+    subsystem: "wasm",
+    level: "info",
+    fields: {
+      buildKind: literal(["packaged", "development"] as const),
+      program: literal<EnhancementProgram>(ENHANCEMENT_PROGRAMS),
+      toolsAtLaunch: boolean,
+      diagnosticProfile: literal<DiagnosticProfile>(DIAGNOSTIC_PROFILES),
+      requestedProfile: nullable(enhancementCapabilityProfile),
+    },
+  },
+  "enhancement.featureVerdict": {
+    scope: "app",
+    subsystem: "wasm",
+    level: "info",
+    fields: {
+      feature: literal<EnhancementCapability>(ENHANCEMENT_CAPABILITY_FIELDS),
+      status: literal(["off", "proved", "changed", "ambiguous"] as const),
+      invariant: nullable(localFeatureInvariant),
+      candidates: nullable(finiteNumber),
+    },
+  },
   "wasm.clientHashUnavailable": {
     scope: "app",
     subsystem: "wasm",

--- a/src/main/diagnostics/schema-protocol-renderer.ts
+++ b/src/main/diagnostics/schema-protocol-renderer.ts
@@ -6,7 +6,9 @@ import type { EventSpec } from "./schema-fields.js";
 import { ALLOWED_PORTS } from "../core/allowlists.js";
 import {
   RELOG_INPUT_OUTCOMES,
+  ENHANCEMENT_OBSERVER_CONSUMERS,
   RELOG_INPUT_STAGES,
+  RELOG_SKIP_REASONS,
   RELOG_TERMINAL_OUTCOMES,
   WASM_ABORT_REASON_KINDS,
   WASM_GROWTH_OUTCOMES,
@@ -247,6 +249,21 @@ export const PROTOCOL_AND_RENDERER_EVENT_SCHEMA = {
     fields: {
       outcome: literal(RELOG_TERMINAL_OUTCOMES),
       clockSynchronized: boolean,
+    },
+  },
+  "relog.skipped": {
+    scope: "owner",
+    subsystem: "renderer",
+    level: "info",
+    fields: { reason: literal(RELOG_SKIP_REASONS) },
+  },
+  "enhancement.consumerSignal": {
+    scope: "owner",
+    subsystem: "renderer",
+    level: "info",
+    fields: {
+      consumer: literal(ENHANCEMENT_OBSERVER_CONSUMERS),
+      signal: literal(["installed", "first-observation"] as const),
     },
   },
   "renderer.processExitedDuringQuit": {

--- a/src/main/game-reload.ts
+++ b/src/main/game-reload.ts
@@ -60,7 +60,13 @@ export class GameReloader {
       Date.now() > intent.expiresAt
       || win.webContents.mainFrame.routingId === intent.sourceDocumentId
     ) {
-      if (Date.now() > intent.expiresAt) this.relogIntents.delete(win);
+      if (Date.now() > intent.expiresAt) {
+        this.relogIntents.delete(win);
+        this.dependencies.record(
+          { k: "relog.skipped", reason: "intent-expired" },
+          this.dependencies.diagnosticOwner(win),
+        );
+      }
       return false;
     }
     this.relogIntents.delete(win);
@@ -102,6 +108,12 @@ export class GameReloader {
     try {
       await this.dependencies.load(win, this.dependencies.rendererUrl);
       this.dependencies.record({ k: "gameReload.loaded", cause }, ownerId);
+      if (!autoRelogAfterReload) {
+        this.dependencies.record(
+          { k: "relog.skipped", reason: "disabled" },
+          ownerId,
+        );
+      }
     } catch (error) {
       this.relogIntents.delete(win);
       throw error;

--- a/src/main/ipc-values.ts
+++ b/src/main/ipc-values.ts
@@ -11,8 +11,10 @@ import type {
 import {
   RELOG_INPUT_OUTCOMES,
   RELOG_INPUT_STAGES,
+  RELOG_SKIP_REASONS,
   RELOG_TERMINAL_OUTCOMES,
   RENDERER_MILESTONES,
+  ENHANCEMENT_OBSERVER_CONSUMERS,
   WASM_ABORT_REASON_KINDS,
   WASM_GROWTH_OUTCOMES,
   WASM_MEMORY_PROBE_STATUSES,
@@ -134,6 +136,14 @@ export function parseRendererMilestoneArgs(args: readonly unknown[]): ParsedMile
     milestoneFields = {
       outcome: record.outcome as (typeof RELOG_TERMINAL_OUTCOMES)[number],
     };
+  } else if (name === "relog.skipped") {
+    const valid = recordIsObject && Object.keys(record).length === 1
+      && typeof record.reason === "string"
+      && (RELOG_SKIP_REASONS as readonly string[]).includes(record.reason);
+    if (!valid) throw new ValidationError("invalid renderer milestone");
+    milestoneFields = {
+      reason: record.reason as (typeof RELOG_SKIP_REASONS)[number],
+    };
   } else if (name === "wasm.abort") {
     const valid = recordIsObject && Object.keys(record).length === 3
       && typeof record.reasonKind === "string"
@@ -239,6 +249,16 @@ export function parseRendererMilestoneArgs(args: readonly unknown[]): ParsedMile
       companionAbi: record.companionAbi as number,
       installation: record.installation as number,
       capabilityProfile: record.capabilityProfile as string,
+    };
+  } else if (name === "enhancement.consumerSignal") {
+    const valid = recordIsObject && Object.keys(record).length === 2
+      && typeof record.consumer === "string"
+      && (ENHANCEMENT_OBSERVER_CONSUMERS as readonly string[]).includes(record.consumer)
+      && (record.signal === "installed" || record.signal === "first-observation");
+    if (!valid) throw new ValidationError("invalid renderer milestone");
+    milestoneFields = {
+      consumer: record.consumer as (typeof ENHANCEMENT_OBSERVER_CONSUMERS)[number],
+      signal: record.signal as "installed" | "first-observation",
     };
   } else if (name === "enhancement.uninstalled") {
     const valid = recordIsObject && Object.keys(record).length === 1

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -30,6 +30,7 @@ import {
 } from "../shared/contracts.js";
 import {
   NO_ENHANCEMENT_CAPABILITIES,
+  enhancementCapabilityProfile,
   type EnhancementProgram,
   type EnhancementSelection,
 } from "../shared/enhancement-contracts.js";
@@ -591,6 +592,14 @@ if (primaryInstance) void app.whenReady().then(async () => {
   const enhancementCapabilities = diagnosticPolicy.officialClient
     ? NO_ENHANCEMENT_CAPABILITIES
     : requestedEnhancementCapabilities(settings, enhancementProgram);
+  logEvent({
+    k: "enhancement.launchSelected",
+    buildKind: app.isPackaged ? "packaged" : "development",
+    program: enhancementProgram,
+    toolsAtLaunch: enhancementSelection.tools,
+    diagnosticProfile,
+    requestedProfile: enhancementCapabilityProfile(enhancementCapabilities),
+  });
   if (activeAccountMode === "single") {
     await prepareWindowState(SINGLE_DIAGNOSTIC_OWNER_ID);
   }
@@ -606,6 +615,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
     hostVersion: HOST_VERSION,
     cachedOnly: process.env.GW_REQUIRE_CACHED_CLIENT === "1",
     enhancementCapabilities,
+    enhancementProgram,
     extendedMemoryEnabled: settings.extendedMemoryEnabled,
     diagnosticProfile,
     onProgress: setProgress,

--- a/src/renderer/automatic-character-return.ts
+++ b/src/renderer/automatic-character-return.ts
@@ -28,6 +28,7 @@ type RecordMilestone = <Name extends RendererMilestone>(
 
 export type AutomaticCharacterReturn = Readonly<{
   savedCredentialsLoaded(): void;
+  savedCredentialsUnavailable(): void;
   tokenRequested(request: XMLHttpRequest): void;
   clearStatus(): void;
   dispose(): void;
@@ -321,6 +322,24 @@ export function installAutomaticCharacterReturn(
     return candidate;
   }).catch(() => null);
 
+  const skip = (
+    candidate: ActiveRun,
+    reason: "saved-login-unavailable" | "pre-game-controls-unavailable",
+  ) => {
+    if (!isActive(candidate)) return;
+    candidate.ended = true;
+    if (candidate.deadlineTimer !== null) clearTimeout(candidate.deadlineTimer);
+    candidate.deadlineTimer = null;
+    dependencies.record("relog.skipped", { reason });
+    clearStatus();
+  };
+
+  const savedCredentialsUnavailable = () => {
+    void intent.then((candidate) => {
+      if (candidate) skip(candidate, "saved-login-unavailable");
+    });
+  };
+
   const savedCredentialsLoaded = () => {
     void intent.then(async (candidate) => {
       if (!candidate || !isActive(candidate) || candidate.loginStarted) return;
@@ -334,12 +353,14 @@ export function installAutomaticCharacterReturn(
       await afterClientPaint();
       if (!isActive(candidate)) return;
       const input = dependencies.input();
-      const outcome = input
-        ? await sendWhenFocused(
-            candidate,
-            () => input.submitSavedLogin(candidate.expiresAt),
-          )
-        : "cancelled";
+      if (!input || !window.gwPreGameControls) {
+        skip(candidate, "pre-game-controls-unavailable");
+        return;
+      }
+      const outcome = await sendWhenFocused(
+        candidate,
+        () => input.submitSavedLogin(candidate.expiresAt),
+      );
       recordInput("login", outcome);
       if (didAdvance(outcome) && isActive(candidate)) {
         step(
@@ -386,6 +407,7 @@ export function installAutomaticCharacterReturn(
 
   return Object.freeze({
     savedCredentialsLoaded,
+    savedCredentialsUnavailable,
     tokenRequested,
     clearStatus,
     dispose() {

--- a/src/renderer/certified-companion-core-installation.ts
+++ b/src/renderer/certified-companion-core-installation.ts
@@ -9,6 +9,7 @@ import {
 } from "../shared/enhancement-contracts.js";
 import { COMPANION_ABI, COMPANION_FEATURE_BITS } from "../shared/companion-abi.js";
 import type {
+  EnhancementObserverConsumer,
   RendererMilestone,
   RendererMilestoneFields,
 } from "../shared/diagnostics.js";
@@ -260,6 +261,15 @@ export async function installCoreCertifiedCompanion(
     });
 
     let cursorRefreshes = 0;
+    const observedConsumers = new Set<EnhancementObserverConsumer>();
+    const firstObservation = (consumer: EnhancementObserverConsumer) => {
+      if (observedConsumers.has(consumer)) return;
+      observedConsumers.add(consumer);
+      recordMilestone("enhancement.consumerSignal", {
+        consumer,
+        signal: "first-observation",
+      });
+    };
     let hiddenRetry: HiddenCursorRetry | null = null;
     let cursor: ReturnType<typeof createCursorConsumer> | null = null;
     if (capabilities.nativeCursor) {
@@ -322,6 +332,7 @@ export async function installCoreCertifiedCompanion(
       poll: () => {
         cursor?.poll();
         if (cursor) hiddenRetry?.afterPoll(cursor.state);
+        if (cursor?.state.valid) firstObservation("cursor");
       },
     };
     stopObserver = observeCompanion(
@@ -338,6 +349,7 @@ export async function installCoreCertifiedCompanion(
       extensionSession?.observer.skillCooldowns ?? null,
       playRegions.sink,
       extensionSession?.observer.readers ?? null,
+      firstObservation,
     );
 
     const installation = coreInstallations + 1;
@@ -401,6 +413,20 @@ export async function installCoreCertifiedCompanion(
     if (program !== "none") window.gwCompanionRuntime = runtime;
     hookSlot.value = manifest.tableSlot + 1;
     extensionSession?.afterHook();
+    const installedConsumers: readonly [boolean, EnhancementObserverConsumer][] = [
+      [capabilities.nativeCursor, "cursor"],
+      [capabilities.playRegionObservation, "region"],
+      [capabilities.targetObservation, "target"],
+      [capabilities.partyObservation, "party"],
+      [capabilities.skillSlotGeometry, "skill-geometry"],
+      [capabilities.skillCooldownObservation, "cooldowns"],
+    ];
+    for (const [installed, consumer] of installedConsumers) {
+      if (installed) recordMilestone("enhancement.consumerSignal", {
+        consumer,
+        signal: "installed",
+      });
+    }
     window.addEventListener("pagehide", cleanupAfterPageHide, { once: true });
     const capabilityProfile = enhancementCapabilityProfile(capabilities);
     if (capabilityProfile !== null) {

--- a/src/renderer/client-compatibility-notice.ts
+++ b/src/renderer/client-compatibility-notice.ts
@@ -11,6 +11,7 @@ import type {
   ClientCompatibility,
   ClientSession,
 } from '../shared/contracts.js';
+import type { EnhancementProgram } from '../shared/enhancement-contracts.js';
 
 export type CompatibilityReport = {
   degraded: boolean;
@@ -37,6 +38,15 @@ const FEATURE_NAMES: Readonly<Record<VisibleFeature, string>> = Object.freeze({
   skillSlotGeometry: 'skill key overlay',
   skillCooldownObservation: 'skill cooldown observation',
 });
+const PROGRAM_NAMES: Readonly<Record<Exclude<EnhancementProgram, 'none'>, string>> =
+  Object.freeze({
+    'cursor-observer': 'Cursor Observer',
+    'target-observer': 'Target Observer',
+    'toolbox-foundation': 'Toolbox Foundation',
+    'toolbox-commands': 'Toolbox Commands',
+    'xunlai-storage': 'Xunlai Storage',
+    'reconnect-probe': 'Reconnect Probe',
+  });
 
 function unavailableFeatures(compatibility: ClientCompatibility): VisibleFeature[] {
   // Area detection is an internal substrate. Its dependants already carry the
@@ -171,10 +181,15 @@ function requiredElement(root: Document, id: string): HTMLElement {
   return node;
 }
 
-function featureStatusLabel(status: ClientCompatibility['features'][Feature]): string {
+function featureStatusLabel(
+  status: ClientCompatibility['features'][Feature],
+  program: EnhancementProgram,
+): string {
   switch (status.status) {
     case 'available': return 'Available';
-    case 'off': return 'Off';
+    case 'off': return program === 'none'
+      ? 'Off'
+      : `Off — excluded by ${PROGRAM_NAMES[program]} live-test mode`;
     case 'unavailable': return 'Unavailable';
   }
 }
@@ -198,6 +213,7 @@ const offFeatureStatus = Object.freeze({ status: 'off' } as const);
 export function renderClientCompatibility(
   root: Document,
   session: ClientSession,
+  program: EnhancementProgram = 'none',
 ): CompatibilityReport | null {
   const settingsStatus = requiredElement(root, 'settings-compat-status');
   const settingsDetail = requiredElement(root, 'settings-compat-detail');
@@ -231,7 +247,7 @@ export function renderClientCompatibility(
       ? cooldownPresentationStatus(session.compatibility.features)
       : session.compatibility.features[feature];
     requiredElement(root, `settings-feature-${feature}`).textContent =
-      featureStatusLabel(status);
+      featureStatusLabel(status, program);
   }
   const detail = report.details.join(' ');
   settingsStatus.hidden = false;

--- a/src/renderer/companion-observer.ts
+++ b/src/renderer/companion-observer.ts
@@ -26,6 +26,7 @@ import {
   readCompanionPlayRegion,
 } from "./companion-play-region-snapshot.js";
 import type * as OptionalObserverReadersModule from "./companion-tools-observer-readers.js";
+import type { EnhancementObserverConsumer } from "../shared/diagnostics.js";
 
 export type SnapshotObserverTarget = {
   memory: WebAssembly.Memory;
@@ -102,6 +103,7 @@ export function observeCompanion(
   skillCooldowns: SkillCooldownConsumer | null = null,
   playRegion: PlayRegionConsumer | null = null,
   readers: OptionalObserverReaders | null = null,
+  firstObservation: (consumer: EnhancementObserverConsumer) => void = () => {},
 ) {
   let frame = 0;
   let cadenceAt = performance.now();
@@ -115,10 +117,12 @@ export function observeCompanion(
     // Publish the sole policy fact before any dependent observation from the
     // same animation frame reaches its consumer.
     if (playRegion) {
-      playRegion.update(readCompanionPlayRegion(
+      const state = readCompanionPlayRegion(
         runtime.memory.buffer,
         runtime.playRegionPointer ?? 0,
-      ));
+      );
+      playRegion.update(state);
+      if (state.status === "ready") firstObservation("region");
     }
     if (observeState && readout?.enabled?.() !== false) {
       if (!readers) throw new Error("Tools snapshot readers are unavailable");
@@ -150,6 +154,7 @@ export function observeCompanion(
       runtime.renderSamples.push(runtime.lastRenderUs);
       if (runtime.renderSamples.length > 240) runtime.renderSamples.shift();
       readout?.update(state);
+      if (state.status === "ready") firstObservation("target");
     }
     if (toolbox && toolbox.enabled?.() !== false) {
       if (!readers) throw new Error("Tools party readers are unavailable");
@@ -185,21 +190,28 @@ export function observeCompanion(
         // Absent, rather than present and undefined: the field means "the
         // roster region was read", and a key holding nothing says the opposite.
         toolbox.update(party === null ? state : { ...state, party });
+        if (state.status === "ready" && state.partyObserved) {
+          firstObservation("party");
+        }
       }
     }
     if (skillSlots && skillSlots.enabled?.() !== false) {
       if (!readers) throw new Error("Tools skill readers are unavailable");
-      skillSlots.update(readers.readCompanionSkillSlots(
+      const state = readers.readCompanionSkillSlots(
         runtime.memory.buffer,
         runtime.skillSlotPointer ?? 0,
-      ));
+      );
+      skillSlots.update(state);
+      if (state.status === "ready") firstObservation("skill-geometry");
     }
     if (skillCooldowns && skillCooldowns.enabled?.() !== false) {
       if (!readers) throw new Error("Tools skill readers are unavailable");
-      skillCooldowns.update(readers.readCompanionSkillCooldowns(
+      const state = readers.readCompanionSkillCooldowns(
         runtime.memory.buffer,
         runtime.skillCooldownPointer ?? 0,
-      ));
+      );
+      skillCooldowns.update(state);
+      if (state.status === "ready") firstObservation("cooldowns");
     }
     // Outside the measured window: lastRenderUs stays the snapshot read cost.
     for (const poller of pollers) {

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -791,6 +791,7 @@ Module = {
       const stored = await native().credentials.load();
       if (!stored) {
         log('secureStorage: no saved credentials — the module should prompt');
+        automaticCharacterReturn?.savedCredentialsUnavailable();
         throw new Error('no stored credentials');
       }
       log('secureStorage: returning saved credentials');

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -209,6 +209,27 @@ async function escalateRepeatedCrash(): Promise<void> {
 let disposeSocketHost = () => {};
 let disposeHostOnlyTools = () => {};
 const native = () => window.gwNative;
+const developerProgramNames: Readonly<Record<
+  Exclude<import('../shared/enhancement-contracts.js').EnhancementProgram, 'none'>,
+  string
+>> = Object.freeze({
+  'cursor-observer': 'Cursor Observer',
+  'target-observer': 'Target Observer',
+  'toolbox-foundation': 'Toolbox Foundation',
+  'toolbox-commands': 'Toolbox Commands',
+  'xunlai-storage': 'Xunlai Storage',
+  'reconnect-probe': 'Reconnect Probe',
+});
+const developerProgram = native().init.enhancementProgram;
+if (developerProgram !== 'none') {
+  const name = developerProgramNames[developerProgram];
+  document.title = `[Live test: ${name}] Guild Wars Reforged`;
+  const banner = document.getElementById('developer-program-banner');
+  if (banner) {
+    banner.textContent = `Live test: ${name} — restricted capabilities`;
+    banner.hidden = false;
+  }
+}
 let automaticCharacterReturn:
   | import('./automatic-character-return.js').AutomaticCharacterReturn
   | null = null;

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -33,6 +33,7 @@
   <!-- The one claim every screenshot of this window must carry: this is not
        an ArenaNet product. Top-left counterpart to the nav, always visible. -->
   <p id="loading-unofficial">Unofficial client for Guild Wars Reforged</p>
+  <p id="developer-program-banner" role="status" hidden></p>
   <nav id="loading-links">
     <a href="#" id="loading-update-check">Check for updates</a>
     <a href="#" id="loading-update-get" class="update"

--- a/src/renderer/loading.css
+++ b/src/renderer/loading.css
@@ -49,6 +49,13 @@
                       color:#ffd9cd; background:#7a2415d9;
                       border:1px solid #b8452f66; border-radius:6px;
                       text-shadow:0 1px 4px #0008; }
+#developer-program-banner { position:absolute; top:48px; left:18px; z-index:3;
+                            margin:0; max-width:min(620px,calc(100vw - 36px));
+                            padding:7px 10px; border:1px solid #ffb48880;
+                            border-radius:4px; background:#24120de8;
+                            color:#ffd4bd; font-size:12px; font-weight:600;
+                            text-shadow:0 1px 3px #000; }
+#developer-program-banner[hidden] { display:none; }
 
 /* Quiet project links in the top-right corner: one row that never reflows. */
 #loading-links { position:absolute; top:14px; right:18px; z-index:2;
@@ -260,6 +267,8 @@
   #loading { --dock-h: 128px; }
   #loading-unofficial { top:10px; left:50%; transform:translateX(-50%);
                         white-space:nowrap; }
+  #developer-program-banner { top:82px; left:12px;
+                              max-width:calc(100vw - 44px); }
   #loading-links { top:46px; left:12px; right:12px;
                    justify-content:center; gap:8px; font-size:12px; }
   #loading-update-line { top:72px; left:12px; right:12px;

--- a/src/renderer/settings.ts
+++ b/src/renderer/settings.ts
@@ -422,6 +422,7 @@
     renderClientCompatibility(
       document,
       session,
+      window.gwNative.init.enhancementProgram,
     );
     const fileSaving = session.compatibility?.features.gameFileSaving;
     templatePane?.setAvailability(

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -26,7 +26,9 @@ import type { ErrorCode } from "./errors.js";
 import {
   ENHANCEMENT_CAPABILITY_FIELDS,
   type EnhancementCapability,
+  type EnhancementCapabilityProfile,
   type EnhancementCapabilities,
+  type EnhancementProgram,
 } from "./enhancement-contracts.js";
 import type { BuildLibrary } from "./builds/library.js";
 import type { ProfileId } from "./multiple-accounts.js";
@@ -68,10 +70,7 @@ import {
   DEFAULT_CUSTOM_UI_THEME,
   type CustomUiTheme,
 } from "./ui-theme.js";
-import type {
-  EnhancementProgram,
-  EnhancementSelection,
-} from "./enhancement-contracts.js";
+import type { EnhancementSelection } from "./enhancement-contracts.js";
 import { RELEASE_REPO } from "./project-identity.js";
 import {
   DEFAULT_UPDATE_TRACK,
@@ -710,11 +709,29 @@ export type ClientTransforms = Readonly<{
   nativeDoubleClick: boolean;
 }>;
 
+export type RuntimeEnhancementFeatureVerdict = Readonly<{
+  status: "off" | "proved" | "changed" | "ambiguous";
+  /** Always sourced from the verifier's closed invariant vocabulary. */
+  invariant: string | null;
+  candidates: number | null;
+}>;
+
+export type RuntimeEnhancementVerification = Readonly<{
+  requestedProfile: EnhancementCapabilityProfile | null;
+  effectiveProfile: EnhancementCapabilityProfile | null;
+  preparationFailureStage: "template-save" | "enhancement" | "native-double-click" | null;
+  featureVerdicts: Readonly<Record<
+    EnhancementCapability,
+    RuntimeEnhancementFeatureVerdict
+  >> | null;
+}>;
+
 /** Effective launch state written into diagnostics without renderer inference. */
 export type RuntimeDiagnosticState =
   | Readonly<{
       status: "preparing";
       diagnosticProfile: DiagnosticProfile;
+      enhancementProgram: EnhancementProgram;
       extendedMemoryRequested: boolean;
       enhancementCapabilitiesRequested: EnhancementCapabilities;
     }>
@@ -722,6 +739,7 @@ export type RuntimeDiagnosticState =
       status: "active";
       generation: number;
       diagnosticProfile: DiagnosticProfile;
+      enhancementProgram: EnhancementProgram;
       presentationPath: "direct-canvas" | "offscreen-imagebitmap";
       artifactKind: "official" | "derived";
       officialWasmSha256: string | null;
@@ -732,6 +750,7 @@ export type RuntimeDiagnosticState =
       extendedMemoryEffective: ExtendedMemoryRuntimeStatus;
       enhancementCapabilitiesRequested: EnhancementCapabilities;
       enhancementFeaturesEffective: ClientCompatibility["features"] | null;
+      enhancementVerification: RuntimeEnhancementVerification;
       transforms: ClientTransforms;
       observers: Readonly<{
         heapGrowth: true;

--- a/src/shared/diagnostics.ts
+++ b/src/shared/diagnostics.ts
@@ -198,6 +198,7 @@ export const RENDERER_MILESTONES = [
   "relog.characterSubmitted",
   "relog.preGameProbe",
   "relog.inputSettled",
+  "relog.skipped",
   "relog.finished",
   "wasm.instantiate.begin",
   "wasm.instantiate.end",
@@ -217,11 +218,23 @@ export const RENDERER_MILESTONES = [
   // *prepared*; only these say the hook was installed, refused, or withdrawn —
   // the first question a wasm.abort triage asks.
   "enhancement.installed",
+  "enhancement.consumerSignal",
   "enhancement.installFailed",
   "enhancement.uninstalled",
 ] as const;
 
 export type RendererMilestone = (typeof RENDERER_MILESTONES)[number];
+
+export const ENHANCEMENT_OBSERVER_CONSUMERS = [
+  "cursor",
+  "region",
+  "target",
+  "party",
+  "skill-geometry",
+  "cooldowns",
+] as const;
+export type EnhancementObserverConsumer =
+  (typeof ENHANCEMENT_OBSERVER_CONSUMERS)[number];
 
 export const RELOG_INPUT_STAGES = ["login", "character", "reconnect"] as const;
 export type RelogInputStage = (typeof RELOG_INPUT_STAGES)[number];
@@ -241,6 +254,14 @@ export const RELOG_TERMINAL_OUTCOMES = [
   "timed-out",
 ] as const;
 export type RelogTerminalOutcome = (typeof RELOG_TERMINAL_OUTCOMES)[number];
+
+export const RELOG_SKIP_REASONS = [
+  "disabled",
+  "saved-login-unavailable",
+  "pre-game-controls-unavailable",
+  "intent-expired",
+] as const;
+export type RelogSkipReason = (typeof RELOG_SKIP_REASONS)[number];
 
 /**
  * The closed vocabulary a WASM abort collapses into before crossing IPC. The
@@ -314,6 +335,7 @@ export interface RendererMilestoneFieldsByName {
     outcome: RelogInputOutcome;
   };
   "relog.finished": { outcome: RelogTerminalOutcome };
+  "relog.skipped": { reason: RelogSkipReason };
   "build.info": { programId: string | number; buildId: string | number };
   /**
    * `heapBytes` is the WASM linear-memory size at the moment of death. The
@@ -360,6 +382,10 @@ export interface RendererMilestoneFieldsByName {
     companionAbi: number;
     installation: number;
     capabilityProfile: string;
+  };
+  "enhancement.consumerSignal": {
+    consumer: EnhancementObserverConsumer;
+    signal: "installed" | "first-observation";
   };
   "enhancement.uninstalled": { installation: number };
 }

--- a/src/tools/diagnostics/common.ts
+++ b/src/tools/diagnostics/common.ts
@@ -34,6 +34,13 @@ import {
   type VisualProblemManifest,
 } from "../../shared/contracts.js";
 import {
+  ENHANCEMENT_CAPABILITY_FIELDS,
+  ENHANCEMENT_PROGRAMS,
+  isEnhancementCapabilityProfile,
+} from "../../shared/enhancement-contracts.js";
+import { LOCAL_FEATURE_INVARIANTS } from
+  "../../main/certification/local-client-verification-contract.js";
+import {
   VISUAL_CAPTURE_FAILURES,
   VISUAL_CAPTURE_STAGES,
   type VisualCaptureFailure,
@@ -150,16 +157,68 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
+const featureInvariants = new Set<string>(
+  Object.values(LOCAL_FEATURE_INVARIANTS).flat(),
+);
+
+function isEnhancementVerification(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+  const profile = (candidate: unknown) =>
+    candidate === null || isEnhancementCapabilityProfile(candidate);
+  const failureStage = value.preparationFailureStage;
+  if (
+    !profile(value.requestedProfile)
+    || !profile(value.effectiveProfile)
+    || !(failureStage === null
+      || failureStage === "template-save"
+      || failureStage === "enhancement"
+      || failureStage === "native-double-click")
+  ) return false;
+  if (value.featureVerdicts === null) return true;
+  const featureVerdicts = value.featureVerdicts;
+  if (!isRecord(featureVerdicts)) return false;
+  if (
+    Object.keys(featureVerdicts).length !== ENHANCEMENT_CAPABILITY_FIELDS.length
+  ) return false;
+  return ENHANCEMENT_CAPABILITY_FIELDS.every((feature) => {
+    const verdict = featureVerdicts[feature];
+    if (!isRecord(verdict)) return false;
+    if (!(verdict.invariant === null
+      || (typeof verdict.invariant === "string"
+        && featureInvariants.has(verdict.invariant)))) return false;
+    if (!(verdict.candidates === null
+      || (Number.isSafeInteger(verdict.candidates)
+        && Number(verdict.candidates) >= 0))) return false;
+    if (verdict.status === "off" || verdict.status === "proved") {
+      return verdict.invariant === null && verdict.candidates === null;
+    }
+    if (verdict.status === "changed") {
+      return verdict.invariant !== null && verdict.candidates === null;
+    }
+    return verdict.status === "ambiguous"
+      && verdict.invariant !== null
+      && verdict.candidates !== null;
+  });
+}
+
 export function isRuntimeDiagnosticState(
   value: unknown,
 ): value is RuntimeDiagnosticState {
   if (!isRecord(value)) return false;
+  const requestedCapabilities = value.enhancementCapabilitiesRequested;
   if (
     !DIAGNOSTIC_PROFILES.includes(
       value.diagnosticProfile as RuntimeDiagnosticState["diagnosticProfile"],
     )
+    || !ENHANCEMENT_PROGRAMS.includes(
+      value.enhancementProgram as RuntimeDiagnosticState["enhancementProgram"],
+    )
     || typeof value.extendedMemoryRequested !== "boolean"
-    || !isRecord(value.enhancementCapabilitiesRequested)
+    || !isRecord(requestedCapabilities)
+    || Object.keys(requestedCapabilities).length
+      !== ENHANCEMENT_CAPABILITY_FIELDS.length
+    || !ENHANCEMENT_CAPABILITY_FIELDS.every((feature) =>
+      typeof requestedCapabilities[feature] === "boolean")
   ) return false;
   if (value.status === "preparing") return true;
   return value.status === "active"
@@ -168,6 +227,9 @@ export function isRuntimeDiagnosticState(
       || value.presentationPath === "offscreen-imagebitmap")
     && (value.artifactKind === "official" || value.artifactKind === "derived")
     && isRecord(value.extendedMemoryEffective)
+    && (value.enhancementFeaturesEffective === null
+      || isRecord(value.enhancementFeaturesEffective))
+    && isEnhancementVerification(value.enhancementVerification)
     && isRecord(value.transforms)
     && isRecord(value.observers)
     && isRecord(value.snapshot);

--- a/tests/electron/sandbox.spec.ts
+++ b/tests/electron/sandbox.spec.ts
@@ -238,6 +238,43 @@ test.describe("sandbox boundary", () => {
     }
   });
 
+  test("an enhancement program is ignored without the live-smoke posture", async () => {
+    const fixture = await launchOffline("gw-enhancement-stray-program-e2e-", {
+      GW_ENHANCEMENT_PROGRAM: "xunlai-storage",
+    });
+    try {
+      expect(await fixture.page.evaluate(() => window.gwNative.init.enhancementProgram))
+        .toBe("none");
+      await expect(fixture.page.locator("#developer-program-banner")).toBeHidden();
+      await expect(fixture.page).toHaveTitle("Guild Wars Reforged");
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
+  test("a live-test program is unmistakable while preserving player launch selection", async () => {
+    const fixture = await launchOffline("gw-enhancement-live-program-e2e-", {
+      GW_LIVE_SMOKE: "1",
+      GW_ENHANCEMENT_PROGRAM: "xunlai-storage",
+    });
+    try {
+      expect(await fixture.page.evaluate(() => ({ ...window.gwNative.init })))
+        .toMatchObject({
+          enhancementProgram: "xunlai-storage",
+          // Program capability projection is independent of the player's
+          // persisted launch selection; the profile test pins it to features-270.
+          enhancementSelection: { nativeCursor: true, tools: false },
+        });
+      await expect(fixture.page.locator("#developer-program-banner"))
+        .toHaveText("Live test: Xunlai Storage — restricted capabilities");
+      await expect(fixture.page).toHaveTitle(
+        "[Live test: Xunlai Storage] Guild Wars Reforged",
+      );
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
   test("passes an explicit template filesystem trace request to the renderer", async () => {
     const fixture = await launchOffline("gw-template-fs-trace-e2e-", {
       GW_TEMPLATE_FS_TRACE: "1",

--- a/tests/release/packaged-enhancement-surface.test.ts
+++ b/tests/release/packaged-enhancement-surface.test.ts
@@ -169,7 +169,10 @@ interface EnhancementGate {
     | "none"
     | "cursor-observer"
     | "target-observer"
-    | "toolbox-foundation";
+    | "toolbox-foundation"
+    | "toolbox-commands"
+    | "xunlai-storage"
+    | "reconnect-probe";
   none: boolean;
   cursorOnly: boolean;
 }
@@ -179,10 +182,12 @@ function enhancementGate({
   isPackaged,
   automationVariable,
   programVariable,
+  liveSmoke = false,
 }: {
   isPackaged: boolean;
   automationVariable: string | undefined;
   programVariable?: string | undefined;
+  liveSmoke?: boolean;
 }): EnhancementGate {
   const environment = { ...process.env };
   delete environment.GW_ENHANCEMENT_AUTOMATION;
@@ -193,6 +198,8 @@ function enhancementGate({
   if (programVariable !== undefined) {
     environment.GW_ENHANCEMENT_PROGRAM = programVariable;
   }
+  if (liveSmoke) environment.GW_LIVE_SMOKE = "1";
+  else delete environment.GW_LIVE_SMOKE;
   environment.GW_PROBE_PACKAGED = isPackaged ? "1" : "0";
   environment.GW_PROBE_POLICY = pathToFileURL(
     path.join(root, "build/main/certification/enhancement-policy.js"),
@@ -227,8 +234,15 @@ test("packaged builds refuse automation and developer programs independently", (
     assert.equal(gate.cursorOnly, true);
   }
 
-  // Unpackaged automation grants input/IPC only. It does not select hooks.
-  const enabled = enhancementGate({ isPackaged: false, automationVariable: "1" });
+  // A stray variable never changes an ordinary development launch.
+  const stray = enhancementGate({ isPackaged: false, automationVariable: "1",
+    programVariable: "toolbox-foundation" });
+  assert.equal(stray.automation, false);
+  assert.equal(stray.program, "none");
+
+  // The explicit live-smoke posture may grant automation without selecting hooks.
+  const enabled = enhancementGate({ isPackaged: false, automationVariable: "1",
+    liveSmoke: true });
   assert.equal(enabled.automation, true);
   assert.equal(enabled.program, "none");
   assert.equal(enabled.none, false);
@@ -242,6 +256,7 @@ test("packaged builds refuse automation and developer programs independently", (
     isPackaged: false,
     automationVariable: undefined,
     programVariable: "toolbox-foundation",
+    liveSmoke: true,
   });
   assert.equal(foundation.automation, false);
   assert.equal(foundation.program, "toolbox-foundation");

--- a/tests/unit/active-client.test.ts
+++ b/tests/unit/active-client.test.ts
@@ -34,6 +34,12 @@ function generation(wasmPath: string, size: number): ClientGeneration {
       ? { requestedAtLaunch: false, status: "standard", effectiveCapBytes: 2_147_483_648, fallbackReason: null }
       : { requestedAtLaunch: true, status: "active", effectiveCapBytes: 4_294_967_296, fallbackReason: null },
     transforms: { templateSave: supported, nativeDoubleClick: supported },
+    enhancementVerification: {
+      requestedProfile: supported ? "features-7ff" : "features-001",
+      effectiveProfile: supported ? "features-7ff" : null,
+      preparationFailureStage: null,
+      featureVerdicts: null,
+    },
   };
 }
 
@@ -51,5 +57,9 @@ describe("atomic active client publication", () => {
     assert.notEqual(rollback.generation, previous.generation);
     assert.equal(slot.current?.compatibility?.features.nativeCursor.status, "available");
     assert.equal(slot.current?.extendedMemory.status, "standard");
+    assert.equal(
+      slot.current?.enhancementVerification.effectiveProfile,
+      "features-7ff",
+    );
   });
 });

--- a/tests/unit/client-compatibility-notice.test.ts
+++ b/tests/unit/client-compatibility-notice.test.ts
@@ -271,6 +271,20 @@ describe("client compatibility notice", () => {
     assert.equal(dom.element("settings-availability").open, true);
   });
 
+  it("names developer-program exclusions instead of showing an ambiguous Off", () => {
+    const dom = compatibilityDom();
+    renderClientCompatibility(dom.root, {
+      appVersion: "2026.8.10",
+      extendedMemory: STANDARD_MEMORY,
+      healthToken: null,
+      compatibility: compatibility(),
+    }, "xunlai-storage");
+    assert.equal(
+      dom.element("settings-feature-nativeCursor").textContent,
+      "Off — excluded by Xunlai Storage live-test mode",
+    );
+  });
+
   it("reports cooldown presentation unavailable when slot geometry is unavailable", () => {
     const dom = compatibilityDom();
     renderClientCompatibility(dom.root, {

--- a/tests/unit/client-runtime-values.test.ts
+++ b/tests/unit/client-runtime-values.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { runtimeFeatureVerdicts } from "../../src/main/client-runtime-values.js";
+import type { LocalFeatureVerdicts } from
+  "../../src/main/certification/local-client-verification-contract.js";
+import { ENHANCEMENT_CAPABILITY_FIELDS } from
+  "../../src/shared/enhancement-contracts.js";
+
+test("runtime verdicts retain only closed per-feature debugging facts", () => {
+  const verdicts = Object.fromEntries(ENHANCEMENT_CAPABILITY_FIELDS.map(
+    (feature) => [feature, { status: "not-requested" }],
+  )) as unknown as LocalFeatureVerdicts;
+  const input = {
+    ...verdicts,
+    nativeCursor: { status: "proved" },
+    targetObservation: {
+      status: "changed",
+      invariant: "target.observation-selection-anchors",
+    },
+    partyObservation: {
+      status: "ambiguous",
+      invariant: "party.observation-anchors",
+      candidates: 2,
+    },
+  } as unknown as LocalFeatureVerdicts;
+
+  const retained = runtimeFeatureVerdicts(input);
+  assert.equal(retained?.nativeCursor.status, "proved");
+  assert.deepEqual(retained?.targetObservation, {
+    status: "changed",
+    invariant: "target.observation-selection-anchors",
+    candidates: null,
+  });
+  assert.deepEqual(retained?.partyObservation, {
+    status: "ambiguous",
+    invariant: "party.observation-anchors",
+    candidates: 2,
+  });
+  assert.deepEqual(retained?.travelAction, {
+    status: "off",
+    invariant: null,
+    candidates: null,
+  });
+});

--- a/tests/unit/diagnostics.test.ts
+++ b/tests/unit/diagnostics.test.ts
@@ -3,6 +3,8 @@ import { describe, it } from "node:test";
 import { diagnosticEventRecord } from "../../src/main/diagnostics/schema.ts";
 import type { DiagnosticEvent } from "../../src/main/diagnostics/schema.ts";
 import { isRendererMetrics, type RendererMetrics } from "../../src/shared/diagnostics.ts";
+import { NO_ENHANCEMENT_CAPABILITIES } from
+  "../../src/shared/enhancement-contracts.ts";
 import {
   analyzeFrames,
   comparisonWarnings,
@@ -289,6 +291,21 @@ describe("capture validation, format 2", () => {
   const events: DiagnosticEvent[] = [
     { k: "socket.close", socketId: 1, reason: "peer" },
     { k: "settings.saveFailed", code: "disk_full" },
+    {
+      k: "enhancement.launchSelected",
+      buildKind: "packaged",
+      program: "none",
+      toolsAtLaunch: true,
+      diagnosticProfile: "standard",
+      requestedProfile: "features-7ff",
+    },
+    {
+      k: "enhancement.featureVerdict",
+      feature: "nativeCursor",
+      status: "proved",
+      invariant: null,
+      candidates: null,
+    },
   ];
 
   it("reproduces the manifest's redaction result from events.jsonl", () => {
@@ -304,7 +321,7 @@ describe("capture validation, format 2", () => {
     capture.manifest.redaction.schemaChecked = 9;
     assert.match(
       validateCapture(capture).join("\n"),
-      /claims 9 schema-checked records, events\.jsonl has 2/,
+      /claims 9 schema-checked records, events\.jsonl has 4/,
     );
   });
 
@@ -447,8 +464,20 @@ function visualCapture(): Capture {
   capture.runtimeState = {
     status: "active",
     diagnosticProfile: "official-baseline",
+    enhancementProgram: "none",
     extendedMemoryRequested: true,
-    enhancementCapabilitiesRequested: {},
+    enhancementCapabilitiesRequested: NO_ENHANCEMENT_CAPABILITIES,
+    enhancementFeaturesEffective: null,
+    enhancementVerification: {
+      requestedProfile: null,
+      effectiveProfile: null,
+      preparationFailureStage: null,
+      featureVerdicts: null,
+    },
+    officialWasmSha256: null,
+    officialJsSha256: null,
+    selectedWasmSha256: null,
+    selectedJsSha256: null,
     generation: 1,
     presentationPath: "offscreen-imagebitmap",
     artifactKind: "official",

--- a/tests/unit/game-reload.test.ts
+++ b/tests/unit/game-reload.test.ts
@@ -12,7 +12,7 @@ function fixture(options: Readonly<{
   let routingId = 10;
   let loads = 0;
   let socketCloses = 0;
-  const events: string[] = [];
+  const events: Array<{ k: string; reason?: string }> = [];
   const win = {
     isDestroyed: () => false,
     webContents: {
@@ -33,7 +33,12 @@ function fixture(options: Readonly<{
       };
     },
     diagnosticOwner: () => 3,
-    record(event) { events.push(event.k); },
+    record(event) {
+      const reason = "reason" in event && typeof event.reason === "string"
+        ? event.reason
+        : undefined;
+      events.push({ k: event.k, ...(reason === undefined ? {} : { reason }) });
+    },
     sync: async () => "completed",
     async load() {
       loads += 1;
@@ -70,4 +75,13 @@ test("a settings read failure performs no partial reload", async () => {
   assert.equal(socketCloses(), 0);
   assert.deepEqual(events, []);
   assert.equal(reloader.claimRelogIntent(win), false);
+});
+
+test("a plain reload records both the renderer restart and disabled automatic return", async () => {
+  const { reloader, win, events } = fixture({ autoRelog: false });
+  await reloader.reload(win, "menu");
+  assert.deepEqual(events.slice(-2), [
+    { k: "gameReload.loaded" },
+    { k: "relog.skipped", reason: "disabled" },
+  ]);
 });

--- a/tests/unit/relog-transcript.test.ts
+++ b/tests/unit/relog-transcript.test.ts
@@ -75,6 +75,20 @@ describe("reload transcript", () => {
     assert.match(absent, /no reload boundary/);
   });
 
+  it("formats a disabled automatic return as a complete terminal outcome", () => {
+    const text = formatRelogTranscript({
+      ownerId: 1,
+      completeFromStart: true,
+      records: [
+        event(1, 1, "gameReload.requested", { cause: "menu" }),
+        event(2, 1, "gameReload.loaded", { cause: "menu" }),
+        event(3, 1, "relog.skipped", { reason: "disabled" }),
+      ],
+    });
+    assert.match(text, /status: complete/);
+    assert.match(text, /relog\.skipped reason=disabled/);
+  });
+
   it("starts a menu trace at its own reload after an older Command-Q run", () => {
     const text = formatRelogTranscript({
       ownerId: 1,


### PR DESCRIPTION
## Problem

A restricted Xunlai Storage live-test launch could look like a normal Tools session. That made intentionally excluded capabilities—cursor, Apply Team, skill overlays, cooldowns, target range, and parts of reload—look broken, while the diagnostics did not show the complete decision chain needed to identify the cause quickly.

## Solution

- Gate developer enhancement programs and automation behind an unpackaged `GW_LIVE_SMOKE=1` launch. Ordinary development and every packaged build now use program `none`.
- Make live-test mode unmistakable with a persistent warning, title prefix, and explicit Settings exclusion labels.
- Record the closed capability chain from launch selection through verifier verdict, effective profile, and observer consumer signals, while retaining the active generation's verifier summary in runtime diagnostics.
- Give every reload a terminal outcome, including closed `relog.skipped` reasons, and include those outcomes in **Copy Reload Trace** without changing the player's automatic-return setting.

## Verification completed

- `pnpm check`
- `pnpm verify`
- Focused Electron launch-policy suite: 6 passed
- Focused reload suite after the final guard: 9 passed
- Exact Hotfix 2 production verifier, transform/cache chain, native double-click route, and template verifier passed
- Exact cached client SHA-256: `3cd87bf15df6812073b558e9f365c8fb8e2a54b1b4c37028e5d3a6cbaf5e6f9e`
- Packaged smoke and packaged runtime verification passed as part of `pnpm verify`

## Required after merge

The Stable dry run, real signed draft, `pnpm release:test v2026.8.10`, live-account feature matrix, reload trace capture, GitHub environment approval, ArenaNet recertification confirmation, publication, checksum verification, and final updater discovery remain release-blocking maintainer steps. Publication must not proceed if any normal Tools capability is unexpectedly Off or Unavailable.

Implemented and verified with Codex.
