### PR TITLE
fix(relog): prevent timeout notices from lingering

### DIFF
--- a/docs/diagnostics.md
+++ b/docs/diagnostics.md
@@ -120,7 +120,8 @@ When automatic return does not run, `relog.skipped` is the terminal row. Its
 reason is one of `disabled`, `saved-login-unavailable`,
 `pre-game-controls-unavailable`, or `intent-expired`. A plain reload still
 records `gameReload.loaded`, which proves that the replacement renderer loaded
-even when automatic return is disabled.
+even when automatic return is disabled. No relog stage event follows a terminal
+`relog.finished` or `relog.skipped` row.
 
 The trace contains only closed stages, outcomes, and bounded native-control
 state. It contains no Guild Wars UI text, dispatcher parameters, pointers,

--- a/docs/process-model.md
+++ b/docs/process-model.md
@@ -214,7 +214,8 @@ not success: completion requires a fresh bounded play-region publication with
 a valid map, instance type, and player. Existing session progress or a physical
 Return cancels the related synthetic one. Losing focus pauses input. The
 renderer records each boundary and shows the current step; after 30 seconds it
-names where progress stopped.
+names where progress stopped for eight seconds. Steam refusal and automatic
+return share one status owner, so only the newest message can dismiss itself.
 
 Right-drag uses pointer lock and a virtual cursor. The host bounds drag
 recycling so camera movement can continue. The host normalizes supported

--- a/src/renderer/automatic-character-return.ts
+++ b/src/renderer/automatic-character-return.ts
@@ -10,6 +10,7 @@ import type {
   RelogInputStage,
   RelogTerminalOutcome,
 } from "../shared/diagnostics.js";
