### PR TITLE
fix(display): keep PlayStation prompts across client rebuilds

### DIFF
--- a/docs/wasm-host.md
+++ b/docs/wasm-host.md
@@ -32,13 +32,13 @@ It wraps only the official client's Emscripten `glTexImage2D` and full-atlas
 `glTexSubImage2D` imports. It does not patch WebGL prototypes, edit `Gw.dat`, or
 alter the verified client artifacts.
 
-The replacement requires an observed WebGL checksum for Guild Wars' 256×512
-RGBA controller atlas, certified against one exact JSPi client SHA. Width and
-height are not proof, and the older native TexMod/uMod checksum is not accepted
-at runtime. A mismatch, malformed heap range, unsupported upload, or missing
-import passes the original call through unchanged. During a match, the host
-temporarily places the app-owned pixels at the existing WASM pointer, calls the
-synchronous upload, and restores the client bytes in `finally`.
+The replacement requires the certified WebGL content checksum for Guild Wars'
+256×512 RGBA controller atlas. The surrounding client SHA, width, and height
+are not proof. The older native TexMod/uMod checksum is not accepted at runtime.
+A content mismatch, malformed heap range, unsupported upload, or missing import
+passes the original call through unchanged. During a match, the host temporarily
+places the app-owned pixels at the existing WASM pointer, calls the synchronous
+upload, and restores the client bytes in `finally`.
 
 A level-zero redefinition, partial or compressed update, texture deletion, or
 WebGL context reset withdraws the remembered match. This prevents a reused or
@@ -55,10 +55,11 @@ key.
 
 This is not a Tools or Enhancement capability. It reads no game state, sends
 no command, and has no PvE/PvP policy. It is a launch-time renderer preference,
-like render scale. ArenaNet updates remain playable because an unknown atlas
-hash passes through unchanged. Supporting a changed atlas requires reviewing
-the new texture and adding one exact client/hash certification; it never
-requires weakening the matcher or changing the Enhancement contract.
+like render scale. An ArenaNet rebuild that retains the certified atlas content
+keeps the setting working without an application release. An unknown atlas hash
+passes through unchanged. Supporting changed atlas content requires reviewing
+the new texture and adding its exact checksum; it never requires weakening the
+matcher or changing the Enhancement contract.
 
 In an unpackaged development build, `gwVirtualGamepad` can expose Guild Wars'
 real gamepad UI without hardware. Run `gwVirtualGamepad.activateUi()` in the

--- a/internal/upstream/README.md
+++ b/internal/upstream/README.md
@@ -30,7 +30,7 @@ named in the file that contains them.
 | [recertify.md](recertify.md) | Maintainer recovery procedure | First test whether the workaround can be deleted. Re-derive semantics when automated proof refuses. |
 | [investigation-log.md](investigation-log.md) | Wrong-turn archive | Real input shapes and live measurements resolved the template, cursor, modifier, and timer failures. |
 | [memory-exhaustion-log.md](memory-exhaustion-log.md) | Long-session memory evidence | The examined client has a 2 GiB WebAssembly maximum and can exhaust it during normal long runs. A larger maximum buys time but does not fix growth. |
-| [controller-prompt-atlas.md](controller-prompt-atlas.md) | Exact-build texture evidence | The PlayStation prompt option replaces one uniquely observed 256×512 RGBA controller atlas and fails closed on other client builds. |
+| [controller-prompt-atlas.md](controller-prompt-atlas.md) | Content-certified texture evidence | The PlayStation prompt option replaces one uniquely observed 256×512 RGBA controller atlas and fails closed when its content changes. |
 | [investigation-template.md](investigation-template.md) | Investigation format | Record one hypothesis, one measurement, and one lesson per round. |
 
 The retired hero-panel observer has a separate

--- a/internal/upstream/controller-prompt-atlas.md
+++ b/internal/upstream/controller-prompt-atlas.md
@@ -1,14 +1,14 @@
 # Controller-prompt atlas evidence
 
-> **Status: exact-build historical evidence.** These values apply only to the
-> client SHA named below. A different client receives ArenaNet's unchanged
-> controller prompts until its atlas is independently certified.
+> **Status: content certification evidence.** The certified checksum applies to
+> this exact atlas content across client rebuilds. Changed atlas content receives
+> ArenaNet's unchanged controller prompts until it is independently certified.
 
 ## Certified upload
 
 | Fact | Value |
 | --- | --- |
-| JSPi client SHA-256 | `b8cc509714b82b69fdfd79a26ba257aa4c9ef23d90bca9dfcbbd044e371cfb17` |
+| Observed JSPi client SHA-256 values | `b8cc509714b82b69fdfd79a26ba257aa4c9ef23d90bca9dfcbbd044e371cfb17`, `3cd87bf15df6812073b558e9f365c8fb8e2a54b1b4c37028e5d3a6cbaf5e6f9e` |
 | WebGL upload | level 0, 256×512, RGBA/unsigned byte |
 | Upload byte length | 524,288 |
 | Direct uMod running CRC-32 | `0x74eb6846` |
