### PR TITLE
fix(travel): use Piken's official map ID

### DIFF
--- a/apps/tools/src/components/TravelPalette.test.ts
+++ b/apps/tools/src/components/TravelPalette.test.ts
@@ -224,7 +224,7 @@ describe("TravelPalette", () => {
     ];
     const { wrapper, state, travel } = fixture({ history: [164, 165], shortcuts });
     const unlockedMapWords = Array.from({ length: 28 }, () => 0);
-    for (const mapId of [148, 164, 165, 166, 163, 778]) {
+    for (const mapId of [148, 164, 165, 166, 163, 779]) {
       unlockedMapWords[Math.floor(mapId / 32)]! |= 1 << (mapId % 32);
     }
     for (const mapId of [188, 248, 281, 282, 330, 368, 467, 721, 795, 796, 857]) {
@@ -301,6 +301,30 @@ describe("TravelPalette", () => {
     expect(wrapper.get(".travel-available").text()).toContain("6 nearby");
     expect(wrapper.get(".travel-available").text()).toContain("Ashford Abbey");
     expect(wrapper.get(".travel-available").text()).not.toContain("unlocked");
+    wrapper.unmount();
+  });
+
+  it("shows a ferried current outpost without claiming it is unlocked", async () => {
+    const { wrapper, state } = fixture();
+    const unlockedMapWords = Array.from({ length: 28 }, () => 0);
+    for (const mapId of [148, 164, 165, 166, 163]) {
+      unlockedMapWords[Math.floor(mapId / 32)]! |= 1 << (mapId % 32);
+    }
+    state.value = {
+      status: "ready",
+      mapId: 779,
+      characterKey: travelCharacterKey("0123456789abcdef"),
+      unlockedMapWords,
+    };
+    await flushPromises();
+
+    expect(wrapper.get("#travel-available-title").text()).toBe("Destinations");
+    expect(wrapper.get(".travel-available").text()).toContain("5 unlocked + current");
+    expect(wrapper.findAll(".travel-available .travel-recent")).toHaveLength(6);
+    expect(wrapper.get('[aria-current="location"]').text()).toContain("Piken Square");
+    expect(wrapper.get('[aria-current="location"]').attributes("disabled")).toBeDefined();
+    await wrapper.get("#travel-search-input").setValue("piken");
+    expect(wrapper.findAll('[role="option"]')).toHaveLength(0);
     wrapper.unmount();
   });
 

--- a/apps/tools/src/components/TravelPalette.vue
+++ b/apps/tools/src/components/TravelPalette.vue
@@ -76,18 +76,38 @@ const browseUnlocksKnown = computed(() =>
   props.host.state.value.status === "ready"
   && props.host.state.value.unlockedMapWords !== null
 );
+const browseScope = computed(() => {
+  const state = props.host.state.value;
+  return state.status === "ready" ? travelBrowseScope(state.mapId) : [];
+});
+const browseTravelableDestinations = computed(() =>
+  browseScope.value.filter(({ mapId }) => isAvailable(mapId))
+);
+const browseIncludesLockedCurrent = computed(() =>
+  currentMapId.value !== null
+  && browseScope.value.some(({ mapId }) => mapId === currentMapId.value)
+  && !browseTravelableDestinations.value.some(({ mapId }) => mapId === currentMapId.value)
+);
 const recentDestinations = computed(() => props.host.history.value
   .filter((mapId) => mapId !== currentMapId.value && isAvailable(mapId))
   .map((mapId) => travelDestination(mapId))
   .filter((destination): destination is TravelDestination => destination !== null)
   .slice(0, TRAVEL_HISTORY_VISIBLE_LIMIT));
 const browseDestinations = computed(() => {
-  const state = props.host.state.value;
-  if (state.status !== "ready") return [];
-  const destinations = travelBrowseScope(state.mapId).filter(({ mapId }) => isAvailable(mapId));
+  const destinations = [...browseTravelableDestinations.value];
+  if (browseIncludesLockedCurrent.value) {
+    const current = browseScope.value.find(({ mapId }) => mapId === currentMapId.value);
+    if (current !== undefined) destinations.push(current);
+  }
   return destinations.length <= SMALL_TRAVEL_CATALOGUE_LIMIT
-    ? [...destinations].sort((left, right) => left.name.localeCompare(right.name, "en"))
+    ? destinations.sort((left, right) => left.name.localeCompare(right.name, "en"))
     : [];
+});
+const browseCountText = computed(() => {
+  if (!browseUnlocksKnown.value) return `${browseDestinations.value.length} nearby`;
+  return `${browseTravelableDestinations.value.length} unlocked${
+    browseIncludesLockedCurrent.value ? " + current" : ""
+  }`;
 });
 const browsingSmallCatalogue = computed(() => browseDestinations.value.length > 0);
 const showingSmallCatalogue = computed(() =>
@@ -422,7 +442,7 @@ function onKeydown(event: KeyboardEvent): void {
 
     <section v-else-if="mode === 'travel'" id="travel-panel" class="ui-scroll travel-body" role="region" aria-label="Travel">
       <section v-if="showingSmallCatalogue" class="travel-section travel-available" aria-labelledby="travel-available-title">
-        <header class="travel-section-head"><h2 id="travel-available-title">{{ browseUnlocksKnown ? 'Available destinations' : 'Destinations' }}</h2><span>{{ browseDestinations.length }} {{ browseUnlocksKnown ? 'unlocked' : 'nearby' }}</span></header>
+        <header class="travel-section-head"><h2 id="travel-available-title">{{ browseUnlocksKnown && !browseIncludesLockedCurrent ? 'Available destinations' : 'Destinations' }}</h2><span>{{ browseCountText }}</span></header>
         <div id="travel-available" class="travel-recent-grid" role="listbox">
           <button v-for="destination in browseDestinations" :id="`travel-${destination.mapId}`" :key="destination.mapId" type="button" class="travel-recent ui-row" role="option" :data-current="destination.mapId === currentMapId || undefined" :disabled="travelPending || host.unavailable !== null || destination.mapId === currentMapId" :aria-current="destination.mapId === currentMapId ? 'location' : undefined" :aria-selected="destination.mapId === activeDestination?.mapId" :aria-label="browseDestinationLabel(destination)" @mouseenter="activateBrowseDestination(destination.mapId)" @click="travel({ mapId: destination.mapId })"><span><strong>{{ destination.name }}</strong><small>{{ destination.campaign }}</small></span><span class="travel-destination-context"><span v-if="shortcutNumber(destination.mapId) !== null" class="travel-shortcut-context" :title="`Shortcut ${shortcutNumber(destination.mapId)}`" aria-hidden="true">{{ shortcutNumber(destination.mapId) }}</span><span v-if="destination.mapId === currentMapId" class="travel-current">Current</span><span v-else-if="wasRecentlyVisited(destination.mapId)" class="travel-current">Recent</span><svg v-else viewBox="0 0 20 20" aria-hidden="true"><path d="m7 4 6 6-6 6" /></svg></span></button>
         </div>

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -166,7 +166,9 @@ After that restart, these choices update immediately:
   **Recent** comes from locations Guild Wars actually reports, including world
   map travel and other in-game paths. It keeps up to ten unique reviewed places
   per character across game and app restarts, hides the current map, and shows
-  the six newest destinations that character can still travel to. When the
+  the six newest destinations that character can still travel to. A reviewed
+  current outpost remains visible and disabled even when the character was
+  ferried there without unlocking map travel. When the
   character has 10 or fewer unlocked destinations, such as early in any
   campaign, Travel shows the complete alphabetical list before the player
   types. The list marks the current location, recent visits, and assigned number

--- a/docs/wasm-host.md
+++ b/docs/wasm-host.md
@@ -322,8 +322,10 @@ changed ready map that belongs to the reviewed direct-travel catalogue,
 including arrivals outside the palette. Main serializes at most ten unique map
 IDs per character in atomic `travel-history.json`. The companion hashes the
 official 128-bit character UUID before publication; raw UUIDs and names never
-cross the boundary or reach disk. The palette excludes the current map and any
-positively locked destination. History cannot authorize travel.
+cross the boundary or reach disk. Recent excludes the current map and any
+positively locked destination. The small local catalogue can still show the
+reviewed current outpost as disabled when a ferry reached it without an unlock.
+History cannot authorize travel.
 
 Shortcut slots remain in `settings.json` using the district-bearing shape the
 published Stable understands. The current runtime projects those records to

--- a/internals/migrations.md
+++ b/internals/migrations.md
@@ -1,5 +1,17 @@
 # Active migrations
 
+## Piken Square Travel map ID projection
+
+- Why: Stable v2026.8.10 released Piken Square (pre-Searing) as map ID 778.
+  The official ID is 779. Current runtime values use 779, while shortcuts,
+  search phrases, and history still serialize 778 for safe rollback.
+- Introduced: 2026-08-29 with the Piken Square Travel correction.
+- Depends on it: profiles written by v2026.8.10 and rollback from the current
+  Beta to that Stable release.
+- Remove when: v2026.8.10 is outside the supported rollback window. Remove the
+  write projection and its rollback tests. Keep the 778 read projection for
+  dormant profiles that have not opened a corrected release.
+
 ## Apply-Team rollback projection
 
 - Why: the supported rollback Stable still reads `teamManagement`, so the

--- a/src/main/core/travel-history.ts
+++ b/src/main/core/travel-history.ts
@@ -14,6 +14,10 @@ import {
   type TravelHistory,
   type TravelHistoryDocument,
 } from "../../shared/travel-history.js";
+import {
+  travelMapIdForStableStorage,
+  travelMapIdFromReleasedStorage,
+} from "../../shared/travel-map-id.js";
 import { writeAtomicJson } from "./atomic-file.js";
 import { quarantineCorruptDocument } from "./corrupt-document.js";
 
@@ -26,11 +30,39 @@ async function readDocument(path: string): Promise<TravelHistoryDocument> {
     throw error;
   }
   try {
-    return parseTravelHistoryDocument(JSON.parse(text) as unknown);
+    return parseTravelHistoryDocument(runtimeHistory(JSON.parse(text) as unknown));
   } catch {
     await quarantineCorruptDocument(path);
     return DEFAULT_TRAVEL_HISTORY;
   }
+}
+
+function runtimeHistory(value: unknown): unknown {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return value;
+  const document = value as Record<string, unknown>;
+  if (document.characters === null || typeof document.characters !== "object"
+    || Array.isArray(document.characters)) return value;
+  return {
+    ...document,
+    characters: Object.fromEntries(Object.entries(document.characters).map(([key, history]) => [
+      key,
+      Array.isArray(history)
+        ? history.map((mapId) => Number.isSafeInteger(mapId)
+            ? travelMapIdFromReleasedStorage(Number(mapId))
+            : mapId)
+        : history,
+    ])),
+  };
+}
+
+function storedHistory(document: TravelHistoryDocument): TravelHistoryDocument {
+  return {
+    ...document,
+    characters: Object.fromEntries(Object.entries(document.characters).map(([key, history]) => [
+      key,
+      history.map(travelMapIdForStableStorage),
+    ])) as Record<TravelCharacterKey, TravelHistory>,
+  };
 }
 
 function updateCharacter(
@@ -77,7 +109,10 @@ export class TravelHistoryStore {
         document.characters[characterKey] ?? EMPTY_TRAVEL_HISTORY,
         mapId,
       );
-      await writeAtomicJson(this.#path, updateCharacter(document, characterKey, next));
+      await writeAtomicJson(
+        this.#path,
+        storedHistory(updateCharacter(document, characterKey, next)),
+      );
       return next;
     });
   }

--- a/src/main/core/travel-preferences-v1.ts
+++ b/src/main/core/travel-preferences-v1.ts
@@ -4,6 +4,10 @@
  */
 import { travelDestination } from "../../shared/travel-destinations.js";
 import {
+  travelMapIdForStableStorage,
+  travelMapIdFromReleasedStorage,
+} from "../../shared/travel-map-id.js";
+import {
   TRAVEL_PREFERENCES_FORMAT,
   createTravelPreferences,
   type TravelPreferencesDocument,
@@ -17,8 +21,20 @@ function isReleasedRecentData(limit: unknown, mapIds: unknown): boolean {
     && mapIds.length <= 10
     && new Set(mapIds).size === mapIds.length
     && mapIds.every((mapId) =>
-      Number.isSafeInteger(mapId) && travelDestination(Number(mapId)) !== null
+      Number.isSafeInteger(mapId)
+      && travelDestination(travelMapIdFromReleasedStorage(Number(mapId))) !== null
     );
+}
+
+function runtimeSynonyms(value: unknown): unknown {
+  if (!Array.isArray(value)) return value;
+  return value.map((entry) => {
+    if (entry === null || typeof entry !== "object" || Array.isArray(entry)) return entry;
+    const synonym = entry as Record<string, unknown>;
+    return Number.isSafeInteger(synonym.mapId)
+      ? { ...synonym, mapId: travelMapIdFromReleasedStorage(Number(synonym.mapId)) }
+      : entry;
+  });
 }
 
 export function parseTravelPreferencesV1(value: unknown): TravelPreferencesDocument {
@@ -31,7 +47,7 @@ export function parseTravelPreferencesV1(value: unknown): TravelPreferencesDocum
     || input.formatVersion !== TRAVEL_PREFERENCES_FORMAT
     || !isReleasedRecentData(input.recentLimit, input.recentMapIds)
   ) throw new TypeError("Travel preferences are invalid");
-  return createTravelPreferences(input.synonyms);
+  return createTravelPreferences(runtimeSynonyms(input.synonyms));
 }
 
 export function serializeTravelPreferencesV1(
@@ -39,7 +55,10 @@ export function serializeTravelPreferencesV1(
 ): Readonly<Record<string, unknown>> {
   return Object.freeze({
     formatVersion: TRAVEL_PREFERENCES_FORMAT,
-    synonyms: preferences.synonyms,
+    synonyms: Object.freeze(preferences.synonyms.map((entry) => Object.freeze({
+      ...entry,
+      mapId: travelMapIdForStableStorage(entry.mapId),
+    }))),
     recentLimit: 0,
     recentMapIds: Object.freeze([]),
   });

--- a/src/shared/travel-destinations.ts
+++ b/src/shared/travel-destinations.ts
@@ -3,6 +3,8 @@
  * Exposes the map-id allowlist used by certification and the UI.
  */
 
+import { PIKEN_SQUARE_PRE_SEARING_MAP_ID } from "./travel-map-id.js";
+
 export type TravelDestination = Readonly<{
   mapId: number;
   name: string;
@@ -30,7 +32,7 @@ export const TRAVEL_DESTINATIONS: readonly TravelDestination[] = Object.freeze([
   destination(165, "Foible's Fair", "Prophecies"),
   destination(166, "Fort Ranik (pre-Searing)", "Prophecies", ["pre ranik"]),
   destination(163, "The Barradin Estate", "Prophecies", ["barradin estate"]),
-  destination(778, "Piken Square (pre-Searing)", "Prophecies", ["pre piken"]),
+  destination(PIKEN_SQUARE_PRE_SEARING_MAP_ID, "Piken Square (pre-Searing)", "Prophecies", ["pre piken"]),
 
   // Prophecies — towns and outposts
   destination(81, "Ascalon City", "Prophecies", ["ac", "ascalon"]),
@@ -245,7 +247,7 @@ export const TRAVEL_DESTINATIONS: readonly TravelDestination[] = Object.freeze([
 ]);
 
 const PRE_SEARING_MAP_IDS: readonly number[] = Object.freeze([
-  148, 164, 165, 166, 163, 778,
+  148, 164, 165, 166, 163, PIKEN_SQUARE_PRE_SEARING_MAP_ID,
 ]);
 
 /**

--- a/src/shared/travel-map-id.ts
+++ b/src/shared/travel-map-id.ts
@@ -1,0 +1,20 @@
+/**
+ * Owns the corrected Piken Square map ID and its released storage projection.
+ * Stable v2026.8.10 wrote 778, so rollback-safe files retain that value while
+ * the current runtime and certified command use the official map ID 779.
+ */
+
+export const PIKEN_SQUARE_PRE_SEARING_MAP_ID = 779;
+const RELEASED_PIKEN_SQUARE_PRE_SEARING_MAP_ID = 778;
+
+export function travelMapIdFromReleasedStorage(mapId: number): number {
+  return mapId === RELEASED_PIKEN_SQUARE_PRE_SEARING_MAP_ID
+    ? PIKEN_SQUARE_PRE_SEARING_MAP_ID
+    : mapId;
+}
+
+export function travelMapIdForStableStorage(mapId: number): number {
+  return mapId === PIKEN_SQUARE_PRE_SEARING_MAP_ID
+    ? RELEASED_PIKEN_SQUARE_PRE_SEARING_MAP_ID
+    : mapId;
+}

--- a/src/shared/travel.ts
+++ b/src/shared/travel.ts
@@ -6,6 +6,10 @@ import {
   travelDestination,
 } from "./travel-destinations.js";
 import {
+  travelMapIdForStableStorage,
+  travelMapIdFromReleasedStorage,
+} from "./travel-map-id.js";
+import {
   createTravelPreferences,
   parseTravelPreferencesPatch,
   type TravelPreferencesPatch,
@@ -18,6 +22,7 @@ export {
   travelDestination,
   type TravelDestination,
 } from "./travel-destinations.js";
+export { PIKEN_SQUARE_PRE_SEARING_MAP_ID } from "./travel-map-id.js";
 
 export const TRAVEL_SHORTCUT_LIMIT = 9;
 export * from "./travel-preferences.js";
@@ -213,7 +218,7 @@ export function isStoredTravelShortcuts(value: unknown): value is StoredTravelSh
       const shortcut = entry as Record<string, unknown>;
       return Object.keys(shortcut).length === 3
         && Number.isSafeInteger(shortcut.mapId)
-        && travelDestination(Number(shortcut.mapId)) !== null
+        && travelDestination(travelMapIdFromReleasedStorage(Number(shortcut.mapId))) !== null
         && TRAVEL_DISTRICTS.some(({ id }) => id === shortcut.district)
         && Number.isSafeInteger(shortcut.districtNumber)
         && Number(shortcut.districtNumber) >= 0
@@ -224,7 +229,9 @@ export function isStoredTravelShortcuts(value: unknown): value is StoredTravelSh
 export function travelShortcutsFromStored(stored: StoredTravelShortcuts): TravelShortcuts {
   return Object.freeze(Array.from({ length: TRAVEL_SHORTCUT_LIMIT }, (_, index) => {
     const shortcut = stored[index];
-    return shortcut ? Object.freeze({ mapId: shortcut.mapId }) : null;
+    return shortcut
+      ? Object.freeze({ mapId: travelMapIdFromReleasedStorage(shortcut.mapId) })
+      : null;
   })) as TravelShortcuts;
 }
 
@@ -236,10 +243,12 @@ export function storeTravelShortcuts(
   return Object.freeze(shortcuts.map((shortcut, index) => {
     if (shortcut === null) return null;
     const existing = previous[index];
-    return existing?.mapId === shortcut.mapId
+    return existing !== undefined
+      && existing !== null
+      && travelMapIdFromReleasedStorage(existing.mapId) === shortcut.mapId
       ? Object.freeze({ ...existing })
       : Object.freeze({
-          mapId: shortcut.mapId,
+          mapId: travelMapIdForStableStorage(shortcut.mapId),
           district: "international" as const,
           districtNumber: 0,
         });

--- a/tests/unit/travel-history.test.ts
+++ b/tests/unit/travel-history.test.ts
@@ -15,10 +15,27 @@ const characterB = travelCharacterKey("fedcba9876543210");
 
 describe("Travel history", () => {
   it("keeps ten unique reviewed destinations in most-recent order", () => {
-    const destinations = [148, 164, 165, 166, 163, 778, 81, 55, 20, 49, 109, 81, 85];
+    const destinations = [148, 164, 165, 166, 163, 779, 81, 55, 20, 49, 109, 81, 85];
     const history = destinations.reduce(recordVisitedTravel, Object.freeze([]) as readonly number[]);
-    assert.deepEqual(history, [85, 81, 109, 49, 20, 55, 778, 163, 166, 165]);
+    assert.deepEqual(history, [85, 81, 109, 49, 20, 55, 779, 163, 166, 165]);
     assert.throws(() => recordVisitedTravel(history, 2_000), /not reviewed/u);
+  });
+
+  it("reads and writes Piken through the Stable-compatible map ID", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "gw-travel-history-"));
+    const path = join(dir, "travel-history.json");
+    await writeFile(path, JSON.stringify({
+      formatVersion: 2,
+      characters: { [characterA]: [778] },
+    }));
+
+    const store = new TravelHistoryStore(path);
+    assert.deepEqual(await store.get(characterA), [779]);
+    await store.record(characterA, 779);
+    assert.deepEqual(JSON.parse(await readFile(path, "utf8")), {
+      formatVersion: 2,
+      characters: { [characterA]: [778] },
+    });
   });
 
   it("persists histories independently per character across store instances", async () => {

--- a/tests/unit/travel-preferences.test.ts
+++ b/tests/unit/travel-preferences.test.ts
@@ -71,6 +71,28 @@ describe("Travel preferences", () => {
     });
   });
 
+  it("keeps the corrected Piken map ID rollback-safe on disk", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "gw-travel-preferences-"));
+    const path = join(dir, "travel-preferences.json");
+    await writeFile(path, JSON.stringify({
+      formatVersion: 1,
+      synonyms: [{ term: "north", mapId: 778 }],
+      recentLimit: 0,
+      recentMapIds: [],
+    }));
+
+    assert.deepEqual(await loadTravelPreferences(path), {
+      formatVersion: 1,
+      synonyms: [{ term: "north", mapId: 779 }],
+    });
+    await updateTravelPreferences(path, {
+      synonyms: [{ term: "north", mapId: 779 }],
+    });
+    assert.deepEqual(JSON.parse(await readFile(path, "utf8")).synonyms, [
+      { term: "north", mapId: 778 },
+    ]);
+  });
+
   it("rejects ambiguous synonyms and unknown document fields", () => {
     const document = {
       formatVersion: 1,

--- a/tests/unit/travel.test.ts
+++ b/tests/unit/travel.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   TRAVEL_DESTINATIONS,
+  PIKEN_SQUARE_PRE_SEARING_MAP_ID,
   TRAVEL_SEARCH_QUERY_LIMIT,
   isStoredTravelShortcuts,
   isTravelRequest,
@@ -30,7 +31,7 @@ describe("Travel", () => {
       407, 414, 421, 424, 425, 426, 427, 428, 431, 433, 434, 435, 438, 440, 442,
       449, 450, 457, 467, 469, 473, 474, 476, 477, 478, 479, 480, 489, 491, 492,
       493, 494, 495, 496, 497, 502, 544, 545, 554, 555, 559, 624, 638, 639, 640,
-      641, 642, 643, 644, 645, 648, 650, 652, 675, 721, 778, 795, 796, 857,
+      641, 642, 643, 644, 645, 648, 650, 652, 675, 721, 779, 795, 796, 857,
     ];
     assert.equal(TRAVEL_DESTINATIONS.length, 199);
     assert.deepEqual(
@@ -83,22 +84,28 @@ describe("Travel", () => {
 
   it("keeps Stable-readable shortcut fields on disk while runtime stays map-only", () => {
     const stored = [
-      { mapId: 55, district: "europe-english" as const, districtNumber: 2 },
+      { mapId: 778, district: "europe-english" as const, districtNumber: 2 },
       null,
     ];
     assert.equal(isStoredTravelShortcuts(stored), true);
     const runtime = travelShortcutsFromStored(stored);
     assert.deepEqual(runtime, [
-      { mapId: 55 }, null, null, null, null, null, null, null, null,
-    ]);
-    assert.deepEqual(storeTravelShortcuts(runtime, stored), [
-      { mapId: 55, district: "europe-english", districtNumber: 2 },
+      { mapId: PIKEN_SQUARE_PRE_SEARING_MAP_ID },
       null, null, null, null, null, null, null, null,
     ]);
+    assert.deepEqual(storeTravelShortcuts(runtime, stored), [
+      { mapId: 778, district: "europe-english", districtNumber: 2 },
+      null, null, null, null, null, null, null, null,
+    ]);
+    assert.equal(storeTravelShortcuts(runtime, [])[0]?.mapId, 778);
   });
 
   it("resolves only catalogue map ids", () => {
     assert.equal(travelDestination(81)?.name, "Ascalon City");
+    assert.equal(travelDestination(PIKEN_SQUARE_PRE_SEARING_MAP_ID)?.name, "Piken Square (pre-Searing)");
+    assert.equal(travelDestination(778), null, "released Piken typo is storage-only");
+    assert.equal(isTravelRequest({ mapId: 778 }), false);
+    assert.equal(isTravelRequest({ mapId: PIKEN_SQUARE_PRE_SEARING_MAP_ID }), true);
     assert.equal(travelDestination(2_000), null);
     assert.equal(isTravelRequest({
       mapId: 2_000,
@@ -108,7 +115,7 @@ describe("Travel", () => {
   it("keeps early-game browse scopes local to the current campaign", () => {
     assert.deepEqual(
       travelBrowseScope(148).map(({ mapId }) => mapId),
-      [148, 164, 165, 166, 163, 778],
+      [148, 164, 165, 166, 163, PIKEN_SQUARE_PRE_SEARING_MAP_ID],
     );
     assert.equal(
       travelBrowseScope(242).every(({ campaign }) => campaign === "Factions"),


### PR DESCRIPTION
Piken Square (pre-Searing) was absent from Travel because the catalogue used map ID 778. The official outpost ID is 779; 778 identifies an unrelated mission cinematic.

This corrects the runtime catalogue and certified Travel allowlist to 779. A ferried character can now see Piken as a disabled current location even before permanently unlocking map travel.

The released 778 value remains only as a storage projection for shortcuts, custom search phrases, and history. This preserves settings and safe rollback to Stable v2026.8.10 while ensuring 778 cannot reach the current Travel command.

Verification:

- `pnpm run check`
- 1,363 unit tests passed
- 184 policy tests passed
- 142 Tools UI tests passed
- Focused coverage rejects runtime map ID 778, admits 779, preserves rollback storage, and covers the ferried-current state

Rollout risk:

- Targets `release/2026.9.0` as a Beta blocker.
- Changes the certified Travel destination allowlist, so Application Verification must prove the complete macOS transform and client path.
- Requires a forward-port to `main` after merge.

Implemented and reviewed with Codex using the repository test harness.
