### PR TITLE
feat(character-switch): search by primary profession

### DIFF
--- a/docs/enhancement-development.md
+++ b/docs/enhancement-development.md
@@ -24,9 +24,11 @@ Current integrated features are:
   character-selection order, opens on the current character, and wraps only
   after navigation reaches a visible end. Its alternative vertical layout is
   alphabetical. Accounts that fit inside the visible carousel are centered and
-  shown in full. Bounded name search is shown by default for every account size
-  and can be hidden. Character focus remains primary until typing starts a
-  search. Direct 1–9 and 0 shortcuts select the first ten characters. The exact
+  shown in full. Bounded name and primary-profession search is shown by default
+  for every account size and can be hidden. Profession search matches a
+  substring of the canonical profession name and does not search the secondary
+  profession. Character focus remains primary until typing starts a search.
+  Direct 1–9 and 0 shortcuts select the first ten characters. The exact
   companion projection owns the live records. Reload Guild Wars uses
   Command-Shift-R.
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -174,9 +174,10 @@ styles. Deleting a custom style requires confirmation.
 Press **Command-R** to open **Switch Character** from a playable outpost.
 The search bar is shown for every account size. Initial focus remains on the
 current character. Press Left or Up for the previous character. Press Right or
-Down for the next character. Start typing to move focus to search. The number
-keys 1–9 and 0 switch to the first ten characters. Press **Command-Shift-R** to
-reload Guild Wars.
+Down for the next character. Start typing a character name or primary profession
+to move focus to search. Secondary professions are not searched. The number keys
+1–9 and 0 switch to the first ten characters. Press **Command-Shift-R** to reload
+Guild Wars.
 
 Character names and search text are not saved.
 

--- a/src/renderer/character-switch-palette.ts
+++ b/src/renderer/character-switch-palette.ts
@@ -79,7 +79,10 @@ export function searchCharacters(
   const terms = term.split(/\s+/u);
   return Object.freeze(rows.filter(({ character }) => {
     const name = normaliseCharacterQuery(character.name);
-    return terms.every((candidate) => name.includes(candidate));
+    const profession = professionPresentation(character.primaryProfession);
+    return terms.every((candidate) => name.includes(candidate))
+      || (profession !== null
+        && normaliseCharacterQuery(profession.name).includes(term));
   }));
 }
 

--- a/tests/electron/input-character-switch.spec.ts
+++ b/tests/electron/input-character-switch.spec.ts
@@ -130,9 +130,9 @@ test("a 27-character account uses the horizontal carousel or vertical list", asy
     await page.keyboard.press("ArrowDown");
     await expect(selected).toContainText("Character 01");
     await expect.poll(() => isDomActiveElement(selected)).toBe(true);
-    await page.keyboard.type("u");
+    await page.keyboard.type("rud");
     await expect.poll(() => isDomActiveElement(search)).toBe(true);
-    await expect(search).toHaveValue("u");
+    await expect(search).toHaveValue("rud");
     await expect(list.getByRole("option")).toHaveCount(1);
     await expect(selected).toContainText("Rudolph Prime");
     await search.press("Escape");
@@ -170,9 +170,9 @@ test("a 27-character account uses the horizontal carousel or vertical list", asy
     await expect(list.getByRole("button").first()).toHaveAccessibleName(
       /Level 20, Lion's Arch/u,
     );
-    await page.keyboard.type("u");
+    await page.keyboard.type("rud");
     await expect.poll(() => isDomActiveElement(search)).toBe(true);
-    await expect(search).toHaveValue("u");
+    await expect(search).toHaveValue("rud");
     await expect(list.getByRole("option")).toHaveCount(1);
     await search.press("Escape");
     await search.press("ArrowDown");

--- a/tests/unit/character-switch-palette.test.ts
+++ b/tests/unit/character-switch-palette.test.ts
@@ -9,12 +9,16 @@ import {
 } from "../../src/renderer/character-switch-palette.js";
 import type { CharacterSummary } from "../../src/renderer/companion-character-list-snapshot.js";
 
-const character = (name: string, primaryProfession = 1): CharacterSummary =>
+const character = (
+  name: string,
+  primaryProfession = 1,
+  secondaryProfession = 0,
+): CharacterSummary =>
   Object.freeze({
     name,
     characterKey: primaryProfession.toString(16).padStart(16, "0"),
     primaryProfession,
-    secondaryProfession: 0,
+    secondaryProfession,
     characterType: "roleplaying",
     campaign: 1,
     level: 20,
@@ -106,5 +110,24 @@ describe("character switch ordering", () => {
       searchCharacters(ordered, "a candy").map(({ character: row }) => row.name),
       ["Á Candy Cane Shard"],
     );
+  });
+
+  it("matches primary profession substrings without searching secondaries", () => {
+    const ordered = orderCharacters(Object.freeze([
+      character("Alpha", 6),
+      character("Helen", 1),
+      character("Gamma", 1, 6),
+      character("Shadow", 7),
+      character("Delta", 1, 7),
+      character("Oracle", 8),
+    ]));
+    const names = (query: string) => searchCharacters(ordered, query)
+      .map(({ character: row }) => row.name);
+
+    assert.deepEqual(names("ele"), ["Alpha", "Helen"]);
+    assert.deepEqual(names("sin"), ["Shadow"]);
+    assert.deepEqual(names("rit"), ["Oracle"]);
+    assert.deepEqual(names("rt"), []);
+    assert.deepEqual(names("alpha ele"), []);
   });
 });


### PR DESCRIPTION
Character Switch can now find a primary profession as well as a character name. Profession matching uses a substring of the canonical profession name: `ele`, `sin`, and `rit` match; secondary professions and abbreviations such as `rt` do not. Existing word-based name search is preserved.

This is the profession-search layer of the stack rooted at #404. Unit tests cover names, primary and secondary professions, and mixed queries. Electron name-search coverage uses an unambiguous name after profession matching expanded the results.

Verification: focused unit tests, Character Switch Electron tests, and the complete stack's `pnpm run check` passed. Interactive exploration in an isolated offline Electron fixture confirmed filtering and keyboard entry. No persistence change.

Prepared with GPT-6 in Codex.
