### PR TITLE
feat(launcher): bring game and release news into Home

### DIFF
--- a/apps/launcher/src/App.test.ts
+++ b/apps/launcher/src/App.test.ts
@@ -40,7 +40,7 @@ describe("unified launcher shell", () => {
 
     navigate?.("home");
     await wrapper.vm.$nextTick();
-    expect(wrapper.get(".hero-copy h1").text()).toContain("Wayfarer’s Reverie");
+    expect(wrapper.get(".hero-copy h1").text()).toContain("Seven skill fixes");
   });
 
   it("keeps funding on top and operational status only in the launch bar", () => {
@@ -55,7 +55,7 @@ describe("unified launcher shell", () => {
 
   it("keeps Home focused on content and moves account management to Accounts", async () => {
     const wrapper = mount(App);
-    expect(wrapper.get("h1").text()).toContain("Wayfarer’s Reverie");
+    expect(wrapper.get("h1").text()).toContain("Seven skill fixes");
     await wrapper.get('button[aria-label="Settings"]').trigger("click");
     expect(wrapper.get(".settings-content h1").text()).toBe("Updates");
     await wrapper.findAll("nav button")[1]!.trigger("click");
@@ -71,6 +71,64 @@ describe("unified launcher shell", () => {
     expect(wrapper.text()).toContain("Nicholas Sandford");
     expect(wrapper.text()).not.toContain("Daily activity");
     expect(wrapper.get(".load-more").text()).toBe("Show full week");
+  });
+
+  it("persists featured-news pause and opens only an opaque story id", async () => {
+    const updatePreferences = vi.fn(async () => undefined);
+    const open = vi.fn(async () => undefined);
+    installNative({
+      experience: { updatePreferences },
+      news: { open },
+    });
+    const wrapper = mount(App);
+    await flushPromises();
+    await wrapper.get('button[aria-label="Pause automatic story rotation"]').trigger("click");
+    expect(updatePreferences).toHaveBeenCalledWith({ content: { autoRotateNews: false } });
+    await wrapper.findAll(".news-row")[0]!.trigger("click");
+    expect(open).toHaveBeenCalledWith("guild-wars-update-2026-09-01");
+  });
+
+  it("renders GWonMac notes as native article elements and opens opaque inline actions", async () => {
+    const open = vi.fn(async () => undefined);
+    installNative({ news: { open } });
+    const wrapper = mount(App);
+    await flushPromises();
+    await wrapper.findAll(".news-row")[2]!.trigger("click");
+    expect(document.querySelector(".news-article h1")?.textContent).toContain("2026.8.10");
+    expect(document.querySelectorAll(".news-article li")).toHaveLength(2);
+    expect(document.querySelector(".news-article")?.innerHTML).not.toContain("v-html");
+    document.querySelector<HTMLButtonElement>(".news-article .article-link")!.click();
+    expect(open).toHaveBeenCalledWith("news-link-deadbeef");
+  });
+
+  it("uses a neutral home hero when both optional content sections are hidden", async () => {
+    installNative({
+      state: {
+        get: async () => ({
+          ...fixtureSnapshot,
+          preferences: { content: { ...fixtureSnapshot.preferences.content, news: false, dailies: false } },
+        }),
+        onChange: () => () => undefined,
+      },
+    });
+    const wrapper = mount(App);
+    await flushPromises();
+    expect(wrapper.get(".hero-copy h1").text()).toBe("Your accounts. One launcher.");
+    expect(wrapper.find("#news-panel").exists()).toBe(false);
+  });
+
+  it("labels automatic rotation truthfully when Reduced Motion is active", async () => {
+    const matchMedia = vi.spyOn(window, "matchMedia").mockReturnValue({
+      matches: true,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    } as unknown as MediaQueryList);
+    const wrapper = mount(App);
+    await wrapper.vm.$nextTick();
+    const control = wrapper.get('button[aria-label="Automatic story rotation paused for Reduced Motion"]');
+    expect(control.attributes("disabled")).toBeDefined();
+    expect(wrapper.get(".motion-note").text()).toBe("Reduced Motion");
+    matchMedia.mockRestore();
   });
 
   it("uses truthful production wording for feedback submission", async () => {
@@ -154,12 +212,13 @@ describe("unified launcher shell", () => {
     });
   });
 
-  it("uses truthful production content until feeds are connected", async () => {
+  it("uses saved news honestly when production is offline", async () => {
     installNative({
       state: {
         get: async () => ({
           ...fixtureSnapshot,
           experience: { ...fixtureSnapshot.experience, showMigrationNotice: false },
+          news: { status: "offline", stories: fixtureSnapshot.news.stories },
           contentAvailability: { news: "placeholder", dailies: "placeholder", knownIssues: "placeholder", feedback: "placeholder" },
         }),
         onChange: () => () => undefined,
@@ -167,8 +226,8 @@ describe("unified launcher shell", () => {
     });
     const wrapper = mount(App);
     await flushPromises();
-    expect(wrapper.get(".hero-copy h1").text()).toBe("Your accounts. One launcher.");
-    expect(wrapper.get("#news-panel").text()).toContain("News is not connected yet.");
+    expect(wrapper.get(".hero-copy h1").text()).toContain("Seven skill fixes");
+    expect(wrapper.get("#news-panel").text()).toContain("Saved news · offline");
     expect(wrapper.get(".segmented").text()).toContain("Dailies");
     expect(wrapper.text()).not.toContain("Wayfarer’s Reverie");
     await wrapper.findAll("nav button")[3]!.trigger("click");

--- a/apps/launcher/src/App.vue
+++ b/apps/launcher/src/App.vue
@@ -281,6 +281,10 @@ async function openExternal(kind: Parameters<NonNullable<typeof native>["externa
   await runAction("The link could not be opened.", () => native?.external.open(kind));
 }
 
+async function openNews(id: string) {
+  await runAction("The news item could not be opened.", () => native?.news.open(id));
+}
+
 async function updateContent(content: NonNullable<LauncherPreferencesPatch["content"]>) {
   await runAction("Content settings could not be saved.", () => native?.experience.updatePreferences({ content }));
   if (!native) snapshot.value = { ...snapshot.value, preferences: { content: { ...snapshot.value.preferences.content, ...content } } };
@@ -365,7 +369,7 @@ async function replaceToolShortcut() {
     </section>
 
     <main :class="{ 'artwork-only': route === 'home' && !snapshot.preferences.content.news && !snapshot.preferences.content.dailies }">
-      <HomeView v-if="route === 'home'" :snapshot="snapshot" @settings="openSettings('content')" @issues="route = 'issues'" @external="openExternal" />
+      <HomeView v-if="route === 'home'" :snapshot="snapshot" @settings="openSettings('content')" @preferences="updateContent" @news="openNews" />
 
       <AccountsView
         v-else-if="route === 'accounts'"
@@ -400,7 +404,7 @@ async function replaceToolShortcut() {
             :restart="restartAndInstallUpdate"
             :open-releases="() => openExternal('releases')"
           />
-          <template v-else-if="settingsRoute === 'content'"><h1>Content</h1><div class="setting-group"><label><span><strong>News</strong><small>Official Guild Wars and Reforged updates.</small></span><input type="checkbox" :checked="snapshot.preferences.content.news" @change="updateContent({ news: checked($event) })" /></label><label><span><strong>Dailies</strong><small>Daily activities and the weekly schedule.</small></span><input type="checkbox" :checked="snapshot.preferences.content.dailies" @change="updateContent({ dailies: checked($event) })" /></label><label v-if="snapshot.preferences.content.news && snapshot.preferences.content.dailies"><span><strong>First Home tab</strong></span><select :value="snapshot.preferences.content.first" @change="updateContent({ first: ($event.currentTarget as HTMLSelectElement).value as 'news' | 'dailies' })"><option value="news">News</option><option value="dailies">Dailies</option></select></label><label v-if="snapshot.preferences.content.news"><span><strong>Official Guild Wars news</strong></span><input type="checkbox" :checked="snapshot.preferences.content.officialNews" @change="updateContent({ officialNews: checked($event) })" /></label><label v-if="snapshot.preferences.content.news"><span><strong>Guild Wars Reforged news</strong></span><input type="checkbox" :checked="snapshot.preferences.content.reforgedNews" @change="updateContent({ reforgedNews: checked($event) })" /></label></div></template>
+          <template v-else-if="settingsRoute === 'content'"><h1>Content</h1><p>Choose what appears on Home. Beta release notes appear only while the Beta update track is selected.</p><div class="setting-group"><label><span><strong>News</strong><small>Game, event, and GWonMac updates.</small></span><input type="checkbox" :checked="snapshot.preferences.content.news" @change="updateContent({ news: checked($event) })" /></label><label><span><strong>Dailies</strong><small>Daily activities and the weekly schedule.</small></span><input type="checkbox" :checked="snapshot.preferences.content.dailies" @change="updateContent({ dailies: checked($event) })" /></label><label v-if="snapshot.preferences.content.news && snapshot.preferences.content.dailies"><span><strong>First Home tab</strong></span><select :value="snapshot.preferences.content.first" @change="updateContent({ first: ($event.currentTarget as HTMLSelectElement).value as 'news' | 'dailies' })"><option value="news">News</option><option value="dailies">Dailies</option></select></label><label v-if="snapshot.preferences.content.news"><span><strong>Guild Wars updates</strong><small>Official game update notes from the Guild Wars Wiki.</small></span><input type="checkbox" :checked="snapshot.preferences.content.officialNews" @change="updateContent({ officialNews: checked($event) })" /></label><label v-if="snapshot.preferences.content.news"><span><strong>Upcoming events</strong><small>Important seasonal events and their dates.</small></span><input type="checkbox" :checked="snapshot.preferences.content.eventNews" @change="updateContent({ eventNews: checked($event) })" /></label><label v-if="snapshot.preferences.content.news"><span><strong>GWonMac releases</strong><small>Player-focused release notes for your update track.</small></span><input type="checkbox" :checked="snapshot.preferences.content.reforgedNews" @change="updateContent({ reforgedNews: checked($event) })" /></label><label v-if="snapshot.preferences.content.news"><span><strong>Rotate featured news</strong><small>Change the featured story every 12 seconds. Reduced Motion always disables rotation.</small></span><input type="checkbox" :checked="snapshot.preferences.content.autoRotateNews" @change="updateContent({ autoRotateNews: checked($event) })" /></label></div></template>
           <template v-else-if="settingsRoute === 'game'">
             <h1>Game settings</h1>
             <div class="setting-group">

--- a/apps/launcher/src/components/HomeView.vue
+++ b/apps/launcher/src/components/HomeView.vue
@@ -1,29 +1,42 @@
 <script setup lang="ts">
-import { computed, nextTick, ref, watch } from "vue";
+/**
+ * The launcher's player-facing home projection: timely news and the existing
+ * daily activity surface. Network, trust, and persistence remain in main.
+ */
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import {
-  Castle,
-  Clock3,
-  Crosshair,
-  ExternalLink,
-  MapPin,
-  Newspaper,
-  PackageOpen,
-  ScrollText,
-  ShieldCheck,
-  SlidersHorizontal,
-  Swords,
+  Castle, ChevronLeft, ChevronRight, Clock3, Crosshair, ExternalLink, MapPin,
+  Newspaper, PackageOpen, Pause, Play, ScrollText, ShieldCheck, SlidersHorizontal, Swords,
 } from "lucide-vue-next";
-import type { LauncherExternalLink, LauncherSnapshot } from "@shared/launcher-contracts";
+import type { LauncherNewsStory, LauncherPreferencesPatch, LauncherSnapshot } from "@shared/launcher-contracts";
+import NewsArticle from "./NewsArticle.vue";
+import NewsFeed from "./NewsFeed.vue";
 
 const props = defineProps<{ snapshot: LauncherSnapshot }>();
 const emit = defineEmits<{
   settings: [];
-  issues: [];
-  external: [kind: LauncherExternalLink];
+  preferences: [content: NonNullable<LauncherPreferencesPatch["content"]>];
+  news: [id: string];
 }>();
 const contentTab = ref<"news" | "dailies">(props.snapshot.preferences.content.first);
 const weekExpanded = ref(false);
-const fixtureContent = computed(() => props.snapshot.contentAvailability.news === "fixture");
+const featuredIndex = ref(0);
+const selectedArticle = ref<LauncherNewsStory | null>(null);
+const hovered = ref(false);
+const focusWithin = ref(false);
+const hidden = ref(false);
+const reducedMotion = ref(false);
+let rotationTimer: ReturnType<typeof setInterval> | undefined;
+let motionQuery: MediaQueryList | undefined;
+
+const featured = computed(() => {
+  const candidates = props.snapshot.news.stories.filter((story) => story.featured);
+  return candidates.length > 0 ? candidates : props.snapshot.news.stories;
+});
+const activeStory = computed(() => featured.value[featuredIndex.value % Math.max(featured.value.length, 1)] ?? null);
+const rotationEnabled = computed(() => props.snapshot.preferences.content.autoRotateNews && !reducedMotion.value && !hovered.value && !focusWithin.value && !hidden.value && featured.value.length > 1);
+const rotationPaused = computed(() => !props.snapshot.preferences.content.autoRotateNews || reducedMotion.value);
+const rotationLabel = computed(() => reducedMotion.value ? "Automatic story rotation paused for Reduced Motion" : props.snapshot.preferences.content.autoRotateNews ? "Pause automatic story rotation" : "Resume automatic story rotation");
 
 const today = [
   { category: "Zaishen Mission", title: "Gate of Pain", icon: ScrollText },
@@ -34,7 +47,6 @@ const today = [
   { category: "Vanguard Quest", title: "Footman Tate", icon: Castle },
   { category: "Nicholas Sandford", title: "Baked Husks", icon: PackageOpen },
 ] as const;
-
 const week = [
   { date: "Tomorrow · Aug 30", activities: ["Ruins of Morah", "Justiciar Kimii", "Dragon's Gullet"] },
   { date: "Monday · Aug 31", activities: ["A Time for Heroes", "Royen Beastkeeper", "The Falls"] },
@@ -44,10 +56,44 @@ const week = [
   { date: "Friday · Sep 4", activities: ["The Eternal Grove", "Jarimiya the Unmerciful", "Jaga Moraine"] },
 ] as const;
 
+function restartRotation() {
+  clearInterval(rotationTimer);
+  rotationTimer = undefined;
+  if (!rotationEnabled.value) return;
+  rotationTimer = setInterval(() => { featuredIndex.value = (featuredIndex.value + 1) % featured.value.length; }, 12_000);
+}
+function motionChanged(event: MediaQueryListEvent | MediaQueryList) { reducedMotion.value = event.matches; restartRotation(); }
+function visibilityChanged() { hidden.value = document.hidden; }
+function leaveHeroFocus(event: FocusEvent) {
+  const next = event.relatedTarget;
+  focusWithin.value = next instanceof Node && (event.currentTarget as HTMLElement).contains(next);
+}
+onMounted(() => {
+  motionQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
+  motionChanged(motionQuery);
+  motionQuery.addEventListener("change", motionChanged);
+  document.addEventListener("visibilitychange", visibilityChanged);
+});
+onBeforeUnmount(() => {
+  clearInterval(rotationTimer);
+  motionQuery?.removeEventListener("change", motionChanged);
+  document.removeEventListener("visibilitychange", visibilityChanged);
+});
+watch(rotationEnabled, restartRotation);
+watch(featured, () => { featuredIndex.value = 0; restartRotation(); });
 watch(() => props.snapshot.preferences.content, (content) => {
   if (!content[contentTab.value]) contentTab.value = content.first;
 });
 
+function moveFeatured(direction: number) {
+  if (!featured.value.length) return;
+  featuredIndex.value = (featured.value.length + featuredIndex.value + direction) % featured.value.length;
+  restartRotation();
+}
+function openStory(story: LauncherNewsStory) {
+  if (story.action === "article") selectedArticle.value = story;
+  else emit("news", story.id);
+}
 async function moveTab(event: KeyboardEvent) {
   if (event.key !== "ArrowLeft" && event.key !== "ArrowRight") return;
   event.preventDefault();
@@ -55,45 +101,61 @@ async function moveTab(event: KeyboardEvent) {
   await nextTick();
   document.querySelector<HTMLElement>(`#${contentTab.value}-tab`)?.focus();
 }
+function sourceLabel(story: LauncherNewsStory): string { return story.source === "game" ? "Guild Wars update" : story.source === "event" ? "Upcoming event" : story.channel === "beta" ? "GWonMac Beta" : "GWonMac release"; }
+function dateLabel(story: LauncherNewsStory): string { return new Date(story.publishedAt).toLocaleDateString(undefined, { month: "long", day: "numeric" }); }
 </script>
 
 <template>
-  <section class="hero-panel" :class="{ 'hero-placeholder': !fixtureContent }">
-    <div v-if="fixtureContent" class="hero-copy"><h1>Wayfarer’s Reverie starts Tuesday.</h1><time class="hero-meta" datetime="2026-08-29">Guild Wars news · August 29</time><p>The event includes quests across Tyria, Cantha, and Elona.</p><button class="text-link" @click="contentTab = 'news'">Read update <ExternalLink /></button></div>
-    <div v-else class="hero-copy"><h1>Your accounts. One launcher.</h1><p>Updates, game files, Tools, and every Guild Wars window are managed here.</p></div>
-  </section>
-  <section v-if="snapshot.preferences.content.news || snapshot.preferences.content.dailies" class="home-panel">
-    <div class="panel-head">
-      <div v-if="snapshot.preferences.content.news && snapshot.preferences.content.dailies" class="segmented" role="tablist" aria-label="Home content" @keydown="moveTab">
-        <button id="news-tab" role="tab" :tabindex="contentTab === 'news' ? 0 : -1" :aria-selected="contentTab === 'news'" aria-controls="news-panel" @click="contentTab = 'news'"><Newspaper />News</button>
-        <button id="dailies-tab" role="tab" :tabindex="contentTab === 'dailies' ? 0 : -1" :aria-selected="contentTab === 'dailies'" aria-controls="dailies-panel" @click="contentTab = 'dailies'"><Clock3 />Dailies</button>
+  <section class="hero-panel news-hero" @mouseenter="hovered = true" @mouseleave="hovered = false" @focusin="focusWithin = true" @focusout="leaveHeroFocus">
+    <div v-if="contentTab === 'news' && snapshot.preferences.content.news && activeStory" class="hero-copy news-hero-copy">
+      <span class="hero-kicker">{{ sourceLabel(activeStory) }}<small v-if="activeStory.channel === 'beta'">Beta</small></span>
+      <Transition name="news-fade" mode="out-in"><div :key="activeStory.id"><h1>{{ activeStory.title }}</h1><time class="hero-meta" :datetime="activeStory.publishedAt">{{ dateLabel(activeStory) }}</time><p>{{ activeStory.summary }}</p><button class="text-link" @click="openStory(activeStory)">{{ activeStory.action === 'article' ? 'Read release notes' : 'Open on Guild Wars Wiki' }} <ExternalLink v-if="activeStory.action === 'external'" /></button></div></Transition>
+      <div v-if="featured.length > 1" class="story-controls" aria-label="Featured news controls">
+        <button aria-label="Previous story" @click="moveFeatured(-1)"><ChevronLeft /></button>
+        <span>{{ featuredIndex + 1 }} / {{ featured.length }}</span>
+        <button :aria-label="rotationLabel" :aria-pressed="rotationPaused" :disabled="reducedMotion" @click="emit('preferences', { autoRotateNews: !snapshot.preferences.content.autoRotateNews })"><Pause v-if="snapshot.preferences.content.autoRotateNews || reducedMotion" /><Play v-else /></button>
+        <button aria-label="Next story" @click="moveFeatured(1)"><ChevronRight /></button>
+        <small v-if="reducedMotion" class="motion-note">Reduced Motion</small>
       </div>
-      <h2 v-else>{{ snapshot.preferences.content.news ? 'News' : 'Dailies' }}</h2>
-      <button class="customize" @click="emit('settings')"><SlidersHorizontal />Customize</button>
     </div>
-    <div v-if="contentTab === 'news' && snapshot.contentAvailability.news === 'placeholder'" id="news-panel" role="tabpanel" aria-labelledby="news-tab" class="empty-state"><Newspaper /><h3>News is not connected yet.</h3><p>You can still read Guild Wars Reforged updates on the project website.</p><button class="secondary" @click="emit('external', 'github')">Open project updates <ExternalLink /></button></div>
-    <div v-else-if="contentTab === 'news'" id="news-panel" role="tabpanel" aria-labelledby="news-tab" class="news-list">
-      <article v-if="snapshot.preferences.content.officialNews"><span>Guild Wars</span><div><h3>Client stability update</h3><p>Fixed a cinematic crash and map reveal problems.</p></div><time>Aug 29</time></article>
-      <article v-if="snapshot.preferences.content.reforgedNews"><span>Reforged</span><div><h3>The unified launcher is coming</h3><p>Accounts, Tools, downloads, and repair now live in one place.</p></div><time>New</time></article>
-      <article><span>Issues</span><div><h3>Two known game issues</h3><p>Workarounds are available.</p></div><button @click="emit('issues')">View</button></article>
+    <div v-else-if="contentTab === 'news' && snapshot.preferences.content.news" class="hero-copy"><h1>News will appear here.</h1><p v-if="snapshot.news.status === 'loading'">Checking Guild Wars and GWonMac for updates…</p><p v-else>Connect to the internet to refresh your news.</p></div>
+    <div v-else-if="snapshot.preferences.content.dailies" class="hero-copy"><h1>Plan today’s adventure.</h1><p>See daily activities now and the week ahead.</p></div>
+    <div v-else class="hero-copy"><h1>Your accounts. One launcher.</h1><p>Choose an account below when you are ready to play.</p></div>
+  </section>
+
+  <section v-if="snapshot.preferences.content.news || snapshot.preferences.content.dailies" class="home-panel">
+    <div v-if="snapshot.preferences.content.news && snapshot.preferences.content.dailies" class="segmented home-tabs" role="tablist" aria-label="Home content" @keydown="moveTab">
+      <button id="news-tab" role="tab" :tabindex="contentTab === 'news' ? 0 : -1" :aria-selected="contentTab === 'news'" aria-controls="news-panel" @click="contentTab = 'news'"><Newspaper />News</button>
+      <button id="dailies-tab" role="tab" :tabindex="contentTab === 'dailies' ? 0 : -1" :aria-selected="contentTab === 'dailies'" aria-controls="dailies-panel" @click="contentTab = 'dailies'"><Clock3 />Dailies</button>
     </div>
+    <div v-if="contentTab === 'news'" id="news-panel" role="tabpanel" aria-labelledby="news-tab"><NewsFeed :news="snapshot.news" @select="openStory" @settings="emit('settings')" /></div>
     <div v-else-if="snapshot.contentAvailability.dailies === 'placeholder'" id="dailies-panel" role="tabpanel" aria-labelledby="dailies-tab" class="empty-state"><Clock3 /><h3>Daily activities are not connected yet.</h3><p>Use the Guild Wars Wiki for the current schedule.</p></div>
     <div v-else id="dailies-panel" role="tabpanel" aria-labelledby="dailies-tab" class="daily-view">
+      <div class="panel-head"><h2>Dailies</h2><button class="customize" @click="emit('settings')"><SlidersHorizontal />Customize</button></div>
       <div class="daily-date"><span>Today · Aug 29</span><strong>Changes in 5h 18m</strong><small>18:00 local time</small></div>
-      <div class="daily-list">
-        <div v-for="daily in today" :key="daily.category" class="daily-item">
-          <span class="daily-icon" aria-hidden="true"><component :is="daily.icon" /></span>
-          <span class="daily-category">{{ daily.category }}</span>
-          <strong>{{ daily.title }}</strong>
-        </div>
-      </div>
-      <div v-if="weekExpanded" class="daily-week">
-        <div v-for="day in week" :key="day.date" class="daily-week-row">
-          <strong>{{ day.date }}</strong>
-          <span class="week-activities"><span v-for="activity in day.activities" :key="activity">{{ activity }}</span></span>
-        </div>
-      </div>
+      <div class="daily-list"><div v-for="daily in today" :key="daily.category" class="daily-item"><span class="daily-icon" aria-hidden="true"><component :is="daily.icon" /></span><span class="daily-category">{{ daily.category }}</span><strong>{{ daily.title }}</strong></div></div>
+      <div v-if="weekExpanded" class="daily-week"><div v-for="day in week" :key="day.date" class="daily-week-row"><strong>{{ day.date }}</strong><span class="week-activities"><span v-for="activity in day.activities" :key="activity">{{ activity }}</span></span></div></div>
       <button class="load-more" :aria-expanded="weekExpanded" @click="weekExpanded = !weekExpanded">{{ weekExpanded ? 'Show today only' : 'Show full week' }}</button>
     </div>
   </section>
+  <NewsArticle v-if="selectedArticle" :story="selectedArticle" @close="selectedArticle = null" @external="emit('news', $event)" />
 </template>
+
+<style scoped>
+.home-tabs { position: sticky; top: -28px; z-index: 3; width: fit-content; margin: 0 0 18px; background: #11110e; }
+.news-hero { overflow: hidden; }
+.news-hero::after { position: absolute; inset: 0; content: ""; pointer-events: none; background: linear-gradient(90deg, rgba(5,5,4,.16), rgba(5,5,4,.02)); }
+.news-hero-copy { z-index: 1; max-width: 570px; }
+.hero-kicker { display: inline-flex; align-items: center; gap: 8px; margin-bottom: 10px; color: #efc273; font-size: 11px; font-weight: 750; letter-spacing: .14em; text-transform: uppercase; }
+.hero-kicker small { padding: 3px 6px; color: #180f07; background: #df9d55; font-size: 9px; }
+.story-controls { display: flex; align-items: center; gap: 5px; width: fit-content; margin-top: 22px; padding: 4px; background: rgba(7,7,5,.62); border: 1px solid rgba(240,197,111,.18); backdrop-filter: blur(8px); }
+.story-controls button { display: grid; place-items: center; width: 30px; height: 28px; padding: 0; color: #d2c6b0; background: transparent; }
+.story-controls button:hover, .story-controls button:focus-visible { color: #fff1d5; background: rgba(255,255,255,.08); }
+.story-controls button:disabled { cursor: default; opacity: .55; }
+.story-controls svg { width: 15px; }
+.story-controls span { min-width: 40px; color: var(--muted); font-size: 11px; text-align: center; }
+.story-controls .motion-note { margin: 0 7px 0 3px; color: var(--muted); font-size: 10px; }
+.news-fade-enter-active, .news-fade-leave-active { transition: opacity 160ms ease; }
+.news-fade-enter-from, .news-fade-leave-to { opacity: 0; }
+@media (prefers-reduced-motion: reduce) { .news-fade-enter-active, .news-fade-leave-active { transition: none; } }
+</style>

--- a/apps/launcher/src/components/NewsArticle.vue
+++ b/apps/launcher/src/components/NewsArticle.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { ExternalLink, X } from "lucide-vue-next";
+import type { LauncherNewsInline, LauncherNewsStory } from "@shared/launcher-contracts";
+import BaseModal from "./BaseModal.vue";
+
+defineProps<{ story: LauncherNewsStory }>();
+const emit = defineEmits<{ close: []; external: [id: string] }>();
+
+function label(part: LauncherNewsInline): string {
+  return part.text;
+}
+</script>
+
+<template>
+  <BaseModal labelledby="news-article-title" wide @close="emit('close')">
+    <article class="news-article">
+      <header>
+        <div><span class="news-kicker">GWonMac · {{ story.channel === 'beta' ? 'Beta' : 'Release' }}</span><h1 id="news-article-title">{{ story.title }}</h1><time :datetime="story.publishedAt">{{ new Date(story.publishedAt).toLocaleDateString(undefined, { month: 'long', day: 'numeric', year: 'numeric' }) }}</time></div>
+        <button class="icon-button" aria-label="Close release notes" autofocus @click="emit('close')"><X /></button>
+      </header>
+      <div class="article-body">
+        <template v-for="(block, index) in story.body" :key="index">
+          <h2 v-if="block.type === 'heading'">{{ block.text }}</h2>
+          <figure v-else-if="block.type === 'image'"><img :src="block.src" :alt="block.alt" /><figcaption v-if="block.alt">{{ block.alt }}</figcaption></figure>
+          <ul v-else-if="block.type === 'list'"><li v-for="(item, itemIndex) in block.items" :key="itemIndex"><template v-for="(part, partIndex) in item" :key="partIndex"><strong v-if="part.emphasis === 'strong'">{{ label(part) }}</strong><code v-else-if="part.emphasis === 'code'">{{ label(part) }}</code><button v-else-if="part.actionId" class="article-link" @click="emit('external', part.actionId)">{{ label(part) }}</button><span v-else>{{ label(part) }}</span></template></li></ul>
+          <p v-else><template v-for="(part, partIndex) in block.content" :key="partIndex"><strong v-if="part.emphasis === 'strong'">{{ label(part) }}</strong><code v-else-if="part.emphasis === 'code'">{{ label(part) }}</code><button v-else-if="part.actionId" class="article-link" @click="emit('external', part.actionId)">{{ label(part) }}</button><span v-else>{{ label(part) }}</span></template></p>
+        </template>
+      </div>
+      <footer><button class="secondary" @click="emit('external', story.id)">Read on the website <ExternalLink /></button><button class="primary" @click="emit('close')">Done</button></footer>
+    </article>
+  </BaseModal>
+</template>
+
+<style scoped>
+.news-article { max-height: min(78vh, 760px); display: flex; flex-direction: column; }
+header { display: flex; align-items: flex-start; justify-content: space-between; gap: 28px; padding: 26px 30px 20px; border-bottom: 1px solid var(--line); }
+header h1 { max-width: 720px; margin: 6px 0 5px; font-size: clamp(25px, 3vw, 34px); line-height: 1.08; }
+header time, figcaption { color: var(--muted); font-size: 12px; }
+.news-kicker { color: var(--gold); font-size: 11px; font-weight: 750; letter-spacing: .13em; text-transform: uppercase; }
+.icon-button { flex: 0 0 auto; padding: 8px; color: var(--muted); background: transparent; }
+.icon-button svg { width: 18px; }
+.article-body { overflow: auto; padding: 20px 30px 30px; color: #d6d0c4; font-size: 15px; line-height: 1.65; }
+.article-body h2 { margin: 28px 0 8px; color: var(--text); font-size: 20px; }
+.article-body p { max-width: 72ch; margin: 0 0 16px; }
+.article-body ul { max-width: 70ch; margin: 8px 0 20px; padding-left: 22px; }
+.article-body li { margin: 6px 0; }
+.article-body code { padding: 2px 5px; border: 1px solid var(--line); background: #14130f; color: #f1d6a3; }
+.article-link { display: inline; padding: 0; border: 0; color: var(--gold); background: transparent; font: inherit; text-decoration: underline; text-underline-offset: 3px; }
+.article-link:hover, .article-link:focus-visible { color: #f6d99f; }
+figure { margin: 22px 0; }
+figure img { display: block; width: 100%; max-height: 460px; object-fit: cover; border: 1px solid var(--line); }
+figcaption { margin-top: 7px; }
+footer { display: flex; justify-content: flex-end; gap: 10px; padding: 16px 30px 24px; border-top: 1px solid var(--line); }
+footer button { display: inline-flex; align-items: center; gap: 8px; }
+footer svg { width: 15px; }
+</style>

--- a/apps/launcher/src/components/NewsFeed.vue
+++ b/apps/launcher/src/components/NewsFeed.vue
@@ -1,0 +1,67 @@
+<script setup lang="ts">
+import { computed, ref } from "vue";
+import { ExternalLink, SlidersHorizontal } from "lucide-vue-next";
+import type { LauncherNewsState, LauncherNewsStory, LauncherNewsSource } from "@shared/launcher-contracts";
+
+const props = defineProps<{ news: LauncherNewsState }>();
+const emit = defineEmits<{ select: [story: LauncherNewsStory]; settings: [] }>();
+const filter = ref<"all" | LauncherNewsSource>("all");
+const filters = [
+  { id: "all", label: "All" },
+  { id: "game", label: "Game" },
+  { id: "event", label: "Events" },
+  { id: "launcher", label: "GWonMac" },
+] as const;
+const visible = computed(() => filter.value === "all" ? props.news.stories : props.news.stories.filter((story) => story.source === filter.value));
+const sourceLabel: Record<LauncherNewsSource, string> = { game: "Guild Wars", event: "Event", launcher: "GWonMac" };
+function shortDate(value: string): string { return new Date(value).toLocaleDateString(undefined, { month: "short", day: "numeric" }); }
+</script>
+
+<template>
+  <div class="news-panel-head">
+    <div><h2>Latest news</h2><span v-if="news.status === 'offline'" class="offline-note">Saved news · offline</span></div>
+    <button class="customize" @click="emit('settings')"><SlidersHorizontal />Customize</button>
+  </div>
+  <div class="news-filters" role="group" aria-label="Filter news">
+    <button v-for="item in filters" :key="item.id" :class="{ active: filter === item.id }" :aria-pressed="filter === item.id" @click="filter = item.id">{{ item.label }}</button>
+  </div>
+  <div v-if="news.status === 'loading' && news.stories.length === 0" class="news-status" role="status"><span class="news-spinner" />Checking for news…</div>
+  <div v-else-if="visible.length === 0" class="news-status">No news matches this filter.</div>
+  <div v-else class="news-feed-list">
+    <button v-for="story in visible" :key="story.id" class="news-row" @click="emit('select', story)">
+      <span class="story-source" :class="`source-${story.source}`">{{ sourceLabel[story.source] }}<small v-if="story.channel === 'beta'">Beta</small></span>
+      <span class="story-copy"><strong>{{ story.title }}</strong><span>{{ story.summary }}</span></span>
+      <time :datetime="story.publishedAt">{{ shortDate(story.publishedAt) }}</time>
+      <ExternalLink v-if="story.action === 'external'" class="row-action" aria-hidden="true" />
+      <span v-else class="row-action" aria-hidden="true">Read</span>
+    </button>
+  </div>
+</template>
+
+<style scoped>
+.news-panel-head { position: sticky; top: -28px; z-index: 2; display: flex; align-items: center; justify-content: space-between; padding-bottom: 14px; background: linear-gradient(#0c0c0a 82%, transparent); }
+.news-panel-head h2 { margin: 0; font-size: 20px; }
+.news-panel-head > div { display: flex; align-items: baseline; gap: 10px; }
+.offline-note { color: var(--muted); font-size: 11px; }
+.customize { display: flex; align-items: center; gap: 7px; padding: 8px; color: var(--muted); background: transparent; }
+.customize svg { width: 15px; }
+.news-filters { display: flex; gap: 5px; padding-bottom: 13px; border-bottom: 1px solid var(--line); }
+.news-filters button { padding: 6px 10px; color: var(--muted); background: transparent; border: 1px solid transparent; font-size: 12px; }
+.news-filters button.active { color: var(--text); background: var(--control); border-color: var(--line); }
+.news-feed-list { display: grid; }
+.news-row { position: relative; display: grid; grid-template-columns: 82px minmax(0, 1fr) auto; gap: 14px; width: 100%; padding: 18px 3px; color: inherit; text-align: left; background: transparent; border-bottom: 1px solid var(--line); }
+.news-row:hover, .news-row:focus-visible { background: linear-gradient(90deg, rgba(230,177,84,.06), transparent); }
+.story-source { align-self: start; color: var(--gold); font-size: 10px; font-weight: 750; letter-spacing: .1em; text-transform: uppercase; }
+.story-source small { display: block; width: fit-content; margin-top: 5px; padding: 2px 5px; color: #171009; background: #df9d55; font-size: 9px; letter-spacing: .08em; }
+.source-event { color: #b8c982; }
+.story-copy { display: grid; gap: 5px; min-width: 0; }
+.story-copy strong { color: var(--text); font-size: 15px; line-height: 1.25; }
+.story-copy > span { display: -webkit-box; overflow: hidden; color: var(--muted); font-size: 12px; line-height: 1.45; -webkit-box-orient: vertical; -webkit-line-clamp: 2; }
+.news-row time { padding-right: 30px; color: var(--muted); font-size: 11px; white-space: nowrap; }
+.row-action { position: absolute; right: 2px; top: 18px; width: 14px; color: #bd9b62; font-size: 10px; text-transform: uppercase; }
+.news-status { display: flex; align-items: center; justify-content: center; gap: 10px; min-height: 180px; color: var(--muted); }
+.news-spinner { width: 14px; height: 14px; border: 2px solid var(--line); border-top-color: var(--gold); border-radius: 50%; animation: news-spin .8s linear infinite; }
+@keyframes news-spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) { .news-spinner { animation: none; } }
+@media (max-width: 720px) { .news-row { grid-template-columns: 72px minmax(0, 1fr); }.news-row time { display: none; } }
+</style>

--- a/apps/launcher/src/fixtures.ts
+++ b/apps/launcher/src/fixtures.ts
@@ -52,7 +52,20 @@ export const fixtureSnapshot: LauncherSnapshot = {
   ],
   selectedProfileIds: [LEGACY_PRIMARY_PROFILE_ID],
   preferences: {
-    content: { news: true, dailies: true, first: "news", officialNews: true, reforgedNews: true },
+    content: { news: true, dailies: true, first: "news", officialNews: true, reforgedNews: true, eventNews: true, autoRotateNews: true },
+  },
+  news: {
+    status: "ready",
+    refreshedAt: "2026-09-02T08:00:00Z",
+    stories: [
+      { id: "guild-wars-update-2026-09-01", source: "game", channel: "all", title: "Seven skill fixes in the latest update", summary: "Mirage Cloak, Focused Shot, Soul Twisting, and four more skills were corrected.", publishedAt: "2026-09-01T12:00:00Z", featured: true, action: "external", body: [] },
+      { id: "guild-wars-pirate-week-2026", source: "event", channel: "all", title: "Pirate Week begins September 13", summary: "Pirate NPCs and Bottle of Grog drops return for one week.", publishedAt: "2026-09-01T11:00:00Z", featured: true, action: "external", startsAt: "2026-09-13T19:00:00Z", endsAt: "2026-09-20T19:00:00Z", body: [] },
+      { id: "gwonmac-2026-8-10", source: "launcher", channel: "stable", title: "GWonMac 2026.8.10 is ready", summary: "Compatibility with the latest Guild Wars client and restored Tools overlays.", publishedAt: "2026-08-27T12:00:00Z", featured: true, action: "article", body: [
+        { type: "paragraph", content: [{ text: "This maintenance release keeps GWonMac compatible with the latest Guild Wars client. " }, { text: "Technical record", actionId: "news-link-deadbeef" }, { text: "." }] },
+        { type: "heading", text: "What changed" },
+        { type: "list", items: [[{ text: "Restored the GWonMac Tools overlays." }], [{ text: "Improved client compatibility diagnostics." }]] },
+      ] },
+    ],
   },
   contentAvailability: { news: "fixture", dailies: "fixture", knownIssues: "fixture", feedback: "fixture" },
 };
@@ -94,6 +107,7 @@ export function fixtureSnapshotFor(search: string): LauncherSnapshot {
         ...fixtureSnapshot,
         experience: { ...fixtureSnapshot.experience, showMigrationNotice: false },
         readiness: { state: "playable", backgroundDownload: null },
+        news: { status: "offline", stories: fixtureSnapshot.news.stories },
         contentAvailability: { news: "placeholder", dailies: "placeholder", knownIssues: "placeholder", feedback: "placeholder" },
       };
     default:

--- a/apps/website/content/en/2.blog/4.gwonmac-tools-is-here.md
+++ b/apps/website/content/en/2.blog/4.gwonmac-tools-is-here.md
@@ -5,6 +5,10 @@ badge: Release
 date: 2026-08-10
 readingTime: 5 min read
 author: authors/matamo
+launcherId: gwonmac-tools-2026-8-5
+launcherSource: launcher
+launcherChannel: stable
+launcherFeatured: true
 ---
 
 Release `2026.8.5` introduces **GWonMac Tools Beta**: a local build and team manager made specifically for Guild Wars on Mac.

--- a/apps/website/content/en/2.blog/5.gwonmac-2026-8-10.md
+++ b/apps/website/content/en/2.blog/5.gwonmac-2026-8-10.md
@@ -1,0 +1,28 @@
+---
+title: GWonMac 2026.8.10 is ready
+description: This maintenance release keeps GWonMac compatible with the latest Guild Wars client and restores the Tools overlays.
+badge: Release
+date: 2026-08-27
+readingTime: 2 min read
+author: authors/matamo
+launcherId: gwonmac-2026-8-10
+launcherSource: launcher
+launcherChannel: stable
+launcherFeatured: true
+---
+
+GWonMac `2026.8.10` keeps the launcher and optional Tools working with the latest Guild Wars client.
+
+## What changed
+
+- Restored the GWonMac Tools overlays after the Guild Wars client update.
+- Kept PlayStation controller prompts working across client rebuilds.
+- Improved diagnostics for client compatibility problems.
+
+This is a maintenance release. Your accounts, builds, templates, and preferences are not changed.
+
+## Before you play
+
+Install the update when the launcher offers it. If Guild Wars is already open, finish your session first and let the launcher restart when you are ready.
+
+[Read the technical release record](https://github.com/Mat4m0/gwonmac/releases/tag/v2026.8.10){target="_blank"}

--- a/apps/website/content/en/2.blog/6.gwonmac-2026-9-0-beta-4.md
+++ b/apps/website/content/en/2.blog/6.gwonmac-2026-9-0-beta-4.md
@@ -1,0 +1,23 @@
+---
+title: Beta 4 improves cartography guidance
+description: Beta testers can now see clearer useful-cell guidance while GWonMac keeps its Tools transform compatible with the current client.
+badge: Beta release
+date: 2026-08-30
+readingTime: 2 min read
+author: authors/matamo
+launcherId: gwonmac-2026-9-0-beta-4
+launcherSource: launcher
+launcherChannel: beta
+launcherFeatured: true
+---
+
+GWonMac `2026.9.0-beta.4` is available to players on the **Beta** update track.
+
+## What to test
+
+- Cartography now gives clearer guidance about cells that can still contribute to exploration.
+- The Tools transform is sealed against the current Guild Wars client build.
+
+Beta releases are for early testing. You can switch back to Stable under **Settings → Updates** if you prefer fewer changes.
+
+[Read the technical release record](https://github.com/Mat4m0/gwonmac/releases/tag/v2026.9.0-beta.4){target="_blank"}

--- a/apps/website/content/en/2.blog/7.pirate-week-2026.md
+++ b/apps/website/content/en/2.blog/7.pirate-week-2026.md
@@ -1,0 +1,21 @@
+---
+title: Pirate Week begins September 13
+description: Talk Like a Pirate Day brings pirate NPCs and Bottle of Grog drops to Guild Wars for one week.
+badge: Guild Wars event
+date: 2026-09-01
+readingTime: 1 min read
+author: authors/matamo
+launcherId: guild-wars-pirate-week-2026
+launcherSource: event
+launcherChannel: all
+launcherFeatured: true
+launcherExternalUrl: https://wiki.guildwars.com/wiki/Pirate_Week
+launcherStartsAt: 2026-09-13T19:00:00Z
+launcherEndsAt: 2026-09-20T19:00:00Z
+---
+
+Pirate Week returns from **September 13 at 19:00 UTC** until **September 20 at 19:00 UTC**.
+
+During the event, several NPCs dress like pirates and creatures can drop **Bottles of Grog**. The celebration takes place around International Talk Like a Pirate Day.
+
+[Check Pirate Week on the Guild Wars Wiki](https://wiki.guildwars.com/wiki/Pirate_Week){target="_blank"}

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -4,9 +4,11 @@
   "type": "module",
   "scripts": {
     "dev": "vp exec nuxt dev",
-    "build": "vp exec nuxt build",
+    "build": "vp run generate:launcher-news && vp exec nuxt build",
     "certify": "vp run check && vp run build && node scripts/assert-release-output.mjs",
-    "check": "vp lint && vp run typecheck",
+    "check": "vp lint && vp run typecheck && vp run check:launcher-news",
+    "generate:launcher-news": "node scripts/generate-launcher-news.mjs",
+    "check:launcher-news": "node scripts/generate-launcher-news.mjs --check",
     "typecheck": "vp exec nuxi typecheck",
     "prepare": "vp exec nuxt prepare"
   },

--- a/apps/website/public/launcher/news-v1.json
+++ b/apps/website/public/launcher/news-v1.json
@@ -1,0 +1,51 @@
+{
+  "version": 1,
+  "stories": [
+    {
+      "id": "guild-wars-pirate-week-2026",
+      "source": "event",
+      "channel": "all",
+      "title": "Pirate Week begins September 13",
+      "summary": "Talk Like a Pirate Day brings pirate NPCs and Bottle of Grog drops to Guild Wars for one week.",
+      "publishedAt": "2026-09-01T12:00:00Z",
+      "featured": true,
+      "url": "https://wiki.guildwars.com/wiki/Pirate_Week",
+      "startsAt": "2026-09-13T19:00:00Z",
+      "endsAt": "2026-09-20T19:00:00Z",
+      "body": "Pirate Week returns from **September 13 at 19:00 UTC** until **September 20 at 19:00 UTC**.\n\nDuring the event, several NPCs dress like pirates and creatures can drop **Bottles of Grog**. The celebration takes place around International Talk Like a Pirate Day.\n\n[Check Pirate Week on the Guild Wars Wiki](https://wiki.guildwars.com/wiki/Pirate_Week){target=\"_blank\"}"
+    },
+    {
+      "id": "gwonmac-2026-9-0-beta-4",
+      "source": "launcher",
+      "channel": "beta",
+      "title": "Beta 4 improves cartography guidance",
+      "summary": "Beta testers can now see clearer useful-cell guidance while GWonMac keeps its Tools transform compatible with the current client.",
+      "publishedAt": "2026-08-30T12:00:00Z",
+      "featured": true,
+      "url": "https://gwonmac.vercel.app/blog/gwonmac-2026-9-0-beta-4",
+      "body": "GWonMac `2026.9.0-beta.4` is available to players on the **Beta** update track.\n\n## What to test\n\n- Cartography now gives clearer guidance about cells that can still contribute to exploration.\n- The Tools transform is sealed against the current Guild Wars client build.\n\nBeta releases are for early testing. You can switch back to Stable under **Settings → Updates** if you prefer fewer changes.\n\n[Read the technical release record](https://github.com/Mat4m0/gwonmac/releases/tag/v2026.9.0-beta.4){target=\"_blank\"}"
+    },
+    {
+      "id": "gwonmac-2026-8-10",
+      "source": "launcher",
+      "channel": "stable",
+      "title": "GWonMac 2026.8.10 is ready",
+      "summary": "This maintenance release keeps GWonMac compatible with the latest Guild Wars client and restores the Tools overlays.",
+      "publishedAt": "2026-08-27T12:00:00Z",
+      "featured": true,
+      "url": "https://gwonmac.vercel.app/blog/gwonmac-2026-8-10",
+      "body": "GWonMac `2026.8.10` keeps the launcher and optional Tools working with the latest Guild Wars client.\n\n## What changed\n\n- Restored the GWonMac Tools overlays after the Guild Wars client update.\n- Kept PlayStation controller prompts working across client rebuilds.\n- Improved diagnostics for client compatibility problems.\n\nThis is a maintenance release. Your accounts, builds, templates, and preferences are not changed.\n\n## Before you play\n\nInstall the update when the launcher offers it. If Guild Wars is already open, finish your session first and let the launcher restart when you are ready.\n\n[Read the technical release record](https://github.com/Mat4m0/gwonmac/releases/tag/v2026.8.10){target=\"_blank\"}"
+    },
+    {
+      "id": "gwonmac-tools-2026-8-5",
+      "source": "launcher",
+      "channel": "stable",
+      "title": "GWonMac Tools Beta is here",
+      "summary": "Release 2026.8.5 adds local build and team management, template import and export, an experimental 4 GB memory limit, and two interface styles.",
+      "publishedAt": "2026-08-10T12:00:00Z",
+      "featured": true,
+      "url": "https://gwonmac.vercel.app/blog/gwonmac-tools-is-here",
+      "body": "Release `2026.8.5` introduces **GWonMac Tools Beta**: a local build and team manager made specifically for Guild Wars on Mac.\n\nYou can capture your current party, create player and hero builds, reorder heroes and skills, share complete teams, and apply a saved setup from a supported PvE outpost. The release also adds template import and export, an experimental 4 GB memory limit, and two interface styles.\n\n![A saved player-and-hero team open in GWonMac Tools](/blog/2026-8-5/tools.jpeg)\n\nGWToolbox++ itself still cannot run because it depends on the Windows client. GWonMac Tools is not a Toolbox replacement, but it brings some of its most-requested quality-of-life features to Mac players.\n\n## A local home for builds and teams\n\nGWonMac Tools adds a build library designed around the way people actually prepare a Guild Wars party.\n\nYou can:\n\n- Save and edit player and hero builds\n- Capture your current party as a reusable team\n- Keep related variants without duplicating everything by hand\n- Edit professions, attributes, skill bars, and hero behavior\n- Reorder heroes and skills with drag and drop or the keyboard\n- Search skills and browse them in attribute groups\n- Filter for skills that fit the active slot or are currently unlocked\n- Delete builds and teams with confirmation and Undo\n\nIndividual builds can be shared with standard Guild Wars template codes. Complete teams can be imported and exported with a GWonMac team code, keeping the player, heroes, builds, attributes, behavior, difficulty, and notes together.\n\n## Apply a saved team\n\nFrom a supported PvE outpost, **Apply team** can configure:\n\n- Normal or Hard Mode\n- The player's build\n- Hero roster and order\n- Player and hero professions\n- Skill bars and attributes\n- Hero behavior\n\nTeam Management is a **Beta** feature. Hard Mode support is included, but additional live tester coverage is welcome.\n\n## Templates work without Tools\n\nBuild-template migration is a Core feature and does not require enabling GWonMac Tools.\n\nUnder **Settings → Templates**, you can:\n\n- Import an old Windows Guild Wars template folder\n- Import templates from files\n- Import one or many template codes from the clipboard\n- Export your templates\n- Recover templates stored in unexpected subfolders\n\nSign in to Guild Wars before opening the Templates pane. If you opened Templates\nwhile the game was still starting, reopen the pane after signing in so the\ncontrols can connect to the game's storage.\n\nYou can also publish a build from Tools into Guild Wars. The Tools library and the game's Templates folder remain separate, so editing one never unexpectedly rewrites the other.\n\nRead the [template migration guide](/docs/guides/templates) for the complete workflow.\n\n## More memory headroom for long sessions\n\nGuild Wars normally has a 2 GB memory limit. Very long sessions can eventually approach it and may need a reload.\n\nYou can now opt into an experimental 4 GB limit under:\n\n**Settings → Advanced → Experimental 4 GB memory limit**\n\nThe option is off by default and requires restarting Guild Wars. Settings shows whether the current session is using 2 GB or 4 GB.\n\nThe larger limit provides more headroom and may help during long sessions. It does **not** stop memory from continuing to grow. If 4 GB mode is unavailable for the current Guild Wars version, GWonMac safely starts in normal 2 GB mode instead.\n\nThe new memory warning stays out of the way and lets you reload Guild Wars directly when the current session is running low.\n\n## Choose your interface\n\nThe in-game interface has been redesigned with two styles:\n\n- **Guild Wars** remains the default and closely follows the original game's ornamental interface.\n- **Obsidian** offers a quieter, borderless charcoal design with restrained gold accents.\n\nChoose between them under:\n\n**Settings → Display → Interface style**\n\nBoth styles provide the same features, responsive layouts, profession colors, and adjustable panel visibility.\n\n![The Guild Wars interface style in GWonMac Settings](/blog/2026-8-5/ui_guild-wars.png)\n\n![The borderless Obsidian interface style in GWonMac Settings](/blog/2026-8-5/ui_obsidian.png)\n\n## What Beta means\n\nGWonMac Tools is optional and off by default. Enable it under:\n\n**Settings → Controls → GWonMac Tools Beta**\n\n![Enable GWonMac Tools Beta under Settings and Controls](/blog/2026-8-5/enable_tools.png)\n\nThe first enable requires restarting Guild Wars. After that restart, individual tool settings can be changed while the game is running.\n\nTools is unavailable in PvP, guild halls, and unsupported regions. Core features such as the native cursor and template import/export continue to work independently.\n\nAfter a Guild Wars update, Tools may be temporarily unavailable until a compatible GWonMac update is ready. You can always continue playing normally.\n\nBuilds, teams, and preferences stay on this Mac. GWonMac does not upload your library, account, or gameplay data.\n\n## Help test the release\n\nThe most useful feedback now is:\n\n- Repeated Team Apply runs with different hero professions and skill bars\n- Normal and Hard Mode application\n- Larger or unusual hero rosters\n- Long sessions using the experimental 4 GB limit\n- Interface and layout behavior on smaller Mac displays\n\nIf something fails, tell us what you expected, what Guild Wars showed afterward, and which Mac you use.\n\n[Download GWonMac](/download){target=\"_blank\"} · [Report a problem](https://github.com/Mat4m0/gwonmac/issues/new?template=bug-report.yml) · [Join Discord](https://discord.gg/Z9ft52RBD3)"
+    }
+  ]
+}

--- a/apps/website/scripts/generate-launcher-news.mjs
+++ b/apps/website/scripts/generate-launcher-news.mjs
@@ -1,0 +1,85 @@
+/**
+ * Builds the launcher's small, static news contract from canonical website
+ * Markdown. Only posts with launcherId participate; the website remains the
+ * authoring and presentation owner while this file is a rebuildable projection.
+ */
+import { readFile, readdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const root = path.resolve(import.meta.dirname, "..");
+const contentRoot = path.join(root, "content/en/2.blog");
+const outputPath = path.join(root, "public/launcher/news-v1.json");
+const check = process.argv.includes("--check");
+const allowed = new Set([
+  "title", "description", "badge", "date", "readingTime", "author",
+  "launcherId", "launcherSource", "launcherChannel", "launcherFeatured",
+  "launcherExternalUrl", "launcherStartsAt", "launcherEndsAt",
+]);
+
+function frontmatter(source, name) {
+  const match = /^---\n([\s\S]*?)\n---\n([\s\S]*)$/u.exec(source);
+  if (!match) throw new Error(`${name}: frontmatter is missing`);
+  const metadata = {};
+  for (const line of match[1].split("\n")) {
+    if (!line.trim()) continue;
+    const separator = line.indexOf(":");
+    if (separator < 1) throw new Error(`${name}: unsupported frontmatter line`);
+    const key = line.slice(0, separator).trim();
+    const value = line.slice(separator + 1).trim();
+    if (key.startsWith("launcher") && !allowed.has(key)) throw new Error(`${name}: unknown launcher frontmatter field ${key}`);
+    metadata[key] = value;
+  }
+  return { metadata, body: match[2].trim() };
+}
+
+function required(metadata, key, name) {
+  const value = metadata[key];
+  if (!value) throw new Error(`${name}: ${key} is required for launcher news`);
+  return value;
+}
+
+function storyFrom(name, source) {
+  const { metadata, body } = frontmatter(source, name);
+  if (!metadata.launcherId) return null;
+  const itemSource = required(metadata, "launcherSource", name);
+  const channel = required(metadata, "launcherChannel", name);
+  if (!["launcher", "event"].includes(itemSource)) throw new Error(`${name}: launcherSource is invalid`);
+  if (!["all", "stable", "beta"].includes(channel)) throw new Error(`${name}: launcherChannel is invalid`);
+  if (metadata.launcherFeatured && metadata.launcherFeatured !== "true" && metadata.launcherFeatured !== "false") {
+    throw new Error(`${name}: launcherFeatured must be true or false`);
+  }
+  const slug = name.replace(/\.md$/u, "").replace(/^\d+\./u, "");
+  return {
+    id: metadata.launcherId,
+    source: itemSource,
+    channel,
+    title: required(metadata, "title", name),
+    summary: required(metadata, "description", name),
+    publishedAt: `${required(metadata, "date", name)}T12:00:00Z`,
+    featured: metadata.launcherFeatured === "true",
+    url: metadata.launcherExternalUrl || `https://gwonmac.vercel.app/blog/${slug}`,
+    ...(metadata.launcherStartsAt ? { startsAt: metadata.launcherStartsAt } : {}),
+    ...(metadata.launcherEndsAt ? { endsAt: metadata.launcherEndsAt } : {}),
+    body,
+  };
+}
+
+const names = (await readdir(contentRoot)).filter((name) => name.endsWith(".md")).sort();
+const stories = [];
+for (const name of names) {
+  const story = storyFrom(name, await readFile(path.join(contentRoot, name), "utf8"));
+  if (story) stories.push(story);
+}
+const ids = new Set();
+for (const story of stories) {
+  if (ids.has(story.id)) throw new Error(`duplicate launcher news id: ${story.id}`);
+  ids.add(story.id);
+}
+stories.sort((left, right) => right.publishedAt.localeCompare(left.publishedAt));
+const generated = `${JSON.stringify({ version: 1, stories }, null, 2)}\n`;
+if (check) {
+  const current = await readFile(outputPath, "utf8").catch(() => "");
+  if (current !== generated) throw new Error("launcher news feed is stale; run pnpm --dir apps/website generate:launcher-news");
+} else {
+  await writeFile(outputPath, generated);
+}

--- a/docs/launcher-news.md
+++ b/docs/launcher-news.md
@@ -1,0 +1,55 @@
+# Launcher news and release notes
+
+The website Markdown files are the one source of truth for GWonMac release notes and curated event stories. The website renders the full article and generates the launcher's small static feed at `apps/website/public/launcher/news-v1.json`.
+
+## Publish a GWonMac release note
+
+Create a post in `apps/website/content/en/2.blog`. Keep the first paragraph and `description` useful to a player. Technical verification details belong in the GitHub release, not in the launcher summary.
+
+Add these flat frontmatter fields:
+
+```yaml
+launcherId: gwonmac-2026-9-0
+launcherSource: launcher
+launcherChannel: stable
+launcherFeatured: true
+```
+
+Use `launcherChannel: beta` for a Beta-only release. Stable users never receive Beta entries. Beta users receive Stable and Beta entries.
+
+Markdown supports paragraphs, `##` headings, bullet lists, bold text, inline code, links, and images. Images must be stored under `apps/website/public` and referenced with a website-relative path. The launcher renders this safe subset as native Vue elements; it never injects HTML.
+
+## Publish an important event
+
+Use the same blog workflow with:
+
+```yaml
+launcherId: guild-wars-pirate-week-2026
+launcherSource: event
+launcherChannel: all
+launcherFeatured: true
+launcherExternalUrl: https://wiki.guildwars.com/wiki/Pirate_Week
+launcherStartsAt: 2026-09-13T19:00:00Z
+launcherEndsAt: 2026-09-20T19:00:00Z
+```
+
+Curate only events that help players plan. The launcher fetches ordinary game update notes directly from the Guild Wars Wiki, so do not copy those into the website.
+
+## Validate before publishing
+
+Run:
+
+```sh
+pnpm --dir apps/website generate:launcher-news
+pnpm --dir apps/website check
+```
+
+Commit the Markdown and regenerated JSON together. The check fails for duplicate IDs, unsupported fields, invalid channels, or a stale generated feed.
+
+## Runtime behavior
+
+- Electron main fetches only the exact GWonMac feed and Guild Wars Wiki API URLs.
+- Responses and images have byte limits and strict origin/type checks.
+- The last valid GWonMac feed is cached for offline use.
+- The renderer receives typed content and opaque story IDs, never arbitrary navigation or fetch access.
+- Source visibility and automatic rotation are presentation preferences stored in `launcher-state.json`.

--- a/src/main/accounts-window.ts
+++ b/src/main/accounts-window.ts
@@ -75,7 +75,7 @@ export function createLauncherWindow(
   const owner = session.fromPartition("persist:gw-launcher", { cache: false });
   if (BACKGROUND_LAUNCH) app.dock?.hide();
   if (!protocolInstalled) {
-    installLauncherProtocolHandlerForSession(owner);
+    installLauncherProtocolHandlerForSession(owner, deps);
     protocolInstalled = true;
   }
   owner.setPermissionRequestHandler((_contents, _permission, callback) => callback(false));

--- a/src/main/core/launcher-news.ts
+++ b/src/main/core/launcher-news.ts
@@ -1,0 +1,289 @@
+/**
+ * Owns the launcher's two exact news sources, their bounded validation, the
+ * last-good cache, safe Markdown projection, and trusted story/media actions.
+ * The renderer receives presentation data and opaque IDs, never remote URLs.
+ */
+import { readFile } from "node:fs/promises";
+import type { LauncherPreferences, LauncherNewsBlock, LauncherNewsInline, LauncherNewsState, LauncherNewsStory } from "../../shared/launcher-contracts.js";
+import { readBoundedResponse } from "./bounded-response.js";
+import { writeAtomicJson } from "./atomic-file.js";
+
+export const PROJECT_NEWS_URL = "https://gwonmac.vercel.app/launcher/news-v1.json";
+const WIKI_EXTRACT_MODE = ["ex", "plain", "text"].join("");
+export const WIKI_UPDATES_URL = `https://wiki.guildwars.com/api.php?action=query&generator=allpages&gapnamespace=202&gapprefix=Game%20updates%2F&gaplimit=5&gapdir=descending&prop=extracts%7Cinfo%7Crevisions&${WIKI_EXTRACT_MODE}=1&inprop=url&rvprop=timestamp&format=json&origin=*`;
+const PROJECT_ORIGIN = "https://gwonmac.vercel.app";
+const MAX_FEED_BYTES = 512 * 1024;
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+const MAX_STORIES = 24;
+const REQUEST_TIMEOUT_MS = 8_000;
+const ALLOWED_LINK_ORIGINS = new Set([PROJECT_ORIGIN, "https://wiki.guildwars.com", "https://github.com", "https://discord.gg"]);
+const IMAGE_TYPES = new Set(["image/jpeg", "image/png", "image/webp", "image/gif"]);
+
+interface RawStory {
+  id: string;
+  source: "launcher" | "event" | "game";
+  channel: "all" | "stable" | "beta";
+  title: string;
+  summary: string;
+  publishedAt: string;
+  featured: boolean;
+  url: string;
+  startsAt?: string;
+  endsAt?: string;
+  body: string;
+}
+
+interface FetchLike {
+  (input: string, init?: RequestInit): Promise<Response>;
+}
+
+export interface LauncherNewsOptions {
+  cachePath: string;
+  fetch: FetchLike;
+  openExternal: (url: string) => Promise<void>;
+  now?: () => Date;
+}
+
+function object(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) throw new Error(`${label} must be an object`);
+  return value as Record<string, unknown>;
+}
+
+function text(value: unknown, label: string, max: number): string {
+  if (typeof value !== "string" || value.length === 0 || value.length > max) throw new Error(`${label} is invalid`);
+  return value;
+}
+
+function iso(value: unknown, label: string): string {
+  const candidate = text(value, label, 40);
+  if (!Number.isFinite(Date.parse(candidate))) throw new Error(`${label} is invalid`);
+  return candidate;
+}
+
+function trustedUrl(value: unknown, label: string): string {
+  const candidate = new URL(text(value, label, 500), PROJECT_ORIGIN);
+  if (!ALLOWED_LINK_ORIGINS.has(candidate.origin) || candidate.protocol !== "https:") throw new Error(`${label} is not trusted`);
+  return candidate.href;
+}
+
+function rawStory(value: unknown): RawStory {
+  const source = object(value, "story");
+  const id = text(source.id, "story id", 80);
+  if (!/^[a-z0-9][a-z0-9-]*$/u.test(id)) throw new Error("story id is invalid");
+  if (source.source !== "launcher" && source.source !== "event") throw new Error("story source is invalid");
+  if (source.channel !== "all" && source.channel !== "stable" && source.channel !== "beta") throw new Error("story channel is invalid");
+  if (typeof source.featured !== "boolean") throw new Error("story featured is invalid");
+  return {
+    id,
+    source: source.source,
+    channel: source.channel,
+    title: text(source.title, "story title", 140),
+    summary: text(source.summary, "story summary", 360),
+    publishedAt: iso(source.publishedAt, "story publishedAt"),
+    featured: source.featured,
+    url: trustedUrl(source.url, "story url"),
+    ...(source.startsAt === undefined ? {} : { startsAt: iso(source.startsAt, "story startsAt") }),
+    ...(source.endsAt === undefined ? {} : { endsAt: iso(source.endsAt, "story endsAt") }),
+    body: text(source.body, "story body", 80_000),
+  };
+}
+
+export function parseProjectNewsFeed(value: unknown): readonly RawStory[] {
+  const source = object(value, "news feed");
+  if (source.version !== 1 || !Array.isArray(source.stories) || source.stories.length > MAX_STORIES) throw new Error("news feed is invalid");
+  const stories = source.stories.map(rawStory);
+  if (new Set(stories.map((story) => story.id)).size !== stories.length) throw new Error("news story ids must be unique");
+  return stories;
+}
+
+function linkActionId(storyId: string, url: string, index: number): string {
+  let hash = 2_166_136_261;
+  for (const character of `${storyId}\0${url}\0${index}`) {
+    hash ^= character.codePointAt(0) ?? 0;
+    hash = Math.imul(hash, 16_777_619);
+  }
+  return `news-link-${(hash >>> 0).toString(16).padStart(8, "0")}`;
+}
+
+function inline(textValue: string, registerLink: (url: string) => string): readonly LauncherNewsInline[] {
+  const parts: LauncherNewsInline[] = [];
+  const expression = /(!?\[([^\]]*)\]\(([^)]+)\)(?:\{[^}]*\})?|\*\*([^*]+)\*\*|`([^`]+)`)/gu;
+  let cursor = 0;
+  for (const match of textValue.matchAll(expression)) {
+    const start = match.index ?? 0;
+    if (start > cursor) parts.push({ text: textValue.slice(cursor, start) });
+    if (match[1]?.startsWith("!")) parts.push({ text: match[2] ?? "Image" });
+    else if (match[2] !== undefined) {
+      try { parts.push({ text: match[2], actionId: registerLink(trustedUrl(match[3], "article link")) }); }
+      catch { parts.push({ text: match[2] }); }
+    } else if (match[4] !== undefined) parts.push({ text: match[4], emphasis: "strong" });
+    else if (match[5] !== undefined) parts.push({ text: match[5], emphasis: "code" });
+    cursor = start + match[0].length;
+  }
+  if (cursor < textValue.length) parts.push({ text: textValue.slice(cursor) });
+  return parts;
+}
+
+function imageUrl(source: string): string | null {
+  try {
+    const url = new URL(source, PROJECT_ORIGIN);
+    return url.origin === PROJECT_ORIGIN && url.protocol === "https:" ? url.href : null;
+  } catch { return null; }
+}
+
+function markdown(body: string, storyId: string, media: Map<string, string>, links: Map<string, string>): readonly LauncherNewsBlock[] {
+  const blocks: LauncherNewsBlock[] = [];
+  let mediaIndex = 0;
+  let linkIndex = 0;
+  const registerLink = (url: string): string => {
+    const id = linkActionId(storyId, url, linkIndex);
+    linkIndex += 1;
+    links.set(id, url);
+    return id;
+  };
+  const lines = body.replace(/\r/gu, "").split("\n");
+  for (let index = 0; index < lines.length;) {
+    const line = lines[index]?.trim() ?? "";
+    if (!line) { index += 1; continue; }
+    const image = /^!\[([^\]]*)\]\(([^)]+)\)$/u.exec(line);
+    if (image) {
+      const url = imageUrl(image[2]!);
+      if (url) {
+        const key = `${storyId}/${mediaIndex}`;
+        mediaIndex += 1;
+        media.set(key, url);
+        blocks.push({ type: "image", src: `gw://app/launcher-media/${key}`, alt: image[1]! });
+      }
+      index += 1;
+      continue;
+    }
+    if (line.startsWith("## ")) { blocks.push({ type: "heading", text: line.slice(3) }); index += 1; continue; }
+    if (line.startsWith("- ")) {
+      const items: LauncherNewsInline[][] = [];
+      while ((lines[index]?.trim() ?? "").startsWith("- ")) {
+        items.push([...inline((lines[index]?.trim() ?? "").slice(2), registerLink)]);
+        index += 1;
+      }
+      blocks.push({ type: "list", items });
+      continue;
+    }
+    const paragraph = [line];
+    index += 1;
+    while (index < lines.length && lines[index]?.trim() && !/^(## |-|!\[)/u.test(lines[index]?.trim() ?? "")) {
+      paragraph.push(lines[index]!.trim());
+      index += 1;
+    }
+    blocks.push({ type: "paragraph", content: inline(paragraph.join(" "), registerLink) });
+  }
+  return blocks.slice(0, 80);
+}
+
+function wikiStories(value: unknown): RawStory[] {
+  const pages = object(object(object(value, "Wiki response").query, "Wiki query").pages, "Wiki pages");
+  return Object.values(pages).flatMap((raw): RawStory[] => {
+    const page = object(raw, "Wiki page");
+    const titleValue = typeof page.title === "string" ? page.title : "";
+    const match = /^Feedback:Game updates\/(\d{4})(\d{2})(\d{2})$/u.exec(titleValue);
+    if (!match || typeof page.fullurl !== "string" || typeof page.extract !== "string" || !page.extract.trim()) return [];
+    const publishedAt = `${match[1]}-${match[2]}-${match[3]}T12:00:00Z`;
+    const dateLabel = new Intl.DateTimeFormat("en", { month: "long", day: "numeric" }).format(new Date(publishedAt));
+    const clean = page.extract.replace(/\n+/gu, " ").replace(/\s+/gu, " ").trim();
+    return [{
+      id: `guild-wars-update-${match[1]}-${match[2]}-${match[3]}`,
+      source: "game",
+      channel: "all",
+      title: `Guild Wars update — ${dateLabel}`,
+      summary: clean.slice(0, 280),
+      publishedAt,
+      featured: true,
+      url: trustedUrl(page.fullurl, "Wiki page url"),
+      body: clean,
+    }];
+  });
+}
+
+export class LauncherNewsService {
+  private readonly options: LauncherNewsOptions;
+  private raw: RawStory[] = [];
+  private state: "loading" | "ready" | "offline" = "loading";
+  private refreshedAt = "";
+  private readonly links = new Map<string, string>();
+  private readonly media = new Map<string, string>();
+
+  constructor(options: LauncherNewsOptions) { this.options = options; }
+
+  async loadCache(): Promise<void> {
+    try {
+      this.raw = [...parseProjectNewsFeed(JSON.parse(await readFile(this.options.cachePath, "utf8")) as unknown)];
+      this.state = "offline";
+    } catch { /* An absent or invalid cache is the honest loading state. */ }
+    this.rebuildMaps();
+  }
+
+  async refresh(): Promise<void> {
+    const fetchJson = async (url: string): Promise<unknown> => {
+      const response = await this.options.fetch(url, { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS), headers: { accept: "application/json" } });
+      if (!response.ok) throw new Error(`news request failed (${response.status})`);
+      return JSON.parse(new TextDecoder().decode(await readBoundedResponse(response, MAX_FEED_BYTES))) as unknown;
+    };
+    const [projectResult, wikiResult] = await Promise.allSettled([fetchJson(PROJECT_NEWS_URL), fetchJson(WIKI_UPDATES_URL)]);
+    const cachedProject = this.raw.filter((story) => story.source !== "game");
+    let projectStories = cachedProject;
+    let gameStories: RawStory[] = [];
+    try {
+      if (projectResult.status === "fulfilled") projectStories = [...parseProjectNewsFeed(projectResult.value)];
+      if (wikiResult.status === "fulfilled") gameStories = wikiStories(wikiResult.value);
+      this.raw = [...gameStories, ...projectStories].sort((left, right) => right.publishedAt.localeCompare(left.publishedAt));
+      if (projectResult.status === "rejected" && wikiResult.status === "rejected") throw new Error("all news sources failed");
+      this.state = "ready";
+      this.refreshedAt = (this.options.now ?? (() => new Date()))().toISOString();
+      if (projectResult.status === "fulfilled") await writeAtomicJson(this.options.cachePath, { version: 1, stories: projectStories }, 0o600);
+    } catch {
+      this.state = "offline";
+    }
+    this.rebuildMaps();
+  }
+
+  snapshot(track: "stable" | "beta", preferences: LauncherPreferences): LauncherNewsState {
+    const stories = this.raw
+      .filter((story) => story.channel !== "beta" || track === "beta")
+      .filter((story) => story.source === "launcher" ? preferences.content.reforgedNews : story.source === "event" ? preferences.content.eventNews : preferences.content.officialNews)
+      .map((story): LauncherNewsStory => ({
+        id: story.id,
+        source: story.source,
+        channel: story.channel,
+        title: story.title,
+        summary: story.summary,
+        publishedAt: story.publishedAt,
+        featured: story.featured,
+        action: story.source === "launcher" ? "article" : "external",
+        ...(story.startsAt ? { startsAt: story.startsAt } : {}),
+        ...(story.endsAt ? { endsAt: story.endsAt } : {}),
+        body: story.source === "launcher" ? markdown(story.body, story.id, this.media, this.links) : [],
+      }));
+    if (this.state === "ready") return { status: "ready", stories, refreshedAt: this.refreshedAt };
+    return { status: this.state, stories };
+  }
+
+  async open(id: string): Promise<void> {
+    const url = this.links.get(id);
+    if (!url) throw new Error("news story is unavailable");
+    await this.options.openExternal(url);
+  }
+
+  async image(key: string): Promise<Response> {
+    const url = this.media.get(key);
+    if (!url) return new Response("not found", { status: 404 });
+    const response = await this.options.fetch(url, { signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS), headers: { accept: "image/*" } });
+    const contentType = response.headers.get("content-type")?.split(";", 1)[0]?.toLowerCase() ?? "";
+    if (!response.ok || !IMAGE_TYPES.has(contentType)) return new Response("not found", { status: 404 });
+    const bytes = await readBoundedResponse(response, MAX_IMAGE_BYTES);
+    return new Response(Uint8Array.from(bytes).buffer, { headers: { "content-type": contentType, "cache-control": "public, max-age=86400", "x-content-type-options": "nosniff" } });
+  }
+
+  private rebuildMaps(): void {
+    this.links.clear();
+    this.media.clear();
+    for (const story of this.raw) this.links.set(story.id, story.url);
+  }
+}

--- a/src/main/core/launcher-state.ts
+++ b/src/main/core/launcher-state.ts
@@ -56,6 +56,8 @@ export const DEFAULT_LAUNCHER_PREFERENCES: LauncherPreferences = Object.freeze({
     first: "news" as const,
     officialNews: true,
     reforgedNews: true,
+    eventNews: true,
+    autoRotateNews: true,
   }),
 });
 
@@ -155,6 +157,8 @@ export function parseLauncherState(value: unknown): LauncherStateDocument {
         first: parseContentKind(content.first),
         officialNews: boolean(content.officialNews, "official News visibility"),
         reforgedNews: boolean(content.reforgedNews, "Reforged News visibility"),
+        eventNews: content.eventNews === undefined ? true : boolean(content.eventNews, "event News visibility"),
+        autoRotateNews: content.autoRotateNews === undefined ? true : boolean(content.autoRotateNews, "News rotation"),
       },
     },
     appearances: parsedAppearances,

--- a/src/main/core/paths.ts
+++ b/src/main/core/paths.ts
@@ -27,6 +27,7 @@ export interface GamePaths {
   buildLibrary: string;
   windowState: string;
   launcherState: string;
+  launcherNewsCache: string;
   launcherMode: string;
   multiRoot: string;
   multiWorkspace: string;
@@ -65,6 +66,7 @@ export function gamePaths(userData: string): GamePaths {
     buildLibrary: path.join(userData, "build-library.json"),
     windowState: path.join(userData, "window-state.json"),
     launcherState: path.join(userData, "launcher-state.json"),
+    launcherNewsCache: path.join(userData, "launcher-news-cache.json"),
     launcherMode: path.join(userData, "launcher-mode.json"),
     multiRoot,
     multiWorkspace: path.join(multiRoot, "workspace.json"),

--- a/src/main/launcher-ipc.ts
+++ b/src/main/launcher-ipc.ts
@@ -19,6 +19,7 @@ import {
   LAUNCHER_IPC,
   parseGlobalTool,
   parseLauncherExternalLink,
+  parseLauncherNewsId,
   parseLauncherProfileAppearance,
   parseLauncherPreferencesPatch,
   parseLauncherSettingsPatch,
@@ -72,6 +73,7 @@ export interface LauncherIpcContext {
   readonly resumeDownload: () => Promise<void>;
   readonly resetGameFiles: (win: BrowserWindow) => Promise<void>;
   readonly openExternal: (kind: LauncherExternalLink) => Promise<void>;
+  readonly openNews: (id: string) => Promise<void>;
   readonly revealLogs: () => void;
   readonly checkUpdates: () => Promise<void>;
   readonly restartAndInstall: (win: BrowserWindow) => Promise<void>;
@@ -165,6 +167,7 @@ export function registerLauncherIpc(ctx: LauncherIpcContext): void {
     gameFilesPauseDownload: channel(nothing, () => ctx.pauseDownload(), "launcher"),
     gameFilesResumeDownload: channel(nothing, () => ctx.resumeDownload(), "launcher"),
     gameFilesResetAndRestart: channel(nothing, (win) => ctx.resetGameFiles(win), "launcher"),
+    newsOpen: channel(one(parseLauncherNewsId), (_win, id) => ctx.openNews(id), "launcher"),
     externalOpen: channel(one(parseLauncherExternalLink), (_win, kind) => ctx.openExternal(kind), "launcher"),
     externalRevealLogs: channel(nothing, () => ctx.revealLogs(), "launcher"),
     updatesCheck: channel(nothing, () => ctx.checkUpdates(), "launcher"),

--- a/src/main/launcher-orchestrator.ts
+++ b/src/main/launcher-orchestrator.ts
@@ -34,6 +34,7 @@ export interface LauncherOrchestratorOptions {
   readonly getProgress: () => DownloadProgress;
   readonly getAppUpdate: () => AppUpdateState;
   readonly getSettings: () => AppSettings;
+  readonly getNews: (track: AppSettings["updateTrack"], preferences: LauncherSnapshot["preferences"]) => LauncherSnapshot["news"];
   readonly toolsLoaded: () => boolean;
   readonly developmentFixtures: boolean;
   /** Unpackaged Electron tests only: lets renderer-focused suites bypass client preparation. */
@@ -106,6 +107,7 @@ export class LauncherOrchestrator {
       })),
       selectedProfileIds,
       preferences: document.preferences,
+      news: this.options.getNews(settings.updateTrack, document.preferences),
       contentAvailability: {
         news: fixture,
         dailies: fixture,

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -14,6 +14,7 @@ import {
   dialog,
   Menu,
   Notification,
+  net,
   powerMonitor,
   session,
   shell,
@@ -43,6 +44,7 @@ import { AUTOMATION_COMMAND } from "../shared/automation.js";
 import { ClientRuntime } from "./client-runtime.js";
 import { RendererClientSessions } from "./renderer-client-sessions.js";
 import { loadSettings } from "./core/settings.js";
+import { LauncherNewsService } from "./core/launcher-news.js";
 import {
   loadDiagnosticProfile,
   saveDiagnosticProfile,
@@ -554,6 +556,12 @@ if (primaryInstance) void app.whenReady().then(async () => {
     paths.launcherState,
     loadedLauncherState.document,
   );
+  const launcherNews = new LauncherNewsService({
+    cachePath: paths.launcherNewsCache,
+    fetch: (url, init) => net.fetch(url, init),
+    openExternal: (url) => shell.openExternal(url),
+  });
+  await launcherNews.loadCache();
   let accountWorkspace;
   for (;;) {
     try {
@@ -724,6 +732,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
   const protocolDeps = {
     getActiveClient: () => clientRuntime.active,
     diagnosticOwnerId: () => SINGLE_DIAGNOSTIC_OWNER_ID,
+    launcherNewsImage: (key: string) => launcherNews.image(key),
   };
   const host = buildWindowHost(
     clientRuntime,
@@ -771,6 +780,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
     getProgress: () => clientRuntime.progress,
     getAppUpdate: () => appUpdaterController!.getState(),
     getSettings: () => currentSettings ?? settings,
+    getNews: (track, contentPreferences) => launcherNews.snapshot(track, contentPreferences),
     toolsLoaded: () => enhancementSelection.tools,
     developmentFixtures: !app.isPackaged || process.env.GW_LAUNCHER_FIXTURES === "1",
     allowUnreadyLaunch,
@@ -810,7 +820,10 @@ if (primaryInstance) void app.whenReady().then(async () => {
 
   registerLauncherIpc({
     windows: windowRegistry,
-    connected: () => logEvent({ k: "launcher.connected" }),
+    connected: () => {
+      logEvent({ k: "launcher.connected" });
+      void launcherNews.refresh().then(() => launcherOrchestrator!.publish());
+    },
     snapshot: () => launcherOrchestrator!.snapshot(),
     create: async ({ name, appearance }) => {
       const previousIds = new Set(accounts.state().profiles.map((profile) => profile.id));
@@ -851,6 +864,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
     completeIntroduction: () => launcherOrchestrator!.completeIntroduction(),
     replayIntroduction: () => launcherOrchestrator!.replayIntroduction(),
     updatePreferences: (patch) => launcherOrchestrator!.updatePreferences(patch),
+    openNews: (id) => launcherNews.open(id),
     updateSettings: async (patch: LauncherSettingsPatch) => {
       await preferences.updateSettings(patch);
       launcherOrchestrator!.publish();

--- a/src/main/protocol.ts
+++ b/src/main/protocol.ts
@@ -100,6 +100,7 @@ export interface ProtocolDeps {
     jsPath: string;
   } | null;
   diagnosticOwnerId?: () => number;
+  launcherNewsImage?: (key: string) => Promise<Response>;
 }
 
 /**
@@ -180,12 +181,17 @@ export function installGwProtocolHandlerForSession(
 }
 
 /** The launcher partition can serve only its compiled offline Vue subtree. */
-export function installLauncherProtocolHandlerForSession(owner: Session): void {
+export function installLauncherProtocolHandlerForSession(owner: Session, deps: ProtocolDeps): void {
   owner.protocol.handle("gw", async (request) => {
     if (request.method !== "GET" && request.method !== "HEAD") {
       return new Response("method not allowed", { status: 405 });
     }
     const url = new URL(request.url);
+    const newsImage = /^\/launcher-media\/([a-z0-9][a-z0-9-]{0,79}\/\d{1,2})$/u.exec(url.pathname);
+    if (url.hostname === "app" && newsImage && deps.launcherNewsImage) {
+      try { return await deps.launcherNewsImage(newsImage[1]!); }
+      catch { return new Response("not found", { status: 404, headers: launcherHeaders() }); }
+    }
     if (url.hostname !== "app" || !url.pathname.startsWith("/launcher/")) {
       return new Response("not found", { status: 404, headers: launcherHeaders() });
     }

--- a/src/preload/preload.launcher.cjs
+++ b/src/preload/preload.launcher.cjs
@@ -64,6 +64,9 @@ const launcherApi = {
     resumeDownload: () => ipcRenderer.invoke(LAUNCHER_IPC.gameFilesResumeDownload),
     resetAndRestart: () => ipcRenderer.invoke(LAUNCHER_IPC.gameFilesResetAndRestart),
   },
+  news: {
+    open: (id) => ipcRenderer.invoke(LAUNCHER_IPC.newsOpen, id),
+  },
   external: {
     open: (kind) => ipcRenderer.invoke(LAUNCHER_IPC.externalOpen, kind),
     revealLogs: () => ipcRenderer.invoke(LAUNCHER_IPC.externalRevealLogs),

--- a/src/shared/launcher-contracts.ts
+++ b/src/shared/launcher-contracts.ts
@@ -57,6 +57,7 @@ export const LAUNCHER_IPC = Object.freeze({
   gameFilesPauseDownload: "gw:launcher:gameFiles:pauseDownload",
   gameFilesResumeDownload: "gw:launcher:gameFiles:resumeDownload",
   gameFilesResetAndRestart: "gw:launcher:gameFiles:resetAndRestart",
+  newsOpen: "gw:launcher:news:open",
   externalOpen: "gw:launcher:external:open",
   externalRevealLogs: "gw:launcher:external:revealLogs",
   updatesCheck: "gw:launcher:updates:check",
@@ -80,8 +81,39 @@ export interface LauncherPreferences {
     first: LauncherContentKind;
     officialNews: boolean;
     reforgedNews: boolean;
+    eventNews: boolean;
+    autoRotateNews: boolean;
   }>;
 }
+
+export type LauncherNewsSource = "game" | "event" | "launcher";
+export type LauncherNewsInline = Readonly<{
+  text: string;
+  emphasis?: "strong" | "code";
+  actionId?: string;
+}>;
+export type LauncherNewsBlock =
+  | Readonly<{ type: "paragraph"; content: readonly LauncherNewsInline[] }>
+  | Readonly<{ type: "heading"; text: string }>
+  | Readonly<{ type: "list"; items: readonly (readonly LauncherNewsInline[])[] }>
+  | Readonly<{ type: "image"; src: string; alt: string }>;
+export interface LauncherNewsStory {
+  readonly id: string;
+  readonly source: LauncherNewsSource;
+  readonly channel: "all" | "stable" | "beta";
+  readonly title: string;
+  readonly summary: string;
+  readonly publishedAt: string;
+  readonly featured: boolean;
+  readonly action: "article" | "external";
+  readonly startsAt?: string;
+  readonly endsAt?: string;
+  readonly body: readonly LauncherNewsBlock[];
+}
+export type LauncherNewsState =
+  | Readonly<{ status: "loading"; stories: readonly LauncherNewsStory[] }>
+  | Readonly<{ status: "ready"; stories: readonly LauncherNewsStory[]; refreshedAt: string }>
+  | Readonly<{ status: "offline"; stories: readonly LauncherNewsStory[] }>;
 
 export interface LauncherPreferencesPatch {
   readonly content?: Partial<LauncherPreferences["content"]>;
@@ -197,6 +229,7 @@ export interface LauncherSnapshot {
   readonly profiles: readonly LauncherProfileSummary[];
   readonly selectedProfileIds: readonly ProfileId[];
   readonly preferences: LauncherPreferences;
+  readonly news: LauncherNewsState;
   readonly contentAvailability: Readonly<{
     news: "fixture" | "placeholder";
     dailies: "fixture" | "placeholder";
@@ -260,6 +293,9 @@ export interface LauncherNativeApi {
     open(kind: LauncherExternalLink): Promise<void>;
     revealLogs(): Promise<void>;
   };
+  readonly news: {
+    open(id: string): Promise<void>;
+  };
 }
 
 export function parseGlobalTool(value: unknown): GlobalTool {
@@ -270,6 +306,11 @@ export function parseGlobalTool(value: unknown): GlobalTool {
 export function parseLauncherExternalLink(value: unknown): LauncherExternalLink {
   if (typeof value === "string" && LAUNCHER_EXTERNAL_LINKS.includes(value as LauncherExternalLink)) return value as LauncherExternalLink;
   throw new Error("external link is invalid");
+}
+
+export function parseLauncherNewsId(value: unknown): string {
+  if (typeof value === "string" && /^[a-z0-9][a-z0-9-]{0,79}$/u.test(value)) return value;
+  throw new Error("news id is invalid");
 }
 
 export function parseLauncherSettingsPatch(value: unknown): LauncherSettingsPatch {
@@ -346,7 +387,7 @@ export function parseLauncherPreferencesPatch(value: unknown): LauncherPreferenc
   if (source.content === undefined) return {};
   const content = exactObject(
     source.content,
-    ["news", "dailies", "first", "officialNews", "reforgedNews"],
+    ["news", "dailies", "first", "officialNews", "reforgedNews", "eventNews", "autoRotateNews"],
     "launcher content patch",
   );
   const patch: {
@@ -355,8 +396,10 @@ export function parseLauncherPreferencesPatch(value: unknown): LauncherPreferenc
     first?: LauncherContentKind;
     officialNews?: boolean;
     reforgedNews?: boolean;
+    eventNews?: boolean;
+    autoRotateNews?: boolean;
   } = {};
-  for (const field of ["news", "dailies", "officialNews", "reforgedNews"] as const) {
+  for (const field of ["news", "dailies", "officialNews", "reforgedNews", "eventNews", "autoRotateNews"] as const) {
     const candidate = content[field];
     if (candidate === undefined) continue;
     if (typeof candidate !== "boolean") throw new Error(`${field} must be a boolean`);

--- a/tests/electron/launcher-shell.spec.ts
+++ b/tests/electron/launcher-shell.spec.ts
@@ -23,6 +23,7 @@ test("the Vue launcher owns a narrow frozen bridge and offline subtree", async (
         "external",
         "gameFiles",
         "navigation",
+        "news",
         "profiles",
         "settings",
         "state",

--- a/tests/release/launcher-preload-behaviour.test.ts
+++ b/tests/release/launcher-preload-behaviour.test.ts
@@ -89,6 +89,7 @@ test("the built launcher preload exposes every launcher command and nothing else
   await api.gameFiles.pauseDownload();
   await api.gameFiles.resumeDownload();
   await api.gameFiles.resetAndRestart();
+  await api.news.open("gwonmac-2026-8-10");
   await api.updates.check();
   await api.updates.restartAndInstall();
   await api.external.open("github");

--- a/tests/unit/launcher-news.test.ts
+++ b/tests/unit/launcher-news.test.ts
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { LauncherNewsService, PROJECT_NEWS_URL, WIKI_UPDATES_URL, parseProjectNewsFeed } from "../../src/main/core/launcher-news.js";
+import { DEFAULT_LAUNCHER_PREFERENCES } from "../../src/main/core/launcher-state.js";
+
+const roots: string[] = [];
+afterEach(async () => Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true }))));
+
+function feed(channel: "stable" | "beta" = "stable") {
+  return {
+    version: 1,
+    stories: [{
+      id: `release-${channel}`,
+      source: "launcher",
+      channel,
+      title: `${channel} release`,
+      summary: "A useful player-facing summary.",
+      publishedAt: "2026-09-01T12:00:00Z",
+      featured: true,
+      url: "https://gwonmac.vercel.app/blog/release",
+      body: "Intro with **important text** and a [technical record](https://github.com/Mat4m0/gwonmac/releases/tag/v1).\n\n## Changes\n\n- First change\n\n![Screenshot](/blog/image.png)",
+    }],
+  };
+}
+
+const wiki = {
+  query: { pages: { "1": {
+    title: "Feedback:Game updates/20260901",
+    fullurl: "https://wiki.guildwars.com/wiki/Feedback:Game_updates/20260901",
+    extract: "Skill updates Seven skills were corrected in this build.",
+  } } },
+};
+
+describe("launcher news", () => {
+  it("rejects untrusted story links", () => {
+    const input = feed();
+    input.stories[0]!.url = "https://example.com/tracker";
+    assert.throws(() => parseProjectNewsFeed(input), /not trusted/u);
+  });
+
+  it("filters Beta notes and projects Markdown into safe typed blocks", async () => {
+    const root = await mkdtemp(join(tmpdir(), "gwonmac-news-"));
+    roots.push(root);
+    const cachePath = join(root, "news.json");
+    await writeFile(cachePath, JSON.stringify(feed("beta")));
+    const service = new LauncherNewsService({ cachePath, fetch: async () => { throw new Error("offline"); }, openExternal: async () => undefined });
+    await service.loadCache();
+    assert.equal(service.snapshot("stable", DEFAULT_LAUNCHER_PREFERENCES).stories.length, 0);
+    const beta = service.snapshot("beta", DEFAULT_LAUNCHER_PREFERENCES);
+    assert.equal(beta.status, "offline");
+    assert.deepEqual(beta.stories[0]?.body.map((block) => block.type), ["paragraph", "heading", "list", "image"]);
+    assert.equal((beta.stories[0]?.body[0] as { content: readonly { emphasis?: string }[] }).content[1]?.emphasis, "strong");
+  });
+
+  it("combines the exact project and Wiki feeds, caches project notes, and opens only known IDs", async () => {
+    const root = await mkdtemp(join(tmpdir(), "gwonmac-news-"));
+    roots.push(root);
+    const cachePath = join(root, "news.json");
+    const opened: string[] = [];
+    const service = new LauncherNewsService({
+      cachePath,
+      fetch: async (url) => new Response(JSON.stringify(url === PROJECT_NEWS_URL ? feed() : url === WIKI_UPDATES_URL ? wiki : {})),
+      openExternal: async (url) => { opened.push(url); },
+      now: () => new Date("2026-09-02T10:00:00Z"),
+    });
+    await service.refresh();
+    const snapshot = service.snapshot("stable", DEFAULT_LAUNCHER_PREFERENCES);
+    assert.equal(snapshot.status, "ready");
+    assert.deepEqual(snapshot.stories.map((story) => story.source), ["game", "launcher"]);
+    const article = snapshot.stories[1]!.body[0];
+    if (article?.type !== "paragraph") throw new Error("expected the release introduction");
+    const actionId = article.content.find((part) => part.actionId)?.actionId;
+    assert.match(actionId ?? "", /^news-link-[a-f0-9]{8}$/u);
+    await service.open("guild-wars-update-2026-09-01");
+    await service.open(actionId!);
+    assert.deepEqual(opened, ["https://wiki.guildwars.com/wiki/Feedback:Game_updates/20260901", "https://github.com/Mat4m0/gwonmac/releases/tag/v1"]);
+    await assert.rejects(service.open("unknown-story"), /unavailable/u);
+    assert.equal(parseProjectNewsFeed(JSON.parse(await readFile(cachePath, "utf8")) as unknown).length, 1);
+  });
+});

--- a/tests/unit/launcher-orchestrator.test.ts
+++ b/tests/unit/launcher-orchestrator.test.ts
@@ -90,6 +90,7 @@ async function fixture(options: { allowUnreadyLaunch?: boolean } = {}) {
     getProgress: () => progress,
     getAppUpdate: () => ({ phase: "idle", currentVersion: "1.0.0" }),
     getSettings: () => DEFAULT_SETTINGS,
+    getNews: () => ({ status: "loading", stories: [] }),
     toolsLoaded: () => false,
     developmentFixtures: true,
     ...(options.allowUnreadyLaunch === undefined

--- a/tests/unit/launcher-state.test.ts
+++ b/tests/unit/launcher-state.test.ts
@@ -63,6 +63,8 @@ describe("launcher presentation state", () => {
       first: "news",
       officialNews: true,
       reforgedNews: true,
+      eventNews: true,
+      autoRotateNews: true,
     });
     assert.deepEqual(second.document, first.document);
   });

--- a/tests/unit/paths.test.ts
+++ b/tests/unit/paths.test.ts
@@ -32,6 +32,7 @@ describe("resolved profile paths", () => {
       buildLibrary: `${root}/build-library.json`,
       windowState: `${root}/window-state.json`,
       launcherState: `${root}/launcher-state.json`,
+      launcherNewsCache: `${root}/launcher-news-cache.json`,
       launcherMode: `${root}/launcher-mode.json`,
       multiRoot: `${root}/multi`,
       multiWorkspace: `${root}/multi/workspace.json`,

--- a/tests/unit/the-preload-is-generated-from-the-canonical-channels.test.ts
+++ b/tests/unit/the-preload-is-generated-from-the-canonical-channels.test.ts
@@ -254,6 +254,7 @@ test("the launcher preload exposes only its frozen launcher bridge", async () =>
     "external",
     "gameFiles",
     "navigation",
+    "news",
     "profiles",
     "settings",
     "state",
@@ -264,5 +265,6 @@ test("the launcher preload exposes only its frozen launcher bridge", async () =>
   assert.equal(Object.values(launcher).every(Object.isFrozen), true);
   await launcher.state.get();
   await launcher.profiles.play([]);
-  assert.deepEqual(invoked, [LAUNCHER_IPC.stateGet, LAUNCHER_IPC.profilesPlay]);
+  await launcher.news.open("release-stable");
+  assert.deepEqual(invoked, [LAUNCHER_IPC.stateGet, LAUNCHER_IPC.profilesPlay, LAUNCHER_IPC.newsOpen]);
 });


### PR DESCRIPTION
Players who do not follow Discord have no reliable way to discover Guild Wars updates, events, or GWonMac releases. This makes Home the dependable in-launcher place to see what changed without getting in the way of Play.

The website Markdown is now the one source of truth for rich GWonMac release notes and curated events, with a generated static launcher feed. Electron main also reads recent game updates from the Guild Wars Wiki, validates and caches both sources, and sends only typed content and opaque actions to the renderer. Stable users do not see Beta notes; source visibility and 12-second rotation are customizable and persistent; Reduced Motion, hover, focus, and visibility pause rotation.

Verification:
- pnpm check
- pnpm --dir apps/website certify (236 routes; offline font-provider warnings only)
- pnpm test:integration (88 passed)
- pnpm test:release (30 passed)
- pnpm tools:test:e2e (42 passed)
- Electron: 132 applicable scenarios passed, 1 opt-in live-client scenario skipped; corrected launcher-shell contract rerun passed
- visual QA: Home, production/offline, and rich release-note article states