### PR TITLE
fix(cartography): restore World Map guidance

### DIFF
--- a/docs/cartography.md
+++ b/docs/cartography.md
@@ -63,9 +63,9 @@ the continent-scale World Map. GWonMac certifies each context independently.
 Both surfaces consume the same continent state and global grid phase. A failure
 on either map hides only that surface.
 
-The World Map projection comes from its native event context. Each presentation
-read also refreshes the retained frame visibility. This hides the overlay when
-the native close fade finishes without another World Map event.
+The World Map projection and visibility come from one complete native event
+context. Unrelated or incomplete events leave the last complete reading intact,
+while a validated close event hides the overlay.
 
 At 18 pixels or more per cell, the map draws individual amber diamonds and
 orange actionable markers. At 8–18 pixels it groups the global grid into 4×4

--- a/src/main/certification/cartography-spike-client.ts
+++ b/src/main/certification/cartography-spike-client.ts
@@ -28,56 +28,28 @@ const CERTIFIED_CARTOGRAPHY_BUILDS: ReadonlyMap<string, CertifiedCartographyBuil
     "62267d95b30752823aa364c289bdc84f2c025dac4caeda86a76a432001667acb",
     {
       memoryLayout: "relocated",
-      outputSha256: "181f06d7f9974b30978b5f211a3c449eccf85392e13822f87264b875faeb2eeb",
+      outputSha256: "946a12cac572ba93149cc5d1e12c7e9976aad93b29fe771f9d82c001ddab38ef",
     },
   ],
   [
     "e22c2c0876f1381a133fbb0c739f73f9fc6a7d8988da5ce0d9789481ab7f0c9e",
     {
       memoryLayout: "relocated",
-      outputSha256: "28d0d1d5805288c4085d309f54c0a87c3c80b0067efeb15195f1e9291f9237e9",
+      outputSha256: "250007f511c495047661736b50cc12cee1f86a317d9698de09fa8beb6ced16c0",
     },
   ],
   [
     "e00e8368a1d0e1003bf1882dce2d4b3cd8e2e8b6c4acc72474c8b56e2e35c6bb",
     {
       memoryLayout: "official",
-      outputSha256: "579b1b3a60821f32fb43899d606b994b6aca531b913a36cd1a91379107dd3de9",
+      outputSha256: "6f546f13bdb2ef6ec4118a5b1550b2523f178fc0a61061896037a44f3ac89659",
     },
   ],
   [
     "7db72c8d5b4864fb4526e1455edfee3755887a242f68ec1c2f8447cfb38ad281",
     {
       memoryLayout: "relocated",
-      outputSha256: "d8f98b51482f722a8154600e2e61ff72c468c11e043dbf44c0b75d8f3a5d4232",
-    },
-  ],
-  [
-    "9d3383ad41e767570a0b2b8d8e2fec2e52cdcbd25d9c1680b8eb979f4eef6991",
-    {
-      memoryLayout: "relocated",
-      outputSha256: "379139b3490aac7007c65a984d5717ae626e15593394b2f3d692a482e873244b",
-    },
-  ],
-  [
-    "1f4a199ea902f839abb3b71861759f956db2aa4e7f31fcabd1970d12d24ca3a0",
-    {
-      memoryLayout: "relocated",
-      outputSha256: "53a4bdff835b46ac8741301e2f37fcf23ccd73716381d0851f0947bd328335e5",
-    },
-  ],
-  [
-    "87469f9cd8b93bd36e5b401bf0450d47b7856322de6e001c9c9d7dd996cd98d4",
-    {
-      memoryLayout: "official",
-      outputSha256: "393b23f080f10491d209031570fdfe7e80063dbb48f8fcb8c33fc662a2067a6b",
-    },
-  ],
-  [
-    "81a2ceb81db4e8ae35f561a20b3c76dbb0b692a1e5ab4de7ff2879e0e8720d53",
-    {
-      memoryLayout: "official",
-      outputSha256: "5ca898031b871a71f8ada41c81cfeb1150261998b866cbfb315fb4607c0fd594",
+      outputSha256: "1892f597d53988b5b541a7ca7997da8fc6758f0793e464293ba5f619152e6583",
     },
   ],
 ]);

