### PR TITLE
fix(cartography): survive unrelated ArenaNet updates

### DIFF
--- a/.github/workflows/client-recertification.yml
+++ b/.github/workflows/client-recertification.yml
@@ -135,6 +135,10 @@ jobs:
             > "$RUNNER_TEMP/double-click.raw.json" \
             2> "$RUNNER_TEMP/double-click.txt"
           double_click_exit=$?
+          node build/tools/certification.js cartography "$WASM" \
+            > "$RUNNER_TEMP/cartography.raw.json" \
+            2> "$RUNNER_TEMP/cartography.txt"
+          cartography_exit=$?
           node --import ./scripts/ts-hook.mjs scripts/qualify-extended-memory.ts \
             "$JS" "$WASM" > "$RUNNER_TEMP/extended-memory.raw.json" \
             2> "$RUNNER_TEMP/extended-memory.txt"
@@ -148,6 +152,15 @@ jobs:
             jq -n --argjson exitCode "$double_click_exit" \
               '{status: "refused", exitCode: $exitCode}' \
               > "$EVIDENCE/double-click.json"
+          fi
+          if [ "$cartography_exit" -eq 0 ]; then
+            jq '. + {status: "proved", exitCode: 0}' \
+              "$RUNNER_TEMP/cartography.raw.json" \
+              > "$EVIDENCE/cartography.json"
+          else
+            jq -n --argjson exitCode "$cartography_exit" \
+              '{status: "refused", exitCode: $exitCode}' \
+              > "$EVIDENCE/cartography.json"
           fi
           if [ "$extended_memory_exit" -eq 0 ]; then
             jq '. + {status: "proved", exitCode: 0}' \
@@ -192,6 +205,7 @@ jobs:
             "$EVIDENCE/runtime-verdicts.json" \
             "$EVIDENCE/client-artifact.json" \
             "$EVIDENCE/double-click.json" \
