### PR TITLE
chore(release): prepare version 2026.9.0-beta.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "guild-wars",
   "productName": "Guild Wars Reforged",
-  "version": "2026.9.0-beta.2",
+  "version": "2026.9.0-beta.3",
   "private": true,
   "packageManager": "pnpm@11.13.1",
   "type": "module",


### PR DESCRIPTION
Cartography and the corrected Piken Square travel catalogue are now together on the frozen September release branch. This gives that combined candidate a new Beta identity so it can be built, signed, and tested without reusing the earlier `beta.2` release.

This changes only the application version from `2026.9.0-beta.2` to `2026.9.0-beta.3`. No additional product code enters the release.

## Invariant

The base version matches `release/2026.9.0`, and the unique `-beta.3` suffix selects the Beta updater channel without colliding with an existing tag or draft.

## Verification

- `pnpm run check`
- 184 repository policy tests passed
- 142 Tools UI tests passed
- diff contains only the `package.json` version change

## Rollout risk

Low. The protected branch gate, dry run, exact current-client qualification, signing, packaging, updater checks, and exact signed-draft QA remain mandatory.