--- a/src/main/certification/cartography-transform-internals.ts
+++ b/src/main/certification/cartography-transform-internals.ts
@@ -472,58 +472,6 @@ export function nativeFrameObserver(
   );
 }
 
-/** Refresh the exact World Map frame retained by its certified event context. */
-export function worldMapFrameObserver(
-  certificate: typeof WORLD_MAP_CERTIFICATE & Pick<CartographyMemoryLayout, "frameArray" | "frameCount">,
-  globals: WorldMapGlobals,
-  areaEpoch: number,
-): Uint8Array {
-  const refuse = (status: number) => concat(
-    i32(0), globalSet(globals.visible),
-    i32(status), globalSet(globals.status), Uint8Array.of(0x0f),
-  );
-  const outsideMemory = (pointerLocal: number, bytes: Uint8Array) => concat(
-    local(4), Uint8Array.of(0x45, 0x45),
-    local(pointerLocal), local(4), bytes, Uint8Array.of(0x6b, 0x4b, 0x71),
-  );
-  return concat(
-    // count, array, frame id, frame, memory bytes.
-    Uint8Array.of(0x01, 0x05, 0x7f),
-    globalGet(globals.status), i32(1), Uint8Array.of(0x47, 0x04, 0x40),
-      i32(0), globalSet(globals.visible), Uint8Array.of(0x0f, 0x0b),
-    globalGet(globals.generation), globalGet(areaEpoch), Uint8Array.of(0x47, 0x04, 0x40),
-      refuse(11), Uint8Array.of(0x0b),
-    Uint8Array.of(0x3f, 0x00), i32(65_536), Uint8Array.of(0x6c, 0x21), uleb(4),
-    i32(certificate.frameCount), i32Load(), Uint8Array.of(0x22), uleb(0),
-    Uint8Array.of(0x45, 0x04, 0x40), refuse(2), Uint8Array.of(0x0b),
-    local(0), i32(16_384), Uint8Array.of(0x4b, 0x04, 0x40), refuse(3), Uint8Array.of(0x0b),
-    i32(certificate.frameArray), i32Load(), Uint8Array.of(0x22), uleb(1),
-    Uint8Array.of(0x45, 0x04, 0x40), refuse(4), Uint8Array.of(0x0b),
-    outsideMemory(1, concat(local(0), i32(4), Uint8Array.of(0x6c))),
-    Uint8Array.of(0x04, 0x40), refuse(5), Uint8Array.of(0x0b),
-    globalGet(globals.frameId), Uint8Array.of(0x22), uleb(2),
-    local(0), Uint8Array.of(0x4f, 0x04, 0x40), refuse(5), Uint8Array.of(0x0b),
-    local(1), local(2), i32(4), Uint8Array.of(0x6c, 0x6a), i32Load(),
-    Uint8Array.of(0x22), uleb(3),
-    Uint8Array.of(0x45, 0x04, 0x40), refuse(6), Uint8Array.of(0x0b),
-    outsideMemory(3, i32(certificate.frameBytes)),
-    Uint8Array.of(0x04, 0x40), refuse(6), Uint8Array.of(0x0b),
-    local(3), i32Load(certificate.frameId), local(2), Uint8Array.of(0x47, 0x04, 0x40),
-      refuse(6), Uint8Array.of(0x0b),
-    local(3), i32Load(certificate.frameState), Uint8Array.of(0x22), uleb(0),
-    i32(4), Uint8Array.of(0x71, 0x45, 0x45),
-    local(0), i32(0x200), Uint8Array.of(0x71, 0x45, 0x71), globalSet(globals.visible),
-    local(3), f32Load(certificate.frameViewportWidth), globalSet(globals.viewportWidth),
-    local(3), f32Load(certificate.frameViewportHeight), globalSet(globals.viewportHeight),
-    local(3), f32Load(certificate.frameScreenLeft), globalSet(globals.left),
-    local(3), f32Load(certificate.frameScreenBottom), globalSet(globals.bottom),
-    local(3), f32Load(certificate.frameScreenRight), globalSet(globals.right),
-    local(3), f32Load(certificate.frameScreenTop), globalSet(globals.top),
-    i32(1), globalSet(globals.status),
-    Uint8Array.of(0x0b),
-  );
-}
-
 /** Retain the exact direction argument consumed by the native CompassMap. */
 export function compassMapRenderWrapper(render: number, globals: CompassGlobals): Uint8Array {
   return concat(
@@ -606,19 +554,19 @@ export function worldMapEventWrapper(
   areaEpoch: number,
   certificate: typeof WORLD_MAP_CERTIFICATE & Pick<CartographyMemoryLayout, "frameArray" | "frameCount">,
 ): Uint8Array {
-  const refuse = (status: number) => concat(
-    i32(0), globalSet(globals.visible),
-    i32(status), globalSet(globals.status), Uint8Array.of(0x0f),
-  );
-  const requirePointer = (pointerLocal: number, bytes: Uint8Array, status: number) => concat(
+  // The dispatcher carries events that do not all contain a usable World Map
+  // context. Publish only a complete reading; a rejected event must not replace
+  // the last certified frame with a partial or unrelated event.
+  const refuse = () => Uint8Array.of(0x0f);
+  const requirePointer = (pointerLocal: number, bytes: Uint8Array) => concat(
     local(pointerLocal), Uint8Array.of(0x45, 0x04, 0x40),
-    refuse(status), Uint8Array.of(0x0b),
+    refuse(), Uint8Array.of(0x0b),
     local(pointerLocal), local(7), bytes, Uint8Array.of(0x6b, 0x4b, 0x04, 0x40),
-    refuse(status), Uint8Array.of(0x0b),
+    refuse(), Uint8Array.of(0x0b),
   );
-  const finite = (valueLocal: number, status: number) => concat(
+  const finite = (valueLocal: number) => concat(
     local(valueLocal), Uint8Array.of(0x8b), f32(1_000_000),
-    Uint8Array.of(0x5f, 0x45, 0x04, 0x40), refuse(status), Uint8Array.of(0x0b),
+    Uint8Array.of(0x5f, 0x45, 0x04, 0x40), refuse(), Uint8Array.of(0x0b),
   );
   return concat(
     // locals 3..7: owner window, context, frame id/index, frame, memory bytes.
@@ -626,41 +574,41 @@ export function worldMapEventWrapper(
     Uint8Array.of(0x02, 0x05, 0x7f, 0x05, 0x7d),
     local(0), local(1), local(2), call(dispatcher),
     Uint8Array.of(0x3f, 0x00), i32(65_536), Uint8Array.of(0x6c, 0x21), uleb(7),
-    requirePointer(0, i32(certificate.ownerWindow + 4), 2),
+    requirePointer(0, i32(certificate.ownerWindow + 4)),
     local(0), i32Load(certificate.ownerWindow), Uint8Array.of(0x21), uleb(3),
-    requirePointer(3, i32(certificate.ownerMap + 4), 3),
+    requirePointer(3, i32(certificate.ownerMap + 4)),
     local(3), i32Load(certificate.ownerMap), Uint8Array.of(0x21), uleb(4),
-    requirePointer(4, i32(certificate.contextBytes), 4),
-    local(4), i32Load(certificate.frameId), Uint8Array.of(0x22), uleb(5),
-    globalSet(globals.frameId), local(5),
+    requirePointer(4, i32(certificate.contextBytes)),
+    local(4), i32Load(certificate.frameId), Uint8Array.of(0x21), uleb(5),
+    local(5),
     i32(certificate.frameCount), i32Load(), Uint8Array.of(0x4f, 0x04, 0x40),
-    refuse(5), Uint8Array.of(0x0b),
+    refuse(), Uint8Array.of(0x0b),
     i32(certificate.frameArray), i32Load(), Uint8Array.of(0x21), uleb(6),
-    requirePointer(6, concat(local(5), i32(4), Uint8Array.of(0x6c)), 5),
+    requirePointer(6, concat(local(5), i32(4), Uint8Array.of(0x6c))),
     local(6), local(5), i32(4), Uint8Array.of(0x6c, 0x6a), i32Load(),
     Uint8Array.of(0x21), uleb(6),
-    requirePointer(6, i32(certificate.frameBytes), 10),
+    requirePointer(6, i32(certificate.frameBytes)),
     local(4), i32Load(certificate.continent), Uint8Array.of(0x22), uleb(3),
-    i32(5), Uint8Array.of(0x4b, 0x04, 0x40), refuse(7), Uint8Array.of(0x0b),
+    i32(5), Uint8Array.of(0x4b, 0x04, 0x40), refuse(), Uint8Array.of(0x0b),
     local(4), f32Load(certificate.zoom), Uint8Array.of(0x21), uleb(8),
     local(4), f32Load(certificate.topLeftX), Uint8Array.of(0x21), uleb(9),
     local(4), f32Load(certificate.topLeftY), Uint8Array.of(0x21), uleb(10),
     local(4), f32Load(certificate.bottomRightX), Uint8Array.of(0x21), uleb(11),
     local(4), f32Load(certificate.bottomRightY), Uint8Array.of(0x21), uleb(12),
-    finite(8, 8), finite(9, 8), finite(10, 8), finite(11, 8), finite(12, 8),
+    finite(8), finite(9), finite(10), finite(11), finite(12),
     local(11), local(9), Uint8Array.of(0x5e, 0x45, 0x04, 0x40),
-    refuse(9), Uint8Array.of(0x0b),
+    refuse(), Uint8Array.of(0x0b),
     local(12), local(10), Uint8Array.of(0x5e, 0x45, 0x04, 0x40),
-    refuse(9), Uint8Array.of(0x0b),
-    local(6), i32Load(certificate.frameState), Uint8Array.of(0x22), uleb(4),
-    i32(4), Uint8Array.of(0x71, 0x45, 0x45),
-    local(4), i32(0x200), Uint8Array.of(0x71, 0x45, 0x71), globalSet(globals.visible),
+    refuse(), Uint8Array.of(0x0b),
+    local(6), i32Load(certificate.frameState), i32(0x08),
+    Uint8Array.of(0x71, 0x45), globalSet(globals.visible),
     local(6), f32Load(certificate.frameViewportWidth), globalSet(globals.viewportWidth),
     local(6), f32Load(certificate.frameViewportHeight), globalSet(globals.viewportHeight),
     local(6), f32Load(certificate.frameScreenLeft), globalSet(globals.left),
     local(6), f32Load(certificate.frameScreenBottom), globalSet(globals.bottom),
     local(6), f32Load(certificate.frameScreenRight), globalSet(globals.right),
     local(6), f32Load(certificate.frameScreenTop), globalSet(globals.top),
+    local(5), globalSet(globals.frameId),
     local(3), globalSet(globals.continent),
     local(8), globalSet(globals.zoom),
     local(9), globalSet(globals.topLeftX),

--- a/src/main/certification/pathing-spike-transform.ts
+++ b/src/main/certification/pathing-spike-transform.ts
@@ -16,7 +16,6 @@ import {
   MISSION_MAP_FRAME_SPIKE_GLOBALS,
   MISSION_MAP_FRAME_SPIKE_SCALARS,
   MISSION_MAP_PROJECTION_SPIKE_SCALARS,
-  WORLD_MAP_FRAME_SPIKE_GLOBALS,
   WORLD_MAP_FRAME_SPIKE_SCALARS,
   WORLD_MAP_ANCHOR_SPIKE_GLOBALS,
   WORLD_MAP_ANCHOR_SPIKE_SCALARS,
@@ -58,7 +57,6 @@ import {
   rewriteExactTableSlot,
   worldMapAnchorObserver,
   worldMapEventWrapper,
-  worldMapFrameObserver,
   type CartographyContextGlobals,
   type CartographyMemoryLayout,
   type CompassGlobals,
@@ -74,7 +72,7 @@ declare const WebAssembly: {
   Module: new (bytes: Uint8Array) => object;
 };
 
-export const CARTOGRAPHY_SPIKE_TRANSFORM_ABI = 28;
+export const CARTOGRAPHY_SPIKE_TRANSFORM_ABI = 30;
 export type CartographyMemoryLayoutId = keyof typeof CARTOGRAPHY_MEMORY_LAYOUTS;
 
 const mutableI32 = () => Uint8Array.of(0x7f, 0x01, 0x41, 0x00, 0x0b);
@@ -284,7 +282,6 @@ export function transformCartographySpikeWasm(
     EXPLORATION_SPIKE_GLOBALS.observe,
     EXPLORATION_SPIKE_GLOBALS.readWord,
     WORLD_MAP_ANCHOR_SPIKE_GLOBALS.observe,
-    WORLD_MAP_FRAME_SPIKE_GLOBALS.observe,
   ];
   const existingExports = new Set(
     parseExports(sectionById(sections, 7)).map((entry) => entry.name),
@@ -324,7 +321,6 @@ export function transformCartographySpikeWasm(
   const explorationReadWordFunction = firstFunction + 6;
   const anchorObserverFunction = firstFunction + 7;
   const worldEventWrapperFunction = firstFunction + 8;
-  const worldObserverFunction = firstFunction + 9;
 
   const compassRender = bodies[compassRenderLocal]?.slice()
     ?? fail("Compass render body is missing");
@@ -381,11 +377,6 @@ export function transformCartographySpikeWasm(
       allocated.context.areaEpoch,
       worldCertificate,
     ),
-    worldMapFrameObserver(
-      worldCertificate,
-      allocated.world,
-      allocated.context.areaEpoch,
-    ),
   );
   const nextFunctionTypes = [
     ...functionTypes,
@@ -398,7 +389,6 @@ export function transformCartographySpikeWasm(
     readWordType,
     voidType,
     worldDispatcherType,
-    voidType,
   ];
 
   const contextEntries = [
@@ -440,7 +430,6 @@ export function transformCartographySpikeWasm(
     [EXPLORATION_SPIKE_GLOBALS.observe, explorationObserverFunction],
     [EXPLORATION_SPIKE_GLOBALS.readWord, explorationReadWordFunction],
     [WORLD_MAP_ANCHOR_SPIKE_GLOBALS.observe, anchorObserverFunction],
-    [WORLD_MAP_FRAME_SPIKE_GLOBALS.observe, worldObserverFunction],
   ] as const;
   const nextExports = concat(
     uleb(exports.count + scalarNames.length + functionNames.length),

--- a/src/renderer/cartography-spike/frame-observer.ts
+++ b/src/renderer/cartography-spike/frame-observer.ts
@@ -189,22 +189,10 @@ export function createCompassFrameSpikeReader(
 export function createWorldMapFrameSpikeReader(
   exports: WebAssembly.Exports,
 ): WorldMapFrameSpikeController | null {
-  if (typeof exports[WORLD_MAP_FRAME_SPIKE_GLOBALS.observe] !== "function"
-    || !WORLD_MAP_FRAME_SPIKE_SCALARS.every(
+  if (!WORLD_MAP_FRAME_SPIKE_SCALARS.every(
     (name) => exports[name] instanceof WebAssembly.Global,
   )) return null;
-  const refresh = (): boolean => {
-    const observe = exports[WORLD_MAP_FRAME_SPIKE_GLOBALS.observe];
-    if (typeof observe !== "function") return false;
-    try {
-      observe();
-      return true;
-    } catch {
-      return false;
-    }
-  };
   const diagnostics = (): WorldMapFrameSpikeDiagnostic => {
-    refresh();
     return Object.freeze({
     status: numberGlobal(exports, WORLD_MAP_FRAME_SPIKE_GLOBALS.status),
     sequence: numberGlobal(exports, WORLD_MAP_FRAME_SPIKE_GLOBALS.sequence),
@@ -222,7 +210,6 @@ export function createWorldMapFrameSpikeReader(
   return Object.freeze({
     diagnostics,
     snapshot() {
-      if (!refresh()) return null;
       const firstSequence = numberGlobal(exports, WORLD_MAP_FRAME_SPIKE_GLOBALS.sequence);
       const values = Object.fromEntries(WORLD_MAP_FRAME_SPIKE_SCALARS.map(
         (name) => [name, numberGlobal(exports, name)],

--- a/src/shared/cartography-spike.ts
+++ b/src/shared/cartography-spike.ts
@@ -148,7 +148,6 @@ export const WORLD_MAP_FRAME_SPIKE_GLOBALS = Object.freeze({
   topLeftY: "gwonmac_world_map_frame_spike_top_left_y",
   bottomRightX: "gwonmac_world_map_frame_spike_bottom_right_x",
   bottomRightY: "gwonmac_world_map_frame_spike_bottom_right_y",
-  observe: "gwonmac_world_map_frame_spike_observe",
 });
 
 export const COMPASS_FRAME_SPIKE_GLOBALS = Object.freeze({

--- a/tests/unit/compass-frame-spike-observer.test.ts
+++ b/tests/unit/compass-frame-spike-observer.test.ts
@@ -226,7 +226,6 @@ function worldMapExports(): WebAssembly.Exports {
       name,
       scalar(values[index]!, index < 5 || index === 11 ? "i32" : "f32"),
     ])),
-    [WORLD_MAP_FRAME_SPIKE_GLOBALS.observe]: () => undefined,
   };
 }
 
@@ -253,12 +252,4 @@ test("reads the dedicated World Map context atomically", () => {
   const invalid = worldMapExports();
   invalid[WORLD_MAP_FRAME_SPIKE_GLOBALS.bottomRightX] = scalar(0, "f32");
   assert.equal(createWorldMapFrameSpikeReader(invalid)?.snapshot(), null);
-});
-
-test("refreshes World Map visibility before every snapshot", () => {
-  const exports = worldMapExports();
-  exports[WORLD_MAP_FRAME_SPIKE_GLOBALS.observe] = () => {
-    (exports[WORLD_MAP_FRAME_SPIKE_GLOBALS.visible] as WebAssembly.Global).value = 0;
-  };
-  assert.equal(createWorldMapFrameSpikeReader(exports)?.snapshot(), null);
 });


### PR DESCRIPTION
## What changed

World Map guidance is visible again and closes with the native World Map. The observer now publishes only complete World Map events, keeps the last good reading when an unrelated event arrives, and uses the live visibility bit observed in Guild Wars.

## Why

The polling observer introduced in #369 could follow a child frame instead of the World Map frame. That made the grid disappear, while rapid close/open timing could also leave stale guidance behind.

## Invariant

An invalid or unrelated event cannot partially replace the published World Map state. A validated close event publishes `visible = false` and the renderer hides the World Map layer.

## Delivery

Targets `main` as the first PR in stack #374. Recommend a Developer Build until the final rapid open/close in-game check passes; then this recovery is suitable for Beta.

## Verification

- `pnpm verify:runtime` (all sandbox-independent stages passed; localhost integration tests were rerun with local socket access)
- `pnpm test:integration` — 88 passed
- `pnpm test:release` — 30 passed
- `pnpm tools:test:e2e` — 42 passed
- `pnpm test:electron` — 132 passed, 1 expected live-client skip
- Exact installed-client Cartography chain — 4 passed
- Live Guild Wars: World Map grid appeared and hid after one normal open/close cycle
- Pending before merge: repeated rapid open/close in-game check

- [x] I kept this pull request focused.
- [x] I ran the relevant checks.
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [x] I updated documentation when behavior or an invariant changed.