+            "$EVIDENCE/cartography.json" \
             "$EVIDENCE/extended-memory.json" \
             > "$EVIDENCE/generation.json"
           {

--- a/docs/arenanet-compatibility.md
+++ b/docs/arenanet-compatibility.md
@@ -56,6 +56,7 @@ official JS/WASM generation
   -> isolated template semantic proof and transform
   -> isolated per-feature semantic proofs
   -> typed manifest containing only proved capabilities
+  -> isolated Cartography layout and transform proof
   -> Main repeats transforms and checks output hashes
   -> renderer validates the instantiated manifest
 ```
@@ -115,6 +116,7 @@ unwitnessed field must fail TypeScript compilation or boundary validation.
 | Xunlai | Three readers, player/area layouts, fixed DataWindow action, handler, bounded drain, and fresh tri-state lifecycle | Disable Xunlai; aliases may retain only independently available Travel commands |
 | Chat aliases | Exact parser relation, bounded comparisons, handled result, original-parser preservation, and at least one proved local action | Rewrite only aliases for proved actions; otherwise preserve the original parser |
 | Team Apply | Seven named builders, exact opcodes/payloads, sender, bounded drain, fresh complete Party proof, and runtime confirmations | Disable Team Apply only; Builds and Teams remain editable |
+| Cartography | Exact frame, game-context, area-table, agent-array, pathing-function, call-site, and surface-dispatch relationships, followed by an independently reproduced output hash | Disable Cartography observers only; the official client and independently proved Tools remain available |
 | 4 GB mode | Manifest-bound JS/WASM pair, normalized Emscripten glue, every audited pointer-conversion site, one memory shape, and memory-only rewrite | Retain safe 2 GB mode |
 
 Chat aliases never own a dispatcher or mailbox. The transform specializes the
@@ -143,7 +145,11 @@ locator already meets the final relocation-resistant bar. At verifier ABI 7:
 - parts of Core and Tools certification still use raw body digests or common
   relocation checks while selecting a candidate; and
 - native double-click verifies the complete known route, but exact body binding
-  can still refuse after a harmless call-index change.
+  can still refuse after a harmless call-index change; and
+- Cartography no longer uses a whole-client hash, but its pathing and surface
+  roles still contain exact function-index and body bindings. Unrelated client
+  changes recover locally; a reindex or equivalent body rewrite can still
+  require a stronger semantic locator.
 
 These checks fail closed. They can therefore disable a feature after an
 equivalent ArenaNet rebuild even when game behavior did not change. A refusal
@@ -165,7 +171,7 @@ For an equivalent rebuild:
 3. Record each feature verdict, invariant, input hash, verifier ABI, and derived
    output hash.
 4. Transform every effective capability profile and validate each output.
-5. Run native double-click and 4 GB pair qualification independently.
+5. Run Cartography, native double-click, and 4 GB pair qualification independently.
 6. Store the signed machine-readable report and mark the generation as already
    processed. The report remains evidence only.
 7. Open no source PR. Players use the locally proved features immediately.

--- a/scripts/client-recertification-evidence.ts
+++ b/scripts/client-recertification-evidence.ts
@@ -323,6 +323,54 @@ function doubleClickEvidence(value: JsonRecord): JsonRecord {
   });
 }
 
+function cartographyEvidence(value: JsonRecord): JsonRecord {
+  const status = string(value.status, "cartography.status");
+  const exitCode = integer(value.exitCode, "cartography.exitCode");
+  if (status === "refused") {
+    if (exitCode === 0) throw new Error("Cartography refusal must fail");
+    return Object.freeze({ status: "refused", exitCode });
+  }
+  if (status !== "proved" || exitCode !== 0 || value.completeProof !== true) {
+    throw new Error("Cartography status is not a complete proof");
+  }
+  const rawChains = value.chains;
+  if (!Array.isArray(rawChains) || rawChains.length === 0) {
+    throw new Error("cartography.chains must be non-empty");
+  }
+  const chains = rawChains.map((raw, index) => {
+    const chain = record(raw, `cartography.chains[${index}]`);
+    const profile = string(chain.profile, `cartography.chains[${index}].profile`);
+    if (profile !== "official" && profile !== "file-compatible"
+      && !isEnhancementCapabilityProfile(profile)) {
+      throw new Error("Cartography chain profile is not closed");
+    }
+    const memoryLayout = string(
+      chain.memoryLayout,
+      `cartography.chains[${index}].memoryLayout`,
+    );
+    if (memoryLayout !== "official" && memoryLayout !== "relocated") {
+      throw new Error("Cartography memory layout is not closed");
+    }
+    return Object.freeze({
+      profile,
+      inputSha256: digest(chain.inputSha256, "Cartography chain input"),
+      outputSha256: digest(chain.outputSha256, "Cartography chain output"),
+      memoryLayout,
+    });
+  });
+  if (new Set(chains.map(({ profile }) => profile)).size !== chains.length
+    || new Set(chains.map(({ inputSha256 }) => inputSha256)).size !== chains.length) {
+    throw new Error("Cartography chains must have unique profiles and inputs");
+  }
+  return Object.freeze({
+    status: "proved",
+    exitCode,
+    officialSha256: digest(value.officialSha256, "cartography.officialSha256"),
+    chains: Object.freeze(chains),
+    completeProof: true,
+  });
+}
+
 function extendedMemoryEvidence(value: JsonRecord): JsonRecord {
   const status = string(value.status, "extendedMemory.status");
   const exitCode = integer(value.exitCode, "extendedMemory.exitCode");
@@ -386,9 +434,10 @@ function generationOutcome(
   runtime: JsonRecord,
   qualification: JsonRecord,
   doubleClick: JsonRecord,
+  cartography: JsonRecord,
   extendedMemory: JsonRecord,
 ): JsonRecord {
-  if ([runtime, qualification, doubleClick, extendedMemory].some(unavailable)) {
+  if ([runtime, qualification, doubleClick, cartography, extendedMemory].some(unavailable)) {
     return Object.freeze({ status: "investigation", reason: "evidence-collection-failed" });
   }
   const features = runtime.features;
@@ -412,6 +461,9 @@ function generationOutcome(
   }
   if (doubleClick.status !== "proved") {
     return Object.freeze({ status: "investigation", reason: "native-double-click-refused" });
+  }
+  if (cartography.status !== "proved") {
+    return Object.freeze({ status: "investigation", reason: "cartography-refused" });
   }
   if (extendedMemory.status !== "proved") {
     return Object.freeze({ status: "investigation", reason: "extended-memory-refused" });
@@ -474,12 +526,13 @@ export async function createClientRecertificationEvidence(
   environment: NodeJS.ProcessEnv = process.env,
 ): Promise<JsonRecord> {
   const [generation, wasmPath, jsPath, runtimePath, qualificationPath,
-    doubleClickPath, extendedMemoryPath] = argv;
+    doubleClickPath, cartographyPath, extendedMemoryPath] = argv;
   if (!generation || !wasmPath || !jsPath || !runtimePath || !qualificationPath
-    || !doubleClickPath || !extendedMemoryPath || argv.length !== 7) {
-    throw new Error("usage: client-recertification-evidence GENERATION WASM JS RUNTIME QUALIFICATION DOUBLE_CLICK EXTENDED_MEMORY");
+    || !doubleClickPath || !cartographyPath || !extendedMemoryPath
+    || argv.length !== 8) {
+    throw new Error("usage: client-recertification-evidence GENERATION WASM JS RUNTIME QUALIFICATION DOUBLE_CLICK CARTOGRAPHY EXTENDED_MEMORY");
   }
-  const [wasm, js, safeRuntime, safeQualification, safeDoubleClick,
+  const [wasm, js, safeRuntime, safeQualification, safeDoubleClick, safeCartography,
     safeExtendedMemory] =
     await Promise.all([
       artifact(wasmPath),
@@ -491,6 +544,7 @@ export async function createClientRecertificationEvidence(
         qualificationEvidence,
       ),
       collectedEvidence(doubleClickPath, "doubleClick", doubleClickEvidence),
+      collectedEvidence(cartographyPath, "cartography", cartographyEvidence),
       collectedEvidence(
         extendedMemoryPath,
         "extendedMemory",
@@ -503,6 +557,8 @@ export async function createClientRecertificationEvidence(
       && safeQualification.officialSha256 !== wasm.sha256)
     || (safeDoubleClick.status === "proved"
       && safeDoubleClick.officialSha256 !== wasm.sha256)
+    || (safeCartography.status === "proved"
+      && safeCartography.officialSha256 !== wasm.sha256)
     || (safeExtendedMemory.status === "proved"
       && safeExtendedMemory.jsInputSha256 !== js.sha256)) {
     throw new Error("evidence files do not describe the supplied official artifacts");
@@ -526,11 +582,13 @@ export async function createClientRecertificationEvidence(
       safeRuntime,
       safeQualification,
       safeDoubleClick,
+      safeCartography,
       safeExtendedMemory,
     ),
     runtime: safeRuntime,
     qualification: safeQualification,
     nativeDoubleClick: safeDoubleClick,
+    cartography: safeCartography,
     extendedMemory: safeExtendedMemory,
   });
 }

--- a/src/main/certification/cartography-spike-client.ts
+++ b/src/main/certification/cartography-spike-client.ts
@@ -14,11 +14,18 @@ import {
 } from "./pathing-spike-transform.js";
 import type { CartographySpikeBuild } from "./cartography-spike-verifier.js";
 
-export type CartographySpikePreparation = Readonly<{
-  wasmPath: string;
-  wasmSha256: string;
-  error: unknown | null;
-}>;
+export type CartographySpikePreparation =
+  | Readonly<{
+      status: "active";
+      wasmPath: string;
+      wasmSha256: string;
+    }>
+  | Readonly<{
+      status: "unavailable";
+      wasmPath: string;
+      wasmSha256: string;
+      error: unknown;
+    }>;
 
 /** Prepare Cartography only from an isolated semantic certificate. */
 export async function prepareCartographySpike(
@@ -34,6 +41,7 @@ export async function prepareCartographySpike(
   if (!build) {
     await discardDerivedWasm(cacheRoot).catch(() => undefined);
     return Object.freeze({
+      status: "unavailable",
       wasmPath,
       wasmSha256,
       error: new Error(`Cartography semantic proof refused input ${wasmSha256}`),
@@ -55,15 +63,20 @@ export async function prepareCartographySpike(
   };
   try {
     return Object.freeze({
+      status: "active",
       wasmPath: await prepareDerivedWasm(
         wasmPath,
         cache,
         (input) => transformCartographySpikeWasm(input, build.memoryLayout),
       ),
       wasmSha256: build.outputSha256,
-      error: null,
     });
   } catch (error) {
-    return Object.freeze({ wasmPath, wasmSha256, error });
+    return Object.freeze({
+      status: "unavailable",
+      wasmPath,
+      wasmSha256,
+      error,
+    });
   }
 }

--- a/src/main/certification/cartography-spike-client.ts
+++ b/src/main/certification/cartography-spike-client.ts
@@ -11,48 +11,8 @@ import {
 import {
   CARTOGRAPHY_SPIKE_TRANSFORM_ABI,
   transformCartographySpikeWasm,
-  type CartographyMemoryLayoutId,
 } from "./pathing-spike-transform.js";
-
-interface CertifiedCartographyBuild {
-  readonly memoryLayout: CartographyMemoryLayoutId;
-  readonly outputSha256: string;
-}
-
-/**
- * Exact outputs of the finite client chains we ship. A transform change must
- * be independently recertified and update these seals before it can run.
- */
-const CERTIFIED_CARTOGRAPHY_BUILDS: ReadonlyMap<string, CertifiedCartographyBuild> = new Map([
-  [
-    "62267d95b30752823aa364c289bdc84f2c025dac4caeda86a76a432001667acb",
-    {
-      memoryLayout: "relocated",
-      outputSha256: "946a12cac572ba93149cc5d1e12c7e9976aad93b29fe771f9d82c001ddab38ef",
-    },
-  ],
-  [
-    "e22c2c0876f1381a133fbb0c739f73f9fc6a7d8988da5ce0d9789481ab7f0c9e",
-    {
-      memoryLayout: "relocated",
-      outputSha256: "250007f511c495047661736b50cc12cee1f86a317d9698de09fa8beb6ced16c0",
-    },
-  ],
-  [
-    "e00e8368a1d0e1003bf1882dce2d4b3cd8e2e8b6c4acc72474c8b56e2e35c6bb",
-    {
-      memoryLayout: "official",
-      outputSha256: "6f546f13bdb2ef6ec4118a5b1550b2523f178fc0a61061896037a44f3ac89659",
-    },
-  ],
-  [
-    "7db72c8d5b4864fb4526e1455edfee3755887a242f68ec1c2f8447cfb38ad281",
-    {
-      memoryLayout: "relocated",
-      outputSha256: "1892f597d53988b5b541a7ca7997da8fc6758f0793e464293ba5f619152e6583",
-    },
-  ],
-]);
+import type { CartographySpikeBuild } from "./cartography-spike-verifier.js";
 
 export type CartographySpikePreparation = Readonly<{
   wasmPath: string;
@@ -60,19 +20,23 @@ export type CartographySpikePreparation = Readonly<{
   error: unknown | null;
 }>;
 
-/** Prepare Cartography only for an exact, independently sealed client chain. */
+/** Prepare Cartography only from an isolated semantic certificate. */
 export async function prepareCartographySpike(
   wasmPath: string,
   wasmSha256: string,
   cacheRoot: string,
+  verifyLocally: (options: {
+    wasmPath: string;
+    inputSha256: string;
+  }) => Promise<CartographySpikeBuild | null> = async () => null,
 ): Promise<CartographySpikePreparation> {
-  const build = CERTIFIED_CARTOGRAPHY_BUILDS.get(wasmSha256);
+  const build = await verifyLocally({ wasmPath, inputSha256: wasmSha256 });
   if (!build) {
     await discardDerivedWasm(cacheRoot).catch(() => undefined);
     return Object.freeze({
       wasmPath,
       wasmSha256,
-      error: new Error(`uncertified Cartography input ${wasmSha256}`),
+      error: new Error(`Cartography semantic proof refused input ${wasmSha256}`),
     });
   }
   const cache: DerivedWasmCache = {

--- a/src/main/certification/cartography-spike-verifier.ts
+++ b/src/main/certification/cartography-spike-verifier.ts
@@ -23,6 +23,10 @@ import {
 import { enhancementProofContext } from "./wasm-evidence.js";
 
 const SHA256 = /^[0-9a-f]{64}$/;
+const MEMORY_LAYOUT_IDS: readonly CartographyMemoryLayoutId[] = [
+  "official",
+  "relocated",
+];
 
 export interface CartographySpikeBuild {
   readonly inputSha256: string;
@@ -44,16 +48,17 @@ function matchingMemoryLayout(input: Uint8Array): CartographyMemoryLayoutId | nu
   const preGame = derivePreGameControls(context, playRegion);
   if (!preGame) return null;
 
-  const matches = Object.entries(CARTOGRAPHY_MEMORY_LAYOUTS).filter(([, layout]) =>
-    layout.frameArray === preGame.layout.frameArray
-    && layout.frameCount === preGame.layout.frameCount
-    && layout.contextRoot === playRegion.contextRoot
-    && layout.areaInfo === playRegion.areaInfo
-    && (layout === CARTOGRAPHY_MEMORY_LAYOUTS.official
-      ? observation.agentArray === 0x5a4de8
-      : observation.agentArray === 0x5a6928),
-  );
-  return matches.length === 1 ? matches[0]![0] as CartographyMemoryLayoutId : null;
+  const matches = MEMORY_LAYOUT_IDS.filter((memoryLayout) => {
+    const layout = CARTOGRAPHY_MEMORY_LAYOUTS[memoryLayout];
+    return (
+      layout.frameArray === preGame.layout.frameArray
+      && layout.frameCount === preGame.layout.frameCount
+      && layout.contextRoot === playRegion.contextRoot
+      && layout.areaInfo === playRegion.areaInfo
+      && layout.agentArray === observation.agentArray
+    );
+  });
+  return matches.length === 1 ? matches[0] ?? null : null;
 }
 
 /** Derive one exact Cartography transaction from semantically unchanged input. */

--- a/src/main/certification/cartography-spike-verifier.ts
+++ b/src/main/certification/cartography-spike-verifier.ts
@@ -1,0 +1,91 @@
+/**
+ * Isolated semantic qualification for the Cartography transform.
+ *
+ * Cartography is not tied to a whole-client hash. Instead, the verifier proves
+ * the exact frame, game-context, area-table, and agent-array layout consumed by
+ * the transform and sealed reachability kernel. The main process receives only
+ * this bounded certificate and independently reproduces its exact output.
+ */
+import { createHash } from "node:crypto";
+import { derivePreGameControls } from "./enhancement-pre-game-proof.js";
+import {
+  deriveObservationLayout,
+  derivePlayRegionLayout,
+} from "./enhancement-target-proof.js";
+import {
+  CARTOGRAPHY_MEMORY_LAYOUTS,
+} from "./cartography-transform-internals.js";
+import {
+  CARTOGRAPHY_SPIKE_TRANSFORM_ABI,
+  transformCartographySpikeWasm,
+  type CartographyMemoryLayoutId,
+} from "./pathing-spike-transform.js";
+import { enhancementProofContext } from "./wasm-evidence.js";
+
+const SHA256 = /^[0-9a-f]{64}$/;
+
+export interface CartographySpikeBuild {
+  readonly inputSha256: string;
+  readonly transformAbi: typeof CARTOGRAPHY_SPIKE_TRANSFORM_ABI;
+  readonly memoryLayout: CartographyMemoryLayoutId;
+  readonly outputSha256: string;
+}
+
+const sha256 = (bytes: Uint8Array): string =>
+  createHash("sha256").update(bytes).digest("hex");
+
+function matchingMemoryLayout(input: Uint8Array): CartographyMemoryLayoutId | null {
+  const context = enhancementProofContext(input);
+  if (!context) return null;
+  const module = context.moduleView();
+  const playRegion = derivePlayRegionLayout(module);
+  const observation = deriveObservationLayout(module);
+  if (!playRegion || !observation) return null;
+  const preGame = derivePreGameControls(context, playRegion);
+  if (!preGame) return null;
+
+  const matches = Object.entries(CARTOGRAPHY_MEMORY_LAYOUTS).filter(([, layout]) =>
+    layout.frameArray === preGame.layout.frameArray
+    && layout.frameCount === preGame.layout.frameCount
+    && layout.contextRoot === playRegion.contextRoot
+    && layout.areaInfo === playRegion.areaInfo
+    && (layout === CARTOGRAPHY_MEMORY_LAYOUTS.official
+      ? observation.agentArray === 0x5a4de8
+      : observation.agentArray === 0x5a6928),
+  );
+  return matches.length === 1 ? matches[0]![0] as CartographyMemoryLayoutId : null;
+}
+
+/** Derive one exact Cartography transaction from semantically unchanged input. */
+export function deriveCartographySpikeBuild(
+  input: Uint8Array,
+): CartographySpikeBuild | null {
+  try {
+    const memoryLayout = matchingMemoryLayout(input);
+    if (!memoryLayout) return null;
+    return Object.freeze({
+      inputSha256: sha256(input),
+      transformAbi: CARTOGRAPHY_SPIKE_TRANSFORM_ABI,
+      memoryLayout,
+      outputSha256: sha256(transformCartographySpikeWasm(input, memoryLayout)),
+    });
+  } catch {
+    return null;
+  }
+}
+
+/** Validate the small record returned across the utility-process boundary. */
+export function isCartographySpikeBuild(
+  value: unknown,
+  inputSha256: string,
+): value is CartographySpikeBuild {
+  if (!value || typeof value !== "object") return false;
+  const build = value as Partial<CartographySpikeBuild>;
+  return Object.keys(value).length === 4
+    && build.inputSha256 === inputSha256
+    && SHA256.test(build.inputSha256)
+    && build.transformAbi === CARTOGRAPHY_SPIKE_TRANSFORM_ABI
+    && (build.memoryLayout === "official" || build.memoryLayout === "relocated")
+    && typeof build.outputSha256 === "string"
+    && SHA256.test(build.outputSha256);
+}

--- a/src/main/certification/cartography-transform-internals.ts
+++ b/src/main/certification/cartography-transform-internals.ts
@@ -109,6 +109,7 @@ export type CartographyMemoryLayout = Readonly<{
   frameCount: number;
   contextRoot: number;
   areaInfo: number;
+  agentArray: number;
 }>;
 
 export const CARTOGRAPHY_MEMORY_LAYOUTS = Object.freeze({
@@ -117,12 +118,14 @@ export const CARTOGRAPHY_MEMORY_LAYOUTS = Object.freeze({
     frameCount: 0x5a1fe4,
     contextRoot: 0x5a0e70,
     areaInfo: 0x1cc5c0,
+    agentArray: 0x5a4de8,
   }),
   relocated: Object.freeze({
     frameArray: 0x5a3b1c,
     frameCount: 0x5a3b24,
     contextRoot: 0x5a29b0,
     areaInfo: 0x1cc700,
+    agentArray: 0x5a6928,
   }),
 } satisfies Readonly<Record<"official" | "relocated", CartographyMemoryLayout>>);
 

--- a/src/main/certification/client-module.ts
+++ b/src/main/certification/client-module.ts
@@ -44,6 +44,7 @@ import {
 } from "./enhancement-builds.js";
 import { transformEnhancementWasm } from "./enhancement-transform.js";
 import { prepareCartographySpike } from "./cartography-spike-client.js";
+import type { CartographySpikeBuild } from "./cartography-spike-verifier.js";
 import { SEMANTIC_VERIFIER_ABI } from "./semantic-proof.js";
 import {
   nativeDoubleClickOutputSha256,
@@ -94,6 +95,8 @@ interface PreparedWasmClientModule {
   readonly nativeDoubleClick: boolean;
   /** Whether the served module carries the certified Cartography observers. */
   readonly cartography: boolean;
+  /** Independent refusal detail; an earlier transform failure must not hide it. */
+  readonly cartographyError: unknown | null;
 }
 
 function productCapabilityCount(capabilities: EnhancementCapabilities): number {
@@ -157,7 +160,13 @@ export interface PrepareClientModuleOptions {
   readonly compatibilityCacheRoot: string;
   readonly enhancementCacheRoot: string;
   /** Omitted only for diagnostic profiles that require the untouched client. */
-  readonly cartographySpike?: Readonly<{ cacheRoot: string }>;
+  readonly cartographySpike?: Readonly<{
+    cacheRoot: string;
+    verifyLocally: (options: {
+      wasmPath: string;
+      inputSha256: string;
+    }) => Promise<CartographySpikeBuild | null>;
+  }>;
   readonly nativeDoubleClickCacheRoot: string;
   readonly extendedMemoryCacheRoot: string;
   readonly extendedMemoryEnabled: boolean;
@@ -310,6 +319,7 @@ export async function prepareClientModule(
         certified.wasmPath,
         certified.wasmSha256,
         options.cartographySpike.cacheRoot,
+        options.cartographySpike.verifyLocally,
       )
     : null;
   const cartographyPrepared: PreparedWasmClientModule = cartography === null
@@ -319,6 +329,7 @@ export async function prepareClientModule(
         wasmPath: cartography.wasmPath,
         wasmSha256: cartography.wasmSha256,
         cartography: cartography.error === null,
+        cartographyError: cartography.error,
         failure: cartography.error === null
           ? certified.failure
           : certified.failure ?? { stage: "cartography", error: cartography.error },
@@ -443,6 +454,7 @@ async function prepareCertifiedChain(
       requestedCapabilities,
       effectiveCapabilities: NO_ENHANCEMENT_CAPABILITIES,
       cartography: false,
+      cartographyError: null,
       nativeDoubleClick: false,
       failure: fileFailure ?? cleanupFailure,
     };
@@ -458,6 +470,7 @@ async function prepareCertifiedChain(
       requestedCapabilities,
       effectiveCapabilities: NO_ENHANCEMENT_CAPABILITIES,
       cartography: false,
+      cartographyError: null,
       nativeDoubleClick: false,
       failure: {
         stage: "enhancement",
@@ -475,6 +488,7 @@ async function prepareCertifiedChain(
       requestedCapabilities,
       effectiveCapabilities: NO_ENHANCEMENT_CAPABILITIES,
       cartography: false,
+      cartographyError: null,
       nativeDoubleClick: false,
       failure: await discardEnhancementCache(enhancementCacheRoot),
     };
@@ -499,6 +513,7 @@ async function prepareCertifiedChain(
         requestedCapabilities,
         effectiveCapabilities: candidate,
         cartography: false,
+        cartographyError: null,
         nativeDoubleClick: false,
         failure: firstFailure === null
           ? fileFailure
@@ -516,6 +531,7 @@ async function prepareCertifiedChain(
     requestedCapabilities,
     effectiveCapabilities: NO_ENHANCEMENT_CAPABILITIES,
     cartography: false,
+    cartographyError: null,
     nativeDoubleClick: false,
     failure: firstFailure === null
       ? null

--- a/src/main/certification/client-module.ts
+++ b/src/main/certification/client-module.ts
@@ -73,10 +73,14 @@ export interface ClientModulePreparationFailure {
   readonly stage:
     | "template-save"
     | "enhancement"
-    | "cartography"
     | "native-double-click";
   readonly error: unknown;
 }
+
+export type CartographyPreparationMode =
+  | { readonly status: "disabled" }
+  | { readonly status: "active" }
+  | { readonly status: "unavailable"; readonly error: unknown };
 
 interface PreparedWasmClientModule {
   readonly wasmPath: string;
@@ -93,10 +97,8 @@ interface PreparedWasmClientModule {
    * renderer's switch and not merely a report.
    */
   readonly nativeDoubleClick: boolean;
-  /** Whether the served module carries the certified Cartography observers. */
-  readonly cartography: boolean;
-  /** Independent refusal detail; an earlier transform failure must not hide it. */
-  readonly cartographyError: unknown | null;
+  /** The single authority for Cartography preparation and its refusal reason. */
+  readonly cartography: CartographyPreparationMode;
 }
 
 function productCapabilityCount(capabilities: EnhancementCapabilities): number {
@@ -322,18 +324,20 @@ export async function prepareClientModule(
         options.cartographySpike.verifyLocally,
       )
     : null;
-  const cartographyPrepared: PreparedWasmClientModule = cartography === null
-    ? certified
-    : {
-        ...certified,
-        wasmPath: cartography.wasmPath,
-        wasmSha256: cartography.wasmSha256,
-        cartography: cartography.error === null,
-        cartographyError: cartography.error,
-        failure: cartography.error === null
-          ? certified.failure
-          : certified.failure ?? { stage: "cartography", error: cartography.error },
-      };
+  let cartographyPrepared: PreparedWasmClientModule = certified;
+  if (cartography?.status === "active") {
+    cartographyPrepared = {
+      ...certified,
+      wasmPath: cartography.wasmPath,
+      wasmSha256: cartography.wasmSha256,
+      cartography: { status: "active" },
+    };
+  } else if (cartography?.status === "unavailable") {
+    cartographyPrepared = {
+      ...certified,
+      cartography: { status: "unavailable", error: cartography.error },
+    };
+  }
   const prepared = await withNativeDoubleClick(
     cartographyPrepared,
     options.nativeDoubleClickCacheRoot,
@@ -453,8 +457,7 @@ async function prepareCertifiedChain(
       enhancementBuild: null,
       requestedCapabilities,
       effectiveCapabilities: NO_ENHANCEMENT_CAPABILITIES,
-      cartography: false,
-      cartographyError: null,
+      cartography: { status: "disabled" },
       nativeDoubleClick: false,
       failure: fileFailure ?? cleanupFailure,
     };
@@ -469,8 +472,7 @@ async function prepareCertifiedChain(
       enhancementBuild: null,
       requestedCapabilities,
       effectiveCapabilities: NO_ENHANCEMENT_CAPABILITIES,
-      cartography: false,
-      cartographyError: null,
+      cartography: { status: "disabled" },
       nativeDoubleClick: false,
       failure: {
         stage: "enhancement",
@@ -487,8 +489,7 @@ async function prepareCertifiedChain(
       enhancementBuild: null,
       requestedCapabilities,
       effectiveCapabilities: NO_ENHANCEMENT_CAPABILITIES,
-      cartography: false,
-      cartographyError: null,
+      cartography: { status: "disabled" },
       nativeDoubleClick: false,
       failure: await discardEnhancementCache(enhancementCacheRoot),
     };
@@ -512,8 +513,7 @@ async function prepareCertifiedChain(
         enhancementBuild,
         requestedCapabilities,
         effectiveCapabilities: candidate,
-        cartography: false,
-        cartographyError: null,
+        cartography: { status: "disabled" },
         nativeDoubleClick: false,
         failure: firstFailure === null
           ? fileFailure
@@ -530,8 +530,7 @@ async function prepareCertifiedChain(
     enhancementBuild,
     requestedCapabilities,
     effectiveCapabilities: NO_ENHANCEMENT_CAPABILITIES,
-    cartography: false,
-    cartographyError: null,
+    cartography: { status: "disabled" },
     nativeDoubleClick: false,
     failure: firstFailure === null
       ? null

--- a/src/main/certification/local-client-verifier-host.ts
+++ b/src/main/certification/local-client-verifier-host.ts
@@ -29,6 +29,10 @@ import {
   isExtendedMemoryStructuralProof,
   type ExtendedMemoryStructuralProof,
 } from "./extended-memory.js";
+import {
+  isCartographySpikeBuild,
+  type CartographySpikeBuild,
+} from "./cartography-spike-verifier.js";
 
 const VERIFIER_TIMEOUT_MS = 5_000;
 
@@ -100,6 +104,35 @@ function runNativeDoubleClickVerifierProcess(
   });
 }
 
+function runCartographyVerifierProcess(
+  wasmPath: string,
+  inputSha256: string,
+): Promise<CartographySpikeBuild | null> {
+  return new Promise((resolve) => {
+    const entry = fileURLToPath(
+      new URL("./local-client-verifier-process.js", import.meta.url),
+    );
+    const child = utilityProcess.fork(
+      entry,
+      ["cartography", wasmPath, inputSha256],
+      { serviceName: "Guild Wars Cartography compatibility verifier" },
+    );
+    let settled = false;
+    const finish = (value: CartographySpikeBuild | null): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      child.kill();
+      resolve(value);
+    };
+    const timeout = setTimeout(() => finish(null), VERIFIER_TIMEOUT_MS);
+    child.once("message", (value: unknown) => {
+      finish(isCartographySpikeBuild(value, inputSha256) ? value : null);
+    });
+    child.once("exit", () => finish(null));
+  });
+}
+
 function runExtendedMemoryVerifierProcess(options: {
   jsPath: string;
   jsInputSha256: string;
@@ -164,6 +197,17 @@ export async function verifyNativeDoubleClickLocally(options: {
   inputSha256: string;
 }): Promise<NativeDoubleClickBuild | null> {
   return runNativeDoubleClickVerifierProcess(
+    options.wasmPath,
+    options.inputSha256,
+  ).catch(() => null);
+}
+
+/** Qualifies Cartography layout and output without parsing client bytes in Main. */
+export async function verifyCartographyLocally(options: {
+  wasmPath: string;
+  inputSha256: string;
+}): Promise<CartographySpikeBuild | null> {
+  return runCartographyVerifierProcess(
     options.wasmPath,
     options.inputSha256,
   ).catch(() => null);

--- a/src/main/certification/local-client-verifier-host.ts
+++ b/src/main/certification/local-client-verifier-host.ts
@@ -36,27 +36,22 @@ import {
 
 const VERIFIER_TIMEOUT_MS = 5_000;
 
-function runVerifierProcess(
-  officialWasmPath: string,
-  officialSha256: string,
-  requestedCapabilities: EnhancementCapabilities,
-): Promise<LocalClientVerification | null> {
+function runIsolatedVerifier<Result>(options: {
+  args: readonly string[];
+  serviceName: string;
+  accept: (value: unknown) => Result | null;
+}): Promise<Result | null> {
   return new Promise((resolve) => {
     const entry = fileURLToPath(
       new URL("./local-client-verifier-process.js", import.meta.url),
     );
     const child = utilityProcess.fork(
       entry,
-      [
-        "client",
-        officialWasmPath,
-        officialSha256,
-        enhancementCapabilityProfile(requestedCapabilities) ?? "none",
-      ],
-      { serviceName: "Guild Wars client compatibility verifier" },
+      [...options.args],
+      { serviceName: options.serviceName },
     );
     let settled = false;
-    const finish = (value: LocalClientVerification | null): void => {
+    const finish = (value: Result | null): void => {
       if (settled) return;
       settled = true;
       clearTimeout(timeout);
@@ -64,112 +59,7 @@ function runVerifierProcess(
       resolve(value);
     };
     const timeout = setTimeout(() => finish(null), VERIFIER_TIMEOUT_MS);
-    child.once("message", (value: unknown) => {
-      finish(
-        isLocalClientVerification(value, officialSha256, requestedCapabilities)
-          ? value
-          : null,
-      );
-    });
-    child.once("exit", () => finish(null));
-  });
-}
-
-function runNativeDoubleClickVerifierProcess(
-  wasmPath: string,
-  inputSha256: string,
-): Promise<NativeDoubleClickBuild | null> {
-  return new Promise((resolve) => {
-    const entry = fileURLToPath(
-      new URL("./local-client-verifier-process.js", import.meta.url),
-    );
-    const child = utilityProcess.fork(
-      entry,
-      ["native-double-click", wasmPath, inputSha256],
-      { serviceName: "Guild Wars double-click verifier" },
-    );
-    let settled = false;
-    const finish = (value: NativeDoubleClickBuild | null): void => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timeout);
-      child.kill();
-      resolve(value);
-    };
-    const timeout = setTimeout(() => finish(null), VERIFIER_TIMEOUT_MS);
-    child.once("message", (value: unknown) => {
-      finish(isDerivedNativeDoubleClickBuild(value, inputSha256) ? value : null);
-    });
-    child.once("exit", () => finish(null));
-  });
-}
-
-function runCartographyVerifierProcess(
-  wasmPath: string,
-  inputSha256: string,
-): Promise<CartographySpikeBuild | null> {
-  return new Promise((resolve) => {
-    const entry = fileURLToPath(
-      new URL("./local-client-verifier-process.js", import.meta.url),
-    );
-    const child = utilityProcess.fork(
-      entry,
-      ["cartography", wasmPath, inputSha256],
-      { serviceName: "Guild Wars Cartography compatibility verifier" },
-    );
-    let settled = false;
-    const finish = (value: CartographySpikeBuild | null): void => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timeout);
-      child.kill();
-      resolve(value);
-    };
-    const timeout = setTimeout(() => finish(null), VERIFIER_TIMEOUT_MS);
-    child.once("message", (value: unknown) => {
-      finish(isCartographySpikeBuild(value, inputSha256) ? value : null);
-    });
-    child.once("exit", () => finish(null));
-  });
-}
-
-function runExtendedMemoryVerifierProcess(options: {
-  jsPath: string;
-  jsInputSha256: string;
-  wasmPath: string;
-  wasmInputSha256: string;
-}): Promise<ExtendedMemoryStructuralProof | null> {
-  return new Promise((resolve) => {
-    const entry = fileURLToPath(
-      new URL("./local-client-verifier-process.js", import.meta.url),
-    );
-    const child = utilityProcess.fork(
-      entry,
-      [
-        "extended-memory",
-        options.jsPath,
-        options.jsInputSha256,
-        options.wasmPath,
-        options.wasmInputSha256,
-      ],
-      { serviceName: "Guild Wars extended-memory verifier" },
-    );
-    let settled = false;
-    const finish = (value: ExtendedMemoryStructuralProof | null): void => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timeout);
-      child.kill();
-      resolve(value);
-    };
-    const timeout = setTimeout(() => finish(null), VERIFIER_TIMEOUT_MS);
-    child.once("message", (value: unknown) => finish(
-      isExtendedMemoryStructuralProof(
-        value,
-        options.jsInputSha256,
-        options.wasmInputSha256,
-      ) ? value : null,
-    ));
+    child.once("message", (value: unknown) => finish(options.accept(value)));
     child.once("exit", () => finish(null));
   });
 }
@@ -184,11 +74,20 @@ export async function verifyClientLocally(options: {
   officialSha256: string;
   requestedCapabilities: EnhancementCapabilities;
 }): Promise<LocalClientVerification | null> {
-  return runVerifierProcess(
-    options.officialWasmPath,
-    options.officialSha256,
-    options.requestedCapabilities,
-  ).catch(() => null);
+  return runIsolatedVerifier({
+    args: [
+      "client",
+      options.officialWasmPath,
+      options.officialSha256,
+      enhancementCapabilityProfile(options.requestedCapabilities) ?? "none",
+    ],
+    serviceName: "Guild Wars client compatibility verifier",
+    accept: (value) => isLocalClientVerification(
+      value,
+      options.officialSha256,
+      options.requestedCapabilities,
+    ) ? value : null,
+  }).catch(() => null);
 }
 
 /** Derives a native callback record without parsing unknown bytes in Main. */
@@ -196,10 +95,13 @@ export async function verifyNativeDoubleClickLocally(options: {
   wasmPath: string;
   inputSha256: string;
 }): Promise<NativeDoubleClickBuild | null> {
-  return runNativeDoubleClickVerifierProcess(
-    options.wasmPath,
-    options.inputSha256,
-  ).catch(() => null);
+  return runIsolatedVerifier({
+    args: ["native-double-click", options.wasmPath, options.inputSha256],
+    serviceName: "Guild Wars double-click verifier",
+    accept: (value) => isDerivedNativeDoubleClickBuild(value, options.inputSha256)
+      ? value
+      : null,
+  }).catch(() => null);
 }
 
 /** Qualifies Cartography layout and output without parsing client bytes in Main. */
@@ -207,10 +109,13 @@ export async function verifyCartographyLocally(options: {
   wasmPath: string;
   inputSha256: string;
 }): Promise<CartographySpikeBuild | null> {
-  return runCartographyVerifierProcess(
-    options.wasmPath,
-    options.inputSha256,
-  ).catch(() => null);
+  return runIsolatedVerifier({
+    args: ["cartography", options.wasmPath, options.inputSha256],
+    serviceName: "Guild Wars Cartography compatibility verifier",
+    accept: (value) => isCartographySpikeBuild(value, options.inputSha256)
+      ? value
+      : null,
+  }).catch(() => null);
 }
 
 /** Qualifies the manifest-bound 4 GB pair without parsing it in Main. */
@@ -220,5 +125,19 @@ export async function verifyExtendedMemoryLocally(options: {
   wasmPath: string;
   wasmInputSha256: string;
 }): Promise<ExtendedMemoryStructuralProof | null> {
-  return runExtendedMemoryVerifierProcess(options).catch(() => null);
+  return runIsolatedVerifier({
+    args: [
+      "extended-memory",
+      options.jsPath,
+      options.jsInputSha256,
+      options.wasmPath,
+      options.wasmInputSha256,
+    ],
+    serviceName: "Guild Wars extended-memory verifier",
+    accept: (value) => isExtendedMemoryStructuralProof(
+      value,
+      options.jsInputSha256,
+      options.wasmInputSha256,
+    ) ? value : null,
+  }).catch(() => null);
 }

--- a/src/main/certification/local-client-verifier-process.ts
+++ b/src/main/certification/local-client-verifier-process.ts
@@ -30,6 +30,10 @@ import {
   deriveExtendedMemoryStructuralProof,
   isExtendedMemoryStructuralProof,
 } from "./extended-memory.js";
+import {
+  deriveCartographySpikeBuild,
+  isCartographySpikeBuild,
+} from "./cartography-spike-verifier.js";
 
 interface ParentPort {
   postMessage(value: unknown): void;
@@ -112,6 +116,16 @@ async function main(): Promise<void> {
   if (mode === "native-double-click") {
     const result = deriveNativeDoubleClickBuild(bytes);
     if (!isDerivedNativeDoubleClickBuild(result, expectedSha256)) {
+      parentPort.postMessage(null);
+      process.exitCode = 4;
+      return;
+    }
+    parentPort.postMessage(result);
+    return;
+  }
+  if (mode === "cartography") {
+    const result = deriveCartographySpikeBuild(bytes);
+    if (!isCartographySpikeBuild(result, expectedSha256)) {
       parentPort.postMessage(null);
       process.exitCode = 4;
       return;

--- a/src/main/certification/pathing-spike-proof.ts
+++ b/src/main/certification/pathing-spike-proof.ts
@@ -11,8 +11,6 @@ import {
 } from "./wasm-evidence.js";
 import type { DecodedFunction, MemoryOperandSite } from "./enhancement-evidence-types.js";
 
-const OFFICIAL_SHA256 =
-  "e00e8368a1d0e1003bf1882dce2d4b3cd8e2e8b6c4acc72474c8b56e2e35c6bb";
 const ANCHORS = Object.freeze({
   bound: "def->trapezoidCount < 1024",
   index: "index < pathMap.trapezoidCount",
@@ -158,12 +156,13 @@ function exactHash(
 }
 
 /**
- * Proves the exact official client's pathing record shape. A null result means
- * no authority, including for an equivalent-looking rebuild.
+ * Proves the exact pathing record shape. Whole-module identity is deliberately
+ * not an invariant: unrelated ArenaNet changes may alter the client hash while
+ * every pathing function and relation below remains byte-for-byte identical.
  */
 export function certifyPathingShape(input: Uint8Array): PathingShapeProof | null {
   const evidence = wasmEvidence(input);
-  if (!evidence || evidence.inputSha256 !== OFFICIAL_SHA256) return null;
+  if (!evidence) return null;
   const decoded = evidence.decodeFunctions([0x30, 1024]);
   const converter = decodedAt(decoded, EXPECTED_FUNCTIONS.converter);
   const loader = decodedAt(decoded, EXPECTED_FUNCTIONS.loader);

--- a/src/main/client-runtime.ts
+++ b/src/main/client-runtime.ts
@@ -472,7 +472,8 @@ export class ClientRuntime {
       },
     };
     gauge("wasm.templateSaveCompatible", prepared.gameFileSaving.status === "available");
-    gauge("wasm.cartographyPrepared", prepared.cartography);
+    const cartographyPrepared = prepared.cartography.status === "active";
+    gauge("wasm.cartographyPrepared", cartographyPrepared);
     gauge("enhancement.effectiveCursor", effective.nativeCursor);
     gauge("enhancement.effectiveTargetObservation", effective.targetObservation);
     gauge("enhancement.effectivePartyObservation", effective.partyObservation);
@@ -508,12 +509,12 @@ export class ClientRuntime {
         code: errorCode(prepared.failure.error),
       });
     }
-    if (prepared.cartographyError !== null) {
+    if (prepared.cartography.status === "unavailable") {
       logEvent({
         k: "wasm.cartographyPrepareFailed",
-        code: errorCode(prepared.cartographyError),
+        code: errorCode(prepared.cartography.error),
       });
-    } else if (this.options.cartographySpike) {
+    } else if (prepared.cartography.status === "active") {
       logEvent({ k: "wasm.cartographyPrepared" });
     }
     if (prepared.enhancementBuild) {
@@ -559,7 +560,7 @@ export class ClientRuntime {
       extendedMemory,
       transforms: {
         templateSave: prepared.gameFileSaving.status === "available",
-        cartography: prepared.cartography,
+        cartography: cartographyPrepared,
         nativeDoubleClick: prepared.nativeDoubleClick,
       },
       enhancementVerification: {

--- a/src/main/client-runtime.ts
+++ b/src/main/client-runtime.ts
@@ -95,6 +95,7 @@ import {
 } from "./diagnostics.js";
 import type { GamePaths } from "./paths.js";
 import {
+  verifyCartographyLocally,
   verifyClientLocally,
   verifyExtendedMemoryLocally,
   verifyNativeDoubleClickLocally,
@@ -367,7 +368,12 @@ export class ClientRuntime {
       compatibilityCacheRoot: this.options.paths.compatibility,
       enhancementCacheRoot: this.options.paths.enhancements,
       ...(this.options.cartographySpike
-        ? { cartographySpike: { cacheRoot: this.options.paths.cartographySpike } }
+        ? {
+            cartographySpike: {
+              cacheRoot: this.options.paths.cartographySpike,
+              verifyLocally: verifyCartographyLocally,
+            },
+          }
         : {}),
       nativeDoubleClickCacheRoot: this.options.paths.nativeDoubleClick,
       extendedMemoryCacheRoot: this.options.paths.extendedMemory,
@@ -466,6 +472,7 @@ export class ClientRuntime {
       },
     };
     gauge("wasm.templateSaveCompatible", prepared.gameFileSaving.status === "available");
+    gauge("wasm.cartographyPrepared", prepared.cartography);
     gauge("enhancement.effectiveCursor", effective.nativeCursor);
     gauge("enhancement.effectiveTargetObservation", effective.targetObservation);
     gauge("enhancement.effectivePartyObservation", effective.partyObservation);
@@ -500,6 +507,14 @@ export class ClientRuntime {
       logEvent({ k: "wasm.nativeDoubleClickPrepareFailed",
         code: errorCode(prepared.failure.error),
       });
+    }
+    if (prepared.cartographyError !== null) {
+      logEvent({
+        k: "wasm.cartographyPrepareFailed",
+        code: errorCode(prepared.cartographyError),
+      });
+    } else if (this.options.cartographySpike) {
+      logEvent({ k: "wasm.cartographyPrepared" });
     }
     if (prepared.enhancementBuild) {
       logEvent({ k: "enhancement.clientPrepared",

--- a/src/main/diagnostics/schema-app-update.ts
+++ b/src/main/diagnostics/schema-app-update.ts
@@ -735,6 +735,18 @@ export const APP_AND_UPDATE_EVENT_SCHEMA = {
     level: "warn",
     fields: { code },
   },
+  "wasm.cartographyPrepareFailed": {
+    scope: "app",
+    subsystem: "wasm",
+    level: "warn",
+    fields: { code },
+  },
+  "wasm.cartographyPrepared": {
+    scope: "app",
+    subsystem: "wasm",
+    level: "info",
+    fields: none,
+  },
   "wasm.extendedMemory": {
     scope: "app",
     subsystem: "wasm",

--- a/src/tools/certification.ts
+++ b/src/tools/certification.ts
@@ -35,6 +35,8 @@ import { transformEnhancementWasm } from "../main/certification/enhancement-tran
 import {
   deriveNativeDoubleClickBuild,
 } from "../main/certification/native-double-click.js";
+import { deriveCartographySpikeBuild } from
+  "../main/certification/cartography-spike-verifier.js";
 import { preparePostTemplateSaveModule } from "../main/certification/template-save-verifier.js";
 import {
   isLocalClientVerification,
@@ -77,7 +79,8 @@ const USAGE =
   + "  template [PATH/Gw.jspi.wasm] [--emit-ts] [--write] [--expect-certified]\n"
   + "                                       re-derive the template-save build entry\n"
   + "  transform INPUT.wasm OUTPUT.wasm     write the derived Enhancement module\n"
-  + "  double-click [PATH/Gw.jspi.wasm]     prove the native double-click route\n";
+  + "  double-click [PATH/Gw.jspi.wasm]     prove the native double-click route\n"
+  + "  cartography [PATH/Gw.jspi.wasm]      prove every Cartography runtime input\n";
 
 /**
  * The one fixed profile the command line emits. The other certified profiles
@@ -322,16 +325,17 @@ async function transform(argv: readonly string[]): Promise<void> {
   })}\n`);
 }
 
