### PR TITLE
fix(character-switch): make search available by default

### DIFF
--- a/docs/enhancement-development.md
+++ b/docs/enhancement-development.md
@@ -24,9 +24,11 @@ Current integrated features are:
   character-selection order, opens on the current character, and wraps only
   after navigation reaches a visible end. Its alternative vertical layout is
   alphabetical. Accounts that fit inside the visible carousel are centered and
-  shown in full. Optional bounded name search is off by default; direct 1–9 and
-  0 shortcuts select the first ten characters. The exact companion projection
-  owns the live records. Reload Guild Wars uses Command-Shift-R.
+  shown in full. Bounded name search is shown by default for every account size
+  and can be hidden. Character focus remains primary until typing starts a
+  search. Direct 1–9 and 0 shortcuts select the first ten characters. The exact
+  companion projection owns the live records. Reload Guild Wars uses
+  Command-Shift-R.
 
 - **Build Library** (Beta): host-owned build and team authoring. Command-B
   opens it when both Tools Beta and Build Library are enabled, and its Apply

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -114,8 +114,8 @@ Character Switch has its own switch, shortcut, and display settings here.
 It is a Core feature and does not require **Enable Tools**.
 The in-game Character Switch settings also select a horizontal or vertical
 layout. Horizontal is the default and follows the character-selection order.
-Search can be enabled there and is off by default. The layout and search choices
-last for the current app session.
+The search bar is shown by default and can be hidden there. The layout and search
+choices last for the current app session.
 
 Shortcuts use macOS Command combinations such as Command-T. Normal editing and
 application shortcuts such as Command-C, Command-V, Command-Q, and Command-W
@@ -171,10 +171,11 @@ styles. Deleting a custom style requires confirmation.
 ## Switch Character
 
 Press **Command-R** to open **Switch Character** from a playable outpost.
-Search is always available, and the complete live account list stays in
-alphabetical order. Browse every character with the pointer or arrow keys;
-the number keys 1–9 and 0 switch to the first ten characters. Press
-**Command-Shift-R** to reload Guild Wars.
+The search bar is shown for every account size. Initial focus remains on the
+current character. Press Left or Up for the previous character. Press Right or
+Down for the next character. Start typing to move focus to search. The number
+keys 1–9 and 0 switch to the first ten characters. Press **Command-Shift-R** to
+reload Guild Wars.
 
 Character names and search text are not saved.
 

