### PR TITLE
feat(travel): add Guild Hall quick travel

### DIFF
--- a/apps/tools/src/components/TravelPalette.test.ts
+++ b/apps/tools/src/components/TravelPalette.test.ts
@@ -25,6 +25,7 @@ function fixture(options: Readonly<{
   history?: readonly number[];
   friends?: TravelFriends;
   unavailable?: string | null;
+  guildHallUnavailable?: string | null;
 }> = {}, attachTo?: Element) {
   const state = ref<TravelHost["state"]["value"]>({
     status: "ready", mapId: 55, travelContext: "world", characterKey: null, unlockedMapWords: null,
@@ -40,6 +41,7 @@ function fixture(options: Readonly<{
   const travel = vi.fn<TravelHost["travel"]>(async (request) => {
     attempt.value = { status: "queued", mapId: request.mapId };
   });
+  const guildHall = vi.fn(async () => {});
   const savePreferences = vi.fn<TravelHost["savePreferences"]>(async (
     patch: TravelPreferencePatch,
   ) => {
@@ -57,10 +59,12 @@ function fixture(options: Readonly<{
     notice,
     history,
     unavailable: options.unavailable ?? null,
+    guildHallUnavailable: options.guildHallUnavailable ?? null,
     async loadPreferences() { return preferences; },
     savePreferences,
     async loadHistory() { return history.value; },
     travel,
+    guildHall,
     updateFriends(next) { friends.value = next; },
     updateGameState(next) {
       state.value = next;
@@ -85,12 +89,36 @@ function fixture(options: Readonly<{
     notice,
     state,
     travel,
+    guildHall,
     savePreferences,
     traceSearch,
   };
 }
 
 describe("TravelPalette", () => {
+  it("finds the own Guild Hall, disables a missing hall, and becomes Leave inside", async () => {
+    const { wrapper, state, guildHall } = fixture();
+    await flushPromises();
+    await wrapper.get("#travel-search-input").setValue("gh");
+    expect(wrapper.text()).toContain("Guild Hall");
+    expect(wrapper.text()).toContain("No Guild Hall");
+    expect(wrapper.get("#travel-guild-hall").attributes("disabled")).toBeDefined();
+
+    state.value = {
+      status: "ready", mapId: 55, travelContext: "world", characterKey: null,
+      unlockedMapWords: null, guildHall: false, hasGuildHall: true,
+    };
+    await flushPromises();
+    await wrapper.get("#travel-guild-hall").trigger("click");
+    expect(guildHall).toHaveBeenCalledOnce();
+
+    state.value = { ...state.value, guildHall: true };
+    await flushPromises();
+    expect(wrapper.text()).toContain("Leave Guild Hall");
+    expect(wrapper.text()).toContain("Return to previous outpost");
+    wrapper.unmount();
+  });
+
   it("opens in Travel with compact assigned favorites", async () => {
     const { wrapper } = fixture();
     await flushPromises();

--- a/apps/tools/src/components/TravelPalette.vue
+++ b/apps/tools/src/components/TravelPalette.vue
@@ -80,7 +80,15 @@ type FriendSearchResult = Readonly<{
   friend: TravelFriend;
   disabledReason: string | null;
 }>;
-type SearchResult = DestinationSearchResult | FriendSearchResult;
+type GuildHallSearchResult = Readonly<{
+  kind: "guild-hall";
+  resultKey: "guild-hall";
+  mapId: 0;
+  destination: null;
+  friend: null;
+  disabledReason: string | null;
+}>;
+type SearchResult = DestinationSearchResult | FriendSearchResult | GuildHallSearchResult;
 const catalogueResults = computed(() => hasQuery.value
   ? searchTravelDestinations(query.value, synonyms.value)
   : []
@@ -124,11 +132,30 @@ const friendResults = computed<FriendSearchResult[]>(() => {
     }];
   });
 });
+const guildHallResults = computed<GuildHallSearchResult[]>(() => {
+  if (!hasQuery.value) return [];
+  const tokens = normaliseTravelTerm(query.value).split(" ").filter(Boolean);
+  if (!tokens.every((token) => "guild hall gh".includes(token))) return [];
+  const state = props.host.state.value;
+  const disabledReason = props.host.guildHallUnavailable
+    ?? (state.status !== "ready"
+    ? "Unavailable right now"
+    : state.guildHall || state.hasGuildHall ? null : "No Guild Hall");
+  return [{
+    kind: "guild-hall",
+    resultKey: "guild-hall",
+    mapId: 0,
+    destination: null,
+    friend: null,
+    disabledReason,
+  }];
+});
 const results = computed<SearchResult[]>(() => {
   const friendMaps = new Set(friendResults.value
     .filter(({ disabledReason }) => disabledReason === null)
     .map(({ mapId }) => mapId));
   return [
+    ...guildHallResults.value,
     ...friendResults.value,
     ...catalogueResults.value
       .filter((destination) => isAvailable(destination.mapId) && !friendMaps.has(destination.mapId))
@@ -249,7 +276,10 @@ function queryMatchLabel(destination: TravelDestination): string {
 }
 
 function searchResultLocation(result: SearchResult): string {
-  return result.kind === "friend" ? result.location : result.destination.name;
+  if (result.kind === "friend") return result.location;
+  if (result.kind === "guild-hall") return props.host.state.value.status === "ready"
+    && props.host.state.value.guildHall ? "Return to previous outpost" : "Your guild";
+  return result.destination.name;
 }
 
 function friendResultLabel(result: FriendSearchResult): string {
@@ -314,7 +344,7 @@ watch(results, (next, previous) => {
   );
   const firstAvailable = next.findIndex((result) => result.disabledReason === null);
   active.value = retained >= 0 ? retained : firstAvailable;
-  props.host.traceSearch(query.value, next.map((result) => result.mapId));
+  props.host.traceSearch(query.value, next.map((result) => result.mapId).filter((mapId) => mapId > 0));
 });
 watch(() => props.visible, async (visible) => {
   if (!visible) return;
@@ -366,6 +396,15 @@ async function travel(request: TravelRequest): Promise<void> {
 }
 
 async function travelToResult(result: SearchResult): Promise<void> {
+  if (result.kind === "guild-hall") {
+    if (result.disabledReason === null) {
+      try {
+        await props.host.guildHall?.();
+        emit("close");
+      } catch { /* The host owns the refusal notice. */ }
+    }
+    return;
+  }
   if (result.kind === "friend") {
     const observed = props.host.friends.value;
     const current = observed.status === "ready"
@@ -596,12 +635,13 @@ function onKeydown(event: KeyboardEvent): void {
     <section v-if="hasQuery" id="travel-results-panel" class="ui-scroll travel-body" role="region" aria-label="Travel search results">
       <div v-if="results.length" class="travel-result-heading">{{ results.length === 1 ? 'Best match for' : 'Matches for' }} <strong>{{ query }}</strong></div>
       <div v-if="results.length" id="travel-results" class="travel-results" role="listbox">
-        <button v-for="(result, index) in results" :id="`travel-${result.resultKey}`" :key="result.resultKey" type="button" class="travel-result ui-row" role="option" tabindex="-1" :aria-selected="index === active" :aria-disabled="searchResultDisabled(result)" :aria-label="result.kind === 'friend' ? `${result.friend.alias}, ${result.friend.character}, ${friendResultLabel(result)}` : undefined" :disabled="searchResultDisabled(result)" @mouseenter="active = index" @click="active = index; travelToResult(result)">
+        <button v-for="(result, index) in results" :id="`travel-${result.resultKey}`" :key="result.resultKey" type="button" class="travel-result ui-row" role="option" tabindex="-1" :aria-selected="index === active" :aria-disabled="searchResultDisabled(result)" :aria-label="result.kind === 'friend' ? `${result.friend.alias}, ${result.friend.character}, ${friendResultLabel(result)}` : result.kind === 'guild-hall' ? `${host.state.value.status === 'ready' && host.state.value.guildHall ? 'Leave' : 'Travel to'} Guild Hall, ${searchResultLocation(result)}` : undefined" :disabled="searchResultDisabled(result)" @mouseenter="active = index" @click="active = index; travelToResult(result)">
           <span class="travel-result-identity">
             <svg v-if="result.kind === 'friend'" class="travel-player-icon" viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="6.5" r="3" /><path d="M4.5 17c.6-3.1 2.4-4.7 5.5-4.7s4.9 1.6 5.5 4.7" /></svg>
-            <span><strong v-if="result.kind === 'friend'">{{ result.friend.alias }}</strong><strong v-else><template v-for="(part, partIndex) in highlightTravelDestinationName(result.destination, query)" :key="partIndex"><mark v-if="part.match">{{ part.text }}</mark><template v-else>{{ part.text }}</template></template></strong><small>{{ result.kind === 'friend' ? result.friend.character : result.destination.campaign }}</small></span>
+            <svg v-else-if="result.kind === 'guild-hall'" class="travel-player-icon" viewBox="0 0 20 20" aria-hidden="true"><path d="M10 2.5 16 5v4.4c0 3.7-2.2 6.4-6 8.1-3.8-1.7-6-4.4-6-8.1V5l6-2.5Z" /><path d="M7.2 9.7h5.6M10 6.8v5.8" /></svg>
+            <span><strong v-if="result.kind === 'friend'">{{ result.friend.alias }}</strong><strong v-else-if="result.kind === 'guild-hall'">{{ host.state.value.status === 'ready' && host.state.value.guildHall ? 'Leave Guild Hall' : 'Guild Hall' }}</strong><strong v-else><template v-for="(part, partIndex) in highlightTravelDestinationName(result.destination, query)" :key="partIndex"><mark v-if="part.match">{{ part.text }}</mark><template v-else>{{ part.text }}</template></template></strong><small>{{ result.kind === 'friend' ? result.friend.character : result.kind === 'guild-hall' ? 'Guild' : result.destination.campaign }}</small></span>
           </span>
-          <span class="travel-result-context"><span class="travel-match" :data-unavailable="result.disabledReason !== null || undefined">{{ result.kind === 'friend' ? searchResultLocation(result) : queryMatchLabel(result.destination) }}</span><small v-if="result.disabledReason !== null" class="travel-unavailable-reason">{{ result.disabledReason }}</small></span>
+          <span class="travel-result-context"><span class="travel-match" :data-unavailable="result.disabledReason !== null || undefined">{{ result.kind === 'destination' ? queryMatchLabel(result.destination) : searchResultLocation(result) }}</span><small v-if="result.disabledReason !== null" class="travel-unavailable-reason">{{ result.disabledReason }}</small></span>
         </button>
       </div>
       <div v-else class="ui-empty travel-empty"><strong>{{ emptySearchTitle }}</strong><p>{{ emptySearchHelp }}</p><button type="button" class="ui-button" @click="query = ''">Clear search</button></div>

--- a/apps/tools/src/travel-host.test.ts
+++ b/apps/tools/src/travel-host.test.ts
@@ -56,7 +56,12 @@ function fixture() {
       record: recordHistory,
     },
   } as unknown as GwNativeApi;
-  const command: TravelCommand = { travel: vi.fn(), unavailable: () => null };
+  const command: TravelCommand = {
+    travel: vi.fn(),
+    guildHall: vi.fn(),
+    guildHallUnavailable: () => null,
+    unavailable: () => null,
+  };
   return {
     host: createNativeTravelHost(api, command),
     command,
@@ -72,6 +77,45 @@ function fixture() {
 afterEach(() => vi.useRealTimers());
 
 describe("native Travel host", () => {
+  it("enters and leaves a Guild Hall through one confirmed native action", async () => {
+    vi.useFakeTimers();
+    const { host, command } = fixture();
+    host.updateGameState({
+      status: "ready", mapId: 55, travelContext: "world", characterKey: null,
+      unlockedMapWords: null, guildHall: false, hasGuildHall: true,
+    });
+
+    await host.guildHall?.();
+    expect(command.guildHall).toHaveBeenCalledOnce();
+    expect(host.attempt.value).toEqual({ status: "queued", guildHall: true, mapId: 0 });
+    host.updateGameState({ status: "waiting", reason: "loading" });
+    host.updateGameState({
+      status: "ready", mapId: 4, travelContext: "world", characterKey: null,
+      unlockedMapWords: null, guildHall: true, hasGuildHall: true,
+    });
+    expect(host.attempt.value).toEqual({ status: "idle" });
+    expect(host.notice.value).toBeNull();
+
+    await host.guildHall?.();
+    expect(command.guildHall).toHaveBeenCalledTimes(2);
+    host.updateGameState({ status: "waiting", reason: "loading" });
+    host.updateGameState({
+      status: "ready", mapId: 55, travelContext: "world", characterKey: null,
+      unlockedMapWords: null, guildHall: false, hasGuildHall: true,
+    });
+    expect(host.attempt.value).toEqual({ status: "idle" });
+  });
+
+  it("refuses Guild Hall travel when the character has no hall", async () => {
+    const { host, command } = fixture();
+    host.updateGameState({
+      status: "ready", mapId: 55, travelContext: "world", characterKey: null,
+      unlockedMapWords: null, guildHall: false, hasGuildHall: false,
+    });
+    await expect(host.guildHall?.()).rejects.toThrow("does not have a Guild Hall");
+    expect(command.guildHall).not.toHaveBeenCalled();
+  });
+
   it("delegates shortcut mutations to Main", async () => {
     const { host, setTravel } = fixture();
     await host.loadPreferences();

--- a/apps/tools/src/travel-host.ts
+++ b/apps/tools/src/travel-host.ts
@@ -28,7 +28,8 @@ import { createTravelHistoryObservation } from "./travel-history-observation";
 
 export type TravelAttempt =
   | Readonly<{ status: "idle" }>
-  | Readonly<{ status: "queued" | "loading"; mapId: number }>;
+  | Readonly<{ status: "queued" | "loading"; mapId: number }>
+  | Readonly<{ status: "queued" | "loading"; guildHall: boolean; mapId: 0 }>;
 export type TravelNotice = Readonly<{
   message: string;
   level: "info" | "success" | "warning" | "danger";
@@ -44,10 +45,12 @@ export interface TravelHost {
   readonly history: Ref<TravelHistory>;
   readonly friends: Ref<TravelFriends>;
   readonly unavailable: string | null;
+  readonly guildHallUnavailable?: string | null;
   loadPreferences(): Promise<TravelPreferences>;
   savePreferences(patch: TravelPreferencePatch): Promise<TravelPreferences>;
   loadHistory(): Promise<TravelHistory>;
   travel(request: TravelRequest): Promise<void>;
+  guildHall?: () => Promise<void>;
   updateGameState(state: TravelGameState): void;
   updateFriends(friends: TravelFriends): void;
   dispose(): void;
@@ -114,6 +117,9 @@ export function createNativeTravelHost(
     get unavailable() {
       return command.unavailable();
     },
+    get guildHallUnavailable() {
+      return command.guildHallUnavailable?.() ?? "Guild Hall travel is unavailable for this client";
+    },
     loadPreferences,
     async savePreferences(patch) {
       const expected = currentPreferences ?? await loadPreferences();
@@ -165,10 +171,71 @@ export function createNativeTravelHost(
         throw error;
       }
     },
+    async guildHall() {
+      if (attempt.value.status !== "idle") return;
+      const ready = state.value.status === "ready" ? state.value : null;
+      if (ready === null || (!ready.guildHall && !ready.hasGuildHall)) {
+        const message = ready === null
+          ? "Guild Hall travel is waiting for Guild Wars."
+          : "This character does not have a Guild Hall.";
+        notice.value = { message, level: "warning" };
+        throw new Error(message);
+      }
+      const destination = !ready.guildHall;
+      attempt.value = { status: "queued", guildHall: destination, mapId: 0 };
+      notice.value = {
+        message: destination ? "Travelling to your Guild Hall…" : "Leaving Guild Hall…",
+        level: "info",
+      };
+      try {
+        const guildHall = command.guildHall;
+        if (guildHall === undefined) {
+          throw new Error("Guild Hall travel is unavailable for this client");
+        }
+        guildHall();
+        attemptTimer = window.setTimeout(() => {
+          const current = attempt.value;
+          if (current.status !== "queued" || !("guildHall" in current)) return;
+          clearAttempt();
+          notice.value = {
+            message: "Guild Wars did not start Guild Hall travel. Try again.",
+            level: "warning",
+          };
+        }, 3_000);
+      } catch (error) {
+        clearAttempt();
+        notice.value = { message: "Guild Hall travel could not start.", level: "danger" };
+        throw error;
+      }
+    },
     updateFriends(next) { friends.value = next; },
     updateGameState(next) {
       state.value = next;
       const current = attempt.value;
+      if (current.status !== "idle" && "guildHall" in current) {
+        if (next.status === "ready" && next.guildHall === current.guildHall) {
+          clearAttempt();
+          notice.value = null;
+        } else if (next.status === "waiting" && next.reason === "loading") {
+          window.clearTimeout(attemptTimer);
+          attempt.value = { status: "loading", guildHall: current.guildHall, mapId: 0 };
+          notice.value = { message: "Travel started.", level: "success" };
+          attemptTimer = window.setTimeout(() => {
+            const active = attempt.value;
+            if (active.status === "loading" && "guildHall" in active) {
+              clearAttempt();
+              notice.value = {
+                message: "Guild Wars did not confirm Guild Hall travel. Try again.",
+                level: "warning",
+              };
+            }
+          }, 30_000);
+        } else if (current.status === "loading" && next.status !== "ready") {
+          clearAttempt();
+          notice.value = { message: "Guild Hall travel was interrupted.", level: "warning" };
+        }
+        return;
+      }
       const arrived = current.status !== "idle"
         && next.status === "ready"
         && next.mapId === current.mapId;
@@ -270,6 +337,7 @@ export function createDemoTravelHost(): TravelHost {
     notice,
     history,
     unavailable: null,
+    guildHallUnavailable: null,
     async loadPreferences() {
       return current;
     },
@@ -287,6 +355,17 @@ export function createDemoTravelHost(): TravelHost {
           status: "ready", mapId: request.mapId, travelContext: "world",
           characterKey, unlockedMapWords,
         };
+        attempt.value = { status: "idle" };
+      }, 600);
+    },
+    async guildHall() {
+      const ready = state.value.status === "ready" ? state.value : null;
+      if (ready === null) return;
+      const destination = !ready.guildHall;
+      attempt.value = { status: "loading", guildHall: destination, mapId: 0 };
+      state.value = { status: "waiting", reason: "loading" };
+      window.setTimeout(() => {
+        state.value = { ...ready, guildHall: destination, hasGuildHall: true };
         attempt.value = { status: "idle" };
       }, 600);
     },

--- a/docs/enhancement-development.md
+++ b/docs/enhancement-development.md
@@ -153,6 +153,8 @@ character names, account data, chat, packet bytes, or Travel search text.
   locked results. A zero result can mean no match, only locked matches, or only
   destinations outside the current context. Passage-scroll locations
   such as Urgoz's Warren and The Deep intentionally use their original UI.
+  The terms `guild`, `guild hall`, and `gh` add the separately certified
+  Guild Hall action. Its trace and UI contain no Guild Hall key.
 
 For a report, reproduce one operation at a time and copy the lines from its
 first request through its final success, refusal, or timeout. Also record the

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -96,7 +96,7 @@ Tools are global. The same master switch, Tool switches, and shortcuts apply to
 every account. The launcher exposes:
 
 - **Build Library** — save and organize builds and teams;
-- **Quick Travel** — search reviewed Guild Wars destinations;
+- **Quick Travel** — search reviewed destinations, online friends, and your Guild Hall;
 - **Xunlai Storage** — open storage in supported PvE outposts;
 - **Trade Chat** — browse the trade feed;
 - **Maps** — enable exploration and walkability guidance;

--- a/docs/wasm-host.md
+++ b/docs/wasm-host.md
@@ -331,6 +331,19 @@ exact client Travel dispatcher with `kTravel`. An unknown or locked map,
 unreadable unlock array, unresolved live context, or changed helper stops only
 Travel without dispatching another client UI message.
 
+Guild Hall travel is a separate named action inside Travel. It does not treat a
+Guild Hall layout map ID as an ordinary destination. The companion publishes
+only whether the current character has a nonzero Guild Hall key and whether
+the current `AreaInfo` record has the Guild Hall flag. The 16-byte key stays
+inside the game module.
+
+At the game-thread drain, the action calls the certified current-area type
+reader. Type `4` sends `kLeaveGuildHall` with no payload. Every other
+supported ready area re-reads the current guild key, checks its pointer and four
+words, copies it into the private Travel payload, and sends `kGuildHall`.
+Changed or missing Guild Hall evidence removes only this action. Ordinary map
+Travel remains available.
+
 The Tools host owns one Travel attempt: `idle`, `queued`, or `loading`. A
 three-second start deadline and a separate thirty-second arrival deadline both
 return it to `idle`; disconnect, corrupt snapshot, and other non-loading states

--- a/scripts/companion-kernel-contract.mjs
+++ b/scripts/companion-kernel-contract.mjs
@@ -40,7 +40,7 @@ export const COMPANION_KERNEL_EXPORT_VALUES = Object.freeze({
 });
 
 export const COMPANION_KERNEL_DYLINK0 = Object.freeze([
-  // Memory footprint 2301 bytes (0xa4 0x11 as LEB128). Documented moves:
+  // Memory footprint 2309 bytes (0x85 0x12 as LEB128). Documented moves:
   //   309 ->  310  the Toolbox observer gained PARTY_OBSERVED, the byte that
   //                separates "you have no heroes" from "nobody read the party";
   //   310 ->  410  Layout grew by the 25 party-detail address words, at 4 bytes
@@ -93,10 +93,12 @@ export const COMPANION_KERNEL_DYLINK0 = Object.freeze([
   //                snapshot remains in host-owned memory.
   //   2244 -> 2301 friend lifecycle state and its bounded snapshot publisher;
   //                the 12312-byte snapshot remains in host-owned memory.
+  //   2301 -> 2309 Guild Hall availability adds two certified layout words;
+  //                its two booleans reuse the play-region flags word.
   // This constant exists so a kernel whose footprint moves cannot ship without
   // someone saying why. One page is still the ceiling, and this remains far
   // under it.
-  0x01, 0x05, 0xfd, 0x11, 0x02, 0x00, 0x00,
+  0x01, 0x05, 0x85, 0x12, 0x02, 0x00, 0x00,
 ]);
 
 const WASM_PAGE_BYTES = 65_536;

--- a/src/companion-kernel/abi.rs
+++ b/src/companion-kernel/abi.rs
@@ -58,12 +58,14 @@ pub(crate) const CHARACTER_NAME_UNITS: usize = 20;
 
 pub(crate) const PLAY_REGION_BYTES: u32 = size_of::<PlayRegionSnapshot>() as u32;
 pub(crate) const PLAY_REGION_MAGIC: u32 = 0x5250_5747;
-pub(crate) const PLAY_REGION_ABI_AND_SIZE: u32 = (PLAY_REGION_BYTES << 16) | 3;
+pub(crate) const PLAY_REGION_ABI_AND_SIZE: u32 = (PLAY_REGION_BYTES << 16) | 4;
 pub(crate) const FLAG_PLAY_REGION_READY: u32 = 1 << 0;
 pub(crate) const FLAG_PLAY_REGION_LOADING: u32 = 1 << 1;
 pub(crate) const FLAG_PLAY_REGION_CHARACTER: u32 = 1 << 2;
 pub(crate) const FLAG_PLAY_REGION_UNLOCKS: u32 = 1 << 3;
 pub(crate) const FLAG_PLAY_REGION_PRE_SEARING: u32 = 1 << 4;
+pub(crate) const FLAG_PLAY_REGION_GUILD_HALL: u32 = 1 << 5;
+pub(crate) const FLAG_PLAY_REGION_HAS_GUILD_HALL: u32 = 1 << 6;
 
 pub(crate) const SKILL_SLOT_BYTES: u32 = size_of::<SkillSlotSnapshot>() as u32;
 pub(crate) const SKILL_SLOT_MAGIC: u32 = 0x534b_5747;
@@ -300,6 +302,8 @@ pub(crate) struct Layout {
     pub(crate) character_array_pointer: u32,
     pub(crate) character_array_count: u32,
     pub(crate) selected_character_name: u32,
+    pub(crate) guild_context_slot: u32,
+    pub(crate) guild_hall_key: u32,
     pub(crate) player_chat_message: u32,
     pub(crate) hide_hero_panel_message: u32,
     pub(crate) show_hero_panel_message: u32,
@@ -411,6 +415,8 @@ impl Layout {
         character_array_pointer: 0,
         character_array_count: 0,
         selected_character_name: 0,
+        guild_context_slot: 0,
+        guild_hall_key: 0,
         player_chat_message: 0,
         hide_hero_panel_message: 0,
         show_hero_panel_message: 0,
@@ -608,7 +614,7 @@ pub(crate) struct PartySnapshot {
     pub(crate) character_skills: [u32; SKILL_UNLOCK_WORDS],
 }
 
-const _: [(); 464] = [(); size_of::<Layout>()];
+const _: [(); 472] = [(); size_of::<Layout>()];
 const _: [(); 72] = [(); size_of::<CharacterRecord>()];
 const _: [(); 4632] = [(); size_of::<CharacterListSnapshot>()];
 const _: [(); 96] = [(); size_of::<PartySlot>()];

--- a/src/companion-kernel/lib.rs
+++ b/src/companion-kernel/lib.rs
@@ -161,6 +161,7 @@ pub(crate) enum GameState {
         play_region: u32,
         pre_searing: bool,
         on_world_map: bool,
+        guild_hall: bool,
     },
 }
 
@@ -195,25 +196,25 @@ unsafe fn classify_play_region(
     layout: Layout,
     map_id: u32,
     instance_type: u32,
-) -> (u32, bool, bool) {
+) -> (u32, bool, bool, bool) {
     if layout.area_info == 0
         || layout.area_info_count == 0
         || layout.area_info_stride < 20
         || layout.area_info_flags + 4 > layout.area_info_stride
         || map_id >= layout.area_info_count
     {
-        return (PLAY_REGION_UNKNOWN, false, false);
+        return (PLAY_REGION_UNKNOWN, false, false, false);
     }
     let Some(record) = indexed(layout.area_info, map_id, layout.area_info_stride) else {
-        return (PLAY_REGION_UNKNOWN, false, false);
+        return (PLAY_REGION_UNKNOWN, false, false, false);
     };
     let mut area_region = 0;
     for (field, maximum) in [0_u32, 4, 8, 12].iter().zip([4_u32, 5, 27, 21].iter()) {
         let Some(value) = offset(record, *field).and_then(|at| unsafe { read_u32(at) }) else {
-            return (PLAY_REGION_UNKNOWN, false, false);
+            return (PLAY_REGION_UNKNOWN, false, false, false);
         };
         if value > *maximum {
-            return (PLAY_REGION_UNKNOWN, false, false);
+            return (PLAY_REGION_UNKNOWN, false, false, false);
         }
         if *field == 8 {
             area_region = value;
@@ -221,7 +222,7 @@ unsafe fn classify_play_region(
     }
     let Some(flags) = offset(record, layout.area_info_flags).and_then(|at| unsafe { read_u32(at) })
     else {
-        return (PLAY_REGION_UNKNOWN, false, false);
+        return (PLAY_REGION_UNKNOWN, false, false, false);
     };
     let play_region = if flags & (0x0004_0001 | 0x0080_0000) != 0 && instance_type == 1 {
         PLAY_REGION_PVP
@@ -232,6 +233,7 @@ unsafe fn classify_play_region(
         play_region,
         area_region == 7 && play_region == PLAY_REGION_PVE,
         flags & 0x20 == 0,
+        flags & 0x0080_0000 != 0,
     )
 }
 
@@ -420,7 +422,7 @@ pub(crate) unsafe fn resolve_game(layout: Layout) -> GameState {
         return GameState::Unavailable;
     }
 
-    let (play_region, pre_searing, on_world_map) = unsafe {
+    let (play_region, pre_searing, on_world_map, guild_hall) = unsafe {
         classify_play_region(layout, map_id, instance_type)
     };
     GameState::Ready {
@@ -431,6 +433,7 @@ pub(crate) unsafe fn resolve_game(layout: Layout) -> GameState {
         play_region,
         pre_searing,
         on_world_map,
+        guild_hall,
     }
 }
 
@@ -962,7 +965,7 @@ pub unsafe extern "C" fn companion_dispatch(kind: u32, a: u32, b: u32, c: u32, d
 
 #[no_mangle]
 pub extern "C" fn companion_abi() -> u32 {
-    22
+    23
 }
 
 #[no_mangle]

--- a/src/companion-kernel/play_region.rs
+++ b/src/companion-kernel/play_region.rs
@@ -99,6 +99,29 @@ unsafe fn current_character_key(layout: Layout, game: u32) -> Option<u64> {
     unsafe { character_key(uuid) }
 }
 
+unsafe fn has_guild_hall(layout: Layout) -> bool {
+    if layout.guild_context_slot == 0 || layout.guild_hall_key == 0 {
+        return false;
+    }
+    let Some(contexts) = (unsafe { pointer(layout.context_root, 28) }) else {
+        return false;
+    };
+    let Some(slot) = indexed(contexts, layout.guild_context_slot, 4) else {
+        return false;
+    };
+    let Some(required) = checked_add(layout.guild_hall_key, 16) else {
+        return false;
+    };
+    let Some(guild) = (unsafe { pointer(slot, required) }) else {
+        return false;
+    };
+    (0..4).any(|index| {
+        offset(guild, layout.guild_hall_key + index * 4)
+            .and_then(|at| unsafe { read_u32(at) })
+            .is_some_and(|word| word != 0)
+    })
+}
+
 pub(crate) unsafe fn tick(layout: Layout) {
     match unsafe { resolve_game(layout) } {
         GameState::Ready {
@@ -107,6 +130,7 @@ pub(crate) unsafe fn tick(layout: Layout) {
             instance_type,
             play_region,
             pre_searing,
+            guild_hall,
             ..
         } if play_region == PLAY_REGION_PVE || play_region == PLAY_REGION_PVP => unsafe {
             let key = current_character_key(layout, game);
@@ -126,7 +150,9 @@ pub(crate) unsafe fn tick(layout: Layout) {
                     FLAG_PLAY_REGION_PRE_SEARING
                 } else {
                     0
-                };
+                }
+                | if guild_hall { FLAG_PLAY_REGION_GUILD_HALL } else { 0 }
+                | if has_guild_hall(layout) { FLAG_PLAY_REGION_HAS_GUILD_HALL } else { 0 };
             publish(
                 flags,
                 map_id,

--- a/src/main/certification/enhancement-build-model.ts
+++ b/src/main/certification/enhancement-build-model.ts
@@ -136,7 +136,9 @@ export function enhancementConfigWords(
           value = build.xunlaiAction?.accessProof?.layout[field.key];
           break;
         case "travel":
-          value = build.travelAction?.unlockProof.layout[field.key];
+          value = field.key === "worldUnlockedMaps"
+            ? build.travelAction?.unlockProof.layout.worldUnlockedMaps
+            : build.travelAction?.guildHall?.layout[field.key];
           break;
         case "skill-slots":
           value = build.skillSlotGeometry?.layout[field.key];
@@ -153,6 +155,10 @@ export function enhancementConfigWords(
         }
       }
       if (field.owner === "storage" && build.xunlaiAction === undefined) {
+        return 0;
+      }
+      if (field.owner === "travel" && field.key !== "worldUnlockedMaps"
+        && build.travelAction?.guildHall === undefined) {
         return 0;
       }
       if (typeof value !== "number") {
@@ -317,7 +323,7 @@ export interface KnownEnhancementBuild {
     messageId: number;
     /** Certified client array and official bit-test consumer. */
     unlockProof: Readonly<{
-      layout: EnhancementTravelLayout;
+      layout: Readonly<Pick<EnhancementTravelLayout, "worldUnlockedMaps">>;
       accessor: Readonly<{
         functionIndex: number;
         params: readonly [];
@@ -345,6 +351,33 @@ export interface KnownEnhancementBuild {
       results: readonly [];
       bodySha256: string;
     }>;
+    guildHall?: Readonly<{
+      enqueueExport: string;
+      enterMessageId: number;
+      leaveMessageId: number;
+      layout: Readonly<Pick<
+        EnhancementTravelLayout,
+        "guildContextSlot" | "guildHallKey"
+      >>;
+      keyAccessor: Readonly<{
+        functionIndex: number;
+        params: readonly [];
+        results: readonly ["i32"];
+        bodySha256: string;
+      }>;
+      areaTypeAccessor: Readonly<{
+        functionIndex: number;
+        params: readonly [];
+        results: readonly ["i32"];
+        bodySha256: string;
+      }>;
+      producer: Readonly<{
+        functionIndex: number;
+        params: readonly ["i32", "i32"];
+        results: readonly [];
+        bodySha256: string;
+      }>;
+    }> | undefined;
   }>;
   chatAliases?: Readonly<{
     parser: Readonly<{

--- a/src/main/certification/enhancement-builds.ts
+++ b/src/main/certification/enhancement-builds.ts
@@ -235,6 +235,32 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
         // writes its four scalar arguments to {map, region, language,
         // district} and sends this message through the certified dispatcher.
         messageId: 0x1000_0183,
+        guildHall: Object.freeze({
+          enqueueExport: "enhancement_guild_hall",
+          // The client's guild command chooses Leave while AreaInfo type is
+          // GuildHall (4); otherwise it sends the current guild's 16-byte key.
+          enterMessageId: 0x1000_0180,
+          leaveMessageId: 0x1000_0182,
+          layout: Object.freeze({ guildContextSlot: 15, guildHallKey: 0x64 }),
+          keyAccessor: Object.freeze({
+            functionIndex: 7960,
+            params: Object.freeze([] as const),
+            results: Object.freeze(["i32"] as const),
+            bodySha256: "f78d0067879c110a5269ab57eaab946525cbc0a7ba09ff02c150db94d5176598",
+          }),
+          areaTypeAccessor: Object.freeze({
+            functionIndex: 9531,
+            params: Object.freeze([] as const),
+            results: Object.freeze(["i32"] as const),
+            bodySha256: "6b1546fa7e04a8f3642c4d5a0daa0d9d58255a879d47965920615013f465172f",
+          }),
+          producer: Object.freeze({
+            functionIndex: 15462,
+            params: Object.freeze(["i32", "i32"] as const),
+            results: Object.freeze([] as const),
+            bodySha256: "ff6bcc8db69cbb7fddc17af6d4b7a4c052cb6cd17e335155db495c2e435290c9",
+          }),
+        }),
         // WorldContext::unlocked_map is not accepted from GWCA's struct.
         // Accessor #9184 returns the exact Array<u32> at +0x60c, while the
         // official map consumer #15978 proves word=map/32 and bit=map%32.

--- a/src/main/certification/enhancement-local-actions-proof.ts
+++ b/src/main/certification/enhancement-local-actions-proof.ts
@@ -25,6 +25,7 @@ import {
   matchesEvidenceInput,
   mutableSpans,
   parseActiveTableRelations,
+  paddedOperand,
   roleFunctions,
   semanticRole,
   signatureMatches,
@@ -55,6 +56,56 @@ import type {
 declare const WebAssembly: {
   validate(bytes: Uint8Array): boolean;
 };
+
+const GUILD_HALL_KEY_ACCESSOR_ROLE = semanticRole(
+  14,
+  "aa6e200ba8acc6089f4d270158e47c99900e3878e50bd8a60b619aae729fa0c9",
+  mutableSpans([[4, 9, "guild.context"]]),
+  [],
+  ["i32"],
+);
+const GUILD_HALL_AREA_TYPE_ROLE = semanticRole(
+  23,
+  "a8b85fbbb029fa5674663b212b1531b0f2602ad64f55fa935a80f58581b66feb",
+  mutableSpans([[4, 9, "area.context"], [14, 19, "area.lookup"]]),
+  [],
+  ["i32"],
+);
+
+function containsBytes(body: Uint8Array, bytes: readonly number[]): boolean {
+  for (let start = body.indexOf(bytes[0]!); start >= 0; start = body.indexOf(bytes[0]!, start + 1)) {
+    let matched = true;
+    for (let index = 1; index < bytes.length; index += 1) {
+      if (body[start + index] !== bytes[index]) {
+        matched = false;
+        break;
+      }
+    }
+    if (matched) return true;
+  }
+  return false;
+}
+
+function guildHallProducer(
+  module: ModuleShape,
+  keyAccessor: number,
+  areaTypeAccessor: number,
+  uiDispatcher: number,
+  enterMessage: number,
+  leaveMessage: number,
+): number | null {
+  const operand = (value: number) => [...paddedOperand(value)];
+  const enter = [0x41, ...operand(enterMessage), 0x10, ...operand(keyAccessor),
+    0x41, 0, 0x10, ...operand(uiDispatcher)];
+  const leave = [0x41, ...operand(leaveMessage), 0x41, 0, 0x41, 0,
+    0x10, ...operand(uiDispatcher)];
+  const area = [0x10, ...operand(areaTypeAccessor), 0x41, 4];
+  const matches = module.bodies.flatMap((body, localIndex) =>
+    signatureMatches(module, module.functionImportCount + localIndex, ["i32", "i32"], [])
+      && containsBytes(body, enter) && containsBytes(body, leave) && containsBytes(body, area)
+      ? [module.functionImportCount + localIndex] : []);
+  return matches.length === 1 ? matches[0]! : null;
+}
 
 export type LocalActionRoleCandidateStatus = "candidate" | "ambiguous" | "unavailable";
 
@@ -747,6 +798,47 @@ export function locateAutomaticLocalActions(
             functionBody(module, unlockConsumer),
             TRAVEL_UNLOCK_CONSUMER_ROLE,
           );
+      const guildExpected = travelExpected?.guildHall;
+      const guildKeyAccessor = guildExpected
+        ? uniqueRoleFunction(module, GUILD_HALL_KEY_ACCESSOR_ROLE) : null;
+      const guildAreaTypeAccessor = guildExpected
+        ? uniqueRoleFunction(module, GUILD_HALL_AREA_TYPE_ROLE) : null;
+      const guildProducer = guildExpected && guildKeyAccessor !== null
+          && guildAreaTypeAccessor !== null && uiDispatcher !== null
+        ? guildHallProducer(
+            module,
+            guildKeyAccessor,
+            guildAreaTypeAccessor,
+            uiDispatcher.functionIndex,
+            guildExpected.enterMessageId,
+            guildExpected.leaveMessageId,
+          )
+        : null;
+      const guildHall = guildExpected && guildKeyAccessor !== null
+          && guildAreaTypeAccessor !== null && guildProducer !== null
+          && unsignedOperand(functionBody(module, guildKeyAccessor), 2)
+            === guildExpected.layout.guildContextSlot
+          && unsignedOperand(functionBody(module, guildKeyAccessor), 10)
+            === guildExpected.layout.guildHallKey
+        ? Object.freeze({
+            ...guildExpected,
+            keyAccessor: Object.freeze({
+              ...guildExpected.keyAccessor,
+              functionIndex: guildKeyAccessor,
+              bodySha256: functionBodySha256(module, guildKeyAccessor),
+            }),
+            areaTypeAccessor: Object.freeze({
+              ...guildExpected.areaTypeAccessor,
+              functionIndex: guildAreaTypeAccessor,
+              bodySha256: functionBodySha256(module, guildAreaTypeAccessor),
+            }),
+            producer: Object.freeze({
+              ...guildExpected.producer,
+              functionIndex: guildProducer,
+              bodySha256: functionBodySha256(module, guildProducer),
+            }),
+          })
+        : undefined;
       const travelAction = uiDispatcher && gameThread && travelExpected && travelBody
         && observationLayout
         && travelAreaCount !== null
@@ -795,6 +887,7 @@ export function locateAutomaticLocalActions(
         && soleValue(unlockConsumerValues, "unlock.bounds") === travelAreaReader
         ? Object.freeze({
             ...travelExpected,
+            guildHall,
             producer: Object.freeze({
               ...travelExpected.producer,
               functionIndex: travelFunction!,

--- a/src/main/certification/enhancement-transform-features.ts
+++ b/src/main/certification/enhancement-transform-features.ts
@@ -23,6 +23,7 @@ import {
   travelConfigure,
   travelDrain,
   travelEnqueue,
+  guildHallEnqueue,
   travelToggleTake,
 } from "./enhancement-travel-command-transform.js";
 import type { EnhancementTransformResolution } from "./enhancement-transform.js";
@@ -68,7 +69,12 @@ export function featureExportNames(
       ? [xunlaiAction.openExport, xunlaiAction.configureExport]
       : []),
     ...(capabilities.travelAction
-      ? [travelAction.enqueueExport, travelAction.configureExport, travelAction.toggleExport]
+      ? [
+          travelAction.enqueueExport,
+          travelAction.configureExport,
+          travelAction.toggleExport,
+          ...(travelAction.guildHall ? [travelAction.guildHall.enqueueExport] : []),
+        ]
       : []),
     ...(capabilities.chatAliases
       ? ["enhancement_configure_trade_toggle", "enhancement_take_trade_toggle"]
@@ -275,6 +281,14 @@ export function applyFeatureContributions(
             messageId: travelAction.messageId,
             payloadGlobalIndex: globalIndices.travelPayload,
             reviewedMapIds: REVIEWED_TRAVEL_MAP_IDS,
+            ...(travelAction.guildHall ? {
+              guildHall: {
+                keyAccessorFunctionIndex: travelAction.guildHall.keyAccessor.functionIndex,
+                areaTypeAccessorFunctionIndex: travelAction.guildHall.areaTypeAccessor.functionIndex,
+                enterMessageId: travelAction.guildHall.enterMessageId,
+                leaveMessageId: travelAction.guildHall.leaveMessageId,
+              },
+            } : {}),
             },
           )
         : null,
@@ -380,6 +394,17 @@ export function applyFeatureContributions(
           ),
         ),
       },
+      ...(travelAction.guildHall ? [{
+        name: travelAction.guildHall.enqueueExport,
+        index: appendFunction(
+          required(typeIndices.travelToggle, "Guild Hall enqueue function type"),
+          guildHallEnqueue(
+            globalIndices.commandPending,
+            globalIndices.travelPayload,
+            globalIndices.travelEnabled,
+          ),
+        ),
+      }] : []),
       {
         name: travelAction.configureExport,
         index: appendFunction(

--- a/src/main/certification/enhancement-transform.ts
+++ b/src/main/certification/enhancement-transform.ts
@@ -543,6 +543,18 @@ function resolveEnhancementTransform(
     && bodyHash(travelAction.unlockProof.accessor.functionIndex)
       !== travelAction.unlockProof.accessor.bodySha256
   ) fail("travel unlock accessor body does not match its certified identity");
+  if (capabilities.travelAction && travelAction.guildHall) {
+    for (const [label, fact] of [
+      ["Guild Hall key accessor", travelAction.guildHall.keyAccessor],
+      ["Guild Hall area type accessor", travelAction.guildHall.areaTypeAccessor],
+      ["Guild Hall native producer", travelAction.guildHall.producer],
+    ] as const) {
+      resolveHook(label, fact.functionIndex, fact.params, fact.results);
+      if (bodyHash(fact.functionIndex) !== fact.bodySha256) {
+        fail(`${label} body does not match its certified identity`);
+      }
+    }
+  }
   const travelUnlockConsumer = capabilities.travelAction
     ? resolveHook(
         "travel unlock bitset consumer",

--- a/src/main/certification/enhancement-travel-command-transform.ts
+++ b/src/main/certification/enhancement-travel-command-transform.ts
@@ -6,6 +6,7 @@ import { concat, sleb, uleb } from "../core/wasm-binary.js";
 import { configureLocalAction } from "./enhancement-command-transform.js";
 
 const TRAVEL_COMMAND = -2;
+const GUILD_HALL_COMMAND = -5;
 const TRAVEL_MAP_OFFSET = 0;
 const TRAVEL_REGION_OFFSET = 4;
 const TRAVEL_LANGUAGE_OFFSET = 8;
@@ -21,6 +22,12 @@ export type TravelDrainConfig = Readonly<{
   messageId: number;
   payloadGlobalIndex: number;
   reviewedMapIds: readonly number[];
+  guildHall?: Readonly<{
+    keyAccessorFunctionIndex: number;
+    areaTypeAccessorFunctionIndex: number;
+    enterMessageId: number;
+    leaveMessageId: number;
+  }>;
 }>;
 
 const TRAVEL_UNLOCK_WORD_LIMIT = 28;
@@ -129,6 +136,77 @@ export function travelEnqueue(
   );
 }
 
+/** Queues the one native enter-or-leave Guild Hall action. */
+export function guildHallEnqueue(
+  pendingGlobalIndex: number,
+  payloadGlobalIndex: number,
+  enabledGlobalIndex: number,
+): Uint8Array {
+  const refuse = (condition: Uint8Array) => concat(
+    condition,
+    Uint8Array.of(0x04, 0x40, 0x41), sleb(0), Uint8Array.of(0x0f, 0x0b),
+  );
+  return concat(
+    uleb(0),
+    refuse(concat(Uint8Array.of(0x23), uleb(enabledGlobalIndex), Uint8Array.of(0x45))),
+    refuse(concat(Uint8Array.of(0x23), uleb(payloadGlobalIndex), Uint8Array.of(0x45))),
+    refuse(concat(Uint8Array.of(0x23), uleb(pendingGlobalIndex))),
+    Uint8Array.of(0x41), sleb(GUILD_HALL_COMMAND),
+    Uint8Array.of(0x24), uleb(pendingGlobalIndex),
+    Uint8Array.of(0x41), sleb(1), Uint8Array.of(0x0b),
+  );
+}
+
+function guildHallDrain(
+  pendingGlobalIndex: number,
+  scratchGlobalIndex: number,
+  travel: TravelDrainConfig,
+): Uint8Array {
+  const guild = travel.guildHall;
+  if (!guild) return new Uint8Array();
+  const pointer = () => concat(Uint8Array.of(0x23), uleb(scratchGlobalIndex));
+  const memoryBytes = () => concat(
+    Uint8Array.of(0x3f, 0x00, 0x41), sleb(16), Uint8Array.of(0x74),
+  );
+  const keyWord = (offset: number) => concat(
+    pointer(), Uint8Array.of(0x28), uleb(2), uleb(offset),
+  );
+  return concat(
+    Uint8Array.of(0x23), uleb(pendingGlobalIndex),
+    Uint8Array.of(0x41), sleb(GUILD_HALL_COMMAND), Uint8Array.of(0x46, 0x04, 0x40),
+    Uint8Array.of(0x41), sleb(0), Uint8Array.of(0x24), uleb(pendingGlobalIndex),
+    // The client's own branch treats AreaInfo type 4 as a Guild Hall.
+    Uint8Array.of(0x10), uleb(guild.areaTypeAccessorFunctionIndex),
+    Uint8Array.of(0x41), sleb(4), Uint8Array.of(0x46, 0x04, 0x40),
+    Uint8Array.of(0x41), sleb(guild.leaveMessageId),
+    Uint8Array.of(0x41), sleb(0), Uint8Array.of(0x41), sleb(0),
+    Uint8Array.of(0x10), uleb(travel.dispatcherFunctionIndex),
+    Uint8Array.of(0x0f, 0x0b),
+    // Re-read the current guild key at the game-thread safe point.
+    Uint8Array.of(0x10), uleb(guild.keyAccessorFunctionIndex),
+    Uint8Array.of(0x24), uleb(scratchGlobalIndex),
+    refuseUnless(concat(pointer(), Uint8Array.of(0x45, 0x45))),
+    refuseUnless(concat(pointer(), Uint8Array.of(0x41), sleb(3), Uint8Array.of(0x71, 0x45))),
+    refuseUnless(concat(
+      pointer(), memoryBytes(), Uint8Array.of(0x41), sleb(16), Uint8Array.of(0x6b, 0x4d),
+    )),
+    refuseUnless(concat(
+      keyWord(0), keyWord(4), Uint8Array.of(0x72),
+      keyWord(8), Uint8Array.of(0x72), keyWord(12), Uint8Array.of(0x72),
+    )),
+    ...[0, 4, 8, 12].map((offset) => concat(
+      Uint8Array.of(0x23), uleb(travel.payloadGlobalIndex),
+      keyWord(offset),
+      Uint8Array.of(0x36), uleb(2), uleb(offset),
+    )),
+    Uint8Array.of(0x41), sleb(guild.enterMessageId),
+    Uint8Array.of(0x23), uleb(travel.payloadGlobalIndex),
+    Uint8Array.of(0x41), sleb(0),
+    Uint8Array.of(0x10), uleb(travel.dispatcherFunctionIndex),
+    Uint8Array.of(0x0f, 0x0b),
+  );
+}
+
 /** Publishes the installer-owned 16-byte travel payload and live policy. */
 export function travelConfigure(
   pendingGlobalIndex: number,
@@ -166,6 +244,7 @@ export function travelDrain(
     Uint8Array.of(0x36), uleb(2), uleb(offset),
   );
   return concat(
+    guildHallDrain(pendingGlobalIndex, argumentGlobalBase, travel),
     Uint8Array.of(0x23), uleb(pendingGlobalIndex),
     Uint8Array.of(0x41), sleb(TRAVEL_COMMAND), Uint8Array.of(0x46, 0x04, 0x40),
     Uint8Array.of(0x41), sleb(0), Uint8Array.of(0x24), uleb(pendingGlobalIndex),

--- a/src/renderer/companion-play-region-snapshot.ts
+++ b/src/renderer/companion-play-region-snapshot.ts
@@ -14,6 +14,8 @@ const FLAGS = Object.freeze({
   character: 4,
   unlocks: 8,
   preSearing: 16,
+  guildHall: 32,
+  hasGuildHall: 64,
 });
 const UNLOCK_WORDS = COMPANION_ABI.travelUnlockWords;
 
@@ -52,9 +54,13 @@ export function readCompanionPlayRegion(buffer: ArrayBuffer, pointer: number) {
     || (secondSequence & 1) !== 0
     || (flags & ~(
       FLAGS.ready | FLAGS.loading | FLAGS.character | FLAGS.unlocks | FLAGS.preSearing
+      | FLAGS.guildHall | FLAGS.hasGuildHall
     )) !== 0
     || (flags & FLAGS.loading) !== 0 && flags !== FLAGS.loading
-    || (flags & (FLAGS.character | FLAGS.unlocks | FLAGS.preSearing)) !== 0
+    || (flags & (
+      FLAGS.character | FLAGS.unlocks | FLAGS.preSearing
+      | FLAGS.guildHall | FLAGS.hasGuildHall
+    )) !== 0
       && (flags & FLAGS.ready) === 0
   ) return Object.freeze({ status: "waiting", reason: "snapshot" } as const);
 
@@ -85,6 +91,7 @@ export function readCompanionPlayRegion(buffer: ArrayBuffer, pointer: number) {
     hasCharacter !== (characterLow !== 0 || characterHigh !== 0)
     || (!hasUnlocks && unlockedMapWords.some((word) => word !== 0))
     || (preSearing && encodedRegion !== 1)
+    || (flags & FLAGS.guildHall) !== 0 && (flags & FLAGS.hasGuildHall) === 0
   ) return Object.freeze({ status: "waiting", reason: "corrupt" } as const);
 
   return Object.freeze({
@@ -98,9 +105,23 @@ export function readCompanionPlayRegion(buffer: ArrayBuffer, pointer: number) {
       ? `${characterHigh.toString(16).padStart(8, "0")}${characterLow.toString(16).padStart(8, "0")}`
       : null,
     unlockedMapWords: hasUnlocks ? unlockedMapWords : null,
+    guildHall: (flags & FLAGS.guildHall) !== 0,
+    hasGuildHall: (flags & FLAGS.hasGuildHall) !== 0,
   });
 }
 
 export type CompanionPlayRegionState =
   | ReturnType<typeof readCompanionPlayRegion>
+  | Readonly<{
+      status: "ready";
+      sequence: number;
+      mapId: number;
+      instanceType: number;
+      playRegion: "pve" | "pvp";
+      travelContext: "pre-searing" | "world";
+      characterKey: string | null;
+      unlockedMapWords: readonly number[] | null;
+      guildHall?: boolean;
+      hasGuildHall?: boolean;
+    }>
   | Readonly<{ status: "waiting"; reason: "stale" }>;

--- a/src/renderer/enhancement-travel-command.ts
+++ b/src/renderer/enhancement-travel-command.ts
@@ -17,9 +17,11 @@ export type EnhancementTravelConfigure = (
 ) => number;
 
 export type EnhancementTravelToggleTake = () => number;
+export type EnhancementGuildHallEnqueue = () => number;
 
 export function createTravelCommand(
   send: EnhancementTravelEnqueue,
+  sendGuildHall: EnhancementGuildHallEnqueue | null,
   unavailable: () => string | null,
 ): TravelCommand {
   return Object.freeze({
@@ -29,6 +31,17 @@ export function createTravelCommand(
       if (send(request.mapId) !== 1) {
         throw new Error("Guild Wars command queue is busy");
       }
+    },
+    guildHall() {
+      const refusal = unavailable()
+        ?? (sendGuildHall === null ? "Guild Hall travel is unavailable for this client" : null);
+      if (refusal !== null) throw new Error(refusal);
+      if (sendGuildHall === null) throw new Error("Guild Hall travel is unavailable for this client");
+      if (sendGuildHall() !== 1) throw new Error("Guild Wars command queue is busy");
+    },
+    guildHallUnavailable() {
+      return unavailable()
+        ?? (sendGuildHall === null ? "Guild Hall travel is unavailable for this client" : null);
     },
     unavailable,
   });

--- a/src/renderer/enhancement-travel-controller.ts
+++ b/src/renderer/enhancement-travel-controller.ts
@@ -12,6 +12,7 @@ import {
   TRAVEL_PAYLOAD_BYTES,
   type EnhancementTravelConfigure,
   type EnhancementTravelEnqueue,
+  type EnhancementGuildHallEnqueue,
 } from "./enhancement-travel-command.js";
 
 export { TRAVEL_PAYLOAD_BYTES };
@@ -50,6 +51,7 @@ function unavailableReason(
 
 export function createTravelController(
   enqueue: EnhancementTravelEnqueue,
+  enqueueGuildHall: EnhancementGuildHallEnqueue | null,
   configure: EnhancementTravelConfigure,
   payloadPointer: number,
 ): TravelController {
@@ -61,7 +63,7 @@ export function createTravelController(
   };
   let configuredEnabled: boolean | null = null;
   const unavailable = () => unavailableReason(active, availability);
-  const command = createTravelCommand(enqueue, unavailable);
+  const command = createTravelCommand(enqueue, enqueueGuildHall, unavailable);
   const sync = () => {
     const enabled = unavailable() === null;
     if (enabled === configuredEnabled) return;

--- a/src/renderer/enhancement-travel-installation.ts
+++ b/src/renderer/enhancement-travel-installation.ts
@@ -8,6 +8,7 @@ import type {
   EnhancementTravelConfigure,
   EnhancementTravelEnqueue,
   EnhancementTravelToggleTake,
+  EnhancementGuildHallEnqueue,
 } from "./enhancement-travel-command.js";
 import { TRAVEL_PAYLOAD_BYTES } from "./enhancement-travel-command.js";
 import {
@@ -44,6 +45,9 @@ export function createTravelInstallation(
   const takeToggle = typeof exports.enhancement_take_travel_toggle === "function"
     ? exports.enhancement_take_travel_toggle as EnhancementTravelToggleTake
     : null;
+  const enqueueGuildHall = typeof exports.enhancement_guild_hall === "function"
+    ? exports.enhancement_guild_hall as EnhancementGuildHallEnqueue
+    : null;
   if (enqueue === null || configure === null || takeToggle === null) {
     throw new Error("the travel profile derived a module with no travel command");
   }
@@ -62,7 +66,7 @@ export function createTravelInstallation(
       configure(payloadPointer, 0);
     },
     mount(parent) {
-      controller = createTravelController(enqueue, configure, payloadPointer);
+      controller = createTravelController(enqueue, enqueueGuildHall, configure, payloadPointer);
       palette = createTravelPalette(parent, controller.command);
     },
     update(availability) {

--- a/src/shared/companion-abi.ts
+++ b/src/shared/companion-abi.ts
@@ -3,8 +3,8 @@
  * Renderer, scripts, and tests derive their ABI constants from this descriptor.
  */
 export const COMPANION_ABI = Object.freeze({
-  kernel: 22,
-  config: Object.freeze({ bytes: 464 }),
+  kernel: 23,
+  config: Object.freeze({ bytes: 472 }),
   snapshot: Object.freeze({ abi: 4, bytes: 64 }),
   friends: Object.freeze({ abi: 1, bytes: 12_312, slots: 128, nameUnits: 20 }),
   travelUnlockWords: 28,
@@ -13,7 +13,7 @@ export const COMPANION_ABI = Object.freeze({
   party: Object.freeze({ abi: 7, bytes: 1_560 }),
   skillSlots: Object.freeze({ abi: 2, bytes: 164 }),
   skillCooldowns: Object.freeze({ abi: 1, bytes: 60 }),
-  playRegion: Object.freeze({ abi: 3, bytes: 148 }),
+  playRegion: Object.freeze({ abi: 4, bytes: 148 }),
   characterList: Object.freeze({ abi: 2, bytes: 4_632, slots: 64, nameUnits: 20 }),
 });
 

--- a/src/shared/enhancement-config.ts
+++ b/src/shared/enhancement-config.ts
@@ -106,6 +106,8 @@ export interface EnhancementLayout {
   characterArrayPointer: number;
   characterArrayCount: number;
   selectedCharacterName: number;
+  guildContextSlot: number;
+  guildHallKey: number;
 }
 
 export type EnhancementPlayRegionLayout = Pick<EnhancementLayout,
@@ -133,7 +135,10 @@ export type EnhancementStorageLayout = Pick<EnhancementLayout,
   | "worldPlayers" | "playerRecordStride" | "playerRecordAgentId"
   | "playerRecordAccessFlags" | "playerRecordNumber" | "areaInfoType"
 >;
-export type EnhancementTravelLayout = Pick<EnhancementLayout, "worldUnlockedMaps">;
+export type EnhancementTravelLayout = Pick<
+  EnhancementLayout,
+  "worldUnlockedMaps" | "guildContextSlot" | "guildHallKey"
+>;
 export type EnhancementSkillSlotGeometryLayout = Pick<EnhancementLayout,
   | "frameArray" | "frameCount" | "frameBytes" | "frameChildOffsetId"
   | "frameId" | "framePositionFlags" | "frameViewportWidth"
@@ -303,6 +308,7 @@ export const ENHANCEMENT_CONFIG_FIELDS = Object.freeze([
   ...characterList(
     "characterArrayPointer", "characterArrayCount", "selectedCharacterName",
   ),
+  ...travel("guildContextSlot", "guildHallKey"),
   { source: "dispatcher", key: "playerChatMessage", owner: "party" },
   { source: "dispatcher", key: "hideHeroPanelMessage", owner: "party" },
   { source: "dispatcher", key: "showHeroPanelMessage", owner: "party" },

--- a/src/shared/enhancement-contracts.ts
+++ b/src/shared/enhancement-contracts.ts
@@ -298,7 +298,7 @@ export {
   ENHANCEMENT_LAYOUT_WORD_COUNT,
   ENHANCEMENT_PARTY_DIRTY_MESSAGE_COUNT,
 } from "./enhancement-config.js";
-export const ENHANCEMENT_TRANSFORM_ABI = 49;
+export const ENHANCEMENT_TRANSFORM_ABI = 50;
 
 export function enhancementConfigWordActive(
   capabilities: EnhancementCapabilities,

--- a/src/shared/travel-command.ts
+++ b/src/shared/travel-command.ts
@@ -24,6 +24,8 @@ export type TravelGameState =
     travelContext: TravelContext;
     characterKey: TravelCharacterKey | null;
     unlockedMapWords: readonly number[] | null;
+    guildHall?: boolean;
+    hasGuildHall?: boolean;
   }>;
 
 export const TRAVEL_UNLOCK_WORDS = 28;
@@ -81,6 +83,8 @@ export function travelGameState(value: unknown): TravelGameState {
         travelContext: input.travelContext,
         characterKey: isTravelCharacterKey(input.characterKey) ? input.characterKey : null,
         unlockedMapWords,
+        guildHall: input.guildHall === true,
+        hasGuildHall: input.hasGuildHall === true,
       });
     }
     if (
@@ -94,5 +98,7 @@ export function travelGameState(value: unknown): TravelGameState {
 
 export type TravelCommand = Readonly<{
   travel(request: TravelRequest): void;
+  guildHall?: () => void;
+  guildHallUnavailable?: () => string | null;
   unavailable(): string | null;
 }>;

--- a/tests/client-artifact/template-save-recert.test.ts
+++ b/tests/client-artifact/template-save-recert.test.ts
@@ -406,8 +406,25 @@ test("the template-save verifier makes a fail-closed decision for a real client"
   }
 
   const certifiedEnhancements = local.enhancementBuild!;
+  const guildHallCertificate = certifiedEnhancements.travelAction?.guildHall;
+  assert.ok(guildHallCertificate, "the real client must prove Guild Hall travel");
+  const completeTemplate = rewriteTemplateSaveWasm(bytes, local.templateSaveBuild!);
+  const completeCapabilities = effectiveCapabilitiesOf(local)!;
+  const completeOutput = transformEnhancementWasm(
+    completeTemplate,
+    certifiedEnhancements,
+    completeCapabilities,
+  );
+  assert.equal(
+    parseExports(sectionById(splitSections(completeOutput), 7)).some(
+      ({ name }) => name === guildHallCertificate.enqueueExport,
+    ),
+    true,
+  );
   const travelProducer = certifiedEnhancements.travelAction!.producer.functionIndex;
   const travelContext = certifiedEnhancements.travelAction!.contextResolver.functionIndex;
+  const guildKeyAccessor = certifiedEnhancements.travelAction!.guildHall!
+    .keyAccessor.functionIndex;
   const xunlaiHandler = certifiedEnhancements.xunlaiAction!.handler.functionIndex;
   const xunlaiAccess = certifiedEnhancements.xunlaiAction!.accessProof!
     .readers["access-flags"].functionIndex;
@@ -434,6 +451,22 @@ test("the template-save verifier makes a fail-closed decision for a real client"
       if (feature !== mutation.feature) assert.equal(capabilities[feature], true, mutation.label);
     }
   }
+
+  const changedGuildKey = rewriteCode(bytes, (bodies) => {
+    const body = bodies[guildKeyAccessor - derived.importCount]!;
+    body[2] = body[2]! ^ 1;
+  });
+  assert.equal(WebAssembly.validate(new Uint8Array(changedGuildKey)), true);
+  const changedGuildKeyDecision = verifyFeatureMutation(changedGuildKey);
+  assert.ok(
+    changedGuildKeyDecision.enhancementBuild?.travelAction,
+    "ordinary map travel must survive a changed Guild Hall key accessor",
+  );
+  assert.equal(
+    changedGuildKeyDecision.enhancementBuild.travelAction.guildHall,
+    undefined,
+  );
+  assert.equal(capabilitiesOf(changedGuildKeyDecision)?.travelAction, true);
 
   const changedTravelContext = rewriteCode(bytes, (bodies) => {
     bodies[travelContext - derived.importCount]![14]

--- a/tests/fixtures/enhancements.ts
+++ b/tests/fixtures/enhancements.ts
@@ -314,6 +314,7 @@ export const ADDRESSES = Object.freeze({
   attributeBuffer: 0x1_4000,
   playerRecordBuffer: 0x1_5000,
   travelUnlockBuffer: 0x1_6000,
+  guild: 0x1_7000,
   areaInfo: 0x20_0000,
   frameArrayGlobal: 0x21_0000,
   frameCountGlobal: 0x21_0004,

--- a/tests/helpers/packaged-enhancement-scenarios.ts
+++ b/tests/helpers/packaged-enhancement-scenarios.ts
@@ -317,9 +317,18 @@ export async function assertTargetReadoutLifecycle() {
       0,
       "pagehide did not dispose the target readout",
     );
+    const targetSnapshotPointer = 0x11_010;
+    const targetConfigPointer = targetSnapshotPointer + COMPANION_SNAPSHOT_BYTES;
+    const targetPlayRegionPointer =
+      (targetConfigPointer + CONFIG_BYTES + 7) & ~7;
     assert.deepEqual(disposed, {
       // Runtime allocation, target snapshot, config, and policy region.
-      freed: [0x1000, 0x11_010, 0x11_050, 0x11_220],
+      freed: [
+        0x1000,
+        targetSnapshotPointer,
+        targetConfigPointer,
+        targetPlayRegionPointer,
+      ],
       hook: 0,
       // Cleanup withdraws the published runtime by writing null over it.
       runtime: null,

--- a/tests/integration/play-region-kernel.test.ts
+++ b/tests/integration/play-region-kernel.test.ts
@@ -10,12 +10,15 @@ import {
   FEATURE_TOOLBOX_FOUNDATION,
   installGameGraph,
   installPlayerSkillbarConfig,
+  setConfigField,
 } from "../fixtures/enhancements.ts";
 
 const AREA_133 = ADDRESSES.areaInfo + 133 * 0x7c;
 const OBSERVED_CHARACTER = Object.freeze({
   characterKey: "e7ecfb4f6e006495",
   unlockedMapWords: null,
+  guildHall: false,
+  hasGuildHall: false,
 });
 
 describe("play-region kernel", () => {
@@ -64,6 +67,32 @@ describe("play-region kernel", () => {
       travelContext: "world",
       ...OBSERVED_CHARACTER,
     });
+  });
+
+  it("publishes the current Guild Hall and whether the character has one", async () => {
+    const kernel = await createKernel();
+    installGameGraph(kernel.view);
+    setConfigField(kernel.config, "guildContextSlot", 15);
+    setConfigField(kernel.config, "guildHallKey", 0x64);
+    kernel.view.setUint32(ADDRESSES.contexts + 15 * 4, ADDRESSES.guild, true);
+    kernel.view.setUint32(ADDRESSES.guild + 0x64, 0x1122_3344, true);
+    kernel.view.setUint32(ADDRESSES.guild + 0x68, 0x5566_7788, true);
+    assert.equal(kernel.init({ features: FEATURE_PLAY_REGION_OBSERVATION }), 1);
+
+    kernel.tick();
+    const outpost = kernel.playRegion();
+    assert.equal(outpost.status, "ready");
+    if (outpost.status !== "ready") return;
+    assert.equal(outpost.hasGuildHall, true);
+    assert.equal(outpost.guildHall, false);
+
+    kernel.view.setUint32(AREA_133 + 0x10, 0x0080_0000, true);
+    kernel.tick();
+    const hall = kernel.playRegion();
+    assert.equal(hall.status, "ready");
+    if (hall.status !== "ready") return;
+    assert.equal(hall.hasGuildHall, true);
+    assert.equal(hall.guildHall, true);
   });
 
   it("derives the closed Travel context from the certified area region", async () => {

--- a/tests/integration/play-region-snapshot.test.ts
+++ b/tests/integration/play-region-snapshot.test.ts
@@ -47,6 +47,8 @@ describe("play-region snapshot ABI", () => {
       travelContext: "world",
       characterKey: null,
       unlockedMapWords: null,
+      guildHall: false,
+      hasGuildHall: false,
     });
     assert.deepEqual(readCompanionPlayRegion(snapshot({
       mapId: 248,
@@ -61,6 +63,8 @@ describe("play-region snapshot ABI", () => {
       travelContext: "world",
       characterKey: null,
       unlockedMapWords: null,
+      guildHall: false,
+      hasGuildHall: false,
     });
   });
 
@@ -74,6 +78,8 @@ describe("play-region snapshot ABI", () => {
       travelContext: "pre-searing",
       characterKey: null,
       unlockedMapWords: null,
+      guildHall: false,
+      hasGuildHall: false,
     });
     assert.deepEqual(readCompanionPlayRegion(snapshot({
       flags: 17,
@@ -84,6 +90,33 @@ describe("play-region snapshot ABI", () => {
     assert.deepEqual(readCompanionPlayRegion(snapshot({
       flags: 16, mapId: 0, instanceType: 0, playRegion: 0,
     }), 0), { status: "waiting", reason: "snapshot" });
+  });
+
+  it("publishes Guild Hall presence and the current Guild Hall state", () => {
+    assert.deepEqual(readCompanionPlayRegion(snapshot({ flags: 65 }), 0), {
+      status: "ready",
+      sequence: 2,
+      mapId: 133,
+      instanceType: 0,
+      playRegion: "pve",
+      travelContext: "world",
+      characterKey: null,
+      unlockedMapWords: null,
+      guildHall: false,
+      hasGuildHall: true,
+    });
+    assert.deepEqual(readCompanionPlayRegion(snapshot({ flags: 97 }), 0), {
+      status: "ready",
+      sequence: 2,
+      mapId: 133,
+      instanceType: 0,
+      playRegion: "pve",
+      travelContext: "world",
+      characterKey: null,
+      unlockedMapWords: null,
+      guildHall: true,
+      hasGuildHall: true,
+    });
   });
 
   it("fails closed for memory, torn headers, contradictory flags, and values", () => {
@@ -103,6 +136,9 @@ describe("play-region snapshot ABI", () => {
       status: "waiting", reason: "corrupt",
     });
     assert.deepEqual(readCompanionPlayRegion(snapshot({ playRegion: 0 }), 0), {
+      status: "waiting", reason: "corrupt",
+    });
+    assert.deepEqual(readCompanionPlayRegion(snapshot({ flags: 33 }), 0), {
       status: "waiting", reason: "corrupt",
     });
   });

--- a/tests/unit/feature-contracts.test.ts
+++ b/tests/unit/feature-contracts.test.ts
@@ -172,8 +172,8 @@ test("dependency pruning is derived from capability contracts", () => {
 });
 
 test("cooldown owns the reusable player skillbar core without Party", () => {
-  assert.equal(ENHANCEMENT_CONFIG_WORD_COUNT * Uint32Array.BYTES_PER_ELEMENT, 464);
-  assert.equal(ENHANCEMENT_LAYOUT_WORD_COUNT, 103);
+  assert.equal(ENHANCEMENT_CONFIG_WORD_COUNT * Uint32Array.BYTES_PER_ELEMENT, 472);
+  assert.equal(ENHANCEMENT_LAYOUT_WORD_COUNT, 105);
   assert.equal(ENHANCEMENT_LAYOUT_OWNERSHIP_IS_EXHAUSTIVE, true);
   assert.equal(
     new Set(ENHANCEMENT_LAYOUT_FIELDS).size,

--- a/tests/unit/the-companion-abi-is-exact-across-typescript-and-rust.test.ts
+++ b/tests/unit/the-companion-abi-is-exact-across-typescript-and-rust.test.ts
@@ -167,7 +167,7 @@ test("the independent TypeScript and Rust companion contracts match exactly", ()
     rustSource.match(/const PLAY_REGION_ABI_AND_SIZE: u32 = \(PLAY_REGION_BYTES << 16\) \| (\d+);/u),
     "Rust play-region ABI",
   )), COMPANION_ABI.playRegion.abi);
-  assert.equal(typescriptConfigSlots().length, 116);
+  assert.equal(typescriptConfigSlots().length, 118);
 });
 
 test("same-size field swaps, bit drift, opcode drift, and new names are rejected", () => {


### PR DESCRIPTION
Quick Travel could send a character only to catalogue destinations and friends. It now finds **Guild Hall** with `guild`, `guild hall`, or `gh`, enters the current character's hall when one exists, and offers **Leave Guild Hall** while inside.

The action follows the client's own GWCA path on the game thread. A bounded companion projection publishes only two booleans: whether the character has a Guild Hall and whether the current map is one. The private 16-byte guild key never crosses into the renderer or diagnostics. The transform re-reads and validates it immediately before dispatch; changed or missing Guild Hall evidence disables only this action while ordinary map travel remains available.

Validation:
- `pnpm check` — 1,570 unit tests, 181 policy tests, 157 Tools tests, and 76 Launcher tests passed
- `pnpm build`
- `pnpm test:integration` — 92 passed
- installed-client semantic recertification — 2 passed, including Guild Hall export proof and isolated mutation refusal
- TypeScript and ESLint passed after the final integration fixtures

Live game QA remains to be done with a developer build; the current installed client passed the complete offline native certificate and transform checks.
