### PR TITLE
fix(cartography): keep layer controls open on click

### DIFF
--- a/src/renderer/cartography-overlay-controls.css
+++ b/src/renderer/cartography-overlay-controls.css
@@ -32,6 +32,11 @@
   cursor: pointer;
 }
 
+.cartography-overlay-trigger:active,
+.cartography-overlay-trigger[aria-expanded="true"] {
+  background: var(--ui-accent-well-fill);
+}
+
 .cartography-overlay-trigger:focus-visible,
 .cartography-overlay-panel :where(button, input, select):focus-visible {
   outline: var(--ui-border-width) solid var(--ui-focus);
@@ -48,7 +53,7 @@
   position: absolute;
   width: var(--cartography-panel-width);
   box-sizing: border-box;
-  padding: var(--ui-space-3);
+  padding: var(--ui-space-2);
   color: var(--ui-text);
   background: var(--ui-panel-fill);
   border: var(--ui-frame-width) solid var(--ui-edge);
@@ -59,7 +64,7 @@
 
 .cartography-overlay-heading {
   display: block;
-  margin: 0 0 var(--ui-space-2);
+  margin: 0 0 var(--ui-space-1);
   color: var(--ui-text-bright);
   font-size: var(--ui-type-caption-size);
 }
@@ -67,8 +72,8 @@
 .cartography-overlay-layers {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  gap: var(--ui-space-2);
-  margin-bottom: var(--ui-space-3);
+  gap: var(--ui-space-1);
+  margin-bottom: var(--ui-space-2);
 }
 
 .cartography-overlay-layer {
@@ -96,19 +101,19 @@
 
 .cartography-overlay-fields {
   display: grid;
-  gap: var(--ui-space-2);
+  gap: var(--ui-space-1);
 }
 
 .cartography-overlay-field {
   display: grid;
-  grid-template-columns: 66px 1fr 30px;
+  grid-template-columns: 58px 1fr 28px;
   align-items: center;
-  gap: var(--ui-space-2);
+  gap: var(--ui-space-1);
   color: var(--ui-text-muted);
 }
 
 .cartography-overlay-field[data-kind="preset"] {
-  grid-template-columns: 66px 1fr;
+  grid-template-columns: 58px 1fr;
 }
 
 .cartography-overlay-field input[type="range"] {
@@ -127,7 +132,7 @@
 .cartography-overlay-field select {
   width: 100%;
   min-width: 0;
-  height: 28px;
+  height: 26px;
   padding: 0 var(--ui-space-1);
   color: var(--ui-text);
   background: var(--ui-well-strong-fill);
@@ -136,32 +141,24 @@
   font: var(--ui-font-weight-semibold) var(--ui-type-caption-size) / 1 var(--ui-font-interface);
 }
 
-.cartography-overlay-hint,
 .cartography-overlay-status,
 .cartography-overlay-export-status,
 .cartography-overlay-qa {
   font: var(--ui-font-weight-medium) 10px / 1.4 var(--ui-font-readable);
 }
 
-.cartography-overlay-hint {
-  margin: var(--ui-space-3) 0 0;
-  color: var(--ui-text-faint);
-}
-
-.cartography-overlay-hint kbd {
-  color: var(--ui-text-muted);
-  font-family: var(--ui-font-data);
-}
-
 .cartography-overlay-status {
-  min-height: 14px;
   margin: var(--ui-space-1) 0 0;
   color: var(--ui-warning);
 }
 
+.cartography-overlay-status:empty {
+  display: none;
+}
+
 .cartography-overlay-qa {
-  margin-top: var(--ui-space-2);
-  padding-top: var(--ui-space-2);
+  margin-top: var(--ui-space-1);
+  padding-top: var(--ui-space-1);
   border-top: var(--ui-border-width) solid var(--ui-edge);
 }
 

--- a/src/renderer/cartography-spike/overlay-controls.ts
+++ b/src/renderer/cartography-spike/overlay-controls.ts
@@ -14,11 +14,10 @@ import {
 import type { CartographyReachabilityDiagnostic } from "./reachability-kernel.js";
 import type { ScreenBox } from "./frame-placement.js";
 
-const COLLAPSE_DELAY_MS = 700;
 const CONTROL_SIZE = 30;
-const PANEL_WIDTH = 232;
-const PANEL_HEIGHT_ESTIMATE = 330;
-type OpenMode = "closed" | "transient" | "pinned";
+const PANEL_WIDTH = 204;
+const PANEL_HEIGHT_ESTIMATE = 230;
+const SAVE_CONFIRMATION_MS = 1_200;
 type Layer = "grid" | "walkability";
 
 export type CartographyQaStatus =
@@ -187,9 +186,11 @@ export function createCartographyOverlayControls(options: Readonly<{
   trigger.className = "cartography-overlay-trigger";
   trigger.setAttribute("aria-label", "Cartography layers");
   trigger.setAttribute("aria-expanded", "false");
+  trigger.setAttribute("aria-controls", "cartography-overlay-panel");
   trigger.title = "Cartography layers";
   trigger.append(layerIcon(document));
   const panel = document.createElement("div");
+  panel.id = "cartography-overlay-panel";
   panel.className = "cartography-overlay-panel";
   panel.hidden = true;
   panel.setAttribute("role", "group");
@@ -235,13 +236,6 @@ export function createCartographyOverlayControls(options: Readonly<{
   preset.setAttribute("aria-label", "Cartography preset");
   presetRow.append(presetLabel, preset);
   fields.append(presetRow);
-  const hint = document.createElement("p");
-  hint.className = "cartography-overlay-hint";
-  hint.innerHTML = [
-    "Hold <kbd>Shift</kbd> to inspect 3×3. Add <kbd>Option</kbd> for 7×7.",
-    "Numbers: solid is reachable now, outline is remembered, and ≈ is estimated.",
-    "Walkable terrain appears on Compass and Mission Map only.",
-  ].join("<br>");
   const saveStatus = document.createElement("p");
   saveStatus.className = "cartography-overlay-status";
   saveStatus.setAttribute("role", "status");
@@ -270,7 +264,7 @@ export function createCartographyOverlayControls(options: Readonly<{
   exportStatus.setAttribute("role", "status");
   exportStatus.setAttribute("aria-live", "polite");
   qa.append(qaSummary, qaRows, exportButton, exportStatus);
-  panel.append(heading, layers, fields, hint, saveStatus, qa);
+  panel.append(heading, layers, fields, saveStatus, qa);
   root.append(trigger, panel);
   options.parent.append(root);
 
@@ -278,8 +272,8 @@ export function createCartographyOverlayControls(options: Readonly<{
   let saving = false;
   let exporting = false;
   let disposed = false;
-  let mode: OpenMode = "closed";
-  let collapseTimer = 0;
+  let open = false;
+  let saveStatusTimer = 0;
   let latestBox: ScreenBox | null = null;
   let renderedLibrary: AppSettings["cartographyPresetLibrary"] | null = null;
   let renderedSettings: AppSettings | null = null;
@@ -313,20 +307,20 @@ export function createCartographyOverlayControls(options: Readonly<{
     root.style.setProperty("--cartography-trigger-color", style.grid.current.color);
   };
   const positionPanel = (): void => {
-    if (latestBox === null || mode === "closed") return;
+    if (latestBox === null || !open) return;
     const margin = 6;
     const rootTop = Number.parseFloat(root.style.top) || margin;
     panel.style.top = `${Math.round(Math.max(margin, Math.min(view.innerHeight - panelHeight - margin, rootTop + (CONTROL_SIZE - panelHeight) / 2)) - rootTop)}px`;
   };
-  const setMode = (next: OpenMode): void => {
-    mode = next;
-    panel.hidden = next === "closed";
-    trigger.setAttribute("aria-expanded", String(next !== "closed"));
-    if (next === "closed") {
+  const setOpen = (next: boolean): void => {
+    open = next;
+    panel.hidden = !next;
+    trigger.setAttribute("aria-expanded", String(next));
+    if (!next) {
       options.previewOpacity("grid", null);
       options.previewOpacity("walkability", null);
     } else positionPanel();
-    root.style.opacity = next === "closed"
+    root.style.opacity = !next
       ? String((currentSettings()?.cartographyControlIdleOpacity ?? 35) / 100) : "1";
   };
   const panelResizeObserver = typeof view.ResizeObserver === "function"
@@ -341,27 +335,24 @@ export function createCartographyOverlayControls(options: Readonly<{
     })
     : null;
   panelResizeObserver?.observe(panel);
-  const cancelCollapse = (): void => {
-    if (collapseTimer !== 0) view.clearTimeout(collapseTimer);
-    collapseTimer = 0;
-  };
-  const scheduleCollapse = (): void => {
-    if (mode !== "transient") return;
-    cancelCollapse();
-    collapseTimer = view.setTimeout(() => {
-      collapseTimer = 0;
-      if (!root.matches(":hover") && !root.contains(document.activeElement)) setMode("closed");
-    }, COLLAPSE_DELAY_MS);
+  const clearSaveStatusTimer = (): void => {
+    if (saveStatusTimer !== 0) view.clearTimeout(saveStatusTimer);
+    saveStatusTimer = 0;
   };
   const apply = (patch: RendererSettingsPatch): void => {
     const current = currentSettings();
     if (current === null || saving) return;
+    clearSaveStatusTimer();
     setSaving(true);
     saveStatus.textContent = "Saving…";
     void options.persist(patch).then((saved) => {
       if (disposed) return;
       canonical = saved;
       saveStatus.textContent = "Saved";
+      saveStatusTimer = view.setTimeout(() => {
+        saveStatusTimer = 0;
+        saveStatus.textContent = "";
+      }, SAVE_CONFIRMATION_MS);
       setSaving(false);
       sync(true);
     }, () => {
@@ -374,25 +365,15 @@ export function createCartographyOverlayControls(options: Readonly<{
   for (const type of ["pointerdown", "pointerup", "click", "wheel", "keydown", "keyup"]) {
     root.addEventListener(type, (event) => event.stopPropagation());
   }
-  root.addEventListener("pointerenter", () => {
-    cancelCollapse();
-    if (mode === "closed") setMode("transient");
-  });
-  root.addEventListener("pointerleave", scheduleCollapse);
-  root.addEventListener("focusin", () => {
-    cancelCollapse();
-    if (mode === "closed") setMode("transient");
-  });
-  root.addEventListener("focusout", scheduleCollapse);
-  trigger.addEventListener("click", () => setMode(mode === "pinned" ? "closed" : "pinned"));
+  trigger.addEventListener("click", () => setOpen(!open));
   root.addEventListener("keydown", (event) => {
-    if (event.key !== "Escape" || mode === "closed") return;
+    if (event.key !== "Escape" || !open) return;
     event.preventDefault();
-    setMode("closed");
+    setOpen(false);
     trigger.focus();
   });
   const outsidePointerDown = (event: Event): void => {
-    if (mode === "pinned" && event.target instanceof Node && !root.contains(event.target)) setMode("closed");
+    if (open && event.target instanceof Node && !root.contains(event.target)) setOpen(false);
   };
   document.addEventListener("pointerdown", outsidePointerDown);
   gridButton.addEventListener("click", () => {
@@ -444,8 +425,7 @@ export function createCartographyOverlayControls(options: Readonly<{
     });
   });
   const hide = (): void => {
-    cancelCollapse();
-    setMode("closed");
+    setOpen(false);
     root.hidden = true;
     latestBox = null;
     canonical = null;
@@ -486,7 +466,7 @@ export function createCartographyOverlayControls(options: Readonly<{
       if (canonical !== settings) {
         canonical = settings;
         sync();
-        if (mode === "closed") {
+        if (!open) {
           root.style.opacity = String(settings.cartographyControlIdleOpacity / 100);
         }
       }
@@ -509,7 +489,7 @@ export function createCartographyOverlayControls(options: Readonly<{
     hide,
     dispose() {
       disposed = true;
-      cancelCollapse();
+      clearSaveStatusTimer();
       panelResizeObserver?.disconnect();
       document.removeEventListener("pointerdown", outsidePointerDown);
       view.removeEventListener("resize", viewportResize);

--- a/tests/unit/cartography-overlay-controls.test.ts
+++ b/tests/unit/cartography-overlay-controls.test.ts
@@ -60,6 +60,25 @@ test("compact Cartography controls avoid frame-loop layout reads and static inli
   assert.match(controls, /boxChanged \|\| becameVisible/u);
 });
 
+test("Cartography controls open only by click and remain open after pointer movement", () => {
+  const controls = readFileSync(
+    "src/renderer/cartography-spike/overlay-controls.ts",
+    "utf8",
+  );
+  assert.match(controls, /trigger\.addEventListener\("click", \(\) => setOpen\(!open\)\)/u);
+  assert.doesNotMatch(controls, /pointerenter|pointerleave|matches\(":hover"\)|transient|collapseTimer/u);
+  assert.match(controls, /if \(open && event\.target instanceof Node/u);
+});
+
+test("compact Cartography panel keeps guidance progressively disclosed", () => {
+  const controls = readFileSync(
+    "src/renderer/cartography-spike/overlay-controls.ts",
+    "utf8",
+  );
+  assert.doesNotMatch(controls, /cartography-overlay-hint|Hold <kbd>|Numbers: solid/u);
+  assert.match(controls, /const qa = document\.createElement\("details"\)/u);
+});
+
 test("unsupported areas hide controls while transient failures leave them available", () => {
   const unavailable = (reason: "unsupported-area" | "loading"): CartographyState => ({
     context: null,


### PR DESCRIPTION
## Problem

The in-game Cartography layers panel opened whenever the pointer crossed its icon and closed after hover ended. This made the controls feel unstable, while the persistent tutorial made a small utility panel visually heavy.

## Solution

The panel now opens only when clicked and remains open until the player clicks the icon again, clicks outside, presses Escape, or leaves a supported Cartography context. One click-owned state now controls both mouse and keyboard behavior.

The panel is narrower and shorter. It keeps the layer toggles, opacity controls, preset, and collapsed Live evidence diagnostics while removing the always-visible tutorial. Save feedback is now transient.

## Invariant

- Pointer hover never changes the panel's open state.
- One boolean owns the open and closed state.
- Cartography diagnostics, data, and native behavior are unchanged.
- Existing accessibility paths remain: `aria-expanded`, `aria-controls`, Escape, and outside click.

## Verification

- `pnpm run check`
  - 1,518 unit tests
  - 181 policy tests
  - 146 Tools tests
  - 49 launcher tests
- Matthias approved the Developer Build interaction for publication.

## Rollout risk

Low. This changes only renderer-side Cartography control interaction and CSS. It does not change native code, settings schema, persistence, or client certification.

Implementation and verification completed with Codex.
