### PR TITLE
fix(effects): hide long placeholder timers

### DIFF
--- a/docs/effect-timers.md
+++ b/docs/effect-timers.md
@@ -29,6 +29,10 @@ The renderer joins the two complete snapshots only at the presentation edge.
 For repeated records with one skill ID it shows the longest finite remaining
 duration. It does not show a multiplier because reapplication normally refreshes
 an effect instead of stacking it. Indefinite or unknown durations show no number.
+Records with an original duration of 3,600 seconds or more also show no number.
+This hides long placeholders such as Displacement without hiding ordinary
+spirit timers or changing the native icon. The cutoff uses original duration,
+so an old placeholder cannot become a countdown later.
 
 - More than 99 seconds: upward-rounded minutes, such as `2m`.
 - Three through 99 seconds: upward-rounded whole seconds.

--- a/src/renderer/effect-timer-overlay-consumer.ts
+++ b/src/renderer/effect-timer-overlay-consumer.ts
@@ -23,6 +23,8 @@ export function projectEffectTimerLabels(
 
   const longest = new Map<number, number>();
   for (const effect of effects.effects) {
+    // Long native durations can be placeholders, including Displacement.
+    if (effect.durationMs >= 3_600_000) continue;
     const remaining = remainingEffectMs(
       effects.gameTimer,
       effect.appliedAtGameMs,

--- a/tests/unit/companion-effect-snapshot.test.ts
+++ b/tests/unit/companion-effect-snapshot.test.ts
@@ -164,6 +164,26 @@ describe("native effect icon geometry", () => {
     }]);
   });
 
+  it("hides hour-long placeholders by original duration, preserving ordinary timers", () => {
+    const geometry = readCompanionEffectIcons(iconSnapshot(), 0);
+    const canvas = {
+      getBoundingClientRect: () => ({ left: 0, top: 0, width: 800, height: 600 }),
+    } as HTMLCanvasElement;
+    for (const durationMs of [3_600_000, 10_000_000]) {
+      const effects = readCompanionPlayerEffects(effectSnapshot([
+        { ...FINITE, durationMs, appliedAtGameMs: 0 },
+      ]), 0);
+      assert.deepEqual(projectEffectTimerLabels(effects, geometry, canvas), []);
+    }
+    for (const durationMs of [62_000, 3_599_999]) {
+      const effects = readCompanionPlayerEffects(effectSnapshot([
+        { ...FINITE, durationMs, appliedAtGameMs: 5_000 },
+        { ...FINITE, effectId: 10, durationMs: 10_000_000 },
+      ]), 0);
+      assert.equal(projectEffectTimerLabels(effects, geometry, canvas)?.length, 1);
+    }
+  });
+
   it("withdraws labels for indefinite-only and unavailable inputs", () => {
     const geometry = readCompanionEffectIcons(iconSnapshot(), 0);
     const canvas = {


### PR DESCRIPTION
Long placeholder durations were rendered as misleading countdowns, such as Displacement showing 167m. The overlay now omits records whose original duration is 3,600 seconds or more. Ordinary spirit timers remain visible, and native icons and observed records stay unchanged.

Depends on #404. The cutoff uses original duration rather than remaining time, so a placeholder does not become visible later. Focused tests cover the exact boundary, ordinary durations, and duplicate records.

Verification: focused unit tests and the complete stack's `pnpm run check` passed. This layer changes display filtering only; release inclusion follows #404's Developer Build/Beta recommendation.

Prepared with GPT-6 in Codex.
