### PR TITLE
fix(cartography): explain World Map guidance numbers

### DIFF
--- a/src/renderer/cartography-spike/cartography-grid-layer.ts
+++ b/src/renderer/cartography-spike/cartography-grid-layer.ts
@@ -29,7 +29,7 @@ export type CartographyProgressClusterSize = 1 | 4 | 16;
 
 export type CartographyClusterPresentation = Readonly<{
   count: number;
-  actionable: boolean;
+  source: "current" | "remembered" | "estimate";
 }>;
 
 /** Prefer exact live or remembered map knowledge over the continent estimate. */
@@ -43,15 +43,15 @@ export function cartographyClusterPresentation(input: Readonly<{
   if (input.estimatedRemaining === 0) return null;
   if (input.currentKnown > 0) {
     return input.currentRemaining > 0
-      ? Object.freeze({ count: input.currentRemaining, actionable: true })
+      ? Object.freeze({ count: input.currentRemaining, source: "current" as const })
       : null;
   }
   if (input.rememberedKnown > 0) {
     return input.rememberedRemaining > 0
-      ? Object.freeze({ count: input.rememberedRemaining, actionable: false })
+      ? Object.freeze({ count: input.rememberedRemaining, source: "remembered" as const })
       : null;
   }
-  return Object.freeze({ count: input.estimatedRemaining, actionable: false });
+  return Object.freeze({ count: input.estimatedRemaining, source: "estimate" as const });
 }
 
 /** Stable level of detail for one projected cartography cell. */
@@ -131,7 +131,7 @@ function drawClusterMarker(
   firstY: number,
   size: number,
   count: number,
-  actionable: boolean,
+  source: CartographyClusterPresentation["source"],
   actionableColor: string,
   casingColor: string,
   opacity: number,
@@ -156,19 +156,21 @@ function drawClusterMarker(
   context.fill();
   context.beginPath();
   context.arc(centerX, centerY, radius, 0, Math.PI * 2);
-  if (actionable) {
+  if (source === "current") {
     context.fillStyle = actionableColor;
     context.fill();
   } else {
-    context.strokeStyle = ESTIMATED_COLOR;
+    context.strokeStyle = source === "remembered" ? actionableColor : ESTIMATED_COLOR;
     context.lineWidth = 2;
     context.stroke();
   }
-  context.fillStyle = actionable ? casingColor : ESTIMATED_COLOR;
+  context.fillStyle = source === "current"
+    ? casingColor
+    : source === "remembered" ? actionableColor : ESTIMATED_COLOR;
   context.font = "600 11px system-ui, sans-serif";
   context.textAlign = "center";
   context.textBaseline = "middle";
-  context.fillText(String(count), centerX, centerY + 0.5);
+  context.fillText(source === "estimate" ? `≈${count}` : String(count), centerX, centerY + 0.5);
   context.restore();
 }
 
@@ -428,7 +430,7 @@ export function createCartographyGridLayer(parent: HTMLElement, id: string): Car
             groupY,
             groupSize,
             cluster.count,
-            cluster.actionable,
+            cluster.source,
             style.unseen.color,
             style.casingColor,
             Math.min(1, strength * 1.2),

--- a/src/renderer/cartography-spike/overlay-controls.ts
+++ b/src/renderer/cartography-spike/overlay-controls.ts
@@ -127,7 +127,7 @@ export function describeCartographyQaStatus(status: CartographyQaStatus): QaPres
     rows.push(
       ["Map", String(current.mapId)],
       ["Epoch", `${current.areaEpoch} · resource ${current.resourceGeneration}`],
-      ["Cells", `${current.actionableCells} actionable · ${current.reachableCells} reachable`],
+      ["Guidance", `${current.actionableCells} targets here · ${current.reachableCells} reachable cells`],
       ["Terrain", `${current.terrain.width}×${current.terrain.height} @ ${current.terrain.mapUnitsPerPixel}`],
     );
   } else rows.push(["Current guidance", `Unavailable · ${status.currentInstance.reason}`]);
@@ -139,7 +139,7 @@ export function describeCartographyQaStatus(status: CartographyQaStatus): QaPres
   return Object.freeze({
     tone: "ready",
     summary: status.currentInstance.status === "ready"
-      ? `Ready · ${status.currentInstance.actionableCells} actionable`
+      ? `Ready · ${status.currentInstance.actionableCells} targets here`
       : `Continent ready · ${status.remainingCells} remaining`,
     rows: Object.freeze(rows),
   });
@@ -239,6 +239,7 @@ export function createCartographyOverlayControls(options: Readonly<{
   hint.className = "cartography-overlay-hint";
   hint.innerHTML = [
     "Hold <kbd>Shift</kbd> to inspect 3×3. Add <kbd>Option</kbd> for 7×7.",
+    "Numbers: solid is reachable now, outline is remembered, and ≈ is estimated.",
     "Walkable terrain appears on Compass and Mission Map only.",
   ].join("<br>");
   const saveStatus = document.createElement("p");

--- a/tests/unit/cartography-grid.test.ts
+++ b/tests/unit/cartography-grid.test.ts
@@ -27,7 +27,7 @@ test("lets proven map knowledge replace a larger continent estimate", () => {
     currentRemaining: 2,
     rememberedKnown: 0,
     rememberedRemaining: 0,
-  }), { count: 2, actionable: true });
+  }), { count: 2, source: "current" });
   assert.equal(cartographyClusterPresentation({
     estimatedRemaining: 10,
     currentKnown: 8,
@@ -41,7 +41,7 @@ test("lets proven map knowledge replace a larger continent estimate", () => {
     currentRemaining: 0,
     rememberedKnown: 8,
     rememberedRemaining: 2,
-  }), { count: 2, actionable: false });
+  }), { count: 2, source: "remembered" });
   assert.equal(cartographyClusterPresentation({
     estimatedRemaining: 10,
     currentKnown: 0,
@@ -55,7 +55,7 @@ test("lets proven map knowledge replace a larger continent estimate", () => {
     currentRemaining: 0,
     rememberedKnown: 0,
     rememberedRemaining: 0,
-  }), { count: 12, actionable: false });
+  }), { count: 12, source: "estimate" });
 });
 
 const missionFrame: MissionMapFrameSpikeSnapshot = Object.freeze({

--- a/tests/unit/cartography-overlay-controls.test.ts
+++ b/tests/unit/cartography-overlay-controls.test.ts
@@ -116,9 +116,9 @@ test("Cartography QA ready status reports player-facing classification counts", 
     },
     kernel: null,
   });
