### PR TITLE
chore(release): prepare version 2026.9.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "guild-wars",
   "productName": "Guild Wars Reforged",
-  "version": "2026.8.10",
+  "version": "2026.9.0-beta.1",
   "private": true,
   "packageManager": "pnpm@11.13.1",
   "type": "module",


### PR DESCRIPTION
The first public Beta for the September release train needs a release identity that is distinct from Stable `2026.8.10`.

This changes only the application version to `2026.9.0-beta.1`. The frozen release branch contains the reviewed early-game Travel catalogue from PR #325 and no additional feature work.

## Invariant

The version's base line matches `release/2026.9.0`, and the prerelease suffix makes the workflow stage it on the Beta channel.

## Verification

- `pnpm run check`
- 1,360 unit tests passed
- 184 policy tests passed
- 139 Tools tests passed

## Rollout risk

Low. This commit changes only package metadata. Signing, packaging, current-client qualification, Stable/Beta round-trip checks, and exact-draft QA remain owned by the Versioned release workflow.

Prepared with Codex.