@@ -18,7 +18,10 @@
 The older native TexMod/uMod texture has running CRC-32 `0xa30969c1`, but the
 JSPi renderer rebuilds/transposes uploads. That native checksum is research
 context only and is deliberately **not** accepted at runtime. Runtime
-certification binds the observed WebGL checksum to the exact client SHA.
+certification binds the replacement to the observed WebGL content checksum.
+The second observed client retained the same checksum after an ArenaNet rebuild.
+This is why the runtime does not bind unchanged atlas content to the whole client
+SHA.
 
 The hook observes the existing synchronous Emscripten WebGL import. It replaces
 the bytes only for that call and restores the WebAssembly heap immediately.
@@ -36,9 +39,9 @@ compressed, redefined, deleted, or context-reset textures lose their match.
    present. Record all four reported hashes; do not choose a nearest match.
 5. Visually confirm that replacing only this upload changes controller prompts
    throughout the UI and does not change unrelated textures.
-6. Add the new exact client SHA, observed direct hash, and required transform to
-   `CONTROLLER_PROMPT_ATLAS_CERTIFICATIONS`. Preserve the old entry only if that
-   client remains distributed.
+6. If the content changed, add the observed hash and required transform to
+   `CONTROLLER_PROMPT_ATLAS_CERTIFICATIONS`. Record the client SHA as evidence,
+   not as runtime authority.
 7. Run the focused texture tests, `pnpm check`, integration tests, release tests,
    and a real-client visual check before publishing.
 

--- a/src/renderer/controller-prompt-texture.ts
+++ b/src/renderer/controller-prompt-texture.ts
@@ -1,24 +1,19 @@
 /**
  * Replaces one certified Guild Wars controller-prompt atlas at its existing
- * Emscripten WebGL upload boundary. Matching is by the atlas' established
- * exact-client checksum, never by dimensions alone. The game's bytes are put
- * back immediately after the synchronous upload, and every mismatch is an
- * unchanged pass-through.
+ * Emscripten WebGL upload boundary. Matching is by the atlas' certified
+ * content checksum, never by dimensions or the surrounding client build. The
+ * game's bytes are put back immediately after the synchronous upload, and
+ * every mismatch is an unchanged pass-through.
  */
 
 // Exact evidence and the recertification procedure live in
 // internal/upstream/controller-prompt-atlas.md.
-export const CONTROLLER_PROMPT_ATLAS_CERTIFICATIONS: Readonly<Record<string, Readonly<{
-  hash: number;
-  transform: AtlasTransform;
-}>>> = Object.freeze({
-  // Current exact JSPi client: the web renderer transposes/rebuilds texture
-  // uploads, so its RGBA checksum differs from the native TexMod checksum.
-  b8cc509714b82b69fdfd79a26ba257aa4c9ef23d90bca9dfcbbd044e371cfb17: Object.freeze({
-    hash: 0x74eb6846,
-    transform: "direct",
-  }),
-});
+const CONTROLLER_PROMPT_ATLAS_CERTIFICATIONS: Readonly<Record<number, AtlasTransform>> =
+  Object.freeze({
+    // The web renderer transposes/rebuilds texture uploads, so this RGBA
+    // checksum differs from the native TexMod checksum.
+    [0x74eb6846]: "direct",
+  });
 const ATLAS_WIDTH = 256;
 const ATLAS_HEIGHT = 512;
 const GL_TEXTURE_2D = 0x0de1;
@@ -174,20 +169,12 @@ export function texmodHash(
   return crc >>> 0;
 }
 
