### PR TITLE
fix(tools): disable Tools in PvP outposts

### DIFF
--- a/docs/enhancement-development.md
+++ b/docs/enhancement-development.md
@@ -37,7 +37,7 @@ Current integrated features are:
 - **Target distance and range** (Test): show the selected target's distance and
   range band.
 - **Xunlai storage**: open the normal storage UI from the Tools title bar,
-  Command-Shift-C, `/chest`, or `/xunlai` in a certified supported outpost. It
+  Command-Shift-C, `/chest`, or `/xunlai` in a certified PvE outpost. It
   has a separate Settings opt-in and requires a live snapshot that proves the
   current character can access storage. It does not depend on party observation.
 - **Quick Item Move**: Control-click moves a whole stack through an open
@@ -63,7 +63,7 @@ Current integrated features are:
 - **Chat Filters**: prevent selected item-drop, Hall of Heroes, and title
   announcements from entering the game chat log. A certified game-module
   pre-handler owns the fixed template checks; Electron receives no chat text.
-  The feature and its three categories change live outside active PvP play.
+  The feature and its three categories change live outside PvP maps.
 
 These features then change live. Live observers and commands stop when disabled
 or when map policy refuses them. Host-only authoring remains available without
@@ -290,10 +290,9 @@ geometry is active when either `skillKeyLabels` or `skillCooldowns` is active;
 it is not a second product feature or setting.
 
 Region selection has three explicit strengths: `any`, `non-pvp`, and `pve`.
-`non-pvp` keeps unknown or loading state eligible. A confirmed safe region
-includes PvE, guild halls, and PvP outposts. Only a PvP explorable instance is
-active PvP play and withdraws the feature. Developer programs can replace saved
-selection, never the registered region rule.
+`non-pvp` keeps unknown or loading state eligible. A positively identified PvP
+map, including a PvP outpost or guild hall, withdraws the feature. Developer
+programs can replace saved selection, never the registered region rule.
 
 Choose the smallest path:
 
@@ -542,7 +541,7 @@ contains zero access words, Xunlai stays disabled, and the independently
 certified Travel action remains available. Never substitute party state or a
 guessed offset.
 
-Run `pnpm enhancements:live xunlai-storage` from a supported outpost. The
+Run `pnpm enhancements:live xunlai-storage` from a supported PvE outpost. The
 scenario records only the tri-state access result and two complete action
 cycles from the same named action used by the button and shortcut. Each cycle
 opens storage, closes it with Escape, and proves that bounded two-button

--- a/docs/enhancement-development.md
+++ b/docs/enhancement-development.md
@@ -291,8 +291,9 @@ it is not a second product feature or setting.
 
 Region selection has three explicit strengths: `any`, `non-pvp`, and `pve`.
 `non-pvp` keeps unknown or loading state eligible. A positively identified PvP
-map, including a PvP outpost or guild hall, withdraws the feature. Developer
-programs can replace saved selection, never the registered region rule.
+map, including a PvP outpost, withdraws the feature. Guild Halls are the one
+explicit exception. Developer programs can replace saved selection, never the
+registered region rule.
 
 Choose the smallest path:
 

--- a/docs/future-effect-durations.md
+++ b/docs/future-effect-durations.md
@@ -36,10 +36,10 @@ answer:
   a documented derived view.
 - Treat party effects and hostile-agent debuffs as separate capabilities. Do
   not infer them from skill-bar recharge or animation state.
-- Keep the present active-PvP restriction by default. Guild halls and PvP
-  outposts are supported, but availability during a PvP match needs a separate
-  fairness review. The review must prove that the UI reveals only information
-  the stock client already gives that player.
+- Keep the present GWToolbox++ PvP-map restriction by default. Any future
+  availability on a PvP map needs a separate fairness review. The review must
+  prove that the UI reveals only information the stock client already gives
+  that player.
 - Require exact hashes, exact function signatures and operands, unique matches,
   bounded reads, sequence-protected publication, and feature-local fail-closed
   behavior, as the cooldown observer does.

