### PR TITLE
fix(deps): resolve qs and xmldom security alerts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3796,10 +3796,9 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
-  '@xmldom/xmldom@0.9.10':
-    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
+  '@xmldom/xmldom@0.9.12':
+    resolution: {integrity: sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==}
     engines: {node: '>=14.6'}
-    deprecated: this version has critical issues, please update to the latest version
 
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
@@ -6955,8 +6954,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.15.3:
-    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+  qs@6.16.0:
+    resolution: {integrity: sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==}
     engines: {node: '>=0.6'}
 
   quansync@0.2.11:
@@ -12383,7 +12382,7 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
-  '@xmldom/xmldom@0.9.10': {}
+  '@xmldom/xmldom@0.9.12': {}
 
   '@xtuc/ieee754@1.2.0': {}
 
@@ -12639,7 +12638,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.3
       on-finished: 2.4.1
-      qs: 6.15.3
+      qs: 6.16.0
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -13613,7 +13612,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.3
+      qs: 6.16.0
       range-parser: 1.3.0
       router: 2.2.0
       send: 1.2.1
@@ -15904,7 +15903,7 @@ snapshots:
 
   plist@3.1.1:
     dependencies:
-      '@xmldom/xmldom': 0.9.10
+      '@xmldom/xmldom': 0.9.12
       base64-js: 1.5.1
       xmlbuilder: 15.1.1
 
@@ -16125,7 +16124,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.15.3:
+  qs@6.16.0:
     dependencies:
       es-define-property: 1.0.1
       side-channel: 1.1.1


### PR DESCRIPTION
Dependabot reports three open alerts in the shared lockfile. Update `qs` from 6.15.3 to 6.16.0 and `@xmldom/xmldom` from 0.9.10 to 0.9.12 to remove all affected versions.

Both updates satisfy the existing parent ranges. The change touches only `pnpm-lock.yaml`; it adds no overrides and preserves the rest of the dependency graph. One PR is sufficient for this dependency maintenance change.

Addresses Dependabot alerts [47](https://github.com/Mat4m0/gwonmac/security/dependabot/47), [48](https://github.com/Mat4m0/gwonmac/security/dependabot/48), and [49](https://github.com/Mat4m0/gwonmac/security/dependabot/49). GitHub will reevaluate them after merge.

Validation:

- Frozen-lockfile installation passes.
- `pnpm run check` passes: type checks, lint, Markdown links, unit/policy tests, and Tools/launcher tests.
- `pnpm test:website` passes locally and in CI, including build/output checks and website smoke tests.
- GitHub dependency review, CodeQL, and required `verify / verify` pass. [Application verification](https://github.com/Mat4m0/gwonmac/actions/runs/33733474591) includes the macOS runtime suite and packaged-app tests.
- All three upstream advisory failures reproduced with the old packages and are rejected or handled safely with the patched packages. Checks include encoded query keys, both prototype-related parse modes, invalid XML names, and post-creation node-name mutation under strict serialization.
- Normal query/Buffer serialization, valid XML references, and plist build/parse round trips pass.
- `pnpm audit --audit-level=moderate --json` passes with no unignored advisories. Existing audit exclusions are unchanged.

Risk is limited to transitive parser updates: qs is used by website MCP/development tooling; xmldom is used through plist in Electron packaging/signing. No application code, signing configuration, or release behavior changes. Live gameplay and signed-release QA are outside this dependency fix.

Prepared with Codex (GPT-5.6).
