### PR TITLE
fix(travel): keep early-game catalogues local

### DIFF
--- a/apps/tools/src/components/TravelPalette.test.ts
+++ b/apps/tools/src/components/TravelPalette.test.ts
@@ -218,13 +218,16 @@ describe("TravelPalette", () => {
     wrapper.unmount();
   });
 
-  it("shows every unlocked destination before typing when the catalogue is small", async () => {
+  it("shows every local unlocked destination when cross-campaign unlocks make the account catalogue large", async () => {
     const shortcuts: TravelShortcuts = [
       { mapId: 164 }, null, null, null, null, null, null, null, null,
     ];
     const { wrapper, state, travel } = fixture({ history: [164, 165], shortcuts });
     const unlockedMapWords = Array.from({ length: 28 }, () => 0);
     for (const mapId of [148, 164, 165, 166, 163, 778]) {
+      unlockedMapWords[Math.floor(mapId / 32)]! |= 1 << (mapId % 32);
+    }
+    for (const mapId of [188, 248, 281, 282, 330, 368, 467, 721, 795, 796, 857]) {
       unlockedMapWords[Math.floor(mapId / 32)]! |= 1 << (mapId % 32);
     }
     state.value = {
@@ -264,10 +267,47 @@ describe("TravelPalette", () => {
     wrapper.unmount();
   });
 
+  it("uses the same local rule for another early campaign", async () => {
+    const { wrapper, state } = fixture();
+    const unlockedMapWords = Array.from({ length: 28 }, () => 0);
+    for (const mapId of [194, 242, 243, 249, 250, 251, 188, 248, 281, 282, 330, 368, 467, 721, 795, 796, 857]) {
+      unlockedMapWords[Math.floor(mapId / 32)]! |= 1 << (mapId % 32);
+    }
+    state.value = {
+      status: "ready",
+      mapId: 242,
+      characterKey: travelCharacterKey("0123456789abcdef"),
+      unlockedMapWords,
+    };
+    await flushPromises();
+
+    expect(wrapper.get(".travel-available").text()).toContain("6 unlocked");
+    expect(wrapper.get(".travel-available").text()).toContain("Shing Jea Monastery");
+    expect(wrapper.get(".travel-available").text()).not.toContain("Great Temple of Balthazar");
+    wrapper.unmount();
+  });
+
+  it("shows the bounded Pre-Searing scope without claiming unknown unlocks", async () => {
+    const { wrapper, state } = fixture();
+    state.value = {
+      status: "ready",
+      mapId: 148,
+      characterKey: travelCharacterKey("0123456789abcdef"),
+      unlockedMapWords: null,
+    };
+    await flushPromises();
+
+    expect(wrapper.get("#travel-available-title").text()).toBe("Destinations");
+    expect(wrapper.get(".travel-available").text()).toContain("6 nearby");
+    expect(wrapper.get(".travel-available").text()).toContain("Ashford Abbey");
+    expect(wrapper.get(".travel-available").text()).not.toContain("unlocked");
+    wrapper.unmount();
+  });
+
   it("keeps Recent and Favorites when more than ten destinations are unlocked", async () => {
     const { wrapper, state } = fixture({ history: [81] });
     const unlockedMapWords = Array.from({ length: 28 }, () => 0);
-    for (const mapId of [148, 164, 165, 166, 163, 778, 81, 55, 20, 49, 109]) {
+    for (const mapId of [81, 55, 20, 49, 109, 85, 133, 136, 57, 155, 159]) {
       unlockedMapWords[Math.floor(mapId / 32)]! |= 1 << (mapId % 32);
     }
     state.value = {

--- a/apps/tools/src/components/TravelPalette.vue
+++ b/apps/tools/src/components/TravelPalette.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
 import { computed, nextTick, ref, watch } from "vue";
 import {
-  TRAVEL_DESTINATIONS,
   TRAVEL_SEARCH_QUERY_LIMIT,
   TRAVEL_SHORTCUT_LIMIT,
   highlightTravelDestinationName,
   isTravelRequest,
   normaliseTravelTerm,
   searchTravelDestinations,
+  travelBrowseScope,
   travelDestination,
   type TravelDestination,
   type TravelRequest,
@@ -72,6 +72,10 @@ const assignedShortcuts = computed(() => shortcutRows.value.filter(
 const currentMapId = computed(() =>
   props.host.state.value.status === "ready" ? props.host.state.value.mapId : null
 );
+const browseUnlocksKnown = computed(() =>
+  props.host.state.value.status === "ready"
+  && props.host.state.value.unlockedMapWords !== null
+);
 const recentDestinations = computed(() => props.host.history.value
   .filter((mapId) => mapId !== currentMapId.value && isAvailable(mapId))
   .map((mapId) => travelDestination(mapId))
@@ -79,8 +83,8 @@ const recentDestinations = computed(() => props.host.history.value
   .slice(0, TRAVEL_HISTORY_VISIBLE_LIMIT));
 const browseDestinations = computed(() => {
   const state = props.host.state.value;
-  if (state.status !== "ready" || state.unlockedMapWords === null) return [];
-  const destinations = TRAVEL_DESTINATIONS.filter(({ mapId }) => isAvailable(mapId));
+  if (state.status !== "ready") return [];
+  const destinations = travelBrowseScope(state.mapId).filter(({ mapId }) => isAvailable(mapId));
   return destinations.length <= SMALL_TRAVEL_CATALOGUE_LIMIT
     ? [...destinations].sort((left, right) => left.name.localeCompare(right.name, "en"))
     : [];
@@ -418,7 +422,7 @@ function onKeydown(event: KeyboardEvent): void {
 
     <section v-else-if="mode === 'travel'" id="travel-panel" class="ui-scroll travel-body" role="region" aria-label="Travel">
       <section v-if="showingSmallCatalogue" class="travel-section travel-available" aria-labelledby="travel-available-title">
-        <header class="travel-section-head"><h2 id="travel-available-title">Available destinations</h2><span>{{ browseDestinations.length }} unlocked</span></header>
+        <header class="travel-section-head"><h2 id="travel-available-title">{{ browseUnlocksKnown ? 'Available destinations' : 'Destinations' }}</h2><span>{{ browseDestinations.length }} {{ browseUnlocksKnown ? 'unlocked' : 'nearby' }}</span></header>
         <div id="travel-available" class="travel-recent-grid" role="listbox">
           <button v-for="destination in browseDestinations" :id="`travel-${destination.mapId}`" :key="destination.mapId" type="button" class="travel-recent ui-row" role="option" :data-current="destination.mapId === currentMapId || undefined" :disabled="travelPending || host.unavailable !== null || destination.mapId === currentMapId" :aria-current="destination.mapId === currentMapId ? 'location' : undefined" :aria-selected="destination.mapId === activeDestination?.mapId" :aria-label="browseDestinationLabel(destination)" @mouseenter="activateBrowseDestination(destination.mapId)" @click="travel({ mapId: destination.mapId })"><span><strong>{{ destination.name }}</strong><small>{{ destination.campaign }}</small></span><span class="travel-destination-context"><span v-if="shortcutNumber(destination.mapId) !== null" class="travel-shortcut-context" :title="`Shortcut ${shortcutNumber(destination.mapId)}`" aria-hidden="true">{{ shortcutNumber(destination.mapId) }}</span><span v-if="destination.mapId === currentMapId" class="travel-current">Current</span><span v-else-if="wasRecentlyVisited(destination.mapId)" class="travel-current">Recent</span><svg v-else viewBox="0 0 20 20" aria-hidden="true"><path d="m7 4 6 6-6 6" /></svg></span></button>
         </div>

--- a/src/shared/travel-destinations.ts
+++ b/src/shared/travel-destinations.ts
@@ -244,6 +244,28 @@ export const TRAVEL_DESTINATIONS: readonly TravelDestination[] = Object.freeze([
   destination(795, "Zaishen Menagerie", "Battle Isles", ["menagerie"]),
 ]);
 
+const PRE_SEARING_MAP_IDS: readonly number[] = Object.freeze([
+  148, 164, 165, 166, 163, 778,
+]);
+
+/**
+ * Returns the destination group that is useful around the current outpost.
+ * Cross-campaign unlocks (especially the Battle Isles) must not make a small
+ * early-game catalogue look large. Pre-Searing is kept separate from the rest
+ * of Prophecies because its characters cannot cross the Searing boundary.
+ */
+export function travelBrowseScope(currentMapId: number): readonly TravelDestination[] {
+  const current = travelDestination(currentMapId);
+  if (current === null) return [];
+  const preSearing = PRE_SEARING_MAP_IDS.includes(currentMapId);
+  return TRAVEL_DESTINATIONS.filter((candidate) =>
+    preSearing
+      ? PRE_SEARING_MAP_IDS.includes(candidate.mapId)
+      : candidate.campaign === current.campaign
+        && !PRE_SEARING_MAP_IDS.includes(candidate.mapId)
+  );
+}
+
 export function travelDestination(mapId: number): TravelDestination | null {
   return TRAVEL_DESTINATIONS.find((candidate) => candidate.mapId === mapId) ?? null;
 }

--- a/src/shared/travel.ts
+++ b/src/shared/travel.ts
@@ -14,6 +14,7 @@ import {
 
 export {
   TRAVEL_DESTINATIONS,
+  travelBrowseScope,
   travelDestination,
   type TravelDestination,
 } from "./travel-destinations.js";

--- a/tests/unit/travel.test.ts
+++ b/tests/unit/travel.test.ts
@@ -10,6 +10,7 @@ import {
   parseTravelUserPreferencesUpdate,
   searchTravelDestinations,
   storeTravelShortcuts,
+  travelBrowseScope,
   travelDestination,
   travelShortcutsFromStored,
 } from "../../src/shared/travel.js";
@@ -102,6 +103,20 @@ describe("Travel", () => {
     assert.equal(isTravelRequest({
       mapId: 2_000,
     }), false);
+  });
+
+  it("keeps early-game browse scopes local to the current campaign", () => {
+    assert.deepEqual(
+      travelBrowseScope(148).map(({ mapId }) => mapId),
+      [148, 164, 165, 166, 163, 778],
+    );
+    assert.equal(
+      travelBrowseScope(242).every(({ campaign }) => campaign === "Factions"),
+      true,
+    );
+    assert.equal(travelBrowseScope(242).some(({ mapId }) => mapId === 248), false);
+    assert.equal(travelBrowseScope(81).some(({ mapId }) => mapId === 148), false);
+    assert.deepEqual(travelBrowseScope(2_000), []);
   });
 
   it("rejects one request that would write both preference files", () => {


### PR DESCRIPTION
The first `2026.9.0-beta.1` draft failed live Pre-Searing QA because cross-campaign unlocks suppressed the small local destination catalogue. This backports only the accepted Travel correction from main into the frozen `release/2026.9.0` line.

The palette now evaluates a local campaign scope, keeps Pre-Searing separate from post-Searing Prophecies, and remains honest when unlock observation is unavailable. No other main-branch work is included.

## Evidence

- Exact backport of main squash commit `f60dc09d5af1d3be7af0eea067c962d6cd8491c9`
- Matthias passed live Pre-Searing QA with Developer Build commit `5d1b93c00e051c43b02d5de435e558786c8a2514`
- Today's new ArenaNet client passed the complete recertification workflow
- `pnpm run check`
- 1,361 unit tests passed
- 184 policy tests passed
- 141 Tools UI tests passed

## Rollout risk

Low and isolated to the empty-query Travel presentation. Search, command execution, persisted shortcuts, and unlock observation are unchanged. The failed `beta.1` workflow is canceled. A new `beta.2` candidate still requires its own dry run and exact signed-draft QA.

Prepared by Codex using the repository test harness. Live gameplay acceptance was performed by Matthias.
