### PR TITLE
fix(tools): stack items before using empty storage slots

### DIFF
--- a/docs/enhancement-development.md
+++ b/docs/enhancement-development.md
@@ -90,19 +90,46 @@ sockets, commands, surfaces, and storage work. Disabling the master applies the
 same shutdown to every child while preserving settings and saved data. Complete
 module unloading happens on the next Core launch.
 
-Quick Item Move replaces only two exact item-slot callbacks and calls the
-copied UI dispatcher already certified for Tools. Its certificate binds the
-callback bodies, item lookup, storage-page preference reader, frame hierarchy,
-and UI dispatcher to the client build. A changed or ambiguous anchor disables
-only this capability. The trade and item structure offsets are reviewed facts
+Quick Item Move wraps two exact item-slot callbacks, the native quantity-move
+helper, and the UI dispatcher already certified for Tools. Its certificate binds
+those bodies, item lookup, the storage-page reader, frame hierarchy, and clock
+to the client build. A changed or ambiguous anchor disables only this capability. The trade and item structure offsets are reviewed facts
 for the exact post-template client build, so an ArenaNet client update disables
-Quick Item Move until those facts are recertified. Storage moves use the first
-empty slot in the visible pane or inventory; they do not merge partial stacks
-or search other storage panes. The renderer sends two modifier bits and owns a
-scratch region whose layout is shared with the transform: 28 bytes for the
-largest native action payload and 64 temporary destination reservations.
-Reservations prevent rapid clicks from choosing the same still-empty slot and
-clear when Control is released.
+Quick Item Move until those facts are recertified. Ordinary storage transfers
+fill compatible stacks before using empty cells. Deposits stay in the visible
+pane. Withdrawals search the backpack, belt pouch, and both bags for stacks
+before selecting empty cells. Excess items remain at the source when no more
+space is available. Material storage uses the same quantity and claim handling,
+with fixed slots and the account's upgraded capacity. As in Toolbox, birthday
+presents are refused by this shortcut.
+
+Stack matching follows Toolbox's model-file, dye, and encoded-name checks and
+requires stackable items. Name reads are bounded. Control-Shift-click opens one
+native quantity prompt at the source, as in Toolbox. Its selected amount enters
+the same stack-first transfer path at the deferred game-thread boundary. Another
+native move cancels prompt ownership. Unrelated native moves pass through;
+trade behavior is unchanged.
+
+The renderer sends two modifier bits and owns the scratch region defined by
+[the shared contract](../src/shared/quick-item-move-contract.ts). Its 64 temporary
+move claims record source locations, source remainders, expected destination
+quantities, and the native start time.
+Claims prevent repeated source moves and overfilled destinations before the
+client observes the result. Observed destination quantities and claims are not
+added together. Claims are reclaimed after both endpoints reflect the move, or
+after Toolbox's three-second retry timeout. Key release does not acknowledge a
+move. A full claim buffer refuses additional moves until claims are reclaimed.
+Claims are temporary; canonical inventory state remains in the game.
+
+The quantity-aware function is the current client's `GmItemHelpers.cpp` move
+helper identified by `ItemCliValidate(sourceItemId)`, also used by GWCA. It takes
+an item ID, quantity, destination bag index, and zero-based slot. Its exact body
+is checked before the transform calls it. Synthetic WebAssembly tests prove
+selection, overflow, identity, and pending-click behavior. The real-client test
+proves certification and bytecode validation; live transfer behavior still
+requires Matthias's in-game check. Material-slot bounds follow this client's
+42-entry table, and capacity follows GWCA's account-unlock `0x83` rule. These
+layout facts remain restricted to the exact reviewed client.
 
 ## Use the cheapest proof
 

--- a/src/main/certification/enhancement-build-model.ts
+++ b/src/main/certification/enhancement-build-model.ts
@@ -510,6 +510,8 @@ export interface KnownEnhancementBuild {
     inventorySlot: Readonly<{ functionIndex: number; params: readonly ["i32", "i32", "i32"]; results: readonly []; bodySha256: string }>;
     materialStorageSlot: Readonly<{ functionIndex: number; params: readonly ["i32", "i32", "i32"]; results: readonly []; bodySha256: string }>;
     numberPreference: Readonly<{ functionIndex: number; params: readonly ["i32"]; results: readonly ["i32"]; bodySha256: string }>;
+    timer: Readonly<{ functionIndex: number; params: readonly []; results: readonly ["i32"]; bodySha256: string }>;
+    moveItem: Readonly<{ functionIndex: number; params: readonly ["i32", "i32", "i32", "i32"]; results: readonly []; bodySha256: string }>;
     storageFrameHash: number;
     tradeCartFrameHash: number;
     tradeDialogFrameHash: number;

--- a/src/main/certification/enhancement-builds.ts
+++ b/src/main/certification/enhancement-builds.ts
@@ -36,17 +36,17 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
       // ENHANCEMENT_TRANSFORM_ABI or any config word changes.
       outputSha256: Object.freeze({
         "features-601":
-          "4a7317c9df48f49c87459fe8db4e8c6647e0b10209f8c665894b493b6621c186",
+          "06e7e534f680cc1ec2c049229b1a7c5e0c8379a46b68ebd8269b972484a22424",
         "features-e01":
-          "31118fac219c22c14b7f2025f7e3bf72802a5fda9376b0fbd03c070b99b0424c",
+          "771c917b5bd59b9d96ae404dac7a8156c3c8b97ffff3914c323f13e4672aa4f6",
         "features-fff":
-          "5c67e7859b14b93c09d807199daffc73a76c8fe683c6c3a9f8c06c8115361098",
+          "421914a8add1c9cd6d88f0124d943a296260bb9e459700d11ab71a9cfc40ae2a",
         "features-1fff":
-          "d8a048527d569c829870d79a5bdd59dd8e6e547e315533465b38cdefbf363ec6",
+          "5aa56c8aadeaddf490948811558cb70fd4528d54109de20167794c75ca50b301",
         "features-2fff":
-          "08227b5388c9fad57309cc891f2164c28c1c38806ed292391f2d2b68317455b5",
+          "f4570ddbd87c876ac6fecbadd5db957108689922efa9077b6c06bac3aab5a350",
         "features-3fff":
-          "a81546a534d0a93b23fac9d65407b35a2b77d6a83385e7c0a1ed3dd276084cfd",
+          "6d843b14c4b468452e7277b9f00a1a2defeaece3a6596d066de331a53b9da0a9",
       }),
       programId: 1,
       // The verifier derives this bounded identity from the exact module; it is
@@ -672,6 +672,20 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
           params: ["i32"] as const,
           results: ["i32"] as const,
           bodySha256: "6bbf1281e9b949a76d31595dddf1f95f6eae8de0f2129214e0ccb059cb46d1e9",
+        }),
+        timer: Object.freeze({
+          functionIndex: 249,
+          params: [] as const,
+          results: ["i32"] as const,
+          bodySha256: "c1f93ac7e783305bff7d976dbf55365b67fa6696243305685aa1fb0fb7901030",
+        }),
+        // GmItemHelpers.cpp: ItemCliValidate(sourceItemId), followed by
+        // quantity, bag-index and slot validation. GWCA MoveItem_Func.
+        moveItem: Object.freeze({
+          functionIndex: 13640,
+          params: ["i32", "i32", "i32", "i32"] as const,
+          results: [] as const,
+          bodySha256: "12b11795227c8ca7ea284798a22fa350234a6d0330fe222caab8b895ffde98e5",
         }),
         storageFrameHash: 0x8a02_f1b2,
         tradeCartFrameHash: 0x72f7_171f,

