### PR TITLE
refactor(storage): define explicit platform roots

### DIFF
--- a/docs/content-pipeline.md
+++ b/docs/content-pipeline.md
@@ -153,6 +153,24 @@ chunk directory.
 Demand reads take priority over prefetch. The scheduler keeps capacity for a
 cold demand read while a full download is active.
 
+## Storage responsibilities
+
+`ApplicationStorageRoots` names six responsibilities: configuration, durable
+data, cache, restart state, logs, and browser sessions. Domain owners receive
+resolved paths and do not choose an operating-system directory.
+
+macOS maps all six responsibilities to the released `Guild Wars` data root.
+This keeps every existing path unchanged. A target platform can split the
+roots before it creates data. The game generation and chunk store use the
+cache root. The profile registry and player-authored libraries use the data
+root. Browser partitions use the sessions root.
+
+Run `pnpm storage:probe` on a target filesystem. Pass `-- --base <directory>`
+to select a specific volume. The command creates and removes only its printed
+temporary fixture. It reports basic atomic replacement, exclusive creation,
+open-file replacement, case behavior, long Unicode paths, and orphan cleanup.
+It does not claim power-loss, disk-full, antivirus, or reboot durability.
+
 ## Download limits and progress
 
 The app uses a fixed maximum of eight concurrent ArenaNet requests. This limit

--- a/docs/multiple-accounts.md
+++ b/docs/multiple-accounts.md
@@ -64,6 +64,11 @@ rollback window and has no operational role in the candidate.
 
 Only `profile-storage.ts` knows about adopted storage.
 
+`ApplicationStorageRoots` decides which durability root owns each resolved
+path. It does not create another profile registry. macOS currently maps every
+root to the released `userData` directory, so adoption remains byte-for-byte
+in place.
+
 The adopted Main account resolves to the released default Electron session,
 fixed Keychain items, root build library, native template filesystem, root
 reset marker, and root window state. No file or credential is copied, moved,

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dev": "pnpm build && electron-forge start",
     "dev:signed": "node --import ./scripts/ts-hook.mjs scripts/run-signed-dev.ts",
     "launcher:fixture": "pnpm build && node --import ./scripts/ts-hook.mjs scripts/launcher-fixture.ts",
+    "storage:probe": "node --import ./scripts/ts-hook.mjs scripts/platform-storage-probe.ts",
     "test:signed-dev": "node --import ./scripts/ts-hook.mjs scripts/run-signed-dev.ts --test-keychain",
     "tools:dev": "pnpm --filter @gwonmac/tools-ui dev",
     "tools:test": "pnpm --filter @gwonmac/tools-ui test",