--- a/docs/future-effect-durations.md
+++ b/docs/future-effect-durations.md
@@ -36,10 +36,10 @@ answer:
   a documented derived view.
 - Treat party effects and hostile-agent debuffs as separate capabilities. Do
   not infer them from skill-bar recharge or animation state.
-- Keep the present GWToolbox++ PvP-map restriction by default. Any future
-  availability on a PvP map needs a separate fairness review. The review must
-  prove that the UI reveals only information the stock client already gives
-  that player.
+- Keep the present PvP-map restriction and Guild Hall exception by default.
+  Any future availability on another PvP map needs a separate fairness review.
+  The review must prove that the UI reveals only information the stock client
+  already gives that player.
 - Require exact hashes, exact function signatures and operands, unique matches,
   bounded reads, sequence-protected publication, and feature-local fail-closed
   behavior, as the cooldown observer does.

--- a/docs/wasm-host.md
+++ b/docs/wasm-host.md
@@ -229,10 +229,9 @@ After that restart, these choices update during the session:
   saved colour remains when the tool is off.
 
 Disabled optional observers stop their domain reads. Core cursor observation
-stays active. A small map-policy projection combines ArenaNet's map flag with
-the instance type. Guild halls and PvP outposts remain supported; active PvP
-play closes Tools and Xunlai storage. Stricter live features also withdraw
-during transitions and unknown regions.
+stays active. A small map-policy projection follows GWToolbox++'s PvP map flag.
+PvP outposts and guild halls close Tools and Xunlai storage. Stricter live
+features also withdraw during transitions and unknown regions.
 
 If live integration is unavailable while Tools Beta and Build Library remain
 enabled, the host can still mount the saved-library part of Tools. Players can
@@ -303,7 +302,7 @@ queues a fixed `{ agent: 0, type: 0, data: 3 }` DataWindow payload, then calls
 the certified client DataWindow handler at the existing game-thread drain. It
 does not send that payload to ArenaNet. The action is enabled only with its
 separate Tools setting and a fresh snapshot that proves the current player is
-in a supported outpost and can access storage. Every snapshot update
+in a supported PvE outpost and can access storage. Every snapshot update
 resynchronizes the action, so loading, character, account, and map transitions
 revoke stale access immediately.
 
@@ -381,7 +380,7 @@ running the reset again safely finishes it. Window-position cleanup is a
 separate best-effort action and cannot change that result.
 
 Team Apply requires enabled Tools and Build Library, a proved Team Apply
-capability, a positively classified supported outpost, fresh party state,
+capability, a positively classified PvE outpost, fresh party state,
 and an explicit player action.
 
 The runner checks policy before each command and while it confirms results. A

--- a/docs/wasm-host.md
+++ b/docs/wasm-host.md
@@ -229,9 +229,10 @@ After that restart, these choices update during the session:
   saved colour remains when the tool is off.
 
 Disabled optional observers stop their domain reads. Core cursor observation
-stays active. A small map-policy projection follows GWToolbox++'s PvP map flag.
-PvP outposts and guild halls close Tools and Xunlai storage. Stricter live
-features also withdraw during transitions and unknown regions.
+stays active. A small map-policy projection reads GWToolbox++'s PvP map flag
+but keeps Guild Halls as an explicit gwonmac exception. PvP outposts close Tools
+and Xunlai storage. Stricter live features also withdraw during transitions and
+unknown regions.
 
 If live integration is unavailable while Tools Beta and Build Library remain
 enabled, the host can still mount the saved-library part of Tools. Players can

