### PR TITLE
fix(travel): keep Pre-Searing destinations isolated

### DIFF
--- a/apps/tools/src/components/TravelPalette.test.ts
+++ b/apps/tools/src/components/TravelPalette.test.ts
@@ -24,7 +24,7 @@ function fixture(options: Readonly<{
   history?: readonly number[];
 }> = {}, attachTo?: Element) {
   const state = ref<TravelHost["state"]["value"]>({
-    status: "ready", mapId: 55, characterKey: null, unlockedMapWords: null,
+    status: "ready", mapId: 55, travelContext: "world", characterKey: null, unlockedMapWords: null,
   });
   let preferences: TravelPreferences = Object.freeze({
     shortcuts: options.shortcuts ?? DEFAULT_TRAVEL_SHORTCUTS,
@@ -208,6 +208,7 @@ describe("TravelPalette", () => {
     state.value = {
       status: "ready",
       mapId: 55,
+      travelContext: "world",
       characterKey: travelCharacterKey("0123456789abcdef"),
       unlockedMapWords,
     };
@@ -233,6 +234,7 @@ describe("TravelPalette", () => {
     state.value = {
       status: "ready",
       mapId: 148,
+      travelContext: "pre-searing",
       characterKey: travelCharacterKey("0123456789abcdef"),
       unlockedMapWords,
     };
@@ -276,6 +278,7 @@ describe("TravelPalette", () => {
     state.value = {
       status: "ready",
       mapId: 242,
+      travelContext: "world",
       characterKey: travelCharacterKey("0123456789abcdef"),
       unlockedMapWords,
     };
@@ -292,6 +295,7 @@ describe("TravelPalette", () => {
     state.value = {
       status: "ready",
       mapId: 148,
+      travelContext: "pre-searing",
       characterKey: travelCharacterKey("0123456789abcdef"),
       unlockedMapWords: null,
     };
@@ -313,6 +317,7 @@ describe("TravelPalette", () => {
     state.value = {
       status: "ready",
       mapId: 55,
+      travelContext: "world",
       characterKey: travelCharacterKey("0123456789abcdef"),
       unlockedMapWords,
     };
@@ -321,6 +326,77 @@ describe("TravelPalette", () => {
     expect(wrapper.find(".travel-available").exists()).toBe(false);
     expect(wrapper.find(".travel-history").exists()).toBe(true);
     expect(wrapper.find(".travel-favorites").exists()).toBe(true);
+    wrapper.unmount();
+  });
+
+  it("keeps typed search inside Pre-Searing and explains excluded matches", async () => {
+    const { wrapper, state } = fixture();
+    state.value = {
+      status: "ready",
+      mapId: 148,
+      travelContext: "pre-searing",
+      characterKey: travelCharacterKey("0123456789abcdef"),
+      unlockedMapWords: Array.from({ length: 28 }, () => 0xffff_ffff),
+    };
+
+    await wrapper.get("#travel-search-input").setValue("asc");
+    expect(wrapper.get("#travel-results-panel").text()).toContain("Ascalon City (pre-Searing)");
+    expect(wrapper.get("#travel-results-panel").text()).not.toContain("Heroes' Ascent");
+
+    await wrapper.get("#travel-search-input").setValue("heroes ascent");
+    expect(wrapper.findAll('[role="option"]')).toHaveLength(0);
+    expect(wrapper.get(".travel-empty").text()).toContain("Destination unavailable here");
+    expect(wrapper.get(".travel-empty").text()).toContain(
+      "Only Pre-Searing destinations are available to this character.",
+    );
+    wrapper.unmount();
+  });
+
+  it("shows the Pre-Searing browse scope from an explorable map", async () => {
+    const { wrapper, state } = fixture();
+    state.value = {
+      status: "ready",
+      mapId: 149,
+      travelContext: "pre-searing",
+      characterKey: travelCharacterKey("0123456789abcdef"),
+      unlockedMapWords: Array.from({ length: 28 }, () => 0xffff_ffff),
+    };
+    await flushPromises();
+
+    expect(wrapper.findAll(".travel-available .travel-recent")).toHaveLength(6);
+    expect(wrapper.get(".travel-available").text()).toContain("Ascalon City (pre-Searing)");
+    wrapper.unmount();
+  });
+
+  it("hides incompatible favorites and recents and blocks their numbered shortcuts", async () => {
+    const shortcuts: TravelShortcuts = [
+      { mapId: 330 }, null, null, null, null, null, null, null, null,
+    ];
+    const { wrapper, state, travel } = fixture({ history: [330], shortcuts });
+    state.value = {
+      status: "ready",
+      mapId: 148,
+      travelContext: "pre-searing",
+      characterKey: travelCharacterKey("0123456789abcdef"),
+      unlockedMapWords: Array.from({ length: 28 }, () => 0xffff_ffff),
+    };
+    await flushPromises();
+
+    expect(wrapper.text()).not.toContain("Heroes' Ascent");
+    await wrapper.get('[role="combobox"]').trigger("keydown", { key: "1", code: "Digit1" });
+    expect(travel).not.toHaveBeenCalled();
+    expect(wrapper.text()).toContain("Only Pre-Searing destinations are available");
+    wrapper.unmount();
+  });
+
+  it("does not offer irreversible Pre-Searing destinations after the Searing", async () => {
+    const { wrapper } = fixture();
+    await wrapper.get("#travel-search-input").setValue("pre ascalon");
+
+    expect(wrapper.findAll('[role="option"]')).toHaveLength(0);
+    expect(wrapper.get(".travel-empty").text()).toContain(
+      "Pre-Searing destinations are unavailable after the Searing.",
+    );
     wrapper.unmount();
   });
 

--- a/apps/tools/src/components/TravelPalette.vue
+++ b/apps/tools/src/components/TravelPalette.vue
@@ -13,7 +13,10 @@ import {
   type TravelRequest,
 } from "../../../../src/shared/travel";
 import type { TravelHost } from "../travel-host";
-import { isTravelMapUnlocked } from "../../../../src/shared/travel-command";
+import {
+  travelContextRefusal,
+  travelDestinationAvailability,
+} from "../../../../src/shared/travel-command";
 import { TRAVEL_HISTORY_VISIBLE_LIMIT } from "../../../../src/shared/travel-history";
 import { useTravelPreferences } from "../travel-preferences";
 import TravelDestinationPicker from "./TravelDestinationPicker.vue";
@@ -61,10 +64,17 @@ const catalogueResults = computed(() => hasQuery.value
   ? searchTravelDestinations(query.value, synonyms.value)
   : []
 );
-const isAvailable = (mapId: number) =>
-  isTravelMapUnlocked(props.host.state.value, mapId) !== false;
+const availability = (mapId: number) =>
+  travelDestinationAvailability(props.host.state.value, mapId);
+const isAvailable = (mapId: number) => {
+  const result = availability(mapId);
+  return result === "available" || result === "unknown";
+};
 const results = computed(() => catalogueResults.value.filter(
   (destination) => isAvailable(destination.mapId),
+));
+const contextExcludedResults = computed(() => catalogueResults.value.filter(
+  (destination) => availability(destination.mapId) === "outside-context",
 ));
 const shortcutRows = computed(() => Array.from({ length: TRAVEL_SHORTCUT_LIMIT }, (_, index) => {
   const request = shortcuts.value[index] ?? null;
@@ -88,7 +98,8 @@ const recentDestinations = computed(() => props.host.history.value
 const browseDestinations = computed(() => {
   const state = props.host.state.value;
   if (state.status !== "ready") return [];
-  const destinations = travelBrowseScope(state.mapId).filter(({ mapId }) => isAvailable(mapId));
+  const destinations = travelBrowseScope(state.mapId, state.travelContext)
+    .filter(({ mapId }) => isAvailable(mapId));
   return destinations.length <= SMALL_TRAVEL_CATALOGUE_LIMIT
     ? [...destinations].sort((left, right) => left.name.localeCompare(right.name, "en"))
     : [];
@@ -115,8 +126,27 @@ const statusLevel = computed(() => feedback.value
 const urgentNoticeVisible = computed(() => statusLevel.value === "warning" || statusLevel.value === "danger");
 const searchStatusText = computed(() => {
   if (!hasQuery.value) return "";
+  if (results.value.length === 0 && contextExcludedResults.value.length > 0) {
+    return props.host.state.value.status === "ready"
+      && props.host.state.value.travelContext === "pre-searing"
+      ? "No destinations are available outside Pre-Searing."
+      : "Pre-Searing destinations are unavailable after the Searing.";
+  }
   if (results.value.length === 0) return "No destinations match your search.";
   return `${results.value.length} ${results.value.length === 1 ? "destination" : "destinations"} found.`;
+});
+const emptySearchTitle = computed(() =>
+  contextExcludedResults.value.length > 0
+    ? "Destination unavailable here"
+    : `No destinations for “${query.value}”`
+);
+const emptySearchHelp = computed(() => {
+  const excluded = contextExcludedResults.value[0];
+  if (excluded !== undefined) {
+    return travelContextRefusal(props.host.state.value, excluded.mapId)
+      ?? "This destination is unavailable from the current location.";
+  }
+  return "Try a destination, campaign, official shortcut, or your own search phrase.";
 });
 
 function setFeedback(message: string, level: typeof feedbackLevel.value): void {
@@ -407,6 +437,10 @@ function onKeydown(event: KeyboardEvent): void {
     const slot = Number(event.code.slice(5)) - 1;
     const shortcut = shortcuts.value[slot];
     if (shortcut && isAvailable(shortcut.mapId)) void travel(shortcut);
+    else if (shortcut && availability(shortcut.mapId) === "outside-context") {
+      const message = travelContextRefusal(props.host.state.value, shortcut.mapId);
+      if (message !== null) setFeedback(message, "warning");
+    }
     else void openShortcutManager(slot);
   }
 }
@@ -428,7 +462,7 @@ function onKeydown(event: KeyboardEvent): void {
       <div v-if="results.length" id="travel-results" class="travel-results" role="listbox">
         <button v-for="(destination, index) in results" :id="`travel-${destination.mapId}`" :key="destination.mapId" type="button" class="travel-result ui-row" role="option" tabindex="-1" :aria-selected="index === active" :disabled="travelPending || host.unavailable !== null" @mouseenter="active = index" @click="active = index; travel({ mapId: destination.mapId })"><span><strong><template v-for="(part, partIndex) in highlightTravelDestinationName(destination, query)" :key="partIndex"><mark v-if="part.match">{{ part.text }}</mark><template v-else>{{ part.text }}</template></template></strong><small>{{ destination.campaign }}</small></span><span class="travel-match">{{ queryMatchLabel(destination) }}</span></button>
       </div>
-      <div v-else class="ui-empty travel-empty"><strong>No destinations for “{{ query }}”</strong><p>Try a destination, campaign, official shortcut, or your own search phrase.</p><button type="button" class="ui-button" @click="query = ''">Clear search</button></div>
+      <div v-else class="ui-empty travel-empty"><strong>{{ emptySearchTitle }}</strong><p>{{ emptySearchHelp }}</p><button type="button" class="ui-button" @click="query = ''">Clear search</button></div>
     </section>
 
     <section v-else-if="mode === 'travel'" id="travel-panel" class="ui-scroll travel-body" role="region" aria-label="Travel">

--- a/apps/tools/src/travel-host.test.ts
+++ b/apps/tools/src/travel-host.test.ts
@@ -87,7 +87,7 @@ describe("native Travel host", () => {
 
     await host.travel({ mapId: 449 });
     host.updateGameState({
-      status: "ready", mapId: 449, characterKey: null, unlockedMapWords: null,
+      status: "ready", mapId: 449, travelContext: "world", characterKey: null, unlockedMapWords: null,
     });
     await vi.runAllTimersAsync();
 
@@ -110,7 +110,7 @@ describe("native Travel host", () => {
     expect(host.notice.value?.message).toContain("Travelling to");
 
     host.updateGameState({
-      status: "ready", mapId: 449, characterKey: null, unlockedMapWords: null,
+      status: "ready", mapId: 449, travelContext: "world", characterKey: null, unlockedMapWords: null,
     });
     expect(host.attempt.value).toEqual({ status: "queued", mapId: 55 });
     expect(host.notice.value?.message).toContain("Travelling to");
@@ -154,7 +154,7 @@ describe("native Travel host", () => {
     expect(interrupted.attempt.value).toEqual({ status: "idle" });
     expect(interrupted.notice.value?.message).toContain("interrupted");
     interrupted.updateGameState({
-      status: "ready", mapId: 449, characterKey: null, unlockedMapWords: null,
+      status: "ready", mapId: 449, travelContext: "world", characterKey: null, unlockedMapWords: null,
     });
     expect(interrupted.notice.value).toBeNull();
 
@@ -173,7 +173,7 @@ describe("native Travel host", () => {
     host.updateGameState({ status: "waiting", reason: "loading" });
 
     host.updateGameState({
-      status: "ready", mapId: 55, characterKey: null, unlockedMapWords: null,
+      status: "ready", mapId: 55, travelContext: "world", characterKey: null, unlockedMapWords: null,
     });
 
     expect(host.attempt.value).toEqual({ status: "idle" });
@@ -183,7 +183,7 @@ describe("native Travel host", () => {
     expect(host.notice.value?.message).toContain("did not confirm arrival");
 
     host.updateGameState({
-      status: "ready", mapId: 449, characterKey: null, unlockedMapWords: null,
+      status: "ready", mapId: 449, travelContext: "world", characterKey: null, unlockedMapWords: null,
     });
     expect(host.notice.value).toBeNull();
   });
@@ -197,7 +197,7 @@ describe("native Travel host", () => {
     expect(host.notice.value?.message).toContain("did not confirm arrival");
 
     host.updateGameState({
-      status: "ready", mapId: 449, characterKey: null, unlockedMapWords: null,
+      status: "ready", mapId: 449, travelContext: "world", characterKey: null, unlockedMapWords: null,
     });
 
     expect(host.attempt.value).toEqual({ status: "idle" });
@@ -210,13 +210,13 @@ describe("native Travel host", () => {
     const characterA = travelCharacterKey("0123456789abcdef");
     const characterB = travelCharacterKey("fedcba9876543210");
     host.updateGameState({
-      status: "ready", mapId: 55, characterKey: characterA, unlockedMapWords,
+      status: "ready", mapId: 55, travelContext: "world", characterKey: characterA, unlockedMapWords,
     });
     host.updateGameState({
-      status: "ready", mapId: 449, characterKey: characterA, unlockedMapWords,
+      status: "ready", mapId: 449, travelContext: "world", characterKey: characterA, unlockedMapWords,
     });
     host.updateGameState({
-      status: "ready", mapId: 81, characterKey: characterB, unlockedMapWords,
+      status: "ready", mapId: 81, travelContext: "world", characterKey: characterB, unlockedMapWords,
     });
 
     await vi.waitFor(() => expect(recordHistory).toHaveBeenCalledTimes(3));
@@ -234,12 +234,12 @@ describe("native Travel host", () => {
     const characterKey = travelCharacterKey("0123456789abcdef");
     const unlockedMapWords = Array.from({ length: 28 }, () => 0xffff_ffff);
     host.updateGameState({
-      status: "ready", mapId: 55, characterKey: null, unlockedMapWords,
+      status: "ready", mapId: 55, travelContext: "world", characterKey: null, unlockedMapWords,
     });
 
     await host.travel({ mapId: 449 });
     host.updateGameState({
-      status: "ready", mapId: 449, characterKey, unlockedMapWords,
+      status: "ready", mapId: 449, travelContext: "world", characterKey, unlockedMapWords,
     });
 
     await vi.waitFor(() => expect(recordHistory).toHaveBeenCalledTimes(2));
@@ -256,18 +256,18 @@ describe("native Travel host", () => {
     const characterB = travelCharacterKey("fedcba9876543210");
     const unlockedMapWords = Array.from({ length: 28 }, () => 0xffff_ffff);
     host.updateGameState({
-      status: "ready", mapId: 55, characterKey: characterA, unlockedMapWords,
+      status: "ready", mapId: 55, travelContext: "world", characterKey: characterA, unlockedMapWords,
     });
     await vi.waitFor(() => expect(host.history.value).toEqual([55]));
 
     host.updateGameState({ status: "waiting", reason: "loading" });
     expect(host.history.value).toEqual([]);
     host.updateGameState({
-      status: "ready", mapId: 55, characterKey: null, unlockedMapWords,
+      status: "ready", mapId: 55, travelContext: "world", characterKey: null, unlockedMapWords,
     });
     expect(host.history.value).toEqual([]);
     host.updateGameState({
-      status: "ready", mapId: 55, characterKey: characterB, unlockedMapWords,
+      status: "ready", mapId: 55, travelContext: "world", characterKey: characterB, unlockedMapWords,
     });
 
     await vi.waitFor(() => expect(host.history.value).toEqual([55]));
@@ -284,6 +284,7 @@ describe("native Travel host", () => {
     test.host.updateGameState({
       status: "ready",
       mapId: 55,
+      travelContext: "world",
       characterKey,
       unlockedMapWords: Array.from({ length: 28 }, () => 0xffff_ffff),
     });
@@ -291,5 +292,26 @@ describe("native Travel host", () => {
 
     await expect(test.host.loadHistory()).resolves.toEqual([55]);
     expect(test.recordHistory).toHaveBeenCalledTimes(2);
+  });
+
+  it("refuses travel outside the active context before enqueueing", async () => {
+    vi.useFakeTimers();
+    const { host, command } = fixture();
+    host.updateGameState({
+      status: "ready",
+      mapId: 148,
+      travelContext: "pre-searing",
+      characterKey: null,
+      unlockedMapWords: Array.from({ length: 28 }, () => 0xffff_ffff),
+    });
+
+    await expect(host.travel({ mapId: 330 })).rejects.toThrow("Only Pre-Searing");
+    expect(command.travel).not.toHaveBeenCalled();
+    expect(host.attempt.value).toEqual({ status: "idle" });
+    expect(host.notice.value).toEqual({
+      message: "Only Pre-Searing destinations are available to this character.",
+      level: "warning",
+    });
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/apps/tools/src/travel-host.ts
+++ b/apps/tools/src/travel-host.ts
@@ -9,6 +9,7 @@ import type {
   TravelCommand,
   TravelGameState,
 } from "../../../src/shared/travel-command";
+import { travelContextRefusal } from "../../../src/shared/travel-command";
 import {
   DEFAULT_TRAVEL_SHORTCUTS,
   TRAVEL_DESTINATIONS,
@@ -116,6 +117,11 @@ export function createNativeTravelHost(
     loadHistory: historyObservation.load,
     async travel(request) {
       if (attempt.value.status !== "idle") return;
+      const contextRefusal = travelContextRefusal(state.value, request.mapId);
+      if (contextRefusal !== null) {
+        notice.value = { message: contextRefusal, level: "warning" };
+        throw new Error(contextRefusal);
+      }
       settledAttempt = null;
       unidentifiedOriginMapId = state.value.status === "ready"
         && state.value.characterKey === null
@@ -234,7 +240,7 @@ export function createDemoTravelHost(): TravelHost {
   const unlockedMapWords = Object.freeze(Array.from({ length: 28 }, () => 0xffff_ffff));
   const characterKey = travelCharacterKey("0123456789abcdef");
   const state = ref<TravelGameState>({
-    status: "ready", mapId: 55, characterKey, unlockedMapWords,
+    status: "ready", mapId: 55, travelContext: "world", characterKey, unlockedMapWords,
   });
   const attempt = ref<TravelAttempt>({ status: "idle" });
   const notice = ref<TravelNotice | null>(null);
@@ -270,7 +276,7 @@ export function createDemoTravelHost(): TravelHost {
       window.setTimeout(() => {
         history.value = recordVisitedTravel(history.value, request.mapId);
         state.value = {
-          status: "ready", mapId: request.mapId,
+          status: "ready", mapId: request.mapId, travelContext: "world",
           characterKey, unlockedMapWords,
         };
         attempt.value = { status: "idle" };

--- a/docs/enhancement-development.md
+++ b/docs/enhancement-development.md
@@ -144,8 +144,9 @@ character names, account data, chat, packet bytes, or Travel search text.
   result count, and bounded result map IDs. It never includes the query itself.
   `travel.queued` or `travel.refused` then identifies the named command result.
   Search covers the reviewed 199-destination direct-travel catalogue and omits
-  positively locked results. A zero result can mean no match or only locked
-  matches; passage-scroll locations
+  destinations outside the current Pre-Searing or world context and positively
+  locked results. A zero result can mean no match, only locked matches, or only
+  destinations outside the current context. Passage-scroll locations
   such as Urgoz's Warren and The Deep intentionally use their original UI.
 
 For a report, reproduce one operation at a time and copy the lines from its

--- a/docs/wasm-host.md
+++ b/docs/wasm-host.md
@@ -300,13 +300,18 @@ remains usable; no party-state fallback is allowed.
 Travel accepts only one reviewed map ID from the renderer. The exact `/tp`
 command sets one named, one-shot palette toggle that the renderer takes and
 clears. Search text, aliases, destinations, and numbered shortcuts stay
-in the host-owned Vue interface. The play-region snapshot publishes a fixed
-28-word map-unlock bitset only after the certified `WorldContext` array is read
-completely; unknown evidence stays unknown instead of looking like every map is
-locked. At the certified frame drain, the transform rechecks the reviewed map
-list and live unlock bit, then invokes the independently proved client helper
-that resolves the player's current region and language, validates those values,
-and writes the four-word Travel payload with district Any. It then calls the
+in the host-owned Vue interface. The play-region snapshot publishes a closed
+Pre-Searing or world Travel context from the certified `AreaInfo` region. It
+also publishes a fixed 28-word map-unlock bitset only after the certified
+`WorldContext` array is read completely; unknown evidence stays unknown instead
+of looking like every map is locked. The host combines both facts before it
+offers or queues a destination. Pre-Searing characters can use only the six
+reviewed Pre-Searing outposts, and world characters cannot return across the
+Searing boundary. At the certified frame drain, the transform rechecks the
+reviewed map list and live unlock bit, then invokes the independently proved
+client helper that resolves the player's current region and language, validates
+those values, and writes the four-word Travel payload with district Any. It then
+calls the
 exact client Travel dispatcher with `kTravel`. An unknown or locked map,
 unreadable unlock array, unresolved live context, or changed helper stops only
 Travel without dispatching another client UI message.

--- a/src/companion-kernel/abi.rs
+++ b/src/companion-kernel/abi.rs
@@ -54,11 +54,12 @@ pub(crate) const CHARACTER_NAME_UNITS: usize = 20;
 
 pub(crate) const PLAY_REGION_BYTES: u32 = size_of::<PlayRegionSnapshot>() as u32;
 pub(crate) const PLAY_REGION_MAGIC: u32 = 0x5250_5747;
-pub(crate) const PLAY_REGION_ABI_AND_SIZE: u32 = (PLAY_REGION_BYTES << 16) | 2;
+pub(crate) const PLAY_REGION_ABI_AND_SIZE: u32 = (PLAY_REGION_BYTES << 16) | 3;
 pub(crate) const FLAG_PLAY_REGION_READY: u32 = 1 << 0;
 pub(crate) const FLAG_PLAY_REGION_LOADING: u32 = 1 << 1;
 pub(crate) const FLAG_PLAY_REGION_CHARACTER: u32 = 1 << 2;
 pub(crate) const FLAG_PLAY_REGION_UNLOCKS: u32 = 1 << 3;
+pub(crate) const FLAG_PLAY_REGION_PRE_SEARING: u32 = 1 << 4;
 
 pub(crate) const SKILL_SLOT_BYTES: u32 = size_of::<SkillSlotSnapshot>() as u32;
 pub(crate) const SKILL_SLOT_MAGIC: u32 = 0x534b_5747;

--- a/src/companion-kernel/lib.rs
+++ b/src/companion-kernel/lib.rs
@@ -156,6 +156,7 @@ pub(crate) enum GameState {
         instance_type: u32,
         player_number: u32,
         play_region: u32,
+        pre_searing: bool,
     },
 }
 
@@ -190,35 +191,43 @@ unsafe fn classify_play_region(
     layout: Layout,
     map_id: u32,
     instance_type: u32,
-) -> u32 {
+) -> (u32, bool) {
     if layout.area_info == 0
         || layout.area_info_count == 0
         || layout.area_info_stride < 20
         || layout.area_info_flags + 4 > layout.area_info_stride
         || map_id >= layout.area_info_count
     {
-        return PLAY_REGION_UNKNOWN;
+        return (PLAY_REGION_UNKNOWN, false);
     }
     let Some(record) = indexed(layout.area_info, map_id, layout.area_info_stride) else {
-        return PLAY_REGION_UNKNOWN;
+        return (PLAY_REGION_UNKNOWN, false);
     };
+    let mut area_region = 0;
     for (field, maximum) in [0_u32, 4, 8, 12].iter().zip([4_u32, 5, 27, 21].iter()) {
         let Some(value) = offset(record, *field).and_then(|at| unsafe { read_u32(at) }) else {
-            return PLAY_REGION_UNKNOWN;
+            return (PLAY_REGION_UNKNOWN, false);
         };
         if value > *maximum {
-            return PLAY_REGION_UNKNOWN;
+            return (PLAY_REGION_UNKNOWN, false);
+        }
+        if *field == 8 {
+            area_region = value;
         }
     }
     let Some(flags) = offset(record, layout.area_info_flags).and_then(|at| unsafe { read_u32(at) })
     else {
-        return PLAY_REGION_UNKNOWN;
+        return (PLAY_REGION_UNKNOWN, false);
     };
-    if flags & (0x0004_0001 | 0x0080_0000) != 0 && instance_type == 1 {
+    let play_region = if flags & (0x0004_0001 | 0x0080_0000) != 0 && instance_type == 1 {
         PLAY_REGION_PVP
     } else {
         PLAY_REGION_PVE
-    }
+    };
+    (
+        play_region,
+        area_region == 7 && play_region == PLAY_REGION_PVE,
+    )
 }
 
 /**
@@ -406,14 +415,16 @@ pub(crate) unsafe fn resolve_game(layout: Layout) -> GameState {
         return GameState::Unavailable;
     }
 
+    let (play_region, pre_searing) = unsafe {
+        classify_play_region(layout, map_id, instance_type)
+    };
     GameState::Ready {
         game,
         map_id,
         instance_type,
         player_number,
-        play_region: unsafe {
-            classify_play_region(layout, map_id, instance_type)
-        },
+        play_region,
+        pre_searing,
     }
 }
 
@@ -432,6 +443,7 @@ unsafe fn collect(layout: Layout, observe_target: bool) -> State {
             instance_type,
             player_number,
             play_region,
+            ..
         } => (game, map_id, instance_type, player_number, play_region),
     };
 
@@ -916,7 +928,7 @@ pub unsafe extern "C" fn companion_dispatch(kind: u32, a: u32, b: u32, c: u32, _
 
 #[no_mangle]
 pub extern "C" fn companion_abi() -> u32 {
-    20
+    21
 }
 
 #[no_mangle]

--- a/src/companion-kernel/play_region.rs
+++ b/src/companion-kernel/play_region.rs
@@ -106,6 +106,7 @@ pub(crate) unsafe fn tick(layout: Layout) {
             map_id,
             instance_type,
             play_region,
+            pre_searing,
             ..
         } if play_region == PLAY_REGION_PVE || play_region == PLAY_REGION_PVP => unsafe {
             let key = current_character_key(layout, game);
@@ -118,6 +119,11 @@ pub(crate) unsafe fn tick(layout: Layout) {
                 }
                 | if unlocks.is_some() {
                     FLAG_PLAY_REGION_UNLOCKS
+                } else {
+                    0
+                }
+                | if pre_searing {
+                    FLAG_PLAY_REGION_PRE_SEARING
                 } else {
                     0
                 };

--- a/src/renderer/companion-play-region-snapshot.ts
+++ b/src/renderer/companion-play-region-snapshot.ts
@@ -8,7 +8,13 @@ export const COMPANION_PLAY_REGION_ABI = COMPANION_ABI.playRegion.abi;
 export const COMPANION_PLAY_REGION_BYTES = COMPANION_ABI.playRegion.bytes;
 
 const MAGIC = 0x5250_5747;
-const FLAGS = Object.freeze({ ready: 1, loading: 2, character: 4, unlocks: 8 });
+const FLAGS = Object.freeze({
+  ready: 1,
+  loading: 2,
+  character: 4,
+  unlocks: 8,
+  preSearing: 16,
+});
 const UNLOCK_WORDS = COMPANION_ABI.travelUnlockWords;
 
 export function readCompanionPlayRegion(buffer: ArrayBuffer, pointer: number) {
@@ -44,9 +50,12 @@ export function readCompanionPlayRegion(buffer: ArrayBuffer, pointer: number) {
     || bytes !== COMPANION_PLAY_REGION_BYTES
     || firstSequence !== secondSequence
     || (secondSequence & 1) !== 0
-    || (flags & ~(FLAGS.ready | FLAGS.loading | FLAGS.character | FLAGS.unlocks)) !== 0
+    || (flags & ~(
+      FLAGS.ready | FLAGS.loading | FLAGS.character | FLAGS.unlocks | FLAGS.preSearing
+    )) !== 0
     || (flags & FLAGS.loading) !== 0 && flags !== FLAGS.loading
-    || (flags & (FLAGS.character | FLAGS.unlocks)) !== 0 && (flags & FLAGS.ready) === 0
+    || (flags & (FLAGS.character | FLAGS.unlocks | FLAGS.preSearing)) !== 0
+      && (flags & FLAGS.ready) === 0
   ) return Object.freeze({ status: "waiting", reason: "snapshot" } as const);
 
   if ((flags & FLAGS.loading) !== 0) {
@@ -71,9 +80,11 @@ export function readCompanionPlayRegion(buffer: ArrayBuffer, pointer: number) {
   ) return Object.freeze({ status: "waiting", reason: "corrupt" } as const);
   const hasCharacter = (flags & FLAGS.character) !== 0;
   const hasUnlocks = (flags & FLAGS.unlocks) !== 0;
+  const preSearing = (flags & FLAGS.preSearing) !== 0;
   if (
     hasCharacter !== (characterLow !== 0 || characterHigh !== 0)
     || (!hasUnlocks && unlockedMapWords.some((word) => word !== 0))
+    || (preSearing && encodedRegion !== 1)
   ) return Object.freeze({ status: "waiting", reason: "corrupt" } as const);
 
   return Object.freeze({
@@ -82,6 +93,7 @@ export function readCompanionPlayRegion(buffer: ArrayBuffer, pointer: number) {
     mapId,
     instanceType,
     playRegion: encodedRegion === 1 ? "pve" as const : "pvp" as const,
+    travelContext: preSearing ? "pre-searing" as const : "world" as const,
     characterKey: hasCharacter
       ? `${characterHigh.toString(16).padStart(8, "0")}${characterLow.toString(16).padStart(8, "0")}`
       : null,

--- a/src/renderer/companion-policy-source.ts
+++ b/src/renderer/companion-policy-source.ts
@@ -34,6 +34,7 @@ function projectPlayRegion(state: CompanionPlayRegionState): string {
     state.playRegion,
     state.mapId,
     state.instanceType,
+    state.travelContext,
     state.characterKey ?? "unknown-character",
     state.unlockedMapWords?.join(",") ?? "unknown-unlocks",
   ].join(":");

--- a/src/shared/companion-abi.ts
+++ b/src/shared/companion-abi.ts
@@ -3,7 +3,7 @@
  * Renderer, scripts, and tests derive their ABI constants from this descriptor.
  */
 export const COMPANION_ABI = Object.freeze({
-  kernel: 20,
+  kernel: 21,
   config: Object.freeze({ bytes: 464 }),
   snapshot: Object.freeze({ abi: 3, bytes: 64 }),
   travelUnlockWords: 28,
@@ -12,7 +12,7 @@ export const COMPANION_ABI = Object.freeze({
   party: Object.freeze({ abi: 7, bytes: 1_560 }),
   skillSlots: Object.freeze({ abi: 2, bytes: 164 }),
   skillCooldowns: Object.freeze({ abi: 1, bytes: 60 }),
-  playRegion: Object.freeze({ abi: 2, bytes: 148 }),
+  playRegion: Object.freeze({ abi: 3, bytes: 148 }),
   characterList: Object.freeze({ abi: 2, bytes: 4_632, slots: 64, nameUnits: 20 }),
 });
 

--- a/src/shared/travel-command.ts
+++ b/src/shared/travel-command.ts
@@ -4,6 +4,10 @@
  */
 import type { TravelRequest } from "./travel.js";
 import {
+  isTravelDestinationInContext,
+  type TravelContext,
+} from "./travel-destinations.js";
+import {
   isTravelCharacterKey,
   type TravelCharacterKey,
 } from "./travel-history.js";
@@ -17,11 +21,18 @@ export type TravelGameState =
   | Readonly<{
     status: "ready";
     mapId: number;
+    travelContext: TravelContext;
     characterKey: TravelCharacterKey | null;
     unlockedMapWords: readonly number[] | null;
   }>;
 
 export const TRAVEL_UNLOCK_WORDS = 28;
+
+export type TravelDestinationAvailability =
+  | "available"
+  | "locked"
+  | "outside-context"
+  | "unknown";
 
 export function isTravelMapUnlocked(state: TravelGameState, mapId: number): boolean | null {
   if (state.status !== "ready" || state.unlockedMapWords == null) return null;
@@ -30,10 +41,34 @@ export function isTravelMapUnlocked(state: TravelGameState, mapId: number): bool
   return word === undefined ? false : ((word >>> (mapId % 32)) & 1) === 1;
 }
 
+export function travelDestinationAvailability(
+  state: TravelGameState,
+  mapId: number,
+): TravelDestinationAvailability {
+  if (state.status !== "ready") return "unknown";
+  if (!isTravelDestinationInContext(state.travelContext, mapId)) return "outside-context";
+  const unlocked = isTravelMapUnlocked(state, mapId);
+  return unlocked === null ? "unknown" : unlocked ? "available" : "locked";
+}
+
+export function travelContextRefusal(
+  state: TravelGameState,
+  mapId: number,
+): string | null {
+  if (travelDestinationAvailability(state, mapId) !== "outside-context") return null;
+  return state.status === "ready" && state.travelContext === "pre-searing"
+    ? "Only Pre-Searing destinations are available to this character."
+    : "Pre-Searing destinations are unavailable after the Searing.";
+}
+
 export function travelGameState(value: unknown): TravelGameState {
   if (value !== null && typeof value === "object" && !Array.isArray(value)) {
     const input = value as Record<string, unknown>;
-    if (input.status === "ready" && Number.isSafeInteger(input.mapId)) {
+    if (
+      input.status === "ready"
+      && Number.isSafeInteger(input.mapId)
+      && (input.travelContext === "pre-searing" || input.travelContext === "world")
+    ) {
       const words = input.unlockedMapWords;
       const unlockedMapWords = Array.isArray(words)
         && words.length === TRAVEL_UNLOCK_WORDS
@@ -43,6 +78,7 @@ export function travelGameState(value: unknown): TravelGameState {
       return Object.freeze({
         status: "ready",
         mapId: Number(input.mapId),
+        travelContext: input.travelContext,
         characterKey: isTravelCharacterKey(input.characterKey) ? input.characterKey : null,
         unlockedMapWords,
       });

--- a/src/shared/travel-destinations.ts
+++ b/src/shared/travel-destinations.ts
@@ -10,6 +10,8 @@ export type TravelDestination = Readonly<{
   aliases: readonly string[];
 }>;
 
+export type TravelContext = "pre-searing" | "world";
+
 const destination = (
   mapId: number,
   name: string,
@@ -248,21 +250,34 @@ const PRE_SEARING_MAP_IDS: readonly number[] = Object.freeze([
   148, 164, 165, 166, 163, 778,
 ]);
 
+export function isTravelDestinationInContext(
+  context: TravelContext,
+  mapId: number,
+): boolean {
+  return context === "pre-searing"
+    ? PRE_SEARING_MAP_IDS.includes(mapId)
+    : !PRE_SEARING_MAP_IDS.includes(mapId);
+}
+
 /**
  * Returns the destination group that is useful around the current outpost.
  * Cross-campaign unlocks (especially the Battle Isles) must not make a small
  * early-game catalogue look large. Pre-Searing is kept separate from the rest
  * of Prophecies because its characters cannot cross the Searing boundary.
  */
-export function travelBrowseScope(currentMapId: number): readonly TravelDestination[] {
+export function travelBrowseScope(
+  currentMapId: number,
+  context: TravelContext,
+): readonly TravelDestination[] {
+  if (context === "pre-searing") {
+    return TRAVEL_DESTINATIONS.filter(({ mapId }) =>
+      isTravelDestinationInContext(context, mapId));
+  }
   const current = travelDestination(currentMapId);
   if (current === null) return [];
-  const preSearing = PRE_SEARING_MAP_IDS.includes(currentMapId);
   return TRAVEL_DESTINATIONS.filter((candidate) =>
-    preSearing
-      ? PRE_SEARING_MAP_IDS.includes(candidate.mapId)
-      : candidate.campaign === current.campaign
-        && !PRE_SEARING_MAP_IDS.includes(candidate.mapId)
+    candidate.campaign === current.campaign
+    && isTravelDestinationInContext(context, candidate.mapId)
   );
 }
 

--- a/tests/electron/input-travel.spec.ts
+++ b/tests/electron/input-travel.spec.ts
@@ -47,6 +47,7 @@ test.describe("renderer Travel input", () => {
           state: {
             status: "ready",
             mapId: 133,
+            travelContext: "world",
             characterKey: null,
             unlockedMapWords: Array.from({ length: 28 }, () => 0xffff_ffff),
           },

--- a/tests/integration/play-region-kernel.test.ts
+++ b/tests/integration/play-region-kernel.test.ts
@@ -34,6 +34,7 @@ describe("play-region kernel", () => {
       mapId: 133,
       instanceType: 0,
       playRegion: "pve",
+      travelContext: "world",
       ...OBSERVED_CHARACTER,
     });
 
@@ -47,6 +48,7 @@ describe("play-region kernel", () => {
       mapId: 133,
       instanceType: 0,
       playRegion: "pve",
+      travelContext: "world",
       ...OBSERVED_CHARACTER,
     });
 
@@ -59,8 +61,29 @@ describe("play-region kernel", () => {
       mapId: 133,
       instanceType: 1,
       playRegion: "pvp",
+      travelContext: "world",
       ...OBSERVED_CHARACTER,
     });
+  });
+
+  it("derives the closed Travel context from the certified area region", async () => {
+    const kernel = await createKernel();
+    installGameGraph(kernel.view);
+    kernel.view.setUint32(AREA_133 + 0x08, 7, true);
+    assert.equal(kernel.init({ features: FEATURE_PLAY_REGION_OBSERVATION }), 1);
+
+    kernel.tick();
+    const preSearing = kernel.playRegion();
+    assert.equal(preSearing.status, "ready");
+    if (preSearing.status !== "ready") return;
+    assert.equal(preSearing.travelContext, "pre-searing");
+
+    kernel.view.setUint32(AREA_133 + 0x08, 2, true);
+    kernel.tick();
+    const world = kernel.playRegion();
+    assert.equal(world.status, "ready");
+    if (world.status !== "ready") return;
+    assert.equal(world.travelContext, "world");
   });
 
   it("publishes loading and withdraws malformed area data", async () => {

--- a/tests/integration/play-region-snapshot.test.ts
+++ b/tests/integration/play-region-snapshot.test.ts
@@ -44,6 +44,7 @@ describe("play-region snapshot ABI", () => {
       mapId: 133,
       instanceType: 0,
       playRegion: "pve",
+      travelContext: "world",
       characterKey: null,
       unlockedMapWords: null,
     });
@@ -57,9 +58,32 @@ describe("play-region snapshot ABI", () => {
       mapId: 248,
       instanceType: 1,
       playRegion: "pvp",
+      travelContext: "world",
       characterKey: null,
       unlockedMapWords: null,
     });
+  });
+
+  it("publishes Pre-Searing only beside a ready PvE record", () => {
+    assert.deepEqual(readCompanionPlayRegion(snapshot({ flags: 17, mapId: 148 }), 0), {
+      status: "ready",
+      sequence: 2,
+      mapId: 148,
+      instanceType: 0,
+      playRegion: "pve",
+      travelContext: "pre-searing",
+      characterKey: null,
+      unlockedMapWords: null,
+    });
+    assert.deepEqual(readCompanionPlayRegion(snapshot({
+      flags: 17,
+      mapId: 148,
+      instanceType: 1,
+      playRegion: 2,
+    }), 0), { status: "waiting", reason: "corrupt" });
+    assert.deepEqual(readCompanionPlayRegion(snapshot({
+      flags: 16, mapId: 0, instanceType: 0, playRegion: 0,
+    }), 0), { status: "waiting", reason: "snapshot" });
   });
 
   it("fails closed for memory, torn headers, contradictory flags, and values", () => {

--- a/tests/unit/companion-policy-source.test.ts
+++ b/tests/unit/companion-policy-source.test.ts
@@ -96,6 +96,7 @@ describe("companion policy source", () => {
       mapId: 42,
       instanceType: 0,
       playRegion: "pve" as const,
+      travelContext: "world" as const,
       characterKey: null,
       unlockedMapWords: null,
     });
@@ -124,6 +125,7 @@ describe("companion policy source", () => {
       mapId: 55,
       instanceType: 0,
       playRegion: "pve" as const,
+      travelContext: "world" as const,
     };
     test.publishRegion(Object.freeze({
       ...ready,
@@ -161,6 +163,7 @@ describe("companion policy source", () => {
       mapId: 188,
       instanceType: 0,
       playRegion: "pvp",
+      travelContext: "world",
       characterKey: null,
       unlockedMapWords: null,
     }));
@@ -183,6 +186,7 @@ describe("companion policy source", () => {
       mapId: 42,
       instanceType: 0,
       playRegion: "pve",
+      travelContext: "world",
       characterKey: null,
       unlockedMapWords: null,
     }));

--- a/tests/unit/play-region-observation-installation.test.ts
+++ b/tests/unit/play-region-observation-installation.test.ts
@@ -8,6 +8,7 @@ const ready = (sequence: number, mapId = 81) => Object.freeze({
   mapId,
   instanceType: 0,
   playRegion: "pve" as const,
+  travelContext: "world" as const,
   characterKey: null,
   unlockedMapWords: null,
 });

--- a/tests/unit/the-companion-abi-is-exact-across-typescript-and-rust.test.ts
+++ b/tests/unit/the-companion-abi-is-exact-across-typescript-and-rust.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { test } from "node:test";
 import {
+  COMPANION_ABI,
   COMPANION_DISPATCH_KINDS,
   COMPANION_FEATURE_BITS,
 } from "../../src/shared/companion-abi.ts";
@@ -11,6 +12,10 @@ import {
 
 const rustSource = readFileSync(
   new URL("../../src/companion-kernel/abi.rs", import.meta.url),
+  "utf8",
+);
+const rustKernelSource = readFileSync(
+  new URL("../../src/companion-kernel/lib.rs", import.meta.url),
   "utf8",
 );
 
@@ -152,6 +157,14 @@ function replaced(source: string, from: string, to: string): string {
 
 test("the independent TypeScript and Rust companion contracts match exactly", () => {
   assertExactContract(rustSource);
+  assert.equal(Number(captured(
+    rustKernelSource.match(/pub extern "C" fn companion_abi\(\) -> u32 \{\s*(\d+)\s*\}/u),
+    "Rust companion ABI",
+  )), COMPANION_ABI.kernel);
+  assert.equal(Number(captured(
+    rustSource.match(/const PLAY_REGION_ABI_AND_SIZE: u32 = \(PLAY_REGION_BYTES << 16\) \| (\d+);/u),
+    "Rust play-region ABI",
+  )), COMPANION_ABI.playRegion.abi);
   assert.equal(typescriptConfigSlots().length, 116);
 });
 

--- a/tests/unit/travel.test.ts
+++ b/tests/unit/travel.test.ts
@@ -14,6 +14,7 @@ import {
   travelDestination,
   travelShortcutsFromStored,
 } from "../../src/shared/travel.js";
+import { travelDestinationAvailability } from "../../src/shared/travel-command.js";
 
 describe("Travel", () => {
   it("contains the complete reviewed direct-travel catalogue", () => {
@@ -107,16 +108,45 @@ describe("Travel", () => {
 
   it("keeps early-game browse scopes local to the current campaign", () => {
     assert.deepEqual(
-      travelBrowseScope(148).map(({ mapId }) => mapId),
+      travelBrowseScope(148, "pre-searing").map(({ mapId }) => mapId),
       [148, 164, 165, 166, 163, 778],
     );
     assert.equal(
-      travelBrowseScope(242).every(({ campaign }) => campaign === "Factions"),
+      travelBrowseScope(242, "world").every(({ campaign }) => campaign === "Factions"),
       true,
     );
-    assert.equal(travelBrowseScope(242).some(({ mapId }) => mapId === 248), false);
-    assert.equal(travelBrowseScope(81).some(({ mapId }) => mapId === 148), false);
-    assert.deepEqual(travelBrowseScope(2_000), []);
+    assert.equal(travelBrowseScope(242, "world").some(({ mapId }) => mapId === 248), false);
+    assert.equal(travelBrowseScope(81, "world").some(({ mapId }) => mapId === 148), false);
+    assert.deepEqual(travelBrowseScope(2_000, "world"), []);
+    assert.deepEqual(
+      travelBrowseScope(2_000, "pre-searing").map(({ mapId }) => mapId),
+      [148, 164, 165, 166, 163, 778],
+    );
+  });
+
+  it("combines the active Travel context with character unlocks", () => {
+    const unlockedMapWords = Array.from({ length: 28 }, () => 0);
+    for (const mapId of [148, 330]) {
+      unlockedMapWords[Math.floor(mapId / 32)]! |= 1 << (mapId % 32);
+    }
+    const preSearing = {
+      status: "ready" as const,
+      mapId: 148,
+      travelContext: "pre-searing" as const,
+      characterKey: null,
+      unlockedMapWords,
+    };
+    const world = { ...preSearing, mapId: 81, travelContext: "world" as const };
+
+    assert.equal(travelDestinationAvailability(preSearing, 148), "available");
+    assert.equal(travelDestinationAvailability(preSearing, 330), "outside-context");
+    assert.equal(travelDestinationAvailability(world, 148), "outside-context");
+    assert.equal(travelDestinationAvailability(world, 330), "available");
+    assert.equal(travelDestinationAvailability(preSearing, 164), "locked");
+    assert.equal(travelDestinationAvailability({
+      ...preSearing,
+      unlockedMapWords: null,
+    }, 164), "unknown");
   });
 
   it("rejects one request that would write both preference files", () => {


### PR DESCRIPTION
Pre-Searing characters could search for and select account-wide destinations such as Heroes' Ascent. The unlock bit made those results look available even though Guild Wars does not allow a Pre-Searing character to cross that boundary.

This publishes a bounded `pre-searing` or `world` Travel context from the already certified `AreaInfo.region` observation. Travel now combines that context with the existing unlock bitmap for search, browse, favorites, recents, numbered shortcuts, and direct host requests. A context mismatch is refused before the command export or attempt timer starts, and search explains why an otherwise matching destination is unavailable.

Saved shortcuts and search phrases remain account-wide, and the customization picker remains global. The change does not add a second map catalogue or alter the certified Travel dispatcher.

## Privacy and safety boundary

- The renderer receives only the closed `pre-searing | world` value; raw area-table data is not exposed.
- Invalid, loading, contradictory, and non-ready observations fail closed.
- The play-region snapshot remains 148 bytes while its ABI moves to 3; the companion kernel ABI moves to 21.
- Unknown unlock evidence remains unknown and is never labelled as unlocked.

## Verification

- `pnpm enhancements:kernel:verify`
- `pnpm run check`
- `git diff --check origin/main...HEAD`
- Focused Travel, palette, host, play-region snapshot, play-region kernel, ABI, and kernel-seal tests

The checks cover the reported `asc` search, exact Heroes' Ascent search, Pre-Searing explorable browse state, context-incompatible favorites/recents/shortcuts, post-Searing exclusion, unknown unlock evidence, direct-host refusal, ABI agreement, and reproducible kernel bytes.

## Rollout risk

This changes a live observation ABI. After CI is green, test the PR through a Developer Build and include it in the next Beta train before Stable. Live gameplay QA has not been performed or claimed here.

Implemented and verified with Codex using the repository test harness.