--- a/scripts/platform-storage-probe.ts
+++ b/scripts/platform-storage-probe.ts
@@ -1,0 +1,131 @@
+/** Probe the real atomic writer and split-root layout on one disposable filesystem. */
+import assert from "node:assert/strict";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  open,
+  readFile,
+  rm,
+  statfs,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import process from "node:process";
+import {
+  sweepOrphans,
+  writeAtomic,
+  writeAtomicExclusive,
+} from "../src/main/core/atomic-file.js";
+import {
+  gamePaths,
+  type ApplicationStorageRoots,
+} from "../src/main/core/paths.js";
+
+function argument(name: string): string | undefined {
+  const index = process.argv.indexOf(name);
+  if (index === -1) return undefined;
+  const value = process.argv[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    throw new Error(`${name} requires a directory`);
+  }
+  return value;
+}
+
+const base = path.resolve(argument("--base") ?? tmpdir());
+await access(base);
+const fixture = await mkdtemp(path.join(base, "gwonmac-storage-probe-"));
+const keep = process.argv.includes("--keep");
+let passed = false;
+globalThis.console.log(`Storage probe fixture: ${fixture}`);
+
+try {
+  const storage: ApplicationStorageRoots = {
+    config: path.join(fixture, "config"),
+    data: path.join(fixture, "data"),
+    cache: path.join(fixture, "cache"),
+    state: path.join(fixture, "state"),
+    logs: path.join(fixture, "logs"),
+    sessions: path.join(fixture, "sessions"),
+  };
+  const paths = gamePaths(storage);
+
+  await writeAtomic(paths.settings, '{"revision":1}\n', 0o600);
+  await writeAtomic(paths.settings, '{"revision":2}\n', 0o600);
+  assert.equal(await readFile(paths.settings, "utf8"), '{"revision":2}\n');
+
+  const exclusive = path.join(paths.multiRoot, "workspace.json");
+  const publications = await Promise.allSettled([
+    writeAtomicExclusive(exclusive, "first", 0o600),
+    writeAtomicExclusive(exclusive, "second", 0o600),
+  ]);
+  assert.equal(
+    publications.filter((result) => result.status === "fulfilled").length,
+    1,
+    "exactly one exclusive publication must win",
+  );
+
+  const unicodeDirectory = path.join(
+    paths.storage.data,
+    `Ü-${"long-segment-".repeat(12)}`,
+  );
+  const unicodeDocument = path.join(unicodeDirectory, "日本語-profile.json");
+  await writeAtomic(unicodeDocument, "unicode", 0o600);
+  assert.equal(await readFile(unicodeDocument, "utf8"), "unicode");
+
+  const held = await open(paths.settings, "r");
+  let replaceWhileOpen: "passed" | "refused";
+  try {
+    await writeAtomic(paths.settings, '{"revision":3}\n', 0o600);
+    replaceWhileOpen = "passed";
+  } catch {
+    replaceWhileOpen = "refused";
+  } finally {
+    await held.close();
+  }
+
+  const caseUpper = path.join(paths.storage.state, "Case-Probe");
+  const caseLower = path.join(paths.storage.state, "case-probe");
+  await writeAtomicExclusive(caseUpper, "upper", 0o600);
+  const caseDistinct = await writeAtomicExclusive(caseLower, "lower", 0o600)
+    .then(() => true, () => false);
+
+  await mkdir(paths.storage.logs, { recursive: true });
+  const orphan = path.join(
+    paths.storage.logs,
+    "probe.json.99999999.deadbeef.tmp",
+  );
+  await writeFile(orphan, "orphan", "utf8");
+  assert.equal(await sweepOrphans(paths.storage.logs), 1);
+
+  const filesystem = await statfs(fixture);
+  passed = true;
+  globalThis.console.log(JSON.stringify({
+    platform: process.platform,
+    filesystem: {
+      type: filesystem.type,
+      blockSize: filesystem.bsize,
+    },
+    results: {
+      atomicReplace: "passed",
+      exclusiveCreate: "passed",
+      unicodeLongPath: "passed",
+      replaceWhileOpen,
+      caseDistinct,
+      orphanRecovery: "passed",
+    },
+    unproven: [
+      "power-loss durability",
+      "disk-full publication",
+      "antivirus deny-delete locks",
+      "reboot durability",
+    ],
+  }, null, 2));
+} finally {
+  if (passed && !keep) {
+    await rm(fixture, { recursive: true, force: true });
+  } else {
+    globalThis.console.log(`Storage probe retained: ${fixture}`);
+  }
+}

