### PR TITLE
ci(release): keep emergency patches isolated from main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,10 @@
 
 <!-- Name the executable behavior or trust boundary that proves the result. -->
 
+## Delivery
+
+<!-- State the target branch and recommend: no app release, Developer Build, Beta, or Stable. Explain any rollout risk. -->
+
 ## Verification
 
 <!-- List the commands or manual checks you ran. -->

--- a/.github/workflows/pr-package.yml
+++ b/.github/workflows/pr-package.yml
@@ -6,7 +6,9 @@ name: Application verification
 on:
   pull_request:
   push:
-    branches: [main]
+    branches:
+      - main
+      - "release/**"
   workflow_dispatch:
     inputs:
       checkout_ref:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
-# The only path to a public versioned release: dispatched by hand, refused off
-# main, and gated on the approval environment holding the Developer ID material.
+# The only path to a public versioned release: dispatched by hand from main or
+# one canonical release branch, and gated on the approval environment holding
+# the Developer ID material.
 name: Versioned release
 
 on:
@@ -23,14 +24,65 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  source:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      bundle-version: ${{ steps.release-source.outputs.bundle-version }}
+      prerelease: ${{ steps.release-source.outputs.prerelease }}
+      tag: ${{ steps.release-source.outputs.tag }}
+      version: ${{ steps.release-source.outputs.version }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+      - name: Resolve and validate the release source
+        id: release-source
+        env:
+          SOURCE_BRANCH: ${{ github.ref_name }}
+          SOURCE_TYPE: ${{ github.ref_type }}
+        run: |
+          test "$SOURCE_TYPE" = "branch"
+          if [ "$SOURCE_BRANCH" != "main" ] \
+            && ! [[ "$SOURCE_BRANCH" =~ ^release/[0-9]{4}\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "Release from main or release/YYYY.M.PATCH, not $SOURCE_BRANCH." >&2
+            exit 1
+          fi
+          version="$(node -p "require('./package.json').version")"
+          release_line="${version%%-*}"
+          if [[ "$SOURCE_BRANCH" == release/* ]] \
+            && [ "${SOURCE_BRANCH#release/}" != "$release_line" ]; then
+            echo "Release branch $SOURCE_BRANCH does not match package version $version." >&2
+            exit 1
+          fi
+          bundle_version="$(node --import ./scripts/ts-hook.mjs -e '
+            const { macOSBundleVersions } = await import("./scripts/macos-version.js");
+            console.log(macOSBundleVersions(process.argv[1]).buildVersion);
+          ' "$version")"
+          prerelease=false
+          if [[ "$version" == *-* ]]; then prerelease=true; fi
+          if [[ "$version" == *-alpha.* ]]; then
+            echo "Alpha builds are internal snapshots, not public releases." >&2
+            exit 1
+          fi
+          {
+            echo "version=$version"
+            echo "bundle-version=$bundle_version"
+            echo "tag=v$version"
+            echo "prerelease=$prerelease"
+          } >> "$GITHUB_OUTPUT"
+
   verify:
+    needs: source
     uses: ./.github/workflows/macos-verify.yml
     with:
       artifact-name: ""
 
   release-build:
-    if: github.ref == 'refs/heads/main'
-    needs: verify
+    needs: [source, verify]
     runs-on: macos-15
     timeout-minutes: 60
     environment: release
@@ -39,11 +91,11 @@ jobs:
       contents: read
     outputs:
       release-assets-name: ${{ steps.release-artifact.outputs.name }}
-      bundle-version: ${{ steps.version.outputs.bundle-version }}
+      bundle-version: ${{ needs.source.outputs.bundle-version }}
       client-generation: ${{ steps.official-client.outputs.fingerprint }}
-      prerelease: ${{ steps.version.outputs.prerelease }}
-      tag: ${{ steps.version.outputs.tag }}
-      version: ${{ steps.version.outputs.version }}
+      prerelease: ${{ needs.source.outputs.prerelease }}
+      tag: ${{ needs.source.outputs.tag }}
+      version: ${{ needs.source.outputs.version }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -62,25 +114,6 @@ jobs:
       - name: Install the pinned Rust toolchain
         run: rustup toolchain install
 
-      - name: Resolve release version
-        id: version
-        run: |
-          version="$(node -p "require('./package.json').version")"
-          bundle_version="$(node --import ./scripts/ts-hook.mjs -e '
-            const { macOSBundleVersions } = await import("./scripts/macos-version.js");
-            console.log(macOSBundleVersions(process.argv[1]).buildVersion);
-          ' "$version")"
-          prerelease=false
-          if [[ "$version" == *-* ]]; then prerelease=true; fi
-          if [[ "$version" == *-alpha.* ]]; then
-            echo "Alpha builds are internal snapshots, not public releases." >&2
-            exit 1
-          fi
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "bundle-version=$bundle_version" >> "$GITHUB_OUTPUT"
-          echo "tag=v$version" >> "$GITHUB_OUTPUT"
-          echo "prerelease=$prerelease" >> "$GITHUB_OUTPUT"
-
       # The same refusal the release job enforces before publishing, moved
       # ahead of the build so a forgotten version bump fails in seconds, not
       # after signing and notarization. This job's read-only token cannot see
@@ -89,7 +122,7 @@ jobs:
       - name: Refuse a version that already shipped
         env:
           GH_TOKEN: ${{ github.token }}
-          TAG: ${{ steps.version.outputs.tag }}
+          TAG: ${{ needs.source.outputs.tag }}
         run: |
           if gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             if [ "$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" \
@@ -305,8 +338,8 @@ jobs:
       - name: Prepare checksum-pinned release assets
         id: assets
         env:
-          VERSION: ${{ steps.version.outputs.version }}
-          TAG: ${{ steps.version.outputs.tag }}
+          VERSION: ${{ needs.source.outputs.version }}
+          TAG: ${{ needs.source.outputs.tag }}
         run: |
           asset_dir="$RUNNER_TEMP/release-assets"
           mkdir -p "$asset_dir"
@@ -362,7 +395,7 @@ jobs:
         env:
           ASSET_DIR: ${{ steps.assets.outputs.asset_dir }}
           DRY_RUN: ${{ inputs.dry_run }}
-          TAG: ${{ steps.version.outputs.tag }}
+          TAG: ${{ needs.source.outputs.tag }}
         run: |
           outcome="built, signed, notarized, stapled, and verified"
           if [ "$DRY_RUN" = "true" ]; then
@@ -429,7 +462,7 @@ jobs:
       - name: Prove beta data returns to latest Stable without signing secrets
         env:
           GH_TOKEN: ${{ github.token }}
-          VERSION: ${{ steps.version.outputs.version }}
+          VERSION: ${{ needs.source.outputs.version }}
           GW_SIGNED_CHANNEL: release
         run: |
           case "$VERSION" in
@@ -492,7 +525,7 @@ jobs:
   # eligible for the website or AppUpdater and gives the release approver one
   # checksum-pinned candidate to test before the separate publish decision.
   stage-release:
-    if: github.ref == 'refs/heads/main' && !inputs.dry_run
+    if: ${{ !inputs.dry_run }}
     needs: release-build
     runs-on: macos-15
     timeout-minutes: 15
@@ -668,7 +701,7 @@ jobs:
   # staged draft again and refuses if any asset or the human-owned Verification
   # record changed or is missing. It never rebuilds or re-uploads an asset.
   release:
-    if: github.ref == 'refs/heads/main' && !inputs.dry_run
+    if: ${{ !inputs.dry_run }}
     needs: [release-build, stage-release]
     runs-on: macos-15
     timeout-minutes: 15

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,34 @@ registry, or compatibility path, answer these questions:
 4. Which requirement needs the new concept?
 5. Which executable test proves that requirement?
 
+## Agent-first operating model
+
+Matthias coordinates the project. Agents execute repository work. Do not make
+him reconstruct repository state or guess the next command.
+
+For every task, an agent must:
+
+1. Inspect the current branch, worktree, recent commits, and applicable CI.
+2. Classify the task as normal development, release stabilization, or an
+   emergency Stable patch.
+3. Read the owning document and existing tests.
+4. State any assumption that changes scope or release risk.
+5. Implement the smallest complete outcome.
+6. Run focused checks, then the applicable local repository gate.
+7. Review the complete diff for unrelated changes and missing cleanup.
+8. Report the outcome, evidence, remaining risk, and one clear next action.
+
+Agents own investigation, implementation, automated verification, diff review,
+pull-request preparation, and CI diagnosis. Matthias owns product priority,
+live game QA, signing approval, publication approval, and release announcements.
+
+An agent must not claim that gameplay, graphics, input feel, or another live
+observation passed unless Matthias performed that check. Automation can report
+only the boundary it executed.
+
+See [Development and rollout](docs/development-workflow.md) for the complete
+branch and release model.
+
 ## Sources of truth
 
 Code and tests own exact schemas, values, hashes, limits, and accepted states.
@@ -155,6 +183,61 @@ Use offline fixtures for automated tests. Run a live ArenaNet check only when a
 local proof cannot establish the invariant. Keep the live check narrow and
 record what it proves.
 
+## Git and delivery
+
+Use one topic branch for one pull-request outcome. Match the existing prefixes,
+such as `feat/`, `fix/`, `refactor/`, `test/`, `docs/`, and `release/`.
+
+Normal feature and maintenance branches start from `main` and target `main`.
+Keep unfinished work on its branch. Do not merge incomplete code behind a
+hidden flag.
+
+Use `release/YYYY.M.PATCH` only for a planned release or emergency Stable patch.
+A planned release branch starts from one selected green `main` commit. An
+emergency release branch starts from the latest signed Stable tag. After the
+branch exists:
+
+- add no new feature;
+- accept only version changes and release blockers;
+- forward-port every release-only fix to `main`;
+- also forward-port an emergency fix to any active planned release branch; and
+- delete the release branch after publication and forward-porting.
+
+Do not create permanent `develop`, `next`, `beta`, or `stable` branches. The
+signed Stable tag is the production source. `main` can continue with completed
+future work while a release branch stabilizes.
+
+Use Conventional Commits. Keep commits atomic. Review staged changes before a
+commit and the complete branch diff before a pull request.
+
+Do not merge a pull request, delete a remote branch, create a tag, approve a
+protected environment, publish a release, deploy update feeds, or announce a
+release unless Matthias explicitly requests that action.
+
+When an agent prepares a pull request, it must:
+
+- update remote references;
+- compare the complete branch against its intended base;
+- confirm that the base matches the development or release path;
+- remove unrelated changes;
+- run the applicable verification;
+- use a concise Conventional Commit title; and
+- explain the outcome, invariant, tests, and rollout risk.
+
+### Rollout choice
+
+Do not publish a Beta for each feature. Use Developer Builds for individual
+feature testing. Use one Beta train for a risky group of completed changes.
+
+Require Beta consideration for persistence, migrations, accounts, Keychain,
+updates, signing, packaging, client certification, native transforms, input,
+controllers, rendering, reload, live observations, default-on behavior, or a
+multi-feature release. A narrow emergency compatibility fix can go directly to
+Stable after exact signed-draft QA.
+
+Only Matthias can accept the exact draft and choose Beta or Stable. An agent
+must present the risk and recommend one path.
+
 ## Verification
 
 Run the narrowest relevant proof while you work. Then run the repository gate
@@ -167,7 +250,12 @@ pnpm run check
 `pnpm run check` runs type checks, lint, Markdown links, unit tests, policy tests,
 and Tools unit tests. It does not build or open a window.
 
-Run the complete local application gate before a pull request:
+GitHub **Application verification** owns the complete macOS gate for a pull
+request. Wait for it, diagnose every failure, and require it to pass before
+merge.
+
+Run the complete gate locally when the change modifies CI, packaging, signing,
+or release behavior, or when CI cannot provide the required evidence:
 
 ```bash
 pnpm verify

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,17 @@ services with other players.
 
 Do not start a rewrite without agreement on the problem and scope.
 
+## Choose the correct branch
+
+Normal feature and maintenance pull requests target `main`. Keep incomplete
+work on its topic branch. A merge to `main` does not require an immediate app
+release.
+
+Only release stabilization and emergency Stable patches target a canonical
+`release/YYYY.M.PATCH` branch. Do not add a feature after a release branch is
+created. Read [Development and rollout](docs/development-workflow.md) before you
+prepare, fix, or publish a release.
+
 ## Report a bug
 
 In the app, select **Help → Report a Problem…**. Attach the exported diagnostics
@@ -86,7 +97,11 @@ Use `pnpm run check` while you work:
 pnpm run check
 ```
 
-Run the complete local gate before you open the pull request:
+GitHub **Application verification** runs the complete macOS gate for the pull
+request. Require it to pass before merge.
+
+Run the complete gate locally when you change CI, packaging, signing, or
+release behavior, or when CI cannot provide the required evidence:
 
 ```bash
 pnpm verify

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,7 @@ its rules.
 | How do client features remain safe across ArenaNet updates? | [ArenaNet compatibility](arenanet-compatibility.md) |
 | How does Trade Chat discovery work? | [Trade Chat discovery](trade-discovery.md) |
 | What can diagnostics record and export? | [Diagnostics](diagnostics.md) |
+| How do agents develop, branch, stabilize, and roll out changes? | [Development and rollout](development-workflow.md) |
 | How do I change or recertify an Enhancement? | [Enhancement development](enhancement-development.md) |
 | How are player skill cooldowns certified and displayed? | [Skill cooldowns](skill-cooldowns.md) |
 | What is the later research path for effects and debuffs? | [Future effect and debuff research](future-effect-durations.md) |

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -1,0 +1,160 @@
+# Development and rollout
+
+This document owns the branch model, agent workflow, release inclusion, and
+Stable/Beta rollout decision. [Release verification](release-verification.md)
+owns the exact signing, draft QA, and publication procedure.
+
+## Roles
+
+Matthias is the coordinator. He chooses the product outcome, performs live game
+QA, approves signing, and decides when to publish.
+
+Coding agents own repository execution. An agent investigates, implements,
+tests, reviews the complete diff, opens the pull request when requested, and
+diagnoses CI. An agent must give Matthias one clear next action when human input
+is required.
+
+Automation cannot claim that live gameplay passed. Only the coordinator can
+approve a result that requires an account, visual judgment, or player input.
+
+## Branches
+
+Use these branch types:
+
+| Branch | Purpose | Allowed work |
+| --- | --- | --- |
+| `main` | Completed future work | Reviewed features, fixes, and maintenance |
+| `feat/*`, `fix/*`, `refactor/*` | One pull request | The named change only |
+| `release/YYYY.M.PATCH` | One release line | Version changes and release blockers only |
+
+Do not create permanent `develop`, `next`, `beta`, or `stable` branches. A
+signed Stable tag is the source for an emergency patch. A release branch is
+temporary.
+
+`main` does not have to equal the latest public version. The signed Stable tag
+and its immutable assets are production truth.
+
+Keep at most one planned release branch. An emergency patch can temporarily add
+one more release branch based on the latest Stable tag.
+
+## Normal development
+
+1. Create one topic branch from `main`.
+2. Read the owning document and tests.
+3. Implement one complete outcome.
+4. Run focused tests and `pnpm run check` before the pull request.
+5. Review the complete diff against `origin/main`.
+6. Open the pull request and wait for **Application verification**.
+7. Diagnose every failure and require the selected CI path to pass.
+8. Merge only complete, safe work.
+
+Keep unfinished work on its topic branch. Do not merge incomplete code only to
+reduce branch drift. Do not add a hidden feature flag for unfinished code.
+
+A merge to `main` does not require an application release. Several completed
+changes can wait for one planned release.
+
+## Planned release
+
+1. Select one green commit on `main`.
+2. Create `release/YYYY.M.PATCH` at that commit.
+3. Change the version on the release branch.
+4. Stop adding features to that branch.
+5. Fix only release blockers on that branch.
+6. Forward-port each release-only fix to `main`.
+7. Run **Versioned release** from the release branch.
+8. Complete the exact-draft QA in
+   [Release verification](release-verification.md).
+9. Publish only after the coordinator records `Passed`.
+10. Delete the release branch after every fix is on `main`.
+
+New work can continue on `main` after the release branch is created. It cannot
+enter the staged release unless it is deliberately backported.
+
+## Emergency Stable patch
+
+Use this path when `main` contains work that must not ship:
+
+1. Start `release/YYYY.M.PATCH` from the latest Stable tag.
+2. Apply the smallest safe fix.
+3. Do not backport unrelated work from `main`.
+4. Run CI and exact signed-draft QA.
+5. Publish the Stable patch.
+6. Forward-port the fix to `main` and any active planned release branch.
+7. Delete the emergency release branch.
+
+An urgent, narrow compatibility repair does not require a Beta when the exact
+draft passes owned live QA. Do not use urgency to include unrelated changes.
+
+## Preview, Beta, and Stable
+
+Use three rollout rings:
+
+| Ring | Audience | Purpose |
+| --- | --- | --- |
+| Developer Build | Coordinator and one or two technical testers | Test one feature before a release line exists |
+| Beta | A small opt-in group | Test the real Release identity, updater, settings, saved login, and gameplay |
+| Stable | All players | Publish the accepted release |
+
+A Developer Build is not release evidence. It uses the Preview identity, has no
+public updater, and cannot prove saved-login continuity. It also uses the
+canonical user-data directory. Back up important player data before testing it.
+
+Beta is a release train, not a build for every feature. Combine completed work
+in one release branch, publish `YYYY.M.PATCH-beta.1`, fix blockers on that branch,
+then publish another Beta or the matching Stable version.
+
+Use Beta for changes to:
+
+- settings, migrations, or durable player data;
+- Multiple Accounts, saved login, or Keychain behavior;
+- updater, signing, packaging, or application identity;
+- native client certification or WASM transforms;
+- input, controllers, cursor, rendering, reload, or live observations;
+- behavior enabled by default; or
+- several substantial features released together.
+
+A direct Stable release is reasonable for:
+
+- an urgent and narrow ArenaNet compatibility patch;
+- a small host-only fix with strong automated evidence;
+- a low-risk presentation correction; or
+- another isolated change that passed exact signed-draft QA.
+
+RC remains supported but is exceptional. Use it only for a large release that
+needs a final code freeze after Beta.
+
+## Version lines
+
+Use one version line for a Beta train and its Stable result:
+
+```text
+2026.9.0-beta.1
+2026.9.0-beta.2
+2026.9.0
+```
+
+Keep the current Stable patch line free for emergency fixes:
+
+```text
+v2026.8.10 -> release/2026.8.11 -> 2026.8.11
+```
+
+Do not use the same future version for an unrelated Beta train and Stable
+hotfix. The updater compares versions, not their intended feature contents.
+
+## Agent release checklist
+
+Before an agent calls a commit release-ready, it must confirm:
+
+- the source branch is `main` or `release/YYYY.M.PATCH`;
+- the version and branch name agree for a release branch;
+- the branch head has green Application Verification;
+- the diff contains no unrelated feature work;
+- every release-only fix has a forward-port path;
+- the current ArenaNet generation has not changed unexpectedly;
+- the signed draft, not a local build, is ready for coordinator QA; and
+- publication still requires explicit coordinator approval.
+
+An agent must not merge, approve signing, mark live QA as passed, publish a
+release, or announce it without an explicit coordinator request.

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -74,7 +74,7 @@ Gatekeeper globally.
 
 Complete this checklist:
 
-- [ ] The release commit is on `main`.
+- [ ] The release commit is on `main` or `release/YYYY.M.PATCH`.
 - [ ] `package.json` contains the intended new version.
 - [ ] The version stage matches Stable, Beta, or RC intent.
 - [ ] The release workflow's exact ArenaNet qualification is green. A recent
@@ -94,7 +94,8 @@ Do not publish a new version only to test the release system. Use the dry run.
 
 ## Safe dry run
 
-Manually run **Versioned release** on `main` with `dry_run` set to `true`.
+Manually run **Versioned release** on the intended source branch with `dry_run`
+set to `true`. Use only `main` or `release/YYYY.M.PATCH`.
 
 This path runs the real verification, build, signing, notarization, stapling,
 and package checks. It skips the GitHub mutation jobs.
@@ -120,7 +121,8 @@ Do not change secrets or add another signing path to bypass the failure.
 
 ## Real release flow
 
-Run **Versioned release** on `main` with `dry_run` set to `false`.
+Run **Versioned release** on the exact branch whose dry run passed, with
+`dry_run` set to `false`.
 
 The workflow has two decisions:
 
@@ -169,6 +171,10 @@ Close the installed application, then run:
 ```bash
 pnpm release:test <tag>
 ```
+
+The command can run from any local branch. It verifies the draft's exact target
+commit, assets, signatures, and Verification record. It does not use the local
+checkout as release authority.
 
 The command downloads every exact draft asset, verifies its checksums, GitHub
 attestations, versions, Release identity, signature, entitlements,

--- a/scripts/test-draft-release.ts
+++ b/scripts/test-draft-release.ts
@@ -199,17 +199,14 @@ function readDraft(
 export function assertDraftMetadata(
   tag: string,
   draft: DraftRelease,
-  mainCommit: string,
   releaseTag: ReleaseTag,
 ): void {
   if (!draft.isDraft) throw new Error(`${tag} is not a draft release`);
   if (draft.isPrerelease !== releaseTag.prerelease) {
     throw new Error(`${tag} has inconsistent GitHub prerelease metadata`);
   }
-  if (draft.targetCommitish !== mainCommit) {
-    throw new Error(
-      `${tag} targets ${draft.targetCommitish}, not current main ${mainCommit}`,
-    );
+  if (!/^[0-9a-f]{40}$/u.test(draft.targetCommitish)) {
+    throw new Error(`${tag} does not target one exact commit`);
   }
   const actual = draft.assets.map(({ name }) => name).sort();
   const expected = expectedAssets(releaseTag.version);
@@ -232,13 +229,8 @@ export async function runDraftReleaseTest(
     throw new Error(`${dependencies.installedApp} is not installed`);
   }
   dependencies.run("gh", ["auth", "status"]);
-  if (dependencies.run("git", ["branch", "--show-current"]) !== "main") {
-    throw new Error("release:test must run from the main branch");
-  }
-
-  const mainCommit = dependencies.run("git", ["rev-parse", "HEAD"]);
   const draft = readDraft(dependencies, tag);
-  assertDraftMetadata(tag, draft, mainCommit, releaseTag);
+  assertDraftMetadata(tag, draft, releaseTag);
   const expectedBundle = macOSBundleVersions(releaseTag.version);
   const installedBundle = plist(
     dependencies,
@@ -309,7 +301,7 @@ export async function runDraftReleaseTest(
     }
 
     const latest = readDraft(dependencies, tag);
-    assertDraftMetadata(tag, latest, mainCommit, releaseTag);
+    assertDraftMetadata(tag, latest, releaseTag);
     const record = parseVerificationRecord(latest.body);
     const downloadedChecksums = readFileSync(
       path.join(temporary, "SHA256SUMS.txt"),

--- a/tests/policy/release-workflow-policy.test.ts
+++ b/tests/policy/release-workflow-policy.test.ts
@@ -23,11 +23,25 @@ test("release workflow stages and publishes one tested, attested package version
   const feedWorkflow = read(".github/workflows/update-feeds.yml");
   const verification = read(".github/workflows/macos-verify.yml");
   assert.match(workflow, /uses: \.\/\.github\/workflows\/macos-verify\.yml/);
+  assert.match(
+    workflow,
+    /source:[\s\S]*outputs:[\s\S]*steps\.release-source\.outputs\.version[\s\S]*name: Resolve and validate the release source[\s\S]*SOURCE_BRANCH: \$\{\{ github\.ref_name \}\}[\s\S]*SOURCE_TYPE: \$\{\{ github\.ref_type \}\}[\s\S]*\^release\/\[0-9\]\{4\}/,
+  );
+  assert.match(workflow, /verify:\n {4}needs: source/);
+  assert.match(workflow, /release-build:\n {4}needs: \[source, verify\]/);
   assert.match(verification, /runs-on: macos-15/);
   assert.match(verification, /test "\$\(uname -m\)" = "arm64"/);
   assert.match(workflow, /test "\$\(uname -m\)" = "arm64"/);
   assert.match(workflow, /persist-credentials: false/);
   assert.match(workflow, /require\('\.\/package\.json'\)\.version/);
+  assert.match(
+    workflow,
+    /release_line="\$\{version%%-\*\}"[\s\S]*\$SOURCE_BRANCH" == release\/\*[\s\S]*\$\{SOURCE_BRANCH#release\/\}" != "\$release_line"[\s\S]*does not match package version/,
+  );
+  assert.match(
+    workflow,
+    /release-build:[\s\S]*bundle-version: \$\{\{ needs\.source\.outputs\.bundle-version \}\}[\s\S]*version: \$\{\{ needs\.source\.outputs\.version \}\}/,
+  );
   assert.match(workflow, /git\/ref\/tags\/\$TAG/);
   assert.match(
     workflow,
@@ -191,14 +205,8 @@ test("release workflow stages and publishes one tested, attested package version
   // build or package-verification step may branch around work for a dry run.
   // The build records what it produced where skipped jobs cannot hide it.
   assert.match(workflow, /workflow_dispatch:\n {4}inputs:\n {6}dry_run:/);
-  assert.match(
-    releaseStage,
-    /stage-release:\n {4}if: github\.ref == 'refs\/heads\/main' && !inputs\.dry_run/,
-  );
-  assert.match(
-    releasePublish,
-    /release:\n {4}if: github\.ref == 'refs\/heads\/main' && !inputs\.dry_run/,
-  );
+  assert.match(releaseStage, /stage-release:\n {4}if: \$\{\{ !inputs\.dry_run \}\}/);
+  assert.match(releasePublish, /release:\n {4}if: \$\{\{ !inputs\.dry_run \}\}/);
   assert.equal(workflow.match(/if: [^\n]*dry_run/gu)?.length, 2);
   assert.match(
     releaseBuild,

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -322,7 +322,10 @@ test("application verification routes conservatively through one required result
   const classifier = read("scripts/ci-impact.ts");
 
   assert.match(workflow, /name: Application verification/);
-  assert.match(workflow, /pull_request:\n {2}push:\n {4}branches: \[main\]/);
+  assert.match(
+    workflow,
+    /pull_request:\n {2}push:\n {4}branches:\n {6}- main\n {6}- "release\/\*\*"/,
+  );
   assert.match(workflow, /workflow_dispatch:[\s\S]*checkout_ref:[\s\S]*pr_number:/);
   assert.doesNotMatch(workflow, /paths:|paths-ignore:/);
   assert.match(workflow, /permissions:\n {2}contents: read/);
@@ -458,7 +461,7 @@ test("developer builds are exact, ad-hoc, bounded, and isolated from releases", 
   assert.doesNotMatch(release, /pull_request:|push:/);
   assert.match(
     release,
-    /release-build:\n {4}if: github\.ref == 'refs\/heads\/main'\n {4}needs: verify/,
+    /name: Resolve and validate the release source[\s\S]*\^release\/\[0-9\]\{4\}[\s\S]*release-build:\n {4}needs: \[source, verify\]/,
   );
 
   // Developer dispatch is possible only from the trusted main workflow. The

--- a/tests/unit/test-draft-release.test.ts
+++ b/tests/unit/test-draft-release.test.ts
@@ -80,7 +80,6 @@ function fixture(): Fixture {
     if (failure === "auth" && call.startsWith("gh auth status")) {
       throw new Error("expired GitHub login");
     }
-    if (command === "git") return args[0] === "branch" ? "main" : COMMIT;
     if (command === "/usr/libexec/PlistBuddy") {
       const key = args[1];
       const application = args[2] ?? "";
@@ -192,7 +191,6 @@ describe("temporary exact-draft testing", () => {
           targetCommitish: COMMIT,
           assets: expectedAssets("2026.8.8-beta.1").map((name) => ({ name })),
         },
-        COMMIT,
         releaseTag,
       ),
       /inconsistent GitHub prerelease metadata/u,
@@ -209,12 +207,20 @@ describe("temporary exact-draft testing", () => {
       assets: expectedAssets(VERSION).map((name) => ({ name })),
     };
     assert.throws(
-      () => assertDraftMetadata(TAG, { ...valid, isDraft: false }, COMMIT, releaseTag),
+      () => assertDraftMetadata(TAG, { ...valid, isDraft: false }, releaseTag),
       /not a draft/u,
     );
     assert.throws(
-      () => assertDraftMetadata(TAG, { ...valid, assets: [] }, COMMIT, releaseTag),
+      () => assertDraftMetadata(TAG, { ...valid, assets: [] }, releaseTag),
       /unexpected release assets/u,
+    );
+    assert.throws(
+      () => assertDraftMetadata(
+        TAG,
+        { ...valid, targetCommitish: "release/2026.8.8" },
+        releaseTag,
+      ),
+      /one exact commit/u,
     );
   });
 
@@ -225,6 +231,7 @@ describe("temporary exact-draft testing", () => {
       assert.deepEqual(readdirSync(test.temporaryParent), []);
       assert.match(test.editedBody() ?? "", /Status: `Passed`/u);
       assert.ok(test.calls.some((call) => call.startsWith("open -n ")));
+      assert.equal(test.calls.some((call) => call.startsWith("git ")), false);
     } finally {
       test.close();
     }


### PR DESCRIPTION
## What changed

New features on `main` could become inseparable from an urgent Stable repair. This made release scope depend on whatever had merged most recently.

Temporary `release/YYYY.M.PATCH` branches are now first-class, verified release sources. Normal development can continue on `main` while one selected commit stabilizes independently. Exact-draft QA now trusts the draft's immutable commit instead of the maintainer's current local branch.

The agent handbook now gives one concise operating model for development, release stabilization, emergency patches, Beta trains, testing, and human approval.

## Why

Matthias coordinates the project while coding agents own implementation, review, verification, and CI diagnosis. The repository therefore needs executable release boundaries and a single agent-readable procedure, rather than relying on remembered steps during an emergency.

## Invariant

- Versioned releases accept only `main` or `release/YYYY.M.PATCH`.
- A release branch must match the package version before expensive macOS verification starts.
- Application Verification runs on pushes to both `main` and `release/**`.
- Draft QA requires one exact commit but does not depend on the local checkout.
- Only Matthias can accept live QA, approve publication, or announce a release.

## Delivery

- Target: `main`
- Rollout: no application release required
- Risk: CI and release orchestration only; no application runtime behavior changes

## Verification

- `pnpm run check`
- `pnpm verify`
- `actionlint -ignore SC2035 .github/workflows/release.yml .github/workflows/pr-package.yml`
- Focused draft-release and release-policy tests: 34 passed
- Full Electron gate: 165 passed, one expected live-client test skipped
- Packaged application smoke and packaged Enhancement runtime passed
- GitHub Application Verification and every CodeQL lane passed. The first macOS attempt lost one isolated Electron test context before setup; its failed-job rerun passed the complete gate.

Implemented and reviewed with Codex. The repository's local test harness produced the verification evidence above; no live gameplay result is claimed.

- [x] I kept this pull request focused.
- [x] I ran the relevant checks.
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [x] I updated documentation when behavior or an invariant changed.
