### PR TITLE
docs(workflow): make release backports unambiguous

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,32 @@ Do not create permanent `develop`, `next`, `beta`, or `stable` branches. The
 signed Stable tag is the production source. `main` can continue with completed
 future work while a release branch stabilizes.
 
+### Merge and commit movement
+
+GitHub accepts only squash merges. The resulting squash commit on the target
+branch is the canonical commit. Do not rely on a topic-branch commit hash after
+merge.
+
+Move a completed change between protected branches only through a focused pull
+request:
+
+- from `main` to a planned release: branch from the exact release branch,
+  `git cherry-pick -x <main-squash-commit>`, and target that release branch;
+- from a release branch to `main`: branch from `main`,
+  `git cherry-pick -x <release-squash-commit>`, and target `main`; and
+- from an emergency release to an active planned release: branch from the
+  planned release, cherry-pick the canonical emergency squash commit with
+  `-x`, and target the planned release.
+
+Name the source pull request and exact canonical source commit in the new pull
+request body. Compare the complete diff with the destination branch. Never
+merge or rebase all of `main` into a release branch, and never copy changes by
+hand when a canonical source commit exists. If the source commit, destination,
+or release inclusion is unclear, stop and resolve it before changing history.
+
+See [Development and rollout](docs/development-workflow.md#merge-and-commit-movement)
+for the decision table and full procedure.
+
 Use Conventional Commits. Keep commits atomic. Review staged changes before a
 commit and the complete branch diff before a pull request.
 

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -54,6 +54,41 @@ reduce branch drift. Do not add a hidden feature flag for unfinished code.
 A merge to `main` does not require an application release. Several completed
 changes can wait for one planned release.
 
+## Merge and commit movement
+
+The repository allows squash merges only. GitHub creates one canonical commit
+on the target branch from the pull-request title and body, then deletes the
+merged topic branch. Use that canonical squash commit for every later backport
+or forward-port.
+
+| Change | Start the topic branch from | Pull-request target | Commit to apply |
+| --- | --- | --- | --- |
+| Normal feature or fix | `main` | `main` | The topic change |
+| Completed `main` fix needed by a planned release | Exact `release/YYYY.M.PATCH` | That release branch | Canonical `main` squash commit |
+| Release-only blocker that `main` also needs | `main` | `main` | Canonical release squash commit |
+| Emergency Stable fix | Latest signed Stable tag | Emergency release branch | The emergency change only |
+| Emergency fix needed by `main` or a planned release | Destination branch | That destination branch | Canonical emergency squash commit |
+
+For a backport or forward-port:
+
+1. Fetch remote references and identify the canonical squash commit on the
+   source branch.
+2. Create a new topic branch from the exact destination branch.
+3. Run `git cherry-pick -x <canonical-source-commit>` so the commit records its
+   origin.
+4. Compare the complete branch diff with the destination. It must contain only
+   the intended change and necessary conflict resolution.
+5. Open a pull request that names the source pull request, canonical source
+   commit, destination, and reason for inclusion.
+6. Require **Application verification** to pass, then squash-merge the pull
+   request.
+
+Do not merge or rebase `main` into a release branch. Do not cherry-pick a
+pre-merge topic commit when a canonical squash commit exists. Do not resolve a
+conflict by broadening the release without an explicit inclusion decision. If
+the histories disagree, stop and explain the exact conflict instead of
+inventing another branch or compatibility path.
+
 ## Planned release
 
 1. Select one green commit on `main`.
@@ -166,9 +201,12 @@ release, or announce it without an explicit coordinator request.
 
 Repository settings enforce the model outside the codebase:
 
-- `main` requires the `verify / verify` check and linear history;
-- the `Protect release branches` ruleset applies the same requirements to
-  `release/*` and refuses force-pushes;
+- GitHub permits squash merges only and deletes merged topic branches;
+- `main` requires a pull request, resolved conversations, linear history, and
+  the strict `verify / verify` check, including for administrators;
+- the `Protect release branches` ruleset requires a pull request with squash
+  merge, resolved conversations, and the strict `verify / verify` check for
+  `release/*`, with no bypass and no force-pushes;
 - the `release` environment accepts `main` and `release/*`; and
 - the `release` environment requires Matthias's approval and does not allow an
   administrator bypass.


### PR DESCRIPTION
Normal development, planned Betas, and emergency Stable patches had the right branch model, but agents still had to infer the exact merge and commit-movement rules. That ambiguity made it too easy to pull unrelated `main` work into a frozen release.

This defines squash commits as the canonical source, gives one decision table for every direction, requires `git cherry-pick -x` for deliberate backports and forward-ports, and tells agents to stop when source or destination history is unclear. The repository settings now match the document: `main` and `release/*` require pull requests and the strict `verify / verify` gate; release branches allow squash only; administrator bypass is disabled while required approvals remain zero.

## Verification

- `pnpm run check`
- 1,361 unit tests passed
- 184 policy tests passed
- 141 Tools UI tests passed
- verified repository merge settings remain squash-only with merged branch deletion
- verified `main` and `release/*` protection after the update

## Rollout risk

Low. This changes process documentation and GitHub protection only. It adds no workflow, release branch, runtime code, or approval burden.