--- a/src/main/core/paths.ts
+++ b/src/main/core/paths.ts
@@ -1,11 +1,15 @@
 /**
- * Every filesystem path this application constructs, in one place.
+ * Every writable application path, rooted by its durability responsibility.
  *
  * Two of these values are load-bearing beyond the code that reads them:
  * `chunks` holds up to ~4 GB of downloaded game data and `userData` is the
  * root of a profile that already exists on alpha machines. Relocating either
  * costs a user a re-download or a reset, so `tests/unit/paths.test.ts` pins
  * every resolved value as a literal.
+ *
+ * macOS deliberately gives every responsibility the released `userData` root.
+ * Other platforms can provide distinct roots without teaching settings, game
+ * content, diagnostics, or profile owners about an operating system.
  *
  * This module is deliberately Electron-free so `src/main/core/**` can share it
  * and so the pinning test can execute it. The Electron-rooted entry point is
@@ -17,6 +21,7 @@ import type { ProfileId } from "../../shared/multiple-accounts.js";
 import { clientGenerationPaths } from "./client-compatibility.js";
 
 export interface GamePaths {
+  readonly storage: ApplicationStorageRoots;
   userData: string;
   settings: string;
   diagnosticProfile: string;
@@ -49,28 +54,56 @@ export interface GamePaths {
   gameStorageClearRequest: string;
 }
 
-export function gamePaths(userData: string): GamePaths {
-  const game = path.join(userData, "game");
-  const artifacts = path.join(game, "artifacts");
-  const multiRoot = path.join(userData, "multi");
+export interface ApplicationStorageRoots {
+  /** Settings and other player-selected application configuration. */
+  readonly config: string;
+  /** Durable player-authored data and the canonical profile registry. */
+  readonly data: string;
+  /** Verified or derived content that the application can reacquire. */
+  readonly cache: string;
+  /** Restart state, window state, and recovery markers. */
+  readonly state: string;
+  /** Diagnostics and bounded local logs. */
+  readonly logs: string;
+  /** Electron browser/session data, isolated from the global game cache. */
+  readonly sessions: string;
+}
+
+/** Preserve a released installation whose stores already share one root. */
+export function colocatedStorageRoots(root: string): ApplicationStorageRoots {
   return {
-    userData,
-    settings: path.join(userData, "settings.json"),
-    diagnosticProfile: path.join(userData, "diagnostic-profile.json"),
-    travelPreferences: path.join(userData, "travel-preferences.json"),
-    travelHistory: path.join(userData, "travel-history.json"),
-    tradeSaved: path.join(userData, "trade-saved.json"),
-    buildLibrary: path.join(userData, "build-library.json"),
-    windowState: path.join(userData, "window-state.json"),
-    launcherState: path.join(userData, "launcher-state.json"),
-    launcherMode: path.join(userData, "launcher-mode.json"),
+    config: root,
+    data: root,
+    cache: root,
+    state: root,
+    logs: root,
+    sessions: root,
+  };
+}
+
+export function gamePaths(storage: ApplicationStorageRoots): GamePaths {
+  const game = path.join(storage.cache, "game");
+  const artifacts = path.join(game, "artifacts");
+  const multiRoot = path.join(storage.data, "multi");
+  return {
+    storage,
+    userData: storage.sessions,
+    settings: path.join(storage.config, "settings.json"),
+    diagnosticProfile: path.join(storage.config, "diagnostic-profile.json"),
+    travelPreferences: path.join(storage.config, "travel-preferences.json"),
+    travelHistory: path.join(storage.data, "travel-history.json"),
+    tradeSaved: path.join(storage.data, "trade-saved.json"),
+    buildLibrary: path.join(storage.data, "build-library.json"),
+    windowState: path.join(storage.state, "window-state.json"),
+    launcherState: path.join(storage.config, "launcher-state.json"),
+    launcherMode: path.join(storage.config, "launcher-mode.json"),
     multiRoot,
     multiWorkspace: path.join(multiRoot, "workspace.json"),
     multiSingleTemplateImport: path.join(multiRoot, "single-template-import.json"),
     multiSharedBuildLibrary: path.join(multiRoot, "shared", "build-library.json"),
     multiSharedTemplates: path.join(multiRoot, "shared", "templates.json"),
     multiProfiles: path.join(multiRoot, "profiles"),
-    diagnostics: path.join(userData, "diagnostics"),
+    diagnostics: path.join(storage.logs, "diagnostics"),
     game,
     artifacts,
     previousArtifacts: clientGenerationPaths(artifacts).previous,
@@ -85,8 +118,8 @@ export function gamePaths(userData: string): GamePaths {
     // per-client-build directory so a new build starts a new cache rather than
     // serving last build's art. Discardable: deleting it costs a re-decode.
     skillAssets: path.join(game, "skill-assets"),
-    cacheClearRequest: path.join(userData, "clear-cache-on-start"),
-    gameStorageClearRequest: path.join(userData, "clear-game-storage-on-start"),
+    cacheClearRequest: path.join(storage.state, "clear-cache-on-start"),
+    gameStorageClearRequest: path.join(storage.state, "clear-game-storage-on-start"),
   };
 }
 
@@ -124,8 +157,11 @@ export function multiProfilePaths(
  * owner is validating it.
  */
 export function documentDirectories(paths: GamePaths): string[] {
-  return [
-    paths.userData,
+  return [...new Set([
+    paths.storage.sessions,
+    paths.storage.config,
+    paths.storage.data,
+    paths.storage.state,
     paths.game,
     paths.diagnostics,
     paths.chunks,
@@ -133,7 +169,7 @@ export function documentDirectories(paths: GamePaths): string[] {
     paths.previousArtifacts,
     paths.compatibility,
     paths.enhancements,
-  ];
+  ])];
 }
 
 /** The published manifest of one client generation (installed, previous or stage). */

--- a/src/main/paths.ts
+++ b/src/main/paths.ts
@@ -9,14 +9,18 @@
  */
 import { app } from "electron";
 import path from "node:path";
-import { gamePaths as resolveGamePaths, unpackedPath } from "./core/paths.js";
+import {
+  colocatedStorageRoots,
+  gamePaths as resolveGamePaths,
+  unpackedPath,
+} from "./core/paths.js";
 import type { GamePaths } from "./core/paths.js";
 
 export type { GamePaths } from "./core/paths.js";
 
 /** The path table rooted at Electron's per-user data directory. */
 export function gamePaths(userData = app.getPath("userData")): GamePaths {
-  return resolveGamePaths(userData);
+  return resolveGamePaths(colocatedStorageRoots(userData));
 }
 
 export function rendererRoot(): string {

--- a/tests/electron/client-runtime-concurrency.spec.ts
+++ b/tests/electron/client-runtime-concurrency.spec.ts
@@ -24,9 +24,9 @@ test.describe("client generation coordination", () => {
           const path = process.getBuiltinModule("node:path");
           const require = createRequire(path.join(process.cwd(), "package.json"));
           const { ClientRuntime } = require(modules.clientRuntime);
-          const { gamePaths } = require(modules.paths);
+          const { colocatedStorageRoots, gamePaths } = require(modules.paths);
           const root = await fs.mkdtemp(path.join(os.tmpdir(), "gw-runtime-auto-download-"));
-          const paths = gamePaths(root);
+          const paths = gamePaths(colocatedStorageRoots(root));
           const progress: DownloadProgress[] = [];
           let downloads = 0;
           const runtime = new ClientRuntime({
@@ -126,11 +126,11 @@ test.describe("client generation coordination", () => {
           const require = createRequire(path.join(process.cwd(), "package.json"));
           const { ClientRuntime } = require(modules.clientRuntime);
           const { FREE_MARGIN } = require(modules.chunkStore);
-          const { gamePaths } = require(modules.paths);
+          const { colocatedStorageRoots, gamePaths } = require(modules.paths);
           const root = await fs.mkdtemp(
             path.join(os.tmpdir(), "gw-runtime-cache-policy-"),
           );
-          const paths = gamePaths(root);
+          const paths = gamePaths(colocatedStorageRoots(root));
           await fs.mkdir(paths.chunks, { recursive: true });
           const size = 10 ** 15;
           const runtime = new ClientRuntime({
@@ -256,11 +256,11 @@ test.describe("client generation coordination", () => {
           const path = process.getBuiltinModule("node:path");
           const require = createRequire(path.join(process.cwd(), "package.json"));
           const { ClientRuntime } = require(modules.clientRuntime);
-          const { gamePaths } = require(modules.paths);
+          const { colocatedStorageRoots, gamePaths } = require(modules.paths);
           const root = await fs.mkdtemp(
             path.join(os.tmpdir(), "gw-runtime-ready-invariant-"),
           );
-          const paths = gamePaths(root);
+          const paths = gamePaths(colocatedStorageRoots(root));
           const readyObservations: boolean[] = [];
           const runtime: InstanceType<typeof ClientRuntime> = new ClientRuntime({
             paths,
@@ -365,11 +365,11 @@ test.describe("client generation coordination", () => {
           const require = createRequire(path.join(process.cwd(), "package.json"));
           const { ClientRuntime } = require(modules.clientRuntime);
           const { PatchClient } = require(modules.patchClient);
-          const { gamePaths } = require(modules.paths);
+          const { colocatedStorageRoots, gamePaths } = require(modules.paths);
           const root = await fs.mkdtemp(
             path.join(os.tmpdir(), "gw-runtime-abort-probe-"),
           );
-          const paths = gamePaths(root);
+          const paths = gamePaths(colocatedStorageRoots(root));
           await fs.mkdir(paths.game, { recursive: true });
           const progress: DownloadProgress[] = [];
           const runtime = new ClientRuntime({
@@ -461,11 +461,11 @@ test.describe("client generation coordination", () => {
           const require = createRequire(path.join(process.cwd(), "package.json"));
           const { ClientRuntime } = require(modules.clientRuntime);
           const { PatchClient } = require(modules.patchClient);
-          const { gamePaths } = require(modules.paths);
+          const { colocatedStorageRoots, gamePaths } = require(modules.paths);
           const root = await fs.mkdtemp(
             path.join(os.tmpdir(), "gw-runtime-shutdown-probe-"),
           );
-          const paths = gamePaths(root);
+          const paths = gamePaths(colocatedStorageRoots(root));
           await fs.mkdir(paths.game, { recursive: true });
           const runtime = new ClientRuntime({
             paths,
@@ -551,11 +551,11 @@ test.describe("client generation coordination", () => {
           const require = createRequire(path.join(process.cwd(), "package.json"));
           const { ClientRuntime } = require(modules.clientRuntime);
           const { PatchClient } = require(modules.patchClient);
-          const { gamePaths } = require(modules.paths);
+          const { colocatedStorageRoots, gamePaths } = require(modules.paths);
           const root = await fs.mkdtemp(
             path.join(os.tmpdir(), "gw-runtime-queued-abort-probe-"),
           );
-          const paths = gamePaths(root);
+          const paths = gamePaths(colocatedStorageRoots(root));
           await fs.mkdir(paths.game, { recursive: true });
           const runtime = new ClientRuntime({
             paths,
@@ -625,11 +625,11 @@ test.describe("client generation coordination", () => {
           const require = createRequire(path.join(process.cwd(), "package.json"));
           const { ClientRuntime } = require(modules.clientRuntime);
           const { PatchClient } = require(modules.patchClient);
-          const { gamePaths } = require(modules.paths);
+          const { colocatedStorageRoots, gamePaths } = require(modules.paths);
           const root = await fs.mkdtemp(
             path.join(os.tmpdir(), "gw-runtime-active-update-probe-"),
           );
-          const paths = gamePaths(root);
+          const paths = gamePaths(colocatedStorageRoots(root));
           await fs.mkdir(paths.artifacts, { recursive: true });
           const progress: DownloadProgress[] = [];
           const runtime = new ClientRuntime({
@@ -720,11 +720,11 @@ test.describe("client generation coordination", () => {
           const require = createRequire(path.join(process.cwd(), "package.json"));
           const { ClientRuntime } = require(modules.clientRuntime);
           const { PatchClient } = require(modules.patchClient);
-          const { gamePaths } = require(modules.paths);
+          const { colocatedStorageRoots, gamePaths } = require(modules.paths);
           const root = await fs.mkdtemp(
             path.join(os.tmpdir(), "gw-runtime-startup-rollback-probe-"),
           );
-          const paths = gamePaths(root);
+          const paths = gamePaths(colocatedStorageRoots(root));
           await fs.mkdir(paths.artifacts, { recursive: true });
           await fs.mkdir(paths.previousArtifacts, { recursive: true });
           await fs.writeFile(
@@ -829,11 +829,11 @@ test.describe("client generation coordination", () => {
           const path = process.getBuiltinModule("node:path");
           const require = createRequire(path.join(process.cwd(), "package.json"));
           const { ClientRuntime } = require(modules.clientRuntime);
-          const { gamePaths } = require(modules.paths);
+          const { colocatedStorageRoots, gamePaths } = require(modules.paths);
           const root = await fs.mkdtemp(
             path.join(os.tmpdir(), "gw-runtime-unpublished-facts-probe-"),
           );
-          const paths = gamePaths(root);
+          const paths = gamePaths(colocatedStorageRoots(root));
           await fs.mkdir(paths.artifacts, { recursive: true });
           const runtime = new ClientRuntime({
             paths,
@@ -930,11 +930,11 @@ test.describe("client generation coordination", () => {
           const path = process.getBuiltinModule("node:path");
           const require = createRequire(path.join(process.cwd(), "package.json"));
           const { ClientRuntime } = require(modules.clientRuntime);
-          const { gamePaths } = require(modules.paths);
+          const { colocatedStorageRoots, gamePaths } = require(modules.paths);
           const root = await fs.mkdtemp(
             path.join(os.tmpdir(), "gw-runtime-confirm-probe-"),
           );
-          const paths = gamePaths(root);
+          const paths = gamePaths(colocatedStorageRoots(root));
           await fs.mkdir(paths.artifacts, { recursive: true });
           await fs.mkdir(paths.previousArtifacts, { recursive: true });
           await fs.writeFile(
@@ -1094,11 +1094,11 @@ test.describe("client generation coordination", () => {
           const path = process.getBuiltinModule("node:path");
           const require = createRequire(path.join(process.cwd(), "package.json"));
           const { ClientRuntime } = require(modules.clientRuntime);
-          const { gamePaths } = require(modules.paths);
+          const { colocatedStorageRoots, gamePaths } = require(modules.paths);
           const root = await fs.mkdtemp(
             path.join(os.tmpdir(), "gw-runtime-exact-token-probe-"),
           );
-          const paths = gamePaths(root);
+          const paths = gamePaths(colocatedStorageRoots(root));
           await fs.mkdir(paths.artifacts, { recursive: true });
           await fs.mkdir(paths.previousArtifacts, { recursive: true });
           await fs.writeFile(

--- a/tests/helpers/launcher-profile-fixtures.ts
+++ b/tests/helpers/launcher-profile-fixtures.ts
@@ -1,7 +1,10 @@
 /** Disposable account-workspace shapes shared by Electron tests and developers. */
 import { mkdir, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { gamePaths } from "../../src/main/core/paths.js";
+import {
+  colocatedStorageRoots,
+  gamePaths,
+} from "../../src/main/core/paths.js";
 
 export const LAUNCHER_FIXTURE_SCENARIOS = [
   "fresh",
@@ -37,7 +40,7 @@ export async function seedLauncherProfileFixture(
   userData: string,
   scenario: LauncherFixtureScenario,
 ): Promise<void> {
-  const paths = gamePaths(userData);
+  const paths = gamePaths(colocatedStorageRoots(userData));
   if (scenario === "fresh") return;
   if (scenario === "single") {
     await Promise.all([

--- a/tests/unit/account-profile-creation.test.ts
+++ b/tests/unit/account-profile-creation.test.ts
@@ -15,7 +15,11 @@ import {
   loadMultiWorkspace,
   saveMultiWorkspace,
 } from "../../src/main/core/multiple-accounts.js";
-import { gamePaths, multiProfilePaths } from "../../src/main/core/paths.js";
+import {
+  colocatedStorageRoots,
+  gamePaths,
+  multiProfilePaths,
+} from "../../src/main/core/paths.js";
 import { EMPTY_LIBRARY } from "../../src/shared/builds/parse-library.js";
 import { parseProfileId } from "../../src/shared/multiple-accounts.js";
 
@@ -41,7 +45,7 @@ async function absent(path: string): Promise<boolean> {
 
 async function setup() {
   const root = await mkdtemp(join(tmpdir(), "gw-account-create-"));
-  const paths = gamePaths(root);
+  const paths = gamePaths(colocatedStorageRoots(root));
   const workspace = createMultiWorkspace();
   await saveMultiWorkspace(paths.multiWorkspace, workspace);
   await writeFile(paths.buildLibrary, JSON.stringify(EMPTY_LIBRARY));

--- a/tests/unit/atomic-file.test.ts
+++ b/tests/unit/atomic-file.test.ts
@@ -25,7 +25,11 @@ import {
   writeAtomicInDir,
   writeAtomicJson,
 } from "../../src/main/core/atomic-file.js";
-import { documentDirectories, gamePaths } from "../../src/main/core/paths.js";
+import {
+  colocatedStorageRoots,
+  documentDirectories,
+  gamePaths,
+} from "../../src/main/core/paths.js";
 
 async function scratch(): Promise<string> {
   return mkdtemp(join(tmpdir(), "gw-atomic-"));
@@ -294,7 +298,7 @@ describe("atomic-file orphan sweep", () => {
     // the diagnostics log all publish through the same `writeAtomic` and so
     // leak the same temp files — they were collected by nothing at all.
     const root = await scratch();
-    const dirs = documentDirectories(gamePaths(root));
+    const dirs = documentDirectories(gamePaths(colocatedStorageRoots(root)));
     for (const dir of dirs) {
       await mkdir(dir, { recursive: true });
       await writeFile(join(dir, `doc.json.${process.pid + 1}.0badcafe.tmp`), "abandoned");

--- a/tests/unit/paths.test.ts
+++ b/tests/unit/paths.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   clientArtifactPath,
   clientManifestPath,
+  colocatedStorageRoots,
   diagnosticFramesPath,
   documentDirectories,
   gamePaths,
@@ -21,7 +22,15 @@ describe("resolved profile paths", () => {
   const root = "/Users/tester/Library/Application Support/Guild Wars";
 
   it("pins the whole profile layout as literals", () => {
-    assert.deepEqual(gamePaths(root), {
+    assert.deepEqual(gamePaths(colocatedStorageRoots(root)), {
+      storage: {
+        config: root,
+        data: root,
+        cache: root,
+        state: root,
+        logs: root,
+        sessions: root,
+      },
       userData: root,
       settings: `${root}/settings.json`,
       diagnosticProfile: `${root}/diagnostic-profile.json`,
@@ -61,7 +70,7 @@ describe("resolved profile paths", () => {
     // here and has to decide whether the new directory receives `writeAtomic`
     // writes. A directory left off this list leaks abandoned temp files forever
     // — nothing else collects them.
-    assert.deepEqual(documentDirectories(gamePaths(root)), [
+    assert.deepEqual(documentDirectories(gamePaths(colocatedStorageRoots(root))), [
       root,
       `${root}/game`,
       `${root}/diagnostics`,
@@ -79,7 +88,7 @@ describe("resolved profile paths", () => {
 
   it("derives profile paths only beneath the Multi namespace", () => {
     const id = parseProfileId("2d31e565-9fc8-4dde-9fd4-9d644f8283ae");
-    assert.deepEqual(multiProfilePaths(gamePaths(root), id), {
+    assert.deepEqual(multiProfilePaths(gamePaths(colocatedStorageRoots(root)), id), {
       root: `${root}/multi/profiles/${id}`,
       buildLibrary: `${root}/multi/profiles/${id}/build-library.json`,
       templates: `${root}/multi/profiles/${id}/templates.json`,
@@ -91,7 +100,10 @@ describe("resolved profile paths", () => {
   it("keeps the downloaded chunk cache exactly where the alpha put it", () => {
     // Called out separately because this is the expensive one: it is the only
     // path in the table whose relocation costs a full re-download.
-    assert.equal(gamePaths(root).chunks, `${root}/game/chunks`);
+    assert.equal(
+      gamePaths(colocatedStorageRoots(root)).chunks,
+      `${root}/game/chunks`,
+    );
   });
 
   it("pins the files published inside a client generation", () => {
@@ -149,9 +161,46 @@ describe("resolved profile paths", () => {
   });
 
   it("resolves a staged generation without escaping the game directory", () => {
-    const paths = gamePaths(root);
+    const paths = gamePaths(colocatedStorageRoots(root));
     assert.equal(clientManifestPath(`${paths.artifacts}.next`).startsWith(
       `${paths.game}/`,
     ), true);
+  });
+
+  it("routes split storage without giving domain owners a platform", () => {
+    const storage = {
+      config: "/roots/config",
+      data: "/roots/data",
+      cache: "/roots/cache",
+      state: "/roots/state",
+      logs: "/roots/logs",
+      sessions: "/roots/sessions",
+    };
+    const paths = gamePaths(storage);
+
+    assert.equal(paths.userData, "/roots/sessions");
+    assert.equal(paths.settings, "/roots/config/settings.json");
+    assert.equal(paths.launcherState, "/roots/config/launcher-state.json");
+    assert.equal(paths.buildLibrary, "/roots/data/build-library.json");
+    assert.equal(paths.multiWorkspace, "/roots/data/multi/workspace.json");
+    assert.equal(paths.travelHistory, "/roots/data/travel-history.json");
+    assert.equal(paths.game, "/roots/cache/game");
+    assert.equal(paths.chunks, "/roots/cache/game/chunks");
+    assert.equal(paths.windowState, "/roots/state/window-state.json");
+    assert.equal(paths.cacheClearRequest, "/roots/state/clear-cache-on-start");
+    assert.equal(paths.diagnostics, "/roots/logs/diagnostics");
+    assert.deepEqual(documentDirectories(paths), [
+      "/roots/sessions",
+      "/roots/config",
+      "/roots/data",
+      "/roots/state",
+      "/roots/cache/game",
+      "/roots/logs/diagnostics",
+      "/roots/cache/game/chunks",
+      "/roots/cache/game/artifacts",
+      "/roots/cache/game/artifacts.previous",
+      "/roots/cache/game/compatibility",
+      "/roots/cache/game/enhancements",
+    ]);
   });
 });

--- a/tests/unit/profile-storage.test.ts
+++ b/tests/unit/profile-storage.test.ts
@@ -5,7 +5,10 @@ import {
   resolveAdoptedProfileStorage,
   resolveProfileStorage,
 } from "../../src/main/core/profile-storage.js";
-import { gamePaths } from "../../src/main/core/paths.js";
+import {
+  colocatedStorageRoots,
+  gamePaths,
+} from "../../src/main/core/paths.js";
 import {
   LEGACY_PRIMARY_PROFILE_ID,
   parseMultiWorkspace,
@@ -17,7 +20,7 @@ import { AppError } from "../../src/shared/errors.js";
 const PRIVATE_ID = parseProfileId("00000000-0000-4000-8000-000000000001");
 const SHARED_ID = parseProfileId("00000000-0000-4000-8000-000000000002");
 const root = "/profile";
-const paths = gamePaths(root);
+const paths = gamePaths(colocatedStorageRoots(root));
 const workspace = parseMultiWorkspace({
   formatVersion: 1,
   legacyPrimaryProfileId: LEGACY_PRIMARY_PROFILE_ID,


### PR DESCRIPTION
## What changed

The launcher now resolves explicit config, data, cache, state, session, and log roots for each supported desktop platform.

## Why

Windows and Linux cannot safely inherit macOS path assumptions. One canonical resolver keeps storage ownership explicit before platform packaging is added.

## Invariant

Explicit `--user-data-dir` fixtures always win, each platform has deterministic roots, and the application never guesses across platform stores.

## Delivery

Review-only foundation on top of #351. No application release.

## Verification

- `pnpm run check`
- path and profile-storage unit tests
- disposable storage probe

- [x] Focused change
- [x] Relevant checks run
- [x] No credentials or private game data added
