### PR TITLE
fix(cartography): keep walkable terrain in limited areas

### DIFF
--- a/docs/cartography.md
+++ b/docs/cartography.md
@@ -63,11 +63,12 @@ the continent-scale World Map. GWonMac certifies each context independently.
 Both surfaces consume the same continent state and global grid phase. A failure
 on either map hides only that surface.
 
-Cartography is limited to the three supported campaign coordinate systems:
-Tyria, Cantha, and Elona. Pre-Searing, the Battle Isles, and the Realm of
-Torment use separate coordinate systems and hide every Cartography layer. The
-compact control hides with the layers; settings remain intact and apply again
-automatically after travel to a supported area.
+Continent progress and guidance cover Tyria, Pre-Searing, Cantha, and Elona.
+The Battle Isles, Realm of Torment, dungeons, and other maps outside a campaign
+world map keep the local walkable-terrain layer but hide the global grid,
+coverage, and guidance. The compact control remains visible and explains this
+limited mode when opened. Settings remain intact and apply again automatically
+after travel to a fully supported area.
 
 The World Map projection and visibility come from one complete native event
 context. Unrelated or incomplete events leave the last complete reading intact,
@@ -101,9 +102,9 @@ invalid scalar, excessive geometry, uncertain projection, or unsupported build
 fails the dependent evidence layer closed. Travel withdraws stale orange and
 terrain immediately without discarding a healthy continent snapshot.
 
-An unsupported area fails both evidence layers closed with the bounded
-`unsupported-area` reason. Its certified map identity remains available to the
-evidence export, but it cannot update visited-map knowledge.
+An area without continent progress fails only that evidence layer closed with
+the bounded `unsupported-area` reason. Certified local terrain can remain
+available, but limited-area reachability cannot update visited-map knowledge.
 
 Main stores visited-map knowledge atomically in
 `cartography-map-knowledge.json`. The file contains global map geometry, not

--- a/docs/live-cartography-certification.md
+++ b/docs/live-cartography-certification.md
@@ -98,11 +98,13 @@ only from complete records with the current matching generation. Include one
 map with bridges, islands, or multiple pathing layers.
 
 Travel to Gate of Madness or another Realm of Torment area. Confirm that the
-Grid, Walkable terrain, World Map guidance, and compact Cartography control are
-all hidden. Export evidence and confirm the current-instance reason is
-`unsupported-area`. Then travel back to a supported Tyria, Cantha, or Elona
-area. The prior settings must still be selected and the eligible layers must
-return without restarting gwonmac.
+Cartography control remains visible, its panel explains the limited area, and
+only enabled Walkable terrain is drawn. Grid, coverage, and guidance must stay
+hidden, while exported evidence reports the continent as `unsupported-area`
+and retains ready current-instance terrain. Repeat in an off-world-map dungeon.
+Then travel to Pre-Searing and confirm both Grid and Walkable terrain work.
+Finally, return to Tyria, Cantha, or Elona and confirm the prior settings and
+eligible layers return without restarting gwonmac.
 
 Stop and fail closed if:
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -113,12 +113,12 @@ unseen marker means the loaded map has ground within reveal range. Grey hatching
 means the cell may need another map or special route. Guidance never changes
 the game's explored state. Hold Shift over a Mission Map cell to inspect its
 normal 3×3 reveal area, or Option-Shift for the Bird's Eye 7×7 area. One style
-applies to the Compass and Mission Map. Both layers hide when the current map
-projection or data cannot be certified. They also hide, together with the
-Cartography control, outside the main Tyria, Cantha, and Elona world maps. This
-includes the Battle Isles, Pre-Searing, and the Realm of Torment. Your
-Cartography settings stay unchanged and the layers return automatically after
-travel to a supported area.
+applies to the Compass and Mission Map. Pre-Searing supports both layers
+alongside Tyria, Cantha, and Elona. In dungeons, underground maps, the Battle
+Isles, and the Realm of Torment, the Grid and global progress hide while local
+Walkable terrain remains available. The Cartography control stays beside the
+Compass and explains the limitation when opened. Your settings remain intact
+and all layers return automatically after travel to a fully supported area.
 
 ## Switch Character
 

--- a/src/companion-kernel/abi.rs
+++ b/src/companion-kernel/abi.rs
@@ -15,7 +15,7 @@ use core::mem::size_of;
 pub(crate) const SNAPSHOT_BYTES: u32 = size_of::<Snapshot>() as u32;
 pub(crate) const CONFIG_BYTES: u32 = size_of::<Layout>() as u32;
 pub(crate) const MAGIC: u32 = 0x4254_5747;
-pub(crate) const ABI_AND_SIZE: u32 = (SNAPSHOT_BYTES << 16) | 3;
+pub(crate) const ABI_AND_SIZE: u32 = (SNAPSHOT_BYTES << 16) | 4;
 
 pub(crate) const FLAG_READY: u32 = 1 << 0;
 pub(crate) const FLAG_PLAYER_VALID: u32 = 1 << 1;
@@ -25,6 +25,8 @@ pub(crate) const FLAG_LOADING: u32 = 1 << 3;
 pub(crate) const FLAG_XUNLAI_ACCESS_OBSERVED: u32 = 1 << 4;
 /// Storage access is positively allowed. Meaningful only with the observed bit.
 pub(crate) const FLAG_XUNLAI_ACCESS_ALLOWED: u32 = 1 << 5;
+/// The current AreaInfo record participates in a native world-map projection.
+pub(crate) const FLAG_ON_WORLD_MAP: u32 = 1 << 6;
 
 pub(crate) const FEATURE_NATIVE_CURSOR: u32 = 1 << 0;
 pub(crate) const FEATURE_GAME_SNAPSHOT: u32 = 1 << 1;

--- a/src/companion-kernel/lib.rs
+++ b/src/companion-kernel/lib.rs
@@ -157,6 +157,7 @@ pub(crate) enum GameState {
         player_number: u32,
         play_region: u32,
         pre_searing: bool,
+        on_world_map: bool,
     },
 }
 