--- a/src/companion-kernel/friends.rs
+++ b/src/companion-kernel/friends.rs
@@ -91,8 +91,8 @@ pub(crate) unsafe fn lifecycle(event: u32, request: u32, connection: u32, succes
 
 pub(crate) unsafe fn tick(layout: Layout) {
     let generation = unsafe { friend_session::accepted_generation() };
-    // This lightweight region proof must precede every roster read. Guild halls
-    // and PvP outposts classify as PVE here; active PvP and loading do not.
+    // This lightweight region proof must precede every roster read. PvP maps
+    // and loading do not reach the roster.
     if generation == 0 || !matches!(unsafe { resolve_game(layout) },
         GameState::Ready { play_region: PLAY_REGION_PVE, .. })
     {

--- a/src/companion-kernel/friends.rs
+++ b/src/companion-kernel/friends.rs
@@ -92,7 +92,7 @@ pub(crate) unsafe fn lifecycle(event: u32, request: u32, connection: u32, succes
 pub(crate) unsafe fn tick(layout: Layout) {
     let generation = unsafe { friend_session::accepted_generation() };
     // This lightweight region proof must precede every roster read. PvP maps
-    // and loading do not reach the roster.
+    // other than Guild Halls, and loading, do not reach the roster.
     if generation == 0 || !matches!(unsafe { resolve_game(layout) },
         GameState::Ready { play_region: PLAY_REGION_PVE, .. })
     {

--- a/src/companion-kernel/lib.rs
+++ b/src/companion-kernel/lib.rs
@@ -186,17 +186,8 @@ impl State {
     }
 }
 
-/**
- * The Tools safety region derived from the client-owned map policy.
- *
- * ArenaNet marks guild halls and PvP outposts as PvP maps too. They are safe
- * outpost instances, so only a PvP explorable instance is active PvP play.
- */
-unsafe fn classify_play_region(
-    layout: Layout,
-    map_id: u32,
-    instance_type: u32,
-) -> (u32, bool, bool, bool) {
+/** The client-owned map policy used by GWToolbox++ itself. */
+unsafe fn classify_play_region(layout: Layout, map_id: u32) -> (u32, bool, bool, bool) {
     if layout.area_info == 0
         || layout.area_info_count == 0
         || layout.area_info_stride < 20
@@ -224,7 +215,7 @@ unsafe fn classify_play_region(
     else {
         return (PLAY_REGION_UNKNOWN, false, false, false);
     };
-    let play_region = if flags & (0x0004_0001 | 0x0080_0000) != 0 && instance_type == 1 {
+    let play_region = if flags & 0x0004_0001 != 0 {
         PLAY_REGION_PVP
     } else {
         PLAY_REGION_PVE
@@ -423,7 +414,7 @@ pub(crate) unsafe fn resolve_game(layout: Layout) -> GameState {
     }
 
     let (play_region, pre_searing, on_world_map, guild_hall) = unsafe {
-        classify_play_region(layout, map_id, instance_type)
+        classify_play_region(layout, map_id)
     };
     GameState::Ready {
         game,

--- a/src/companion-kernel/lib.rs
+++ b/src/companion-kernel/lib.rs
@@ -186,7 +186,7 @@ impl State {
     }
 }
 
-/** The client-owned map policy used by GWToolbox++ itself. */
+/** The Tools map policy, including gwonmac's explicit Guild Hall exception. */
 unsafe fn classify_play_region(layout: Layout, map_id: u32) -> (u32, bool, bool, bool) {
     if layout.area_info == 0
         || layout.area_info_count == 0
@@ -215,7 +215,8 @@ unsafe fn classify_play_region(layout: Layout, map_id: u32) -> (u32, bool, bool,
     else {
         return (PLAY_REGION_UNKNOWN, false, false, false);
     };
-    let play_region = if flags & 0x0004_0001 != 0 {
+    let guild_hall = flags & 0x0080_0000 != 0;
+    let play_region = if flags & 0x0004_0001 != 0 && !guild_hall {
         PLAY_REGION_PVP
     } else {
         PLAY_REGION_PVE
@@ -224,7 +225,7 @@ unsafe fn classify_play_region(layout: Layout, map_id: u32) -> (u32, bool, bool,
         play_region,
         area_region == 7 && play_region == PLAY_REGION_PVE,
         flags & 0x20 == 0,
-        flags & 0x0080_0000 != 0,
+        guild_hall,
     )
 }
 

--- a/src/renderer/enhancement-runtime-policy.ts
+++ b/src/renderer/enhancement-runtime-policy.ts
@@ -34,7 +34,7 @@ export function enhancementRuntimePolicy(
     characterSwitch: selected("characterSwitch"),
     cartography: selected("cartography"),
     // The local Tools host remains reachable without a live observation, but
-    // follows GWToolbox++ by withdrawing on a certified PvP map.
+    // withdraws on a certified PvP map outside a Guild Hall.
     tools: selected("tools", developerToolbox),
     buildLibrary: selected("buildLibrary", developerToolbox),
     tradeChat: selected("tradeChat", developerToolbox),

--- a/src/renderer/enhancement-runtime-policy.ts
+++ b/src/renderer/enhancement-runtime-policy.ts
@@ -34,7 +34,7 @@ export function enhancementRuntimePolicy(
     characterSwitch: selected("characterSwitch"),
     cartography: selected("cartography"),
     // The local Tools host remains reachable without a live observation, but
-    // withdraws when the certified region reports active PvP play.
+    // follows GWToolbox++ by withdrawing on a certified PvP map.
     tools: selected("tools", developerToolbox),
     buildLibrary: selected("buildLibrary", developerToolbox),
     tradeChat: selected("tradeChat", developerToolbox),

--- a/src/shared/feature-contracts.ts
+++ b/src/shared/feature-contracts.ts
@@ -102,7 +102,7 @@ export const FEATURE_SELECTION_POLICIES = defineFeatureSelectionPolicies({
       master: "gwonmacTools",
     },
     // The storage controller still owns the stronger, fresh access gate.
-    // This coarse rule withdraws the complete feature during active PvP play.
+    // This coarse rule follows GWToolbox++ and withdraws on a certified PvP map.
     region: "non-pvp",
   },
   quickItemMove: {

--- a/src/shared/feature-contracts.ts
+++ b/src/shared/feature-contracts.ts
@@ -102,7 +102,7 @@ export const FEATURE_SELECTION_POLICIES = defineFeatureSelectionPolicies({
       master: "gwonmacTools",
     },
     // The storage controller still owns the stronger, fresh access gate.
-    // This coarse rule follows GWToolbox++ and withdraws on a certified PvP map.
+    // This coarse rule withdraws on a certified PvP map outside a Guild Hall.
     region: "non-pvp",
   },
   quickItemMove: {

--- a/tests/integration/enhancements-xunlai-kernel.test.ts
+++ b/tests/integration/enhancements-xunlai-kernel.test.ts
@@ -54,7 +54,7 @@ describe("Companion Xunlai access kernel", () => {
     assert.equal(
       decoded(readCompanionSnapshot(kernel.memory.buffer, ADDRESSES.snapshot))
         .xunlaiAccess,
-      true,
+      false,
     );
 
     kernel.view.setUint32(ADDRESSES.character + 0x19c, 1, true);

--- a/tests/integration/play-region-kernel.test.ts
+++ b/tests/integration/play-region-kernel.test.ts
@@ -41,8 +41,7 @@ describe("play-region kernel", () => {
       ...OBSERVED_CHARACTER,
     });
 
-    // Guild halls and PvP outposts carry the PvP area flag, but an outpost is
-    // not active player-versus-player play and remains supported.
+    // GWToolbox++ disables from the map flag alone, including in an outpost.
     kernel.view.setUint32(AREA_133 + 0x10, 1, true);
     kernel.tick();
     assert.deepEqual(kernel.playRegion(), {
@@ -50,7 +49,7 @@ describe("play-region kernel", () => {
       sequence: 6,
       mapId: 133,
       instanceType: 0,
-      playRegion: "pve",
+      playRegion: "pvp",
       travelContext: "world",
       ...OBSERVED_CHARACTER,
     });
@@ -86,11 +85,12 @@ describe("play-region kernel", () => {
     assert.equal(outpost.hasGuildHall, true);
     assert.equal(outpost.guildHall, false);
 
-    kernel.view.setUint32(AREA_133 + 0x10, 0x0080_0000, true);
+    kernel.view.setUint32(AREA_133 + 0x10, 0x0080_0001, true);
     kernel.tick();
     const hall = kernel.playRegion();
     assert.equal(hall.status, "ready");
     if (hall.status !== "ready") return;
+    assert.equal(hall.playRegion, "pvp");
     assert.equal(hall.hasGuildHall, true);
     assert.equal(hall.guildHall, true);
   });

--- a/tests/integration/play-region-kernel.test.ts
+++ b/tests/integration/play-region-kernel.test.ts
@@ -90,7 +90,7 @@ describe("play-region kernel", () => {
     const hall = kernel.playRegion();
     assert.equal(hall.status, "ready");
     if (hall.status !== "ready") return;
-    assert.equal(hall.playRegion, "pvp");
+    assert.equal(hall.playRegion, "pve");
     assert.equal(hall.hasGuildHall, true);
     assert.equal(hall.guildHall, true);
   });

--- a/tests/integration/skill-cooldown-kernel.test.ts
+++ b/tests/integration/skill-cooldown-kernel.test.ts
@@ -169,11 +169,10 @@ describe("skill cooldown kernel", () => {
     assert.equal(kernel.skillCooldowns().status, "ready");
     kernel.view.setUint32(ADDRESSES.areaInfo + 133 * 0x7c + 0x10, 1, true);
     kernel.tick(0, 10_000);
-    assert.equal(
-      kernel.skillCooldowns().status,
-      "ready",
-      "PvP outposts remain supported",
-    );
+    assert.deepEqual(kernel.skillCooldowns(), {
+      status: "waiting",
+      reason: "game",
+    });
 
     kernel.view.setUint32(ADDRESSES.character + 0x19c, 1, true);
     kernel.view.setUint32(ADDRESSES.character + 0x23c, 1, true);

--- a/tests/unit/companion-policy-source.test.ts
+++ b/tests/unit/companion-policy-source.test.ts
@@ -190,7 +190,7 @@ describe("companion policy source", () => {
     assert.deepEqual(guildStates, [[false, false], [false, true], [true, true]]);
   });
 
-  it("withdraws local Tools only for positively identified active PvP play", () => {
+  it("withdraws local Tools on a positively identified PvP map", () => {
     const test = fixture();
     test.setSettings({ ...DEFAULT_SETTINGS, gwonmacTools: true });
     test.settingsEvents.dispatchEvent(new Event("gw:tools-settings"));

--- a/tests/unit/enhancement-runtime-policy.test.ts
+++ b/tests/unit/enhancement-runtime-policy.test.ts
@@ -115,7 +115,7 @@ test("unknown regions keep local Tools while live PvE features fail closed", () 
   });
 });
 
-test("confirmed active PvP play disables every product and developer tool", () => {
+test("a confirmed PvP map disables every product and developer tool", () => {
   const on = Object.freeze({
     characterSwitchEnabled: false,
     cartographyEnabled: false,
@@ -226,7 +226,7 @@ test("runtime policy projects every registered feature exactly once", () => {
   );
 });
 
-test("local Tools require their setting or developer program and only active PvP blocks them", () => {
+test("local Tools require their setting or developer program and PvP maps block them", () => {
   const regions = ["pve", "pvp", "unknown"] as const;
   const programs = [
     "none",


### PR DESCRIPTION
GWonMac Tools remained available in PvP outposts. That made our safety boundary too permissive: PvP outposts must disable Tools just like PvP explorable maps, while Guild Halls remain the supported exception.

This change removes the general outpost exception from the existing certified map classifier. The classifier reads the `AreaInfo` PvP mask, `flags & 0x00040001`, regardless of instance type, then keeps maps carrying the Guild Hall flag, `0x00800000`, eligible. The existing central policy withdraws optional Tools everywhere else in PvP. Core features remain independent.

## Invariant

- A PvE map remains eligible for Tools.
- PvP outposts and PvP explorable maps withdraw Tools.
- A Guild Hall remains eligible even when it also carries a PvP flag.
- Unknown and loading behavior remains unchanged.

## Verification

- `pnpm run check`
- `pnpm enhancements:kernel:verify`
- `pnpm test:integration` — 92 passed
- Focused map-policy, policy-source, runtime-policy, cooldown, and Xunlai tests — 33 passed

## Rollout risk

This changes the certified live-region policy, so it needs Beta consideration under the repository rollout rules. Automated tests prove the boundary; live Guild Wars QA has not been performed.

Implemented and verified with the Codex desktop agent.
