### PR TITLE
fix(cartography): keep World Map guidance stable and accurate

### DIFF
--- a/docs/cartography.md
+++ b/docs/cartography.md
@@ -29,6 +29,21 @@ The current instance adds exact, live evidence:
 actionable now = remaining estimate AND currently reachable
 ```
 
+GWonMac remembers the revealable-cell mask for each visited map. It does not
+store the number shown on the World Map. The current exploration bitmap always
+recalculates that number.
+
+For a grouped World Map number, evidence has this priority:
+
+1. Use live current-map cells when that map overlaps the group.
+2. Otherwise, use remembered visited-map cells when they overlap the group.
+3. Otherwise, use the continent-wide estimate.
+
+A proven zero hides the group. It does not fall back to a larger estimate. For
+example, live map evidence can replace an estimated `12` with actionable `2`.
+After both cells are explored, the number disappears. After travel or restart,
+the remembered `2` remains the basis for the lighter non-current number.
+
 The default visual language is:
 
 - soft green coverage: creditable progress already explored;
@@ -79,6 +94,13 @@ Raw WASM addresses never reach the renderer. A generation mismatch, loading,
 invalid scalar, excessive geometry, uncertain projection, or unsupported build
 fails the dependent evidence layer closed. Travel withdraws stale orange and
 terrain immediately without discarding a healthy continent snapshot.
+
+Main stores visited-map knowledge atomically in
+`cartography-map-knowledge.json`. The file contains global map geometry, not
+account or character progress. Normal and Bird's Eye reveal modes stay
+separate. Repeated visits only add proven cells. Corrupt data is quarantined,
+and a different installed Guild Wars content generation or reachability kernel
+starts an empty ledger.
 
 ## Evidence export
 

--- a/docs/cartography.md
+++ b/docs/cartography.md
@@ -48,6 +48,10 @@ the continent-scale World Map. GWonMac certifies each context independently.
 Both surfaces consume the same continent state and global grid phase. A failure
 on either map hides only that surface.
 
+The World Map projection comes from its native event context. Each presentation
+read also refreshes the retained frame visibility. This hides the overlay when
+the native close fade finishes without another World Map event.
+
 At 18 pixels or more per cell, the map draws individual amber diamonds and
 orange actionable markers. At 8–18 pixels it groups the global grid into 4×4
 clusters. Below 8 pixels it uses 16×16 clusters. Cluster origins are fixed to

--- a/docs/live-cartography-certification.md
+++ b/docs/live-cartography-certification.md
@@ -70,6 +70,15 @@ thin current-instance boundary. The World Map observer must report `ready` only
 while the surface is visible. Its failure must not affect the Compass or Mission
 Map.
 
+Close the World Map during its fade, reopen it immediately, and close it again.
+The grid must hide when the native frame finishes closing. Reopening must show
+one attached grid without a stale duplicate.
+
+Find one grouped estimate where the current map proves a smaller number. Record
+the estimate and proven number, travel away, and restart gwonmac. The remembered
+number must remain lighter outside the map. Explore every proven cell. The
+number must disappear and must not return to the larger estimate.
+
 ## Layers and lifecycle
 
 Capture `layers-grid-only`, `layers-walkability-only`, and `layers-all` from

--- a/docs/multiple-accounts.md
+++ b/docs/multiple-accounts.md
@@ -24,6 +24,7 @@ Failure in one profile does not close another profile.
 | Launcher and game-window identity | Main-process window registry |
 | Window presentation | Main-process window coordinator |
 | Application settings, client downloads, repair, updates, Tools install | Global main-process owners |
+| Cartography visited-map knowledge | Global `cartography-map-knowledge.json` |
 | Login, Steam session, game storage, private libraries, window state | Resolved profile storage |
 | Shared templates and builds | Existing shared Multi libraries |
 

--- a/src/main/active-client.ts
+++ b/src/main/active-client.ts
@@ -17,6 +17,7 @@ import type { ChunkStore } from "./core/chunk-store.js";
 
 export interface ActiveClient {
   readonly generation: number;
+  readonly clientFingerprint: string;
   readonly artifactsDir: string;
   readonly store: ChunkStore;
   readonly wasmPath: string;

--- a/src/main/certification/cartography-transform-internals.ts
+++ b/src/main/certification/cartography-transform-internals.ts
@@ -472,6 +472,58 @@ export function nativeFrameObserver(
   );
 }
 
+/** Refresh the exact World Map frame retained by its certified event context. */
+export function worldMapFrameObserver(
+  certificate: typeof WORLD_MAP_CERTIFICATE & Pick<CartographyMemoryLayout, "frameArray" | "frameCount">,
+  globals: WorldMapGlobals,
+  areaEpoch: number,
+): Uint8Array {
+  const refuse = (status: number) => concat(
+    i32(0), globalSet(globals.visible),
+    i32(status), globalSet(globals.status), Uint8Array.of(0x0f),
+  );
+  const outsideMemory = (pointerLocal: number, bytes: Uint8Array) => concat(
+    local(4), Uint8Array.of(0x45, 0x45),
+    local(pointerLocal), local(4), bytes, Uint8Array.of(0x6b, 0x4b, 0x71),
+  );
+  return concat(
+    // count, array, frame id, frame, memory bytes.
+    Uint8Array.of(0x01, 0x05, 0x7f),
+    globalGet(globals.status), i32(1), Uint8Array.of(0x47, 0x04, 0x40),
+      i32(0), globalSet(globals.visible), Uint8Array.of(0x0f, 0x0b),
+    globalGet(globals.generation), globalGet(areaEpoch), Uint8Array.of(0x47, 0x04, 0x40),
+      refuse(11), Uint8Array.of(0x0b),
+    Uint8Array.of(0x3f, 0x00), i32(65_536), Uint8Array.of(0x6c, 0x21), uleb(4),
+    i32(certificate.frameCount), i32Load(), Uint8Array.of(0x22), uleb(0),
+    Uint8Array.of(0x45, 0x04, 0x40), refuse(2), Uint8Array.of(0x0b),
+    local(0), i32(16_384), Uint8Array.of(0x4b, 0x04, 0x40), refuse(3), Uint8Array.of(0x0b),
+    i32(certificate.frameArray), i32Load(), Uint8Array.of(0x22), uleb(1),
+    Uint8Array.of(0x45, 0x04, 0x40), refuse(4), Uint8Array.of(0x0b),
+    outsideMemory(1, concat(local(0), i32(4), Uint8Array.of(0x6c))),
+    Uint8Array.of(0x04, 0x40), refuse(5), Uint8Array.of(0x0b),
+    globalGet(globals.frameId), Uint8Array.of(0x22), uleb(2),
+    local(0), Uint8Array.of(0x4f, 0x04, 0x40), refuse(5), Uint8Array.of(0x0b),
+    local(1), local(2), i32(4), Uint8Array.of(0x6c, 0x6a), i32Load(),
+    Uint8Array.of(0x22), uleb(3),
+    Uint8Array.of(0x45, 0x04, 0x40), refuse(6), Uint8Array.of(0x0b),
+    outsideMemory(3, i32(certificate.frameBytes)),
+    Uint8Array.of(0x04, 0x40), refuse(6), Uint8Array.of(0x0b),
+    local(3), i32Load(certificate.frameId), local(2), Uint8Array.of(0x47, 0x04, 0x40),
+      refuse(6), Uint8Array.of(0x0b),
+    local(3), i32Load(certificate.frameState), Uint8Array.of(0x22), uleb(0),
+    i32(4), Uint8Array.of(0x71, 0x45, 0x45),
+    local(0), i32(0x200), Uint8Array.of(0x71, 0x45, 0x71), globalSet(globals.visible),
+    local(3), f32Load(certificate.frameViewportWidth), globalSet(globals.viewportWidth),
+    local(3), f32Load(certificate.frameViewportHeight), globalSet(globals.viewportHeight),
+    local(3), f32Load(certificate.frameScreenLeft), globalSet(globals.left),
+    local(3), f32Load(certificate.frameScreenBottom), globalSet(globals.bottom),
+    local(3), f32Load(certificate.frameScreenRight), globalSet(globals.right),
+    local(3), f32Load(certificate.frameScreenTop), globalSet(globals.top),
+    i32(1), globalSet(globals.status),
+    Uint8Array.of(0x0b),
+  );
+}
+
 /** Retain the exact direction argument consumed by the native CompassMap. */
 export function compassMapRenderWrapper(render: number, globals: CompassGlobals): Uint8Array {
   return concat(

--- a/src/main/certification/pathing-spike-transform.ts
+++ b/src/main/certification/pathing-spike-transform.ts
@@ -16,6 +16,7 @@ import {
   MISSION_MAP_FRAME_SPIKE_GLOBALS,
   MISSION_MAP_FRAME_SPIKE_SCALARS,
   MISSION_MAP_PROJECTION_SPIKE_SCALARS,
+  WORLD_MAP_FRAME_SPIKE_GLOBALS,
   WORLD_MAP_FRAME_SPIKE_SCALARS,
   WORLD_MAP_ANCHOR_SPIKE_GLOBALS,
   WORLD_MAP_ANCHOR_SPIKE_SCALARS,
@@ -57,6 +58,7 @@ import {
   rewriteExactTableSlot,
   worldMapAnchorObserver,
   worldMapEventWrapper,
+  worldMapFrameObserver,
   type CartographyContextGlobals,
   type CartographyMemoryLayout,
   type CompassGlobals,
@@ -72,7 +74,7 @@ declare const WebAssembly: {
   Module: new (bytes: Uint8Array) => object;
 };
 
-export const CARTOGRAPHY_SPIKE_TRANSFORM_ABI = 27;
+export const CARTOGRAPHY_SPIKE_TRANSFORM_ABI = 28;
 export type CartographyMemoryLayoutId = keyof typeof CARTOGRAPHY_MEMORY_LAYOUTS;
 
 const mutableI32 = () => Uint8Array.of(0x7f, 0x01, 0x41, 0x00, 0x0b);
@@ -282,6 +284,7 @@ export function transformCartographySpikeWasm(
     EXPLORATION_SPIKE_GLOBALS.observe,
     EXPLORATION_SPIKE_GLOBALS.readWord,
     WORLD_MAP_ANCHOR_SPIKE_GLOBALS.observe,
+    WORLD_MAP_FRAME_SPIKE_GLOBALS.observe,
   ];
   const existingExports = new Set(
     parseExports(sectionById(sections, 7)).map((entry) => entry.name),
@@ -321,6 +324,7 @@ export function transformCartographySpikeWasm(
   const explorationReadWordFunction = firstFunction + 6;
   const anchorObserverFunction = firstFunction + 7;
   const worldEventWrapperFunction = firstFunction + 8;
+  const worldObserverFunction = firstFunction + 9;
 
   const compassRender = bodies[compassRenderLocal]?.slice()
     ?? fail("Compass render body is missing");
@@ -377,6 +381,11 @@ export function transformCartographySpikeWasm(
       allocated.context.areaEpoch,
       worldCertificate,
     ),
+    worldMapFrameObserver(
+      worldCertificate,
+      allocated.world,
+      allocated.context.areaEpoch,
+    ),
   );
   const nextFunctionTypes = [
     ...functionTypes,
@@ -389,6 +398,7 @@ export function transformCartographySpikeWasm(
     readWordType,
     voidType,
     worldDispatcherType,
+    voidType,
   ];
 
   const contextEntries = [
@@ -430,6 +440,7 @@ export function transformCartographySpikeWasm(
     [EXPLORATION_SPIKE_GLOBALS.observe, explorationObserverFunction],
     [EXPLORATION_SPIKE_GLOBALS.readWord, explorationReadWordFunction],
     [WORLD_MAP_ANCHOR_SPIKE_GLOBALS.observe, anchorObserverFunction],
+    [WORLD_MAP_FRAME_SPIKE_GLOBALS.observe, worldObserverFunction],
   ] as const;
   const nextExports = concat(
     uleb(exports.count + scalarNames.length + functionNames.length),

--- a/src/main/client-runtime.ts
+++ b/src/main/client-runtime.ts
@@ -577,6 +577,7 @@ export class ClientRuntime {
 
   private async activateStore(
     store: ChunkStore,
+    clientFingerprint: string,
     candidateFingerprint: string | null = null,
   ): Promise<ActiveClient> {
     this.initialResidencyRecorded = false;
@@ -589,6 +590,7 @@ export class ClientRuntime {
     // or game update prepares a fresh session and must get a fresh attempt.
     const active: ActiveClient = this.activeSlot.publish({
       artifactsDir: this.options.paths.artifacts,
+      clientFingerprint,
       store,
       wasmPath: enhancement.wasmPath,
       jsPath: enhancement.jsPath,
@@ -611,6 +613,7 @@ export class ClientRuntime {
 
   private async activateManifest(
     manifest: Manifest,
+    clientFingerprint: string,
     candidateFingerprint: string | null = null,
   ): Promise<ActiveClient> {
     const entry = manifest.entry(SNAPSHOT);
@@ -622,6 +625,7 @@ export class ClientRuntime {
         entry.chunkHashes,
         manifest.compression,
       ),
+      clientFingerprint,
       candidateFingerprint,
     );
   }
@@ -634,6 +638,9 @@ export class ClientRuntime {
     // has a sentence for each, and "unknown" would have collapsed them into
     // the generic one.
     if (!value) throw new NotReadyError("no published client is available");
+    if (!value.clientFingerprint) {
+      throw new AppError("bad_manifest", "published client has no generation fingerprint");
+    }
     if (
       (await verifyPublishedClientArtifacts(
         this.options.paths.artifacts,
@@ -653,6 +660,7 @@ export class ClientRuntime {
         value.chunkHashes,
         value.compressionMode,
       ),
+      value.clientFingerprint,
       candidate.status === "pending" &&
         candidate.fingerprint === value.clientFingerprint
         ? candidate.fingerprint
@@ -789,6 +797,7 @@ export class ClientRuntime {
       }
       const active = await this.activateManifest(
         result.manifest,
+        result.fingerprint,
         result.candidate ? result.fingerprint : null,
       );
       await this.pruneChunkCache();

--- a/src/main/core/cartography-map-knowledge.ts
+++ b/src/main/core/cartography-map-knowledge.ts
@@ -1,0 +1,203 @@
+/**
+ * Serializes the global Cartography map-knowledge ledger. The records contain
+ * reusable revealable-cell masks, never character progress or display counts.
+ */
+import { readFile } from "node:fs/promises";
+import { isDigest } from "../../shared/digest.js";
+import {
+  CARTOGRAPHY_MAP_KNOWLEDGE_LIMIT,
+  parseCartographyMapKnowledge,
+  type CartographyMapKnowledge,
+} from "../../shared/cartography-map-knowledge.js";
+import { writeAtomicJson } from "./atomic-file.js";
+import { quarantineCorruptDocument } from "./corrupt-document.js";
+
+const FORMAT_VERSION = 1;
+const BASE64 = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/u;
+
+type StoredRecord = Omit<CartographyMapKnowledge, "kernelSha256" | "words">
+  & Readonly<{ wordsBase64: string }>;
+type StoredDocument = Readonly<{
+  formatVersion: typeof FORMAT_VERSION;
+  clientFingerprint: string;
+  kernelSha256: string;
+  records: readonly StoredRecord[];
+}>;
+
+function encodeWords(words: readonly number[]): string {
+  const bytes = Buffer.allocUnsafe(words.length * 4);
+  words.forEach((word, index) => bytes.writeUInt32LE(word, index * 4));
+  return bytes.toString("base64");
+}
+
+function decodeRecord(value: unknown, kernelSha256: string): CartographyMapKnowledge {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("cartography map knowledge record must be an object");
+  }
+  const source = value as Record<string, unknown>;
+  if (typeof source.wordsBase64 !== "string" || !BASE64.test(source.wordsBase64)) {
+    throw new Error("cartography map knowledge record has invalid encoding");
+  }
+  const unknown = Object.keys(source).filter((key) => ![
+    "mapId", "continent", "width", "height", "revealRadius", "wordsBase64",
+  ].includes(key));
+  if (unknown.length > 0) {
+    throw new Error(`cartography map knowledge record has unknown fields: ${unknown.join(", ")}`);
+  }
+  const bytes = Buffer.from(source.wordsBase64, "base64");
+  if (bytes.byteLength % 4 !== 0) {
+    throw new Error("cartography map knowledge record has partial words");
+  }
+  const words = Array.from(
+    { length: bytes.byteLength / 4 },
+    (_, index) => bytes.readUInt32LE(index * 4),
+  );
+  return parseCartographyMapKnowledge({
+    kernelSha256,
+    mapId: source.mapId,
+    continent: source.continent,
+    width: source.width,
+    height: source.height,
+    revealRadius: source.revealRadius,
+    words,
+  });
+}
+
+function parseDocument(value: unknown): StoredDocument {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("cartography map knowledge document must be an object");
+  }
+  const source = value as Record<string, unknown>;
+  const kernelSha256 = source.kernelSha256;
+  if (
+    source.formatVersion !== FORMAT_VERSION
+    || !isDigest(source.clientFingerprint)
+    || !isDigest(kernelSha256)
+  ) {
+    throw new Error("cartography map knowledge document has invalid identity");
+  }
+  if (!Array.isArray(source.records) || source.records.length > CARTOGRAPHY_MAP_KNOWLEDGE_LIMIT) {
+    throw new Error("cartography map knowledge document has invalid records");
+  }
+  const records = source.records.map((record) => store(decodeRecord(record, kernelSha256)));
+  const keys = records.map((record) => `${record.mapId}:${record.revealRadius}`);
+  if (new Set(keys).size !== keys.length) {
+    throw new Error("cartography map knowledge document has duplicate records");
+  }
+  const unknown = Object.keys(source).filter(
+    (key) => !["formatVersion", "clientFingerprint", "kernelSha256", "records"].includes(key),
+  );
+  if (unknown.length > 0) {
+    throw new Error(`cartography map knowledge document has unknown fields: ${unknown.join(", ")}`);
+  }
+  return Object.freeze({
+    formatVersion: FORMAT_VERSION,
+    clientFingerprint: source.clientFingerprint,
+    kernelSha256,
+    records: Object.freeze(records),
+  });
+}
+
+async function readDocument(path: string): Promise<StoredDocument | null> {
+  let text: string;
+  try {
+    text = await readFile(path, "utf8");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+  try {
+    return parseDocument(JSON.parse(text) as unknown);
+  } catch {
+    await quarantineCorruptDocument(path);
+    return null;
+  }
+}
+
+function decode(
+  records: readonly StoredRecord[],
+  kernelSha256: string,
+): readonly CartographyMapKnowledge[] {
+  return Object.freeze(records.map((record) => decodeRecord(record, kernelSha256)));
+}
+
+function store(record: CartographyMapKnowledge): StoredRecord {
+  return Object.freeze({
+    mapId: record.mapId,
+    continent: record.continent,
+    width: record.width,
+    height: record.height,
+    revealRadius: record.revealRadius,
+    wordsBase64: encodeWords(record.words),
+  });
+}
+
+export class CartographyMapKnowledgeStore {
+  readonly #path: string;
+  #tail: Promise<void> = Promise.resolve();
+
+  constructor(path: string) {
+    this.#path = path;
+  }
+
+  #enqueue<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.#tail.then(operation);
+    this.#tail = result.then(() => undefined, () => undefined);
+    return result;
+  }
+
+  get(
+    clientFingerprint: string,
+    kernelSha256: string,
+  ): Promise<readonly CartographyMapKnowledge[]> {
+    return this.#enqueue(async () => {
+      const document = await readDocument(this.#path);
+      return document?.clientFingerprint === clientFingerprint
+        && document.kernelSha256 === kernelSha256
+        ? decode(document.records, kernelSha256)
+        : [];
+    });
+  }
+
+  record(
+    clientFingerprint: string,
+    value: CartographyMapKnowledge,
+  ): Promise<readonly CartographyMapKnowledge[]> {
+    return this.#enqueue(async () => {
+      const document = await readDocument(this.#path);
+      const records = document?.clientFingerprint === clientFingerprint
+        && document.kernelSha256 === value.kernelSha256
+        ? [...document.records]
+        : [];
+      const index = records.findIndex(
+        (record) => record.mapId === value.mapId && record.revealRadius === value.revealRadius,
+      );
+      const previous = index < 0 ? null : decodeRecord(records[index], value.kernelSha256);
+      const compatible = previous !== null
+        && previous.continent === value.continent
+        && previous.width === value.width
+        && previous.height === value.height;
+      const words = compatible
+        ? value.words.map((word, wordIndex) => (word | previous.words[wordIndex]!) >>> 0)
+        : value.words;
+      const next = parseCartographyMapKnowledge({ ...value, words });
+      const unchanged = compatible && next.words.every(
+        (word, wordIndex) => word === previous.words[wordIndex],
+      );
+      if (unchanged && document !== null) {
+        return decode(document.records, value.kernelSha256);
+      }
+      if (index >= 0) records.splice(index, 1);
+      records.push(store(next));
+      const bounded = records.slice(-CARTOGRAPHY_MAP_KNOWLEDGE_LIMIT);
+      const saved: StoredDocument = Object.freeze({
+        formatVersion: FORMAT_VERSION,
+        clientFingerprint,
+        kernelSha256: value.kernelSha256,
+        records: Object.freeze(bounded),
+      });
+      await writeAtomicJson(this.#path, saved, 0o600);
+      return decode(saved.records, value.kernelSha256);
+    });
+  }
+}

--- a/src/main/core/paths.ts
+++ b/src/main/core/paths.ts
@@ -23,6 +23,7 @@ export interface GamePaths {
   travelPreferences: string;
   travelHistory: string;
   characterSwitchUsage: string;
+  cartographyMapKnowledge: string;
   tradeSaved: string;
   buildLibrary: string;
   windowState: string;
@@ -61,6 +62,7 @@ export function gamePaths(userData: string): GamePaths {
     travelPreferences: path.join(userData, "travel-preferences.json"),
     travelHistory: path.join(userData, "travel-history.json"),
     characterSwitchUsage: path.join(userData, "character-switch-usage.json"),
+    cartographyMapKnowledge: path.join(userData, "cartography-map-knowledge.json"),
     tradeSaved: path.join(userData, "trade-saved.json"),
     buildLibrary: path.join(userData, "build-library.json"),
     windowState: path.join(userData, "window-state.json"),

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -107,6 +107,10 @@ import {
 } from "../shared/character-switch-usage.js";
 import { exportCartographyEvidence } from "./cartography-evidence-export.js";
 import { parseCartographyEvidenceCapture } from "./cartography-evidence/capture.js";
+import {
+  parseCartographyMapKnowledge,
+  type CartographyMapKnowledge,
+} from "../shared/cartography-map-knowledge.js";
 
 export interface IpcContext {
   sockets: SocketManager;
@@ -118,6 +122,12 @@ export interface IpcContext {
   updateSettings: (patch: RendererSettingsPatch) => Promise<AppSettings>;
   getCharacterSwitchUsage: () => Promise<CharacterSwitchUsageDocument>;
   recordCharacterSwitchUsage: (characterKey: string) => Promise<CharacterSwitchUsageDocument>;
+  getCartographyMapKnowledge: (
+    kernelSha256: string,
+  ) => Promise<readonly CartographyMapKnowledge[]>;
+  recordCartographyMapKnowledge: (
+    value: CartographyMapKnowledge,
+  ) => Promise<readonly CartographyMapKnowledge[]>;
   setDiagnosticProfile: (profile: DiagnosticProfile) => Promise<DiagnosticProfile>;
   confirmClientHealthy: (token: ClientHealthToken) => Promise<void>;
   getClientSession: (win: BrowserWindow) => ClientSession;
@@ -225,6 +235,11 @@ const asFiniteNumber = (what: string) =>
     }
     return value;
   });
+
+const asDigestValue = one((value: unknown): string => {
+  if (!isDigest(value)) throw new ValidationError("invalid digest");
+  return value;
+});
 
 const asSocketPayload: Parser<{ socketId: number; bytes: Uint8Array }> = (args) => {
   exact(args, 2);
@@ -553,6 +568,16 @@ export function registerIpcHandlers(ctx: IpcContext): {
         ctx.getClientSession(win),
         ctx.getSettings,
       ),
+    ),
+
+    cartographyMapKnowledgeGet: channel(
+      asDigestValue,
+      (_win, kernelSha256) => ctx.getCartographyMapKnowledge(kernelSha256),
+    ),
+
+    cartographyMapKnowledgeRecord: channel(
+      one(parseCartographyMapKnowledge),
+      (_win, value) => ctx.recordCartographyMapKnowledge(value),
     ),
 
     appOpenExternal: channel(asExternalLinkKind, async (_win, kind) => {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -132,6 +132,7 @@ import { MultipleAccountsController } from "./multiple-accounts-controller.js";
 import { WindowCoordinator } from "./window-coordinator.js";
 import { GameReloader } from "./game-reload.js";
 import { CharacterSwitchUsageStore } from "./core/character-switch-usage.js";
+import { CartographyMapKnowledgeStore } from "./core/cartography-map-knowledge.js";
 import { updateToolsMenuItems } from "./window-menu.js";
 import { resolveAdoptedProfileStorage } from "./core/profile-storage.js";
 import {
@@ -744,6 +745,9 @@ if (primaryInstance) void app.whenReady().then(async () => {
   applyToolsSettings = toolsRuntime?.applySettings ?? null;
   await toolsRuntime?.applySettings(settings);
   const characterSwitchUsage = new CharacterSwitchUsageStore(paths.characterSwitchUsage);
+  const cartographyMapKnowledge = new CartographyMapKnowledgeStore(
+    paths.cartographyMapKnowledge,
+  );
 
   launcherOrchestrator = new LauncherOrchestrator({
     accounts,
@@ -944,6 +948,18 @@ if (primaryInstance) void app.whenReady().then(async () => {
     updateSettings: (patch) => preferences.updateRendererSettings(patch),
     getCharacterSwitchUsage: () => characterSwitchUsage.get(),
     recordCharacterSwitchUsage: (characterKey) => characterSwitchUsage.record(characterKey),
+    getCartographyMapKnowledge: (kernelSha256) => {
+      const fingerprint = clientRuntime.active?.clientFingerprint;
+      return fingerprint
+        ? cartographyMapKnowledge.get(fingerprint, kernelSha256)
+        : Promise.resolve([]);
+    },
+    recordCartographyMapKnowledge: (value) => {
+      const fingerprint = clientRuntime.active?.clientFingerprint;
+      return fingerprint
+        ? cartographyMapKnowledge.record(fingerprint, value)
+        : Promise.resolve([]);
+    },
     setDiagnosticProfile: async (profile) => {
       diagnosticProfile = await saveDiagnosticProfile(
         paths.diagnosticProfile,

--- a/src/preload/preload.body.cjs
+++ b/src/preload/preload.body.cjs
@@ -219,6 +219,10 @@ const api = {
     setProfile: (value) => ipcRenderer.invoke(IPC.diagnosticsProfileSet, value),
   },
   cartography: {
+    getMapKnowledge: (kernelSha256) =>
+      ipcRenderer.invoke(IPC.cartographyMapKnowledgeGet, kernelSha256),
+    recordMapKnowledge: (value) =>
+      ipcRenderer.invoke(IPC.cartographyMapKnowledgeRecord, value),
     exportEvidence: (value) =>
       ipcRenderer.invoke(IPC.cartographyEvidenceExport, value),
   },

--- a/src/renderer/cartography-spike/cartography-grid-layer.ts
+++ b/src/renderer/cartography-spike/cartography-grid-layer.ts
@@ -27,6 +27,33 @@ const ESTIMATED_COLOR = "#E2AE3E";
 
 export type CartographyProgressClusterSize = 1 | 4 | 16;
 
+export type CartographyClusterPresentation = Readonly<{
+  count: number;
+  actionable: boolean;
+}>;
+
+/** Prefer exact live or remembered map knowledge over the continent estimate. */
+export function cartographyClusterPresentation(input: Readonly<{
+  estimatedRemaining: number;
+  currentKnown: number;
+  currentRemaining: number;
+  rememberedKnown: number;
+  rememberedRemaining: number;
+}>): CartographyClusterPresentation | null {
+  if (input.estimatedRemaining === 0) return null;
+  if (input.currentKnown > 0) {
+    return input.currentRemaining > 0
+      ? Object.freeze({ count: input.currentRemaining, actionable: true })
+      : null;
+  }
+  if (input.rememberedKnown > 0) {
+    return input.rememberedRemaining > 0
+      ? Object.freeze({ count: input.rememberedRemaining, actionable: false })
+      : null;
+  }
+  return Object.freeze({ count: input.estimatedRemaining, actionable: false });
+}
+
 /** Stable level of detail for one projected cartography cell. */
 export function cartographyProgressClusterSize(
   cellPixels: number,
@@ -74,6 +101,7 @@ export type CartographyGridLayer = Readonly<{
     isRemaining(cellX: number, cellY: number): boolean | null;
     revealabilityVersion: string;
     canCurrentMapReveal(cellX: number, cellY: number): boolean | null;
+    canVisitedMapReveal(cellX: number, cellY: number): boolean | null;
     hoveredCell: CartographyCell | null;
     revealRadius: CartographyRevealRadius;
   }>): void;
@@ -255,6 +283,7 @@ export function createCartographyGridLayer(parent: HTMLElement, id: string): Car
     isExplored: (cellX: number, cellY: number) => boolean | null,
     isRemaining: (cellX: number, cellY: number) => boolean | null,
     canCurrentMapReveal: (cellX: number, cellY: number) => boolean | null,
+    canVisitedMapReveal: (cellX: number, cellY: number) => boolean | null,
     hoveredCell: CartographyCell | null,
     revealRadius: CartographyRevealRadius,
   ): boolean => {
@@ -366,24 +395,40 @@ export function createCartographyGridLayer(parent: HTMLElement, id: string): Car
       for (let groupY = firstGroupY; groupY <= projection.lastCellY; groupY += groupSize) {
         for (let groupX = firstGroupX; groupX <= projection.lastCellX; groupX += groupSize) {
           let remainingCount = 0;
-          let actionableCount = 0;
+          let currentKnownCount = 0;
+          let currentRemainingCount = 0;
+          let rememberedKnownCount = 0;
+          let rememberedRemainingCount = 0;
           for (let y = Math.max(groupY, projection.firstCellY);
             y <= Math.min(groupY + groupSize - 1, projection.lastCellY); y += 1) {
             for (let x = Math.max(groupX, projection.firstCellX);
               x <= Math.min(groupX + groupSize - 1, projection.lastCellX); x += 1) {
-              if (isRemaining(x, y) === true) remainingCount += 1;
-              if (canCurrentMapReveal(x, y) === true) actionableCount += 1;
+              const remaining = isRemaining(x, y) === true;
+              const currentKnown = canCurrentMapReveal(x, y) === true;
+              const rememberedKnown = canVisitedMapReveal(x, y) === true;
+              if (remaining) remainingCount += 1;
+              if (currentKnown) currentKnownCount += 1;
+              if (remaining && currentKnown) currentRemainingCount += 1;
+              if (rememberedKnown) rememberedKnownCount += 1;
+              if (remaining && rememberedKnown) rememberedRemainingCount += 1;
             }
           }
-          if (remainingCount === 0) continue;
+          const cluster = cartographyClusterPresentation({
+            estimatedRemaining: remainingCount,
+            currentKnown: currentKnownCount,
+            currentRemaining: currentRemainingCount,
+            rememberedKnown: rememberedKnownCount,
+            rememberedRemaining: rememberedRemainingCount,
+          });
+          if (cluster === null) continue;
           drawClusterMarker(
             context,
             projection,
             groupX,
             groupY,
             groupSize,
-            actionableCount > 0 ? actionableCount : remainingCount,
-            actionableCount > 0,
+            cluster.count,
+            cluster.actionable,
             style.unseen.color,
             style.casingColor,
             Math.min(1, strength * 1.2),
@@ -418,6 +463,7 @@ export function createCartographyGridLayer(parent: HTMLElement, id: string): Car
       isRemaining,
       revealabilityVersion,
       canCurrentMapReveal,
+      canVisitedMapReveal,
       hoveredCell,
       revealRadius,
     }) {
@@ -454,6 +500,7 @@ export function createCartographyGridLayer(parent: HTMLElement, id: string): Car
           isExplored,
           isRemaining,
           canCurrentMapReveal,
+          canVisitedMapReveal,
           hoveredCell,
           revealRadius,
         );

--- a/src/renderer/cartography-spike/frame-observer.ts
+++ b/src/renderer/cartography-spike/frame-observer.ts
@@ -189,10 +189,23 @@ export function createCompassFrameSpikeReader(
 export function createWorldMapFrameSpikeReader(
   exports: WebAssembly.Exports,
 ): WorldMapFrameSpikeController | null {
-  if (!WORLD_MAP_FRAME_SPIKE_SCALARS.every(
+  if (typeof exports[WORLD_MAP_FRAME_SPIKE_GLOBALS.observe] !== "function"
+    || !WORLD_MAP_FRAME_SPIKE_SCALARS.every(
     (name) => exports[name] instanceof WebAssembly.Global,
   )) return null;
-  const diagnostics = (): WorldMapFrameSpikeDiagnostic => Object.freeze({
+  const refresh = (): boolean => {
+    const observe = exports[WORLD_MAP_FRAME_SPIKE_GLOBALS.observe];
+    if (typeof observe !== "function") return false;
+    try {
+      observe();
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  const diagnostics = (): WorldMapFrameSpikeDiagnostic => {
+    refresh();
+    return Object.freeze({
     status: numberGlobal(exports, WORLD_MAP_FRAME_SPIKE_GLOBALS.status),
     sequence: numberGlobal(exports, WORLD_MAP_FRAME_SPIKE_GLOBALS.sequence),
     generation: numberGlobal(exports, WORLD_MAP_FRAME_SPIKE_GLOBALS.generation),
@@ -204,10 +217,12 @@ export function createWorldMapFrameSpikeReader(
     topLeftY: numberGlobal(exports, WORLD_MAP_FRAME_SPIKE_GLOBALS.topLeftY),
     bottomRightX: numberGlobal(exports, WORLD_MAP_FRAME_SPIKE_GLOBALS.bottomRightX),
     bottomRightY: numberGlobal(exports, WORLD_MAP_FRAME_SPIKE_GLOBALS.bottomRightY),
-  });
+    });
+  };
   return Object.freeze({
     diagnostics,
     snapshot() {
+      if (!refresh()) return null;
       const firstSequence = numberGlobal(exports, WORLD_MAP_FRAME_SPIKE_GLOBALS.sequence);
       const values = Object.fromEntries(WORLD_MAP_FRAME_SPIKE_SCALARS.map(
         (name) => [name, numberGlobal(exports, name)],

--- a/src/renderer/cartography-spike/index.ts
+++ b/src/renderer/cartography-spike/index.ts
@@ -7,6 +7,8 @@ import type {
   CartographyEvidenceExportResult,
 } from "../../shared/cartography-evidence.js";
 import type { AppSettings, RendererSettingsPatch } from "../../shared/contracts.js";
+import type { CartographyMapKnowledge } from
+  "../../shared/cartography-map-knowledge.js";
 import type {
   CompassFrameSpikeController,
   MissionMapFrameSpikeController,
@@ -63,6 +65,10 @@ export async function installCartographySpike(options: Readonly<{
   exportEvidence(
     capture: CartographyEvidenceCapture,
   ): Promise<CartographyEvidenceExportResult>;
+  getMapKnowledge(kernelSha256: string): Promise<readonly CartographyMapKnowledge[]>;
+  recordMapKnowledge(
+    value: CartographyMapKnowledge,
+  ): Promise<readonly CartographyMapKnowledge[]>;
 }>): Promise<() => void> {
   const context = createCartographyContextReader(options.exports);
   const compassReader = createCompassFrameSpikeReader(options.exports);
@@ -95,6 +101,14 @@ export async function installCartographySpike(options: Readonly<{
       dispose: () => undefined,
     });
   }
+  let initialMapKnowledge: readonly CartographyMapKnowledge[] = [];
+  if (kernel.sha256 !== null) {
+    try {
+      initialMapKnowledge = await options.getMapKnowledge(kernel.sha256);
+    } catch (cause) {
+      console.error("[cartography] remembered map knowledge unavailable", cause);
+    }
+  }
   if (compassReader !== null) window.gwCompassFrameSpike = compassReader;
   if (missionMapReader !== null) window.gwMissionMapFrameSpike = missionMapReader;
   if (worldMapReader !== null) window.gwWorldMapFrameSpike = worldMapReader;
@@ -117,6 +131,8 @@ export async function installCartographySpike(options: Readonly<{
     settings: options.settings,
     persist: options.persist,
     exportEvidence: options.exportEvidence,
+    initialMapKnowledge,
+    recordMapKnowledge: options.recordMapKnowledge,
   });
 
   return () => {

--- a/src/renderer/cartography-spike/map-knowledge.ts
+++ b/src/renderer/cartography-spike/map-knowledge.ts
@@ -1,0 +1,41 @@
+/**
+ * Aggregates persisted per-map revealable cells for the current continent and
+ * reveal mode. Persisted records stay immutable and main-owned.
+ */
+import type { CartographyMapKnowledge } from
+  "../../shared/cartography-map-knowledge.js";
+
+export function mergeCartographyMapKnowledge(
+  records: readonly CartographyMapKnowledge[],
+  target: Readonly<{
+    kernelSha256: string;
+    continent: number;
+    width: number;
+    height: number;
+    revealRadius: 1 | 3;
+  }>,
+): Uint32Array | null {
+  let merged: Uint32Array | null = null;
+  for (const record of records) {
+    if (
+      record.kernelSha256 !== target.kernelSha256
+      || record.continent !== target.continent
+      || record.width !== target.width
+      || record.height !== target.height
+      || record.revealRadius !== target.revealRadius
+    ) continue;
+    merged ??= new Uint32Array(record.words.length);
+    record.words.forEach((word, index) => {
+      merged![index] = (merged![index]! | word) >>> 0;
+    });
+  }
+  return merged;
+}
+
+export function cartographyKnowledgeWordsFingerprint(words: Uint32Array): number {
+  let value = 2_166_136_261;
+  for (const word of words) {
+    value = Math.imul(value ^ word, 16_777_619) >>> 0;
+  }
+  return value;
+}

--- a/src/renderer/cartography-spike/overlay.ts
+++ b/src/renderer/cartography-spike/overlay.ts
@@ -8,6 +8,8 @@ import type {
   CartographyEvidenceExportResult,
 } from "../../shared/cartography-evidence.js";
 import type { AppSettings, RendererSettingsPatch } from "../../shared/contracts.js";
+import type { CartographyMapKnowledge } from
+  "../../shared/cartography-map-knowledge.js";
 import {
   bitsetHasCell,
   readCartographyState,
@@ -43,6 +45,10 @@ import {
   createWalkableTerrainSurface,
   type WalkableTerrainSurface,
 } from "./walkable-terrain-surface.js";
+import {
+  cartographyKnowledgeWordsFingerprint,
+  mergeCartographyMapKnowledge,
+} from "./map-knowledge.js";
 
 const MODEL_POLL_MS = 200;
 
@@ -114,6 +120,10 @@ export function mountCartographyOverlay(options: Readonly<{
   exportEvidence(
     capture: CartographyEvidenceCapture,
   ): Promise<CartographyEvidenceExportResult>;
+  initialMapKnowledge: readonly CartographyMapKnowledge[];
+  recordMapKnowledge(
+    value: CartographyMapKnowledge,
+  ): Promise<readonly CartographyMapKnowledge[]>;
 }>): () => void {
   const document = options.parent.ownerDocument;
   const view = document.defaultView;
@@ -186,6 +196,16 @@ export function mountCartographyOverlay(options: Readonly<{
   let nextModelPoll = 0;
   let explorationVersion = 0;
   let actionabilityVersion = 0;
+  let mapKnowledge = options.initialMapKnowledge;
+  let mapKnowledgeVersion = 0;
+  let mapKnowledgeProjectionKey = "";
+  let rememberedReachable: Readonly<{
+    width: number;
+    height: number;
+    words: Uint32Array;
+  }> | null = null;
+  let requestedKnowledgeKey = "";
+  let knowledgeWrites: Promise<void> = Promise.resolve();
   let terrainKey = "";
   let terrain: WalkableTerrainSurface | null = null;
   let pointerX = Number.NaN;
@@ -296,6 +316,42 @@ export function mountCartographyOverlay(options: Readonly<{
     }
   };
 
+  const rememberCurrentMap = (
+    current: Extract<CartographyState["currentInstance"], { status: "ready" }>,
+    revealRadius: 1 | 3,
+  ): void => {
+    const kernelSha256 = options.modelSources.kernel.sha256;
+    if (kernelSha256 === null) return;
+    const wordsFingerprint = cartographyKnowledgeWordsFingerprint(current.reachableCells.words);
+    const key = [
+      current.epoch.mapId,
+      current.continent,
+      current.reachableCells.width,
+      current.reachableCells.height,
+      revealRadius,
+      current.epoch.resource,
+      wordsFingerprint,
+    ].join(":");
+    if (key === requestedKnowledgeKey) return;
+    requestedKnowledgeKey = key;
+    const record = Object.freeze({
+      kernelSha256,
+      mapId: current.epoch.mapId,
+      continent: current.continent,
+      width: current.reachableCells.width,
+      height: current.reachableCells.height,
+      revealRadius,
+      words: Object.freeze(Array.from(current.reachableCells.words)),
+    });
+    knowledgeWrites = knowledgeWrites.then(async () => {
+      mapKnowledge = await options.recordMapKnowledge(record);
+      mapKnowledgeVersion += 1;
+    }).catch((cause) => {
+      if (requestedKnowledgeKey === key) requestedKnowledgeKey = "";
+      console.error("[cartography] could not remember current map knowledge", cause);
+    });
+  };
+
   const render = (): void => {
     const now = view.performance.now();
     if (now >= nextModelPoll) {
@@ -313,12 +369,18 @@ export function mountCartographyOverlay(options: Readonly<{
         if (
           previous.currentInstance.status !== "ready"
           || !bitsetsEqual(
-            previous.currentInstance.actionableCells,
-            next.currentInstance.actionableCells,
+            previous.currentInstance.reachableCells,
+            next.currentInstance.reachableCells,
           )
         ) actionabilityVersion += 1;
       }
       state = next;
+      if (state.currentInstance.status === "ready") {
+        rememberCurrentMap(
+          state.currentInstance,
+          options.settings().cartographyRevealMode === "birds-eye" ? 3 : 1,
+        );
+      }
       controls.updateQaStatus(modelStats());
       nextModelPoll = now + MODEL_POLL_MS;
     }
@@ -349,11 +411,41 @@ export function mountCartographyOverlay(options: Readonly<{
     const explorationKey = `${state.continent.status === "ready"
       ? `${state.continent.continent}:${state.continent.generation}:${state.continent.explorationSequence}`
       : "unavailable"}:${explorationVersion}`;
+    const nextMapKnowledgeProjectionKey = state.continent.status === "ready"
+      ? [
+          state.continent.continent,
+          state.continent.explored.width,
+          state.continent.explored.height,
+          revealRadius,
+          mapKnowledgeVersion,
+        ].join(":")
+      : "";
+    if (nextMapKnowledgeProjectionKey !== mapKnowledgeProjectionKey) {
+      const kernelSha256 = options.modelSources.kernel.sha256;
+      const words = state.continent.status === "ready" && kernelSha256 !== null
+        ? mergeCartographyMapKnowledge(mapKnowledge, {
+            kernelSha256,
+            continent: state.continent.continent,
+            width: state.continent.explored.width,
+            height: state.continent.explored.height,
+            revealRadius,
+          })
+        : null;
+      rememberedReachable = state.continent.status === "ready" && words !== null
+        ? Object.freeze({
+            width: state.continent.explored.width,
+            height: state.continent.explored.height,
+            words,
+          })
+        : null;
+      mapKnowledgeProjectionKey = nextMapKnowledgeProjectionKey;
+    }
     const actionabilityKey = [
       state.currentInstance.status === "ready" ? state.currentInstance.epoch.mapId : "-",
       state.currentInstance.status === "ready" ? state.currentInstance.epoch.area : "-",
       state.currentInstance.status === "ready" ? state.currentInstance.epoch.resource : "-",
       actionabilityVersion,
+      mapKnowledgeVersion,
     ].join(":");
     const nextTerrainKey = state.currentInstance.status === "ready"
       ? `${state.currentInstance.epoch.area}:${state.currentInstance.epoch.resource}`
@@ -372,9 +464,13 @@ export function mountCartographyOverlay(options: Readonly<{
       if (state.continent.status !== "ready") return null;
       return bitsetHasCell(state.continent.remaining, { x, y });
     };
-    const isActionable = (x: number, y: number): boolean | null => {
+    const canCurrentMapReveal = (x: number, y: number): boolean | null => {
       if (state.currentInstance.status !== "ready") return null;
-      return bitsetHasCell(state.currentInstance.actionableCells, { x, y }) === true ? true : null;
+      return bitsetHasCell(state.currentInstance.reachableCells, { x, y });
+    };
+    const canVisitedMapReveal = (x: number, y: number): boolean | null => {
+      if (rememberedReachable === null) return null;
+      return bitsetHasCell(rememberedReachable, { x, y });
     };
     const canvasBox = options.canvas.getBoundingClientRect();
 
@@ -412,7 +508,8 @@ export function mountCartographyOverlay(options: Readonly<{
           isExplored,
           isRemaining,
           revealabilityVersion: actionabilityKey,
-          canCurrentMapReveal: isActionable,
+          canCurrentMapReveal,
+          canVisitedMapReveal,
           hoveredCell: null,
           revealRadius,
         });
@@ -477,7 +574,8 @@ export function mountCartographyOverlay(options: Readonly<{
             isExplored,
             isRemaining,
             revealabilityVersion: actionabilityKey,
-            canCurrentMapReveal: isActionable,
+            canCurrentMapReveal,
+            canVisitedMapReveal,
             hoveredCell,
             revealRadius: hoveredCell === null
               ? revealRadius
@@ -548,7 +646,8 @@ export function mountCartographyOverlay(options: Readonly<{
         isExplored,
         isRemaining,
         revealabilityVersion: actionabilityKey,
-        canCurrentMapReveal: isActionable,
+        canCurrentMapReveal,
+        canVisitedMapReveal,
         hoveredCell,
         revealRadius: hoveredCell === null
           ? 0

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -792,6 +792,9 @@ Module = {
           return saved;
         },
         exportEvidence: (capture) => native().cartography.exportEvidence(capture),
+        getMapKnowledge: (kernelSha256) =>
+          native().cartography.getMapKnowledge(kernelSha256),
+        recordMapKnowledge: (value) => native().cartography.recordMapKnowledge(value),
       });
       maybeInstallEnhancements();
       success(result.instance, result.module);

--- a/src/shared/cartography-map-knowledge.ts
+++ b/src/shared/cartography-map-knowledge.ts
@@ -1,0 +1,76 @@
+/**
+ * Defines the bounded map-knowledge records exchanged between Cartography and
+ * main. Main owns persistence; the renderer owns display-time aggregation.
+ */
+import { CARTOGRAPHY_REACHABILITY_MAX_CELLS } from
+  "./cartography-reachability-kernel-contract.js";
+import { isDigest } from "./digest.js";
+
+export const CARTOGRAPHY_MAP_KNOWLEDGE_LIMIT = 2_048;
+
+export type CartographyMapKnowledge = Readonly<{
+  kernelSha256: string;
+  mapId: number;
+  continent: number;
+  width: number;
+  height: number;
+  revealRadius: 1 | 3;
+  words: readonly number[];
+}>;
+
+function uint(value: unknown, maximum: number): value is number {
+  return Number.isSafeInteger(value) && Number(value) >= 0 && Number(value) <= maximum;
+}
+
+/** Refuse oversized, malformed, or covertly padded bitsets at the IPC boundary. */
+export function parseCartographyMapKnowledge(value: unknown): CartographyMapKnowledge {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("cartography map knowledge must be an object");
+  }
+  const source = value as Record<string, unknown>;
+  const { kernelSha256, mapId, continent, width, height, revealRadius, words } = source;
+  if (!isDigest(kernelSha256)) {
+    throw new Error("cartography map knowledge has an invalid kernel identity");
+  }
+  if (!uint(mapId, 2_000) || mapId === 0) {
+    throw new Error("cartography map knowledge has an invalid map id");
+  }
+  if (!uint(continent, 5)) {
+    throw new Error("cartography map knowledge has an invalid continent");
+  }
+  if (!uint(width, 8_192) || width === 0 || !uint(height, 8_192) || height === 0) {
+    throw new Error("cartography map knowledge has invalid dimensions");
+  }
+  const cells = width * height;
+  if (!Number.isSafeInteger(cells) || cells > CARTOGRAPHY_REACHABILITY_MAX_CELLS) {
+    throw new Error("cartography map knowledge is too large");
+  }
+  if (revealRadius !== 1 && revealRadius !== 3) {
+    throw new Error("cartography map knowledge has an invalid reveal radius");
+  }
+  const wordCount = Math.ceil(cells / 32);
+  if (!Array.isArray(words) || words.length !== wordCount || words.some(
+    (word) => !uint(word, 0xffff_ffff),
+  )) {
+    throw new Error("cartography map knowledge has invalid words");
+  }
+  const usedBits = cells % 32;
+  if (usedBits !== 0 && ((words.at(-1)! >>> usedBits) !== 0)) {
+    throw new Error("cartography map knowledge has nonzero padding");
+  }
+  const unknown = Object.keys(source).filter((key) => ![
+    "kernelSha256", "mapId", "continent", "width", "height", "revealRadius", "words",
+  ].includes(key));
+  if (unknown.length > 0) {
+    throw new Error(`cartography map knowledge has unknown fields: ${unknown.join(", ")}`);
+  }
+  return Object.freeze({
+    kernelSha256,
+    mapId,
+    continent,
+    width,
+    height,
+    revealRadius,
+    words: Object.freeze([...words] as number[]),
+  });
+}

--- a/src/shared/cartography-spike.ts
+++ b/src/shared/cartography-spike.ts
@@ -148,6 +148,7 @@ export const WORLD_MAP_FRAME_SPIKE_GLOBALS = Object.freeze({
   topLeftY: "gwonmac_world_map_frame_spike_top_left_y",
   bottomRightX: "gwonmac_world_map_frame_spike_bottom_right_x",
   bottomRightY: "gwonmac_world_map_frame_spike_bottom_right_y",
+  observe: "gwonmac_world_map_frame_spike_observe",
 });
 
 export const COMPASS_FRAME_SPIKE_GLOBALS = Object.freeze({

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -69,6 +69,7 @@ import type {
   CartographyEvidenceCapture,
   CartographyEvidenceExportResult,
 } from "./cartography-evidence.js";
+import type { CartographyMapKnowledge } from "./cartography-map-knowledge.js";
 import type { EnhancementSelection } from "./enhancement-contracts.js";
 import { RELEASE_REPO } from "./project-identity.js";
 import {
@@ -1019,6 +1020,8 @@ export const CORE_IPC = {
   diagnosticsProfileSet: "gw:diagnostics:profileSet",
   diagnosticsCurrent: "gw:diagnostics:current",
   cartographyEvidenceExport: "gw:cartography:evidenceExport",
+  cartographyMapKnowledgeGet: "gw:cartography:mapKnowledgeGet",
+  cartographyMapKnowledgeRecord: "gw:cartography:mapKnowledgeRecord",
   appOpenExternal: "gw:app:openExternal",
   appRevealPath: "gw:app:revealPath",
   appRequestQuit: "gw:app:requestQuit",
@@ -1214,6 +1217,10 @@ export interface CoreGwNativeApiBase {
     setProfile(value: DiagnosticProfile): Promise<DiagnosticProfile>;
   };
   cartography: {
+    getMapKnowledge(kernelSha256: string): Promise<readonly CartographyMapKnowledge[]>;
+    recordMapKnowledge(
+      value: CartographyMapKnowledge,
+    ): Promise<readonly CartographyMapKnowledge[]>;
     exportEvidence(
       value: CartographyEvidenceCapture,
     ): Promise<CartographyEvidenceExportResult>;

--- a/tests/release/preload-behaviour.test.ts
+++ b/tests/release/preload-behaviour.test.ts
@@ -347,6 +347,24 @@ const INVOCATIONS: Invocation[] = [
     channel: IPC.diagnosticsProfileSet,
   },
   {
+    path: "cartography.getMapKnowledge",
+    args: ["a".repeat(64)],
+    channel: IPC.cartographyMapKnowledgeGet,
+  },
+  {
+    path: "cartography.recordMapKnowledge",
+    args: [{
+      kernelSha256: "a".repeat(64),
+      mapId: 55,
+      continent: 0,
+      width: 4,
+      height: 4,
+      revealRadius: 1,
+      words: [3],
+    }],
+    channel: IPC.cartographyMapKnowledgeRecord,
+  },
+  {
     path: "cartography.exportEvidence",
     args: [CARTOGRAPHY_EVIDENCE_CAPTURE],
     channel: IPC.cartographyEvidenceExport,

--- a/tests/unit/active-client.test.ts
+++ b/tests/unit/active-client.test.ts
@@ -9,6 +9,7 @@ function generation(wasmPath: string, size: number): ClientGeneration {
   const supported = size === 10;
   return {
     artifactsDir: `/client/${size}`,
+    clientFingerprint: String(size).padStart(64, "f"),
     store: { size } as ClientGeneration["store"],
     wasmPath,
     jsPath: wasmPath.replace(/\.wasm$/, ".js"),

--- a/tests/unit/cartography-grid.test.ts
+++ b/tests/unit/cartography-grid.test.ts
@@ -15,9 +15,48 @@ import {
   projectCartographyGridToWorldMap,
 } from "../../src/renderer/cartography-spike/cartography-grid-projection.js";
 import {
+  cartographyClusterPresentation,
   cartographyProgressClusterOrigin,
   cartographyProgressClusterSize,
 } from "../../src/renderer/cartography-spike/cartography-grid-layer.js";
+
+test("lets proven map knowledge replace a larger continent estimate", () => {
+  assert.deepEqual(cartographyClusterPresentation({
+    estimatedRemaining: 12,
+    currentKnown: 8,
+    currentRemaining: 2,
+    rememberedKnown: 0,
+    rememberedRemaining: 0,
+  }), { count: 2, actionable: true });
+  assert.equal(cartographyClusterPresentation({
+    estimatedRemaining: 10,
+    currentKnown: 8,
+    currentRemaining: 0,
+    rememberedKnown: 0,
+    rememberedRemaining: 0,
+  }), null);
+  assert.deepEqual(cartographyClusterPresentation({
+    estimatedRemaining: 12,
+    currentKnown: 0,
+    currentRemaining: 0,
+    rememberedKnown: 8,
+    rememberedRemaining: 2,
+  }), { count: 2, actionable: false });
+  assert.equal(cartographyClusterPresentation({
+    estimatedRemaining: 10,
+    currentKnown: 0,
+    currentRemaining: 0,
+    rememberedKnown: 8,
+    rememberedRemaining: 0,
+  }), null);
+  assert.deepEqual(cartographyClusterPresentation({
+    estimatedRemaining: 12,
+    currentKnown: 0,
+    currentRemaining: 0,
+    rememberedKnown: 0,
+    rememberedRemaining: 0,
+  }), { count: 12, actionable: false });
+});
 
 const missionFrame: MissionMapFrameSpikeSnapshot = Object.freeze({
   status: 1,

--- a/tests/unit/cartography-map-knowledge-renderer.test.ts
+++ b/tests/unit/cartography-map-knowledge-renderer.test.ts
@@ -1,0 +1,37 @@
+/** Proves that renderer aggregation keeps persisted map records immutable. */
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  cartographyKnowledgeWordsFingerprint,
+  mergeCartographyMapKnowledge,
+} from "../../src/renderer/cartography-spike/map-knowledge.js";
+
+test("unions only matching continent knowledge for the selected reveal mode", () => {
+  const records = [
+    { kernelSha256: "a".repeat(64), mapId: 55, continent: 0, width: 8, height: 4, revealRadius: 1 as const, words: [3] },
+    { kernelSha256: "a".repeat(64), mapId: 81, continent: 0, width: 8, height: 4, revealRadius: 1 as const, words: [12] },
+    { kernelSha256: "a".repeat(64), mapId: 82, continent: 0, width: 8, height: 4, revealRadius: 3 as const, words: [16] },
+    { kernelSha256: "a".repeat(64), mapId: 449, continent: 1, width: 8, height: 4, revealRadius: 1 as const, words: [32] },
+  ];
+  const merged = mergeCartographyMapKnowledge(records, {
+    kernelSha256: "a".repeat(64),
+    continent: 0,
+    width: 8,
+    height: 4,
+    revealRadius: 1,
+  });
+  assert.deepEqual(merged, new Uint32Array([15]));
+  assert.deepEqual(records[0]!.words, [3]);
+});
+
+test("fingerprints identical masks consistently", () => {
+  const first = new Uint32Array([1, 2, 3]);
+  assert.equal(
+    cartographyKnowledgeWordsFingerprint(first),
+    cartographyKnowledgeWordsFingerprint(first.slice()),
+  );
+  assert.notEqual(
+    cartographyKnowledgeWordsFingerprint(first),
+    cartographyKnowledgeWordsFingerprint(new Uint32Array([1, 2, 4])),
+  );
+});

--- a/tests/unit/cartography-map-knowledge.test.ts
+++ b/tests/unit/cartography-map-knowledge.test.ts
@@ -1,0 +1,102 @@
+/** Proves that remembered map coverage is bounded, merged, and disposable. */
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { CartographyMapKnowledgeStore } from
+  "../../src/main/core/cartography-map-knowledge.js";
+import { parseCartographyMapKnowledge } from
+  "../../src/shared/cartography-map-knowledge.js";
+
+const FIRST_CLIENT = "a".repeat(64);
+const NEXT_CLIENT = "b".repeat(64);
+const FIRST_KERNEL = "c".repeat(64);
+const NEXT_KERNEL = "d".repeat(64);
+
+const knowledge = (words: readonly number[], revealRadius: 1 | 3 = 1) => ({
+  kernelSha256: FIRST_KERNEL,
+  mapId: 55,
+  continent: 0,
+  width: 8,
+  height: 4,
+  revealRadius,
+  words,
+});
+
+describe("Cartography map knowledge", () => {
+  it("unions repeated visits and keeps reveal modes independent", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "gw-cartography-knowledge-"));
+    const path = join(dir, "cartography-map-knowledge.json");
+    const store = new CartographyMapKnowledgeStore(path);
+
+    await store.record(FIRST_CLIENT, parseCartographyMapKnowledge(knowledge([0b0011])));
+    await store.record(FIRST_CLIENT, parseCartographyMapKnowledge(knowledge([0b1100])));
+    await store.record(FIRST_CLIENT, parseCartographyMapKnowledge(knowledge([0b10000], 3)));
+
+    assert.deepEqual(await new CartographyMapKnowledgeStore(path).get(
+      FIRST_CLIENT,
+      FIRST_KERNEL,
+    ), [
+      knowledge([0b1111]),
+      knowledge([0b10000], 3),
+    ]);
+    const persisted = JSON.parse(await readFile(path, "utf8")) as Record<string, unknown>;
+    assert.equal(persisted.clientFingerprint, FIRST_CLIENT);
+    assert.equal(persisted.kernelSha256, FIRST_KERNEL);
+    assert.equal(JSON.stringify(persisted).includes("wordsBase64"), true);
+    assert.equal(JSON.stringify(persisted).includes('"words"'), false);
+  });
+
+  it("starts empty after the installed Guild Wars content changes", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "gw-cartography-knowledge-"));
+    const path = join(dir, "cartography-map-knowledge.json");
+    const store = new CartographyMapKnowledgeStore(path);
+    await store.record(FIRST_CLIENT, parseCartographyMapKnowledge(knowledge([3])));
+
+    assert.deepEqual(await store.get(NEXT_CLIENT, FIRST_KERNEL), []);
+    assert.deepEqual(
+      await store.record(NEXT_CLIENT, parseCartographyMapKnowledge(knowledge([4]))),
+      [knowledge([4])],
+    );
+  });
+
+  it("starts empty after the reachability kernel changes", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "gw-cartography-knowledge-"));
+    const path = join(dir, "cartography-map-knowledge.json");
+    const store = new CartographyMapKnowledgeStore(path);
+    await store.record(FIRST_CLIENT, parseCartographyMapKnowledge(knowledge([3])));
+
+    assert.deepEqual(await store.get(FIRST_CLIENT, NEXT_KERNEL), []);
+    const next = parseCartographyMapKnowledge({
+      ...knowledge([4]),
+      kernelSha256: NEXT_KERNEL,
+    });
+    assert.deepEqual(await store.record(FIRST_CLIENT, next), [next]);
+  });
+
+  it("quarantines corrupt convenience data", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "gw-cartography-knowledge-"));
+    const path = join(dir, "cartography-map-knowledge.json");
+    await writeFile(path, "not json");
+
+    assert.deepEqual(
+      await new CartographyMapKnowledgeStore(path).get(FIRST_CLIENT, FIRST_KERNEL),
+      [],
+    );
+    await assert.rejects(readFile(path, "utf8"), /ENOENT/u);
+  });
+
+  it("refuses nonzero padding and oversized records", () => {
+    assert.throws(() => parseCartographyMapKnowledge({
+      ...knowledge([0xffff_ffff]),
+      width: 3,
+      height: 3,
+    }), /padding/u);
+    assert.throws(() => parseCartographyMapKnowledge({
+      ...knowledge([]),
+      width: 8_192,
+      height: 8_192,
+    }), /too large/u);
+  });
+});

--- a/tests/unit/compass-frame-spike-observer.test.ts
+++ b/tests/unit/compass-frame-spike-observer.test.ts
@@ -221,10 +221,13 @@ test("refuses incomplete, stale, and invalid Mission Map projection state", () =
 
 function worldMapExports(): WebAssembly.Exports {
   const values = [1, 12, 5, 200, 1, 1_920, 1_080, 0, 0, 1_920, 1_080, 0, 0, 0, 0, 8_192, 16_384];
-  return Object.fromEntries(WORLD_MAP_FRAME_SPIKE_SCALARS.map((name, index) => [
-    name,
-    scalar(values[index]!, index < 5 || index === 11 ? "i32" : "f32"),
-  ]));
+  return {
+    ...Object.fromEntries(WORLD_MAP_FRAME_SPIKE_SCALARS.map((name, index) => [
+      name,
+      scalar(values[index]!, index < 5 || index === 11 ? "i32" : "f32"),
+    ])),
+    [WORLD_MAP_FRAME_SPIKE_GLOBALS.observe]: () => undefined,
+  };
 }
 
 test("reads the dedicated World Map context atomically", () => {
@@ -250,4 +253,12 @@ test("reads the dedicated World Map context atomically", () => {
   const invalid = worldMapExports();
   invalid[WORLD_MAP_FRAME_SPIKE_GLOBALS.bottomRightX] = scalar(0, "f32");
   assert.equal(createWorldMapFrameSpikeReader(invalid)?.snapshot(), null);
+});
+
+test("refreshes World Map visibility before every snapshot", () => {
+  const exports = worldMapExports();
+  exports[WORLD_MAP_FRAME_SPIKE_GLOBALS.observe] = () => {
+    (exports[WORLD_MAP_FRAME_SPIKE_GLOBALS.visible] as WebAssembly.Global).value = 0;
+  };
+  assert.equal(createWorldMapFrameSpikeReader(exports)?.snapshot(), null);
 });

--- a/tests/unit/paths.test.ts
+++ b/tests/unit/paths.test.ts
@@ -28,6 +28,7 @@ describe("resolved profile paths", () => {
       travelPreferences: `${root}/travel-preferences.json`,
       travelHistory: `${root}/travel-history.json`,
       characterSwitchUsage: `${root}/character-switch-usage.json`,
+      cartographyMapKnowledge: `${root}/cartography-map-knowledge.json`,
       tradeSaved: `${root}/trade-saved.json`,
       buildLibrary: `${root}/build-library.json`,
       windowState: `${root}/window-state.json`,


### PR DESCRIPTION
The World Map grid could remain visible after a fast close because its last retained frame still said the map was open. Cartography estimates could also replace a precise local number with a larger continent-wide estimate after the current map stopped being observable.

This change makes the native frame observer refresh World Map visibility before every render, so a closed map fails closed. It also adds one global, bounded cartography knowledge ledger: the current map is authoritative, previously visited maps are remembered, and the broad estimate is used only when no exact map evidence exists. A proven zero remains zero and hides the number instead of falling back to a larger estimate.

## Player-visible behavior

- Closing the World Map reliably removes its grid, including rapid close and reopen sequences.
- A current-map number such as `2` overrides a broad estimate such as `12`.
- A known `0` hides the number instead of restoring the estimate.
- Visited-map evidence persists across restarts and is shared across account profiles.
- Current evidence stays visually strong; remembered or estimated evidence stays visually lighter.

## Safety and storage

- Stores reachability masks rather than derived counts, so counts are recalculated from current exploration state.
- Separates normal and bird's-eye map modes.
- Invalidates stored evidence when the Guild Wars client content or reachability kernel changes.
- Bounds and strictly validates records, quarantines corrupt files, and writes atomically with owner-only permissions.

## Verification

- `pnpm run check`
- `pnpm build`
- Focused cartography, preload, path, and active-client tests
- Branch rebased on `origin/main` at `271828b8611a0dd9435ff346dee44a6d6ae7c47c`

Live gameplay QA was not performed. Because this touches native observation, rendering, and persistence, it should be exercised in a Developer Build and shipped through Beta before Stable.

## Model attribution

Implemented with Codex (GPT-5.6).
