### PR TITLE
chore(release): prepare version 2026.9.0-beta.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "guild-wars",
   "productName": "Guild Wars Reforged",
-  "version": "2026.9.0-beta.1",
+  "version": "2026.9.0-beta.2",
   "private": true,
   "packageManager": "pnpm@11.13.1",
   "type": "module",


### PR DESCRIPTION
The corrected early-game Travel catalogue is now on the frozen September release branch, but the failed `2026.9.0-beta.1` staging attempt must not be reused. This gives the next candidate its own Beta identity.

This changes only the application version from `2026.9.0-beta.1` to `2026.9.0-beta.2`. No additional feature work enters the release.

## Invariant

The base version matches `release/2026.9.0`, and the unique `-beta.2` suffix selects the Beta updater channel without colliding with the earlier failed draft.

## Verification

- `pnpm run check`
- 1,361 unit tests passed
- 184 policy tests passed
- 141 Tools UI tests passed

## Rollout risk

Low. The commit changes only package metadata. The protected branch gate, exact current-client qualification, signing, packaging, updater checks, and exact signed-draft QA remain mandatory.

Prepared with Codex.