### PR TITLE
fix(tools): keep wheel scrolling responsive

### DIFF
--- a/src/renderer/toolbox-foundation.ts
+++ b/src/renderer/toolbox-foundation.ts
@@ -203,8 +203,11 @@ export function createToolboxFoundation(
   const stopAtOverlay = (event: Event) => event.stopPropagation();
   for (const name of [
     "keydown", "keyup", "pointerdown", "pointerup", "pointermove",
-    "mousedown", "mouseup", "mousemove", "click", "wheel", "contextmenu",
+    "mousedown", "mouseup", "mousemove", "click", "contextmenu",
   ]) root.addEventListener(name, stopAtOverlay);
+  // A non-passive wheel listener makes Chromium send native scrolling through
+  // the main thread. Tools only contains the event; it never cancels scrolling.
+  root.addEventListener("wheel", stopAtOverlay, { passive: true });
 
   const mirrorCursor = () => { root.style.cursor = canvas.style.cursor; };
   const cursorMirror = new MutationObserver(mirrorCursor);

--- a/tests/electron/input-toolbox.spec.ts
+++ b/tests/electron/input-toolbox.spec.ts
@@ -240,6 +240,19 @@ test.describe("renderer Tools input", () => {
       const trade = page.getByTestId("stub-trade");
       await expect(root).not.toHaveAttribute("data-open");
       await expect(tool).toBeHidden();
+      const cdp = await fixture.app.context().newCDPSession(page);
+      const rootHandle = await cdp.send("Runtime.evaluate", {
+        expression: "document.querySelector('#toolbox-foundation')",
+      });
+      if (!rootHandle.result.objectId) throw new Error("Tools root is missing");
+      const { listeners } = await cdp.send("DOMDebugger.getEventListeners", {
+        objectId: rootHandle.result.objectId,
+      });
+      expect(listeners).toContainEqual(expect.objectContaining({
+        type: "wheel",
+        passive: true,
+      }));
+      await cdp.detach();
 
       // The game owns canvas clicks while the palette is closed.
       await page.locator("#canvas").click({ position: GAME_POINT });


### PR DESCRIPTION
## Problem

Scrolling the Kamadan Trade ledger with a wheel or trackpad felt sluggish even though dragging the scrollbar thumb was responsive. The Tools overlay registered a non-passive wheel listener, so Chromium had to wait for the renderer main thread before native scrolling could begin.

## Solution

Register the overlay's wheel-containment listener as passive. The listener still stops the event at the Tools boundary so it cannot reach Guild Wars, but it can no longer cancel native scrolling.

The Electron input test now reads Chromium's installed listener state through CDP and requires the shipped Tools root to expose a passive wheel listener.

## Verification

- `pnpm check` — 1,361 unit tests, 184 policy tests, and 141 Tools tests passed
- `pnpm build`
- Focused Electron input-boundary test passed
- Nuclear code-quality review completed with no remaining blockers

## Risk and rollout

This is a narrow renderer input-boundary change. Automated checks prove registration and isolation; they do not claim live scrolling feel. Verify the exact Developer Build in Guild Wars and include the change in the next Beta train.

## Attribution

Implemented and verified with Codex. The Electron harness provides the automated browser-boundary evidence.