--- a/src/main/certification/enhancement-local-actions-proof.ts
+++ b/src/main/certification/enhancement-local-actions-proof.ts
@@ -705,12 +705,16 @@ function deriveQuickItemMove(
     certificate.inventorySlot,
     certificate.materialStorageSlot,
     certificate.numberPreference,
+    certificate.moveItem,
+    certificate.timer,
   ] as const;
   const resolved = entries.map((entry) =>
     uniqueExactFunction(module, entry.bodySha256, entry.params, entry.results));
   if (resolved.some((functionIndex) => functionIndex === null)) return null;
   return Object.freeze({
     ...certificate,
+    timer: Object.freeze({ ...certificate.timer, functionIndex: resolved[4]! }),
+    moveItem: Object.freeze({ ...certificate.moveItem, functionIndex: resolved[3]! }),
     inventorySlot: Object.freeze({ ...certificate.inventorySlot, functionIndex: resolved[0]! }),
     materialStorageSlot: Object.freeze({
       ...certificate.materialStorageSlot,

--- a/src/main/certification/enhancement-quick-item-move-transform.ts
+++ b/src/main/certification/enhancement-quick-item-move-transform.ts
@@ -4,6 +4,10 @@
  */
 import { concat, sleb, uleb, type FunctionType } from "../core/wasm-binary.js";
 import {
+  QUICK_ITEM_MOVE_SCRATCH_BYTES,
+  QUICK_ITEM_MOVE_PROMPT,
+  QUICK_ITEM_MOVE_RESERVATION as CLAIM,
+  QUICK_ITEM_MOVE_RESERVATION_BYTES,
   QUICK_ITEM_MOVE_RESERVATION_COUNT,
   QUICK_ITEM_MOVE_RESERVATION_OFFSET,
 } from "../../shared/quick-item-move-contract.js";
@@ -17,10 +21,15 @@ const global = (n: number) => concat(op(0x23), uleb(n));
 const setGlobal = (n: number) => concat(op(0x24), uleb(n));
 const call = (n: number) => concat(op(0x10), uleb(n));
 const load = (offset = 0) => concat(op(0x28), uleb(2), uleb(offset));
+const load8 = (offset = 0) => concat(op(0x2d), uleb(0), uleb(offset));
 const load16 = (offset = 0) => concat(op(0x2f), uleb(1), uleb(offset));
 const store = (offset = 0) => concat(op(0x36), uleb(2), uleb(offset));
 const ret = (value: number) => concat(i32(value), op(0x0f));
 const memoryBytes = () => concat(op(0x3f, 0x00), i32(16), op(0x74));
+const requireMemory = (pointer: number, bytes: number) => concat(
+  local(pointer), op(0x45), local(pointer), memoryBytes(), i32(bytes),
+  op(0x6b, 0x4b, 0x72, 0x04, 0x40), ret(0), op(0x0b),
+);
 const UI_MESSAGE = Object.freeze({
   moveItem: 0x1000_01af,
   frameMouseAction: 49,
@@ -28,6 +37,9 @@ const UI_MESSAGE = Object.freeze({
 export const QUICK_ITEM_MOVE_COMMAND = -20;
 const ITEM_OFFSET = Object.freeze({
   bag: 0x0c,
+  modelFile: 0x1c,
+  typeAndDye: 0x20,
+  name: 0x34,
   modifiers: 0x10,
   modifierCount: 0x14,
   interaction: 0x28,
@@ -36,7 +48,7 @@ const ITEM_OFFSET = Object.freeze({
 });
 const BAG_OFFSET = Object.freeze({ index: 0x04, items: 0x18, itemCount: 0x20 });
 const BAG_TYPE = Object.freeze({ inventory: 1, storage: 4, materialStorage: 5 });
-const INVENTORY_BAG_INDEX = Object.freeze({ backpack: 1, afterBag2: 5, material: 6, storage1: 8 });
+const INVENTORY_BAG_INDEX = Object.freeze({ backpack: 1, afterBag2: 5, material: 6, storage1: 8, afterStorage: 22 });
 const GAME_CONTEXT_OFFSET = Object.freeze({ items: 0x40, trade: 0x58 });
 const ITEM_CONTEXT_OFFSET = Object.freeze({ inventory: 0xf8 });
 const ITEM_ARRAY_OFFSET = Object.freeze({ buffer: 0xb8, size: 0xc0 });
@@ -46,7 +58,7 @@ const TRADE_INITIATED_FLAG = 1;
 const TRADE_MAX_ITEMS = 7;
 const STORAGE_PANE = Object.freeze({ count: 15, material: 14 });
 const NUMBER_PREFERENCE_STORAGE_PANE = 20;
-const MATERIAL_SLOT_COUNT = 41;
+const MATERIAL_SLOT_COUNT = 42;
 const NOT_TRADABLE_INTERACTION = 0x100;
 const MOVE_DIRECTION = Object.freeze({ store: 1, withdraw: 2 });
 const ITEM_MOUSE_ACTION = Object.freeze({
@@ -60,7 +72,7 @@ const clearReservations = (globals: QuickItemMoveGlobals) => concat(
   global(globals.scratch), op(0x04, 0x40),
     ...Array.from({ length: QUICK_ITEM_MOVE_RESERVATION_COUNT }, (_, index) =>
       concat(global(globals.scratch), i32(0), store(
-        QUICK_ITEM_MOVE_RESERVATION_OFFSET + index * Uint32Array.BYTES_PER_ELEMENT,
+        QUICK_ITEM_MOVE_RESERVATION_OFFSET + index * QUICK_ITEM_MOVE_RESERVATION_BYTES,
       ))),
   op(0x0b),
 );
@@ -85,6 +97,7 @@ export type QuickItemMoveResolution = Readonly<{
   certificate: QuickItemMoveCertificate;
   inventorySlot: ResolvedQuickItemMoveFunction;
   materialStorageSlot: ResolvedQuickItemMoveFunction;
+  moveItem: ResolvedQuickItemMoveFunction;
 }> | null;
 
 type ResolveFunction = (
@@ -109,6 +122,8 @@ export function resolveQuickItemMoveTransform(options: Readonly<{
     ["quick item inventory slot", certificate.inventorySlot],
     ["quick item material slot", certificate.materialStorageSlot],
     ["quick item number preference", certificate.numberPreference],
+    ["quick item quantity move", certificate.moveItem],
+    ["quick item timer", certificate.timer],
   ] as const;
   const resolved = entries.map(([label, entry]) => {
     const fn = options.resolveFunction(label, entry.functionIndex, entry.params, entry.results);
@@ -121,6 +136,7 @@ export function resolveQuickItemMoveTransform(options: Readonly<{
     certificate,
     inventorySlot: resolved[0]!,
     materialStorageSlot: resolved[1]!,
+    moveItem: resolved[3]!,
   });
 }
 
@@ -130,6 +146,7 @@ export type QuickItemMoveTypes = Readonly<{
   unaryType: number;
   binaryType: number;
   ternaryType: number;
+  slotType: number;
 }> | null;
 
 export function quickItemMoveGlobals(base: number): QuickItemMoveGlobals {
@@ -155,6 +172,7 @@ export function reserveQuickItemMoveTypes(options: Readonly<{
     modifierType,
     unaryType: modifierType,
     binaryType: options.appendType({ params: [0x7f, 0x7f], results: [0x7f] }),
+    slotType: options.appendType({ params: [0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f], results: [0x7f] }),
     ternaryType: options.appendType({ params: [0x7f, 0x7f, 0x7f], results: [0x7f] }),
   });
 }
@@ -173,6 +191,10 @@ export function quickItemMoveConfigure(
       global(pendingGlobal), i32(QUICK_ITEM_MOVE_COMMAND), op(0x46, 0x04, 0x40),
         i32(0), setGlobal(pendingGlobal),
       op(0x0b),
+      global(globals.scratch), op(0x04, 0x40),
+        global(globals.scratch), i32(0), store(QUICK_ITEM_MOVE_PROMPT.item),
+        global(globals.scratch), i32(0), store(QUICK_ITEM_MOVE_PROMPT.quantity),
+      op(0x0b),
       clearReservations(globals),
     op(0x0b),
     global(globals.enabled), op(0x0b),
@@ -183,32 +205,38 @@ export function quickItemMoveModifiers(globals: QuickItemMoveGlobals): Uint8Arra
   return concat(
     uleb(0),
     local(0), i32(3), op(0x71), setGlobal(globals.modifiers),
-    local(0), i32(1), op(0x71, 0x45, 0x04, 0x40),
-      clearReservations(globals),
-    op(0x0b),
     i32(1), op(0x0b),
   );
 }
 
-/** Claims a transient destination slot until Control is released. */
-export function quickItemMoveClaimDestination(globals: QuickItemMoveGlobals): Uint8Array {
+/** Toolbox's stack identity checks, with bounded UTF-16 name reads. */
+export function quickItemMoveSameItem(): Uint8Array {
   return concat(
-    // params destination bag index, zero-based slot; locals key, index, entry
-    uleb(1), uleb(3), op(0x7f),
-    global(globals.scratch), op(0x45, 0x04, 0x40), ret(0), op(0x0b),
-    local(0), i32(0xffff), op(0x71), i32(16), op(0x74),
-      local(1), i32(0xffff), op(0x71, 0x72), i32(1), op(0x6a), setLocal(2),
-    i32(0), setLocal(3),
-    op(0x02, 0x40, 0x03, 0x40),
-      local(3), i32(QUICK_ITEM_MOVE_RESERVATION_COUNT), op(0x4f, 0x0d), uleb(1),
-      global(globals.scratch), local(3), i32(Uint32Array.BYTES_PER_ELEMENT), op(0x6c),
-        i32(QUICK_ITEM_MOVE_RESERVATION_OFFSET), op(0x6a, 0x6a), load(), setLocal(4),
-      local(4), local(2), op(0x46, 0x04, 0x40), ret(0), op(0x0b),
-      local(4), op(0x45, 0x04, 0x40),
-        global(globals.scratch), local(3), i32(Uint32Array.BYTES_PER_ELEMENT), op(0x6c),
-          i32(QUICK_ITEM_MOVE_RESERVATION_OFFSET), op(0x6a, 0x6a), local(2), store(), ret(1),
-      op(0x0b),
-      local(3), i32(1), op(0x6a), setLocal(3), op(0x0c), uleb(0),
+    // params item pointers; locals left name, right name, index, character
+    uleb(1), uleb(4), op(0x7f),
+    ...[0, 1].map((item) => concat(
+      local(item), op(0x45), local(item), memoryBytes(), i32(ITEM_BYTES),
+      op(0x6b, 0x4b, 0x72, 0x04, 0x40), ret(0), op(0x0b),
+      local(item), load(ITEM_OFFSET.interaction), i32(0x80000), op(0x71, 0x45, 0x04, 0x40), ret(0), op(0x0b),
+    )),
+    local(0), load(ITEM_OFFSET.modelFile), op(0x04, 0x40),
+      local(0), load(ITEM_OFFSET.modelFile), local(1), load(ITEM_OFFSET.modelFile), op(0x47, 0x04, 0x40), ret(0), op(0x0b),
+    op(0x0b),
+    // ItemType::Dye is 10; type and its three DyeInfo bytes share this word.
+    local(0), load(ITEM_OFFSET.typeAndDye), i32(255), op(0x71), i32(10), op(0x46, 0x04, 0x40),
+      local(0), load(ITEM_OFFSET.typeAndDye), local(1), load(ITEM_OFFSET.typeAndDye), op(0x47, 0x04, 0x40), ret(0), op(0x0b),
+    op(0x0b),
+    local(0), load(ITEM_OFFSET.name), setLocal(2), local(1), load(ITEM_OFFSET.name), setLocal(3),
+    local(2), op(0x45), local(3), op(0x45, 0x72, 0x04, 0x40), ret(0), op(0x0b),
+    i32(0), setLocal(4), op(0x02, 0x40, 0x03, 0x40),
+      local(4), i32(512), op(0x4f, 0x0d), uleb(1),
+      ...[2, 3].map((pointer) => concat(
+        local(pointer), memoryBytes(), i32(2), op(0x6b, 0x4b, 0x04, 0x40), ret(0), op(0x0b),
+      )),
+      local(2), load16(), setLocal(5), local(5), local(3), load16(), op(0x47, 0x04, 0x40), ret(0), op(0x0b),
+      local(5), op(0x45, 0x04, 0x40), ret(1), op(0x0b),
+      local(2), i32(2), op(0x6a), setLocal(2), local(3), i32(2), op(0x6a), setLocal(3),
+      local(4), i32(1), op(0x6a), setLocal(4), op(0x0c), uleb(0),
     op(0x0b, 0x0b), ret(0), op(0x0b),
   );
 }
@@ -268,15 +296,20 @@ export function quickItemMoveFindAncestor(
   );
 }
 
-export type QuickExecutorConfig = Readonly<{
+type QuickMoveContext = Readonly<{
   certificate: NonNullable<KnownEnhancementBuild["quickItemMove"]>;
   layout: NonNullable<KnownEnhancementBuild["preGameControls"]>["layout"];
   globals: QuickItemMoveGlobals;
   itemLookup: number;
-  numberPreference: number;
   uiDispatcher: number;
   findFrame: number;
-  claimDestination: number;
+}>;
+
+export type QuickExecutorConfig = QuickMoveContext & Readonly<{
+  numberPreference: number;
+  availableSource: number;
+  moveSlot: number;
+  materialCapacity: number;
 }>;
 
 /** Mirrors GWCA Items::GetItemById against the already certified GameContext.
@@ -303,91 +336,295 @@ export function quickItemMoveItemLookup(
   );
 }
 
-export function quickItemMoveStorageExecutor(c: QuickExecutorConfig): Uint8Array {
-  const g = c.globals;
+const claimAddress = (g: QuickItemMoveGlobals, index: number) => concat(
+  global(g.scratch), i32(QUICK_ITEM_MOVE_RESERVATION_OFFSET), op(0x6a),
+  local(index), i32(QUICK_ITEM_MOVE_RESERVATION_BYTES), op(0x6c, 0x6a),
+);
+const increment = (index: number) => concat(local(index), i32(1), op(0x6a), setLocal(index));
+const itemKey = (item: number) => concat(
+  local(item), load(ITEM_OFFSET.bag), load(BAG_OFFSET.index), i32(16), op(0x74),
+  local(item), load8(ITEM_OFFSET.slot), op(0x72),
+);
+
+/** Reclaims acknowledged or timed-out moves before calculating source capacity.
+ * Key release is not an acknowledgement. Timeouts follow Toolbox's three seconds. */
+export function quickItemMoveAvailableSource(c: Pick<QuickMoveContext, "globals" | "itemLookup" | "certificate">): Uint8Array {
+  const p = { sourceId: 0, inventory: 1 };
+  const v = { source: 2, remaining: 3, now: 4, index: 5, claim: 6,
+    priorSource: 7, bag: 8, target: 9, acknowledged: 10, key: 11, slots: 12, count: 13 };
+  // params source id, inventory pointer; locals source, remaining, now, index,
+  // claim, prior source, destination bag, target, acknowledged, key, slots, count
   return concat(
-    // params id, quantity, direction; locals item, bag, contexts, game, items, inventory, page, dest, bagNo, slot, slots, count, mod, end
-    uleb(1), uleb(15), op(0x7f),
-    global(g.enabled), op(0x45, 0x04, 0x40), ret(0), op(0x0b),
-    i32(c.certificate.storageFrameHash), call(c.findFrame), op(0x45, 0x04, 0x40), ret(0), op(0x0b),
-    local(0), call(c.itemLookup), setLocal(3), local(3), op(0x45, 0x04, 0x40), ret(0), op(0x0b),
-    local(1), op(0x45), local(1), local(3), load16(ITEM_OFFSET.quantity), op(0x4b, 0x72, 0x04, 0x40), ret(0), op(0x0b),
-    local(3), load(ITEM_OFFSET.bag), setLocal(4), local(4), op(0x45, 0x04, 0x40), ret(0), op(0x0b),
-    i32(c.layout.contextRoot), load(), setLocal(5), local(5), op(0x45, 0x04, 0x40), ret(0), op(0x0b),
-    local(5), load(c.layout.gameContextSlot * 4), setLocal(6), local(6), op(0x45, 0x04, 0x40), ret(0), op(0x0b),
-    local(6), load(GAME_CONTEXT_OFFSET.items), setLocal(7), local(7), op(0x45, 0x04, 0x40), ret(0), op(0x0b),
-    local(7), load(ITEM_CONTEXT_OFFSET.inventory), setLocal(8), local(8), op(0x45, 0x04, 0x40), ret(0), op(0x0b),
-    // Store to the visible pane.
-    local(2), i32(MOVE_DIRECTION.store), op(0x46, 0x04, 0x40),
-      local(4), load(), i32(BAG_TYPE.inventory), op(0x47, 0x04, 0x40), ret(0), op(0x0b),
-      i32(NUMBER_PREFERENCE_STORAGE_PANE), call(c.numberPreference), i32(255), op(0x71), setLocal(9),
-      local(9), i32(STORAGE_PANE.count), op(0x4f, 0x04, 0x40), ret(0), op(0x0b),
-      local(9), i32(STORAGE_PANE.material), op(0x49, 0x04, 0x40),
-        local(8), local(9), i32(INVENTORY_BAG_INDEX.storage1), op(0x6a), i32(4), op(0x6c, 0x6a), load(), setLocal(10),
-      op(0x05),
-        // Material slot is encoded by modifier 0x2508 at bits 8..15.
-        local(3), load(ITEM_OFFSET.modifiers), setLocal(15), local(3), load(ITEM_OFFSET.modifierCount), i32(4), op(0x6c), local(15), op(0x6a), setLocal(16),
-        i32(MATERIAL_SLOT_COUNT), setLocal(12), op(0x02, 0x40, 0x03, 0x40),
-          local(15), local(16), op(0x4f, 0x0d), uleb(1), local(15), load(), setLocal(17),
-          local(17), i32(-65536), op(0x71), i32(0x2508_0000), op(0x46, 0x04, 0x40),
-            local(17), i32(8), op(0x76), i32(255), op(0x71), setLocal(12), op(0x0c), uleb(2),
-          op(0x0b), local(15), i32(4), op(0x6a), setLocal(15), op(0x0c), uleb(0),
-        op(0x0b, 0x0b),
-        // 41 is GWCA MaterialSlot::Count, including all three Zaishen coins.
-        local(12), i32(MATERIAL_SLOT_COUNT), op(0x4f, 0x04, 0x40), ret(0), op(0x0b),
-        local(8), load(INVENTORY_BAG_INDEX.material * 4), setLocal(10),
-      op(0x0b),
-      local(10), op(0x45, 0x04, 0x40), ret(0), op(0x0b),
-      // Standard panes still need an empty-slot scan. A material slot is fixed
-      // by item identity, so compatible rapid moves may safely share it.
-      local(9), i32(STORAGE_PANE.material), op(0x49, 0x04, 0x40),
-        i32(-1), setLocal(12),
-      op(0x0b),
-    op(0x05),
-      // Withdraw into the first empty inventory slot.
-      local(4), load(), i32(BAG_TYPE.storage), op(0x46), local(4), load(), i32(BAG_TYPE.materialStorage), op(0x46, 0x72, 0x45, 0x04, 0x40), ret(0), op(0x0b),
-      i32(INVENTORY_BAG_INDEX.backpack), setLocal(11), i32(-1), setLocal(12), i32(0), setLocal(17),
-      op(0x02, 0x40, 0x03, 0x40), local(11), i32(INVENTORY_BAG_INDEX.afterBag2), op(0x4f, 0x0d), uleb(1),
-        local(8), local(11), i32(4), op(0x6c, 0x6a), load(), setLocal(10),
-        local(10), op(0x04, 0x40),
-          local(10), load(BAG_OFFSET.items), setLocal(13), local(10), load(BAG_OFFSET.itemCount), setLocal(14), i32(0), setLocal(12),
-          op(0x02, 0x40, 0x03, 0x40), local(12), local(14), op(0x4f, 0x0d), uleb(1),
-            local(13), local(12), i32(4), op(0x6c, 0x6a), load(), op(0x45, 0x04, 0x40),
-              local(10), load(BAG_OFFSET.index), local(12), call(c.claimDestination), setLocal(17),
-              local(17), op(0x0d), uleb(2),
+    uleb(1), uleb(Object.keys(v).length), op(0x7f),
+    local(p.sourceId), call(c.itemLookup), setLocal(v.source), local(v.source), op(0x45, 0x04, 0x40), ret(0), op(0x0b),
+    requireMemory(p.inventory, INVENTORY_BAG_INDEX.afterStorage * 4),
+    local(v.source), load16(ITEM_OFFSET.quantity), setLocal(v.remaining), call(c.certificate.timer.functionIndex), setLocal(v.now),
+    i32(0), setLocal(v.index), op(0x02, 0x40, 0x03, 0x40),
+      local(v.index), i32(QUICK_ITEM_MOVE_RESERVATION_COUNT), op(0x4f, 0x0d), uleb(1),
+      claimAddress(c.globals, v.index), setLocal(v.claim),
+      op(0x02, 0x40),
+        local(v.claim), load(CLAIM.source), op(0x45, 0x0d), uleb(0),
+        local(v.now), local(v.claim), load(CLAIM.started), op(0x6b), i32(3_000), op(0x4f, 0x04, 0x40),
+          local(v.claim), i32(0), store(CLAIM.source), op(0x0c), uleb(1),
+        op(0x0b),
+        local(v.claim), load(CLAIM.source), call(c.itemLookup), setLocal(v.priorSource),
+        i32(1), setLocal(v.acknowledged),
+        local(v.priorSource), op(0x04, 0x40),
+          local(v.priorSource), load(ITEM_OFFSET.bag), setLocal(v.bag), local(v.bag), op(0x04, 0x40),
+            requireMemory(v.bag, 40),
+            itemKey(v.priorSource), local(v.claim), load(CLAIM.sourceKey), op(0x46),
+            local(v.priorSource), load16(ITEM_OFFSET.quantity), local(v.claim), load(CLAIM.remaining), op(0x4b, 0x71, 0x45), setLocal(v.acknowledged),
+          op(0x0b),
+        op(0x0b),
+        // Both sides must reflect the move: source and destination updates can
+        // arrive separately. A missing source alone does not free a destination.
+        local(v.acknowledged), op(0x04, 0x40),
+          local(v.claim), load(CLAIM.destination), setLocal(v.key),
+          local(v.key), i32(16), op(0x76), i32(1), op(0x6a), i32(INVENTORY_BAG_INDEX.afterStorage), op(0x49, 0x04, 0x40),
+            local(p.inventory), local(v.key), i32(16), op(0x76), i32(1), op(0x6a), i32(4), op(0x6c, 0x6a), load(), setLocal(v.bag),
+            local(v.bag), op(0x04, 0x40),
+              requireMemory(v.bag, 40),
+              local(v.bag), load(BAG_OFFSET.items), setLocal(v.slots), local(v.bag), load(BAG_OFFSET.itemCount), setLocal(v.count),
+              local(v.key), i32(0xffff), op(0x71), local(v.count), op(0x49), local(v.count), i32(256), op(0x4d, 0x71, 0x04, 0x40),
+                requireMemory(v.slots, 4),
+                local(v.slots), memoryBytes(), local(v.count), i32(4), op(0x6c, 0x6b, 0x4b, 0x04, 0x40), ret(0), op(0x0b),
+                local(v.slots), local(v.key), i32(0xffff), op(0x71), i32(4), op(0x6c, 0x6a), load(), setLocal(v.target),
+                local(v.target), op(0x04, 0x40),
+                  requireMemory(v.target, ITEM_BYTES),
+                  local(v.target), load16(ITEM_OFFSET.quantity), local(v.claim), load(CLAIM.expected), op(0x4f, 0x04, 0x40),
+                    local(v.claim), i32(0), store(CLAIM.source),
+                  op(0x0b),
+                op(0x0b),
+              op(0x0b),
             op(0x0b),
-            local(12), i32(1), op(0x6a), setLocal(12), op(0x0c), uleb(0),
-          op(0x0b, 0x0b),
-          local(17), op(0x0d), uleb(2),
+          op(0x0b),
         op(0x0b),
-        local(11), i32(1), op(0x6a), setLocal(11), op(0x0c), uleb(0),
-      op(0x0b, 0x0b),
-      local(17), op(0x45, 0x04, 0x40), ret(0), op(0x0b),
-    op(0x0b),
-    // For normal storage pages, locate the first empty slot now.
-    local(2), i32(MOVE_DIRECTION.store), op(0x46),
-      local(9), i32(STORAGE_PANE.material), op(0x49, 0x71, 0x04, 0x40),
-      local(10), load(BAG_OFFSET.items), setLocal(13), local(10), load(BAG_OFFSET.itemCount), setLocal(14), i32(0), setLocal(12),
-      op(0x02, 0x40, 0x03, 0x40), local(12), local(14), op(0x4f, 0x0d), uleb(1),
-        local(13), local(12), i32(4), op(0x6c, 0x6a), load(), op(0x45, 0x04, 0x40),
-          local(10), load(BAG_OFFSET.index), local(12), call(c.claimDestination), op(0x0d), uleb(2),
+        local(v.claim), load(CLAIM.source), local(p.sourceId), op(0x46, 0x04, 0x40),
+          local(v.claim), load(CLAIM.remaining), local(v.remaining), op(0x49, 0x04, 0x40), local(v.claim), load(CLAIM.remaining), setLocal(v.remaining), op(0x0b),
         op(0x0b),
-        local(12), i32(1), op(0x6a), setLocal(12), op(0x0c), uleb(0),
-      op(0x0b, 0x0b), local(12), local(14), op(0x4f, 0x04, 0x40), ret(0), op(0x0b),
-    op(0x0b),
-    // Native kMoveItem {item id, destination bag index, zero-based slot,
-    // prompt}. GWCA's similarly shaped kSendMoveItem number is private to
-    // GWCA's callback bus and is not a Guild Wars UI command.
-    global(g.scratch), setLocal(15), local(15), op(0x45, 0x04, 0x40), ret(0), op(0x0b),
-    local(15), local(0), store(),
-    local(15), local(10), load(BAG_OFFSET.index), store(4),
-    local(15), local(12), store(8),
-    local(15), effectiveModifiers(g), i32(2), op(0x71, 0x45, 0x45), store(12),
-    i32(UI_MESSAGE.moveItem), local(15), i32(0), call(c.uiDispatcher), ret(1), op(0x0b),
+      op(0x0b), increment(v.index), op(0x0c), uleb(0),
+    op(0x0b, 0x0b), local(v.remaining), op(0x0b),
   );
 }
 
-export type QuickHandlerConfig = QuickExecutorConfig & Readonly<{
+/** One bounded slot transaction: validate identity, reserve capacity, then move.
+ * The caller owns stack-first bag traversal; this helper never chooses a bag. */
+export function quickItemMoveSlot(c: Pick<QuickMoveContext, "globals" | "itemLookup" | "certificate"> & Readonly<{ sameItem: number }>): Uint8Array {
+  const p = { sourceId: 0, remaining: 1, bag: 2, slot: 3, pass: 4, capacity: 5 };
+  const v = { source: 6, target: 7, expected: 8, key: 9, index: 10,
+    claim: 11, freeClaim: 12, quantity: 13, available: 14 };
+  // params source id, remaining, bag pointer, slot, pass (0 stacks / 1 empty / 2 fixed), capacity
+  // locals source, target, expected, key, index, claim, free claim, quantity, available source
+  return concat(
+    uleb(1), uleb(Object.keys(v).length), op(0x7f),
+    local(p.capacity), op(0x45), local(p.capacity), i32(65_535), op(0x4b, 0x72, 0x04, 0x40), ret(0), op(0x0b),
+    local(p.sourceId), call(c.itemLookup), setLocal(v.source), local(v.source), op(0x45, 0x04, 0x40), ret(0), op(0x0b),
+    local(v.source), load16(ITEM_OFFSET.quantity), setLocal(v.available),
+    local(p.bag), load(BAG_OFFSET.items), local(p.slot), i32(4), op(0x6c, 0x6a), load(), setLocal(v.target),
+    local(v.target), op(0x04, 0x40),
+      local(v.source), local(v.target), call(c.sameItem), op(0x45, 0x04, 0x40), ret(0), op(0x0b),
+      local(v.target), load16(ITEM_OFFSET.quantity), setLocal(v.expected),
+    op(0x0b),
+    local(p.bag), load(BAG_OFFSET.index), i32(16), op(0x74), local(p.slot), op(0x72), setLocal(v.key),
+    i32(0), setLocal(v.index), op(0x02, 0x40, 0x03, 0x40),
+      local(v.index), i32(QUICK_ITEM_MOVE_RESERVATION_COUNT), op(0x4f, 0x0d), uleb(1),
+      claimAddress(c.globals, v.index), setLocal(v.claim),
+      local(v.claim), load(CLAIM.source), local(p.sourceId), op(0x46, 0x04, 0x40),
+        local(v.claim), load(CLAIM.remaining), local(v.available), op(0x49, 0x04, 0x40), local(v.claim), load(CLAIM.remaining), setLocal(v.available), op(0x0b),
+      op(0x0b),
+      local(v.claim), load(CLAIM.source), op(0x45, 0x04, 0x40),
+        local(v.freeClaim), op(0x45, 0x04, 0x40), local(v.claim), setLocal(v.freeClaim), op(0x0b),
+      op(0x05),
+        local(v.claim), load(CLAIM.destination), local(v.key), op(0x46, 0x04, 0x40),
+          // An unacknowledged move owns identity even if a target is visible.
+          local(v.source), local(v.claim), load(CLAIM.source), call(c.itemLookup), call(c.sameItem),
+          op(0x45, 0x04, 0x40), ret(0), op(0x0b),
+          local(v.claim), load(CLAIM.expected), local(v.expected), op(0x4b, 0x04, 0x40), local(v.claim), load(CLAIM.expected), setLocal(v.expected), op(0x0b),
+        op(0x0b),
+      op(0x0b), increment(v.index), op(0x0c), uleb(0),
+    op(0x0b, 0x0b),
+    local(v.freeClaim), op(0x45), local(v.expected), local(p.capacity), op(0x4f, 0x72),
+    local(v.expected), op(0x45), local(p.pass), op(0x47), local(p.pass), i32(2), op(0x49, 0x71, 0x72, 0x04, 0x40), ret(0), op(0x0b),
+    local(p.capacity), local(v.expected), op(0x6b), setLocal(v.quantity),
+    local(v.quantity), local(p.remaining), op(0x4b, 0x04, 0x40), local(p.remaining), setLocal(v.quantity), op(0x0b),
+    local(v.quantity), local(v.available), op(0x4b, 0x04, 0x40), local(v.available), setLocal(v.quantity), op(0x0b),
+    local(v.quantity), op(0x45, 0x04, 0x40), ret(0), op(0x0b),
+    local(v.freeClaim), local(p.sourceId), store(CLAIM.source),
+    local(v.freeClaim), local(v.available), local(v.quantity), op(0x6b), store(CLAIM.remaining),
+    local(v.freeClaim), local(v.key), store(CLAIM.destination),
+    local(v.freeClaim), local(v.expected), local(v.quantity), op(0x6a), store(CLAIM.expected),
+    local(v.freeClaim), call(c.certificate.timer.functionIndex), store(CLAIM.started),
+    local(v.freeClaim), itemKey(v.source), store(CLAIM.sourceKey),
+    local(p.sourceId), local(v.quantity), local(p.bag), load(BAG_OFFSET.index), local(p.slot), call(c.certificate.moveItem.functionIndex),
+    local(v.quantity), op(0x0b),
+  );
+}
+
+/** Mirrors GWCA's account unlock 0x83 capacity rule, bounded to uint16 item quantities. */
+export function quickItemMoveMaterialCapacity(): Uint8Array {
+  // param game context; locals account, array, count, index, row
+  return concat(
+    uleb(1), uleb(5), op(0x7f),
+    requireMemory(0, 0x2c), local(0), load(0x28), setLocal(1),
+    local(1), op(0x45, 0x04, 0x40), ret(250), op(0x0b), requireMemory(1, 16),
+    local(1), load(), setLocal(2), local(1), load(8), setLocal(3),
+    local(3), i32(4_096), op(0x4b, 0x04, 0x40), ret(0), op(0x0b),
+    local(2), memoryBytes(), local(3), i32(12), op(0x6c, 0x6b, 0x4b, 0x04, 0x40), ret(0), op(0x0b),
+    i32(0), setLocal(4), op(0x02, 0x40, 0x03, 0x40),
+      local(4), local(3), op(0x4f, 0x0d), uleb(1),
+      local(2), local(4), i32(12), op(0x6c, 0x6a), setLocal(5),
+      local(5), load(), i32(0x83), op(0x46, 0x04, 0x40),
+        local(5), load(4), i32(261), op(0x4b, 0x04, 0x40), ret(0), op(0x0b),
+        local(5), load(4), i32(1), op(0x6a), i32(250), op(0x6c, 0x0f),
+      op(0x0b), increment(4), op(0x0c), uleb(0),
+    op(0x0b, 0x0b), ret(250), op(0x0b),
+  );
+}
+
+export function quickItemMoveStorageExecutor(c: QuickExecutorConfig): Uint8Array {
+  const g = c.globals;
+  // Native parameters are item id, requested quantity and transfer direction.
+  const v = { item: 3, sourceBag: 4, context: 5, game: 6, items: 7, inventory: 8,
+    page: 9, bag: 10, bagNo: 11, slot: 12, slots: 13, count: 14,
+    first: 15, end: 16, pass: 17, remaining: 18, quantity: 19, moved: 20,
+    modifier: 21, modifierEnd: 22 };
+  return concat(
+    uleb(1), uleb(20), op(0x7f),
+    global(g.enabled), op(0x45), global(g.scratch), op(0x45, 0x72, 0x04, 0x40), ret(0), op(0x0b),
+    global(g.scratch), memoryBytes(), i32(QUICK_ITEM_MOVE_SCRATCH_BYTES), op(0x6b, 0x4b, 0x04, 0x40), ret(0), op(0x0b),
+    i32(c.certificate.storageFrameHash), call(c.findFrame), op(0x45, 0x04, 0x40), ret(0), op(0x0b),
+    local(2), i32(MOVE_DIRECTION.store), op(0x47), local(2), i32(MOVE_DIRECTION.withdraw), op(0x47, 0x71, 0x04, 0x40), ret(0), op(0x0b),
+    local(0), call(c.itemLookup), setLocal(v.item), local(v.item), op(0x45, 0x04, 0x40), ret(0), op(0x0b),
+    local(v.item), load(ITEM_OFFSET.modelFile), i32(0x2f301), op(0x46, 0x04, 0x40), ret(0), op(0x0b),
+    local(1), op(0x45), local(1), local(v.item), load16(ITEM_OFFSET.quantity), op(0x4b, 0x72, 0x04, 0x40), ret(0), op(0x0b),
+    local(v.item), load(ITEM_OFFSET.bag), setLocal(v.sourceBag), requireMemory(v.sourceBag, 40),
+    i32(c.layout.contextRoot), load(), setLocal(v.context), requireMemory(v.context, c.layout.gameContextSlot * 4 + 4),
+    local(v.context), load(c.layout.gameContextSlot * 4), setLocal(v.game), requireMemory(v.game, GAME_CONTEXT_OFFSET.items + 4),
+    local(v.game), load(GAME_CONTEXT_OFFSET.items), setLocal(v.items), requireMemory(v.items, ITEM_CONTEXT_OFFSET.inventory + 4),
+    local(v.items), load(ITEM_CONTEXT_OFFSET.inventory), setLocal(v.inventory), requireMemory(v.inventory, INVENTORY_BAG_INDEX.afterStorage * 4),
+    local(2), i32(MOVE_DIRECTION.store), op(0x46, 0x04, 0x7f),
+      local(v.sourceBag), load(), i32(BAG_TYPE.inventory), op(0x46),
+    op(0x05),
+      local(v.sourceBag), load(), i32(BAG_TYPE.storage), op(0x46),
+      local(v.sourceBag), load(), i32(BAG_TYPE.materialStorage), op(0x46, 0x72),
+    op(0x0b, 0x45, 0x04, 0x40), ret(0), op(0x0b),
+    local(0), local(v.inventory), call(c.availableSource), setLocal(v.remaining),
+    local(v.remaining), local(1), op(0x4b, 0x04, 0x40), local(1), setLocal(v.remaining), op(0x0b),
+    local(v.remaining), op(0x45, 0x04, 0x40), ret(0), op(0x0b),
+    effectiveModifiers(g), i32(2), op(0x71, 0x45, 0x45), local(1), i32(1), op(0x4b, 0x71, 0x04, 0x40),
+      global(g.scratch), local(0), store(QUICK_ITEM_MOVE_PROMPT.item),
+      global(g.scratch), itemKey(v.item), store(QUICK_ITEM_MOVE_PROMPT.sourceKey),
+      global(g.scratch), local(2), store(QUICK_ITEM_MOVE_PROMPT.direction),
+      global(g.scratch), local(0), store(),
+      global(g.scratch), local(v.sourceBag), load(BAG_OFFSET.index), store(4),
+      global(g.scratch), local(v.item), load8(ITEM_OFFSET.slot), store(8),
+      global(g.scratch), i32(1), store(12),
+      i32(UI_MESSAGE.moveItem), global(g.scratch), i32(0), call(c.uiDispatcher), ret(1),
+    op(0x0b),
+    local(2), i32(MOVE_DIRECTION.store), op(0x46, 0x04, 0x40),
+      i32(NUMBER_PREFERENCE_STORAGE_PANE), call(c.numberPreference), i32(255), op(0x71), setLocal(v.page),
+      local(v.page), i32(STORAGE_PANE.count), op(0x4f, 0x04, 0x40), ret(0), op(0x0b),
+      local(v.page), i32(STORAGE_PANE.material), op(0x46, 0x04, 0x40),
+        // Materials use fixed slots but share quantity and pending-move handling.
+        local(v.inventory), load(INVENTORY_BAG_INDEX.material * 4), setLocal(v.bag),
+        requireMemory(v.bag, 40),
+        local(v.item), load(ITEM_OFFSET.modifiers), setLocal(v.modifier),
+        local(v.item), load(ITEM_OFFSET.modifierCount), setLocal(v.count),
+        local(v.count), i32(64), op(0x4b, 0x04, 0x40), ret(0), op(0x0b),
+        local(v.modifier), memoryBytes(), local(v.count), i32(4), op(0x6c, 0x6b, 0x4b, 0x04, 0x40), ret(0), op(0x0b),
+        local(v.count), i32(4), op(0x6c), local(v.modifier), op(0x6a), setLocal(v.modifierEnd),
+        i32(MATERIAL_SLOT_COUNT), setLocal(v.slot), op(0x02, 0x40, 0x03, 0x40),
+          local(v.modifier), local(v.modifierEnd), op(0x4f, 0x0d), uleb(1),
+          local(v.modifier), load(), i32(-65536), op(0x71), i32(0x2508_0000), op(0x46, 0x04, 0x40),
+            local(v.modifier), load(), i32(8), op(0x76), i32(255), op(0x71), setLocal(v.slot), op(0x0c), uleb(2),
+          op(0x0b), local(v.modifier), i32(4), op(0x6a), setLocal(v.modifier), op(0x0c), uleb(0),
+        op(0x0b, 0x0b),
+        local(v.slot), i32(MATERIAL_SLOT_COUNT), op(0x4f, 0x04, 0x40), ret(0), op(0x0b),
+        local(v.slot), local(v.bag), load(BAG_OFFSET.itemCount), op(0x4f, 0x04, 0x40), ret(0), op(0x0b),
+        local(v.bag), load(BAG_OFFSET.items), setLocal(v.slots), requireMemory(v.slots, MATERIAL_SLOT_COUNT * 4),
+        local(0), local(v.remaining), local(v.bag), local(v.slot), i32(2), local(v.game), call(c.materialCapacity), call(c.moveSlot),
+        op(0x45, 0x45, 0x0f),
+      op(0x0b),
+      local(v.page), i32(INVENTORY_BAG_INDEX.storage1), op(0x6a), setLocal(v.first),
+      local(v.first), i32(1), op(0x6a), setLocal(v.end),
+    op(0x05),
+      i32(INVENTORY_BAG_INDEX.backpack), setLocal(v.first), i32(INVENTORY_BAG_INDEX.afterBag2), setLocal(v.end),
+    op(0x0b),
+    // Scan all eligible bags for stacks before considering any empty cell.
+    i32(0), setLocal(v.pass), op(0x03, 0x40),
+      local(v.first), setLocal(v.bagNo), op(0x02, 0x40, 0x03, 0x40),
+        local(v.bagNo), local(v.end), op(0x4f, 0x0d), uleb(1),
+        local(v.inventory), local(v.bagNo), i32(4), op(0x6c, 0x6a), load(), setLocal(v.bag),
+        local(v.bag), op(0x04, 0x40),
+          requireMemory(v.bag, 40),
+          local(v.bag), load(BAG_OFFSET.items), setLocal(v.slots), local(v.bag), load(BAG_OFFSET.itemCount), setLocal(v.count),
+          local(v.count), i32(256), op(0x4b, 0x04, 0x40), ret(0), op(0x0b),
+          local(v.count), op(0x04, 0x40), requireMemory(v.slots, 4), op(0x0b),
+          local(v.slots), memoryBytes(), local(v.count), i32(4), op(0x6c, 0x6b, 0x4b, 0x04, 0x40), ret(0), op(0x0b),
+          i32(0), setLocal(v.slot), op(0x02, 0x40, 0x03, 0x40),
+            local(v.slot), local(v.count), op(0x4f, 0x0d), uleb(1),
+            local(0), local(v.remaining), local(v.bag), local(v.slot), local(v.pass), i32(250), call(c.moveSlot), setLocal(v.quantity),
+            local(v.quantity), op(0x04, 0x40),
+              local(v.remaining), local(v.quantity), op(0x6b), setLocal(v.remaining), i32(1), setLocal(v.moved),
+              local(v.remaining), op(0x45, 0x04, 0x40), ret(1), op(0x0b),
+            op(0x0b), increment(v.slot), op(0x0c), uleb(0),
+          op(0x0b, 0x0b),
+        op(0x0b), increment(v.bagNo), op(0x0c), uleb(0),
+      op(0x0b, 0x0b), increment(v.pass), local(v.pass), i32(2), op(0x49, 0x0d), uleb(0),
+    op(0x0b), local(v.moved), op(0x0b),
+  );
+}
+
+/** Cancels stale prompt ownership whenever another native move UI starts. */
+export function quickItemMoveUiWrapper(g: QuickItemMoveGlobals, original: number): Uint8Array {
+  return concat(
+    uleb(0), global(g.scratch), op(0x04, 0x40),
+      local(0), i32(UI_MESSAGE.moveItem), op(0x46, 0x04, 0x40),
+        global(g.scratch), i32(0), store(QUICK_ITEM_MOVE_PROMPT.item),
+      op(0x0b),
+    op(0x0b), local(0), local(1), local(2), call(original), op(0x0b),
+  );
+}
+
+/** Intercepts only our same-source quantity confirmation. The chosen amount
+ * enters the existing game-thread mailbox; unrelated native moves pass through. */
+export function quickItemMoveQuantityWrapper(c: Readonly<{
+  globals: QuickItemMoveGlobals; original: number; pendingGlobal: number; argumentGlobalBase: number;
+}>): Uint8Array {
+  const g = c.globals;
+  return concat(
+    uleb(0), global(g.scratch), op(0x04, 0x40),
+      global(g.scratch), load(QUICK_ITEM_MOVE_PROMPT.item), local(0), op(0x46),
+      local(2), i32(16), op(0x74), local(3), op(0x72),
+      global(g.scratch), load(QUICK_ITEM_MOVE_PROMPT.sourceKey), op(0x46, 0x71, 0x04, 0x40),
+        global(g.scratch), i32(0), store(QUICK_ITEM_MOVE_PROMPT.item),
+        global(g.enabled), global(c.pendingGlobal), op(0x45, 0x71), local(1), op(0x45, 0x45, 0x71, 0x04, 0x40),
+          global(g.scratch), local(1), store(QUICK_ITEM_MOVE_PROMPT.quantity),
+          local(0), setGlobal(c.argumentGlobalBase), i32(0), setGlobal(c.argumentGlobalBase + 1),
+          i32(1), setGlobal(g.intentModifiers), i32(QUICK_ITEM_MOVE_COMMAND), setGlobal(c.pendingGlobal),
+        op(0x0b, 0x0f),
+      op(0x0b),
+    op(0x0b),
+    local(0), local(1), local(2), local(3), call(c.original), op(0x0b),
+  );
+}
+
+/** A quantity confirmation has no originating item frame. Drain it through
+ * the same storage executor; ordinary clicks retain their trade-aware handler. */
+export function quickItemMoveDispatch(g: QuickItemMoveGlobals, handler: number, storage: number): Uint8Array {
+  return concat(
+    uleb(1), uleb(1), op(0x7f),
+    global(g.scratch), op(0x04, 0x40),
+      global(g.scratch), load(QUICK_ITEM_MOVE_PROMPT.quantity), setLocal(2),
+      global(g.scratch), i32(0), store(QUICK_ITEM_MOVE_PROMPT.quantity),
+      local(1), op(0x45), local(2), op(0x45, 0x45, 0x71, 0x04, 0x40),
+        local(0), local(2), global(g.scratch), load(QUICK_ITEM_MOVE_PROMPT.direction), call(storage), op(0x0f),
+      op(0x0b),
+    op(0x0b), local(0), local(1), call(handler), op(0x0b),
+  );
+}
+
+export type QuickHandlerConfig = QuickMoveContext & Readonly<{
   frameDispatch: number;
   frameDispatchOffset: number;
   findAncestor: number;
@@ -423,6 +660,7 @@ export function quickItemMoveHandler(c: QuickHandlerConfig): Uint8Array {
       i32(c.certificate.storageFrameHash), call(c.findFrame), op(0x45, 0x45, 0x72, 0x45),
       op(0x04, 0x40), ret(0), op(0x0b),
       global(c.pendingGlobal), op(0x04, 0x40), ret(0), op(0x0b),
+      global(g.scratch), i32(0), store(QUICK_ITEM_MOVE_PROMPT.quantity),
       local(0), setGlobal(c.argumentGlobalBase),
       local(1), setGlobal(c.argumentGlobalBase + 1),
       global(g.modifiers), setGlobal(g.intentModifiers),
@@ -555,10 +793,16 @@ export function applyQuickItemMoveTransform(options: Readonly<{
   exports: readonly Readonly<{ name: string; index: number }>[];
   handlerIndex: number;
 }> {
-  const { certificate, inventorySlot, materialStorageSlot } = options.resolution;
+  const { certificate, inventorySlot, materialStorageSlot, moveItem } = options.resolution;
   const action = options.preGame.characterSwitchAction;
   const append = options.appendFunction;
   const uiForward = append(options.uiHook.typeIndex, options.nextBodies[options.uiHook.localIndex]!);
+  options.nextBodies[options.uiHook.localIndex] = quickItemMoveUiWrapper(options.globals, uiForward);
+  const moveOriginal = append(moveItem.typeIndex, options.nextBodies[moveItem.localIndex]!);
+  options.nextBodies[moveItem.localIndex] = quickItemMoveQuantityWrapper({
+    globals: options.globals, original: moveOriginal,
+    pendingGlobal: options.pendingGlobal, argumentGlobalBase: options.argumentGlobalBase,
+  });
   const findFrame = append(options.types.unaryType, quickItemMoveFindFrame(options.preGame.layout));
   const findAncestor = append(options.types.binaryType, quickItemMoveFindAncestor(
     action.frameResolver.functionIndex,
@@ -567,14 +811,18 @@ export function applyQuickItemMoveTransform(options: Readonly<{
     options.preGame.layout.frameId,
     options.preGame.layout.frameBytes,
   ));
-  const claimDestination = append(
-    options.types.binaryType,
-    quickItemMoveClaimDestination(options.globals),
-  );
+  const sameItem = append(options.types.binaryType, quickItemMoveSameItem());
   const itemLookup = append(
     options.types.unaryType,
     quickItemMoveItemLookup(options.preGame.layout),
   );
+  const materialCapacity = append(options.types.unaryType, quickItemMoveMaterialCapacity());
+  const availableSource = append(options.types.binaryType, quickItemMoveAvailableSource({
+    certificate, globals: options.globals, itemLookup,
+  }));
+  const moveSlot = append(options.types.slotType, quickItemMoveSlot({
+    certificate, globals: options.globals, itemLookup, sameItem,
+  }));
   const executor = append(options.types.ternaryType, quickItemMoveStorageExecutor({
     certificate,
     layout: options.preGame.layout,
@@ -583,17 +831,17 @@ export function applyQuickItemMoveTransform(options: Readonly<{
     numberPreference: certificate.numberPreference.functionIndex,
     uiDispatcher: uiForward,
     findFrame,
-    claimDestination,
+    availableSource,
+    moveSlot,
+    materialCapacity,
   }));
   const handler = append(options.types.binaryType, quickItemMoveHandler({
     certificate,
     layout: options.preGame.layout,
     globals: options.globals,
     itemLookup,
-    numberPreference: certificate.numberPreference.functionIndex,
     uiDispatcher: uiForward,
     findFrame,
-    claimDestination,
     frameDispatch: action.frameDispatch.functionIndex,
     frameDispatchOffset: action.frameDispatchOffset,
     findAncestor,
@@ -601,6 +849,7 @@ export function applyQuickItemMoveTransform(options: Readonly<{
     pendingGlobal: options.pendingGlobal,
     argumentGlobalBase: options.argumentGlobalBase,
   }));
+  const dispatch = append(options.types.binaryType, quickItemMoveDispatch(options.globals, handler, executor));
   const inventoryOriginal = append(inventorySlot.typeIndex, options.bodies[inventorySlot.localIndex]!);
   const materialOriginal = append(
     materialStorageSlot.typeIndex,
@@ -630,7 +879,7 @@ export function applyQuickItemMoveTransform(options: Readonly<{
       name: certificate.modifierExport,
       index: append(options.types.modifierType, quickItemMoveModifiers(options.globals)),
     }),
-  ]), handlerIndex: handler });
+  ]), handlerIndex: dispatch });
 }
 
 /** Runs one captured click from the same certified game-thread safe point as

--- a/src/main/certification/enhancement-transform.ts
+++ b/src/main/certification/enhancement-transform.ts
@@ -525,6 +525,9 @@ function resolveEnhancementTransform(
     }, {
       name: "quick item material slot",
       functionIndex: quickItemMoveResolution.materialStorageSlot.localIndex + importCount,
+    }, {
+      name: "quick item quantity confirmation",
+      functionIndex: quickItemMoveResolution.moveItem.localIndex + importCount,
     }] : []),
   ];
   const roleByFunction = new Map<number, string>();

--- a/src/shared/enhancement-contracts.ts
+++ b/src/shared/enhancement-contracts.ts
@@ -316,7 +316,7 @@ export {
   ENHANCEMENT_LAYOUT_WORD_COUNT,
   ENHANCEMENT_PARTY_DIRTY_MESSAGE_COUNT,
 } from "./enhancement-config.js";
-export const ENHANCEMENT_TRANSFORM_ABI = 51;
+export const ENHANCEMENT_TRANSFORM_ABI = 52;
 
 export const ENHANCEMENT_CHAT_FILTER_MASKS = Object.freeze({
   allyDrops: 1,

--- a/src/shared/quick-item-move-contract.ts
+++ b/src/shared/quick-item-move-contract.ts
@@ -3,7 +3,18 @@
  * in-flight destination claims.
  */
 export const QUICK_ITEM_MOVE_PAYLOAD_BYTES = 28;
-export const QUICK_ITEM_MOVE_RESERVATION_OFFSET = QUICK_ITEM_MOVE_PAYLOAD_BYTES;
+export const QUICK_ITEM_MOVE_PROMPT = Object.freeze({
+  item: QUICK_ITEM_MOVE_PAYLOAD_BYTES,
+  sourceKey: QUICK_ITEM_MOVE_PAYLOAD_BYTES + 4,
+  quantity: QUICK_ITEM_MOVE_PAYLOAD_BYTES + 8,
+  direction: QUICK_ITEM_MOVE_PAYLOAD_BYTES + 12,
+});
+export const QUICK_ITEM_MOVE_RESERVATION_OFFSET = QUICK_ITEM_MOVE_PROMPT.direction + 4;
 export const QUICK_ITEM_MOVE_RESERVATION_COUNT = 64;
+// Each claim tracks the expected endpoints of one pending native move.
+export const QUICK_ITEM_MOVE_RESERVATION = Object.freeze({
+  source: 0, remaining: 4, destination: 8, expected: 12, started: 16, sourceKey: 20,
+});
+export const QUICK_ITEM_MOVE_RESERVATION_BYTES = QUICK_ITEM_MOVE_RESERVATION.sourceKey + 4;
 export const QUICK_ITEM_MOVE_SCRATCH_BYTES = QUICK_ITEM_MOVE_RESERVATION_OFFSET
-  + QUICK_ITEM_MOVE_RESERVATION_COUNT * Uint32Array.BYTES_PER_ELEMENT;
+  + QUICK_ITEM_MOVE_RESERVATION_COUNT * QUICK_ITEM_MOVE_RESERVATION_BYTES;

--- a/tests/unit/enhancement-quick-item-move-transform.test.ts
+++ b/tests/unit/enhancement-quick-item-move-transform.test.ts
@@ -2,6 +2,16 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  quickItemMoveMaterialCapacity,
+  quickItemMoveConfigure,
+  quickItemMoveAvailableSource,
+  quickItemMoveSlot,
+  quickItemMoveQuantityWrapper,
+  quickItemMoveUiWrapper,
+  quickItemMoveDispatch,
+  resolveQuickItemMoveTransform,
+  quickItemMoveSameItem,
+  quickItemMoveModifiers,
   quickItemMoveHandler,
   quickItemMoveItemLookup,
   quickItemMoveDrain,
@@ -62,17 +72,16 @@ const handlerState = Object.freeze({
 });
 
 const storageState = Object.freeze({
-  itemPointer: 7,
-  page: 8,
-  storageFrame: 9,
-  claimAllowed: 10,
-  claimBag: 11,
-  claimSlot: 12,
-  uiMessage: 13,
-  uiItem: 14,
-  uiQuantity: 15,
-  uiBag: 16,
-  uiSlot: 17,
+  page: 7,
+  storageFrame: 8,
+  uiMessage: 9,
+  uiItem: 10,
+  uiQuantity: 11,
+  uiBag: 12,
+  uiSlot: 13,
+  nativeCalls: 14,
+  clock: 15,
+  pending: 16,
 });
 
 function handlerModule(): Uint8Array {
@@ -117,10 +126,8 @@ function handlerModule(): Uint8Array {
     layout,
     globals,
     itemLookup: 0,
-    numberPreference: 1,
     uiDispatcher: 2,
     findFrame: 3,
-    claimDestination: 4,
     frameDispatch: 5,
     frameDispatchOffset: 0,
     findAncestor: 6,
@@ -175,11 +182,15 @@ function storageExecutorModule(): Uint8Array {
   const certificate = build.quickItemMove!;
   const layout = { ...build.preGameControls!.layout, contextRoot: 32, gameContextSlot: 0 };
   const types = concat(
-    uleb(4),
+    uleb(8),
     op(0x60), uleb(1), op(0x7f), uleb(1), op(0x7f),
     op(0x60), uleb(3), op(0x7f, 0x7f, 0x7f), uleb(0),
     op(0x60), uleb(2), op(0x7f, 0x7f), uleb(1), op(0x7f),
     op(0x60), uleb(3), op(0x7f, 0x7f, 0x7f), uleb(1), op(0x7f),
+    op(0x60), uleb(4), op(0x7f, 0x7f, 0x7f, 0x7f), uleb(0),
+    op(0x60), uleb(0), uleb(1), op(0x7f),
+    op(0x60), uleb(6), op(0x7f, 0x7f, 0x7f, 0x7f, 0x7f, 0x7f), uleb(1), op(0x7f),
+    op(0x60), uleb(0), uleb(0),
   );
   const returnGlobal = (index: number) => concat(uleb(0), global(index), op(0x0b));
   const uiDispatcher = concat(
@@ -191,21 +202,27 @@ function storageExecutorModule(): Uint8Array {
     local(1), load(12), setGlobal(storageState.uiSlot),
     op(0x0b),
   );
-  const claimDestination = concat(
-    uleb(0),
-    local(0), setGlobal(storageState.claimBag),
-    local(1), setGlobal(storageState.claimSlot),
-    global(storageState.claimAllowed), op(0x0b),
+  const nativeMove = concat(
+    uleb(1), uleb(1), op(0x7f),
+    i32(40_000), global(storageState.nativeCalls), i32(16), op(0x6c, 0x6a, 0x21, 0x04),
+    ...[0, 1, 2, 3].map((index) => concat(local(4), local(index), op(0x36, 0x02), uleb(index * 4))),
+    global(storageState.nativeCalls), i32(1), op(0x6a), setGlobal(storageState.nativeCalls), op(0x0b),
   );
+  const config = {
+    certificate: { ...certificate, moveItem: { ...certificate.moveItem, functionIndex: 6 }, timer: { ...certificate.timer, functionIndex: 8 } },
+    globals, itemLookup: 0, sameItem: 4,
+  };
   const executor = quickItemMoveStorageExecutor({
-    certificate,
+    certificate: config.certificate,
     layout,
     globals,
     itemLookup: 0,
     numberPreference: 1,
     uiDispatcher: 2,
     findFrame: 3,
-    claimDestination: 4,
+    availableSource: 9,
+    moveSlot: 10,
+    materialCapacity: 17,
   });
   const stateExports = Object.entries(storageState).map(([key, index]) =>
     exported(key, 0x03, index));
@@ -213,31 +230,44 @@ function storageExecutorModule(): Uint8Array {
     WASM_HEADER,
     encodeSection({ id: 1, body: types }),
     encodeSection({ id: 3, body: concat(
-      uleb(6), uleb(0), uleb(0), uleb(1), uleb(0), uleb(2), uleb(3),
+      uleb(18), uleb(0), uleb(0), uleb(1), uleb(0), uleb(2), uleb(3), uleb(4), uleb(0), uleb(5), uleb(2), uleb(6), uleb(4), uleb(1), uleb(2), uleb(2), uleb(7), uleb(2), uleb(0),
     ) }),
     encodeSection({ id: 5, body: concat(uleb(1), op(0x00), uleb(1)) }),
     encodeSection({ id: 6, body: concat(
-      uleb(18), mutableGlobal(1), mutableGlobal(1), mutableGlobal(2_048),
+      uleb(19), mutableGlobal(1), mutableGlobal(1), mutableGlobal(32_000),
       mutableGlobal(), mutableGlobal(), mutableGlobal(), mutableGlobal(),
-      mutableGlobal(256), mutableGlobal(),
-      mutableGlobal(1), mutableGlobal(1),
-      ...Array.from({ length: 7 }, () => mutableGlobal()),
+      mutableGlobal(), mutableGlobal(1),
+      ...Array.from({ length: 10 }, () => mutableGlobal()),
     ) }),
     encodeSection({ id: 7, body: concat(
-      uleb(5 + stateExports.length),
-      exported("memory", 0x02, 0), exported("executor", 0x00, 5),
+      uleb(10 + stateExports.length),
+      exported("memory", 0x02, 0), exported("executor", 0x00, 5), exported("setModifiers", 0x00, 7),
+      exported("confirm", 0x00, 6), exported("ui", 0x00, 12),
+      exported("drain", 0x00, 15), exported("configure", 0x00, 16),
       exported("modifiers", 0x03, globals.modifiers),
       exported("draining", 0x03, globals.draining),
       exported("intentModifiers", 0x03, globals.intentModifiers),
       ...stateExports,
     ) }),
     encodeSection({ id: 10, body: encodeCode([
-      returnGlobal(storageState.itemPointer),
+      quickItemMoveItemLookup(layout),
       returnGlobal(storageState.page),
       uiDispatcher,
       returnGlobal(storageState.storageFrame),
-      claimDestination,
+      quickItemMoveSameItem(),
       executor,
+      quickItemMoveQuantityWrapper({ globals, original: 11, pendingGlobal: 16, argumentGlobalBase: 17 }),
+      quickItemMoveModifiers(globals),
+      returnGlobal(storageState.clock),
+      quickItemMoveAvailableSource(config),
+      quickItemMoveSlot(config),
+      nativeMove,
+      quickItemMoveUiWrapper(globals, 2),
+      quickItemMoveDispatch(globals, 14, 5),
+      concat(uleb(0), i32(0), op(0x0b)),
+      concat(uleb(0), quickItemMoveDrain(16, 17, globals, 13), op(0x0b)),
+      quickItemMoveConfigure(globals, 16),
+      quickItemMoveMaterialCapacity(),
     ]) }),
   );
 }
@@ -562,85 +592,338 @@ test("handler routes inventory, storage, own offers, and partner offers safely",
   assert.equal(state("frameMessage").value, 0);
 });
 
-test("storage executor validates direction, capacity, material slots, and quantity", async () => {
+
+async function storageFixture(direction = 1) {
   const instance = await instantiate(storageExecutorModule());
-  const exports = instance.exports;
-  const memory = exports.memory as WebAssembly.Memory;
-  const execute = exports.executor as (itemId: number, quantity: number, direction: number) => number;
-  const state = (nameValue: keyof typeof storageState) => exports[nameValue] as WebAssembly.Global;
-  const view = new DataView(memory.buffer);
-  const itemId = 1_234;
-  const item = 256;
-  const inventory = 400;
-  const sourceBag = 600;
-  const storageBag = 700;
-  const materialBag = 720;
-  const backpack = 740;
-  const slots = 900;
-  view.setUint32(32, 128, true);
-  view.setUint32(128, 160, true);
-  view.setUint32(160 + 0x40, 200, true);
-  view.setUint32(200 + 0xf8, inventory, true);
-  view.setUint32(item + 12, sourceBag, true);
-  view.setUint16(item + 76, 9, true);
-  view.setUint32(sourceBag + 4, 3, true);
-  view.setUint32(inventory + 8 * 4, storageBag, true);
-  view.setUint32(storageBag + 4, 8, true);
-  view.setUint32(storageBag + 24, slots, true);
-  view.setUint32(storageBag + 32, 2, true);
+  const view = new DataView((instance.exports.memory as WebAssembly.Memory).buffer);
+  const state = (key: keyof typeof storageState) => instance.exports[key] as WebAssembly.Global;
+  const execute = instance.exports.executor as (id: number, quantity: number, direction: number) => number;
+  const setModifiers = instance.exports.setModifiers as (modifiers: number) => number;
+  const u32 = (address: number, value: number) => view.setUint32(address, value, true);
+  u32(32, 128); u32(128, 256); u32(256 + 0x40, 512);
+  u32(512 + 0xf8, 1_024); u32(512 + 0xb8, 12_000); u32(512 + 0xc0, 100);
+  const bag = (index: number, slots: readonly number[]) => {
+    const pointer = 4_096 + index * 64;
+    const array = 6_000 + index * 256;
+    u32(1_024 + index * 4, pointer);
+    u32(pointer, index < 5 ? 1 : index === 6 ? 5 : 4);
+    u32(pointer + 4, index - 1);
+    u32(pointer + 24, array); u32(pointer + 32, slots.length);
+    slots.forEach((id, slot) => u32(array + slot * 4, id ? 2_048 + id * 128 : 0));
+    return pointer;
+  };
+  const item = (id: number, quantity: number, bagIndex: number, options: {
+    name?: string; model?: number; stackable?: boolean; dye?: number;
+  } = {}) => {
+    const pointer = 2_048 + id * 128;
+    u32(12_000 + id * 4, pointer); u32(pointer, id);
+    u32(pointer + 12, 4_096 + bagIndex * 64);
+    u32(pointer + 0x1c, options.model ?? 777);
+    u32(pointer + 0x20, options.dye === undefined ? 11 : 10 | options.dye << 8);
+    u32(pointer + 0x28, options.stackable === false ? 0 : 0x80000);
+    view.setUint16(pointer + 76, quantity, true);
+    const namePointer = 20_000 + id * 128;
+    u32(pointer + 0x34, namePointer);
+    const text = options.name ?? 'same encoded item';
+    [...text, '\0'].forEach((character, index) => view.setUint16(namePointer + index * 2, character.charCodeAt(0), true));
+    return pointer;
+  };
+  const moves = () => Array.from({ length: Number(state('nativeCalls').value) }, (_, index) =>
+    Array.from({ length: 4 }, (_, word) => view.getUint32(40_000 + index * 16 + word * 4, true)));
+  bag(direction === 1 ? 1 : 8, [1]);
+  item(1, 3, direction === 1 ? 1 : 8);
+  const confirm = instance.exports.confirm as (id: number, quantity: number, bag: number, slot: number) => void;
+  const ui = instance.exports.ui as (message: number, pointer: number, extra: number) => void;
+  const drain = instance.exports.drain as () => void;
+  const configure = instance.exports.configure as (enabled: number, scratch: number) => number;
+  return { view, state, bag, item, moves, u32, setModifiers, confirm, ui, drain, configure,
+    move: (id = 1, quantity = 3) => execute(id, quantity, direction),
+    execute };
+}
 
-  view.setUint32(sourceBag, 1, true);
-  assert.equal(execute(itemId, 9, 1), 1);
-  assert.equal(state("claimBag").value, 8);
-  assert.equal(state("claimSlot").value, 0);
-  assert.equal(state("uiMessage").value, 0x1000_01af);
-  assert.equal(state("uiItem").value, itemId);
-  assert.equal(state("uiQuantity").value, 8, "kMoveItem word 2 is the destination bag index");
-  assert.equal(state("uiBag").value, 0, "kMoveItem word 3 is the destination slot");
-  assert.equal(state("uiSlot").value, 0, "plain Control does not request a quantity prompt");
+test('storage merges 3 into 18 before an earlier empty cell, including a full pane', async () => {
+  for (const slots of [[0, 2], [2]]) {
+    const f = await storageFixture();
+    f.bag(8, slots); f.item(2, 18, 8);
+    assert.equal(f.move(), 1);
+    assert.deepEqual(f.moves(), [[1, 3, 7, slots.indexOf(2)]]);
+  }
+});
 
-  (exports.modifiers as WebAssembly.Global).value = 3;
-  assert.equal(execute(itemId, 9, 1), 1);
-  assert.equal(state("uiSlot").value, 1, "Control+Shift requests the native quantity prompt");
-  (exports.modifiers as WebAssembly.Global).value = 1;
+test('withdrawal searches all four bags for stacks before using backpack space', async () => {
+  const f = await storageFixture(2);
+  f.bag(1, [0]); f.bag(4, [2]); f.item(2, 18, 4);
+  assert.equal(f.move(), 1);
+  assert.deepEqual(f.moves(), [[1, 3, 3, 0]]);
+});
 
-  state("uiMessage").value = 0;
-  assert.equal(execute(itemId, 0, 1), 0);
-  assert.equal(execute(itemId, 10, 1), 0);
-  assert.equal(state("uiMessage").value, 0);
+test('overflow fills stacks then empty cells and leaves any excess at source', async () => {
+  for (const hasEmpty of [false, true]) {
+    const f = await storageFixture();
+    f.item(1, 20, 1); f.item(2, 245, 8); f.item(3, 248, 8);
+    f.bag(8, hasEmpty ? [0, 2, 3] : [2, 3]);
+    assert.equal(f.move(1, 20), 1);
+    assert.deepEqual(f.moves(), hasEmpty
+      ? [[1, 5, 7, 1], [1, 2, 7, 2], [1, 13, 7, 0]]
+      : [[1, 5, 7, 0], [1, 2, 7, 1]]);
+  }
+});
 
-  view.setUint32(slots, 1, true);
-  view.setUint32(slots + 4, 1, true);
-  assert.equal(execute(itemId, 9, 1), 0, "a full normal pane fails closed");
-  view.setUint32(slots, 0, true);
-  view.setUint32(slots + 4, 0, true);
+test('withdrawal skips full and absent bags and splits large material stacks', async () => {
+  const f = await storageFixture(2);
+  f.item(1, 600, 8); f.item(2, 250, 1); f.bag(1, [2]); f.bag(4, [0, 0]);
+  assert.equal(f.move(1, 600), 1);
+  assert.deepEqual(f.moves(), [[1, 250, 3, 0], [1, 250, 3, 1]]);
+});
 
-  state("page").value = 15;
-  assert.equal(execute(itemId, 9, 1), 0, "an unknown storage pane fails closed");
+test('matching respects encoded names, model files, stackability and dye variants', async () => {
+  for (const options of [{ name: 'different' }, { model: 778 }, { stackable: false }, { dye: 4 }]) {
+    const f = await storageFixture();
+    f.item(1, 3, 1, { dye: 3 }); f.item(2, 18, 8, options); f.bag(8, [2, 0]);
+    assert.equal(f.move(), 1);
+    assert.deepEqual(f.moves(), [[1, 3, 7, 1]]);
+  }
+  const f = await storageFixture();
+  f.item(1, 3, 1, { dye: 3 }); f.item(2, 18, 8, { dye: 3 }); f.bag(8, [2]);
+  assert.equal(f.move(), 1);
+  assert.deepEqual(f.moves(), [[1, 3, 7, 0]]);
+});
 
-  state("page").value = 14;
-  view.setUint32(inventory + 6 * 4, materialBag, true);
-  view.setUint32(materialBag + 4, 6, true);
-  view.setUint32(item + 16, 1_000, true);
-  view.setUint32(item + 20, 1, true);
-  view.setUint32(1_000, 0x2508_2800, true);
-  state("claimAllowed").value = 0;
-  assert.equal(execute(itemId, 9, 1), 1);
-  assert.equal(state("uiQuantity").value, 6);
-  assert.equal(state("uiBag").value, 40, "Zaishen coin material slots are valid");
-  assert.equal(state("uiSlot").value, 0);
+test('rapid clicks reserve quantities, share pending stacks and do not repeat a source', async () => {
+  const f = await storageFixture();
+  f.item(1, 10, 1); f.item(2, 10, 1); f.item(3, 245, 8); f.bag(8, [3, 0]);
+  assert.equal(f.move(1, 10), 1);
+  assert.equal(f.move(1, 10), 0);
+  assert.equal(f.move(2, 10), 1);
+  assert.deepEqual(f.moves(), [[1, 5, 7, 0], [1, 5, 7, 1], [2, 10, 7, 1]]);
+  // Acknowledged destination quantities do not get counted twice.
+  f.item(4, 3, 1); f.item(5, 15, 8); f.bag(8, [3, 5]);
+  assert.equal(f.move(4, 3), 1);
+  assert.deepEqual(f.moves().at(-1), [4, 3, 7, 1]);
+});
 
-  state("page").value = 0;
-  state("claimAllowed").value = 1;
-  view.setUint32(sourceBag, 4, true);
-  view.setUint32(inventory + 4, backpack, true);
-  view.setUint32(backpack + 4, 1, true);
-  view.setUint32(backpack + 24, slots, true);
-  view.setUint32(backpack + 32, 2, true);
-  assert.equal(execute(itemId, 9, 2), 1);
-  assert.equal(state("claimBag").value, 1);
-  assert.equal(state("claimSlot").value, 0);
+test('pending destinations cannot accept different items or nonstackable items', async () => {
+  for (const stackable of [true, false]) {
+    const f = await storageFixture();
+    f.item(1, 1, 1, { stackable }); f.item(2, 1, 1, { stackable, name: 'other item' }); f.bag(8, [0]);
+    assert.equal(f.move(1, 1), 1);
+    assert.equal(f.move(2, 1), 0);
+    assert.deepEqual(f.moves(), [[1, 1, 7, 0]]);
+    f.setModifiers(0); f.setModifiers(1);
+    assert.equal(f.move(2, 1), 0, 'modifier release cannot acknowledge a pending move');
+    f.state('clock').value = 3_000;
+    assert.equal(f.move(2, 1), 1, 'a rejected move becomes retryable after the timeout');
+  }
+});
 
-  state("claimAllowed").value = 0;
-  assert.equal(execute(itemId, 9, 2), 0, "an in-flight destination is not reused");
+test('invalid quantities, directions, storage pages and closed storage do not move', async () => {
+  const f = await storageFixture(); f.bag(8, [0]);
+  assert.equal(f.move(1, 0), 0); assert.equal(f.move(1, 4), 0);
+  assert.equal(f.execute(1, 3, 0), 0); assert.equal(f.execute(1, 3, 2), 0);
+  f.state('page').value = 15; assert.equal(f.move(), 0);
+  f.state('page').value = 0; f.state('storageFrame').value = 0;
+  assert.equal(f.move(), 0); assert.deepEqual(f.moves(), []);
+});
+
+test('Control-Shift prompts at the source before choosing destinations', async () => {
+  const f = await storageFixture(); f.bag(8, [0, 2]); f.item(2, 18, 8);
+  f.setModifiers(3); assert.equal(f.move(), 1);
+  assert.equal(f.state('uiMessage').value, 0x1000_01af);
+  assert.equal(f.state('uiItem').value, 1);
+  assert.equal(f.state('uiQuantity').value, 0); // Source bag index.
+  assert.equal(f.state('uiBag').value, 0); // Source slot.
+  assert.equal(f.state('uiSlot').value, 1); // Native prompt flag.
+  assert.deepEqual(f.moves(), []);
+});
+
+test('material storage uses the fixed slot and explicit quantity', async () => {
+  const f = await storageFixture(); f.bag(6, Array.from({ length: 42 }, () => 0)); f.state('page').value = 14;
+  const item = f.item(1, 3, 1);
+  f.u32(item + 16, 30_000); f.u32(item + 20, 1); f.u32(30_000, 0x2508_2800);
+  assert.equal(f.move(), 1);
+  assert.deepEqual(f.moves(), [[1, 3, 5, 40]]);
+});
+
+test('acknowledged stack moves remain usable after the source item disappears', async () => {
+  const f = await storageFixture(); f.bag(8, [0]);
+  assert.equal(f.move(), 1);
+  f.u32(12_000 + 4, 0); // Server removed the original source id.
+  f.item(3, 3, 8); f.bag(8, [3]); f.item(2, 3, 1);
+  assert.equal(f.move(2), 1);
+  assert.deepEqual(f.moves(), [[1, 3, 7, 0], [2, 3, 7, 0]]);
+});
+
+test('deposits do not spill into another storage pane', async () => {
+  const f = await storageFixture(); f.bag(8, [2]); f.item(2, 250, 8); f.bag(9, [0]);
+  assert.equal(f.move(), 0);
+  assert.deepEqual(f.moves(), []);
+});
+
+test('malformed item identity cannot select an occupied slot', async () => {
+  for (const namePointer of [0, 65_535]) {
+    const f = await storageFixture(); f.bag(8, [2]);
+    const target = f.item(2, 18, 8); f.u32(target + 0x34, namePointer);
+    assert.equal(f.move(), 0);
+    assert.deepEqual(f.moves(), []);
+  }
+});
+
+test('changed native move or clock bodies refuse Quick Item Move certification', () => {
+  const build = ENHANCEMENT_BUILDS[0]!;
+  const certificate = build.quickItemMove!;
+  const entries = [certificate.inventorySlot, certificate.materialStorageSlot,
+    certificate.numberPreference, certificate.moveItem, certificate.timer];
+  for (const changed of [certificate.moveItem, certificate.timer]) {
+    assert.throws(() => resolveQuickItemMoveTransform({
+      build, enabled: true,
+      resolveFunction: (_label, functionIndex) => ({ localIndex: functionIndex, typeIndex: 0 }),
+      bodyHash: (functionIndex) => functionIndex === changed.functionIndex
+        ? 'changed' : entries.find((entry) => entry.functionIndex === functionIndex)!.bodySha256,
+      fail: (message) => { throw new Error(message); },
+    }), /body does not match/);
+  }
+});
+
+test('a full reservation buffer stops safely instead of issuing untracked moves', async () => {
+  const f = await storageFixture(2);
+  f.item(1, 16_001, 8); f.bag(1, Array.from({ length: 64 }, () => 0)); f.bag(2, [0]);
+  assert.equal(f.move(1, 16_001), 1);
+  assert.equal(f.moves().length, 64);
+  assert.equal(f.moves().reduce((total, move) => total + move[1]!, 0), 16_000);
+});
+
+test('confirmed quantities use the shared stack-first path exactly once', async () => {
+  const f = await storageFixture(); f.item(1, 20, 1); f.item(2, 245, 8); f.bag(8, [2, 0]);
+  f.setModifiers(3); f.move(1, 20); f.setModifiers(0);
+  f.confirm(1, 10, 0, 0);
+  assert.equal(f.state('pending').value, -20); assert.deepEqual(f.moves(), []);
+  f.drain(); f.drain();
+  assert.deepEqual(f.moves(), [[1, 5, 7, 0], [1, 5, 7, 1]]);
+});
+
+test('cancelled prompts and unrelated native moves are never rerouted', async () => {
+  const f = await storageFixture(); f.bag(8, [0]);
+  f.setModifiers(3); f.move();
+  f.confirm(1, 1, 7, 0); // An unrelated move goes to its actual destination.
+  assert.equal(f.state('pending').value, 0);
+  f.ui(0x1000_01af, 32_000, 0); // A new native move cancels old prompt ownership.
+  f.confirm(1, 2, 0, 0); f.drain();
+  assert.deepEqual(f.moves(), [[1, 1, 7, 0], [1, 2, 0, 0]]);
+});
+
+test('quantity confirmation refuses busy, disabled, changed-source and closed-storage states', async () => {
+  for (const condition of ['busy', 'disabled', 'changed', 'closed', 'too-many', 'zero']) {
+    const f = await storageFixture(); f.bag(8, [0]); f.setModifiers(3); f.move();
+    if (condition === 'busy') f.state('pending').value = 99;
+    if (condition === 'disabled') f.configure(0, 32_000);
+    if (condition === 'changed') f.item(1, 3, 8);
+    if (condition === 'closed') f.state('storageFrame').value = 0;
+    f.confirm(1, condition === 'too-many' ? 4 : condition === 'zero' ? 0 : 2, 0, 0);
+    f.drain();
+    // Disabling relinquishes the native prompt; its same-source action is left to the game.
+    assert.deepEqual(f.moves(), condition === 'disabled' ? [[1, 2, 0, 0]] : [], condition);
+  }
+});
+
+test('source and destination acknowledgements may arrive in either order', async () => {
+  for (const first of ['source', 'destination']) {
+    const f = await storageFixture(); f.bag(8, [2]); f.item(2, 18, 8); f.move();
+    if (first === 'source') f.u32(12_000 + 4, 0);
+    else f.item(2, 21, 8);
+    if (first === 'destination') assert.equal(f.move(), 0, 'source still has an unacknowledged move');
+    else { f.item(3, 3, 1); assert.equal(f.move(3), 0, 'missing source alone cannot free a claim'); }
+    f.u32(12_000 + 4, 0); f.item(2, 21, 8); f.item(3, 3, 1);
+    assert.equal(f.move(3), 1);
+    assert.deepEqual(f.moves().at(-1), [3, 3, 7, 0]);
+  }
+});
+
+test('acknowledged claims are recycled while Control stays held', async () => {
+  const f = await storageFixture(); f.bag(8, [2]); f.item(2, 18, 8);
+  for (let index = 0; index < 80; index += 1) {
+    const id = index % 2 === 0 ? 1 : 3;
+    f.item(id, 1, 1); assert.equal(f.move(id, 1), 1);
+    f.u32(12_000 + id * 4, 0); f.item(2, 19 + index, 8);
+  }
+  assert.equal(f.moves().length, 80);
+});
+
+test('whole-stack moves preserving the item id can be reversed after acknowledgement', async () => {
+  const f = await storageFixture(); f.bag(8, [0]); f.move();
+  f.item(1, 3, 8); f.bag(8, [1]); f.bag(1, [0]);
+  assert.equal(f.execute(1, 3, 2), 1);
+  assert.deepEqual(f.moves(), [[1, 3, 7, 0], [1, 3, 0, 0]]);
+});
+
+test('retry timeout survives key release and unsigned clock wrap', async () => {
+  const f = await storageFixture(); f.bag(8, [0]);
+  f.state('clock').value = 0xffff_ff00; f.move(); f.setModifiers(0); f.setModifiers(1);
+  f.state('clock').value = (0xffff_ff00 + 2_999) >>> 0; assert.equal(f.move(), 0);
+  f.state('clock').value = (0xffff_ff00 + 3_000) >>> 0; assert.equal(f.move(), 1);
+});
+
+test('the last storage tab also reclaims acknowledged moves', async () => {
+  const f = await storageFixture(); f.state('page').value = 13; f.bag(21, [2]); f.item(2, 18, 21);
+  f.move(); f.u32(12_000 + 4, 0); f.item(2, 21, 21); f.item(3, 3, 1);
+  assert.equal(f.move(3), 1); assert.deepEqual(f.moves().at(-1), [3, 3, 20, 0]);
+});
+
+test('unsupported presents and malformed memory fail without native moves or traps', async () => {
+  for (const condition of ['present', 'source-bag', 'destination-bag', 'slots', 'count', 'scratch']) {
+    const f = await storageFixture(); const bag = f.bag(8, [0]); const item = f.item(1, 3, 1);
+    if (condition === 'present') f.u32(item + 0x1c, 0x2f301);
+    if (condition === 'source-bag') f.u32(item + 12, 65_520);
+    if (condition === 'destination-bag') f.u32(1_024 + 8 * 4, 65_520);
+    if (condition === 'slots') f.u32(bag + 24, 0);
+    if (condition === 'count') f.u32(bag + 32, 0xffff_ffff);
+    if (condition === 'scratch') f.configure(1, 65_520);
+    assert.equal(f.move(), 0, condition); assert.deepEqual(f.moves(), []);
+  }
+});
+
+test('material transfers respect upgrades, remaining capacity and the selected quantity', async () => {
+  for (const upgrades of [0, 3, 9]) {
+    const f = await storageFixture(); f.state('page').value = 14;
+    const slots = Array.from({ length: 42 }, () => 0); slots[41] = 2; f.bag(6, slots);
+    const limit = (upgrades + 1) * 250;
+    f.item(2, limit - 5, 6); const source = f.item(1, 20, 1);
+    f.u32(source + 16, 30_000); f.u32(source + 20, 1); f.u32(30_000, 0x2508_2900);
+    f.u32(256 + 0x28, 28_000); f.u32(28_000, 28_100); f.u32(28_000 + 8, 1);
+    f.u32(28_100, 0x83); f.u32(28_104, upgrades);
+    f.setModifiers(3); f.move(1, 20); f.confirm(1, 3, 0, 0); f.drain();
+    assert.deepEqual(f.moves(), [[1, 3, 5, 41]]);
+    f.item(3, 20, 1); f.u32(2_048 + 3 * 128 + 16, 30_000); f.u32(2_048 + 3 * 128 + 20, 1);
+    f.setModifiers(1); f.move(3, 20);
+    assert.deepEqual(f.moves().at(-1), [3, 2, 5, 41]);
+  }
+});
+
+test('capacity accounting conserves quantities across empty, partial and full stacks', async () => {
+  for (const quantity of [1, 3, 249, 250, 251, 600]) {
+    for (const stacks of [[0], [18], [249, 249], [250, 250], [18, 0, 249, 0]]) {
+      const f = await storageFixture(2); f.item(1, quantity, 8);
+      f.bag(1, stacks.map((count, index) => count ? index + 2 : 0));
+      stacks.forEach((count, index) => { if (count) f.item(index + 2, count, 1); });
+      f.move(1, quantity);
+      const moved = f.moves().reduce((total, move) => total + move[1]!, 0);
+      assert.equal(moved, Math.min(quantity, stacks.reduce((total, count) => total + 250 - count, 0)));
+      for (const move of f.moves()) assert.ok(stacks[move[3]!]! + move[1]! <= 250);
+    }
+  }
+});
+
+test('a chosen partial amount does not reserve the unselected source remainder', async () => {
+  const f = await storageFixture(); f.item(1, 20, 1); f.bag(8, [2, 0]); f.item(2, 245, 8);
+  f.setModifiers(3); f.move(1, 20); f.confirm(1, 5, 0, 0); f.drain();
+  f.item(1, 15, 1); f.item(2, 250, 8); f.setModifiers(1);
+  assert.equal(f.move(1, 15), 1);
+  assert.deepEqual(f.moves(), [[1, 5, 7, 0], [1, 15, 7, 1]]);
+});
+
+test('a withdrawal cannot repeat when only its destination has updated', async () => {
+  const f = await storageFixture(2); f.bag(8, [0, 0, 0, 0, 0, 1]);
+  f.view.setUint8(2_048 + 128 + 80, 5); f.bag(1, [2]); f.item(2, 18, 1);
+  f.move(); f.item(2, 21, 1);
+  assert.equal(f.move(), 0);
+  assert.deepEqual(f.moves(), [[1, 3, 0, 0]]);
 });


### PR DESCRIPTION
Quick Item Move currently puts items into empty cells even when a matching stack exists. This makes storage needlessly fragmented. Transfers now fill compatible stacks first, following GWToolbox's stack matching and quantity-selection behavior.

Deposits stay in the visible storage pane. Withdrawals search all four inventory bags for matching stacks before using empty cells. Any quantity that does not fit stays at the source. Control-Shift-click applies the selected amount through the same path, including upgraded material storage.

Pending moves reserve source quantities and destination capacity until both inventory endpoints update, with Toolbox's three-second retry timeout. Releasing Control does not clear those claims. Birthday presents retain Toolbox's exclusion.

## Invariant

Native moves remain behind exact client certification and the existing deferred game-thread boundary. Unsupported client changes disable Quick Item Move. Inventory remains the source of truth; temporary claims only prevent overlapping requests.

## Verification

- 33 focused generated-WebAssembly tests, including a 30-case quantity/capacity matrix.
- Coverage for full bags, overflow, incompatible stacks, delayed updates in either order, rapid clicks, quantity prompts, material upgrades, malformed memory, and certification refusal.
- `pnpm check` and `pnpm build`, repeated after rebasing onto current `main`.
- Real installed-client Quick Item Move certification and WebAssembly validation.
- All six derived runtime profiles validated and their output hashes regenerated.

## Rollout risk

This changes a native client transform and input handling. Recommend a Developer Build for live transfer, quantity-prompt, and upgraded material-storage QA, with Beta consideration before release. Live gameplay QA has not been performed for this change.

Implemented and reviewed with GPT-6 in the Codex desktop harness, using the local GWToolbox and GWCA sources as behavioral references.