+import type { LoginStatus } from "./login-status.js";
 import {
   isRelogCharacterEntryState,
   isRelogPostCharacterState,
@@ -18,6 +19,7 @@ import {
 
 const AUTHORITY_BUDGET_MS = 30_000;
 const STATUS_REVEAL_DELAY_MS = 350;
+const FAILURE_STATUS_DURATION_MS = 8_000;
 
 type RecordMilestone = <Name extends RendererMilestone>(
   name: Name,
@@ -49,6 +51,7 @@ type Dependencies = Readonly<{
   claimIntent(): Promise<boolean>;
   input(): GameInputController | null;
   record: RecordMilestone;
+  status: Pick<LoginStatus, "clear" | "show">;
 }>;
 
 const didAdvance = (outcome: AutomaticEnterOutcome): boolean =>
@@ -72,7 +75,6 @@ export function installAutomaticCharacterReturn(
   let disposed = false;
   let run: ActiveRun | null = null;
   let revealTimer: ReturnType<typeof setTimeout> | null = null;
-  let statusVisible = false;
 
   const cancelReveal = () => {
     if (revealTimer === null) return;
@@ -82,19 +84,12 @@ export function installAutomaticCharacterReturn(
 
   const clearStatus = () => {
     cancelReveal();
-    if (!statusVisible) return;
-    statusVisible = false;
-    const status = document.getElementById("login-status");
-    if (status) status.hidden = true;
+    dependencies.status.clear();
   };
 
-  const showStatus = (text: string) => {
+  const showStatus = (text: string, durationMs?: number) => {
     cancelReveal();
-    const status = document.getElementById("login-status");
-    if (!status) return;
-    statusVisible = true;
-    status.textContent = text;
-    status.hidden = false;
+    dependencies.status.show(text, durationMs);
   };
 
   const deferStatus = (text: string) => {
@@ -125,7 +120,8 @@ export function installAutomaticCharacterReturn(
     dependencies.record("relog.finished", { outcome });
     if (outcome === "timed-out") {
       showStatus(
-        `Automatic return stopped while ${candidate.lastStep}. Press Return to continue.`,
+        `Automatic return stopped while ${candidate.lastStep}. You can continue manually.`,
+        FAILURE_STATUS_DURATION_MS,
       );
     } else {
       clearStatus();
@@ -263,6 +259,7 @@ export function installAutomaticCharacterReturn(
         ? await sendWhenFocused(candidate, () => input.playSelectedCharacter())
         : "cancelled"
       : "progressed";
+    if (!isActive(candidate)) return;
     recordInput("character", characterOutcome);
     if (!didAdvance(characterOutcome) || !isActive(candidate)) {
       candidate.lastStep = characterOutcome === "unfocused"
@@ -288,6 +285,7 @@ export function installAutomaticCharacterReturn(
         ? await sendWhenFocused(candidate, () => input.acceptReconnect())
         : "cancelled"
       : "progressed";
+    if (!isActive(candidate)) return;
     recordInput("reconnect", restoreOutcome);
     if (!didAdvance(restoreOutcome) || !isActive(candidate)) {
       candidate.lastStep = restoreOutcome === "unfocused"
@@ -365,6 +363,7 @@ export function installAutomaticCharacterReturn(
         candidate,
         () => input.submitSavedLogin(candidate.expiresAt),
       );
+      if (!isActive(candidate)) return;
       recordInput("login", outcome);
       if (didAdvance(outcome) && isActive(candidate)) {
         step(
@@ -415,17 +414,17 @@ export function installAutomaticCharacterReturn(
     tokenRequested,
     clearStatus,
     cancelForCharacterSwitch() {
+      clearStatus();
       if (run && !run.ended) {
         run.ended = true;
         if (run.deadlineTimer !== null) clearTimeout(run.deadlineTimer);
         run.deadlineTimer = null;
-        clearStatus();
       }
       dependencies.input()?.cancelAutomaticEnter();
     },
     dispose() {
       disposed = true;
-      cancelReveal();
+      clearStatus();
       if (run && !run.ended) {
         run.ended = true;
         if (run.deadlineTimer !== null) clearTimeout(run.deadlineTimer);

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -234,6 +234,7 @@ if (developerProgram !== 'none') {
 let automaticCharacterReturn:
   | import('./automatic-character-return.js').AutomaticCharacterReturn
   | null = null;
+let loginStatus: import('./login-status.js').LoginStatus | null = null;
 let characterSwitchHost:
   | import('./character-switch-host.js').CharacterSwitchHost
   | null = null;
@@ -617,27 +618,15 @@ async function fetchSnapshotRange(
   return new Uint8Array(await res.arrayBuffer());
 }
 
-// The one explanation the host draws beside the client's login screen: why an
-// interactive Steam sign-in produced no login. Transient and non-blocking —
-// the login screen itself stays entirely the client's.
-let loginStatusTimer: ReturnType<typeof setTimeout> | null = null;
-
 function showLoginStatus(
   reason: import('../shared/contracts.js').SteamRefusalReason,
 ): void {
   void (async () => {
     const { describeSteamRefusal } = await import('./failure-messages.js');
     const text = describeSteamRefusal(reason);
-    const status = document.getElementById('login-status');
-    if (!text || !status) return;
+    if (!text) return;
     automaticCharacterReturn?.clearStatus();
-    status.textContent = text;
-    status.hidden = false;
-    if (loginStatusTimer) clearTimeout(loginStatusTimer);
-    loginStatusTimer = setTimeout(() => {
-      status.hidden = true;
-      loginStatusTimer = null;
-    }, 12_000);
+    loginStatus?.show(text, 12_000);
   })();
 }
 
@@ -653,6 +642,7 @@ addEventListener('beforeunload', () => {
   controllerPrompts = null;
   disposeMemoryWarningSettings();
   automaticCharacterReturn?.dispose();
+  loginStatus?.dispose();
   characterSwitchHost?.dispose();
   characterSwitchHost = null;
   delete window.gwCharacterSwitchHost;
@@ -1283,13 +1273,19 @@ function loadGlue(isProxyRouteLabel: (route: string) => boolean) {
     );
     return;
   }
-  const { installAutomaticCharacterReturn } = await import(
-    './automatic-character-return.js'
-  );
+  const [
+    { installAutomaticCharacterReturn },
+    { installLoginStatus },
+  ] = await Promise.all([
+    import('./automatic-character-return.js'),
+    import('./login-status.js'),
+  ]);
+  loginStatus = installLoginStatus(document.getElementById('login-status'));
   automaticCharacterReturn = installAutomaticCharacterReturn({
     claimIntent: () => native().app.claimRelogIntent(),
     input: () => inputHost,
     record: milestone,
+    status: loginStatus,
   });
   milestone('renderer.loaded');
   let isProxyRouteLabel: (route: string) => boolean;

--- a/src/renderer/login-status.ts
+++ b/src/renderer/login-status.ts
@@ -1,0 +1,37 @@
+/**
+ * Owns the one transient status line beside the Guild Wars login screen.
+ * Steam refusal and automatic return share this owner so an older timeout
+ * cannot hide a newer message.
+ */
+
+export type LoginStatus = Readonly<{
+  show(text: string, durationMs?: number): void;
+  clear(): void;
+  dispose(): void;
+}>;
+
+export function installLoginStatus(element: HTMLElement | null): LoginStatus {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const clear = () => {
+    if (timer !== null) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    if (element) element.hidden = true;
+  };
+
+  const show = (text: string, durationMs?: number) => {
+    clear();
+    if (!element) return;
+    element.textContent = text;
+    element.hidden = false;
+    if (durationMs === undefined) return;
+    timer = setTimeout(() => {
+      timer = null;
+      element.hidden = true;
+    }, durationMs);
+  };
+
+  return Object.freeze({ show, clear, dispose: clear });
+}

--- a/tests/unit/automatic-character-return.test.ts
+++ b/tests/unit/automatic-character-return.test.ts
@@ -2,13 +2,149 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import { installAutomaticCharacterReturn } from "../../src/renderer/automatic-character-return.js";
+import { installLoginStatus } from "../../src/renderer/login-status.js";
 import type { RendererMilestone } from "../../src/shared/diagnostics.js";
+
+test("a timed-out return notice clears itself", async (context) => {
+  const status = { hidden: true, textContent: "" };
+  const loginStatus = installLoginStatus(status as unknown as HTMLElement);
+  context.mock.timers.enable({ apis: ["setTimeout"] });
+
+  const controller = installAutomaticCharacterReturn({
+    claimIntent: async () => true,
+    input: () => null,
+    record() {},
+    status: loginStatus,
+  });
+
+  try {
+    await Promise.resolve();
+    context.mock.timers.tick(30_000);
+
+    assert.equal(status.hidden, false);
+    assert.match(status.textContent, /You can continue manually\./);
+
+    context.mock.timers.tick(7_999);
+    assert.equal(status.hidden, false);
+
+    context.mock.timers.tick(1);
+    assert.equal(status.hidden, true);
+  } finally {
+    controller.dispose();
+    context.mock.timers.reset();
+  }
+});
+
+test("manual character switching clears an elapsed return notice", async (context) => {
+  const status = { hidden: true, textContent: "" };
+  const loginStatus = installLoginStatus(status as unknown as HTMLElement);
+  context.mock.timers.enable({ apis: ["setTimeout"] });
+  const controller = installAutomaticCharacterReturn({
+    claimIntent: async () => true,
+    input: () => null,
+    record() {},
+    status: loginStatus,
+  });
+
+  try {
+    await Promise.resolve();
+    context.mock.timers.tick(30_000);
+    assert.equal(status.hidden, false);
+
+    controller.cancelForCharacterSwitch();
+    assert.equal(status.hidden, true);
+  } finally {
+    controller.dispose();
+    context.mock.timers.reset();
+  }
+});
+
+test("a pending login cannot record input after its terminal timeout", async (context) => {
+  const originalDocument = globalThis.document;
+  const originalWindow = globalThis.window;
+  const originalAnimationFrame = globalThis.requestAnimationFrame;
+  const browserWindow = new EventTarget() as EventTarget & {
+    gwPreGameControls: PreGameControls;
+  };
+  browserWindow.gwPreGameControls = {
+    state: () => "unknown",
+    switchContext: () => "unavailable",
+    diagnosticMask: () => 0,
+  };
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: browserWindow,
+  });
+  Object.defineProperty(globalThis, "document", {
+    configurable: true,
+    value: {
+      visibilityState: "visible",
+      hasFocus: () => true,
+    },
+  });
+  globalThis.requestAnimationFrame = ((callback: FrameRequestCallback) => {
+    queueMicrotask(() => callback(performance.now()));
+    return 1;
+  });
+  context.mock.timers.enable({ apis: ["setTimeout"] });
+
+  let settleLogin: ((outcome: AutomaticEnterOutcome) => void) | null = null;
+  const records: Array<{ name: RendererMilestone; fields: unknown }> = [];
+  const input: GameInputController = {
+    releaseAll() {},
+    traceState() {},
+    cancelAutomaticEnter() {
+      settleLogin?.("cancelled");
+      settleLogin = null;
+    },
+    setLoginProviderChooser() {},
+    expectCharacterSelection() {},
+    submitSavedLogin: () => new Promise((resolve) => { settleLogin = resolve; }),
+    playSelectedCharacter: async () => "sent",
+    acceptReconnect: async () => "sent",
+  };
+  const controller = installAutomaticCharacterReturn({
+    claimIntent: async () => true,
+    input: () => input,
+    record(name, ...fields) {
+      records.push({ name, fields: fields[0] });
+    },
+    status: installLoginStatus(null),
+  });
+
+  try {
+    await Promise.resolve();
+    controller.savedCredentialsLoaded();
+    for (let index = 0; index < 6; index += 1) await Promise.resolve();
+    assert.notEqual(settleLogin, null);
+
+    context.mock.timers.tick(30_000);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert.equal(records.at(-1)?.name, "relog.finished");
+    assert.equal(records.some(({ name }) => name === "relog.inputSettled"), false);
+  } finally {
+    controller.dispose();
+    context.mock.timers.reset();
+    Object.defineProperty(globalThis, "document", {
+      configurable: true,
+      value: originalDocument,
+    });
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow,
+    });
+    globalThis.requestAnimationFrame = originalAnimationFrame;
+  }
+});
 
 test("transient loading cannot skip character selection", async () => {
   const originalDocument = globalThis.document;
   const originalWindow = globalThis.window;
   const originalAnimationFrame = globalThis.requestAnimationFrame;
   const status = { hidden: true, textContent: "" };
+  const loginStatus = installLoginStatus(status as unknown as HTMLElement);
   let screen: "loading" | "character" | "playable" = "loading";
   let characterSubmissions = 0;
   const records: Array<{ name: RendererMilestone; fields: unknown }> = [];
@@ -61,6 +197,7 @@ test("transient loading cannot skip character selection", async () => {
     record(name, ...fields) {
       records.push({ name, fields: fields[0] });
     },
+    status: loginStatus,
   });
 
   try {

--- a/tests/unit/login-status.test.ts
+++ b/tests/unit/login-status.test.ts
@@ -1,0 +1,36 @@
+/** The login status must give its newest message sole dismissal authority. */
+import assert from "node:assert/strict";
+import test from "node:test";
+import { installLoginStatus } from "../../src/renderer/login-status.js";
+
+test("an older timer cannot hide a newer login status", (context) => {
+  context.mock.timers.enable({ apis: ["setTimeout"] });
+  const element = { hidden: true, textContent: "" };
+  const status = installLoginStatus(element as unknown as HTMLElement);
+
+  try {
+    status.show("Steam sign-in stopped", 12_000);
+    context.mock.timers.tick(5_000);
+    status.show("Automatic return stopped", 8_000);
+
+    context.mock.timers.tick(7_000);
+    assert.equal(element.hidden, false);
+    assert.equal(element.textContent, "Automatic return stopped");
+
+    context.mock.timers.tick(1_000);
+    assert.equal(element.hidden, true);
+  } finally {
+    status.dispose();
+    context.mock.timers.reset();
+  }
+});
+
+test("disposing the owner clears its current status", () => {
+  const element = { hidden: true, textContent: "" };
+  const status = installLoginStatus(element as unknown as HTMLElement);
+
+  status.show("Signing in");
+  status.dispose();
+
+  assert.equal(element.hidden, true);
+});


### PR DESCRIPTION
## Problem

Quick reload can time out while checking the previous Guild Wars session and leave its status banner over the game indefinitely. The same status element also had two independent timer owners, so an older Steam notice could hide newer automatic-return feedback.

## Solution

The login screen now has one transient-status owner. A failed automatic return remains readable for eight seconds and then clears itself. Newer messages replace older timers, Character Switch clears stale automatic-return feedback immediately, and a terminal timeout cannot be followed by late input-stage diagnostics.

Focused simulations cover timeout dismissal, timer replacement, manual handoff, disposal, pending-input cancellation, and the existing fast character-selection path. The process and diagnostics documents now state the lifecycle invariants.

## Verification

- `pnpm run check`
- `pnpm build`
- Focused relog/status tests: 16 passed
- Full local gate: 1,509 unit tests, 181 policy tests, 146 Tools tests, and 48 launcher tests passed

## Rollout risk

The change is limited to renderer-owned status presentation and terminal diagnostic ordering. It does not change the 30-second automatic-return authority budget or add game input. Live Guild Wars behavior was not claimed or tested locally. Because this touches reload behavior, include it in the next Beta consideration under the repository rollout policy.

## Attribution

Implemented and reviewed with Codex. Automated behavior was verified with the repository's Node timer and renderer harnesses; no live-player observation is represented by these tests.
