### PR TITLE
fix(input): keep memory warning keyboard-passive

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -330,7 +330,8 @@ cannot stop memory that continues to grow.
 When the app warns about memory, choose whether to return to the selected
 character automatically, then choose **Reload Guild Wars**. This uses the same
 saved preference as Command-Q and **View → Reload Guild Wars**. Reload in an
-outpost when you want the lowest gameplay risk.
+outpost when you want the lowest gameplay risk. The warning does not take
+keyboard focus from Guild Wars. Click a warning control when you want to use it.
 
 ## Updates
 

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -435,7 +435,6 @@ function requestHeapCap() {
             }
           },
         },
-        window.gwSurfaces,
       );
       disposeMemoryWarningSettings();
       disposeMemoryWarningSettings = native().settings.onChange((updated) => {

--- a/src/renderer/memory-warning.ts
+++ b/src/renderer/memory-warning.ts
@@ -22,7 +22,6 @@ export type MemoryWarningActions = Readonly<{
 export function bindMemoryWarning(
   document: Document,
   actions: MemoryWarningActions,
-  surfaces: GwonmacSurfaceController | null = null,
 ): MemoryWarningPresenter | null {
   const root = document.getElementById("memory-notice");
   const live = document.getElementById("memory-notice-text");
@@ -52,14 +51,8 @@ export function bindMemoryWarning(
     dismissedLevel = currentLevel;
     root.hidden = true;
     details.open = false;
-    dismissable?.setOpen(false);
     document.getElementById("canvas")?.focus();
   };
-  const dismissable = surfaces?.register({
-    root,
-    priority: 8,
-    dismiss,
-  }) ?? null;
 
   for (const name of [
     "keydown", "keyup", "pointerdown", "pointerup", "pointermove",
@@ -81,13 +74,11 @@ export function bindMemoryWarning(
 
   reloadButton.addEventListener("click", () => {
     root.hidden = true;
-    dismissable?.setOpen(false);
     (reloadButton as HTMLButtonElement).disabled = true;
     void pendingPreferenceSave.then(() => actions.reload())
       .catch(() => {
         (reloadButton as HTMLButtonElement).disabled = false;
         root.hidden = false;
-        dismissable?.setOpen(true);
       });
   });
   laterButton.addEventListener("click", dismiss);
@@ -106,7 +97,6 @@ export function bindMemoryWarning(
       live.setAttribute("role", level === "critical" ? "alert" : "status");
       live.setAttribute("aria-live", level === "critical" ? "assertive" : "polite");
       root.hidden = false;
-      dismissable?.setOpen(true);
     },
     setAutoRelog(enabled) {
       savedAutoRelog = enabled;
@@ -115,7 +105,6 @@ export function bindMemoryWarning(
     hide() {
       root.hidden = true;
       details.open = false;
-      dismissable?.setOpen(false);
     },
   };
 }

--- a/tests/electron/input-keyboard.spec.ts
+++ b/tests/electron/input-keyboard.spec.ts
@@ -6,6 +6,8 @@ type KeyboardInputWindow = typeof window & {
   __gameKeys: string[];
 };
 
+type MemoryWarningModule = typeof import("../../src/renderer/memory-warning.js");
+
 /**
  * ArenaNet's generated host object owns the active OSK field. Intersecting its
  * declaration keeps these tests narrower than an untyped Module replacement.
@@ -152,6 +154,62 @@ test.describe("renderer keyboard input", () => {
         await Promise.resolve();
         return document.activeElement?.id;
       })).toBe("canvas");
+    } finally {
+      await closeOffline(fixture);
+    }
+  });
+
+  test("keeps the memory warning passive until a player clicks it", async () => {
+    const fixture = await launchCachedClient("gw-memory-warning-input-e2e-");
+    try {
+      const { page } = fixture;
+      await startGameInput(page);
+      await page.evaluate(async () => {
+        const canvas = document.getElementById("canvas");
+        if (!(canvas instanceof HTMLCanvasElement)) {
+          throw new Error("#canvas is missing");
+        }
+        const moduleUrl: string = "gw://app/memory-warning.js";
+        const { bindMemoryWarning } = await import(moduleUrl) as MemoryWarningModule;
+        const presenter = bindMemoryWarning(document, {
+          autoRelogAfterReload: false,
+          async saveAutoRelog() {},
+          reload() {},
+        });
+        if (!presenter) throw new Error("memory warning is unavailable");
+
+        canvas.dataset.memoryWarningKeys = "";
+        canvas.addEventListener("keydown", (event) => {
+          canvas.dataset.memoryWarningKeys += `${event.code} `;
+        }, true);
+        canvas.focus();
+        presenter.present("critical", 2_147_483_648);
+      });
+
+      const canvas = page.locator("#canvas");
+      await expect(page.locator("#memory-notice")).toBeVisible();
+      expect(await page.evaluate(() => document.activeElement?.id)).toBe("canvas");
+      await page.keyboard.press("Tab");
+      // This fixture has no client-owned Tab default. Restore the game target
+      // so Escape independently proves that the warning does not claim it.
+      await canvas.evaluate((element) => {
+        if (!(element instanceof HTMLCanvasElement)) {
+          throw new Error("#canvas is missing");
+        }
+        element.focus();
+      });
+      await page.keyboard.press("Escape");
+      await expect(canvas).toHaveAttribute("data-memory-warning-keys", "Tab Escape ");
+      await expect(page.locator("#memory-notice")).toBeVisible();
+
+      await page.getByRole("button", { name: "Later" }).evaluate((button) => {
+        if (!(button instanceof HTMLButtonElement)) {
+          throw new Error("Later button is missing");
+        }
+        button.click();
+      });
+      await expect(page.locator("#memory-notice")).toBeHidden();
+      expect(await page.evaluate(() => document.activeElement?.id)).toBe("canvas");
     } finally {
       await closeOffline(fixture);
     }

--- a/tests/electron/multiple-accounts.spec.ts
+++ b/tests/electron/multiple-accounts.spec.ts
@@ -659,7 +659,6 @@ test("Multi isolates profile windows and Copy Reload Trace", async () => {
             await window.gwNative.app.reloadGame("memory-warning");
           },
         },
-        window.gwSurfaces,
       );
       if (!presenter) throw new Error("memory warning is unavailable");
       presenter.present("critical", 2_147_483_648);

--- a/tests/unit/memory-warning.test.ts
+++ b/tests/unit/memory-warning.test.ts
@@ -113,31 +113,6 @@ describe("memory warning presenter", () => {
     assert.equal(dom.element("memory-notice").hidden, true);
   });
 
-  it("registers as a dismissible keyboard surface while visible", () => {
-    const dom = memoryDom();
-    const open: boolean[] = [];
-    let dismiss = () => {};
-    const surfaces: GwonmacSurfaceController = {
-      register(surface) {
-        dismiss = surface.dismiss;
-        return {
-          setOpen(value) { open.push(value); },
-          raise() {},
-          dispose() {},
-        };
-      },
-    };
-    const presenter = bindMemoryWarning(dom.document, warningActions(), surfaces);
-    assert.ok(presenter);
-
-    presenter.present("low", 2_147_483_648);
-    assert.deepEqual(open, [true]);
-    dismiss();
-    assert.equal(dom.element("memory-notice").hidden, true);
-    assert.equal(dom.element("canvas").focused, true);
-    assert.deepEqual(open, [true, false]);
-  });
-
   it("shares and saves the automatic-return preference", async () => {
     const dom = memoryDom();
     const saved: boolean[] = [];


### PR DESCRIPTION
The low-memory warning could register itself as the top keyboard surface while the player was still controlling Guild Wars. That made ordinary Tab or Escape input operate the warning simply because it appeared.

The warning is now display-only until the player clicks one of its controls. It no longer joins the host surface controller, while reload, dismissal, automatic-return preference handling, and focus restoration after dismissal stay unchanged.

## Verification

- `pnpm check` — 1,360 unit tests, 184 policy tests, and 141 Tools tests passed
- `pnpm build`
- Focused Electron keyboard test proves showing the warning preserves canvas focus and does not claim Tab or Escape
- Existing Electron multi-account reload test passed
- Nuclear code-quality review passed

## Risk and rollout

This changes the renderer input boundary. The automated proof uses the cached-client Electron harness; it does not replace live Guild Wars input-feel QA. Verify it in a Developer Build and include it in the next Beta train.