--- a/src/renderer/character-switch-palette.ts
+++ b/src/renderer/character-switch-palette.ts
@@ -140,7 +140,7 @@ export function createCharacterSwitchPalette(
   root.id = "character-switch-root";
   root.className = "ui-modal ui-modal-layer";
   root.setAttribute("aria-labelledby", "character-switch-title");
-  root.innerHTML = `<div class="ui-frame character-switch-panel"><header class="character-switch-head"><h2 id="character-switch-title">Switch Character</h2><span class="character-switch-count" aria-live="polite" aria-atomic="true"></span><button class="ui-button character-switch-head-action character-switch-settings-toggle" type="button" aria-label="Character Switch settings" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.38a2 2 0 0 0-.73-2.73l-.15-.09a2 2 0 0 1-1-1.74v-.51a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2Z"/><circle cx="12" cy="12" r="3"/></svg></button><button class="ui-button character-switch-head-action character-switch-close" type="button" aria-label="Close Switch Character"><svg viewBox="0 0 16 16" aria-hidden="true"><path d="m3 3 10 10M13 3 3 13" /></svg></button></header><div class="character-switch-carousel"><button class="ui-button character-switch-arrow character-switch-previous" type="button" aria-label="Previous character"><svg viewBox="0 0 16 16" aria-hidden="true"><path d="m10.5 2.5-5 5 5 5"/></svg></button><ul id="character-switch-list" class="character-switch-list" aria-label="Characters"></ul><button class="ui-button character-switch-arrow character-switch-next" type="button" aria-label="Next character"><svg viewBox="0 0 16 16" aria-hidden="true"><path d="m5.5 2.5 5 5-5 5"/></svg></button></div><section class="character-switch-settings" aria-label="Character Switch settings" hidden><fieldset class="character-switch-layout-setting"><legend>Layout</legend><div><label class="ui-choice-row"><input type="radio" name="character-switch-layout" value="horizontal"><span><strong>Horizontal</strong><small>Selection-screen order</small></span></label><label class="ui-choice-row"><input type="radio" name="character-switch-layout" value="vertical"><span><strong>Vertical</strong><small>Alphabetical list</small></span></label></div></fieldset><label class="character-switch-setting" for="character-switch-enable-search"><span><strong>Enable search</strong><small>Search characters by name</small></span><input id="character-switch-enable-search" type="checkbox"></label><label class="character-switch-setting" for="character-switch-show-profession"><span><strong>Show profession</strong><small>Icon, primary, and secondary profession</small></span><input id="character-switch-show-profession" type="checkbox"></label><label class="character-switch-setting" for="character-switch-show-level"><span><strong>Show level</strong><small>Character level</small></span><input id="character-switch-show-level" type="checkbox"></label><label class="character-switch-setting" for="character-switch-show-location"><span><strong>Show known location</strong><small>Locations from the reviewed Travel catalogue</small></span><input id="character-switch-show-location" type="checkbox"></label></section><section class="character-switch-confirm" aria-describedby="character-switch-confirm-copy" hidden><p id="character-switch-confirm-copy">Switching characters will leave this explorable area. You may lose progress in this instance.</p><div class="character-switch-confirm-actions"><button type="button" class="ui-button character-switch-stay">Stay here</button><button type="button" class="ui-button character-switch-leave" data-variant="primary">Leave and switch</button></div></section><p class="character-switch-status" role="status" aria-live="polite" aria-atomic="true"></p><details class="character-switch-details"><summary>Technical details</summary><pre></pre><button type="button" class="ui-button character-switch-copy">Copy diagnostics</button></details><footer class="character-switch-footer"><span class="character-switch-hints character-switch-list-hints"></span><span class="character-switch-hints character-switch-settings-hints" hidden><kbd class="ui-kbd">esc</kbd> back</span><span class="character-switch-hints character-switch-confirm-hints" hidden><kbd class="ui-kbd">esc</kbd> back</span></footer></div>`;
+  root.innerHTML = `<div class="ui-frame character-switch-panel"><header class="character-switch-head"><h2 id="character-switch-title">Switch Character</h2><span class="character-switch-count" aria-live="polite" aria-atomic="true"></span><button class="ui-button character-switch-head-action character-switch-settings-toggle" type="button" aria-label="Character Switch settings" aria-pressed="false"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.38a2 2 0 0 0-.73-2.73l-.15-.09a2 2 0 0 1-1-1.74v-.51a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2Z"/><circle cx="12" cy="12" r="3"/></svg></button><button class="ui-button character-switch-head-action character-switch-close" type="button" aria-label="Close Switch Character"><svg viewBox="0 0 16 16" aria-hidden="true"><path d="m3 3 10 10M13 3 3 13" /></svg></button></header><div class="character-switch-carousel"><button class="ui-button character-switch-arrow character-switch-previous" type="button" aria-label="Previous character"><svg viewBox="0 0 16 16" aria-hidden="true"><path d="m10.5 2.5-5 5 5 5"/></svg></button><ul id="character-switch-list" class="character-switch-list" aria-label="Characters"></ul><button class="ui-button character-switch-arrow character-switch-next" type="button" aria-label="Next character"><svg viewBox="0 0 16 16" aria-hidden="true"><path d="m5.5 2.5 5 5-5 5"/></svg></button></div><section class="character-switch-settings" aria-label="Character Switch settings" hidden><fieldset class="character-switch-layout-setting"><legend>Layout</legend><div><label class="ui-choice-row"><input type="radio" name="character-switch-layout" value="horizontal"><span><strong>Horizontal</strong><small>Selection-screen order</small></span></label><label class="ui-choice-row"><input type="radio" name="character-switch-layout" value="vertical"><span><strong>Vertical</strong><small>Alphabetical list</small></span></label></div></fieldset><label class="character-switch-setting" for="character-switch-enable-search"><span><strong>Show search bar</strong><small>Type from a character to search</small></span><input id="character-switch-enable-search" type="checkbox"></label><label class="character-switch-setting" for="character-switch-show-profession"><span><strong>Show profession</strong><small>Icon, primary, and secondary profession</small></span><input id="character-switch-show-profession" type="checkbox"></label><label class="character-switch-setting" for="character-switch-show-level"><span><strong>Show level</strong><small>Character level</small></span><input id="character-switch-show-level" type="checkbox"></label><label class="character-switch-setting" for="character-switch-show-location"><span><strong>Show known location</strong><small>Locations from the reviewed Travel catalogue</small></span><input id="character-switch-show-location" type="checkbox"></label></section><section class="character-switch-confirm" aria-describedby="character-switch-confirm-copy" hidden><p id="character-switch-confirm-copy">Switching characters will leave this explorable area. You may lose progress in this instance.</p><div class="character-switch-confirm-actions"><button type="button" class="ui-button character-switch-stay">Stay here</button><button type="button" class="ui-button character-switch-leave" data-variant="primary">Leave and switch</button></div></section><p class="character-switch-status" role="status" aria-live="polite" aria-atomic="true"></p><details class="character-switch-details"><summary>Technical details</summary><pre></pre><button type="button" class="ui-button character-switch-copy">Copy diagnostics</button></details><footer class="character-switch-footer"><span class="character-switch-hints character-switch-list-hints"></span><span class="character-switch-hints character-switch-settings-hints" hidden><kbd class="ui-kbd">esc</kbd> back</span><span class="character-switch-hints character-switch-confirm-hints" hidden><kbd class="ui-kbd">esc</kbd> back</span></footer></div>`;
   parent.append(root);
   const panel = root.querySelector<HTMLElement>(".character-switch-panel")!;
   const carousel = root.querySelector<HTMLElement>(".character-switch-carousel")!;
@@ -182,7 +182,7 @@ export function createCharacterSwitchPalette(
   let selected = 0;
   let query = "";
   let layout: "horizontal" | "vertical" = "horizontal";
-  let searchEnabled = false;
+  let searchEnabled = true;
   type DisplayPreferences = Readonly<{
     characterSwitchProfession: boolean;
     characterSwitchLevel: boolean;
@@ -409,10 +409,8 @@ export function createCharacterSwitchPalette(
       input.disabled = preferencePending;
     }
     for (const input of layoutInputs) input.checked = input.value === layout;
-    const searchHint = searchEnabled ? ' <kbd class="ui-kbd">↑</kbd> search' : "";
-    listHints.innerHTML = `${horizontal
-      ? '<kbd class="ui-kbd">←→</kbd>'
-      : '<kbd class="ui-kbd">↑↓</kbd>'} choose${searchHint} <kbd class="ui-kbd">return</kbd> switch <kbd class="ui-kbd">esc</kbd> close`;
+    const searchHint = searchEnabled ? ' <kbd class="ui-kbd">type</kbd> search' : "";
+    listHints.innerHTML = `<kbd class="ui-kbd">←↑</kbd> <kbd class="ui-kbd">→↓</kbd> choose${searchHint} <kbd class="ui-kbd">return</kbd> switch <kbd class="ui-kbd">esc</kbd> close`;
     queryInput.setAttribute("aria-expanded", String(searching && rows.length > 0));
     if (searching) queryInput.setAttribute("aria-controls", "character-switch-list");
     else queryInput.removeAttribute("aria-controls");
@@ -540,18 +538,11 @@ export function createCharacterSwitchPalette(
     const button = (event.target as Element).closest<HTMLButtonElement>("button[data-row]");
     if (!button || view.kind !== "characters") return;
     selected = Number(button.dataset.row);
-    const horizontal = root.dataset.layout === "horizontal";
-    const horizontalMove = horizontal
-      && (event.key === "ArrowLeft" || event.key === "ArrowRight");
-    const verticalMove = !horizontal
-      && (event.key === "ArrowUp" || event.key === "ArrowDown");
-    if (horizontalMove || verticalMove) {
+    const arrowMove = event.key === "ArrowLeft" || event.key === "ArrowRight"
+      || event.key === "ArrowUp" || event.key === "ArrowDown";
+    if (arrowMove) {
       event.preventDefault();
       event.stopPropagation();
-      if (!horizontal && searchEnabled && event.key === "ArrowUp" && selected === 0) {
-        queryInput.focus({ preventScroll: true });
-        return;
-      }
       const backwards = event.key === "ArrowLeft" || event.key === "ArrowUp";
       selected = moveCharacterSelection(selected, rows.length, backwards ? -1 : 1);
       render(false);
@@ -559,13 +550,9 @@ export function createCharacterSwitchPalette(
       revealSelected();
       return;
     }
-    if (horizontal && searchEnabled && event.key === "ArrowUp") {
-      event.preventDefault();
-      event.stopPropagation();
-      queryInput.focus({ preventScroll: true });
-      return;
-    }
-    if (horizontal && searchEnabled && event.key.length === 1
+    if (normaliseCharacterQuery(query) === ""
+      && numberedCharacterPosition(event.key, Math.min(rows.length, 10)) !== null) return;
+    if (searchEnabled && event.key.length === 1
       && !event.metaKey && !event.ctrlKey && !event.altKey) {
       event.preventDefault();
       event.stopPropagation();

--- a/tests/electron/input-character-switch.spec.ts
+++ b/tests/electron/input-character-switch.spec.ts
@@ -88,7 +88,7 @@ test("a 27-character account uses the horizontal carousel or vertical list", asy
     const search = page.getByRole("combobox", { name: "Search characters" });
     const list = dialog.locator("#character-switch-list");
     await expect(dialog).toBeVisible();
-    await expect(search).toBeHidden();
+    await expect(search).toBeVisible();
     const selected = list.locator(".character-switch-row[data-selected=true]");
     await expect(selected).toContainText("Character 01");
     await expect.poll(() => isDomActiveElement(selected)).toBe(true);
@@ -96,6 +96,7 @@ test("a 27-character account uses the horizontal carousel or vertical list", asy
     const edgeSlotCount = Math.floor(carouselCapacity / 2);
     await expect(list.locator(".character-switch-slot")).toHaveCount(edgeSlotCount);
     await page.evaluate(() => window.dispatchEvent(new Event("test-character-five")));
+    await expect(search).toBeVisible();
     const fiveCharacterCount = carouselCapacity >= 5 ? 5 : Math.ceil(carouselCapacity / 2);
     await expect(list.getByRole("option")).toHaveCount(fiveCharacterCount);
     await expect(list.locator(".character-switch-slot")).toHaveCount(
@@ -125,30 +126,35 @@ test("a 27-character account uses the horizontal carousel or vertical list", asy
     await page.keyboard.press("ArrowLeft");
     await expect(selected).toContainText("Character 01");
     await page.keyboard.press("ArrowUp");
+    await expect(selected).toContainText("Rudolph Prime");
+    await page.keyboard.press("ArrowDown");
+    await expect(selected).toContainText("Character 01");
+    await expect.poll(() => isDomActiveElement(selected)).toBe(true);
+    await page.keyboard.type("u");
+    await expect.poll(() => isDomActiveElement(search)).toBe(true);
+    await expect(search).toHaveValue("u");
+    await expect(list.getByRole("option")).toHaveCount(1);
+    await expect(selected).toContainText("Rudolph Prime");
+    await search.press("Escape");
+    await search.press("ArrowDown");
     await expect.poll(() => isDomActiveElement(selected)).toBe(true);
 
     await dialog.getByRole("button", { name: "Character Switch settings" }).click();
     const horizontalLayout = dialog.getByRole("radio", { name: /Horizontal/u });
     const verticalLayout = dialog.getByRole("radio", { name: /Vertical/u });
-    const searchSetting = dialog.getByRole("checkbox", { name: /Enable search/u });
+    const searchSetting = dialog.getByRole("checkbox", { name: /Show search bar/u });
     await expect(horizontalLayout).toBeChecked();
-    await expect(searchSetting).not.toBeChecked();
-    await searchSetting.check();
+    await expect(searchSetting).toBeChecked();
+    await searchSetting.uncheck();
     await page.keyboard.press("Escape");
-    await expect(search).toBeVisible();
-    await page.keyboard.press("ArrowUp");
-    await expect.poll(() => isDomActiveElement(search)).toBe(true);
-    await search.press("ArrowDown");
+    await expect(search).toBeHidden();
     await expect.poll(() => isDomActiveElement(selected)).toBe(true);
-    await page.keyboard.type("u");
-    await expect(search).toHaveValue("u");
-    await expect(list.getByRole("option")).toHaveCount(1);
-    await expect(selected).toContainText("Rudolph Prime");
-    await search.press("Escape");
 
     await dialog.getByRole("button", { name: "Character Switch settings" }).click();
+    await searchSetting.check();
     await verticalLayout.check();
     await page.keyboard.press("Escape");
+    await expect(search).toBeVisible();
     await expect(dialog).toHaveAttribute("data-layout", "vertical");
     await expect(list.getByRole("button")).toHaveCount(27);
     await expect(list.locator("img")).toHaveCount(27);
@@ -164,6 +170,12 @@ test("a 27-character account uses the horizontal carousel or vertical list", asy
     await expect(list.getByRole("button").first()).toHaveAccessibleName(
       /Level 20, Lion's Arch/u,
     );
+    await page.keyboard.type("u");
+    await expect.poll(() => isDomActiveElement(search)).toBe(true);
+    await expect(search).toHaveValue("u");
+    await expect(list.getByRole("option")).toHaveCount(1);
+    await search.press("Escape");
+    await search.press("ArrowDown");
     const focusedRow = list.getByRole("button").nth(1);
     await focusedRow.focus();
     const focusedName = await focusedRow.getAttribute("aria-label");
@@ -245,7 +257,7 @@ test("a 27-character account uses the horizontal carousel or vertical list", asy
     ));
     await expect(selected).toContainText("Character 01");
     await expect.poll(() => isDomActiveElement(selected)).toBe(true);
-    await search.press("0");
+    await selected.press("0");
     await expect(page.locator("body")).toHaveAttribute("data-character-switch-request", "9");
     await expect(dialog).toBeHidden();
     await page.evaluate(() => window.dispatchEvent(
@@ -337,7 +349,7 @@ test("the modal confirms PvE departure, blocks click-through, and retains post-l
       new CustomEvent("gw:character-toggle", { cancelable: true }),
     ));
     await expect(dialog).toBeVisible();
-    await expect(search).toBeHidden();
+    await expect(search).toBeVisible();
     await expect.poll(() => isDomActiveElement(
       dialog.getByRole("option", { name: /Private Alpha/u }),
     )).toBe(true);


### PR DESCRIPTION
Character Switch hid name search by default and used different arrow-key behavior in each layout. Search is now visible for every account size, while initial focus stays on the current character. Left/Up selects the previous character, Right/Down selects the next, and typing starts a search in either layout.

Players can hide the search bar in settings. Number shortcuts still switch to the first ten characters from the focused row instead of starting a search. Search text and layout preferences retain their existing session-only lifetime. Documentation and Electron coverage describe the new behavior.

Verification:
- `pnpm run check` passed.
- `pnpm build` passed.
- Both tests in `tests/electron/input-character-switch.spec.ts` passed, including focus, search, navigation, number shortcuts, and confirmation behavior.
- Matthias tested the dev build in-game and confirmed it works.

This is a focused renderer interaction change with no persistence migration. Include it in the normal release process; the live dev test is not signed release QA.

Prepared with GPT-6 in Codex.
