### PR TITLE
ci(release): reuse protected branch verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
-# The only path to a public versioned release: dispatched by hand from main or
-# one canonical release branch, and gated on the approval environment holding
-# the Developer ID material.
+# The only path to a public versioned release: dispatched by hand from one
+# canonical release branch and gated on the approval environment holding the
+# Developer ID material.
 name: Versioned release
 
 on:
@@ -17,6 +17,7 @@ on:
         type: boolean
 
 permissions:
+  checks: read
   contents: read
 
 concurrency:
@@ -46,15 +47,13 @@ jobs:
           SOURCE_TYPE: ${{ github.ref_type }}
         run: |
           test "$SOURCE_TYPE" = "branch"
-          if [ "$SOURCE_BRANCH" != "main" ] \
-            && ! [[ "$SOURCE_BRANCH" =~ ^release/[0-9]{4}\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
-            echo "Release from main or release/YYYY.M.PATCH, not $SOURCE_BRANCH." >&2
+          if ! [[ "$SOURCE_BRANCH" =~ ^release/[0-9]{4}\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]; then
+            echo "Release from release/YYYY.M.PATCH, not $SOURCE_BRANCH." >&2
             exit 1
           fi
           version="$(node -p "require('./package.json').version")"
           release_line="${version%%-*}"
-          if [[ "$SOURCE_BRANCH" == release/* ]] \
-            && [ "${SOURCE_BRANCH#release/}" != "$release_line" ]; then
+          if [ "${SOURCE_BRANCH#release/}" != "$release_line" ]; then
             echo "Release branch $SOURCE_BRANCH does not match package version $version." >&2
             exit 1
           fi
@@ -75,14 +74,30 @@ jobs:
             echo "prerelease=$prerelease"
           } >> "$GITHUB_OUTPUT"
 
-  verify:
-    needs: source
-    uses: ./.github/workflows/macos-verify.yml
-    with:
-      artifact-name: ""
+      # The protected source branch already ran Application verification for
+      # this exact commit. Reuse that result instead of repeating the complete
+      # macOS gate. The release build still owns current-client qualification,
+      # signing, notarization, and packaged runtime checks.
+      - name: Require green Application verification for this commit
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          passed="$(gh api \
+            "repos/$GITHUB_REPOSITORY/commits/$GITHUB_SHA/check-runs?filter=latest&per_page=100" \
+            --jq '[.check_runs[] | select(
+              .name == "verify / verify"
+              and .app.slug == "github-actions"
+              and .status == "completed"
+              and .conclusion == "success"
+            )] | length')"
+          if [ "$passed" -lt 1 ]; then
+            echo "Application verification has not passed for $GITHUB_SHA." >&2
+            echo "Wait for verify / verify on the release branch, then run this workflow again." >&2
+            exit 1
+          fi
 
   release-build:
-    needs: [source, verify]
+    needs: source
     runs-on: macos-15
     timeout-minutes: 60
     environment: release

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -58,15 +58,17 @@ changes can wait for one planned release.
 
 1. Select one green commit on `main`.
 2. Create `release/YYYY.M.PATCH` at that commit.
-3. Change the version on the release branch.
-4. Stop adding features to that branch.
-5. Fix only release blockers on that branch.
-6. Forward-port each release-only fix to `main`.
-7. Run **Versioned release** from the release branch.
-8. Complete the exact-draft QA in
+3. Open a version-change pull request against the release branch.
+4. Merge it only after **Application verification** passes.
+5. Stop adding features to that branch.
+6. Fix release blockers through focused pull requests against that branch.
+7. Forward-port each release-only fix to `main`.
+8. Wait for **Application verification** on the release branch.
+9. Run **Versioned release** from the release branch.
+10. Complete the exact-draft QA in
    [Release verification](release-verification.md).
-9. Publish only after the coordinator records `Passed`.
-10. Delete the release branch after every fix is on `main`.
+11. Publish only after the coordinator records `Passed`.
+12. Delete the release branch after every fix is on `main`.
 
 New work can continue on `main` after the release branch is created. It cannot
 enter the staged release unless it is deliberately backported.
@@ -76,12 +78,13 @@ enter the staged release unless it is deliberately backported.
 Use this path when `main` contains work that must not ship:
 
 1. Start `release/YYYY.M.PATCH` from the latest Stable tag.
-2. Apply the smallest safe fix.
-3. Do not backport unrelated work from `main`.
-4. Run CI and exact signed-draft QA.
-5. Publish the Stable patch.
-6. Forward-port the fix to `main` and any active planned release branch.
-7. Delete the emergency release branch.
+2. Apply the smallest safe fix on a topic branch.
+3. Open a pull request against the emergency release branch.
+4. Do not backport unrelated work from `main`.
+5. Run CI and exact signed-draft QA.
+6. Publish the Stable patch.
+7. Forward-port the fix to `main` and any active planned release branch.
+8. Delete the emergency release branch.
 
 An urgent, narrow compatibility repair does not require a Beta when the exact
 draft passes owned live QA. Do not use urgency to include unrelated changes.
@@ -147,7 +150,7 @@ hotfix. The updater compares versions, not their intended feature contents.
 
 Before an agent calls a commit release-ready, it must confirm:
 
-- the source branch is `main` or `release/YYYY.M.PATCH`;
+- the source branch is `release/YYYY.M.PATCH`;
 - the version and branch name agree for a release branch;
 - the branch head has green Application Verification;
 - the diff contains no unrelated feature work;
@@ -158,3 +161,19 @@ Before an agent calls a commit release-ready, it must confirm:
 
 An agent must not merge, approve signing, mark live QA as passed, publish a
 release, or announce it without an explicit coordinator request.
+
+## GitHub enforcement
+
+Repository settings enforce the model outside the codebase:
+
+- `main` requires the `verify / verify` check and linear history;
+- the `Protect release branches` ruleset applies the same requirements to
+  `release/*` and refuses force-pushes;
+- the `release` environment accepts `main` and `release/*`; and
+- the `release` environment requires Matthias's approval and does not allow an
+  administrator bypass.
+
+The Versioned release workflow accepts only `release/YYYY.M.PATCH`. It reuses
+the exact commit's required Application verification result. It does not rerun
+that complete macOS gate. The signed build still qualifies the current ArenaNet
+client and runs the release-only package, Keychain, and updater checks.

--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -74,7 +74,7 @@ Gatekeeper globally.
 
 Complete this checklist:
 
-- [ ] The release commit is on `main` or `release/YYYY.M.PATCH`.
+- [ ] The release commit is on `release/YYYY.M.PATCH`.
 - [ ] `package.json` contains the intended new version.
 - [ ] The version stage matches Stable, Beta, or RC intent.
 - [ ] The release workflow's exact ArenaNet qualification is green. A recent
@@ -94,11 +94,12 @@ Do not publish a new version only to test the release system. Use the dry run.
 
 ## Safe dry run
 
-Manually run **Versioned release** on the intended source branch with `dry_run`
-set to `true`. Use only `main` or `release/YYYY.M.PATCH`.
+Wait for **Application verification** to pass on the release branch. Then run
+**Versioned release** on that branch with `dry_run` set to `true`.
 
-This path runs the real verification, build, signing, notarization, stapling,
-and package checks. It skips the GitHub mutation jobs.
+This path reuses Application verification for the exact source commit. It then
+runs the release-only current-client qualification, build, signing,
+notarization, stapling, and package checks. It skips the GitHub mutation jobs.
 
 Immediately before packaging, the workflow downloads the current verified
 ArenaNet JS/WASM pair. It runs the runtime feature verifier, every transform

--- a/tests/policy/release-workflow-policy.test.ts
+++ b/tests/policy/release-workflow-policy.test.ts
@@ -22,13 +22,18 @@ test("release workflow stages and publishes one tested, attested package version
   const workflow = read(".github/workflows/release.yml");
   const feedWorkflow = read(".github/workflows/update-feeds.yml");
   const verification = read(".github/workflows/macos-verify.yml");
-  assert.match(workflow, /uses: \.\/\.github\/workflows\/macos-verify\.yml/);
+  assert.doesNotMatch(workflow, /uses: \.\/\.github\/workflows\/macos-verify\.yml/);
   assert.match(
     workflow,
     /source:[\s\S]*outputs:[\s\S]*steps\.release-source\.outputs\.version[\s\S]*name: Resolve and validate the release source[\s\S]*SOURCE_BRANCH: \$\{\{ github\.ref_name \}\}[\s\S]*SOURCE_TYPE: \$\{\{ github\.ref_type \}\}[\s\S]*\^release\/\[0-9\]\{4\}/,
   );
-  assert.match(workflow, /verify:\n {4}needs: source/);
-  assert.match(workflow, /release-build:\n {4}needs: \[source, verify\]/);
+  assert.doesNotMatch(workflow, /\n {2}verify:/);
+  assert.match(workflow, /release-build:\n {4}needs: source/);
+  assert.match(workflow, /checks: read/);
+  assert.match(
+    workflow,
+    /name: Require green Application verification for this commit[\s\S]*check-runs\?filter=latest&per_page=100[\s\S]*\.name == "verify \/ verify"[\s\S]*\.app\.slug == "github-actions"[\s\S]*\.conclusion == "success"/,
+  );
   assert.match(verification, /runs-on: macos-15/);
   assert.match(verification, /test "\$\(uname -m\)" = "arm64"/);
   assert.match(workflow, /test "\$\(uname -m\)" = "arm64"/);
@@ -36,7 +41,7 @@ test("release workflow stages and publishes one tested, attested package version
   assert.match(workflow, /require\('\.\/package\.json'\)\.version/);
   assert.match(
     workflow,
-    /release_line="\$\{version%%-\*\}"[\s\S]*\$SOURCE_BRANCH" == release\/\*[\s\S]*\$\{SOURCE_BRANCH#release\/\}" != "\$release_line"[\s\S]*does not match package version/,
+    /release_line="\$\{version%%-\*\}"[\s\S]*\$\{SOURCE_BRANCH#release\/\}" != "\$release_line"[\s\S]*does not match package version/,
   );
   assert.match(
     workflow,

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -401,8 +401,9 @@ test("developer builds are exact, ad-hoc, bounded, and isolated from releases", 
     ".github/ISSUE_TEMPLATE/developer-build-feedback.yml",
   );
 
-  // One read-only verification path owns PR, manual developer, and release
-  // gates. No publishing permission reaches that reusable workflow.
+  // One read-only verification path owns PR and manual developer gates. The
+  // release workflow reuses its exact-commit result. No publishing permission
+  // reaches the reusable workflow.
   assert.match(verification, /workflow_call:/);
   assert.match(verification, /permissions:\n {2}contents: read/);
   assert.doesNotMatch(
@@ -461,8 +462,9 @@ test("developer builds are exact, ad-hoc, bounded, and isolated from releases", 
   assert.doesNotMatch(release, /pull_request:|push:/);
   assert.match(
     release,
-    /name: Resolve and validate the release source[\s\S]*\^release\/\[0-9\]\{4\}[\s\S]*release-build:\n {4}needs: \[source, verify\]/,
+    /name: Resolve and validate the release source[\s\S]*\^release\/\[0-9\]\{4\}[\s\S]*name: Require green Application verification for this commit[\s\S]*release-build:\n {4}needs: source/,
   );
+  assert.doesNotMatch(release, /uses: \.\/\.github\/workflows\/macos-verify\.yml/);
 
   // Developer dispatch is possible only from the trusted main workflow. The
   // selected source is an exact commit, and the workflow stops at an ad-hoc


### PR DESCRIPTION
The new release-branch model was merged, but the versioned release still repeated the full macOS application gate and still allowed `main` as a release source. That kept roughly nine minutes of duplicate work and left two valid release paths.

This change makes `release/YYYY.M.PATCH` the only versioned-release source. The workflow requires the exact branch commit's successful `verify / verify` check, then proceeds directly to the release-only work: current ArenaNet qualification, signing, notarization, packaged runtime checks, Keychain continuity, draft QA, and publication approvals.

Repository settings were aligned during rollout:

- `release/*` now has an active ruleset requiring linear history, no force-pushes, and `verify / verify` from GitHub Actions.
- `release/*` is allowed to use the existing protected `release` environment.
- Temporary release branches remain deletable after publication and forward-porting.

## Verification

- `pnpm run check` passed.
- Policy suite passed: 184 tests.
- `actionlint -ignore SC2035 .github/workflows/release.yml .github/workflows/pr-package.yml` passed.
- The exact GitHub check-run query was validated against real repository data and correctly refused a queued result.
- `pnpm verify` completed all pre-Electron layers; 164 Electron tests passed, one live-client test skipped, and one unrelated native pointer-lock focus test timed out once.
- The failed pointer-lock test then passed three consecutive isolated reruns.

CI remains the merge gate and will run the complete macOS application verification for this exact commit.

## Rollout risk

Low and contained to release orchestration. No application runtime, signing identity, release asset, updater feed, or certification behavior changes. The workflow now reuses evidence from the protected branch instead of recreating it.

Prepared with Codex GPT-5.6.
