### PR TITLE
fix(cartography): open Compass range settings only on click

### DIFF
--- a/docs/cartography.md
+++ b/docs/cartography.md
@@ -120,10 +120,10 @@ green continent tint. It works before the map window is opened.
 
 Compass ranges also work without opening the Mission Map. Their radii are
 1012, 1248, 2512, and 3500 Guild Wars units, projected from the certified
-5000-unit Compass edge. The separate circular control beside the Compass
-toggles all ranges when clicked. Hover it to choose individual ranges and
-preview each ring's opacity. Turning the master off preserves those choices.
-Settings → Maps provides the same durable visibility and opacity controls.
+5000-unit Compass edge. Click the separate circular control beside the Compass
+to open its menu. Use the menu to show or hide all ranges, choose individual
+ranges, and preview each ring's opacity. Turning the master off preserves those
+choices. Settings → Maps provides the same durable controls.
 
 The Cartography and Compass-range controls form one centred stack. A lone
 available control remains centred by itself. Both menus use the same size,

--- a/src/renderer/cartography-spike/compass-range-controls.ts
+++ b/src/renderer/cartography-spike/compass-range-controls.ts
@@ -24,7 +24,6 @@ import {
 } from "./compass-range-layer.js";
 import type { ScreenBox } from "./frame-placement.js";
 
-const COLLAPSE_DELAY_MS = 600;
 const PANEL_WIDTH = 220;
 const PANEL_HEIGHT_ESTIMATE = 290;
 
