### PR TITLE
fix(travel): harden Guild Hall state and command flow

### DIFF
--- a/apps/tools/src/components/TravelPalette.test.ts
+++ b/apps/tools/src/components/TravelPalette.test.ts
@@ -29,6 +29,7 @@ function fixture(options: Readonly<{
 }> = {}, attachTo?: Element) {
   const state = ref<TravelHost["state"]["value"]>({
     status: "ready", mapId: 55, travelContext: "world", characterKey: null, unlockedMapWords: null,
+    guildHall: false, hasGuildHall: false,
   });
   let preferences: TravelPreferences = Object.freeze({
     shortcuts: options.shortcuts ?? DEFAULT_TRAVEL_SHORTCUTS,
@@ -39,7 +40,7 @@ function fixture(options: Readonly<{
   const notice = ref<TravelHost["notice"]["value"]>(null);
   const history = ref(options.history ?? EMPTY_TRAVEL_HISTORY);
   const travel = vi.fn<TravelHost["travel"]>(async (request) => {
-    attempt.value = { status: "queued", mapId: request.mapId };
+    attempt.value = { status: "queued", kind: "map", mapId: request.mapId };
   });
   const guildHall = vi.fn(async () => {});
   const savePreferences = vi.fn<TravelHost["savePreferences"]>(async (
@@ -71,7 +72,9 @@ function fixture(options: Readonly<{
       const current = attempt.value;
       if (current.status === "idle") return;
       if (next.status === "waiting" && next.reason === "loading") {
-        attempt.value = { status: "loading", mapId: current.mapId };
+        if (current.kind === "map") {
+          attempt.value = { status: "loading", kind: "map", mapId: current.mapId };
+        }
       } else if (current.status === "loading" && next.status === "ready") {
         attempt.value = { status: "idle" };
       }
@@ -103,6 +106,11 @@ describe("TravelPalette", () => {
     expect(wrapper.text()).toContain("Guild Hall");
     expect(wrapper.text()).toContain("No Guild Hall");
     expect(wrapper.get("#travel-guild-hall").attributes("disabled")).toBeDefined();
+
+    await wrapper.get("#travel-search-input").setValue("alligator");
+    expect(wrapper.find("#travel-guild-hall").exists()).toBe(false);
+    await wrapper.get("#travel-search-input").setValue("hall");
+    expect(wrapper.find("#travel-guild-hall").exists()).toBe(true);
 
     state.value = {
       status: "ready", mapId: 55, travelContext: "world", characterKey: null,
@@ -245,6 +253,7 @@ describe("TravelPalette", () => {
       travelContext: "world",
       characterKey: travelCharacterKey("0123456789abcdef"),
       unlockedMapWords,
+      guildHall: false, hasGuildHall: false,
     };
     await wrapper.get("#travel-search-input").setValue("Kamadan");
     expect(wrapper.findAll('[role="option"]')).toHaveLength(0);
@@ -271,6 +280,7 @@ describe("TravelPalette", () => {
       travelContext: "pre-searing",
       characterKey: travelCharacterKey("0123456789abcdef"),
       unlockedMapWords,
+      guildHall: false, hasGuildHall: false,
     };
     await flushPromises();
 
@@ -315,6 +325,7 @@ describe("TravelPalette", () => {
       travelContext: "world",
       characterKey: travelCharacterKey("0123456789abcdef"),
       unlockedMapWords,
+      guildHall: false, hasGuildHall: false,
     };
     await flushPromises();
 
@@ -332,6 +343,7 @@ describe("TravelPalette", () => {
       travelContext: "pre-searing",
       characterKey: travelCharacterKey("0123456789abcdef"),
       unlockedMapWords: null,
+      guildHall: false, hasGuildHall: false,
     };
     await flushPromises();
 
@@ -354,6 +366,7 @@ describe("TravelPalette", () => {
       travelContext: "world",
       characterKey: travelCharacterKey("0123456789abcdef"),
       unlockedMapWords,
+      guildHall: false, hasGuildHall: false,
     };
     await flushPromises();
 
@@ -371,6 +384,7 @@ describe("TravelPalette", () => {
       travelContext: "pre-searing",
       characterKey: travelCharacterKey("0123456789abcdef"),
       unlockedMapWords: Array.from({ length: 28 }, () => 0xffff_ffff),
+      guildHall: false, hasGuildHall: false,
     };
 
     await wrapper.get("#travel-search-input").setValue("asc");
@@ -394,6 +408,7 @@ describe("TravelPalette", () => {
       travelContext: "pre-searing",
       characterKey: travelCharacterKey("0123456789abcdef"),
       unlockedMapWords: Array.from({ length: 28 }, () => 0xffff_ffff),
+      guildHall: false, hasGuildHall: false,
     };
     await flushPromises();
 
@@ -413,6 +428,7 @@ describe("TravelPalette", () => {
       travelContext: "pre-searing",
       characterKey: travelCharacterKey("0123456789abcdef"),
       unlockedMapWords: Array.from({ length: 28 }, () => 0xffff_ffff),
+      guildHall: false, hasGuildHall: false,
     };
     await flushPromises();
 
@@ -760,6 +776,7 @@ describe("TravelPalette", () => {
       travelContext: "world",
       characterKey: travelCharacterKey("0123456789abcdef"),
       unlockedMapWords,
+      guildHall: false, hasGuildHall: false,
     };
     await flushPromises();
 

--- a/apps/tools/src/components/TravelPalette.vue
+++ b/apps/tools/src/components/TravelPalette.vue
@@ -31,6 +31,7 @@ const props = defineProps<{
 const emit = defineEmits<{ close: [] }>();
 type PaletteMode = "travel" | "customize";
 const SMALL_TRAVEL_CATALOGUE_LIMIT = 10;
+const GUILD_HALL_SEARCH_TERMS = Object.freeze(["guild hall", "guild", "hall", "gh"]);
 const COMPACT_FAVORITE_LABELS: Readonly<Record<string, string>> = Object.freeze({
   "Ascalon City": "Ascalon",
   "Kaineng Center": "Kaineng",
@@ -67,7 +68,6 @@ type DestinationSearchResult = Readonly<{
   resultKey: string;
   mapId: number;
   destination: TravelDestination;
-  friend: null;
   disabledReason: null;
 }>;
 type FriendSearchResult = Readonly<{
@@ -83,9 +83,6 @@ type FriendSearchResult = Readonly<{
 type GuildHallSearchResult = Readonly<{
   kind: "guild-hall";
   resultKey: "guild-hall";
-  mapId: 0;
-  destination: null;
-  friend: null;
   disabledReason: string | null;
 }>;
 type SearchResult = DestinationSearchResult | FriendSearchResult | GuildHallSearchResult;
@@ -134,8 +131,8 @@ const friendResults = computed<FriendSearchResult[]>(() => {
 });
 const guildHallResults = computed<GuildHallSearchResult[]>(() => {
   if (!hasQuery.value) return [];
-  const tokens = normaliseTravelTerm(query.value).split(" ").filter(Boolean);
-  if (!tokens.every((token) => "guild hall gh".includes(token))) return [];
+  const term = normaliseTravelTerm(query.value);
+  if (!GUILD_HALL_SEARCH_TERMS.some((candidate) => candidate.startsWith(term))) return [];
   const state = props.host.state.value;
   const disabledReason = props.host.guildHallUnavailable
     ?? (state.status !== "ready"
@@ -144,9 +141,6 @@ const guildHallResults = computed<GuildHallSearchResult[]>(() => {
   return [{
     kind: "guild-hall",
     resultKey: "guild-hall",
-    mapId: 0,
-    destination: null,
-    friend: null,
     disabledReason,
   }];
 });
@@ -164,7 +158,6 @@ const results = computed<SearchResult[]>(() => {
         resultKey: `map-${destination.mapId}`,
         mapId: destination.mapId,
         destination,
-        friend: null,
         disabledReason: null,
       })),
   ];
@@ -282,6 +275,40 @@ function searchResultLocation(result: SearchResult): string {
   return result.destination.name;
 }
 
+function searchResultTitle(result: SearchResult): string {
+  if (result.kind === "friend") return result.friend.alias;
+  if (result.kind === "guild-hall") {
+    return props.host.state.value.status === "ready" && props.host.state.value.guildHall
+      ? "Leave Guild Hall"
+      : "Guild Hall";
+  }
+  return result.destination.name;
+}
+
+function searchResultSubtitle(result: SearchResult): string {
+  if (result.kind === "friend") return result.friend.character;
+  return result.kind === "guild-hall" ? "Guild" : result.destination.campaign;
+}
+
+function searchResultContext(result: SearchResult): string {
+  return result.kind === "destination"
+    ? queryMatchLabel(result.destination)
+    : searchResultLocation(result);
+}
+
+function searchResultAriaLabel(result: SearchResult): string | undefined {
+  if (result.kind === "friend") {
+    return `${result.friend.alias}, ${result.friend.character}, ${friendResultLabel(result)}`;
+  }
+  if (result.kind === "guild-hall") {
+    const action = props.host.state.value.status === "ready" && props.host.state.value.guildHall
+      ? "Leave"
+      : "Travel to";
+    return `${action} Guild Hall, ${searchResultLocation(result)}`;
+  }
+  return undefined;
+}
+
 function friendResultLabel(result: FriendSearchResult): string {
   const location = searchResultLocation(result);
   return result.disabledReason === null
@@ -298,7 +325,8 @@ function selectable(entry: TravelDestination | SearchResult): boolean {
 }
 
 function resultDestination(entry: TravelDestination | SearchResult): TravelDestination | null {
-  return "resultKey" in entry ? entry.destination : entry;
+  if (!("resultKey" in entry)) return entry;
+  return entry.kind === "guild-hall" ? null : entry.destination;
 }
 
 function favoriteLabel(destination: TravelDestination): string {
@@ -329,7 +357,9 @@ function browseDestinationLabel(destination: TravelDestination): string {
 }
 
 function activateBrowseDestination(mapId: number): void {
-  const index = selectableDestinations.value.findIndex((destination) => destination.mapId === mapId);
+  const index = selectableDestinations.value.findIndex(
+    (entry) => resultDestination(entry)?.mapId === mapId,
+  );
   if (index >= 0) active.value = index;
 }
 
@@ -344,7 +374,9 @@ watch(results, (next, previous) => {
   );
   const firstAvailable = next.findIndex((result) => result.disabledReason === null);
   active.value = retained >= 0 ? retained : firstAvailable;
-  props.host.traceSearch(query.value, next.map((result) => result.mapId).filter((mapId) => mapId > 0));
+  props.host.traceSearch(query.value, next.flatMap(
+    (result) => result.kind === "guild-hall" ? [] : [result.mapId],
+  ));
 });
 watch(() => props.visible, async (visible) => {
   if (!visible) return;
@@ -399,7 +431,7 @@ async function travelToResult(result: SearchResult): Promise<void> {
   if (result.kind === "guild-hall") {
     if (result.disabledReason === null) {
       try {
-        await props.host.guildHall?.();
+        await props.host.guildHall();
         emit("close");
       } catch { /* The host owns the refusal notice. */ }
     }
@@ -635,13 +667,13 @@ function onKeydown(event: KeyboardEvent): void {
     <section v-if="hasQuery" id="travel-results-panel" class="ui-scroll travel-body" role="region" aria-label="Travel search results">
       <div v-if="results.length" class="travel-result-heading">{{ results.length === 1 ? 'Best match for' : 'Matches for' }} <strong>{{ query }}</strong></div>
       <div v-if="results.length" id="travel-results" class="travel-results" role="listbox">
-        <button v-for="(result, index) in results" :id="`travel-${result.resultKey}`" :key="result.resultKey" type="button" class="travel-result ui-row" role="option" tabindex="-1" :aria-selected="index === active" :aria-disabled="searchResultDisabled(result)" :aria-label="result.kind === 'friend' ? `${result.friend.alias}, ${result.friend.character}, ${friendResultLabel(result)}` : result.kind === 'guild-hall' ? `${host.state.value.status === 'ready' && host.state.value.guildHall ? 'Leave' : 'Travel to'} Guild Hall, ${searchResultLocation(result)}` : undefined" :disabled="searchResultDisabled(result)" @mouseenter="active = index" @click="active = index; travelToResult(result)">
+        <button v-for="(result, index) in results" :id="`travel-${result.resultKey}`" :key="result.resultKey" type="button" class="travel-result ui-row" role="option" tabindex="-1" :aria-selected="index === active" :aria-disabled="searchResultDisabled(result)" :aria-label="searchResultAriaLabel(result)" :disabled="searchResultDisabled(result)" @mouseenter="active = index" @click="active = index; travelToResult(result)">
           <span class="travel-result-identity">
             <svg v-if="result.kind === 'friend'" class="travel-player-icon" viewBox="0 0 20 20" aria-hidden="true"><circle cx="10" cy="6.5" r="3" /><path d="M4.5 17c.6-3.1 2.4-4.7 5.5-4.7s4.9 1.6 5.5 4.7" /></svg>
             <svg v-else-if="result.kind === 'guild-hall'" class="travel-player-icon" viewBox="0 0 20 20" aria-hidden="true"><path d="M10 2.5 16 5v4.4c0 3.7-2.2 6.4-6 8.1-3.8-1.7-6-4.4-6-8.1V5l6-2.5Z" /><path d="M7.2 9.7h5.6M10 6.8v5.8" /></svg>
-            <span><strong v-if="result.kind === 'friend'">{{ result.friend.alias }}</strong><strong v-else-if="result.kind === 'guild-hall'">{{ host.state.value.status === 'ready' && host.state.value.guildHall ? 'Leave Guild Hall' : 'Guild Hall' }}</strong><strong v-else><template v-for="(part, partIndex) in highlightTravelDestinationName(result.destination, query)" :key="partIndex"><mark v-if="part.match">{{ part.text }}</mark><template v-else>{{ part.text }}</template></template></strong><small>{{ result.kind === 'friend' ? result.friend.character : result.kind === 'guild-hall' ? 'Guild' : result.destination.campaign }}</small></span>
+            <span><strong v-if="result.kind !== 'destination'">{{ searchResultTitle(result) }}</strong><strong v-else><template v-for="(part, partIndex) in highlightTravelDestinationName(result.destination, query)" :key="partIndex"><mark v-if="part.match">{{ part.text }}</mark><template v-else>{{ part.text }}</template></template></strong><small>{{ searchResultSubtitle(result) }}</small></span>
           </span>
-          <span class="travel-result-context"><span class="travel-match" :data-unavailable="result.disabledReason !== null || undefined">{{ result.kind === 'destination' ? queryMatchLabel(result.destination) : searchResultLocation(result) }}</span><small v-if="result.disabledReason !== null" class="travel-unavailable-reason">{{ result.disabledReason }}</small></span>
+          <span class="travel-result-context"><span class="travel-match" :data-unavailable="result.disabledReason !== null || undefined">{{ searchResultContext(result) }}</span><small v-if="result.disabledReason !== null" class="travel-unavailable-reason">{{ result.disabledReason }}</small></span>
         </button>
       </div>
       <div v-else class="ui-empty travel-empty"><strong>{{ emptySearchTitle }}</strong><p>{{ emptySearchHelp }}</p><button type="button" class="ui-button" @click="query = ''">Clear search</button></div>

--- a/apps/tools/src/travel-host.test.ts
+++ b/apps/tools/src/travel-host.test.ts
@@ -85,9 +85,11 @@ describe("native Travel host", () => {
       unlockedMapWords: null, guildHall: false, hasGuildHall: true,
     });
 
-    await host.guildHall?.();
+    await host.guildHall();
     expect(command.guildHall).toHaveBeenCalledOnce();
-    expect(host.attempt.value).toEqual({ status: "queued", guildHall: true, mapId: 0 });
+    expect(host.attempt.value).toEqual({
+      status: "queued", kind: "guild-hall", target: "inside",
+    });
     host.updateGameState({ status: "waiting", reason: "loading" });
     host.updateGameState({
       status: "ready", mapId: 4, travelContext: "world", characterKey: null,
@@ -96,7 +98,7 @@ describe("native Travel host", () => {
     expect(host.attempt.value).toEqual({ status: "idle" });
     expect(host.notice.value).toBeNull();
 
-    await host.guildHall?.();
+    await host.guildHall();
     expect(command.guildHall).toHaveBeenCalledTimes(2);
     host.updateGameState({ status: "waiting", reason: "loading" });
     host.updateGameState({
@@ -112,8 +114,25 @@ describe("native Travel host", () => {
       status: "ready", mapId: 55, travelContext: "world", characterKey: null,
       unlockedMapWords: null, guildHall: false, hasGuildHall: false,
     });
-    await expect(host.guildHall?.()).rejects.toThrow("does not have a Guild Hall");
+    await expect(host.guildHall()).rejects.toThrow("does not have a Guild Hall");
     expect(command.guildHall).not.toHaveBeenCalled();
+  });
+
+  it("keeps one Guild Hall arrival deadline across repeated loading snapshots", async () => {
+    vi.useFakeTimers();
+    const { host } = fixture();
+    host.updateGameState({
+      status: "ready", mapId: 55, travelContext: "world", characterKey: null,
+      unlockedMapWords: null, guildHall: false, hasGuildHall: true,
+    });
+    await host.guildHall();
+    host.updateGameState({ status: "waiting", reason: "loading" });
+    await vi.advanceTimersByTimeAsync(20_000);
+    host.updateGameState({ status: "waiting", reason: "loading" });
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(host.attempt.value).toEqual({ status: "idle" });
+    expect(host.notice.value?.message).toContain("did not confirm Guild Hall travel");
   });
 
   it("delegates shortcut mutations to Main", async () => {
@@ -132,6 +151,7 @@ describe("native Travel host", () => {
     await host.travel({ mapId: 449 });
     host.updateGameState({
       status: "ready", mapId: 449, travelContext: "world", characterKey: null, unlockedMapWords: null,
+      guildHall: false, hasGuildHall: false,
     });
     await vi.runAllTimersAsync();
 
@@ -155,8 +175,9 @@ describe("native Travel host", () => {
 
     host.updateGameState({
       status: "ready", mapId: 449, travelContext: "world", characterKey: null, unlockedMapWords: null,
+      guildHall: false, hasGuildHall: false,
     });
-    expect(host.attempt.value).toEqual({ status: "queued", mapId: 55 });
+    expect(host.attempt.value).toEqual({ status: "queued", kind: "map", mapId: 55 });
     expect(host.notice.value?.message).toContain("Travelling to");
   });
 
@@ -170,7 +191,7 @@ describe("native Travel host", () => {
 
     host.updateGameState({ status: "waiting", reason: "loading" });
 
-    expect(host.attempt.value).toEqual({ status: "loading", mapId: 449 });
+    expect(host.attempt.value).toEqual({ status: "loading", kind: "map", mapId: 449 });
     expect(host.notice.value).toMatchObject({ level: "success" });
     expect(host.notice.value?.message).not.toContain("did not start");
   });
@@ -199,13 +220,16 @@ describe("native Travel host", () => {
     expect(interrupted.notice.value?.message).toContain("interrupted");
     interrupted.updateGameState({
       status: "ready", mapId: 449, travelContext: "world", characterKey: null, unlockedMapWords: null,
+      guildHall: false, hasGuildHall: false,
     });
     expect(interrupted.notice.value).toBeNull();
 
     const expired = fixture().host;
     await expired.travel({ mapId: 449 });
     expired.updateGameState({ status: "waiting", reason: "loading" });
-    await vi.advanceTimersByTimeAsync(30_000);
+    await vi.advanceTimersByTimeAsync(20_000);
+    expired.updateGameState({ status: "waiting", reason: "loading" });
+    await vi.advanceTimersByTimeAsync(10_000);
     expect(expired.attempt.value).toEqual({ status: "idle" });
     expect(expired.notice.value?.message).toContain("ready to try again");
   });
@@ -218,6 +242,7 @@ describe("native Travel host", () => {
 
     host.updateGameState({
       status: "ready", mapId: 55, travelContext: "world", characterKey: null, unlockedMapWords: null,
+      guildHall: false, hasGuildHall: false,
     });
 
     expect(host.attempt.value).toEqual({ status: "idle" });
@@ -228,6 +253,7 @@ describe("native Travel host", () => {
 
     host.updateGameState({
       status: "ready", mapId: 449, travelContext: "world", characterKey: null, unlockedMapWords: null,
+      guildHall: false, hasGuildHall: false,
     });
     expect(host.notice.value).toBeNull();
   });
@@ -242,6 +268,7 @@ describe("native Travel host", () => {
 
     host.updateGameState({
       status: "ready", mapId: 449, travelContext: "world", characterKey: null, unlockedMapWords: null,
+      guildHall: false, hasGuildHall: false,
     });
 
     expect(host.attempt.value).toEqual({ status: "idle" });
@@ -255,12 +282,15 @@ describe("native Travel host", () => {
     const characterB = travelCharacterKey("fedcba9876543210");
     host.updateGameState({
       status: "ready", mapId: 55, travelContext: "world", characterKey: characterA, unlockedMapWords,
+      guildHall: false, hasGuildHall: false,
     });
     host.updateGameState({
       status: "ready", mapId: 449, travelContext: "world", characterKey: characterA, unlockedMapWords,
+      guildHall: false, hasGuildHall: false,
     });
     host.updateGameState({
       status: "ready", mapId: 81, travelContext: "world", characterKey: characterB, unlockedMapWords,
+      guildHall: false, hasGuildHall: false,
     });
 
     await vi.waitFor(() => expect(recordHistory).toHaveBeenCalledTimes(3));
@@ -279,11 +309,13 @@ describe("native Travel host", () => {
     const unlockedMapWords = Array.from({ length: 28 }, () => 0xffff_ffff);
     host.updateGameState({
       status: "ready", mapId: 55, travelContext: "world", characterKey: null, unlockedMapWords,
+      guildHall: false, hasGuildHall: false,
     });
 
     await host.travel({ mapId: 449 });
     host.updateGameState({
       status: "ready", mapId: 449, travelContext: "world", characterKey, unlockedMapWords,
+      guildHall: false, hasGuildHall: false,
     });
 
     await vi.waitFor(() => expect(recordHistory).toHaveBeenCalledTimes(2));
@@ -301,6 +333,7 @@ describe("native Travel host", () => {
     const unlockedMapWords = Array.from({ length: 28 }, () => 0xffff_ffff);
     host.updateGameState({
       status: "ready", mapId: 55, travelContext: "world", characterKey: characterA, unlockedMapWords,
+      guildHall: false, hasGuildHall: false,
     });
     await vi.waitFor(() => expect(host.history.value).toEqual([55]));
 
@@ -308,10 +341,12 @@ describe("native Travel host", () => {
     expect(host.history.value).toEqual([]);
     host.updateGameState({
       status: "ready", mapId: 55, travelContext: "world", characterKey: null, unlockedMapWords,
+      guildHall: false, hasGuildHall: false,
     });
     expect(host.history.value).toEqual([]);
     host.updateGameState({
       status: "ready", mapId: 55, travelContext: "world", characterKey: characterB, unlockedMapWords,
+      guildHall: false, hasGuildHall: false,
     });
 
     await vi.waitFor(() => expect(host.history.value).toEqual([55]));
@@ -331,6 +366,7 @@ describe("native Travel host", () => {
       travelContext: "world",
       characterKey,
       unlockedMapWords: Array.from({ length: 28 }, () => 0xffff_ffff),
+      guildHall: false, hasGuildHall: false,
     });
     await vi.waitFor(() => expect(test.recordHistory).toHaveBeenCalledTimes(1));
 
@@ -347,6 +383,7 @@ describe("native Travel host", () => {
       travelContext: "pre-searing",
       characterKey: null,
       unlockedMapWords: Array.from({ length: 28 }, () => 0xffff_ffff),
+      guildHall: false, hasGuildHall: false,
     });
 
     await expect(host.travel({ mapId: 330 })).rejects.toThrow("Only Pre-Searing");

--- a/apps/tools/src/travel-host.ts
+++ b/apps/tools/src/travel-host.ts
@@ -28,8 +28,12 @@ import { createTravelHistoryObservation } from "./travel-history-observation";
 
 export type TravelAttempt =
   | Readonly<{ status: "idle" }>
-  | Readonly<{ status: "queued" | "loading"; mapId: number }>
-  | Readonly<{ status: "queued" | "loading"; guildHall: boolean; mapId: 0 }>;
+  | Readonly<{ status: "queued" | "loading"; kind: "map"; mapId: number }>
+  | Readonly<{
+      status: "queued" | "loading";
+      kind: "guild-hall";
+      target: "inside" | "outside";
+    }>;
 export type TravelNotice = Readonly<{
   message: string;
   level: "info" | "success" | "warning" | "danger";
@@ -45,12 +49,12 @@ export interface TravelHost {
   readonly history: Ref<TravelHistory>;
   readonly friends: Ref<TravelFriends>;
   readonly unavailable: string | null;
-  readonly guildHallUnavailable?: string | null;
+  readonly guildHallUnavailable: string | null;
   loadPreferences(): Promise<TravelPreferences>;
   savePreferences(patch: TravelPreferencePatch): Promise<TravelPreferences>;
   loadHistory(): Promise<TravelHistory>;
   travel(request: TravelRequest): Promise<void>;
-  guildHall?: () => Promise<void>;
+  guildHall(): Promise<void>;
   updateGameState(state: TravelGameState): void;
   updateFriends(friends: TravelFriends): void;
   dispose(): void;
@@ -90,10 +94,12 @@ export function createNativeTravelHost(
   const beginLoading = (mapId: number) => {
     window.clearTimeout(attemptTimer);
     settledAttempt = null;
-    attempt.value = { status: "loading", mapId };
+    attempt.value = { status: "loading", kind: "map", mapId };
     notice.value = { message: "Travel started.", level: "success" };
     attemptTimer = window.setTimeout(() => {
-      if (attempt.value.status !== "loading" || attempt.value.mapId !== mapId) return;
+      if (attempt.value.status !== "loading"
+        || attempt.value.kind !== "map"
+        || attempt.value.mapId !== mapId) return;
       settleAttempt(mapId, "loading");
       notice.value = {
         message: "Guild Wars did not confirm arrival. Travel is ready to try again.",
@@ -118,7 +124,7 @@ export function createNativeTravelHost(
       return command.unavailable();
     },
     get guildHallUnavailable() {
-      return command.guildHallUnavailable?.() ?? "Guild Hall travel is unavailable for this client";
+      return command.guildHallUnavailable();
     },
     loadPreferences,
     async savePreferences(patch) {
@@ -138,7 +144,7 @@ export function createNativeTravelHost(
         && state.value.characterKey === null
         ? state.value.mapId
         : null;
-      attempt.value = { status: "queued", mapId: request.mapId };
+      attempt.value = { status: "queued", kind: "map", mapId: request.mapId };
       notice.value = {
         message: `Travelling to ${travelDestination(request.mapId)?.name ?? "destination"}…`,
         level: "info",
@@ -146,7 +152,9 @@ export function createNativeTravelHost(
       try {
         command.travel(request);
         attemptTimer = window.setTimeout(() => {
-          if (attempt.value.status !== "queued" || attempt.value.mapId !== request.mapId) return;
+          if (attempt.value.status !== "queued"
+            || attempt.value.kind !== "map"
+            || attempt.value.mapId !== request.mapId) return;
           settleAttempt(request.mapId, "queued");
           notice.value = {
             message: "Travel did not start. Check that this destination is unlocked, then try again.",
@@ -181,21 +189,17 @@ export function createNativeTravelHost(
         notice.value = { message, level: "warning" };
         throw new Error(message);
       }
-      const destination = !ready.guildHall;
-      attempt.value = { status: "queued", guildHall: destination, mapId: 0 };
+      const target = ready.guildHall ? "outside" : "inside";
+      attempt.value = { status: "queued", kind: "guild-hall", target };
       notice.value = {
-        message: destination ? "Travelling to your Guild Hall…" : "Leaving Guild Hall…",
+        message: target === "inside" ? "Travelling to your Guild Hall…" : "Leaving Guild Hall…",
         level: "info",
       };
       try {
-        const guildHall = command.guildHall;
-        if (guildHall === undefined) {
-          throw new Error("Guild Hall travel is unavailable for this client");
-        }
-        guildHall();
+        command.guildHall();
         attemptTimer = window.setTimeout(() => {
           const current = attempt.value;
-          if (current.status !== "queued" || !("guildHall" in current)) return;
+          if (current.status !== "queued" || current.kind !== "guild-hall") return;
           clearAttempt();
           notice.value = {
             message: "Guild Wars did not start Guild Hall travel. Try again.",
@@ -212,24 +216,28 @@ export function createNativeTravelHost(
     updateGameState(next) {
       state.value = next;
       const current = attempt.value;
-      if (current.status !== "idle" && "guildHall" in current) {
-        if (next.status === "ready" && next.guildHall === current.guildHall) {
+      if (current.status !== "idle" && current.kind === "guild-hall") {
+        const arrived = next.status === "ready"
+          && next.guildHall === (current.target === "inside");
+        if (arrived) {
           clearAttempt();
           notice.value = null;
         } else if (next.status === "waiting" && next.reason === "loading") {
-          window.clearTimeout(attemptTimer);
-          attempt.value = { status: "loading", guildHall: current.guildHall, mapId: 0 };
-          notice.value = { message: "Travel started.", level: "success" };
-          attemptTimer = window.setTimeout(() => {
-            const active = attempt.value;
-            if (active.status === "loading" && "guildHall" in active) {
-              clearAttempt();
-              notice.value = {
-                message: "Guild Wars did not confirm Guild Hall travel. Try again.",
-                level: "warning",
-              };
-            }
-          }, 30_000);
+          if (current.status === "queued") {
+            window.clearTimeout(attemptTimer);
+            attempt.value = { ...current, status: "loading" };
+            notice.value = { message: "Travel started.", level: "success" };
+            attemptTimer = window.setTimeout(() => {
+              const active = attempt.value;
+              if (active.status === "loading" && active.kind === "guild-hall") {
+                clearAttempt();
+                notice.value = {
+                  message: "Guild Wars did not confirm Guild Hall travel. Try again.",
+                  level: "warning",
+                };
+              }
+            }, 30_000);
+          }
         } else if (current.status === "loading" && next.status !== "ready") {
           clearAttempt();
           notice.value = { message: "Guild Hall travel was interrupted.", level: "warning" };
@@ -237,6 +245,7 @@ export function createNativeTravelHost(
         return;
       }
       const arrived = current.status !== "idle"
+        && current.kind === "map"
         && next.status === "ready"
         && next.mapId === current.mapId;
       if (arrived
@@ -270,7 +279,7 @@ export function createNativeTravelHost(
         return;
       }
       if (next.status === "waiting" && next.reason === "loading") {
-        beginLoading(current.mapId);
+        if (current.status === "queued") beginLoading(current.mapId);
         return;
       }
       if (current.status !== "loading") return;
@@ -314,6 +323,7 @@ export function createDemoTravelHost(): TravelHost {
   const characterKey = travelCharacterKey("0123456789abcdef");
   const state = ref<TravelGameState>({
     status: "ready", mapId: 55, travelContext: "world", characterKey, unlockedMapWords,
+    guildHall: false, hasGuildHall: true,
   });
   const friends = ref<TravelFriends>({ status: "waiting", reason: "unavailable" });
   const attempt = ref<TravelAttempt>({ status: "idle" });
@@ -346,14 +356,14 @@ export function createDemoTravelHost(): TravelHost {
     },
     async loadHistory() { return history.value; },
     async travel(request) {
-      attempt.value = { status: "queued", mapId: request.mapId };
+      attempt.value = { status: "queued", kind: "map", mapId: request.mapId };
       state.value = { status: "waiting", reason: "loading" };
-      attempt.value = { status: "loading", mapId: request.mapId };
+      attempt.value = { status: "loading", kind: "map", mapId: request.mapId };
       window.setTimeout(() => {
         history.value = recordVisitedTravel(history.value, request.mapId);
         state.value = {
           status: "ready", mapId: request.mapId, travelContext: "world",
-          characterKey, unlockedMapWords,
+          characterKey, unlockedMapWords, guildHall: false, hasGuildHall: true,
         };
         attempt.value = { status: "idle" };
       }, 600);
@@ -361,11 +371,11 @@ export function createDemoTravelHost(): TravelHost {
     async guildHall() {
       const ready = state.value.status === "ready" ? state.value : null;
       if (ready === null) return;
-      const destination = !ready.guildHall;
-      attempt.value = { status: "loading", guildHall: destination, mapId: 0 };
+      const target = ready.guildHall ? "outside" : "inside";
+      attempt.value = { status: "loading", kind: "guild-hall", target };
       state.value = { status: "waiting", reason: "loading" };
       window.setTimeout(() => {
-        state.value = { ...ready, guildHall: destination, hasGuildHall: true };
+        state.value = { ...ready, guildHall: target === "inside", hasGuildHall: true };
         attempt.value = { status: "idle" };
       }, 600);
     },

--- a/src/main/certification/enhancement-build-model.ts
+++ b/src/main/certification/enhancement-build-model.ts
@@ -377,7 +377,7 @@ export interface KnownEnhancementBuild {
         results: readonly [];
         bodySha256: string;
       }>;
-    }> | undefined;
+    }>;
   }>;
   chatAliases?: Readonly<{
     parser: Readonly<{

--- a/src/main/certification/enhancement-local-actions-proof.ts
+++ b/src/main/certification/enhancement-local-actions-proof.ts
@@ -886,8 +886,11 @@ export function locateAutomaticLocalActions(
         ) === LOCAL_ACTION_HASHES.unlockAssertionFile
         && soleValue(unlockConsumerValues, "unlock.bounds") === travelAreaReader
         ? Object.freeze({
-            ...travelExpected,
-            guildHall,
+            enqueueExport: travelExpected.enqueueExport,
+            configureExport: travelExpected.configureExport,
+            toggleExport: travelExpected.toggleExport,
+            messageId: travelExpected.messageId,
+            ...(guildHall ? { guildHall } : {}),
             producer: Object.freeze({
               ...travelExpected.producer,
               functionIndex: travelFunction!,

--- a/src/main/certification/enhancement-transform.ts
+++ b/src/main/certification/enhancement-transform.ts
@@ -347,6 +347,22 @@ function resolveEnhancementTransform(
     if (!body) fail(`function ${functionIndex} has no body`);
     return createHash("sha256").update(body).digest("hex");
   };
+  const resolveCertifiedHook = (
+    label: string,
+    fact: Readonly<{
+      functionIndex: number;
+      params: readonly string[];
+      results: readonly string[];
+      bodySha256: string;
+    }>,
+    identity: "semantic fingerprint" | "certified identity",
+  ) => {
+    const hook = resolveHook(label, fact.functionIndex, fact.params, fact.results);
+    if (bodyHash(fact.functionIndex) !== fact.bodySha256) {
+      fail(`${label} body does not match its ${identity}`);
+    }
+    return hook;
+  };
   const skillResolution = resolveEnhancementSkillTransform({
     build,
     capabilities,
@@ -501,73 +517,27 @@ function resolveEnhancementTransform(
     fail("storage slash parser body does not match its semantic fingerprint");
   }
   const travelProducer = capabilities.travelAction
-    ? resolveHook(
-        "travel payload producer",
-        travelAction.producer.functionIndex,
-        travelAction.producer.params,
-        travelAction.producer.results,
-      )
-    : null;
-  if (
-    travelProducer
-    && bodyHash(travelAction.producer.functionIndex)
-      !== travelAction.producer.bodySha256
-  ) {
-    fail("travel payload producer body does not match its semantic fingerprint");
-  }
-  const travelContextResolver = capabilities.travelAction
-    ? resolveHook(
-        "travel context resolver",
-        travelAction.contextResolver.functionIndex,
-        travelAction.contextResolver.params,
-        travelAction.contextResolver.results,
-      )
-    : null;
-  if (
-    travelContextResolver
-    && bodyHash(travelAction.contextResolver.functionIndex)
-      !== travelAction.contextResolver.bodySha256
-  ) {
-    fail("travel context resolver body does not match its semantic fingerprint");
-  }
-  const travelUnlockAccessor = capabilities.travelAction
-    ? resolveHook(
-        "travel unlock array accessor",
-        travelAction.unlockProof.accessor.functionIndex,
-        travelAction.unlockProof.accessor.params,
-        travelAction.unlockProof.accessor.results,
-      )
-    : null;
-  if (
-    travelUnlockAccessor
-    && bodyHash(travelAction.unlockProof.accessor.functionIndex)
-      !== travelAction.unlockProof.accessor.bodySha256
-  ) fail("travel unlock accessor body does not match its certified identity");
-  if (capabilities.travelAction && travelAction.guildHall) {
-    for (const [label, fact] of [
-      ["Guild Hall key accessor", travelAction.guildHall.keyAccessor],
-      ["Guild Hall area type accessor", travelAction.guildHall.areaTypeAccessor],
-      ["Guild Hall native producer", travelAction.guildHall.producer],
+    ? resolveCertifiedHook(
+        "travel payload producer", travelAction.producer, "semantic fingerprint",
+      ) : null;
+  if (capabilities.travelAction) {
+    for (const [label, fact, identity] of [
+      ["travel context resolver", travelAction.contextResolver, "semantic fingerprint"],
+      ["travel unlock array accessor", travelAction.unlockProof.accessor, "certified identity"],
+      ["travel unlock bitset consumer", travelAction.unlockProof.consumer, "certified identity"],
     ] as const) {
-      resolveHook(label, fact.functionIndex, fact.params, fact.results);
-      if (bodyHash(fact.functionIndex) !== fact.bodySha256) {
-        fail(`${label} body does not match its certified identity`);
+      resolveCertifiedHook(label, fact, identity);
+    }
+    if (travelAction.guildHall) {
+      for (const [label, fact] of [
+        ["Guild Hall key accessor", travelAction.guildHall.keyAccessor],
+        ["Guild Hall area type accessor", travelAction.guildHall.areaTypeAccessor],
+        ["Guild Hall native producer", travelAction.guildHall.producer],
+      ] as const) {
+        resolveCertifiedHook(label, fact, "certified identity");
       }
     }
   }
-  const travelUnlockConsumer = capabilities.travelAction
-    ? resolveHook(
-        "travel unlock bitset consumer",
-        travelAction.unlockProof.consumer.functionIndex,
-        travelAction.unlockProof.consumer.params,
-        travelAction.unlockProof.consumer.results,
-      )
-    : null;
-  if (
-    travelUnlockConsumer
-    && bodyHash(travelAction.unlockProof.consumer.functionIndex)
-      !== travelAction.unlockProof.consumer.bodySha256
-  ) fail("travel unlock consumer body does not match its certified identity");
   const packetSender = capabilities.teamApply
     ? resolveHook(
         "traced packet sender",

--- a/src/renderer/companion-play-region-snapshot.ts
+++ b/src/renderer/companion-play-region-snapshot.ts
@@ -112,16 +112,4 @@ export function readCompanionPlayRegion(buffer: ArrayBuffer, pointer: number) {
 
 export type CompanionPlayRegionState =
   | ReturnType<typeof readCompanionPlayRegion>
-  | Readonly<{
-      status: "ready";
-      sequence: number;
-      mapId: number;
-      instanceType: number;
-      playRegion: "pve" | "pvp";
-      travelContext: "pre-searing" | "world";
-      characterKey: string | null;
-      unlockedMapWords: readonly number[] | null;
-      guildHall?: boolean;
-      hasGuildHall?: boolean;
-    }>
   | Readonly<{ status: "waiting"; reason: "stale" }>;

--- a/src/renderer/companion-policy-source.ts
+++ b/src/renderer/companion-policy-source.ts
@@ -37,6 +37,8 @@ function projectPlayRegion(state: CompanionPlayRegionState): string {
     state.travelContext,
     state.characterKey ?? "unknown-character",
     state.unlockedMapWords?.join(",") ?? "unknown-unlocks",
+    state.guildHall ? "guild-hall" : "outside-guild-hall",
+    state.hasGuildHall ? "has-guild-hall" : "no-guild-hall",
   ].join(":");
 }
 

--- a/src/renderer/enhancement-travel-command.ts
+++ b/src/renderer/enhancement-travel-command.ts
@@ -33,8 +33,7 @@ export function createTravelCommand(
       }
     },
     guildHall() {
-      const refusal = unavailable()
-        ?? (sendGuildHall === null ? "Guild Hall travel is unavailable for this client" : null);
+      const refusal = unavailable();
       if (refusal !== null) throw new Error(refusal);
       if (sendGuildHall === null) throw new Error("Guild Hall travel is unavailable for this client");
       if (sendGuildHall() !== 1) throw new Error("Guild Wars command queue is busy");

--- a/src/shared/travel-command.ts
+++ b/src/shared/travel-command.ts
@@ -24,8 +24,8 @@ export type TravelGameState =
     travelContext: TravelContext;
     characterKey: TravelCharacterKey | null;
     unlockedMapWords: readonly number[] | null;
-    guildHall?: boolean;
-    hasGuildHall?: boolean;
+    guildHall: boolean;
+    hasGuildHall: boolean;
   }>;
 
 export const TRAVEL_UNLOCK_WORDS = 28;
@@ -98,7 +98,7 @@ export function travelGameState(value: unknown): TravelGameState {
 
 export type TravelCommand = Readonly<{
   travel(request: TravelRequest): void;
-  guildHall?: () => void;
-  guildHallUnavailable?: () => string | null;
+  guildHall(): void;
+  guildHallUnavailable(): string | null;
   unavailable(): string | null;
 }>;

--- a/tests/electron/input-character-switch.spec.ts
+++ b/tests/electron/input-character-switch.spec.ts
@@ -407,6 +407,8 @@ test("the modal confirms PvE departure, blocks click-through, and retains post-l
         typeof import("../../src/renderer/travel-palette.js");
       const palette = module.createTravelPalette(document.body, {
         travel: () => undefined,
+        guildHall: () => undefined,
+        guildHallUnavailable: () => null,
         unavailable: () => null,
       });
       palette.setEnabled(true);

--- a/tests/electron/input-travel.spec.ts
+++ b/tests/electron/input-travel.spec.ts
@@ -50,6 +50,8 @@ test.describe("renderer Travel input", () => {
             travelContext: "world",
             characterKey: null,
             unlockedMapWords: Array.from({ length: 28 }, () => 0xffff_ffff),
+            guildHall: false,
+            hasGuildHall: false,
           },
         });
         installation.poll();
@@ -80,6 +82,8 @@ test.describe("renderer Travel input", () => {
           typeof import("../../src/renderer/travel-palette.js");
         const palette = module.createTravelPalette(document.body, {
           travel: () => undefined,
+          guildHall: () => undefined,
+          guildHallUnavailable: () => null,
           unavailable: () => null,
         });
         palette.setEnabled(true);

--- a/tests/fixtures/enhancement-transform.ts
+++ b/tests/fixtures/enhancement-transform.ts
@@ -235,10 +235,13 @@ export function fixture(hookParamType = 0x7f): Uint8Array {
     ...env, 1, 99, 0, 1,
     ...env, 1, 117, 0, 2,
   ]);
-  // Sixteen defined functions: three hooks, three commands, the recurring
+  // Nineteen defined functions: three hooks, three commands, the recurring
   // game-thread callback, packet sender, DataWindow, slash parser, and Travel
-  // producer, plus three exact-signature Xunlai fact readers.
-  const functions = section(3, [16, 0, 1, 2, 0, 2, 3, 3, 2, 0, 4, 1, 5, 5, 5, 6, 5]);
+  // producer, three exact-signature Xunlai fact readers, and the three Guild
+  // Hall certificate functions.
+  const functions = section(3, [
+    19, 0, 1, 2, 0, 2, 3, 3, 2, 0, 4, 1, 5, 5, 5, 6, 5, 6, 6, 3,
+  ]);
   const table = section(4, [1, 0x70, 1, 5, 5]);
   const memory = section(5, [1, 1, 1, 1]);
   const globals = section(6, [0]);
@@ -305,8 +308,13 @@ export function fixture(hookParamType = 0x7f): Uint8Array {
   const slash = [0, 0x20, 0, 0x10, 0, 0x41, 0, 0x0b];
   const reader = [0, 0x20, 0, 0x0b];
   const unlockAccessor = [0, 0x41, ...sleb(256), 0x0b];
+  const guildKeyAccessor = [0, 0x41, ...sleb(512), 0x0b];
+  const guildAreaTypeAccessor = [
+    0, 0x41, ...sleb(600), 0x28, 2, 0, 0x0b,
+  ];
+  const guildProducer = [0, 0x20, 0, 0x1a, 0x20, 1, 0x1a, 0x0b];
   const code = section(10, [
-    16,
+    19,
     ...uleb(tick.length), ...tick,
     ...uleb(cursor.length), ...cursor,
     ...uleb(ui.length), ...ui,
@@ -323,6 +331,9 @@ export function fixture(hookParamType = 0x7f): Uint8Array {
     ...uleb(reader.length), ...reader,
     ...uleb(unlockAccessor.length), ...unlockAccessor,
     ...uleb(reader.length), ...reader,
+    ...uleb(guildKeyAccessor.length), ...guildKeyAccessor,
+    ...uleb(guildAreaTypeAccessor.length), ...guildAreaTypeAccessor,
+    ...uleb(guildProducer.length), ...guildProducer,
   ]);
   const unlockData = [
     0x20, 0x01, 0, 0,
@@ -386,6 +397,30 @@ export function manifest(bytes: Uint8Array): KnownEnhancementBuild {
       configureExport: "enhancement_configure_travel",
       toggleExport: "enhancement_take_travel_toggle",
       messageId: 0x1000_0183,
+      guildHall: {
+        enqueueExport: "enhancement_guild_hall",
+        enterMessageId: 0x1000_0180,
+        leaveMessageId: 0x1000_0182,
+        layout: { guildContextSlot: 15, guildHallKey: 0x64 },
+        keyAccessor: {
+          functionIndex: 19,
+          params: [],
+          results: ["i32"],
+          bodySha256: createHash("sha256").update(commandBody(bytes, 16)).digest("hex"),
+        },
+        areaTypeAccessor: {
+          functionIndex: 20,
+          params: [],
+          results: ["i32"],
+          bodySha256: createHash("sha256").update(commandBody(bytes, 17)).digest("hex"),
+        },
+        producer: {
+          functionIndex: 21,
+          params: ["i32", "i32"],
+          results: [],
+          bodySha256: createHash("sha256").update(commandBody(bytes, 18)).digest("hex"),
+        },
+      },
       unlockProof: {
         layout: { worldUnlockedMaps: 0x60c },
         accessor: {

--- a/tests/unit/companion-policy-source.test.ts
+++ b/tests/unit/companion-policy-source.test.ts
@@ -101,6 +101,8 @@ describe("companion policy source", () => {
       travelContext: "world" as const,
       characterKey: null,
       unlockedMapWords: null,
+      guildHall: false,
+      hasGuildHall: false,
     });
     test.publishRegion(pve);
     test.publishRegion({ ...pve, sequence: 4 });
@@ -128,6 +130,8 @@ describe("companion policy source", () => {
       instanceType: 0,
       playRegion: "pve" as const,
       travelContext: "world" as const,
+      guildHall: false,
+      hasGuildHall: false,
     };
     test.publishRegion(Object.freeze({
       ...ready,
@@ -152,6 +156,38 @@ describe("companion policy source", () => {
     assert.deepEqual(unlocks, [1, 1, 3]);
   });
 
+  it("publishes same-map Guild Hall availability changes", () => {
+    const test = fixture();
+    const guildStates: Array<[boolean, boolean]> = [];
+    test.source.subscribe(({ snapshot }) => {
+      if (snapshot.playRegionState.status !== "ready") return;
+      guildStates.push([
+        snapshot.playRegionState.guildHall,
+        snapshot.playRegionState.hasGuildHall,
+      ]);
+    });
+    const ready = {
+      status: "ready" as const,
+      mapId: 55,
+      instanceType: 0,
+      playRegion: "pve" as const,
+      travelContext: "world" as const,
+      characterKey: null,
+      unlockedMapWords: null,
+    };
+    test.publishRegion(Object.freeze({
+      ...ready, sequence: 2, guildHall: false, hasGuildHall: false,
+    }));
+    test.publishRegion(Object.freeze({
+      ...ready, sequence: 4, guildHall: false, hasGuildHall: true,
+    }));
+    test.publishRegion(Object.freeze({
+      ...ready, sequence: 6, guildHall: true, hasGuildHall: true,
+    }));
+
+    assert.deepEqual(guildStates, [[false, false], [false, true], [true, true]]);
+  });
+
   it("withdraws local Tools only for positively identified active PvP play", () => {
     const test = fixture();
     test.setSettings({ ...DEFAULT_SETTINGS, gwonmacTools: true });
@@ -168,6 +204,8 @@ describe("companion policy source", () => {
       travelContext: "world",
       characterKey: null,
       unlockedMapWords: null,
+      guildHall: false,
+      hasGuildHall: false,
     }));
     test.publishRegion(Object.freeze({ status: "waiting", reason: "loading" }));
 
@@ -191,6 +229,8 @@ describe("companion policy source", () => {
       travelContext: "world",
       characterKey: null,
       unlockedMapWords: null,
+      guildHall: false,
+      hasGuildHall: false,
     }));
 
     assert.equal(publications, 1);

--- a/tests/unit/enhancement-command-transform.test.ts
+++ b/tests/unit/enhancement-command-transform.test.ts
@@ -369,6 +369,54 @@ describe("Enhancement command transform", () => {
     assert.deepEqual(dispatches, [[build.travelAction!.messageId, payload, 0]]);
   });
 
+  it("enters and leaves the Guild Hall through the bounded Travel mailbox", () => {
+    const input = fixture();
+    const build = manifest(input);
+    const guildHall = build.travelAction!.guildHall!;
+    const output = transformEnhancementWasm(input, build, CURSOR_TOOLBOX_STORAGE);
+    const dispatches: number[][] = [];
+    const instance = new WebAssembly.Instance(
+      new WebAssembly.Module(new Uint8Array(output)),
+      {
+        env: {
+          t: () => {},
+          c: () => {},
+          u: (...args: number[]) => { dispatches.push(args); },
+          tbl: new WebAssembly.Table({ initial: 6, maximum: 6, element: "anyfunc" }),
+        },
+      },
+    );
+    const memory = instance.exports.memory as WebAssembly.Memory;
+    const words = new Uint32Array(memory.buffer);
+    const frame = instance.exports.frame as (value: number, context: number) => void;
+    const configure = instance.exports[build.travelAction!.configureExport] as
+      (payload: number, enabled: number) => number;
+    const enqueue = instance.exports[guildHall.enqueueExport] as () => number;
+    const payload = 128;
+    const key = [0x1122_3344, 0x5566_7788, 0x99aa_bbcc, 0xddee_ff00];
+    words.set(key, 512 / 4);
+
+    assert.equal(enqueue(), 0, "Guild Hall travel refuses before installation");
+    assert.equal(configure(payload, 1), 1);
+    assert.equal(enqueue(), 1);
+    assert.equal(enqueue(), 0, "one queued Guild Hall action owns the mailbox");
+    assert.deepEqual(dispatches, [], "enqueue never calls client code re-entrantly");
+    frame(70, 700);
+    assert.deepEqual([...new Uint32Array(memory.buffer, payload, 4)], key);
+    assert.deepEqual(dispatches, [[guildHall.enterMessageId, payload, 0]]);
+
+    new DataView(memory.buffer).setUint32(600, 4, true);
+    assert.equal(enqueue(), 1);
+    frame(80, 800);
+    assert.deepEqual(dispatches.at(-1), [guildHall.leaveMessageId, 0, 0]);
+
+    new DataView(memory.buffer).setUint32(600, 0, true);
+    words.fill(0, 512 / 4, 512 / 4 + 4);
+    assert.equal(enqueue(), 1);
+    frame(90, 900);
+    assert.equal(dispatches.length, 2, "an empty guild key must fail closed");
+  });
+
   it("consumes /trade, /tp and exact storage commands at their named boundaries", () => {
     const input = fixture();
     const build = manifest(input);

--- a/tests/unit/play-region-observation-installation.test.ts
+++ b/tests/unit/play-region-observation-installation.test.ts
@@ -11,6 +11,8 @@ const ready = (sequence: number, mapId = 81) => Object.freeze({
   travelContext: "world" as const,
   characterKey: null,
   unlockedMapWords: null,
+  guildHall: false,
+  hasGuildHall: false,
 });
 
 test("play-region authority withdraws on staleness and requires a newer publication to recover", (context) => {

--- a/tests/unit/travel.test.ts
+++ b/tests/unit/travel.test.ts
@@ -135,6 +135,8 @@ describe("Travel", () => {
       travelContext: "pre-searing" as const,
       characterKey: null,
       unlockedMapWords,
+      guildHall: false,
+      hasGuildHall: false,
     };
     const world = { ...preSearing, mapId: 81, travelContext: "world" as const };
 


### PR DESCRIPTION
Guild Hall quick travel needed stronger state and update-failure boundaries after the initial feature merged. Repeated loading snapshots could extend a travel timeout forever, same-map Guild Hall changes could be deduplicated away, and a changed optional Guild Hall certificate could accidentally disable ordinary map travel.

This makes ready-state Guild Hall facts explicit, keeps one fixed deadline per attempt, includes Guild Hall facts in the canonical projection, and removes only Guild Hall authority when its native proof changes. It also replaces synthetic result fields with a discriminated result type, narrows Guild Hall search terms, simplifies presentation helpers, and adds executable coverage for the native enter/leave mailbox.

Validation:
- `pnpm check`
- `pnpm build`
- `pnpm test:integration` — 92 passed
- packaged macOS app smoke and Enhancement runtime tests
- installed-client semantic recertification — 2 passed, including isolated Guild Hall certificate failure while ordinary map travel survives
