### PR TITLE
fix(launcher): keep game window switching focused

### DIFF
--- a/apps/launcher/src/App.test.ts
+++ b/apps/launcher/src/App.test.ts
@@ -6,6 +6,7 @@ import { fixtureSnapshot } from "./fixtures";
 
 function installNative(overrides: Record<string, unknown>): LauncherNativeApi {
   const native = {
+    navigation: { onRequest: () => () => undefined },
     state: { get: async () => fixtureSnapshot, onChange: () => () => undefined },
     ...overrides,
   } as unknown as LauncherNativeApi;
@@ -20,6 +21,28 @@ afterEach(() => {
 });
 
 describe("unified launcher shell", () => {
+  it("opens the destination requested by the native application menu", async () => {
+    let navigate: ((destination: "home" | "settings") => void) | undefined;
+    installNative({
+      navigation: {
+        onRequest(callback: (destination: "home" | "settings") => void) {
+          navigate = callback;
+          return () => undefined;
+        },
+      },
+    });
+    const wrapper = mount(App);
+    await flushPromises();
+
+    navigate?.("settings");
+    await wrapper.vm.$nextTick();
+    expect(wrapper.get(".settings-content h1").text()).toBe("Updates");
+
+    navigate?.("home");
+    await wrapper.vm.$nextTick();
+    expect(wrapper.get(".hero-copy h1").text()).toContain("Wayfarer’s Reverie");
+  });
+
   it("keeps funding on top and operational status only in the launch bar", () => {
     const wrapper = mount(App);
 
@@ -90,12 +113,9 @@ describe("unified launcher shell", () => {
         showMigrationNotice: false,
       },
     };
-    Object.defineProperty(window, "launcherNative", {
-      configurable: true,
-      value: {
-        state: { get: async () => fresh, onChange: () => () => undefined },
-        experience: { completeSetup },
-      } as unknown as LauncherNativeApi,
+    installNative({
+      state: { get: async () => fresh, onChange: () => () => undefined },
+      experience: { completeSetup },
     });
     const wrapper = mount(App);
     await flushPromises();
@@ -110,19 +130,15 @@ describe("unified launcher shell", () => {
 
   it("asks before replacing another Tool shortcut", async () => {
     const replaceShortcut = vi.fn(async () => undefined);
-    Object.defineProperty(window, "launcherNative", {
-      configurable: true,
-      value: {
-        state: { get: async () => fixtureSnapshot, onChange: () => () => undefined },
-        tools: {
-          captureShortcut: async () => ({
-            status: "conflict" as const,
-            tool: "quick-travel" as const,
-            binding: { key: "t", shift: false, option: false },
-          }),
-          replaceShortcut,
-        },
-      } as unknown as LauncherNativeApi,
+    installNative({
+      tools: {
+        captureShortcut: async () => ({
+          status: "conflict" as const,
+          tool: "quick-travel" as const,
+          binding: { key: "t", shift: false, option: false },
+        }),
+        replaceShortcut,
+      },
     });
     const wrapper = mount(App);
     await flushPromises();

--- a/apps/launcher/src/App.vue
+++ b/apps/launcher/src/App.vue
@@ -14,7 +14,7 @@ import {
   Crown,
   X,
 } from "lucide-vue-next";
-import type { LauncherSnapshot } from "@shared/launcher-contracts";
+import type { LauncherDestination, LauncherSnapshot } from "@shared/launcher-contracts";
 import type { GlobalTool, LauncherPreferencesPatch, LauncherSettingsPatch } from "@shared/launcher-contracts";
 import type { CacheInfo } from "@shared/contracts";
 import { shortcutDisplay } from "@shared/keyboard-shortcuts";
@@ -73,6 +73,7 @@ const gameFilesInfo = ref<CacheInfo | null>(null);
 const gameFilesLoading = ref(false);
 const MIGRATION_NOTICE_DURATION_MS = 8_000;
 let unsubscribe: (() => void) | undefined;
+let unsubscribeNavigation: (() => void) | undefined;
 let migrationNoticeTimer: ReturnType<typeof setTimeout> | undefined;
 
 const native = window.launcherNative;
@@ -80,6 +81,7 @@ const synchronized = ref(!native);
 const fixtureContent = computed(() => snapshot.value.contentAvailability.news === "fixture");
 onMounted(async () => {
   if (!native) return;
+  unsubscribeNavigation = native.navigation.onRequest(navigateFromMain);
   try {
     const initial = await native.state.get();
     snapshot.value = initial;
@@ -96,6 +98,7 @@ onMounted(async () => {
 });
 onBeforeUnmount(() => {
   unsubscribe?.();
+  unsubscribeNavigation?.();
   clearTimeout(migrationNoticeTimer);
 });
 watch([synchronized, () => snapshot.value.experience.introduction], async ([ready, introduction]) => {
@@ -195,6 +198,11 @@ function openSettings(section: SettingsRoute = "general") {
   settingsRoute.value = section;
   route.value = "settings";
   if (section === "game-files") void loadGameFilesInfo();
+}
+
+function navigateFromMain(destination: LauncherDestination) {
+  if (destination === "settings") openSettings();
+  else route.value = "home";
 }
 
 function selectSettings(section: SettingsRoute) {

--- a/docs/multiple-accounts.md
+++ b/docs/multiple-accounts.md
@@ -80,12 +80,17 @@ storage.
 
 ## Companion window policy
 
-The launcher remains available while games run. Focusing a game naturally
-places it in front of the launcher. Closing the launcher hides it while a game
-is open. Closing one game affects only that profile; closing the final game
-reveals the launcher. A Dock activation restores the most recently used live
-window. If that window has closed, it falls back through the previous game
-windows before revealing the launcher.
+The launcher remains visible while profiles open. After complete success, it
+hides and focuses the first selected game. **Show** also hides the launcher
+after it restores the selected game. A failure keeps the launcher visible for
+recovery. This keeps the launcher out of normal game-window switching.
+
+**Window → Show Launcher** restores it without changing a game. **Settings…**
+restores it at Settings. Closing the launcher hides it while a game is open.
+Closing one game affects only that profile; closing the final game reveals the
+launcher. A Dock activation restores the most recently used live window. If
+that window has closed, it falls back through the previous game windows before
+revealing the launcher.
 A second app launch restores the launcher explicitly. An asynchronous Play
 completion does not steal focus if the player has already moved to another app.
 

--- a/docs/process-model.md
+++ b/docs/process-model.md
@@ -388,8 +388,11 @@ most recently used live window. If that window has closed, the coordinator
 falls back through its recent-window order. Neither action creates another
 game window.
 
-Closing the launcher hides it while games run. Closing one game window closes
-only that profile. Closing the final game leaves the launcher available.
+Complete profile launch success hides the launcher. A launch failure keeps it
+visible. The native Window menu and Settings command can restore it while games
+run. Closing the launcher also hides it while games run. Closing one game
+window closes only that profile. Closing the final game leaves the launcher
+available.
 Application quit saves
 all live renderer filesystems in parallel, closes sockets, stops background
 work, flushes diagnostics, and exits through one bounded cleanup path.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -42,10 +42,13 @@ When updating from the old Single Account experience, **Main account** continues
 to use the existing saved login, builds, templates, game files, and window
 position in place. The cutover does not copy, move, or delete that data.
 
-Closing the launcher hides it while games run. Closing one game affects only
-that account. Closing the last game leaves the launcher available. Clicking the
-Dock icon restores the most recent launcher or game window that you used. If
-that window has closed, the next most recent game window is restored.
+The launcher hides after every selected account opens successfully. It stays
+visible if an account needs attention. Use **Window → Show Launcher** to open
+another account. **Settings…** opens launcher Settings directly. Closing one
+game affects only that account. Closing the last game shows the launcher.
+Clicking the Dock icon restores the most recent launcher or game window that
+you used. If that window has closed, the next most recent game window is
+restored.
 
 ## Home content
 

--- a/src/main/accounts-window.ts
+++ b/src/main/accounts-window.ts
@@ -5,7 +5,7 @@
  * coordinator. This module owns only construction, trust, and local renderer
  * recovery so a launcher failure never closes a running game.
  */
-import { app, BrowserWindow, Menu, session } from "electron";
+import { app, BrowserWindow, session } from "electron";
 import { BACKGROUND_LAUNCH } from "./background-launch.js";
 import { isQuitting } from "./lifecycle.js";
 import { launcherPreloadPath } from "./paths.js";
@@ -13,17 +13,33 @@ import type { ProtocolDeps } from "./protocol.js";
 import { installLauncherProtocolHandlerForSession } from "./protocol.js";
 import type { WindowCoordinator } from "./window-coordinator.js";
 import { windowRegistry } from "./window-registry.js";
+import {
+  installNativeApplicationMenu,
+  type LauncherReveal,
+} from "./window-menu.js";
 
 const LAUNCHER_URL = "gw://app/launcher/index.html";
 let protocolInstalled = false;
 
-function installLauncherMenu(): void {
-  Menu.setApplicationMenu(Menu.buildFromTemplate([
+function installLauncherMenu(revealLauncher: LauncherReveal): void {
+  installNativeApplicationMenu([
     ...(process.platform === "darwin"
       ? [{
           label: app.name,
           submenu: [
             { role: "about" as const },
+            { type: "separator" as const },
+            {
+              id: "check-for-updates",
+              label: "Check for Updates…",
+              click: () => revealLauncher("settings"),
+            },
+            {
+              id: "show-settings",
+              label: "Settings…",
+              accelerator: "CmdOrCtrl+,",
+              click: () => revealLauncher("settings"),
+            },
             { type: "separator" as const },
             { role: "hide" as const },
             { role: "hideOthers" as const },
@@ -42,12 +58,14 @@ function installLauncherMenu(): void {
         { role: "selectAll" as const },
       ],
     },
-  ]));
+    { role: "windowMenu" },
+  ], revealLauncher);
 }
 
 export function createLauncherWindow(
   deps: ProtocolDeps,
   coordinator: WindowCoordinator<BrowserWindow>,
+  revealLauncher: LauncherReveal,
 ): BrowserWindow {
   const existing = windowRegistry.launcherWindow();
   if (existing) {
@@ -95,9 +113,9 @@ export function createLauncherWindow(
   });
   win.on("focus", () => {
     coordinator.recordFocused(win);
-    installLauncherMenu();
+    installLauncherMenu(revealLauncher);
   });
-  installLauncherMenu();
+  installLauncherMenu(revealLauncher);
   win.on("close", (event) => {
     if (!isQuitting()) coordinator.handleLauncherClose(event);
   });
@@ -114,7 +132,7 @@ export function createLauncherWindow(
       return;
     }
     windowRegistry.unregister(win);
-    const replacement = createLauncherWindow(deps, coordinator);
+    const replacement = createLauncherWindow(deps, coordinator, revealLauncher);
     if (!win.isDestroyed()) win.destroy();
     coordinator.revealLauncher();
     replacement.focus();

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -143,7 +143,12 @@ import {
 import { LauncherOrchestrator } from "./launcher-orchestrator.js";
 import { registerLauncherIpc } from "./launcher-ipc.js";
 import { LAUNCHER_IPC } from "../shared/launcher-contracts.js";
-import type { GlobalTool, LauncherSettingsPatch, ShortcutReplacement } from "../shared/launcher-contracts.js";
+import type {
+  GlobalTool,
+  LauncherDestination,
+  LauncherSettingsPatch,
+  ShortcutReplacement,
+} from "../shared/launcher-contracts.js";
 import {
   DEFAULT_SHORTCUTS,
   shortcutReserved,
@@ -215,8 +220,19 @@ const windowCoordinator = new WindowCoordinator(
 const INJECT_STARTUP_FAILURE =
   !app.isPackaged && process.env.GW_TEST_STARTUP_FAILURE === "1";
 
+function revealLauncher(destination?: LauncherDestination): boolean {
+  if (!windowCoordinator.revealLauncher({ activateApp: true })) return false;
+  if (destination) {
+    windowRegistry.launcherWindow()?.webContents.send(
+      LAUNCHER_IPC.navigationEvent,
+      destination,
+    );
+  }
+  return true;
+}
+
 function revealMainWindow(): void {
-  if (!windowCoordinator.revealLauncher({ activateApp: true })) {
+  if (!revealLauncher()) {
     secondInstanceRequested = true;
   }
   else secondInstanceRequested = false;
@@ -467,8 +483,8 @@ function buildWindowHost(
     prepareRendererRecovery: async () => {
       await clientRuntime.recoverRendererCrash();
     },
-    revealLauncher: () => {
-      windowCoordinator.revealLauncher({ activateApp: true });
+    revealLauncher: (destination) => {
+      revealLauncher(destination);
     },
     gameWindowClosed: () => {
       windowCoordinator.afterGameClosed();
@@ -1021,7 +1037,11 @@ if (primaryInstance) void app.whenReady().then(async () => {
     await stopDiagnostics();
   });
 
-  const win = createLauncherWindow(protocolDeps, windowCoordinator);
+  const win = createLauncherWindow(
+    protocolDeps,
+    windowCoordinator,
+    revealLauncher,
+  );
   let automaticUpdateCheckInFlight = false;
   const maybeCheckForAppUpdates = async (): Promise<void> => {
     if (automaticUpdateCheckInFlight) return;
@@ -1118,7 +1138,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
   });
   app.on("activate", () => {
     if (!windowCoordinator.restoreMostRecentWindow()) {
-      createLauncherWindow(protocolDeps, windowCoordinator);
+      createLauncherWindow(protocolDeps, windowCoordinator, revealLauncher);
     }
   });
   app.on("child-process-gone", (_event, details) => {

--- a/src/main/multiple-accounts-controller.ts
+++ b/src/main/multiple-accounts-controller.ts
@@ -308,8 +308,7 @@ export class MultipleAccountsController {
       throw firstFailure;
     }
     if (firstSelectedWindow && !firstSelectedWindow.isDestroyed()) {
-      this.options.windows.revealAsyncGameIfLauncherFocused(firstSelectedWindow);
-      this.options.windows.hideLauncher();
+      this.options.windows.completeAsyncGameLaunch(firstSelectedWindow);
     }
     this.publish();
   }

--- a/src/main/multiple-accounts-controller.ts
+++ b/src/main/multiple-accounts-controller.ts
@@ -251,6 +251,7 @@ export class MultipleAccountsController {
     const win = windowRegistry.profileWindow(profileId);
     if (!win) return false;
     this.options.windows.revealGame(win, { activateApp: true });
+    this.options.windows.hideLauncher();
     return true;
   }
 
@@ -308,6 +309,7 @@ export class MultipleAccountsController {
     }
     if (firstSelectedWindow && !firstSelectedWindow.isDestroyed()) {
       this.options.windows.revealAsyncGameIfLauncherFocused(firstSelectedWindow);
+      this.options.windows.hideLauncher();
     }
     this.publish();
   }

--- a/src/main/window-coordinator.ts
+++ b/src/main/window-coordinator.ts
@@ -55,6 +55,14 @@ export class WindowCoordinator<Window extends PresentableWindow> {
     return true;
   }
 
+  /** Remove the completed launch surface from normal game-window switching. */
+  hideLauncher(): boolean {
+    const launcher = this.#registry.launcherWindow();
+    if (!launcher || !launcher.isVisible()) return false;
+    launcher.hide();
+    return true;
+  }
+
   /** Keep a most-recently-used order for every launcher and game window. */
   recordFocused(win: Window): void {
     const context = this.#registry.contextForWebContents(win.webContents.id);
@@ -100,7 +108,7 @@ export class WindowCoordinator<Window extends PresentableWindow> {
     const launcher = this.#registry.launcherWindow();
     if (!launcher) return false;
     event.preventDefault();
-    launcher.hide();
+    this.hideLauncher();
     return true;
   }
 

--- a/src/main/window-coordinator.ts
+++ b/src/main/window-coordinator.ts
@@ -14,6 +14,7 @@ interface PresentableWindow extends RegisteredWindow {
   show(): void;
   hide(): void;
   focus(): void;
+  blur(): void;
 }
 
 interface ApplicationPresentation {
@@ -123,9 +124,12 @@ export class WindowCoordinator<Window extends PresentableWindow> {
    * has moved on. Game windows stay hidden until their first submitted frame,
    * then appear inactive before this explicit launch-owner check may focus one.
    */
-  revealAsyncGameIfLauncherFocused(win: Window): boolean {
-    if (!this.#registry.launcherWindow()?.isFocused()) return false;
-    return this.revealGame(win);
+  completeAsyncGameLaunch(win: Window): boolean {
+    const shouldFocusGame = this.#registry.launcherWindow()?.isFocused() ?? false;
+    if (shouldFocusGame) this.revealGame(win);
+    this.hideLauncher();
+    if (!shouldFocusGame && !win.isDestroyed()) win.blur();
+    return shouldFocusGame;
   }
 
   private present(win: Window, activateApp: boolean): void {

--- a/src/main/window-menu.ts
+++ b/src/main/window-menu.ts
@@ -13,10 +13,12 @@ import {
   clipboard,
   dialog,
   Menu,
+  MenuItem,
   shell,
   type BaseWindow,
   type MenuItemConstructorOptions,
 } from "electron";
+import type { LauncherDestination } from "../shared/launcher-contracts.js";
 import {
   EXTERNAL_URLS,
   type AppSettings,
@@ -50,7 +52,29 @@ export interface ApplicationMenuActions {
   host: WindowHost;
   /** Window state stays window.ts's; the menu only asks for the reset. */
   resetWindowState: (win: BrowserWindow) => Promise<void>;
-  revealLauncher: () => void;
+  revealLauncher: LauncherReveal;
+}
+
+export type LauncherReveal = (destination?: LauncherDestination) => void;
+
+/** Install one native Window menu and add the launcher's explicit recovery. */
+export function installNativeApplicationMenu(
+  template: MenuItemConstructorOptions[],
+  revealLauncher: LauncherReveal,
+): void {
+  const menu = Menu.buildFromTemplate(template);
+  const windowMenu = menu.items.find(
+    (item) => item.role?.toLowerCase() === "windowmenu",
+  )?.submenu;
+  if (windowMenu) {
+    windowMenu.insert(0, new MenuItem({
+      id: "show-launcher",
+      label: "Show Launcher",
+      click: () => revealLauncher("home"),
+    }));
+    windowMenu.insert(1, new MenuItem({ type: "separator" }));
+  }
+  Menu.setApplicationMenu(menu);
 }
 
 /** Keep optional commands visible while removing every disabled action. */
@@ -320,13 +344,15 @@ export function installApplicationMenu({
               { role: "about" as const },
               { type: "separator" as const },
               {
+                id: "check-for-updates",
                 label: "Check for Updates…",
-                click: revealLauncher,
+                click: () => revealLauncher("settings"),
               },
               {
+                id: "show-settings",
                 label: "Settings…",
                 accelerator: "CmdOrCtrl+,",
-                click: revealLauncher,
+                click: () => revealLauncher("settings"),
               },
               { type: "separator" as const },
               { role: "hide" as const },
@@ -429,6 +455,7 @@ export function installApplicationMenu({
           : []),
       ],
     },
+    { role: "windowMenu" },
     {
       label: "Help",
       submenu: [
@@ -555,5 +582,5 @@ export function installApplicationMenu({
     },
   ];
 
-  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
+  installNativeApplicationMenu(template, revealLauncher);
 }

--- a/src/main/window.ts
+++ b/src/main/window.ts
@@ -21,6 +21,7 @@ import type {
   GameReloadCause,
   RendererInit,
 } from "../shared/contracts.js";
+import type { LauncherDestination } from "../shared/launcher-contracts.js";
 import { RENDERER_INIT_ARGUMENT } from "../shared/contracts.js";
 import type {
   EnhancementProgram,
@@ -82,7 +83,7 @@ export interface WindowHost {
   claimRelogIntent: (win: BrowserWindow) => boolean;
   requestQuit: (win: BrowserWindow) => void;
   prepareRendererRecovery: () => Promise<void>;
-  revealLauncher: () => void;
+  revealLauncher: (destination?: LauncherDestination) => void;
   gameWindowClosed?: () => void;
 }
 

--- a/src/preload/preload.launcher.cjs
+++ b/src/preload/preload.launcher.cjs
@@ -18,6 +18,9 @@ function listen(channel, callback) {
 
 /** @type {import("../shared/launcher-contracts.js").LauncherNativeApi} */
 const launcherApi = {
+  navigation: {
+    onRequest: (callback) => listen(LAUNCHER_IPC.navigationEvent, callback),
+  },
   state: {
     get: () => ipcRenderer.invoke(LAUNCHER_IPC.stateGet),
     onChange: (callback) => listen(LAUNCHER_IPC.stateEvent, callback),

--- a/src/shared/launcher-contracts.ts
+++ b/src/shared/launcher-contracts.ts
@@ -27,6 +27,7 @@ import type { ProfileId } from "./multiple-accounts.js";
 export const LAUNCHER_IPC = Object.freeze({
   stateGet: "gw:launcher:state:get",
   stateEvent: "gw:launcher:state:event",
+  navigationEvent: "gw:launcher:navigation:event",
   profilesCreate: "gw:launcher:profiles:create",
   profilesUpdateAppearance: "gw:launcher:profiles:updateAppearance",
   profilesSetSelection: "gw:launcher:profiles:setSelection",
@@ -61,6 +62,8 @@ export const LAUNCHER_IPC = Object.freeze({
   updatesCheck: "gw:launcher:updates:check",
   updatesRestartAndInstall: "gw:launcher:updates:restartAndInstall",
 } as const);
+
+export type LauncherDestination = "home" | "settings";
 
 export type LauncherInstallationKind =
   | "fresh"
@@ -203,6 +206,9 @@ export interface LauncherSnapshot {
 }
 
 export interface LauncherNativeApi {
+  readonly navigation: {
+    onRequest(callback: (destination: LauncherDestination) => void): () => void;
+  };
   readonly state: {
     get(): Promise<LauncherSnapshot>;
     onChange(callback: (snapshot: LauncherSnapshot) => void): () => void;

--- a/tests/electron/launcher-shell.spec.ts
+++ b/tests/electron/launcher-shell.spec.ts
@@ -18,7 +18,17 @@ test("the Vue launcher owns a narrow frozen bridge and offline subtree", async (
     }));
     expect(boundary).toEqual({
       gameBridge: "undefined",
-      launcherKeys: ["experience", "external", "gameFiles", "profiles", "settings", "state", "tools", "updates"],
+      launcherKeys: [
+        "experience",
+        "external",
+        "gameFiles",
+        "navigation",
+        "profiles",
+        "settings",
+        "state",
+        "tools",
+        "updates",
+      ],
       rootFrozen: true,
       namespacesFrozen: true,
       nodeRequire: "undefined",

--- a/tests/electron/multiple-accounts.spec.ts
+++ b/tests/electron/multiple-accounts.spec.ts
@@ -356,12 +356,39 @@ test("Show never duplicates a game and companion close policy stays profile-loca
     await expect.poll(() => fixture.page.evaluate(() =>
       window.launcherNative.state.get().then((snapshot) => snapshot.profiles[0]?.state),
     )).toBe("running");
+    await expect.poll(() => fixture.app.evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getAllWindows()
+        .find((win) => win.webContents.getURL().endsWith("launcher/index.html"))
+        ?.isVisible(),
+    )).toBe(false);
 
     await fixture.app.evaluate(({ BrowserWindow }) => {
       BrowserWindow.getAllWindows()
         .find((win) => win.webContents.getURL() === "gw://app/")
         ?.minimize();
     });
+    expect(await fixture.app.evaluate(({ Menu }) => {
+      const menu = Menu.getApplicationMenu();
+      return {
+        hasWindowMenu: menu?.items.some(
+          (item) => item.role?.toLowerCase() === "windowmenu",
+        ) ?? false,
+        showLauncher: menu?.getMenuItemById("show-launcher")?.label ?? null,
+      };
+    })).toEqual({ hasWindowMenu: true, showLauncher: "Show Launcher" });
+    await fixture.app.evaluate(({ Menu }) => {
+      Menu.getApplicationMenu()?.getMenuItemById("show-launcher")?.click();
+    });
+    await expect.poll(() => fixture.app.evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getAllWindows()
+        .find((win) => win.webContents.getURL().endsWith("launcher/index.html"))
+        ?.isVisible(),
+    )).toBe(true);
+    await fixture.app.evaluate(({ Menu }) => {
+      Menu.getApplicationMenu()?.getMenuItemById("show-settings")?.click();
+    });
+    await expect(fixture.page.locator(".settings-content h1")).toHaveText("Updates");
+
     const profileId = await fixture.page.evaluate(() =>
       window.launcherNative.state.get().then((snapshot) => snapshot.profiles[0]!.id));
     await fixture.page.evaluate((id) => window.launcherNative.profiles.show(id), profileId);
@@ -371,6 +398,11 @@ test("Show never duplicates a game and companion close policy stays profile-loca
         .find((win) => win.webContents.getURL() === "gw://app/");
       return game ? { visible: game.isVisible(), minimized: game.isMinimized() } : null;
     })).toEqual({ visible: true, minimized: false });
+    await expect.poll(() => fixture.app.evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getAllWindows()
+        .find((win) => win.webContents.getURL().endsWith("launcher/index.html"))
+        ?.isVisible(),
+    )).toBe(false);
 
     await fixture.app.evaluate(({ BrowserWindow }) => {
       BrowserWindow.getAllWindows()

--- a/tests/release/launcher-preload-behaviour.test.ts
+++ b/tests/release/launcher-preload-behaviour.test.ts
@@ -54,6 +54,10 @@ test("the built launcher preload exposes every launcher command and nothing else
   assert.equal(listeners.get(LAUNCHER_IPC.stateEvent)?.length, 1);
   stop();
   assert.equal(listeners.get(LAUNCHER_IPC.stateEvent)?.length, 0);
+  const stopNavigation = api.navigation.onRequest(() => undefined);
+  assert.equal(listeners.get(LAUNCHER_IPC.navigationEvent)?.length, 1);
+  stopNavigation();
+  assert.equal(listeners.get(LAUNCHER_IPC.navigationEvent)?.length, 0);
 
   await api.state.get();
   await api.profiles.create({ name: "Second account" });
@@ -92,6 +96,9 @@ test("the built launcher preload exposes every launcher command and nothing else
 
   assert.deepEqual(
     new Set(invoked.map(({ channel }) => channel)),
-    new Set(Object.values(LAUNCHER_IPC).filter((channel) => channel !== LAUNCHER_IPC.stateEvent)),
+    new Set(Object.values(LAUNCHER_IPC).filter((channel) => (
+      channel !== LAUNCHER_IPC.stateEvent
+      && channel !== LAUNCHER_IPC.navigationEvent
+    ))),
   );
 });

--- a/tests/unit/the-preload-is-generated-from-the-canonical-channels.test.ts
+++ b/tests/unit/the-preload-is-generated-from-the-canonical-channels.test.ts
@@ -253,6 +253,7 @@ test("the launcher preload exposes only its frozen launcher bridge", async () =>
     "experience",
     "external",
     "gameFiles",
+    "navigation",
     "profiles",
     "settings",
     "state",

--- a/tests/unit/window-coordinator.test.ts
+++ b/tests/unit/window-coordinator.test.ts
@@ -180,6 +180,18 @@ describe("window coordinator", () => {
     assert.equal(coordinator.revealGame(game), false);
   });
 
+  it("hides the launcher after its launch task completes", () => {
+    const { coordinator, registry } = setup();
+    const launcher = fakeWindow(1);
+    launcher.setVisible(true);
+    registry.register(launcher, { role: "launcher" });
+
+    assert.equal(coordinator.hideLauncher(), true);
+    assert.deepEqual(launcher.calls, ["hide"]);
+    assert.equal(coordinator.hideLauncher(), false);
+    assert.deepEqual(launcher.calls, ["hide"]);
+  });
+
   it("hides a closed launcher only while games remain", () => {
     const { coordinator, registry } = setup();
     const launcher = fakeWindow(1);

--- a/tests/unit/window-coordinator.test.ts
+++ b/tests/unit/window-coordinator.test.ts
@@ -37,6 +37,10 @@ function fakeWindow(id: number) {
       calls.push("focus");
       focused = true;
     },
+    blur() {
+      calls.push("blur");
+      focused = false;
+    },
     setDestroyed(value: boolean) { destroyed = value; },
     setFocused(value: boolean) { focused = value; },
     setMinimized(value: boolean) { minimized = value; },
@@ -232,22 +236,32 @@ describe("window coordinator", () => {
     assert.deepEqual(launcher.calls, ["show", "focus"]);
   });
 
-  it("focuses an asynchronous game only while the launcher remains focused", () => {
+  it("completes an asynchronous launch without stealing focus", () => {
     const { coordinator, registry } = setup();
     const launcher = fakeWindow(1);
     const game = fakeWindow(2);
     launcher.setVisible(true);
+    game.setVisible(true);
+    game.setFocused(true);
     registry.register(launcher, { role: "launcher" });
     registry.register(game, { role: "game", profileId: FIRST }, 2);
 
-    assert.equal(coordinator.revealAsyncGameIfLauncherFocused(game), false);
-    assert.deepEqual(game.calls, []);
+    assert.equal(coordinator.completeAsyncGameLaunch(game), false);
+    assert.deepEqual(launcher.calls, ["hide"]);
+    assert.deepEqual(game.calls, ["blur"]);
+  });
 
+  it("focuses an asynchronous game when the launcher remains focused", () => {
+    const { coordinator, registry } = setup();
+    const launcher = fakeWindow(1);
+    const game = fakeWindow(2);
+    launcher.setVisible(true);
     launcher.setFocused(true);
-    assert.equal(coordinator.revealAsyncGameIfLauncherFocused(game), true);
-    assert.deepEqual(game.calls, ["show", "focus"]);
+    registry.register(launcher, { role: "launcher" });
+    registry.register(game, { role: "game", profileId: FIRST }, 2);
 
-    registry.unregister(launcher);
-    assert.equal(coordinator.revealAsyncGameIfLauncherFocused(game), false);
+    assert.equal(coordinator.completeAsyncGameLaunch(game), true);
+    assert.deepEqual(launcher.calls, ["hide"]);
+    assert.deepEqual(game.calls, ["show", "focus"]);
   });
 });


### PR DESCRIPTION
The unified launcher stayed in macOS window switching after every selected account opened. With several accounts running, players had to pass through a launcher they no longer needed, but hiding it left no clearly named way to bring it back.

This change treats the launcher as the owner of the launch task. It stays visible while accounts open and when a launch needs attention, then hides after complete success or **Show**. The native **Window → Show Launcher** command restores it, while **Settings…** opens launcher Settings directly. Dock activation keeps the existing most-recent-window behavior.

The application menu now uses Electron's native Window menu, so macOS keeps its standard window list and controls. Main sends one closed navigation destination through the reduced launcher preload instead of exposing a general navigation bridge.

## Verification

- `pnpm run check`
  - 1,506 unit tests
  - 181 policy tests
  - 146 Tools tests
  - 49 launcher tests
- `pnpm build`
- focused launcher preload release test
- focused Electron multi-account window test
  - launcher hides after successful Play
  - Window → Show Launcher restores it
  - Settings opens the Updates settings page
  - Show restores the existing game without duplicating it and hides the launcher again

The repository's required Application verification still owns the complete packaged macOS gate. No live Guild Wars gameplay claim is made by this change.

Implemented and verified with Codex using the repository's Node, Vitest, and Playwright Electron harnesses.
