### PR TITLE
feat(launcher): restore launcher from the Dock menu

### DIFF
--- a/docs/multiple-accounts.md
+++ b/docs/multiple-accounts.md
@@ -90,7 +90,8 @@ restores it at Settings. Closing the launcher hides it while a game is open.
 Closing one game affects only that profile; closing the final game reveals the
 launcher. A Dock activation restores the most recently used live window. If
 that window has closed, it falls back through the previous game windows before
-revealing the launcher.
+revealing the launcher. The Dock menu's **Show Launcher** command always
+restores the launcher at Home.
 A second app launch restores the launcher explicitly. An asynchronous Play
 completion does not steal focus if the player has already moved to another app.
 

--- a/docs/process-model.md
+++ b/docs/process-model.md
@@ -390,10 +390,10 @@ falls back through its recent-window order. Neither action creates another
 game window.
 
 Complete profile launch success hides the launcher. A launch failure keeps it
-visible. The native Window menu and Settings command can restore it while games
-run. Closing the launcher also hides it while games run. Closing one game
-window closes only that profile. Closing the final game leaves the launcher
-available.
+visible. The native Window menu, Dock menu, and Settings command can restore it
+while games run. Closing the launcher also hides it while games run. Closing
+one game window closes only that profile. Closing the final game leaves the
+launcher available.
 Application quit saves
 all live renderer filesystems in parallel, closes sockets, stops background
 work, flushes diagnostics, and exits through one bounded cleanup path.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -44,11 +44,11 @@ position in place. The cutover does not copy, move, or delete that data.
 
 The launcher hides after every selected account opens successfully. It stays
 visible if an account needs attention. Use **Window → Show Launcher** to open
-another account. **Settings…** opens launcher Settings directly. Closing one
-game affects only that account. Closing the last game shows the launcher.
-Clicking the Dock icon restores the most recent launcher or game window that
-you used. If that window has closed, the next most recent game window is
-restored.
+another account. You can also right-click the Dock icon and choose **Show
+Launcher**. **Settings…** opens launcher Settings directly. Closing one game
+affects only that account. Closing the last game shows the launcher. Clicking
+the Dock icon restores the most recent launcher or game window that you used.
+If that window has closed, the next most recent game window is restored.
 
 ## Home content
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -12,6 +12,7 @@ import {
   autoUpdater,
   type BrowserWindow,
   dialog,
+  Menu,
   Notification,
   powerMonitor,
   session,
@@ -1042,6 +1043,13 @@ if (primaryInstance) void app.whenReady().then(async () => {
     windowCoordinator,
     revealLauncher,
   );
+  app.dock?.setMenu(Menu.buildFromTemplate([
+    {
+      id: "show-launcher",
+      label: "Show Launcher",
+      click: () => revealLauncher("home"),
+    },
+  ]));
   let automaticUpdateCheckInFlight = false;
   const maybeCheckForAppUpdates = async (): Promise<void> => {
     if (automaticUpdateCheckInFlight) return;

--- a/tests/electron/multiple-accounts.spec.ts
+++ b/tests/electron/multiple-accounts.spec.ts
@@ -361,6 +361,17 @@ test("Show never duplicates a game and companion close policy stays profile-loca
         .find((win) => win.webContents.getURL().endsWith("launcher/index.html"))
         ?.isVisible(),
     )).toBe(false);
+    expect(await fixture.app.evaluate(({ app }) =>
+      app.dock?.getMenu()?.getMenuItemById("show-launcher")?.label ?? null,
+    )).toBe("Show Launcher");
+    await fixture.app.evaluate(({ app }) => {
+      app.dock?.getMenu()?.getMenuItemById("show-launcher")?.click();
+    });
+    await expect.poll(() => fixture.app.evaluate(({ BrowserWindow }) =>
+      BrowserWindow.getAllWindows()
+        .find((win) => win.webContents.getURL().endsWith("launcher/index.html"))
+        ?.isVisible(),
+    )).toBe(true);
 
     await fixture.app.evaluate(({ BrowserWindow }) => {
       BrowserWindow.getAllWindows()


### PR DESCRIPTION
After the launcher hides behind running game windows, the Dock menu has no explicit way to bring it back. Players must know about the application Window menu or close the final game.

This adds a permanent **Show Launcher** command to the macOS Dock menu. It reuses the existing launcher reveal command, so it restores Home when hidden and focuses the same launcher when already visible. No new window state or recovery path is introduced.

The account-profile, process-model, and user-guide documentation now include the Dock recovery command.

## Verification

- `pnpm run check`
- `pnpm build`
- `pnpm exec playwright test tests/electron/multiple-accounts.spec.ts --grep "Show never duplicates"`
- GitHub Application verification owns the complete macOS runtime and packaged-build gate.

## Rollout risk

Low. The command is macOS-only through Electron's optional `app.dock` API. It changes no persisted data, IPC contract, game window, or client lifecycle.

Implemented and verified with OpenAI Codex.