-export function certifiedWebGlAtlasTransform(
-  clientSha256: string | null,
-  hash: number,
-): AtlasTransform | null {
-  if (!clientSha256) return null;
-  const certification = CONTROLLER_PROMPT_ATLAS_CERTIFICATIONS[clientSha256];
-  return certification?.hash === hash ? certification.transform : null;
+export function certifiedWebGlAtlasTransform(hash: number): AtlasTransform | null {
+  return CONTROLLER_PROMPT_ATLAS_CERTIFICATIONS[hash] ?? null;
 }
 
-export function identifyControllerPromptAtlas(
-  bytes: Uint8Array,
-  clientSha256: string | null = null,
-): AtlasTransform | null {
-  return certifiedWebGlAtlasTransform(clientSha256, texmodHash(bytes));
+export function identifyControllerPromptAtlas(bytes: Uint8Array): AtlasTransform | null {
+  return certifiedWebGlAtlasTransform(texmodHash(bytes));
 }
 
 function atlasHashes(bytes: Uint8Array, width: number, height: number) {
@@ -291,11 +278,9 @@ function validRange(heap: Uint8Array | undefined, pointer: number, length: numbe
 }
 
 export async function preparePlayStationControllerPrompts({
-  clientSha256,
   diagnostics,
   log,
 }: {
-  clientSha256: string | null;
   diagnostics: boolean;
   log: (...values: unknown[]) => void;
 }): Promise<PreparedControllerPrompts> {
@@ -314,7 +299,6 @@ export async function preparePlayStationControllerPrompts({
         imports,
         module,
         atlas,
-        clientSha256,
         diagnostics,
         log,
       });
@@ -333,15 +317,13 @@ export function installControllerPromptTexture({
   imports,
   module,
   atlas,
-  clientSha256 = null,
-  identify = (bytes) => identifyControllerPromptAtlas(bytes, clientSha256),
+  identify = identifyControllerPromptAtlas,
   diagnostics = false,
   log,
 }: {
   imports: TextureImports;
   module: ClientMemory;
   atlas: ControllerPromptAtlas;
-  clientSha256?: string | null;
   identify?: (bytes: Uint8Array) => AtlasTransform | null;
   diagnostics?: boolean;
   log: (...values: unknown[]) => void;

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -1361,7 +1361,6 @@ function loadGlue(isProxyRouteLabel: (route: string) => boolean) {
     if (settings.controllerPromptStyle === 'playstation') {
       try {
         controllerPrompts = await host.preparePlayStationControllerPrompts({
-          clientSha256: session.compatibility?.clientSha256 ?? null,
           diagnostics: window.gwNative.init.development,
           log,
         });

--- a/tests/policy/controller-prompt-asset.test.ts
+++ b/tests/policy/controller-prompt-asset.test.ts
@@ -28,6 +28,7 @@ test("the PlayStation prompt atlas is the reviewed 256×512 CC0 composition", as
 
   const evidence = await readFile(evidencePath, "utf8");
   assert.match(evidence, /b8cc509714b82b69fdfd79a26ba257aa4c9ef23d90bca9dfcbbd044e371cfb17/u);
+  assert.match(evidence, /3cd87bf15df6812073b558e9f365c8fb8e2a54b1b4c37028e5d3a6cbaf5e6f9e/u);
   assert.match(evidence, /0x74eb6846/u);
   assert.match(evidence, /d3dcb98fa3bbc9541f6456a36611ebad44e557ef1099aad328393b4eca25f294/u);
   assert.match(evidence, /Matching candidates in the bounded diagnostic capture.*\| 1 \|/u);

--- a/tests/unit/controller-prompt-texture.test.ts
+++ b/tests/unit/controller-prompt-texture.test.ts
@@ -56,12 +56,9 @@ describe("controller prompt texture", () => {
     assert.equal(identifyControllerPromptAtlas(new Uint8Array(100)), null);
   });
 
-  it("pins the current WebGL fingerprint to the exact certified client", () => {
-    const currentClient = "b8cc509714b82b69fdfd79a26ba257aa4c9ef23d90bca9dfcbbd044e371cfb17";
-    assert.equal(certifiedWebGlAtlasTransform(currentClient, 0x74eb6846), "direct");
-    assert.equal(certifiedWebGlAtlasTransform(currentClient, 0x74eb6847), null);
-    assert.equal(certifiedWebGlAtlasTransform("0".repeat(64), 0x74eb6846), null);
-    assert.equal(certifiedWebGlAtlasTransform(null, 0x74eb6846), null);
+  it("pins the WebGL fingerprint to the atlas content instead of the client build", () => {
+    assert.equal(certifiedWebGlAtlasTransform(0x74eb6846), "direct");
+    assert.equal(certifiedWebGlAtlasTransform(0x74eb6847), null);
   });
 
   it("substitutes synchronously and restores the client's heap", () => {


### PR DESCRIPTION
The PlayStation controller prompt setting fell back to Xbox icons after a small ArenaNet client rebuild, even though the controller atlas itself had not changed. The renderer tied the atlas checksum to the whole client SHA, so any rebuild disabled the replacement until the app shipped another exact-build entry.

This changes the certification boundary to the object that is actually replaced: the exact WebGL atlas content. The renderer now accepts the certified `0x74eb6846` atlas checksum across client rebuilds while retaining every existing upload-shape, format, pointer, texture-lifecycle, and mismatch refusal. Changed or unknown atlas content still passes through untouched.

The evidence record now includes both observed clients:

- previous client: `b8cc509714b82b69fdfd79a26ba257aa4c9ef23d90bca9dfcbbd044e371cfb17`
- current client: `3cd87bf15df6812073b558e9f365c8fb8e2a54b1b4c37028e5d3a6cbaf5e6f9e`
- both exposed one unique 256×512 RGBA atlas with direct checksum `0x74eb6846`

Verification:

- focused controller texture and asset policy tests: 12 passed
- `pnpm run check`: passed (1,360 unit, 184 policy, and 137 Tools tests)
- live current-client QA: PlayStation icons confirmed by Matthias
- `pnpm verify`: passed build, kernel, integration, release, and 42 Tools end-to-end tests; the Electron portion was stopped after 12 passing tests because final automation will run in CI

Developed with Codex. Runtime capture and live visual QA were provided by Matthias.
