### PR TITLE
fix(character-switch): finish accepted switches after focus loss

### DIFF
--- a/docs/enhancement-development.md
+++ b/docs/enhancement-development.md
@@ -169,6 +169,14 @@ fixed logout/Selector/Play state machine, and is absent from the reconnect
 profile. A read-only pre-game observer therefore cannot enqueue a native
 action.
 
+Character Switch requires focus when a request or explorable confirmation is
+accepted. That one window-local transaction then owns the native action channel
+through Logout, Selector, and Play, including while the window is unfocused or
+hidden. Completion, failure, timeout, and disposal disable the channel and clear
+pending native work. Focus alone never enables it. The existing context, target
+identity, selection proof, and deadline checks still apply; automatic return
+after reload retains its separate focus policy.
+
 Run the unpackaged developer probe with:
 
 ```sh

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -154,6 +154,10 @@ the number keys 1–9 and 0 switch to the first ten characters. Press
 
 Character names and search text are not saved.
 
+Start the switch while Guild Wars is focused. Once accepted, it continues if
+you switch to another app or minimize the game. Guild Wars does not take focus
+back. Closing or reloading that game window stops the switch.
+
 ## Saved login
 
 Guild Wars owns sign-in inside each game window. The launcher does not ask for

--- a/src/main/certification/enhancement-character-switch-transform.ts
+++ b/src/main/certification/enhancement-character-switch-transform.ts
@@ -101,7 +101,7 @@ export function characterActionEnqueue(
   );
 }
 
-/** Publishes the private fixed action packet and current focus/policy gate. */
+/** Publishes the private fixed action packet and transaction policy gate. */
 export function characterActionConfigure(
   pendingGlobal: number,
   payloadGlobal: number,

--- a/src/renderer/character-switch-controller.ts
+++ b/src/renderer/character-switch-controller.ts
@@ -22,7 +22,7 @@ const SELECTOR_READY_POLL_MS = 100;
 
 type Enqueue = (action: number, argument: number) => number;
 type Configure = (payload: number, enabled: number) => number;
-type NativeSend = "sent" | "refused" | "invalid" | "timeout" | "focus"
+type NativeSend = "sent" | "refused" | "invalid" | "timeout"
   | "selector-frame" | "selector-child" | "selector-index"
   | "selector-context" | "selector-target"
   | "selector-array"
@@ -61,7 +61,6 @@ function classifySelectorResult(result: NativeSend): SelectorOutcome {
     case "selector-target": return {
       kind: "retryable", readiness: "target", terminalCode: "selector-target-missing",
     };
-    case "focus": return { kind: "terminal", code: "focus-lost" };
     case "refused": return { kind: "terminal", code: "selector-refused" };
     case "invalid": return { kind: "terminal", code: "selector-invalid" };
     case "selector-parent": return { kind: "terminal", code: "selector-parent-invalid" };
@@ -125,21 +124,22 @@ export function createCharacterSwitchController(options: Readonly<{
     if (transitions.length > TRANSITION_LIMIT) transitions.shift();
   };
   const publish = (next: CharacterSwitchActionState, stage: CharacterSwitchTransitionStage) => {
+    if (disposed) return;
     action = Object.freeze(next);
+    // Revoke the channel before a listener can start another transaction.
+    if (next.status !== "switching") options.configure(0, 0);
     transition(stage);
     emit();
   };
   const fail = (code: CharacterSwitchFailureCode, retryable = false) => {
+    if (disposed) return;
     pendingCharacterKey = null;
     lastCode = code;
     publish({ status: "failed", code, retryable }, `failed:${code}`);
   };
   const focused = () => !disposed && document.visibilityState === "visible"
     && document.hasFocus();
-  const configure = () => options.configure(
-    focused() ? options.payloadPointer : 0,
-    focused() ? 1 : 0,
-  );
+  const switching = () => !disposed && action.status === "switching";
   const view = () => new DataView(options.memory.buffer);
   const validPayload = () => options.payloadPointer > 0
     && options.payloadPointer + CHARACTER_SWITCH_ACTION_ABI.bytes
@@ -151,8 +151,7 @@ export function createCharacterSwitchController(options: Readonly<{
     pollMilliseconds = 25,
   ): Promise<boolean> => {
     const deadline = performance.now() + timeoutMs;
-    while (!disposed && performance.now() < deadline) {
-      if (!focused()) return false;
+    while (switching() && performance.now() < deadline) {
       if (accept()) return true;
       await delay(pollMilliseconds);
     }
@@ -163,8 +162,8 @@ export function createCharacterSwitchController(options: Readonly<{
     kind: CharacterSwitchActionKind,
     argument: number,
   ): NativeEnqueue => {
-    if (!validPayload() || !focused()) return "focus";
-    configure();
+    if (!switching()) return "refused";
+    if (!validPayload()) return "invalid";
     view().setUint32(
       options.payloadPointer + CHARACTER_SWITCH_ACTION_ABI.fields.result,
       0,
@@ -188,10 +187,7 @@ export function createCharacterSwitchController(options: Readonly<{
       ) !== 0,
       timeoutMs,
     );
-    if (!settled) {
-      options.configure(0, 0);
-      return focused() ? "timeout" : "focus";
-    }
+    if (!settled || !switching()) return "timeout";
     const result = view().getUint32(
       options.payloadPointer + CHARACTER_SWITCH_ACTION_ABI.fields.result,
       true,
@@ -247,8 +243,7 @@ export function createCharacterSwitchController(options: Readonly<{
     publish({ status: "switching", stage: "logout" }, "logout:queued");
     const logout = await settle("logout", 2_000);
     if (logout !== "sent") {
-      fail(logout === "focus" ? "focus-lost"
-        : logout === "refused" ? "logout-refused"
+      fail(logout === "refused" ? "logout-refused"
           : logout === "invalid" ? "logout-invalid" : "logout-timeout");
       return;
     }
@@ -258,7 +253,7 @@ export function createCharacterSwitchController(options: Readonly<{
       return state.status === "ready" && state.sequence !== snapshotSequence;
     }, 3_000, 50);
     if (!selectorSettled) {
-      fail(focused() ? "selector-timeout" : "focus-lost");
+      fail("selector-timeout");
       return;
     }
     const fresh = options.characters.state;
@@ -282,7 +277,7 @@ export function createCharacterSwitchController(options: Readonly<{
     let selection: SelectorOutcome = classifySelectorResult("selector-frame");
     while (performance.now() < selectorDeadline) {
       const settledList = options.characters.state;
-      if (!focused()) { fail("focus-lost"); return; }
+      if (!switching()) return;
       if (settledList.status !== "ready" || accountSignature(settledList) !== initialSignature) {
         fail("target-missing");
         return;
@@ -307,12 +302,11 @@ export function createCharacterSwitchController(options: Readonly<{
     // its selected index. The list's selected name describes the entered
     // character, so it must not be misused as carousel confirmation here.
     await delay(300);
-    if (!focused()) { fail("focus-lost"); return; }
+    if (!switching()) return;
     publish({ status: "switching", stage: "play" }, "selection:sent");
     const play = await send("play", 0, 2_000);
     if (play !== "sent") {
-      fail(play === "focus" ? "focus-lost"
-        : play === "refused" ? "play-refused"
+      fail(play === "refused" ? "play-refused"
           : play === "play-frame" ? "play-frame-missing"
             : play === "play-parent" ? "play-parent-invalid"
           : play === "invalid" ? "play-invalid" : "play-timeout");
@@ -328,16 +322,18 @@ export function createCharacterSwitchController(options: Readonly<{
         && state.characters[state.selectedIndex]?.characterKey === targetKey;
     }, 30_000);
     if (!confirmed) {
-      fail(focused() ? "confirmation-timeout" : "focus-lost");
+      fail("confirmation-timeout");
       return;
     }
     publish({ status: "complete" }, "confirmation:complete");
   };
 
   const start = (characterKey: string, confirmedExplorable: boolean) => {
+    if (disposed) return;
     if (action.status === "switching" || (action.status === "confirming" && !confirmedExplorable)) {
       return;
     }
+    if (!focused()) { fail("focus-lost", true); return; }
     const state = options.characters.state;
     if (state.status !== "ready") { fail("list-unavailable", true); return; }
     const matches = state.characters
@@ -356,7 +352,6 @@ export function createCharacterSwitchController(options: Readonly<{
       publish({ status: "confirming" }, "confirmation:required");
       return;
     }
-    if (!focused()) { fail("focus-lost", true); return; }
     const targetName = state.characters[targetIndex]!.name;
     started = performance.now();
     requestSequence = state.sequence;
@@ -374,24 +369,34 @@ export function createCharacterSwitchController(options: Readonly<{
         : drainContext === "loading" ? "game-loading" : "logout-refused");
       return;
     }
-    const logout = queue("logout", 0);
-    if (logout !== "queued") {
-      fail(logout === "focus" ? "focus-lost" : "logout-refused");
+    if (!validPayload()) { fail("logout-invalid"); return; }
+    // Focus authorizes this one bounded transaction, not each later stage.
+    // Claim ownership before enabling or enqueueing; blur cannot revoke it.
+    action = Object.freeze({ status: "switching", stage: "logout" });
+    let logout: NativeEnqueue;
+    try {
+      options.configure(options.payloadPointer, 1);
+      logout = queue("logout", 0);
+    } catch {
+      fail("logout-invalid");
       return;
     }
+    if (logout !== "queued") {
+      fail(logout === "invalid" ? "logout-invalid" : "logout-refused");
+      return;
+    }
+    const sequence = actionSequence;
     void run(
       state.sequence,
       targetName,
       characterKey,
       accountSignature(state),
-    );
+    ).catch(() => {
+      if (switching() && actionSequence === sequence) fail("state-unavailable");
+    });
   };
 
-  const onFocusPolicyChanged = () => { configure(); };
-  window.addEventListener("focus", onFocusPolicyChanged);
-  window.addEventListener("blur", onFocusPolicyChanged);
-  document.addEventListener("visibilitychange", onFocusPolicyChanged);
-  configure();
+  options.configure(0, 0);
 
   return Object.freeze({
     payloadBytes: CHARACTER_SWITCH_ACTION_ABI.bytes,
@@ -406,6 +411,7 @@ export function createCharacterSwitchController(options: Readonly<{
       start(characterKey, true);
     },
     cancelConfirmation() {
+      if (disposed) return;
       if (action.status !== "confirming") return;
       pendingCharacterKey = null;
       action = Object.freeze({ status: "idle" });
@@ -413,6 +419,7 @@ export function createCharacterSwitchController(options: Readonly<{
       emit();
     },
     reset() {
+      if (disposed) return;
       if (action.status === "switching") return;
       pendingCharacterKey = null;
       action = Object.freeze({ status: "idle" });
@@ -443,7 +450,7 @@ export function createCharacterSwitchController(options: Readonly<{
         requestSequence: requestSequence >>> 0,
         actionSequence: actionSequence >>> 0,
         focused: focused(),
-        policyEnabled: focused() && validPayload(),
+        policyEnabled: switching() && validPayload(),
         stage: "stage" in action ? action.stage : action.status,
         lastCode,
         elapsedBucketMs: started === 0 ? 0 : elapsedBucket(started),
@@ -493,10 +500,8 @@ export function createCharacterSwitchController(options: Readonly<{
     },
     dispose() {
       disposed = true;
+      pendingCharacterKey = null;
       options.configure(0, 0);
-      window.removeEventListener("focus", onFocusPolicyChanged);
-      window.removeEventListener("blur", onFocusPolicyChanged);
-      document.removeEventListener("visibilitychange", onFocusPolicyChanged);
       listeners.clear();
     },
   });

--- a/tests/electron/character-switch-background.spec.ts
+++ b/tests/electron/character-switch-background.spec.ts
@@ -1,0 +1,110 @@
+/** Real window focus changes exercise the shipped controller with offline actions. */
+import { expect, test } from "@playwright/test";
+import { closeOffline, launchPlayableClient } from "./fixtures.mjs";
+import type { CharacterSwitchController } from "../../src/renderer/character-switch-controller.js";
+
+type SwitchFixtureWindow = typeof window & {
+  __backgroundSwitch: {
+    controller: CharacterSwitchController;
+    calls: number[];
+    enabled(): boolean;
+    release(): void;
+  };
+};
+
+for (const [boundary, heldAction] of [["immediately", 1], ["after logout", 2], ["after selection", 3]] as const) {
+  for (const minimize of [false, true]) {
+    test(`switch finishes ${boundary} when the game ${minimize ? "is minimized" : "loses focus"}`, async () => {
+      const fixture = await launchPlayableClient("gw-switch-background-", { GW_BACKGROUND_LAUNCH: "0" });
+      try {
+        const { app, page } = fixture;
+        // Playwright normally emulates focus even when the native window blurs.
+        const session = await page.context().newCDPSession(page);
+        await session.send("Emulation.setFocusEmulationEnabled", { enabled: false });
+        await app.evaluate(({ app: electronApp, BrowserWindow }) => {
+          const game = BrowserWindow.getAllWindows().find(win => win.webContents.getURL() === "gw://app/");
+          if (!game) throw new Error("game window is required");
+          game.show();
+          electronApp.focus({ steal: true });
+          game.focus();
+        });
+        await expect.poll(() => page.evaluate(() => document.hasFocus())).toBe(true);
+        await page.evaluate(async (hold) => {
+          const specifier = "gw://app/character-switch-controller.js";
+          const module: typeof import("../../src/renderer/character-switch-controller.js") = await import(specifier);
+          const memory = new WebAssembly.Memory({ initial: 1 });
+          const pointer = 64;
+          let enabled = false;
+          let released = false;
+          let pending: { kind: number; argument: number } | null = null;
+          let selectedIndex = 0;
+          let sequence = 2;
+          let context: CharacterSwitchContext = "outpost";
+          const characters = [
+            { name: "Alpha", characterKey: "0000000000000001", primaryProfession: 1, secondaryProfession: 0, characterType: "roleplaying", campaign: 1, level: 20, mapId: 55 },
+            { name: "Beta", characterKey: "0000000000000002", primaryProfession: 2, secondaryProfession: 0, characterType: "roleplaying", campaign: 1, level: 20, mapId: 55 },
+          ] as const;
+          const calls: number[] = [];
+          const drain = () => {
+            if (!enabled || !pending || (!released && pending.kind === hold)) return;
+            const { kind, argument } = pending;
+            pending = null;
+            if (kind === 1) { context = "character-select"; sequence += 2; }
+            if (kind === 2) selectedIndex = argument;
+            if (kind === 3) context = "outpost";
+            new DataView(memory.buffer).setUint32(pointer + 20, 1, true);
+          };
+          const controller = module.createCharacterSwitchController({
+            memory, payloadPointer: pointer, buildId: 7, programId: 1,
+            configure(payload, policy) {
+              enabled = payload === pointer && policy === 1;
+              if (!enabled) pending = null;
+              return 1;
+            },
+            enqueue(kind, argument) {
+              if (!enabled || pending) return 0;
+              calls.push(kind);
+              pending = { kind, argument };
+              setTimeout(drain, 25);
+              return 1;
+            },
+            characters: {
+              get state() { return { status: "ready" as const, sequence, selectedIndex, characters }; },
+              subscribe: () => () => false,
+              dispose() {},
+            },
+            controls: { state: () => "unknown", switchContext: () => context, diagnosticMask: () => 0 },
+          });
+          window.addEventListener("pagehide", () => controller.dispose(), { once: true });
+          (window as SwitchFixtureWindow).__backgroundSwitch = {
+            controller, calls, enabled: () => enabled,
+            release() { released = true; drain(); },
+          };
+          controller.request(characters[1].characterKey);
+        }, heldAction);
+        await expect.poll(() => page.evaluate(() =>
+          (window as SwitchFixtureWindow).__backgroundSwitch.calls.at(-1))).toBe(heldAction);
+        await app.evaluate(({ BrowserWindow }, hide) => {
+          const game = BrowserWindow.getAllWindows().find(win => win.webContents.getURL() === "gw://app/");
+          const launcher = BrowserWindow.getAllWindows().find(win => win.webContents.getURL().endsWith("launcher/index.html"));
+          if (!game || !launcher) throw new Error("game and launcher windows are required");
+          if (hide) game.minimize();
+          launcher.show();
+          launcher.focus();
+        }, minimize);
+        await expect.poll(() => page.evaluate(() => document.hasFocus())).toBe(false);
+        await page.evaluate(() => (window as SwitchFixtureWindow).__backgroundSwitch.release());
+        await expect.poll(() => page.evaluate(() =>
+          (window as SwitchFixtureWindow).__backgroundSwitch.controller.action.status)).toBe("complete");
+        expect(await page.evaluate(() => {
+          const f = (window as SwitchFixtureWindow).__backgroundSwitch;
+          return { calls: f.calls, enabled: f.enabled(), focused: document.hasFocus() };
+        })).toEqual({ calls: [1, 2, 3], enabled: false, focused: false });
+        if (minimize) expect(await app.evaluate(({ BrowserWindow }) =>
+          BrowserWindow.getAllWindows().find(win => win.webContents.getURL() === "gw://app/")?.isMinimized())).toBe(true);
+      } finally {
+        await closeOffline(fixture);
+      }
+    });
+  }
+}

--- a/tests/unit/character-switch-background.test.ts
+++ b/tests/unit/character-switch-background.test.ts
@@ -1,0 +1,239 @@
+/** The accepted switch owns its native channel independently of window focus. */
+import assert from "node:assert/strict";
+import { setTimeout as delay } from "node:timers/promises";
+import { describe, it, type TestContext } from "node:test";
+import { createCharacterSwitchController } from "../../src/renderer/character-switch-controller.js";
+import type { CharacterSummary, CompanionCharacterListState } from "../../src/renderer/companion-character-list-snapshot.js";
+import { CHARACTER_SWITCH_ACTION_ABI as ABI } from "../../src/shared/character-switch-action-abi.js";
+
+const characters = [
+  { name: "Alpha", characterKey: "0000000000000001", primaryProfession: 1, secondaryProfession: 0, characterType: "roleplaying", campaign: 1, level: 20, mapId: 55 },
+  { name: "Beta", characterKey: "0000000000000002", primaryProfession: 2, secondaryProfession: 0, characterType: "roleplaying", campaign: 1, level: 20, mapId: 55 },
+] as const;
+
+async function until(accept: () => boolean, timeout = 1_500): Promise<void> {
+  const deadline = performance.now() + timeout;
+  while (!accept() && performance.now() < deadline) await delay(10);
+  assert.ok(accept(), "the expected transaction boundary was reached");
+}
+
+function fixture(t: TestContext, options: {
+  refusedAction?: number;
+  heldAction?: number;
+  throwingAction?: number;
+} = {}) {
+  const previousWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+  const previousDocument = Object.getOwnPropertyDescriptor(globalThis, "document");
+  let focused = true;
+  const events = new EventTarget();
+  const document = Object.assign(new EventTarget(), {
+    visibilityState: "visible",
+    hasFocus: () => focused,
+  });
+  Object.defineProperty(globalThis, "window", { configurable: true, value: events });
+  Object.defineProperty(globalThis, "document", { configurable: true, value: document });
+  const memory = new WebAssembly.Memory({ initial: 1 });
+  const pointer = 64;
+  let enabled = false;
+  let pending: { kind: number; argument: number } | null = null;
+  let selectedIndex = 0;
+  let sequence = 2;
+  let context: CharacterSwitchContext = "outpost";
+  let records: readonly CharacterSummary[] = characters;
+  const calls: number[] = [];
+  const drained: number[] = [];
+  const list = (): CompanionCharacterListState => ({
+    status: "ready", sequence, selectedIndex, characters: records,
+  });
+  const drain = () => {
+    if (!enabled || pending === null) return;
+    const { kind, argument } = pending;
+    pending = null;
+    drained.push(kind);
+    if (kind === ABI.action.logout) { context = "character-select"; sequence += 2; }
+    if (kind === ABI.action.select) selectedIndex = argument;
+    if (kind === ABI.action.play) context = "outpost";
+    new DataView(memory.buffer).setUint32(pointer + ABI.fields.result, ABI.result.sent, true);
+  };
+  const controller = createCharacterSwitchController({
+    memory, payloadPointer: pointer, buildId: 7, programId: 1,
+    configure(payload, policy) {
+      enabled = payload === pointer && policy === 1;
+      // Match native configure: disabling clears a queued action.
+      if (!enabled) pending = null;
+      return 1;
+    },
+    enqueue(kind, argument) {
+      assert.ok(enabled, "the channel must be owned before enqueue");
+      if (kind === options.throwingAction) throw new Error("native action unavailable");
+      calls.push(kind);
+      if (kind === options.refusedAction) return 0;
+      assert.equal(pending, null, "only one native action may be pending");
+      pending = { kind, argument };
+      if (kind !== options.heldAction) setImmediate(drain);
+      return 1;
+    },
+    characters: { get state() { return list(); }, subscribe: () => () => false, dispose() {} },
+    controls: { state: () => "unknown", switchContext: () => context, diagnosticMask: () => 0 },
+  });
+  t.after(() => {
+    controller.dispose();
+    if (previousWindow) Object.defineProperty(globalThis, "window", previousWindow);
+    else Reflect.deleteProperty(globalThis, "window");
+    if (previousDocument) Object.defineProperty(globalThis, "document", previousDocument);
+    else Reflect.deleteProperty(globalThis, "document");
+  });
+  return {
+    controller, calls, drained, drain,
+    enabled: () => enabled,
+    pending: () => pending,
+    setContext(next: CharacterSwitchContext) { context = next; },
+    changeAccount() { records = characters.map(character => ({ ...character, characterKey: `1${character.characterKey.slice(1)}` })); },
+    blur(hidden = false) {
+      focused = false;
+      events.dispatchEvent(new Event("blur"));
+      if (hidden) {
+        document.visibilityState = "hidden";
+        document.dispatchEvent(new Event("visibilitychange"));
+      }
+    },
+    focus() {
+      document.visibilityState = "visible";
+      focused = true;
+      events.dispatchEvent(new Event("focus"));
+      document.dispatchEvent(new Event("visibilitychange"));
+    },
+  };
+}
+
+describe("background character switch", { concurrency: false }, () => {
+  for (const boundary of ["immediate", "selector", "selection", "confirmation"] as const) {
+    for (const hidden of [false, true]) {
+      it(`finishes after ${hidden ? "hiding" : "blur"} at ${boundary}`, async (t) => {
+        const f = fixture(t);
+        assert.equal(f.enabled(), false, "idle focus must not enable native actions");
+        f.controller.subscribe(() => {
+          const action = f.controller.action;
+          if (action.status === "switching" && action.stage === boundary) f.blur(hidden);
+          if (action.status === "complete") assert.equal(f.enabled(), false);
+        });
+        f.controller.request(characters[1].characterKey);
+        if (boundary === "immediate") f.blur(hidden);
+        assert.equal(f.enabled(), true);
+        const diagnostics = f.controller.diagnostics();
+        if (diagnostics.version !== 7) throw new Error("expected live diagnostics");
+        assert.equal(diagnostics.policyEnabled, true);
+        if (boundary === "immediate") assert.equal(diagnostics.focused, false);
+        f.controller.request(characters[1].characterKey);
+        f.controller.reset();
+        await until(() => f.controller.action.status === "complete");
+        assert.deepEqual(f.calls, [1, 2, 3]);
+        assert.deepEqual(f.drained, [1, 2, 3]);
+        assert.equal(f.enabled(), false);
+        assert.equal(f.pending(), null);
+        f.focus();
+        assert.equal(f.enabled(), false, "regaining focus does not rearm a finished switch");
+      });
+    }
+  }
+
+  it("requires focus both for a new request and for explorable confirmation", (t) => {
+    const f = fixture(t);
+    f.blur();
+    f.controller.request(characters[1].characterKey);
+    assert.deepEqual(f.controller.action, { status: "failed", code: "focus-lost", retryable: true });
+    f.focus();
+    f.setContext("pve-explorable");
+    f.controller.request(characters[1].characterKey);
+    assert.equal(f.controller.action.status, "confirming");
+    assert.equal(f.enabled(), false);
+    f.blur(true);
+    f.controller.confirm();
+    assert.deepEqual(f.controller.action, { status: "failed", code: "focus-lost", retryable: true });
+    assert.deepEqual(f.calls, []);
+    assert.equal(f.enabled(), false);
+  });
+
+  for (const kind of [ABI.action.logout, ABI.action.select, ABI.action.play]) {
+    it(`disposal clears pending action ${kind} and prevents later actions`, async (t) => {
+      const f = fixture(t, { heldAction: kind });
+      f.controller.request(characters[1].characterKey);
+      await until(() => f.calls.includes(kind));
+      f.blur(true);
+      f.controller.dispose();
+      const calls = [...f.calls];
+      f.drain();
+      f.focus();
+      f.controller.request(characters[0].characterKey);
+      await delay(100);
+      assert.equal(f.enabled(), false);
+      assert.equal(f.pending(), null);
+      assert.deepEqual(f.calls, calls);
+      assert.equal(f.drained.includes(kind), false);
+    });
+
+    it(`native refusal at action ${kind} releases the channel before failure publication`, async (t) => {
+      const f = fixture(t, { refusedAction: kind });
+      f.controller.subscribe(() => {
+        if (f.controller.action.status === "failed") assert.equal(f.enabled(), false);
+      });
+      f.controller.request(characters[1].characterKey);
+      f.blur();
+      await until(() => f.controller.action.status === "failed");
+      assert.deepEqual(f.calls, [1, 2, 3].slice(0, kind));
+      assert.equal(f.enabled(), false);
+      assert.equal(f.pending(), null);
+    });
+  }
+
+  it("times out in the background and clears an undrained logout", async (t) => {
+    const f = fixture(t, { heldAction: ABI.action.logout });
+    f.controller.request(characters[1].characterKey);
+    f.blur(true);
+    await until(() => f.controller.action.status === "failed", 3_000);
+    assert.deepEqual(f.controller.action, { status: "failed", code: "logout-timeout", retryable: false });
+    assert.equal(f.enabled(), false);
+    f.drain();
+    assert.deepEqual(f.drained, []);
+  });
+
+  it("still refuses a changed account after background logout", async (t) => {
+    const f = fixture(t);
+    f.controller.subscribe(() => {
+      const action = f.controller.action;
+      if (action.status === "switching" && action.stage === "selector") {
+        f.changeAccount();
+        f.blur();
+      }
+    });
+    f.controller.request(characters[1].characterKey);
+    await until(() => f.controller.action.status === "failed");
+    assert.deepEqual(f.controller.action, { status: "failed", code: "target-missing", retryable: false });
+    assert.deepEqual(f.calls, [1]);
+    assert.equal(f.enabled(), false);
+  });
+
+  for (const kind of [ABI.action.logout, ABI.action.select]) {
+    it(`releases the channel if native action ${kind} throws`, async (t) => {
+      const f = fixture(t, { throwingAction: kind });
+      f.controller.request(characters[1].characterKey);
+      await until(() => f.controller.action.status === "failed");
+      assert.equal(f.enabled(), false);
+      assert.equal(f.pending(), null);
+    });
+  }
+
+  it("terminal cleanup cannot disable a new switch started by a subscriber", async (t) => {
+    const f = fixture(t);
+    let completed = 0;
+    f.controller.subscribe(() => {
+      if (f.controller.action.status !== "complete") return;
+      assert.equal(f.enabled(), false);
+      if (++completed === 1) f.controller.request(characters[0].characterKey);
+    });
+    f.controller.request(characters[1].characterKey);
+    await until(() => completed === 2);
+    assert.deepEqual(f.calls, [1, 2, 3, 1, 2, 3]);
+    assert.equal(f.enabled(), false);
+  });
+});


### PR DESCRIPTION
## Problem

Alt-Tabbing just after choosing a character cancels the switch and can leave Guild Wars at character selection. Losing focus currently disables the native action channel and clears pending Logout, Select, or Play work.

## Solution

Require focus when the player starts a switch or confirms leaving an explorable area. Once accepted, that single bounded transaction owns its native action channel until completion, failure, timeout, or disposal, even while the game is unfocused or minimized.

- Remove focus-driven channel configuration and intermediate focus cancellation from the existing controller.
- Keep the channel disabled while idle and release it before publishing a terminal result.
- Preserve account and target identity checks, native selection confirmation, context restrictions, and deadlines.
- Do not steal focus, add generic input, or change native transform output. Automatic return after reload keeps its separate focus policy.

## Verification

- [Application verification](https://github.com/Mat4m0/gwonmac/actions/runs/33729853567) passed, including the complete macOS runtime suite and packaged-build tests. CodeQL also passed.
- `pnpm check` passed: types, lint, documentation links, unit and policy tests, and Tools/launcher tests.
- `pnpm build` passed.
- Twenty focused unit cases cover background stages, duplicate requests, refusal, timeout, disposal, account changes, thrown native actions, and reentrant completion listeners.
- Eight scoped Electron tests passed, including six real-window blur/minimize cases at the Logout, Select, and Play boundaries and both existing Character Switch UI tests.
- The Electron cases use the shipped controller with offline native-action fixtures. Playwright focus emulation is disabled so the tests exercise actual window focus loss.

## Rollout and remaining risk

Normal bug fix from `main` to `main`. No persistence migration or native bytecode change. Because this changes controller/input policy, consider it with the next Beta train; a Developer Build is suitable for focused tester verification first.

Live official-client gameplay was not tested. Before release, verify Alt-Tab immediately after starting, after Logout, and after selection, plus minimize and closing the window. This PR does not authorize a merge or release.

## Attribution

Implemented and verified with OpenAI Codex in the Codex desktop harness.
