### PR TITLE
fix(cartography): seal the Tools transform for Beta 4

### DIFF
--- a/src/main/certification/cartography-spike-client.ts
+++ b/src/main/certification/cartography-spike-client.ts
@@ -49,7 +49,7 @@ const CERTIFIED_CARTOGRAPHY_BUILDS: ReadonlyMap<string, CertifiedCartographyBuil
     "aca501484f766c95c27a47ffbd09bb5f5a162de7106500450295d4e61272efbb",
     {
       memoryLayout: "relocated",
-      outputSha256: "8a61e05c24f205d104e3f2950f5834667437a48ee080767080585b428bbc9f31",
+      outputSha256: "aad630368312cdcb30812c4c942d78b6041678105a6acf806d161a225a2a3b58",
     },
   ],
   [


### PR DESCRIPTION
The Beta 4 release build failed closed while reproducing the current ArenaNet client chain. The useful-cell cartography change updated the sealed outputs for the official, template, and Core transforms, but the Tools `features-7ff` output still named the previous transform result.

This pins the deterministic Tools cartography output produced from the already-certified `features-7ff` input. It does not broaden accepted clients, change the verifier, or add fallback behavior.

Verification:

- Exact current ArenaNet client: all four cartography inputs were transformed locally and hashed.
- Previously failing `client-chain-qualification.test.ts`: passed.
- `pnpm run check`: passed (1,439 unit, 184 policy, and 142 Tools tests).

Prepared with Codex.