-/**
- * Proves the native double-click route against each output of the whole chain.
- * Each result is one exact input/output transaction; there is no Cartesian
- * predecessor table to update when an unrelated capability profile changes.
- */
-async function doubleClick(argv: readonly string[]): Promise<void> {
-  const [filename] = positionalArguments(argv);
-  const official = new Uint8Array(
-    await readFile(filename ?? installedClientArtifact()),
-  );
+interface RuntimePredecessor {
+  readonly profile: string;
+  readonly bytes: Uint8Array;
+  readonly enhancementInputSha256?: string;
+}
+
+/** One canonical enumeration of every module the runtime can serve. */
+function runtimePredecessors(official: Uint8Array): Readonly<{
+  officialSha256: string;
+  predecessors: readonly RuntimePredecessor[];
+}> {
   const officialSha256 = createHash("sha256").update(official).digest("hex");
   const verification = verifyLocalClientBytes(official);
   const templateBuild = verification.templateSaveBuild;
@@ -341,11 +345,7 @@ async function doubleClick(argv: readonly string[]): Promise<void> {
   const enhancementInputSha256 = createHash("sha256")
     .update(selectedInput)
     .digest("hex");
-  const predecessors: Array<Readonly<{
-    profile: string;
-    bytes: Uint8Array;
-    enhancementInputSha256?: string;
-  }>> = [
+  const predecessors: RuntimePredecessor[] = [
     { profile: templateBuild ? "file-compatible" : "official", bytes: selectedInput },
   ];
   for (const [launch, capabilities] of Object.entries(
@@ -361,6 +361,20 @@ async function doubleClick(argv: readonly string[]): Promise<void> {
       enhancementInputSha256,
     });
   }
+  return Object.freeze({ officialSha256, predecessors: Object.freeze(predecessors) });
+}
+
+/**
+ * Proves the native double-click route against each output of the whole chain.
+ * Each result is one exact input/output transaction; there is no Cartesian
+ * predecessor table to update when an unrelated capability profile changes.
+ */
+async function doubleClick(argv: readonly string[]): Promise<void> {
+  const [filename] = positionalArguments(argv);
+  const official = new Uint8Array(
+    await readFile(filename ?? installedClientArtifact()),
+  );
+  const { officialSha256, predecessors } = runtimePredecessors(official);
   const chains: Array<Readonly<{
     profile: string;
     inputSha256: string;
@@ -399,6 +413,36 @@ async function doubleClick(argv: readonly string[]): Promise<void> {
   }
 }
 
+/** Proves Cartography against every predecessor the release can serve. */
+async function cartography(argv: readonly string[]): Promise<void> {
+  const [filename] = positionalArguments(argv);
+  const official = new Uint8Array(
+    await readFile(filename ?? installedClientArtifact()),
+  );
+  const { officialSha256, predecessors } = runtimePredecessors(official);
+  const chains = predecessors.flatMap(({ profile, bytes }) => {
+    const build = deriveCartographySpikeBuild(bytes);
+    return build ? [{
+      profile,
+      inputSha256: build.inputSha256,
+      outputSha256: build.outputSha256,
+      memoryLayout: build.memoryLayout,
+    }] : [];
+  });
+  const completeProof = chains.length === predecessors.length;
+  process.stdout.write(`${JSON.stringify({
+    officialSha256,
+    chains,
+    completeProof,
+  }, null, 2)}\n`);
+  if (!completeProof) {
+    process.stderr.write(
+      "certification cartography: one or more runtime inputs did not prove\n",
+    );
+    process.exitCode = 1;
+  }
+}
+
 const COMMANDS = Object.freeze({
   doctor,
   recertify,
@@ -407,6 +451,7 @@ const COMMANDS = Object.freeze({
   template,
   transform,
   "double-click": doubleClick,
+  cartography,
 });
 
 // The subcommand name is argv, so the lookup has to be closed over own

--- a/tests/client-artifact/cartography-spike-client.test.ts
+++ b/tests/client-artifact/cartography-spike-client.test.ts
@@ -7,6 +7,8 @@ import { join } from "node:path";
 import test from "node:test";
 import { prepareCartographySpike } from
   "../../src/main/certification/cartography-spike-client.js";
+import { deriveCartographySpikeBuild } from
+  "../../src/main/certification/cartography-spike-verifier.js";
 import { verifyLocalClientBytes } from
   "../../src/main/certification/local-client-verifier.js";
 import { rewriteTemplateSaveWasm } from
@@ -15,6 +17,15 @@ import { rewriteTemplateSaveWasm } from
 const sha256 = (bytes: Uint8Array): string =>
   createHash("sha256").update(bytes).digest("hex");
 
+const verifyCartography = async ({ wasmPath, inputSha256 }: {
+  wasmPath: string;
+  inputSha256: string;
+}) => {
+  const input = new Uint8Array(await readFile(wasmPath));
+  assert.equal(sha256(input), inputSha256);
+  return deriveCartographySpikeBuild(input);
+};
+
 test("prepares and reuses the certified cartography client", async () => {
   const artifact = process.env.GW_CLIENT_WASM;
   assert.ok(artifact, "GW_CLIENT_WASM must name the retained official artifact");
@@ -22,12 +33,16 @@ test("prepares and reuses the certified cartography client", async () => {
   const inputSha256 = sha256(official);
   const cacheRoot = await mkdtemp(join(tmpdir(), "gwonmac-cartography-spike-"));
   try {
-    const first = await prepareCartographySpike(artifact, inputSha256, cacheRoot);
+    const first = await prepareCartographySpike(
+      artifact, inputSha256, cacheRoot, verifyCartography,
+    );
     assert.equal(first.error, null);
     assert.notEqual(first.wasmPath, artifact);
     assert.equal(sha256(new Uint8Array(await readFile(first.wasmPath))), first.wasmSha256);
 
-    const second = await prepareCartographySpike(artifact, inputSha256, cacheRoot);
+    const second = await prepareCartographySpike(
+      artifact, inputSha256, cacheRoot, verifyCartography,
+    );
     assert.deepEqual(second, first);
   } finally {
     await rm(cacheRoot, { recursive: true, force: true });
@@ -49,6 +64,7 @@ test("prepares the sealed template-only fallback chain", async () => {
       templatePath,
       sha256(template),
       join(root, "cache"),
+      verifyCartography,
     );
     assert.equal(prepared.error, null);
     assert.equal(sha256(await readFile(prepared.wasmPath)), prepared.wasmSha256);

--- a/tests/client-artifact/cartography-spike-client.test.ts
+++ b/tests/client-artifact/cartography-spike-client.test.ts
@@ -36,7 +36,7 @@ test("prepares and reuses the certified cartography client", async () => {
     const first = await prepareCartographySpike(
       artifact, inputSha256, cacheRoot, verifyCartography,
     );
-    assert.equal(first.error, null);
+    assert.equal(first.status, "active");
     assert.notEqual(first.wasmPath, artifact);
     assert.equal(sha256(new Uint8Array(await readFile(first.wasmPath))), first.wasmSha256);
 
@@ -66,7 +66,7 @@ test("prepares the sealed template-only fallback chain", async () => {
       join(root, "cache"),
       verifyCartography,
     );
-    assert.equal(prepared.error, null);
+    assert.equal(prepared.status, "active");
     assert.equal(sha256(await readFile(prepared.wasmPath)), prepared.wasmSha256);
   } finally {
     await rm(root, { recursive: true, force: true });

--- a/tests/client-artifact/client-chain-qualification.test.ts
+++ b/tests/client-artifact/client-chain-qualification.test.ts
@@ -118,7 +118,7 @@ test("every shipped runtime profile reproduces the real client chain", async () 
     try {
       const prepared = await prepare();
       assert.equal(prepared.failure, null);
-      assert.equal(prepared.cartography, true);
+      assert.deepEqual(prepared.cartography, { status: "active" });
       assert.equal(prepared.nativeDoubleClick, true);
       assert.equal(prepared.extendedMemory.status, "active");
       assert.deepEqual(prepared.effectiveCapabilities, capabilities);
@@ -129,7 +129,7 @@ test("every shipped runtime profile reproduces the real client chain", async () 
       await writeFile(prepared.wasmPath, "stale release qualification cache");
       const rebuilt = await prepare();
       assert.equal(rebuilt.failure, null);
-      assert.equal(rebuilt.cartography, true);
+      assert.deepEqual(rebuilt.cartography, { status: "active" });
       assert.equal(rebuilt.nativeDoubleClick, true);
       assert.equal(rebuilt.extendedMemory.status, "active");
       assert.equal(rebuilt.wasmSha256, prepared.wasmSha256);

--- a/tests/client-artifact/client-chain-qualification.test.ts
+++ b/tests/client-artifact/client-chain-qualification.test.ts
@@ -21,6 +21,8 @@ import {
   isDerivedNativeDoubleClickBuild,
   rewriteNativeDoubleClickWasm,
 } from "../../src/main/certification/native-double-click.js";
+import { deriveCartographySpikeBuild } from
+  "../../src/main/certification/cartography-spike-verifier.js";
 import {
   deriveExtendedMemoryStructuralProof,
   rewriteExtendedMemoryWasm,
@@ -89,7 +91,14 @@ test("every shipped runtime profile reproduces the real client chain", async () 
       enhancementCapabilities: capabilities,
       compatibilityCacheRoot: join(cacheRoot, "file"),
       enhancementCacheRoot: join(cacheRoot, "enhancement"),
-      cartographySpike: { cacheRoot: join(cacheRoot, "cartography") },
+      cartographySpike: {
+        cacheRoot: join(cacheRoot, "cartography"),
+        verifyLocally: async ({ wasmPath, inputSha256 }) => {
+          const input = new Uint8Array(await readFile(wasmPath));
+          assert.equal(sha256(input), inputSha256);
+          return deriveCartographySpikeBuild(input);
+        },
+      },
       nativeDoubleClickCacheRoot: join(cacheRoot, "double-click"),
       extendedMemoryCacheRoot: join(cacheRoot, "memory"),
       extendedMemoryEnabled: true,

--- a/tests/client-artifact/pathing-spike-transform.test.ts
+++ b/tests/client-artifact/pathing-spike-transform.test.ts
@@ -5,6 +5,8 @@ import { readFile } from "node:fs/promises";
 import test from "node:test";
 import { transformCartographySpikeWasm } from
   "../../src/main/certification/pathing-spike-transform.js";
+import { deriveCartographySpikeBuild } from
+  "../../src/main/certification/cartography-spike-verifier.js";
 import { wasmEvidence } from "../../src/main/certification/wasm-evidence.js";
 import {
   CARTOGRAPHY_CONTEXT_GLOBALS,
@@ -25,9 +27,11 @@ test("the certified context is added without intercepting native pathing", {
   const artifact = process.env.GW_CLIENT_WASM;
   assert.ok(artifact, "GW_CLIENT_WASM must name the exact official artifact");
   const official = new Uint8Array(await readFile(artifact));
-  assert.equal(sha256(official), "e00e8368a1d0e1003bf1882dce2d4b3cd8e2e8b6c4acc72474c8b56e2e35c6bb");
   const before = official.slice();
-  const transformed = transformCartographySpikeWasm(official, "official");
+  const build = deriveCartographySpikeBuild(official);
+  assert.ok(build, "the current client must prove its Cartography layout");
+  const transformed = transformCartographySpikeWasm(official, build.memoryLayout);
+  assert.equal(sha256(transformed), build.outputSha256);
   assert.deepEqual(official, before, "the predecessor module was mutated");
 
   const evidence = wasmEvidence(transformed);

--- a/tests/electron/fixtures/local-verifier-app/main.mjs
+++ b/tests/electron/fixtures/local-verifier-app/main.mjs
@@ -8,6 +8,7 @@ const hostUrl = new URL(
   import.meta.url,
 );
 const {
+  verifyCartographyLocally,
   verifyClientLocally,
   verifyExtendedMemoryLocally,
   verifyNativeDoubleClickLocally,
@@ -40,6 +41,11 @@ void app.whenReady().then(async () => {
       })
     : mode === "native-double-click"
     ? await verifyNativeDoubleClickLocally({
+        wasmPath: officialWasmPath,
+        inputSha256: officialSha256,
+      })
+    : mode === "cartography"
+    ? await verifyCartographyLocally({
         wasmPath: officialWasmPath,
         inputSha256: officialSha256,
       })

--- a/tests/electron/local-client-verifier.spec.ts
+++ b/tests/electron/local-client-verifier.spec.ts
@@ -101,6 +101,42 @@ test("refuses an unknown native callback inside the isolated process", async () 
   }
 });
 
+test("refuses changed Cartography input inside the isolated process", async () => {
+  const root = await mkdtemp(path.join(tmpdir(), "gw-cartography-verifier-"));
+  const wasmPath = path.join(root, "unknown.wasm");
+  const wasm = Uint8Array.of(0, 97, 115, 109, 1, 0, 0, 0);
+  const sha256 = createHash("sha256").update(wasm).digest("hex");
+  await writeFile(wasmPath, wasm);
+  const env = Object.fromEntries(
+    Object.entries(process.env).filter(
+      (entry): entry is [string, string] =>
+        entry[1] !== undefined && entry[0] !== "ELECTRON_RUN_AS_NODE",
+    ),
+  );
+  const run = async () => {
+    const application = await electron.launch({
+      cwd: path.resolve("."),
+      args: [fixture, "cartography", wasmPath, sha256],
+      executablePath: electronPath,
+      env,
+    });
+    try {
+      await expect.poll(() => completed(application), { timeout: 10_000 }).toBe(true);
+      return await outcome(application);
+    } finally {
+      await application.close();
+    }
+  };
+
+  try {
+    expect(await run()).toBeNull();
+    await writeFile(wasmPath, Uint8Array.of(0, 97, 115, 109, 1, 0, 0, 1));
+    expect(await run()).toBeNull();
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("refuses changed 4 GB glue inside the isolated process", async () => {
   const root = await mkdtemp(path.join(tmpdir(), "gw-extended-memory-verifier-"));
   const jsPath = path.join(root, "Gw.jspi.js");

--- a/tests/unit/cartography-architecture.test.ts
+++ b/tests/unit/cartography-architecture.test.ts
@@ -67,4 +67,8 @@ test("both native owners agree on the exact finite layout roots", async () => {
     assert.equal(transform.match(new RegExp(root, "g"))?.length, 1, root);
     assert.equal(kernel.match(new RegExp(root, "g"))?.length, 1, root);
   }
+  for (const agentArray of ["0x5a4de8", "0x5a6928"]) {
+    assert.equal(transform.match(new RegExp(agentArray, "g"))?.length, 1, agentArray);
+    assert.equal(kernel.match(new RegExp(agentArray, "g"))?.length, 1, agentArray);
+  }
 });

--- a/tests/unit/cartography-spike-verifier.test.ts
+++ b/tests/unit/cartography-spike-verifier.test.ts
@@ -1,0 +1,23 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { isCartographySpikeBuild } from
+  "../../src/main/certification/cartography-spike-verifier.js";
+import { CARTOGRAPHY_SPIKE_TRANSFORM_ABI } from
+  "../../src/main/certification/pathing-spike-transform.js";
+
+const inputSha256 = "a".repeat(64);
+const outputSha256 = "b".repeat(64);
+const build = Object.freeze({
+  inputSha256,
+  transformAbi: CARTOGRAPHY_SPIKE_TRANSFORM_ABI,
+  memoryLayout: "relocated",
+  outputSha256,
+});
+
+test("accepts only an exact input-bound Cartography certificate", () => {
+  assert.equal(isCartographySpikeBuild(build, inputSha256), true);
+  assert.equal(isCartographySpikeBuild(build, "c".repeat(64)), false);
+  assert.equal(isCartographySpikeBuild({ ...build, memoryLayout: "guessed" }, inputSha256), false);
+  assert.equal(isCartographySpikeBuild({ ...build, outputSha256: "short" }, inputSha256), false);
+  assert.equal(isCartographySpikeBuild({ ...build, nativePointer: 0x5a6928 }, inputSha256), false);
+});

--- a/tests/unit/client-module.test.ts
+++ b/tests/unit/client-module.test.ts
@@ -755,8 +755,7 @@ describe("client module preparation", () => {
       enhancementBuild: null,
       requestedCapabilities: CURSOR_TOOLBOX,
       effectiveCapabilities: NO_CAPABILITIES,
-      cartography: false,
-      cartographyError: null,
+      cartography: { status: "disabled" },
       // An unrecognised client is served exactly as downloaded, so it receives
       // neither the double-click transform nor substitute touch input.
       nativeDoubleClick: false,
@@ -766,6 +765,32 @@ describe("client module preparation", () => {
       assertMissing(value.compatibilityCacheRoot),
       assertMissing(value.enhancementCacheRoot),
     ]);
+  });
+
+  it("keeps Cartography refusal independent from an earlier transform failure", async () => {
+    const value = await fixture();
+    const templateError = {
+      ...value.templateSaveBuild,
+      sha256: "0".repeat(64),
+    };
+    const prepared = await prepareClientModule({
+      ...options(
+        value,
+        { templateSaveBuild: templateError, enhancementBuild: null },
+        CURSOR_TOOLBOX,
+      ),
+      cartographySpike: {
+        cacheRoot: join(value.root, "cartography"),
+        verifyLocally: async () => null,
+      },
+    });
+
+    assert.equal(prepared.failure?.stage, "template-save");
+    assert.equal(prepared.cartography.status, "unavailable");
+    assert.equal(prepared.wasmPath, value.officialWasmPath);
+    if (prepared.cartography.status === "unavailable") {
+      assert.match(String(prepared.cartography.error), /semantic proof refused/);
+    }
   });
 
   it("serves independently certified enhancements when file proof refuses", async () => {

--- a/tests/unit/client-module.test.ts
+++ b/tests/unit/client-module.test.ts
@@ -756,6 +756,7 @@ describe("client module preparation", () => {
       requestedCapabilities: CURSOR_TOOLBOX,
       effectiveCapabilities: NO_CAPABILITIES,
       cartography: false,
+      cartographyError: null,
       // An unrecognised client is served exactly as downloaded, so it receives
       // neither the double-click transform nor substitute touch input.
       nativeDoubleClick: false,

--- a/tests/unit/client-recertification-evidence.test.ts
+++ b/tests/unit/client-recertification-evidence.test.ts
@@ -35,6 +35,7 @@ test("retains bounded generation evidence without paths or raw addresses", async
     runtime: path.join(root, "runtime.json"),
     qualification: path.join(root, "qualification.json"),
     doubleClick: path.join(root, "double-click.json"),
+    cartography: path.join(root, "cartography.json"),
     extendedMemory: path.join(root, "extended-memory.json"),
   };
   const doubleClick = {
@@ -84,6 +85,28 @@ test("retains bounded generation evidence without paths or raw addresses", async
     crossed3GiB: true,
     freedBlockReusedWithoutGrowth: true,
   };
+  const cartography = {
+    status: "proved",
+    exitCode: 0,
+    officialSha256: wasmDigest,
+    chains: [{
+      profile: "file-compatible",
+      inputSha256: fileOutputDigest,
+      outputSha256: sha256("cartography-file"),
+      memoryLayout: "relocated",
+    }, {
+      profile: "features-e01",
+      inputSha256: feature601Input,
+      outputSha256: sha256("cartography-e01"),
+      memoryLayout: "relocated",
+    }, {
+      profile: "features-fff",
+      inputSha256: feature7ffInput,
+      outputSha256: sha256("cartography-fff"),
+      memoryLayout: "relocated",
+    }],
+    completeProof: true,
+  };
   const args = [
     generation,
     files.wasm,
@@ -91,6 +114,7 @@ test("retains bounded generation evidence without paths or raw addresses", async
     files.runtime,
     files.qualification,
     files.doubleClick,
+    files.cartography,
     files.extendedMemory,
   ];
   const environment = {
@@ -136,6 +160,7 @@ test("retains bounded generation evidence without paths or raw addresses", async
         log: "must not survive",
       })),
       writeFile(files.doubleClick, JSON.stringify(doubleClick)),
+      writeFile(files.cartography, JSON.stringify(cartography)),
       writeFile(files.extendedMemory, JSON.stringify(extendedMemory)),
     ]);
     const evidence = await createClientRecertificationEvidence(args, environment);
@@ -341,6 +366,7 @@ test("rejects poison strings and contradictory proved states", async () => {
     runtime: path.join(root, "runtime.json"),
     qualification: path.join(root, "qualification.json"),
     doubleClick: path.join(root, "double-click.json"),
+    cartography: path.join(root, "cartography.json"),
     extendedMemory: path.join(root, "extended-memory.json"),
   };
   try {
@@ -379,6 +405,18 @@ test("rejects poison strings and contradictory proved states", async () => {
         }],
         completeRouteProved: false,
       })),
+      writeFile(files.cartography, JSON.stringify({
+        status: "proved",
+        exitCode: 0,
+        officialSha256: wasmDigest,
+        chains: [{
+          profile: poison,
+          inputSha256: wasmDigest,
+          outputSha256: outputDigest,
+          memoryLayout: poison,
+        }],
+        completeProof: false,
+      })),
       writeFile(files.extendedMemory, JSON.stringify({
         status: "proved",
         exitCode: 0,
@@ -402,6 +440,7 @@ test("rejects poison strings and contradictory proved states", async () => {
       files.runtime,
       files.qualification,
       files.doubleClick,
+      files.cartography,
       files.extendedMemory,
     ], {
       GITHUB_REPOSITORY: "lupinum-dev/gwonmac",
@@ -415,6 +454,7 @@ test("rejects poison strings and contradictory proved states", async () => {
       evidence.runtime,
       evidence.qualification,
       evidence.nativeDoubleClick,
+      evidence.cartography,
       evidence.extendedMemory,
     ]) {
       assert.deepEqual(section, {
@@ -435,7 +475,9 @@ test("retains artifact identities when a detailed evidence tool crashes", async 
   const root = await mkdtemp(path.join(tmpdir(), "gwonmac-client-evidence-"));
   const wasm = Uint8Array.of(0, 97, 115, 109, 1, 0, 0, 0);
   const js = "const client = true;";
-  const paths = ["runtime", "qualification", "double-click", "extended-memory"]
+  const paths = [
+    "runtime", "qualification", "double-click", "cartography", "extended-memory",
+  ]
     .map((name) => path.join(root, `${name}.json`));
   try {
     const wasmPath = path.join(root, "Gw.jspi.wasm");


### PR DESCRIPTION
## What changed

Cartography now survives ArenaNet patches that change unrelated client code. Instead of trusting one whole-module hash, an isolated verifier proves the exact Cartography functions, calls, anchors, and supported memory layout, then binds the accepted transformation to its input and output hashes.

Patch-day recertification now runs the same Cartography proof for every shipped runtime chain and records a dedicated, privacy-safe refusal reason when Cartography is the incompatible feature.

## Why

The latest skill-balance patch changed the official WASM hash without changing Cartography's participating code or memory layout. The previous static allowlist rejected the new build, so Cartography disappeared while features with semantic verification continued to work.

This removes that brittle whole-client coupling while preserving fail-closed behavior when Cartography's actual native assumptions change.

Closes #375.

## Invariant

- Main accepts only an exact, bounded Cartography certificate containing the input hash, transform ABI, supported layout ID, and locally reproduced output hash.
- The isolated verifier accepts exactly one complete known layout and proves every participating function/body/call before transformation.
- Unknown layouts, malformed certificates, changed pathing semantics, and input/output mismatches remain unavailable rather than guessed.
- No pointers, native graphs, raw client bytes, or generic memory access cross the verifier boundary.

## Delivery

Target: `main`.

Recommend a Developer Build first because this changes patch-day compatibility and certification behavior. The runtime remains fail closed if ArenaNet genuinely changes Cartography's pathing layout or participating functions.

## Verification

- `pnpm check`
- `pnpm build`
- `pnpm test:integration`
- `pnpm test:release`
- `pnpm tools:test:e2e`
- `pnpm test:electron` — 131 passed, 1 skipped, 1 unrelated macOS clipboard timing failure; the failed clipboard test passed immediately in isolation
- `node scripts/verify-companion-kernel.mjs`
- `node scripts/verify-cartography-reachability-kernel.mjs`
- Current official client Cartography qualification: all three shipped runtime profiles proved complete with exact input/output hashes and the relocated layout
- Relevant current-client artifact tests passed, including Cartography preparation/cache reuse, all runtime-chain profiles, Compass/Core/Mission Map proofs, pathing mutation refusal, transform, and template layout
- `git diff --check origin/main...HEAD`

- [x] I kept this pull request focused.
- [x] I ran the relevant checks.
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [x] I updated documentation when behavior or an invariant changed.