-  assert.equal(ready.summary, "Ready · 92 actionable");
+  assert.equal(ready.summary, "Ready · 92 targets here");
   assert.ok(ready.rows.some(([label, value]) =>
-    label === "Cells" && value === "92 actionable · 228 reachable"));
+    label === "Guidance" && value === "92 targets here · 228 reachable cells"));
 });
 
 test("Cartography QA keeps continent progress visible without current guidance", () => {


### PR DESCRIPTION
## What changed

World Map numbers now explain what they mean. A solid number is reachable in the current map, an outlined number is remembered from a visited map, and `≈` marks a continent-wide estimate. Player-facing status now says “targets here” instead of the engineering term “actionable.”

## Why

The system already lets exact live knowledge replace a larger estimate—for example, live `2` replaces estimated `12` in the same block—but the old styling made remembered facts and estimates look like the same kind of number.

## Invariant

Each map block renders one number only, with this priority: current map, remembered map, then estimate. If exact knowledge says zero targets remain, the larger estimate is hidden instead of resurfacing.

## Delivery

Depends on #372 and is the third PR in stack #374. Recommend merging only after the complete stack passes the final in-game visual check.

## Verification

- Cartography grid and controls — 15 passed
- `pnpm verify:runtime` (all sandbox-independent stages passed; localhost integration tests were rerun with local socket access)
- `pnpm tools:test:e2e` — 42 passed
- `pnpm test:electron` — 132 passed, 1 expected live-client skip
- Pending before merge: inspect solid, outlined, and `≈` numbers in-game

- [x] I kept this pull request focused.
- [x] I ran the relevant checks.
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [x] I updated documentation when behavior or an invariant changed.