@@ -85,7 +84,7 @@ export function createCompassRangeControls(options: Readonly<{
   const trigger = document.createElement("button");
   trigger.type = "button";
   trigger.className = "compass-range-control-trigger";
-  trigger.setAttribute("aria-label", "Toggle Compass ranges");
+  trigger.setAttribute("aria-label", "Compass range settings");
   trigger.setAttribute("aria-controls", "compass-range-control-panel");
   trigger.setAttribute("aria-expanded", "false");
   trigger.title = "Compass ranges";
@@ -158,14 +157,12 @@ export function createCompassRangeControls(options: Readonly<{
   let saving = false;
   let disposed = false;
   let open = false;
-  let collapseTimer = 0;
   let latestBox: ScreenBox | null = null;
   let latestPlacement: CompassControlPlacement = { index: 0, count: 1 };
   let renderedSettings: AppSettings | null = null;
   let panelHeight = PANEL_HEIGHT_ESTIMATE;
 
   const syncDisabled = (): void => {
-    trigger.disabled = saving;
     allButton.disabled = saving;
     for (const button of themeButtons.values()) button.disabled = saving;
     for (const { button, input } of rangeControls.values()) {
@@ -179,7 +176,6 @@ export function createCompassRangeControls(options: Readonly<{
     if (settings === null || (!force && renderedSettings === settings)) return;
     renderedSettings = settings;
     const enabled = settings.compassRangeIndicatorsEnabled;
-    trigger.setAttribute("aria-pressed", String(enabled));
     allButton.setAttribute("aria-pressed", String(enabled));
     allButton.textContent = enabled ? "Hide all ranges" : "Show all ranges";
     for (const [theme, button] of themeButtons) {
@@ -238,17 +234,6 @@ export function createCompassRangeControls(options: Readonly<{
     })
     : null;
   observer?.observe(panel);
-  const cancelCollapse = (): void => {
-    if (collapseTimer !== 0) view.clearTimeout(collapseTimer);
-    collapseTimer = 0;
-  };
-  const scheduleCollapse = (): void => {
-    cancelCollapse();
-    collapseTimer = view.setTimeout(() => {
-      collapseTimer = 0;
-      if (!root.matches(":hover") && !root.contains(document.activeElement)) setOpen(false);
-    }, COLLAPSE_DELAY_MS);
-  };
   const apply = (patch: RendererSettingsPatch): void => {
     if (canonical === null || saving) return;
     setSaving(true);
@@ -274,10 +259,13 @@ export function createCompassRangeControls(options: Readonly<{
   for (const type of ["pointerdown", "pointerup", "click", "wheel", "keydown", "keyup"]) {
     root.addEventListener(type, (event) => event.stopPropagation());
   }
-  root.addEventListener("pointerenter", () => { cancelCollapse(); setOpen(true); });
-  root.addEventListener("pointerleave", scheduleCollapse);
-  root.addEventListener("focusin", () => { cancelCollapse(); setOpen(true); });
-  root.addEventListener("focusout", scheduleCollapse);
+  trigger.addEventListener("click", () => setOpen(!open));
+  const outsidePointerDown = (event: Event): void => {
+    if (open && event.target instanceof Node && !root.contains(event.target)) {
+      setOpen(false);
+    }
+  };
+  document.addEventListener("pointerdown", outsidePointerDown);
   const otherControlOpened = (event: Event): void => {
     if (event instanceof CustomEvent && event.detail !== "ranges") setOpen(false);
   };
@@ -288,7 +276,6 @@ export function createCompassRangeControls(options: Readonly<{
     setOpen(false);
     trigger.focus();
   });
-  trigger.addEventListener("click", toggleAll);
   allButton.addEventListener("click", toggleAll);
   for (const [theme, button] of themeButtons) {
     button.addEventListener("click", () => apply({ compassRangeTheme: theme }));
@@ -345,7 +332,6 @@ export function createCompassRangeControls(options: Readonly<{
       if (boxChanged || placementChanged || becameVisible) positionRoot();
     },
     hide() {
-      cancelCollapse();
       setOpen(false);
       root.hidden = true;
       latestBox = null;
@@ -354,9 +340,9 @@ export function createCompassRangeControls(options: Readonly<{
     },
     dispose() {
       disposed = true;
-      cancelCollapse();
       observer?.disconnect();
       view.removeEventListener("resize", viewportResize);
+      document.removeEventListener("pointerdown", outsidePointerDown);
       document.removeEventListener(COMPASS_CONTROL_OPEN_EVENT, otherControlOpened);
       root.remove();
     },

--- a/tests/unit/cartography-overlay-controls.test.ts
+++ b/tests/unit/cartography-overlay-controls.test.ts
@@ -70,6 +70,23 @@ test("Cartography controls open only by click and remain open after pointer move
   assert.match(controls, /if \(open && event\.target instanceof Node/u);
 });
 
+test("Compass range controls open only by click", () => {
+  const controls = readFileSync(
+    "src/renderer/cartography-spike/compass-range-controls.ts",
+    "utf8",
+  );
+  assert.match(
+    controls,
+    /trigger\.addEventListener\("click", \(\) => setOpen\(!open\)\)/u,
+  );
+  assert.doesNotMatch(
+    controls,
+    /pointerenter|pointerleave|focusin|focusout|matches\(":hover"\)|collapseTimer/u,
+  );
+  assert.match(controls, /if \(open && event\.target instanceof Node/u);
+  assert.match(controls, /allButton\.addEventListener\("click", toggleAll\)/u);
+});
+
 test("compact Cartography panel keeps guidance progressively disclosed", () => {
   const controls = readFileSync(
     "src/renderer/cartography-spike/overlay-controls.ts",


### PR DESCRIPTION
The Compass range control opened on hover and toggled all ranges when clicked. It now opens and closes its settings menu only on click, matching the adjacent Cartography control.

Applies both supplied patches. The menu stays open after pointer movement and closes on an outside click, Escape, or opening the other control. Show/hide all ranges remains an explicit menu action, and saved range choices remain intact. Removes the obsolete collapse timer and updates the control label, documentation, and regression test.

Verification: all 10 focused control tests and `pnpm run check` passed (type checks, lint, Markdown links, unit and policy tests, Tools and Launcher tests). Live gameplay was not tested. This is a narrow host UI interaction change; recommend a Developer Build check before release inclusion.

Prepared with GPT-6 in Codex.
