### PR TITLE
fix(release): respect library gate in rollback proof

### DIFF
--- a/scripts/verify-stable-beta-roundtrip.ts
+++ b/scripts/verify-stable-beta-roundtrip.ts
@@ -540,16 +540,14 @@ async function proveToolsRoundTrip(toolsCohort: Cohort): Promise<void> {
   // on whether both packaged versions read the exact same durable shape.
   await publishWindowSize(toolsCohort, 1_000, 700);
   await withPackagedApp(toolsCohort, stablePath, async (running) => {
-    const stableInitial = await readToolsCanonical(running.page);
-    assert.equal(
-      canonicalizeStableSettings(stableInitial.settings, { disk: false }).buildLibrary,
-      false,
-      "latest Stable lost the legacy Apply-Team opt-out before upgrade",
+    const stableInitialSettings = canonicalizeStableSettings(
+      await running.page.evaluate(() => window.gwNative.settings.get()),
+      { disk: false },
     );
     assert.equal(
-      stableInitial.recovered,
+      stableInitialSettings.buildLibrary,
       false,
-      "latest Stable recovered its fresh build library before the round-trip",
+      "latest Stable lost the legacy Apply-Team opt-out before upgrade",
     );
     const launchedStableVersion = (await running.page.evaluate(
       () => window.gwNative.appUpdates.getState(),
@@ -567,10 +565,17 @@ async function proveToolsRoundTrip(toolsCohort: Cohort): Promise<void> {
         uiStyle: "obsidian",
         uiPanelOpacity: 88,
         updateTrack: "beta",
+        buildLibrary: true,
       })
     ), { disk: false });
     assert.equal(stableSettings.updateTrack, "beta", "latest Stable lacks the Beta enabler");
-    assert.equal(stableSettings.buildLibrary, false, "latest Stable enabled Apply Team while saving");
+    assert.equal(stableSettings.buildLibrary, true, "latest Stable did not enable Build Library");
+    const stableTools = await readToolsCanonical(running.page);
+    assert.equal(
+      stableTools.recovered,
+      false,
+      "latest Stable recovered its fresh build library before the round-trip",
+    );
     assert.deepEqual(
       await running.page.evaluate((library) => {
         const api = window.gwNative;
@@ -601,7 +606,7 @@ async function proveToolsRoundTrip(toolsCohort: Cohort): Promise<void> {
     assert.equal(candidateInitial.recovered, false);
     assert.equal(candidateInitialSettings.updateTrack, "beta");
     assert.equal(candidateInitialSettings.uiPanelOpacity, 88);
-    assert.equal(candidateInitialSettings.buildLibrary, false);
+    assert.equal(candidateInitialSettings.buildLibrary, true);
     assert.deepEqual(candidateInitial.library, initialLibrary);
     await assertWindowMatchesPersistedState(candidateWindowState, running.page);
     await roundTripProfileStore(running.page, "stable-template", "candidate-template");
@@ -609,13 +614,14 @@ async function proveToolsRoundTrip(toolsCohort: Cohort): Promise<void> {
       async ({ settings, library }) => {
         const api = window.gwNative;
         if (!("buildLibrary" in api)) throw new Error("Tools preload is unavailable");
-        await api.settings.set(settings);
         await api.buildLibrary.set(library);
+        await api.settings.set(settings);
       },
       {
         settings: {
           showDiagnostics: true,
           uiPanelOpacity: 87,
+          buildLibrary: false,
         } satisfies Partial<AppSettings>,
         library: candidateLibrary,
       },
@@ -644,15 +650,19 @@ async function proveToolsRoundTrip(toolsCohort: Cohort): Promise<void> {
       stableVersion,
       "the return launch did not use the exact Stable baseline",
     );
-    const returned = await readToolsCanonical(running.page);
-    const returnedSettings = canonicalizeStableSettings(returned.settings, { disk: false });
-    assert.equal(returned.recovered, false);
-    assert.equal(returnedSettings.buildLibrary, false, "rollback Stable enabled Apply Team");
+    const returnedSettings = canonicalizeStableSettings(
+      await running.page.evaluate(() => window.gwNative.settings.get()),
+      { disk: false },
+    );
+    assert.equal(returnedSettings.buildLibrary, false, "rollback Stable lost the opt-out");
     assert.deepEqual(
       returnedSettings,
       validateCandidateSettings(candidateSettingsDocument, { disk: true }),
       "Stable did not read every candidate-written settings value",
     );
+    await running.page.evaluate(() => window.gwNative.settings.set({ buildLibrary: true }));
+    const returned = await readToolsCanonical(running.page);
+    assert.equal(returned.recovered, false);
     assert.deepEqual(returned.library, candidateLibrary);
     await assertWindowMatchesPersistedState(rollbackWindowState, running.page);
     await roundTripProfileStore(running.page, "candidate-template", "stable-return-template");
@@ -660,26 +670,28 @@ async function proveToolsRoundTrip(toolsCohort: Cohort): Promise<void> {
       async ({ settings, library }) => {
         const api = window.gwNative;
         if (!("buildLibrary" in api)) throw new Error("Tools preload is unavailable");
-        await api.settings.set(settings);
         await api.buildLibrary.set(library);
+        await api.settings.set(settings);
       },
       {
         settings: {
           showDiagnostics: false,
           updateTrack: "stable",
+          buildLibrary: false,
         } satisfies Partial<AppSettings>,
         library: finalLibrary,
       },
     );
-    const final = await readToolsCanonical(running.page);
-    const finalSettings = canonicalizeStableSettings(final.settings, { disk: false });
+    const finalSettings = canonicalizeStableSettings(
+      await running.page.evaluate(() => window.gwNative.settings.get()),
+      { disk: false },
+    );
     assert.equal(finalSettings.buildLibrary, false, "Stable save enabled Apply Team");
     assert.deepEqual(
       finalSettings,
       expectedFinalSettings,
       "Stable lost candidate-written settings while saving its own patch",
     );
-    assert.deepEqual(final.library, finalLibrary);
   });
 
   const names = await readdir(toolsCohort.userData);

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -276,23 +276,60 @@ test("release entitlements are an exact three-key allowlist", () => {
 });
 
 
-test("the Stable rollback proof establishes its write generation before saving", () => {
+test("the Stable rollback proof respects the Build Library feature gate", () => {
   const roundTrip = read("scripts/verify-stable-beta-roundtrip.ts");
   const stableCreation = roundTrip.indexOf(
     'console.log("stable/beta compatibility: latest Stable creates canonical state")',
   );
-  const baselineRead = roundTrip.indexOf(
-    "await readToolsCanonical(running.page)",
+  const legacyOptOut = roundTrip.indexOf(
+    "stableInitialSettings.buildLibrary",
     stableCreation,
+  );
+  const stableEnable = roundTrip.indexOf("buildLibrary: true", legacyOptOut);
+  const baselineRead = roundTrip.indexOf(
+    "const stableTools = await readToolsCanonical(running.page)",
+    stableEnable,
   );
   const firstLibraryWrite = roundTrip.indexOf(
     "api.buildLibrary.set(library)",
-    stableCreation,
+    baselineRead,
+  );
+  const candidatePhase = roundTrip.indexOf(
+    'console.log("stable/beta compatibility: candidate reads, modifies, and writes")',
+  );
+  const candidateLibraryWrite = roundTrip.indexOf(
+    "api.buildLibrary.set(library)",
+    candidatePhase,
+  );
+  const candidateOptOut = roundTrip.indexOf(
+    "buildLibrary: false",
+    candidateLibraryWrite,
+  );
+  const rollbackPhase = roundTrip.indexOf(
+    'console.log("stable/beta compatibility: the same Stable reads and writes again")',
+  );
+  const rollbackOptOut = roundTrip.indexOf("returnedSettings.buildLibrary", rollbackPhase);
+  const rollbackEnable = roundTrip.indexOf(
+    "settings.set({ buildLibrary: true })",
+    rollbackOptOut,
+  );
+  const rollbackLibraryRead = roundTrip.indexOf(
+    "const returned = await readToolsCanonical(running.page)",
+    rollbackEnable,
   );
 
   assert.ok(stableCreation >= 0);
-  assert.ok(baselineRead > stableCreation);
+  assert.ok(legacyOptOut > stableCreation);
+  assert.ok(stableEnable > legacyOptOut);
+  assert.ok(baselineRead > stableEnable);
   assert.ok(firstLibraryWrite > baselineRead);
+  assert.ok(candidatePhase > firstLibraryWrite);
+  assert.ok(candidateLibraryWrite > candidatePhase);
+  assert.ok(candidateOptOut > candidateLibraryWrite);
+  assert.ok(rollbackPhase > candidateOptOut);
+  assert.ok(rollbackOptOut > rollbackPhase);
+  assert.ok(rollbackEnable > rollbackOptOut);
+  assert.ok(rollbackLibraryRead > rollbackEnable);
   assert.match(roundTrip, /saveWindowState\(cohort\.windowStatePath/);
   assert.doesNotMatch(
     roundTrip,


### PR DESCRIPTION
The Beta dry run exposed a latent contradiction in the Stable/Beta rollback proof: it tested the disabled Build Library setting and then called the gated library API. PR #329 fixed the protected release branch; this required forward-port keeps `main` as the source of truth.

The proof now checks disabled migration without library access, explicitly enables the feature for each data read or write, and restores the disabled setting afterward. A policy test pins this ordering.

Verification:

- Exact patch from green release PR #329
- focused policy test: 21 passed
- `pnpm run check` passed on the release-fix branch