@@ -191,25 +192,25 @@ unsafe fn classify_play_region(
     layout: Layout,
     map_id: u32,
     instance_type: u32,
-) -> (u32, bool) {
+) -> (u32, bool, bool) {
     if layout.area_info == 0
         || layout.area_info_count == 0
         || layout.area_info_stride < 20
         || layout.area_info_flags + 4 > layout.area_info_stride
         || map_id >= layout.area_info_count
     {
-        return (PLAY_REGION_UNKNOWN, false);
+        return (PLAY_REGION_UNKNOWN, false, false);
     }
     let Some(record) = indexed(layout.area_info, map_id, layout.area_info_stride) else {
-        return (PLAY_REGION_UNKNOWN, false);
+        return (PLAY_REGION_UNKNOWN, false, false);
     };
     let mut area_region = 0;
     for (field, maximum) in [0_u32, 4, 8, 12].iter().zip([4_u32, 5, 27, 21].iter()) {
         let Some(value) = offset(record, *field).and_then(|at| unsafe { read_u32(at) }) else {
-            return (PLAY_REGION_UNKNOWN, false);
+            return (PLAY_REGION_UNKNOWN, false, false);
         };
         if value > *maximum {
-            return (PLAY_REGION_UNKNOWN, false);
+            return (PLAY_REGION_UNKNOWN, false, false);
         }
         if *field == 8 {
             area_region = value;
@@ -217,7 +218,7 @@ unsafe fn classify_play_region(
     }
     let Some(flags) = offset(record, layout.area_info_flags).and_then(|at| unsafe { read_u32(at) })
     else {
-        return (PLAY_REGION_UNKNOWN, false);
+        return (PLAY_REGION_UNKNOWN, false, false);
     };
     let play_region = if flags & (0x0004_0001 | 0x0080_0000) != 0 && instance_type == 1 {
         PLAY_REGION_PVP
@@ -227,6 +228,7 @@ unsafe fn classify_play_region(
     (
         play_region,
         area_region == 7 && play_region == PLAY_REGION_PVE,
+        flags & 0x20 == 0,
     )
 }
 
@@ -415,7 +417,7 @@ pub(crate) unsafe fn resolve_game(layout: Layout) -> GameState {
         return GameState::Unavailable;
     }
 
-    let (play_region, pre_searing) = unsafe {
+    let (play_region, pre_searing, on_world_map) = unsafe {
         classify_play_region(layout, map_id, instance_type)
     };
     GameState::Ready {
@@ -425,12 +427,13 @@ pub(crate) unsafe fn resolve_game(layout: Layout) -> GameState {
         player_number,
         play_region,
         pre_searing,
+        on_world_map,
     }
 }
 
 unsafe fn collect(layout: Layout, observe_target: bool) -> State {
     let mut state = State::empty();
-    let (game, map_id, instance_type, player_number, play_region) = match unsafe { resolve_game(layout) }
+    let (game, map_id, instance_type, player_number, play_region, on_world_map) = match unsafe { resolve_game(layout) }
     {
         GameState::Unavailable => return state,
         GameState::Loading => {
@@ -443,8 +446,9 @@ unsafe fn collect(layout: Layout, observe_target: bool) -> State {
             instance_type,
             player_number,
             play_region,
+            on_world_map,
             ..
-        } => (game, map_id, instance_type, player_number, play_region),
+        } => (game, map_id, instance_type, player_number, play_region, on_world_map),
     };
 
     if !contains(layout.agent_array, 16) {
@@ -497,7 +501,8 @@ unsafe fn collect(layout: Layout, observe_target: bool) -> State {
         let Some(player) = (unsafe { read_agent(layout, agent_buffer, size, id) }) else {
             return state;
         };
-        state.flags = FLAG_READY | FLAG_PLAYER_VALID;
+        state.flags = FLAG_READY | FLAG_PLAYER_VALID
+            | if on_world_map { FLAG_ON_WORLD_MAP } else { 0 };
         state.map_id = map_id;
         state.instance_type = instance_type;
         state.play_region = play_region;

--- a/src/renderer/cartography-overlay-controls.css
+++ b/src/renderer/cartography-overlay-controls.css
@@ -69,6 +69,20 @@
   font-size: var(--ui-type-caption-size);
 }
 
+.cartography-overlay-availability {
+  margin: 0 0 var(--ui-space-2);
+  padding: var(--ui-space-1) var(--ui-space-2);
+  color: var(--ui-text-muted);
+  font: var(--ui-font-weight-medium) 10px / 1.4 var(--ui-font-readable);
+  background: var(--ui-well-fill);
+  border: var(--ui-border-width) solid var(--ui-warning);
+  border-radius: var(--ui-radius-sm);
+}
+
+.cartography-overlay-availability[hidden] {
+  display: none;
+}
+
 .cartography-overlay-layers {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -197,6 +211,10 @@
 }
 
 .cartography-overlay-qa[data-tone="loading"] .cartography-overlay-qa-indicator {
+  background: var(--ui-warning);
+}
+
+.cartography-overlay-qa[data-tone="limited"] .cartography-overlay-qa-indicator {
   background: var(--ui-warning);
 }
 

--- a/src/renderer/cartography-spike/cartography-model.ts
+++ b/src/renderer/cartography-spike/cartography-model.ts
@@ -77,6 +77,10 @@ export type CartographyContinentState =
       remaining: RemainingCellBitset;
     }>;
 
+export type CartographyGuidanceState =
+  | Readonly<{ status: "unavailable"; reason: CartographyUnavailableReason }>
+  | Readonly<{ status: "ready"; actionableCells: ActionableCellBitset }>;
+
 export type CartographyCurrentInstanceState =
   | Readonly<{ status: "unavailable"; reason: CartographyUnavailableReason }>
   | Readonly<{
@@ -89,7 +93,7 @@ export type CartographyCurrentInstanceState =
       player: GamePoint;
       walkableTerrain: WalkableTerrainRaster;
       reachableCells: ReachableCellBitset;
-      actionableCells: ActionableCellBitset;
+      guidance: CartographyGuidanceState;
     }>;
 
 export type CartographyState = Readonly<{
@@ -169,26 +173,14 @@ function emptyState(reason: CartographyUnavailableReason): CartographyState {
   });
 }
 
-function unavailableStateWithContext(
-  context: NonNullable<ReturnType<CartographyContextController["snapshot"]>>,
-  reason: CartographyUnavailableReason,
-): CartographyState {
-  return Object.freeze({
-    context: Object.freeze({
-      sequence: context.sequence,
-      mapId: context.mapId,
-      areaEpoch: context.areaEpoch,
-      layoutId: context.layoutId,
-    }),
-    continent: unavailable(reason),
-    currentInstance: unavailable(reason),
-    surfaces: Object.freeze({ compass: null, missionMap: null, worldMap: null }),
-  });
-}
-
-/** Cartography masks cover only the three main campaign world-map coordinate systems. */
-export function isCartographyAreaSupported(continent: number): boolean {
-  return continent === 0 || continent === 2 || continent === 4;
+/** Progress masks are meaningful on the campaign and Pre-Searing world maps. */
+export function isCartographyProgressSupported(
+  continent: number,
+  onWorldMap: boolean,
+): boolean {
+  return onWorldMap && (
+    continent === 0 || continent === 1 || continent === 2 || continent === 4
+  );
 }
 
 /** Build one continent partition. Every creditable cell is exactly explored or remaining. */
@@ -282,6 +274,27 @@ function deriveContinentCached(
   return value;
 }
 
+function deriveGuidance(
+  continent: CartographyContinentState,
+  reachableCells: ReachableCellBitset,
+): CartographyGuidanceState {
+  if (continent.status === "unavailable") return unavailable(continent.reason);
+  const actionableWords = new Uint32Array(reachableCells.words.length);
+  for (let index = 0; index < reachableCells.width * reachableCells.height; index += 1) {
+    if (bit(continent.remaining.words, index) && bit(reachableCells.words, index)) {
+      set(actionableWords, index);
+    }
+  }
+  return Object.freeze({
+    status: "ready",
+    actionableCells: Object.freeze({
+      width: reachableCells.width,
+      height: reachableCells.height,
+      words: actionableWords,
+    }) as ActionableCellBitset,
+  });
+}
+
 /**
  * Read one immutable state or fail the affected evidence level closed. Native
  * context, exploration, and anchor observations must share one even epoch.
@@ -297,41 +310,29 @@ export function readCartographyState(sources: CartographyModelSources): Cartogra
     anchor === null || anchor.status !== 1
     || anchor.generation !== contextA.areaEpoch
   ) return emptyState("anchor");
-  if (!isCartographyAreaSupported(anchor.continent)) {
-    const contextB = sources.context.snapshot();
-    if (contextB === null || contextB.status !== 1 || !contextEqual(contextA, contextB)) {
-      return emptyState("epoch-mismatch");
-    }
-    return unavailableStateWithContext(contextA, "unsupported-area");
-  }
   const exploration = sources.exploration.readBitmap();
   if (
     exploration === null || exploration.snapshot.status !== 1
     || exploration.snapshot.generation !== contextA.areaEpoch
   ) return emptyState("exploration");
 
-  const continent = deriveContinentCached(
-    sources.exploration,
-    anchor.continent,
-    contextA.areaEpoch,
-    exploration.snapshot.sequence,
-    exploration.snapshot.width,
-    exploration.snapshot.height,
-    exploration.words,
-  );
-  if (continent.status === "unavailable") return Object.freeze({
-    context: Object.freeze({
-      sequence: contextA.sequence,
-      mapId: contextA.mapId,
-      areaEpoch: contextA.areaEpoch,
-      layoutId: contextA.layoutId,
-    }),
-    continent,
-    currentInstance: unavailable(continent.reason),
-    surfaces: Object.freeze({ compass: null, missionMap: null, worldMap: null }),
-  });
-
   const companion = sources.companion();
+  const continent: CartographyContinentState = companion?.status !== "ready"
+    || companion.playRegion === "unknown"
+    ? unavailable("companion")
+    : companion.mapId !== contextA.mapId
+      ? unavailable("map-mismatch")
+      : !isCartographyProgressSupported(anchor.continent, companion.onWorldMap)
+        ? unavailable("unsupported-area")
+        : deriveContinentCached(
+            sources.exploration,
+            anchor.continent,
+            contextA.areaEpoch,
+            exploration.snapshot.sequence,
+            exploration.snapshot.width,
+            exploration.snapshot.height,
+            exploration.words,
+          );
   let current: CartographyCurrentInstanceState = unavailable("companion");
   if (companion?.status === "ready") {
     if (companion.mapId !== contextA.mapId) current = unavailable("map-mismatch");
@@ -360,12 +361,11 @@ export function readCartographyState(sources: CartographyModelSources): Cartogra
         || kernel.height !== exploration.snapshot.height
       ) current = unavailable("kernel");
       else {
-        const actionableWords = new Uint32Array(kernel.reachableCells.words.length);
-        for (let index = 0; index < kernel.width * kernel.height; index += 1) {
-          if (bit(continent.remaining.words, index) && bit(kernel.reachableCells.words, index)) {
-            set(actionableWords, index);
-          }
-        }
+        const reachableCells = Object.freeze({
+          width: kernel.width,
+          height: kernel.height,
+          words: kernel.reachableCells.words,
+        }) as ReachableCellBitset;
         current = Object.freeze({
           status: "ready",
           sequence: contextA.sequence,
@@ -382,16 +382,8 @@ export function readCartographyState(sources: CartographyModelSources): Cartogra
           }),
           player: Object.freeze({ x: companion.playerX, y: companion.playerY }),
           walkableTerrain: Object.freeze(kernel.walkableTerrain) as WalkableTerrainRaster,
-          reachableCells: Object.freeze({
-            width: kernel.width,
-            height: kernel.height,
-            words: kernel.reachableCells.words,
-          }) as ReachableCellBitset,
-          actionableCells: Object.freeze({
-            width: kernel.width,
-            height: kernel.height,
-            words: actionableWords,
-          }) as ActionableCellBitset,
+          reachableCells,
+          guidance: deriveGuidance(continent, reachableCells),
         });
       }
     }

--- a/src/renderer/cartography-spike/evidence-capture.ts
+++ b/src/renderer/cartography-spike/evidence-capture.ts
@@ -135,9 +135,13 @@ export function captureCartographyEvidence(
           current.reachableCells.words,
         ),
         actionable: cloneBitset(
-          current.actionableCells.width,
-          current.actionableCells.height,
-          current.actionableCells.words,
+          current.reachableCells.width,
+          current.reachableCells.height,
+          // Limited areas have terrain evidence but no progress mask, so they
+          // intentionally publish no confirmed actionable cells.
+          current.guidance.status === "ready"
+            ? current.guidance.actionableCells.words
+            : new Uint32Array(current.reachableCells.words.length),
         ),
         terrain: Object.freeze({
           mapLeft: current.walkableTerrain.mapLeft,

--- a/src/renderer/cartography-spike/overlay-controls.ts
+++ b/src/renderer/cartography-spike/overlay-controls.ts
@@ -20,38 +20,38 @@ const PANEL_HEIGHT_ESTIMATE = 230;
 const SAVE_CONFIRMATION_MS = 1_200;
 type Layer = "grid" | "walkability";
 
-export type CartographyQaStatus =
-  | Readonly<{
-      status: "unavailable";
-      reason: string;
-      worldMapObserver: WorldMapFrameSpikeDiagnostic;
-      kernel: CartographyReachabilityDiagnostic | null;
-    }>
-  | Readonly<{
-      status: "ready";
-      continentId: number;
-      exploredCreditableCells: number;
-      remainingCells: number;
-      compassReady: boolean;
-      missionMapReady: boolean;
-      worldMapReady: boolean;
-      worldMapObserver: WorldMapFrameSpikeDiagnostic;
-      currentInstance:
-        | Readonly<{ status: "unavailable"; reason: string }>
-        | Readonly<{
-            status: "ready";
-            mapId: number;
-            areaEpoch: number;
-            resourceGeneration: number;
-            terrain: Readonly<{ width: number; height: number; mapUnitsPerPixel: number }>;
-            reachableCells: number;
-            actionableCells: number;
-          }>;
-      kernel: CartographyReachabilityDiagnostic | null;
-    }>;
+export type CartographyQaStatus = Readonly<{
+  continent:
+    | Readonly<{ status: "unavailable"; reason: string }>
+    | Readonly<{
+        status: "ready";
+        continentId: number;
+        exploredCreditableCells: number;
+        remainingCells: number;
+      }>;
+  currentInstance:
+    | Readonly<{ status: "unavailable"; reason: string }>
+    | Readonly<{
+        status: "ready";
+        sequence: number;
+        mapId: number;
+        areaEpoch: number;
+        resourceGeneration: number;
+        terrain: Readonly<{ width: number; height: number; mapUnitsPerPixel: number }>;
+        reachableCells: number;
+        guidance:
+          | Readonly<{ status: "unavailable"; reason: string }>
+          | Readonly<{ status: "ready"; actionableCells: number }>;
+      }>;
+  compassReady: boolean;
+  missionMapReady: boolean;
+  worldMapReady: boolean;
+  worldMapObserver: WorldMapFrameSpikeDiagnostic;
+  kernel: CartographyReachabilityDiagnostic | null;
+}>;
 
 type QaPresentation = Readonly<{
-  tone: "ready" | "loading" | "unavailable";
+  tone: "ready" | "limited" | "loading" | "unavailable";
   summary: string;
   rows: readonly (readonly [label: string, value: string])[];
 }>;
@@ -94,13 +94,19 @@ function worldMapStatus(value: WorldMapFrameSpikeDiagnostic): string {
 }
 
 export function describeCartographyQaStatus(status: CartographyQaStatus): QaPresentation {
-  if (status.status === "unavailable") {
-    const loading = status.reason === "loading";
+  const continent = status.continent;
+  const current = status.currentInstance;
+  const limited = continent.status === "unavailable"
+    && continent.reason === "unsupported-area";
+  if (continent.status === "unavailable" && current.status === "unavailable") {
+    const reason = limited ? current.reason : continent.reason;
+    const loading = reason === "loading";
     const kernel = status.kernel;
-    const exactReason = status.reason === "kernel" && kernel !== null
+    const exactReason = reason === "kernel" && kernel !== null
       ? `kernel/${kernelStatus(kernel.status)}`
-      : status.reason;
+      : reason;
     const rows: (readonly [string, string])[] = [
+      ...(limited ? [["Grid", "Unavailable in this area"]] as const : []),
       ["Reason", exactReason],
       ["World observer", worldMapStatus(status.worldMapObserver)],
     ];
@@ -113,33 +119,43 @@ export function describeCartographyQaStatus(status: CartographyQaStatus): QaPres
     }
     return Object.freeze({
       tone: loading ? "loading" : "unavailable",
-      summary: loading ? "Loading" : `Unavailable · ${exactReason}`,
+      summary: loading ? "Loading" : limited
+        ? "Limited · Walkable unavailable"
+        : `Unavailable · ${exactReason}`,
       rows: Object.freeze(rows),
     });
   }
-  const rows: (readonly [string, string])[] = [
-    ["Continent", `${status.continentId} · ${status.remainingCells} estimated remaining`],
-    ["Coverage", `${status.exploredCreditableCells} explored creditable`],
-  ];
-  if (status.currentInstance.status === "ready") {
-    const current = status.currentInstance;
+  const rows: (readonly [string, string])[] = [];
+  if (continent.status === "ready") {
+    rows.push(
+      ["Continent", `${continent.continentId} · ${continent.remainingCells} estimated remaining`],
+      ["Coverage", `${continent.exploredCreditableCells} explored creditable`],
+    );
+  } else rows.push(["Grid", "Unavailable in this area"]);
+  if (current.status === "ready") {
     rows.push(
       ["Map", String(current.mapId)],
       ["Epoch", `${current.areaEpoch} · resource ${current.resourceGeneration}`],
-      ["Guidance", `${current.actionableCells} targets here · ${current.reachableCells} reachable cells`],
       ["Terrain", `${current.terrain.width}×${current.terrain.height} @ ${current.terrain.mapUnitsPerPixel}`],
     );
-  } else rows.push(["Current guidance", `Unavailable · ${status.currentInstance.reason}`]);
+    rows.push(current.guidance.status === "ready"
+      ? ["Guidance", `${current.guidance.actionableCells} targets here · ${current.reachableCells} reachable cells`]
+      : ["Guidance", `Unavailable · ${current.guidance.reason}`]);
+  } else rows.push(["Walkable", `Unavailable · ${current.reason}`]);
   rows.push([
     "Surfaces",
     `Compass ${status.compassReady ? "ready" : "off"} · Mission ${status.missionMapReady ? "ready" : "off"} · World ${status.worldMapReady ? "ready" : "off"}`,
   ]);
   rows.push(["World observer", worldMapStatus(status.worldMapObserver)]);
   return Object.freeze({
-    tone: "ready",
-    summary: status.currentInstance.status === "ready"
-      ? `Ready · ${status.currentInstance.actionableCells} targets here`
-      : `Continent ready · ${status.remainingCells} remaining`,
+    tone: limited ? "limited" : "ready",
+    summary: limited
+      ? "Limited · Walkable terrain ready"
+      : current.status === "ready" && current.guidance.status === "ready"
+        ? `Ready · ${current.guidance.actionableCells} targets here`
+        : continent.status === "ready"
+          ? `Continent ready · ${continent.remainingCells} remaining`
+          : "Walkable terrain ready",
     rows: Object.freeze(rows),
   });
 }
@@ -198,6 +214,9 @@ export function createCartographyOverlayControls(options: Readonly<{
   const heading = document.createElement("strong");
   heading.className = "cartography-overlay-heading";
   heading.textContent = "Map layers";
+  const availabilityNotice = document.createElement("p");
+  availabilityNotice.className = "cartography-overlay-availability";
+  availabilityNotice.hidden = true;
   const layers = document.createElement("div");
   layers.className = "cartography-overlay-layers";
   const layerButton = (label: string): HTMLButtonElement => {
@@ -264,12 +283,13 @@ export function createCartographyOverlayControls(options: Readonly<{
   exportStatus.setAttribute("role", "status");
   exportStatus.setAttribute("aria-live", "polite");
   qa.append(qaSummary, qaRows, exportButton, exportStatus);
-  panel.append(heading, layers, fields, saveStatus, qa);
+  panel.append(heading, availabilityNotice, layers, fields, saveStatus, qa);
   root.append(trigger, panel);
   options.parent.append(root);
 
   let canonical: AppSettings | null = null;
   let saving = false;
+  let gridAvailable = false;
   let exporting = false;
   let disposed = false;
   let open = false;
@@ -279,10 +299,16 @@ export function createCartographyOverlayControls(options: Readonly<{
   let renderedSettings: AppSettings | null = null;
   let panelHeight = PANEL_HEIGHT_ESTIMATE;
   const currentSettings = (): AppSettings | null => canonical;
+  const syncDisabled = (): void => {
+    gridButton.disabled = saving || !gridAvailable;
+    gridOpacity.input.disabled = saving || !gridAvailable;
+    for (const control of [walkabilityButton, walkabilityOpacity.input, preset]) {
+      control.disabled = saving;
+    }
+  };
   const setSaving = (value: boolean): void => {
     saving = value;
-    for (const control of [gridButton, walkabilityButton, gridOpacity.input,
-      walkabilityOpacity.input, preset]) control.disabled = value;
+    syncDisabled();
   };
   const renderPresetOptions = (settings: AppSettings): void => {
     if (renderedLibrary === settings.cartographyPresetLibrary) return;
@@ -476,6 +502,20 @@ export function createCartographyOverlayControls(options: Readonly<{
     },
     updateQaStatus(status) {
       const presentation = describeCartographyQaStatus(status);
+      gridAvailable = status.continent.status === "ready";
+      const limited = status.continent.status === "unavailable"
+        && status.continent.reason === "unsupported-area";
+      availabilityNotice.hidden = !limited;
+      availabilityNotice.textContent = limited
+        ? status.currentInstance.status === "ready"
+          ? "Limited in this area. Cartography progress and guidance are unavailable. Walkable terrain is still available."
+          : "Limited in this area. Cartography progress and guidance are unavailable, and walkable terrain could not be loaded."
+        : "";
+      gridButton.title = gridAvailable ? "" : limited
+        ? "Grid and progress are unavailable in this area"
+        : "Grid is temporarily unavailable";
+      gridOpacity.input.title = gridButton.title;
+      syncDisabled();
       qa.dataset.tone = presentation.tone;
       qaValue.textContent = presentation.summary;
       qaRows.replaceChildren(...presentation.rows.flatMap(([label, value]) => {

--- a/src/renderer/cartography-spike/overlay.ts
+++ b/src/renderer/cartography-spike/overlay.ts
@@ -40,7 +40,10 @@ import {
 import { captureCartographyEvidence } from "./evidence-capture.js";
 import { createContinentCoverageLayer } from "./continent-coverage-layer.js";
 import { createCurrentInstanceBoundaryLayer } from "./current-instance-boundary-layer.js";
-import { createCartographyOverlayControls } from "./overlay-controls.js";
+import {
+  createCartographyOverlayControls,
+  type CartographyQaStatus,
+} from "./overlay-controls.js";
 import {
   createWalkableTerrainSurface,
   type WalkableTerrainSurface,
@@ -58,36 +61,7 @@ export type CartographyGridStats = Readonly<{
   worldMap: CartographyGridLayerSnapshot | null;
 }>;
 
-export type CartographyModelStats =
-  | Readonly<{
-      status: "unavailable";
-      reason: string;
-      worldMapObserver: ReturnType<CartographyModelSources["worldMap"]["diagnostics"]>;
-      kernel: ReturnType<CartographyModelSources["kernel"]["diagnostic"]>;
-    }>
-  | Readonly<{
-      status: "ready";
-      continentId: number;
-      exploredCreditableCells: number;
-      remainingCells: number;
-      compassReady: boolean;
-      missionMapReady: boolean;
-      worldMapReady: boolean;
-      worldMapObserver: ReturnType<CartographyModelSources["worldMap"]["diagnostics"]>;
-      currentInstance:
-        | Readonly<{ status: "unavailable"; reason: string }>
-        | Readonly<{
-            status: "ready";
-            sequence: number;
-            mapId: number;
-            areaEpoch: number;
-            resourceGeneration: number;
-            terrain: Readonly<{ width: number; height: number; mapUnitsPerPixel: number }>;
-            reachableCells: number;
-            actionableCells: number;
-          }>;
-      kernel: ReturnType<CartographyModelSources["kernel"]["diagnostic"]>;
-    }>;
+export type CartographyModelStats = CartographyQaStatus;
 
 function countSetBits(words: Uint32Array): number {
   let count = 0;
@@ -111,7 +85,7 @@ function bitsetsEqual(
     && left.words.every((word, index) => word === right.words[index]);
 }
 
-export type CartographyOverlayDisposition = "hidden" | "controls-only" | "layers";
+export type CartographyOverlayDisposition = "controls-only" | "layers";
 
 /** Decide the whole overlay surface policy from the canonical model state. */
 export function cartographyOverlayDisposition(
@@ -120,7 +94,7 @@ export function cartographyOverlayDisposition(
   if (state.continent.status === "ready" || state.currentInstance.status === "ready") {
     return "layers";
   }
-  return state.continent.reason === "unsupported-area" ? "hidden" : "controls-only";
+  return "controls-only";
 }
 
 export function mountCartographyOverlay(options: Readonly<{
@@ -278,43 +252,45 @@ export function mountCartographyOverlay(options: Readonly<{
     });
   };
   view.gwCartographyGridStats = gridStats;
-  const modelStats = (): CartographyModelStats => state.continent.status === "unavailable"
-    ? Object.freeze({
-        status: "unavailable",
-        reason: state.continent.reason,
-        worldMapObserver: options.modelSources.worldMap.diagnostics(),
-        kernel: options.modelSources.kernel.diagnostic(),
-      })
-    : Object.freeze({
-        status: "ready",
-        continentId: state.continent.continent,
-        exploredCreditableCells: countSetBits(state.continent.exploredCreditable.words),
-        remainingCells: countSetBits(state.continent.remaining.words),
-        compassReady: presentation.compass !== null,
-        missionMapReady: missionGridLayer.snapshot() !== null,
-        worldMapReady: worldGridLayer.snapshot() !== null,
-        worldMapObserver: options.modelSources.worldMap.diagnostics(),
-        currentInstance: state.currentInstance.status === "ready"
-          ? Object.freeze({
-              status: "ready" as const,
-              sequence: state.currentInstance.sequence,
-              mapId: state.currentInstance.epoch.mapId,
-              areaEpoch: state.currentInstance.epoch.area,
-              resourceGeneration: state.currentInstance.epoch.resource,
-              terrain: Object.freeze({
-                width: state.currentInstance.walkableTerrain.width,
-                height: state.currentInstance.walkableTerrain.height,
-                mapUnitsPerPixel: state.currentInstance.walkableTerrain.mapUnitsPerPixel,
-              }),
-              reachableCells: countSetBits(state.currentInstance.reachableCells.words),
-              actionableCells: countSetBits(state.currentInstance.actionableCells.words),
-            })
-          : Object.freeze({
-              status: "unavailable" as const,
-              reason: state.currentInstance.reason,
-            }),
-        kernel: options.modelSources.kernel.diagnostic(),
-      });
+  const modelStats = (): CartographyModelStats => Object.freeze({
+    continent: state.continent.status === "ready"
+      ? Object.freeze({
+          status: "ready" as const,
+          continentId: state.continent.continent,
+          exploredCreditableCells: countSetBits(state.continent.exploredCreditable.words),
+          remainingCells: countSetBits(state.continent.remaining.words),
+        })
+      : state.continent,
+    currentInstance: state.currentInstance.status === "ready"
+      ? Object.freeze({
+          status: "ready" as const,
+          sequence: state.currentInstance.sequence,
+          mapId: state.currentInstance.epoch.mapId,
+          areaEpoch: state.currentInstance.epoch.area,
+          resourceGeneration: state.currentInstance.epoch.resource,
+          terrain: Object.freeze({
+            width: state.currentInstance.walkableTerrain.width,
+            height: state.currentInstance.walkableTerrain.height,
+            mapUnitsPerPixel: state.currentInstance.walkableTerrain.mapUnitsPerPixel,
+          }),
+          reachableCells: countSetBits(state.currentInstance.reachableCells.words),
+          guidance: state.currentInstance.guidance.status === "ready"
+            ? Object.freeze({
+                status: "ready" as const,
+                actionableCells: countSetBits(
+                  state.currentInstance.guidance.actionableCells.words,
+                ),
+              })
+            : state.currentInstance.guidance,
+        })
+      : state.currentInstance,
+    compassReady: presentation.compass !== null,
+    missionMapReady: presentation.missionMap !== null
+      && (state.continent.status === "ready" || state.currentInstance.status === "ready"),
+    worldMapReady: worldGridLayer.snapshot() !== null,
+    worldMapObserver: options.modelSources.worldMap.diagnostics(),
+    kernel: options.modelSources.kernel.diagnostic(),
+  });
   view.gwCartographyModelStats = modelStats;
 
   const safe = (surface: "compass" | "mission-map" | "world-map", render: () => void): void => {
@@ -378,16 +354,26 @@ export function mountCartographyOverlay(options: Readonly<{
         ) explorationVersion += 1;
       }
       if (next.currentInstance.status === "ready") {
+        const previousGuidance = previous.currentInstance.status === "ready"
+          ? previous.currentInstance.guidance
+          : null;
+        const nextGuidance = next.currentInstance.guidance;
         if (
-          previous.currentInstance.status !== "ready"
-          || !bitsetsEqual(
-            previous.currentInstance.reachableCells,
-            next.currentInstance.reachableCells,
-          )
+          previousGuidance === null
+          || previousGuidance.status !== nextGuidance.status
+          || previousGuidance.status === "ready" && nextGuidance.status === "ready"
+            && !bitsetsEqual(
+              previousGuidance.actionableCells,
+              nextGuidance.actionableCells,
+            )
         ) actionabilityVersion += 1;
       }
       state = next;
-      if (state.currentInstance.status === "ready") {
+      if (
+        state.continent.status === "ready"
+        && state.currentInstance.status === "ready"
+        && state.currentInstance.guidance.status === "ready"
+      ) {
         rememberCurrentMap(
           state.currentInstance,
           options.settings().cartographyRevealMode === "birds-eye" ? 3 : 1,
@@ -402,10 +388,6 @@ export function mountCartographyOverlay(options: Readonly<{
       terrainKey = "";
       terrain = null;
       hideAllLayers();
-      if (disposition === "hidden") {
-        controls.hide();
-        return;
-      }
       const compass = options.modelSources.compass.snapshot();
       const box = compass === null
         ? null
@@ -482,7 +464,10 @@ export function mountCartographyOverlay(options: Readonly<{
       return bitsetHasCell(state.continent.remaining, { x, y });
     };
     const canCurrentMapReveal = (x: number, y: number): boolean | null => {
-      if (state.currentInstance.status !== "ready") return null;
+      if (
+        state.currentInstance.status !== "ready"
+        || state.currentInstance.guidance.status !== "ready"
+      ) return null;
       return bitsetHasCell(state.currentInstance.reachableCells, { x, y });
     };
     const canVisitedMapReveal = (x: number, y: number): boolean | null => {
@@ -490,6 +475,11 @@ export function mountCartographyOverlay(options: Readonly<{
       return bitsetHasCell(rememberedReachable, { x, y });
     };
     const canvasBox = options.canvas.getBoundingClientRect();
+    const controlBox = presentation.compass === null
+      ? null
+      : projectNativeFrame(presentation.compass, canvasBox);
+    if (controlBox === null) controls.hide();
+    else controls.update(controlBox, settings);
 
     safe("compass", () => {
       if (
@@ -510,7 +500,7 @@ export function mountCartographyOverlay(options: Readonly<{
         + presentation.player.x / GAME_UNITS_PER_MAP_UNIT;
       const playerMapY = state.currentInstance.worldAnchor.y
         - presentation.player.y / GAME_UNITS_PER_MAP_UNIT;
-      if (settings.cartographyGridEnabled) {
+      if (settings.cartographyGridEnabled && state.continent.status === "ready") {
         const projection = projectCartographyGridToCompass({
           frame: { generation: state.currentInstance.epoch.area, playerMapX, playerMapY },
           compass,
@@ -549,14 +539,12 @@ export function mountCartographyOverlay(options: Readonly<{
           opacity: walkabilityOpacity,
         });
       } else compassTerrainLayer.hide();
-      controls.update(box, settings);
     });
 
     safe("mission-map", () => {
       if (
         presentation.compass === null
         || presentation.missionMap === null
-        || state.continent.status !== "ready"
       ) {
         hideMission();
         return;
@@ -573,7 +561,7 @@ export function mountCartographyOverlay(options: Readonly<{
         return;
       }
       const mapProjection = projectCartographyGridToMissionMap({ frame: mission, box });
-      if (settings.cartographyGridEnabled) {
+      if (settings.cartographyGridEnabled && state.continent.status === "ready") {
         if (mapProjection === null) {
           missionGridLayer.hide();
           missionCoverageLayer.hide();
@@ -612,7 +600,7 @@ export function mountCartographyOverlay(options: Readonly<{
           } else missionBoundaryLayer.hide();
         }
       } else missionGridLayer.hide();
-      if (!settings.cartographyGridEnabled) {
+      if (!settings.cartographyGridEnabled || state.continent.status !== "ready") {
         missionCoverageLayer.hide();
         missionBoundaryLayer.hide();
       }

--- a/src/renderer/companion-snapshot.ts
+++ b/src/renderer/companion-snapshot.ts
@@ -39,10 +39,11 @@ const FLAGS = Object.freeze({
   loading: 1 << 3,
   xunlaiObserved: 1 << 4,
   xunlaiAllowed: 1 << 5,
+  onWorldMap: 1 << 6,
 });
 const KNOWN_FLAGS =
   FLAGS.ready | FLAGS.player | FLAGS.target | FLAGS.loading
-  | FLAGS.xunlaiObserved | FLAGS.xunlaiAllowed;
+  | FLAGS.xunlaiObserved | FLAGS.xunlaiAllowed | FLAGS.onWorldMap;
 
 function validCoordinate(value: number) {
   return Number.isFinite(value) && Math.abs(value) <= 1_000_000;
@@ -116,6 +117,10 @@ export function readCompanionSnapshot(buffer: ArrayBuffer, pointer: number) {
       (flags & FLAGS.xunlaiAllowed) !== 0
       && (flags & FLAGS.xunlaiObserved) === 0
     )
+    || (
+      (flags & FLAGS.onWorldMap) !== 0
+      && (flags & (FLAGS.ready | FLAGS.player)) !== (FLAGS.ready | FLAGS.player)
+    )
   ) {
     return Object.freeze({ status: "waiting", reason: "snapshot" });
   }
@@ -175,6 +180,7 @@ export function readCompanionSnapshot(buffer: ArrayBuffer, pointer: number) {
     xunlaiAccess: (flags & FLAGS.xunlaiObserved) === 0
       ? null
       : (flags & FLAGS.xunlaiAllowed) !== 0,
+    onWorldMap: (flags & FLAGS.onWorldMap) !== 0,
     instanceName: INSTANCE_NAMES[state.instanceType] ?? "Unknown",
     targetValid,
     targetKind: targetValid ? agentKind(state.agentTypeBits) : "None",

--- a/src/shared/companion-abi.ts
+++ b/src/shared/companion-abi.ts
@@ -5,7 +5,7 @@
 export const COMPANION_ABI = Object.freeze({
   kernel: 21,
   config: Object.freeze({ bytes: 464 }),
-  snapshot: Object.freeze({ abi: 3, bytes: 64 }),
+  snapshot: Object.freeze({ abi: 4, bytes: 64 }),
   travelUnlockWords: 28,
   cursor: Object.freeze({ abi: 1, bytes: 4_160 }),
   toolbox: Object.freeze({ abi: 4, bytes: 64 }),

--- a/tests/fixtures/enhancements.ts
+++ b/tests/fixtures/enhancements.ts
@@ -149,7 +149,7 @@ export function snapshot(overrides: SnapshotOverrides = {}) {
   view.setUint16(4, COMPANION_SNAPSHOT_ABI, true);
   view.setUint16(6, COMPANION_SNAPSHOT_BYTES, true);
   view.setUint32(8, overrides.sequence ?? 2, true);
-  const flags = overrides.flags ?? 7;
+  const flags = overrides.flags ?? (7 | 1 << 6);
   const hasPlayer = (flags & 2) !== 0;
   const hasTarget = (flags & 4) !== 0;
   view.setUint32(12, flags, true);

--- a/tests/integration/enhancements-kernel.test.ts
+++ b/tests/integration/enhancements-kernel.test.ts
@@ -128,6 +128,15 @@ describe("Companion kernel", () => {
     assert.equal(state.targetId, 9);
     assert.ok(Math.abs(state.distance - 100) < 0.1);
     assert.equal(state.rangeName, "Adjacent");
+    assert.equal(state.onWorldMap, true);
+
+    view.setUint32(ADDRESSES.areaInfo + 133 * 0x7c + 0x10, 0x20, true);
+    kernel.tick();
+    assert.equal(
+      decoded(readCompanionSnapshot(kernel.memory.buffer, ADDRESSES.snapshot))
+        .onWorldMap,
+      false,
+    );
 
     const boundaries: [distance: number, band: number][] = [
       [166, 1],

--- a/tests/integration/enhancements-snapshot.test.ts
+++ b/tests/integration/enhancements-snapshot.test.ts
@@ -18,6 +18,7 @@ describe("Companion snapshot ABI", () => {
     assert.equal(state.targetKind, "Living");
     assert.equal(state.rangeName, "Adjacent");
     assert.equal(state.xunlaiAccess, null);
+    assert.equal(state.onWorldMap, true);
   });
 
   it("rejects torn, incompatible, loading, and absent-target snapshots", () => {
@@ -55,6 +56,10 @@ describe("Companion snapshot ABI", () => {
   });
 
   it("rejects unknown flags, invalid identities, bands, and non-finite values", () => {
+    assert.equal(
+      rejected(readCompanionSnapshot(snapshot({ flags: 0x80 }), 0)),
+      "snapshot",
+    );
     assert.equal(
       rejected(readCompanionSnapshot(snapshot({ flags: 0x40 }), 0)),
       "snapshot",

--- a/tests/unit/cartography-model.test.ts
+++ b/tests/unit/cartography-model.test.ts
@@ -11,6 +11,7 @@ import {
   bitsetHasCell,
   readCartographyState,
   readCartographyPresentation,
+  isCartographyProgressSupported,
   type CartographyModelSources,
   type GridCell,
 } from "../../src/renderer/cartography-spike/cartography-model.js";
@@ -87,6 +88,8 @@ const COMPANION = Object.freeze({
   playerId: 123,
   playerX: 10,
   playerY: 20,
+  playRegion: "pve",
+  onWorldMap: true,
 }) as PublishedCompanionState;
 
 function sources(
@@ -100,6 +103,7 @@ function sources(
     worldAnchorX: 100, worldAnchorY: 200,
     mapMinX: 0, mapMinY: 0, mapMaxX: 1_000, mapMaxY: 1_000,
   }),
+  companionState: PublishedCompanionState = COMPANION,
 ): CartographyModelSources {
   let contextIndex = 0;
   const context = {
@@ -150,7 +154,7 @@ function sources(
     exploration,
     anchor,
     kernel,
-    companion: () => COMPANION,
+    companion: () => companionState,
     revealRadius: () => 1,
   };
 }
@@ -165,7 +169,12 @@ test("publishes independent continent and current-instance state for one epoch",
   });
   assert.equal(bitsetHasCell(state.continent.remaining, CREDITABLE_CELL), true);
   assert.equal(bitsetHasCell(state.currentInstance.reachableCells, CREDITABLE_CELL), true);
-  assert.equal(bitsetHasCell(state.currentInstance.actionableCells, CREDITABLE_CELL), true);
+  assert.equal(state.currentInstance.guidance.status, "ready");
+  if (state.currentInstance.guidance.status !== "ready") return;
+  assert.equal(bitsetHasCell(
+    state.currentInstance.guidance.actionableCells,
+    CREDITABLE_CELL,
+  ), true);
   assert.equal(state.surfaces.compass, null);
   assert.equal(state.surfaces.missionMap, null);
   assert.equal(state.surfaces.worldMap, null);
@@ -216,29 +225,62 @@ test("withdraws immediately while the certified context is loading", () => {
   );
 });
 
-test("hides Cartography throughout unsupported world-map coordinate systems", () => {
+test("keeps local terrain in the Realm of Torment without global guidance", () => {
   const current = sources(undefined, undefined, Object.freeze({
     status: 1, generation: AREA_EPOCH, continent: 5,
     worldAnchorX: 100, worldAnchorY: 200,
     mapMinX: 0, mapMinY: 0, mapMaxX: 1_000, mapMaxY: 1_000,
   }));
   const state = readCartographyState(current);
-  assert.deepEqual(state, {
-    context: {
-      sequence: READY_CONTEXT.sequence,
-      mapId: MAP_ID,
-      areaEpoch: AREA_EPOCH,
-      layoutId: READY_CONTEXT.layoutId,
-    },
-    continent: { status: "unavailable", reason: "unsupported-area" },
-    currentInstance: { status: "unavailable", reason: "unsupported-area" },
-    surfaces: { compass: null, missionMap: null, worldMap: null },
+  assert.deepEqual(state.continent, { status: "unavailable", reason: "unsupported-area" });
+  assert.equal(state.currentInstance.status, "ready");
+  if (state.currentInstance.status !== "ready") return;
+  assert.deepEqual(state.currentInstance.guidance, {
+    status: "unavailable",
+    reason: "unsupported-area",
   });
+  assert.equal(state.currentInstance.walkableTerrain.width, 2);
   const evidence = captureCartographyEvidence(state, current);
-  assert.equal(evidence.currentInstance.status, "unavailable");
-  if (evidence.currentInstance.status === "unavailable") {
-    assert.equal(evidence.currentInstance.reason, "unsupported-area");
-    assert.equal(evidence.currentInstance.mapId, MAP_ID);
+  assert.equal(evidence.continent.status, "unavailable");
+  assert.equal(evidence.currentInstance.status, "ready");
+  if (evidence.currentInstance.status !== "ready") return;
+  assert.ok(evidence.currentInstance.actionable.words.every((word) => word === 0));
+});
+
+test("enables full Cartography in Pre-Searing", () => {
+  const preSearing = Object.freeze({
+    status: 1, generation: AREA_EPOCH, continent: 1,
+    worldAnchorX: 100, worldAnchorY: 200,
+    mapMinX: 0, mapMinY: 0, mapMaxX: 1_000, mapMaxY: 1_000,
+  });
+  const state = readCartographyState(sources(undefined, undefined, preSearing));
+  assert.equal(isCartographyProgressSupported(1, true), true);
+  assert.equal(state.continent.status, "ready");
+  assert.equal(state.currentInstance.status, "ready");
+  if (state.currentInstance.status === "ready") {
+    assert.equal(state.currentInstance.guidance.status, "ready");
+  }
+});
+
+test("keeps local terrain in off-world-map dungeons", () => {
+  const dungeonCompanion = Object.freeze({
+    ...COMPANION,
+    onWorldMap: false,
+  }) as PublishedCompanionState;
+  const state = readCartographyState(sources(
+    undefined,
+    undefined,
+    undefined,
+    dungeonCompanion,
+  ));
+  assert.equal(isCartographyProgressSupported(CONTINENT, false), false);
+  assert.deepEqual(state.continent, { status: "unavailable", reason: "unsupported-area" });
+  assert.equal(state.currentInstance.status, "ready");
+  if (state.currentInstance.status === "ready") {
+    assert.deepEqual(state.currentInstance.guidance, {
+      status: "unavailable",
+      reason: "unsupported-area",
+    });
   }
 });
 
@@ -304,8 +346,8 @@ test("semantic bitsets are not interchangeable", () => {
   const terrain: typeof state.currentInstance.walkableTerrain = state.currentInstance.reachableCells;
   assert.notEqual(terrain, state.currentInstance.walkableTerrain);
   // @ts-expect-error Reachable input cannot masquerade as derived actionability.
-  const actionable: typeof state.currentInstance.actionableCells = state.currentInstance.reachableCells;
-  assert.notEqual(actionable, state.currentInstance.actionableCells);
+  const actionable: typeof state.currentInstance.guidance = state.currentInstance.reachableCells;
+  assert.notEqual(actionable, state.currentInstance.guidance);
 });
 
 test("refreshes frame-sensitive presentation without rerunning classification", () => {

--- a/tests/unit/cartography-overlay-controls.test.ts
+++ b/tests/unit/cartography-overlay-controls.test.ts
@@ -79,21 +79,24 @@ test("compact Cartography panel keeps guidance progressively disclosed", () => {
   assert.match(controls, /const qa = document\.createElement\("details"\)/u);
 });
 
-test("unsupported areas hide controls while transient failures leave them available", () => {
+test("unsupported areas and transient failures leave controls available", () => {
   const unavailable = (reason: "unsupported-area" | "loading"): CartographyState => ({
     context: null,
     continent: { status: "unavailable", reason },
     currentInstance: { status: "unavailable", reason },
     surfaces: { compass: null, missionMap: null, worldMap: null },
   });
-  assert.equal(cartographyOverlayDisposition(unavailable("unsupported-area")), "hidden");
+  assert.equal(cartographyOverlayDisposition(unavailable("unsupported-area")), "controls-only");
   assert.equal(cartographyOverlayDisposition(unavailable("loading")), "controls-only");
 });
 
 test("Cartography QA status distinguishes loading from exact kernel failures", () => {
   assert.deepEqual(describeCartographyQaStatus({
-    status: "unavailable",
-    reason: "loading",
+    continent: { status: "unavailable", reason: "loading" },
+    currentInstance: { status: "unavailable", reason: "loading" },
+    compassReady: false,
+    missionMapReady: false,
+    worldMapReady: false,
     worldMapObserver: worldObserver,
     kernel: null,
   }), {
@@ -105,8 +108,11 @@ test("Cartography QA status distinguishes loading from exact kernel failures", (
     ],
   });
   const failed = describeCartographyQaStatus({
-    status: "unavailable",
-    reason: "kernel",
+    continent: { status: "unavailable", reason: "kernel" },
+    currentInstance: { status: "unavailable", reason: "kernel" },
+    compassReady: false,
+    missionMapReady: false,
+    worldMapReady: false,
     worldMapObserver: worldObserver,
     kernel: {
       status: 7,
@@ -132,22 +138,25 @@ test("Cartography QA status distinguishes loading from exact kernel failures", (
 
 test("Cartography QA ready status reports player-facing classification counts", () => {
   const ready = describeCartographyQaStatus({
-    status: "ready",
-    continentId: 1,
-    exploredCreditableCells: 4_500,
-    remainingCells: 120,
+    continent: {
+      status: "ready",
+      continentId: 1,
+      exploredCreditableCells: 4_500,
+      remainingCells: 120,
+    },
     compassReady: true,
     missionMapReady: false,
     worldMapReady: false,
     worldMapObserver: worldObserver,
     currentInstance: {
       status: "ready",
+      sequence: 4,
       mapId: 58,
       areaEpoch: 3,
       resourceGeneration: 2,
       terrain: { width: 256, height: 272, mapUnitsPerPixel: 2 },
       reachableCells: 228,
-      actionableCells: 92,
+      guidance: { status: "ready", actionableCells: 92 },
     },
     kernel: null,
   });
@@ -158,10 +167,12 @@ test("Cartography QA ready status reports player-facing classification counts", 
 
 test("Cartography QA keeps continent progress visible without current guidance", () => {
   const ready = describeCartographyQaStatus({
-    status: "ready",
-    continentId: 2,
-    exploredCreditableCells: 7_000,
-    remainingCells: 31,
+    continent: {
+      status: "ready",
+      continentId: 2,
+      exploredCreditableCells: 7_000,
+      remainingCells: 31,
+    },
     compassReady: false,
     missionMapReady: true,
     worldMapReady: true,
@@ -172,5 +183,30 @@ test("Cartography QA keeps continent progress visible without current guidance",
   assert.equal(ready.tone, "ready");
   assert.equal(ready.summary, "Continent ready · 31 remaining");
   assert.ok(ready.rows.some(([label, value]) =>
-    label === "Current guidance" && value === "Unavailable · kernel"));
+    label === "Walkable" && value === "Unavailable · kernel"));
+});
+
+test("Cartography QA explains terrain-only areas", () => {
+  const limited = describeCartographyQaStatus({
+    continent: { status: "unavailable", reason: "unsupported-area" },
+    currentInstance: {
+      status: "ready",
+      sequence: 4,
+      mapId: 495,
+      areaEpoch: 9,
+      resourceGeneration: 3,
+      terrain: { width: 128, height: 96, mapUnitsPerPixel: 2 },
+      reachableCells: 81,
+      guidance: { status: "unavailable", reason: "unsupported-area" },
+    },
+    compassReady: true,
+    missionMapReady: true,
+    worldMapReady: false,
+    worldMapObserver: worldObserver,
+    kernel: null,
+  });
+  assert.equal(limited.tone, "limited");
+  assert.equal(limited.summary, "Limited · Walkable terrain ready");
+  assert.ok(limited.rows.some(([label, value]) =>
+    label === "Grid" && value === "Unavailable in this area"));
 });


### PR DESCRIPTION
## Summary

Gate of Madness and other maps outside the supported campaign world maps previously disabled every Cartography layer and hid the control. This also excluded Pre-Searing even though its progress mask is available.

This change treats continent progress and current-instance terrain as separate capabilities:

- enable full Grid, progress, and guidance in Tyria, Pre-Searing, Cantha, and Elona
- keep Walkable terrain available in the Battle Isles, Realm of Torment, dungeons, and other off-world-map areas
- keep the Cartography icon visible and explain limited mode when opened
- disable Grid without changing the player's saved layer settings
- prevent terrain-only reachability from entering global visited-map knowledge

The native snapshot now publishes the game's certified `on world map` area flag, avoiding a brittle map-ID allowlist.

## Verification

- `pnpm check`
- `pnpm build`
- `pnpm test:integration` (88 passed)
- `node scripts/verify-companion-kernel.mjs`
- `node scripts/verify-cartography-reachability-kernel.mjs`
- focused Cartography model, controls, snapshot, and kernel tests

Live checks for Gate of Madness, an off-world dungeon, and Pre-Searing are documented in the Cartography certification guide.

## Attribution

Implemented with Codex and verified with the repository's automated test harness.
