### PR TITLE
fix(cartography): recertify the current client for 2026.9.0

### DIFF
--- a/src/main/certification/cartography-spike-client.ts
+++ b/src/main/certification/cartography-spike-client.ts
@@ -46,6 +46,13 @@ const CERTIFIED_CARTOGRAPHY_BUILDS: ReadonlyMap<string, CertifiedCartographyBuil
     },
   ],
   [
+    "aca501484f766c95c27a47ffbd09bb5f5a162de7106500450295d4e61272efbb",
+    {
+      memoryLayout: "relocated",
+      outputSha256: "8a61e05c24f205d104e3f2950f5834667437a48ee080767080585b428bbc9f31",
+    },
+  ],
+  [
     "1f4a199ea902f839abb3b71861759f956db2aa4e7f31fcabd1970d12d24ca3a0",
     {
       memoryLayout: "relocated",

--- a/src/main/certification/compass-frame-spike-proof.ts
+++ b/src/main/certification/compass-frame-spike-proof.ts
@@ -16,7 +16,7 @@ import { deriveSkillSlotGeometry } from "./enhancement-skill-slot-geometry-proof
 import type { KnownEnhancementBuild } from "./enhancement-builds.js";
 
 const COMPASS_OWNER_BODY_SHA256 =
-  "e4ae212b84a9b2270784ed4fe46a24b6a3b757f80e16ed341388f449e342d29f";
+  "9df419f84c93ec674540ef60dc74cae03495e3308843ab3fcc594cad93e97043";
 
 type PreGameProof = NonNullable<KnownEnhancementBuild["preGameControls"]>;
 type SkillFrameProof = NonNullable<KnownEnhancementBuild["skillSlotGeometry"]>;

--- a/src/main/certification/pathing-spike-proof.ts
+++ b/src/main/certification/pathing-spike-proof.ts
@@ -12,7 +12,7 @@ import {
 import type { DecodedFunction, MemoryOperandSite } from "./enhancement-evidence-types.js";
 
 const OFFICIAL_SHA256 =
-  "3cd87bf15df6812073b558e9f365c8fb8e2a54b1b4c37028e5d3a6cbaf5e6f9e";
+  "e00e8368a1d0e1003bf1882dce2d4b3cd8e2e8b6c4acc72474c8b56e2e35c6bb";
 const ANCHORS = Object.freeze({
   bound: "def->trapezoidCount < 1024",
   index: "index < pathMap.trapezoidCount",

--- a/tests/client-artifact/compass-frame-spike-recert.test.ts
+++ b/tests/client-artifact/compass-frame-spike-recert.test.ts
@@ -2,10 +2,10 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
-import { ENHANCEMENT_BUILDS } from
-  "../../src/main/certification/enhancement-builds.js";
 import { deriveCompassFrameSpikeProof } from
   "../../src/main/certification/compass-frame-spike-proof.js";
+import { verifyLocalClientBytes } from
+  "../../src/main/certification/local-client-verifier.js";
 import { wasmEvidence } from
   "../../src/main/certification/wasm-evidence.js";
 import {
@@ -39,12 +39,13 @@ test("certifies one named Compass frame and refuses owner mutations", {
   assert.ok(artifact, "GW_CLIENT_WASM must name the retained official artifact");
   const bytes = new Uint8Array(await readFile(artifact));
   const context = wasmEvidence(bytes);
-  const retained = ENHANCEMENT_BUILDS[0];
-  assert.ok(context && retained?.preGameControls && retained.skillSlotGeometry);
+  const verified = verifyLocalClientBytes(bytes);
+  const current = verified.enhancementBuild;
+  assert.ok(context && current?.preGameControls && current.skillSlotGeometry);
   const proof = deriveCompassFrameSpikeProof(
     context,
-    retained.preGameControls,
-    retained.skillSlotGeometry,
+    current.preGameControls,
+    current.skillSlotGeometry,
   );
   assert.ok(proof);
   assert.equal(proof.ownerFunction, 15_750);
@@ -67,8 +68,8 @@ test("certifies one named Compass frame and refuses owner mutations", {
   assert.equal(
     deriveCompassFrameSpikeProof(
       changedContext,
-      retained.preGameControls,
-      retained.skillSlotGeometry,
+      current.preGameControls,
+      current.skillSlotGeometry,
     ),
     null,
   );


### PR DESCRIPTION
The `2026.9.0-beta.3` release stopped before signing after ArenaNet published a new client generation. Existing Core and Tools capabilities still proved, but Cartography correctly refused the changed Compass owner, pathing generation, and full-Tools derived input.

This backports the reviewed fix from #343 to the protected `release/2026.9.0` branch. It recertifies only evidence proven equivalent for the current client. No locator was loosened and no fallback was added; mutated Compass and pathing owners still refuse.

## Verification

- Exact release-branch client chain, Compass, pathing, and transform tests: 4 passed
- `pnpm run check`: passed
- Version remains `2026.9.0-beta.3`
- Diff contains only four Cartography certification and test files

The prior release attempt created no tag, draft, assets, or publication, so this keeps the same Beta version.
