### PR TITLE
fix(travel): remove first-open focus flash

### DIFF
--- a/apps/tools/src/styles/base-shell.css
+++ b/apps/tools/src/styles/base-shell.css
@@ -142,7 +142,7 @@ body[data-tools-standalone="true"] {
 
 .window-close { font-size: var(--ui-font-size-lg); }
 
-.ui-modal {
+.ui-dialog {
   position: fixed;
   z-index: var(--ui-z-toast);
   inset: 50% auto auto 50%;
@@ -159,7 +159,7 @@ body[data-tools-standalone="true"] {
   transform: translate(-50%, -50%);
 }
 
-.ui-modal-overlay {
+.ui-dialog-overlay {
   position: fixed;
   z-index: calc(var(--ui-z-toast) - 1);
   inset: 0;

--- a/apps/tools/src/ui/UiDialog.vue
+++ b/apps/tools/src/ui/UiDialog.vue
@@ -30,10 +30,10 @@ const focusInitial = (event: Event) => {
 <template>
   <DialogRoot :open="open" @update:open="!$event && emit('close')">
     <DialogPortal disabled>
-      <DialogOverlay class="ui-modal-overlay" />
+      <DialogOverlay class="ui-dialog-overlay" />
       <DialogContent
         v-bind="$attrs"
-        class="ui-modal"
+        class="ui-dialog"
         :aria-labelledby="labelledby"
         :aria-describedby="describedby"
         @open-auto-focus="focusInitial"

--- a/src/shared/ui/components.css
+++ b/src/shared/ui/components.css
@@ -85,6 +85,10 @@
   color: var(--ui-text);
 }
 
+/* This viewport-sized element is a backdrop hit area, not the visible dialog.
+ * Chromium can focus it briefly before lazy dialog content mounts. */
+.ui-modal-layer:focus { outline: none; }
+
 .ui-frame::before,
 .ui-frame::after {
   content: "";

--- a/tests/electron/input-travel.spec.ts
+++ b/tests/electron/input-travel.spec.ts
@@ -114,6 +114,20 @@ test.describe("renderer Travel input", () => {
       });
       await expect(palette).toBeVisible();
       await expect.poll(() => isDomActiveElement(search)).toBe(true);
+      const viewport = await page.evaluate(() => ({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      }));
+      const modalLayer = page.locator("#travel-palette-root");
+      const modalLayerBox = await modalLayer.boundingBox();
+      expect(modalLayerBox).toEqual({
+        x: 0,
+        y: 0,
+        width: viewport.width,
+        height: viewport.height,
+      });
+      await modalLayer.focus();
+      await expect(modalLayer).toHaveCSS("outline-style", "none");
       await expect(page.locator("body")).toHaveAttribute(
         "data-travel-canvas-blurs",
         "0",


### PR DESCRIPTION
The first time a player opened Quick Travel, Chromium briefly drew a tall blue focus rectangle before the Travel interface appeared. The lazy Tools stylesheet reused `.ui-modal` for a different dialog implementation, so it partially overrode the native full-window modal layer while that empty layer held focus.

This change gives Vue dialogs their own `.ui-dialog` class and keeps `.ui-modal` owned by native renderer dialogs. It also prevents the viewport-sized backdrop hit layer from painting a focus outline while lazy Travel content mounts.

## Player-visible behavior

- Quick Travel opens without the blue portrait-shaped focus flash.
- The Travel search field still receives focus automatically.
- Native modal dismissal continues to use the complete viewport.

## Verification

- `pnpm run check`
- `pnpm build`
- `pnpm --filter @gwonmac/tools-ui exec vitest run src/ui/UiDialog.test.ts`
- `pnpm exec playwright test --config=tests/electron/playwright.config.ts tests/electron/input-travel.spec.ts` (2 passed)

Live gameplay QA was not performed. The focused Electron test verifies the modal geometry and focus styling used by the packaged renderer boundary.

## Model attribution

Implemented with Codex (GPT-5.6).
