### PR TITLE
feat(memory): remember the warning position after dragging

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -233,6 +233,11 @@ only the affected profile.
 custom map styles, and panel colors. The confirmation lists affected and kept
 data. It is separate from resetting downloaded game files.
 
+The memory warning can be moved by dragging its heading. Focus the heading and
+use arrow keys to move it with the keyboard; Shift moves one pixel at a time.
+The app remembers its position for later warnings and keeps it inside the window
+when the window size changes.
+
 ## Updates
 
 Automatic application updates are enabled by default. Stable is recommended;

--- a/scripts/verify-stable-beta-roundtrip.ts
+++ b/scripts/verify-stable-beta-roundtrip.ts
@@ -458,6 +458,7 @@ const candidateSettingsDomains = Array.from(
       skillCooldownColor: { kind: "preset", preset: "red" },
       extendedMemoryEnabled: cycle(booleanValues, index + 1),
       autoRelogAfterReload: cycle(booleanValues, index),
+      memoryWarningPosition: null,
       showDiagnostics: cycle(booleanValues, index),
       dataStrategy: "full",
       autoCheckUpdates: false,

--- a/src/main/core/settings.ts
+++ b/src/main/core/settings.ts
@@ -303,6 +303,21 @@ export function parseSettings(raw: unknown): AppSettings {
   ] as const) {
     if (setting in src) out[setting] = asBool(src[setting], setting);
   }
+  if ("memoryWarningPosition" in src) {
+    const position = src.memoryWarningPosition;
+    if (position === null) out.memoryWarningPosition = null;
+    else {
+      if (typeof position !== "object" || Array.isArray(position)
+        || !("x" in position) || !("y" in position)
+        || Object.keys(position).length !== 2
+        || typeof position.x !== "number" || !Number.isFinite(position.x)
+        || typeof position.y !== "number" || !Number.isFinite(position.y)
+        || position.x < 0 || position.x > 1 || position.y < 0 || position.y > 1) {
+        throw new AppError("bad_settings", "settings.memoryWarningPosition must contain x and y between 0 and 1");
+      }
+      out.memoryWarningPosition = { x: position.x, y: position.y };
+    }
+  }
   if ("showDiagnostics" in src) {
     out.showDiagnostics = asBool(src.showDiagnostics, "showDiagnostics");
   }

--- a/src/renderer/harness.css
+++ b/src/renderer/harness.css
@@ -85,6 +85,8 @@ html,body { width:100%; height:100%; margin:0; overflow:hidden;
   align-items: center;
   gap: 16px;
   max-width: min(92vw, 600px);
+  max-height: calc(100vh - 16px);
+  overflow: auto;
   box-sizing: border-box;
   padding: 11px 13px;
   border: 1px solid var(--ui-warning-border);
@@ -226,3 +228,7 @@ html,body { width:100%; height:100%; margin:0; overflow:hidden;
 .osk-input { width:80%; font-size:1.5rem; color:#fff; background:#404040;
              border:2px solid #666; border-radius:4px; outline:none; resize:none; }
 .osk-input:focus { outline:none; border-width:4px; }
+
+#memory-notice-label { cursor: grab; touch-action: none; user-select: none; }
+#memory-notice-label:active { cursor: grabbing; }
+#memory-notice-label:focus-visible { outline: 2px solid currentColor; outline-offset: 3px; }

--- a/src/renderer/harness.ts
+++ b/src/renderer/harness.ts
@@ -437,6 +437,10 @@ function requestHeapCap() {
       heapWarning = bindMemoryWarning(
         document,
         {
+          position: settings.memoryWarningPosition,
+          async savePosition(memoryWarningPosition) {
+            await native().settings.set({ memoryWarningPosition });
+          },
           autoRelogAfterReload: settings.autoRelogAfterReload,
           async saveAutoRelog(autoRelogAfterReload) {
             await native().settings.set({ autoRelogAfterReload });
@@ -457,6 +461,7 @@ function requestHeapCap() {
       disposeMemoryWarningSettings();
       disposeMemoryWarningSettings = native().settings.onChange((updated) => {
         heapWarning?.setAutoRelog(updated.autoRelogAfterReload);
+        heapWarning?.setPosition(updated.memoryWarningPosition);
       });
     })
     // A failed load retries on the next tick rather than silencing the
@@ -663,6 +668,7 @@ addEventListener('beforeunload', () => {
   controllerPrompts = null;
   texturePack?.dispose();
   texturePack = null;
+  heapWarning?.dispose();
   disposeMemoryWarningSettings();
   disposeSettings();
   automaticCharacterReturn?.dispose();

--- a/src/renderer/memory-warning.ts
+++ b/src/renderer/memory-warning.ts
@@ -2,6 +2,7 @@
  * Owns the memory warning's single non-modal DOM surface and session-local
  * dismissal. Heap sampling and escalation remain in heap-pressure.ts.
  */
+import type { AppSettings } from "../shared/contracts.js";
 import { memoryWarningCopy } from "./failure-messages.js";
 
 export type MemoryWarningLevel = "low" | "critical";
@@ -9,10 +10,14 @@ export type MemoryWarningLevel = "low" | "critical";
 export interface MemoryWarningPresenter {
   present(level: MemoryWarningLevel, capBytes: number): void;
   setAutoRelog(enabled: boolean): void;
+  setPosition(position: AppSettings["memoryWarningPosition"]): void;
+  dispose(): void;
   hide(): void;
 }
 
 export type MemoryWarningActions = Readonly<{
+  position: AppSettings["memoryWarningPosition"];
+  savePosition(position: AppSettings["memoryWarningPosition"]): Promise<void>;
   autoRelogAfterReload: boolean;
   saveAutoRelog(enabled: boolean): Promise<void>;
   reload(): void | Promise<void>;
@@ -43,6 +48,83 @@ export function bindMemoryWarning(
   let savedAutoRelog = actions.autoRelogAfterReload;
   let pendingPreferenceSave = Promise.resolve();
   autoRelog.checked = savedAutoRelog;
+
+  const view = document.defaultView;
+  let position = actions.position;
+  let savedPosition = position;
+  let positionSave = Promise.resolve();
+  let drag: { id: number; dx: number; dy: number; before: typeof position } | null = null;
+  const place = () => {
+    if (!view || root.hidden) return;
+    if (position === null) {
+      root.style.left = "";
+      root.style.top = "";
+      root.style.transform = "";
+      return;
+    }
+    const box = root.getBoundingClientRect();
+    root.style.left = `${8 + position.x * Math.max(0, view.innerWidth - box.width - 16)}px`;
+    root.style.top = `${8 + position.y * Math.max(0, view.innerHeight - box.height - 16)}px`;
+    root.style.transform = "none";
+  };
+  const move = (left: number, top: number) => {
+    if (!view) return;
+    const box = root.getBoundingClientRect();
+    position = {
+      x: Math.max(0, Math.min(1, (left - 8) / Math.max(1, view.innerWidth - box.width - 16))),
+      y: Math.max(0, Math.min(1, (top - 8) / Math.max(1, view.innerHeight - box.height - 16))),
+    };
+    place();
+  };
+  const savePosition = () => {
+    const next = position;
+    positionSave = positionSave.then(() => actions.savePosition(next)).then(() => {
+      savedPosition = next;
+    }).catch(() => {
+      if (position === next) { position = savedPosition; place(); }
+      detail.textContent = "Position could not be saved. Move the warning to try again.";
+    });
+  };
+  label.tabIndex = 0;
+  label.setAttribute("role", "button");
+  label.setAttribute("aria-description", "Drag to move the warning, or use arrow keys.");
+  label.addEventListener("pointerdown", (event) => {
+    if (event.button !== 0 || drag !== null) return;
+    event.preventDefault();
+    const box = root.getBoundingClientRect();
+    drag = { id: event.pointerId, dx: event.clientX - box.left, dy: event.clientY - box.top, before: position };
+    label.setPointerCapture(event.pointerId);
+  });
+  label.addEventListener("pointermove", (event) => {
+    if (drag?.id !== event.pointerId) return;
+    move(event.clientX - drag.dx, event.clientY - drag.dy);
+  });
+  label.addEventListener("pointerup", (event) => {
+    if (drag?.id !== event.pointerId) return;
+    drag = null;
+    label.releasePointerCapture(event.pointerId);
+    savePosition();
+  });
+  label.addEventListener("lostpointercapture", () => {
+    if (drag === null) return;
+    position = drag.before;
+    drag = null;
+    place();
+  });
+  label.addEventListener("keydown", (event) => {
+    if (!["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"].includes(event.key)) return;
+    event.preventDefault();
+    const box = root.getBoundingClientRect();
+    const step = event.shiftKey ? 1 : 10;
+    move(box.left + (event.key === "ArrowLeft" ? -step : event.key === "ArrowRight" ? step : 0),
+      box.top + (event.key === "ArrowUp" ? -step : event.key === "ArrowDown" ? step : 0));
+  });
+  label.addEventListener("keyup", (event) => {
+    if (["ArrowLeft", "ArrowRight", "ArrowUp", "ArrowDown"].includes(event.key)) savePosition();
+  });
+  const observer = view && typeof view.ResizeObserver === "function" ? new view.ResizeObserver(place) : null;
+  observer?.observe(root);
+  view?.addEventListener("resize", place);
 
   let currentLevel: MemoryWarningLevel | null = null;
   let dismissedLevel: MemoryWarningLevel | null = null;
@@ -97,11 +179,17 @@ export function bindMemoryWarning(
       live.setAttribute("role", level === "critical" ? "alert" : "status");
       live.setAttribute("aria-live", level === "critical" ? "assertive" : "polite");
       root.hidden = false;
+      place();
     },
     setAutoRelog(enabled) {
       savedAutoRelog = enabled;
       autoRelog.checked = enabled;
     },
+    setPosition(next) {
+      savedPosition = next;
+      if (drag === null) { position = next; place(); }
+    },
+    dispose() { observer?.disconnect(); view?.removeEventListener("resize", place); },
     hide() {
       root.hidden = true;
       details.open = false;

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -466,6 +466,8 @@ export interface AppSettings {
   extendedMemoryEnabled: boolean;
   /** Return toward the current character after an explicit game reload. */
   autoRelogAfterReload: boolean;
+  /** Warning position within the available viewport space; null keeps the default. */
+  memoryWarningPosition: Readonly<{ x: number; y: number }> | null;
   showDiagnostics: boolean;
   /**
    * Rollback-only storage field. Runtime behavior is always `full`; keeping
@@ -513,6 +515,7 @@ export type AppSettingsPatch = Partial<AppSettings>;
  */
 export const RENDERER_WRITABLE_SETTINGS = [
   "autoRelogAfterReload",
+  "memoryWarningPosition",
   "cartographyOverlayEnabled",
   "cartographyGridEnabled",
   "compassRangeIndicatorsEnabled",
@@ -619,6 +622,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   skillCooldownColor: DEFAULT_SKILL_COOLDOWN_COLOR,
   extendedMemoryEnabled: false,
   autoRelogAfterReload: false,
+  memoryWarningPosition: null,
   showDiagnostics: false,
   dataStrategy: "full",
   autoCheckUpdates: true,

--- a/tests/electron/input-keyboard.spec.ts
+++ b/tests/electron/input-keyboard.spec.ts
@@ -172,7 +172,9 @@ test.describe("renderer keyboard input", () => {
         const moduleUrl: string = "gw://app/memory-warning.js";
         const { bindMemoryWarning } = await import(moduleUrl) as MemoryWarningModule;
         const presenter = bindMemoryWarning(document, {
-          autoRelogAfterReload: false,
+          position: null,
+        async savePosition() {},
+        autoRelogAfterReload: false,
           async saveAutoRelog() {},
           reload() {},
         });

--- a/tests/electron/memory-warning-position.spec.ts
+++ b/tests/electron/memory-warning-position.spec.ts
@@ -1,0 +1,65 @@
+/** Verifies warning placement using pointer, keyboard, and durable settings. */
+import { expect, test, type Page } from "@playwright/test";
+import { closeOffline, launchPlayableClient } from "./fixtures.mjs";
+import { startGameInput } from "./input-helpers.js";
+
+type WarningModule = typeof import("../../src/renderer/memory-warning.js");
+
+async function showWarning(page: Page) {
+  await page.evaluate(async () => {
+    document.getElementById("loading")?.classList.add("gone");
+    const old = document.getElementById("memory-notice")!;
+    old.replaceWith(old.cloneNode(true));
+    const url: string = "gw://app/memory-warning.js";
+    const { bindMemoryWarning } = await import(url) as WarningModule;
+    const settings = await window.gwNative.settings.get();
+    const warning = bindMemoryWarning(document, {
+      position: settings.memoryWarningPosition,
+      savePosition: async (memoryWarningPosition) => { await window.gwNative.settings.set({ memoryWarningPosition }); },
+      autoRelogAfterReload: false,
+      async saveAutoRelog() {},
+      reload() {},
+    });
+    warning?.present("critical", 2_147_483_648);
+    document.getElementById("canvas")?.focus();
+  });
+}
+
+test("dragged and keyboard positions survive reload and stay in a smaller viewport", async () => {
+  const fixture = await launchPlayableClient("gw-memory-position-");
+  try {
+    const { page } = fixture;
+    await startGameInput(page);
+    await showWarning(page);
+    const warning = page.locator("#memory-notice");
+    const heading = page.getByRole("button", { name: "Guild Wars is almost out of memory." });
+    const before = (await warning.boundingBox())!;
+    const handle = (await heading.boundingBox())!;
+    await page.mouse.move(handle.x + 20, handle.y + 10);
+    await page.mouse.down();
+    await page.mouse.move(handle.x + 70, handle.y + 150, { steps: 5 });
+    await page.mouse.up();
+    await expect.poll(async () => (await warning.boundingBox())!.y).toBeGreaterThan(before.y + 100);
+    await expect.poll(() => page.evaluate(async () => (await window.gwNative.settings.get()).memoryWarningPosition)).not.toBeNull();
+    await heading.focus();
+    const dragged = (await warning.boundingBox())!;
+    await heading.press("ArrowDown");
+    await expect.poll(async () => (await warning.boundingBox())!.y).toBeCloseTo(dragged.y + 10, 0);
+    const position = await page.evaluate(async () => (await window.gwNative.settings.get()).memoryWarningPosition);
+    await page.reload();
+    await startGameInput(page);
+    await showWarning(page);
+    expect(await page.evaluate(async () => (await window.gwNative.settings.get()).memoryWarningPosition)).toEqual(position);
+    await expect.poll(async () => (await warning.boundingBox())!.y).toBeCloseTo(dragged.y + 10, 0);
+    await page.setViewportSize({ width: 400, height: 300 });
+    await page.locator("#memory-notice-details summary").click();
+    await expect.poll(async () => {
+      const box = (await warning.boundingBox())!;
+      return box.y >= 7 && box.x >= 7 && box.y + box.height <= 293 && box.x + box.width <= 393;
+    }).toBe(true);
+    await page.getByRole("button", { name: "Later" }).click();
+    await expect(warning).toBeHidden();
+  } finally {
+    await closeOffline(fixture);
+  }
+});

--- a/tests/unit/memory-warning.test.ts
+++ b/tests/unit/memory-warning.test.ts
@@ -64,6 +64,8 @@ const warningActions = (
   autoRelogAfterReload = false,
   reload: () => void | Promise<void> = () => {},
 ) => ({
+  position: null,
+  async savePosition() {},
   autoRelogAfterReload,
   async saveAutoRelog() {},
   reload,
@@ -120,6 +122,8 @@ describe("memory warning presenter", () => {
     const presenter = bindMemoryWarning(
       dom.document,
       {
+        position: null,
+        async savePosition() {},
         autoRelogAfterReload: false,
         async saveAutoRelog(enabled) { saved.push(enabled); },
         reload() { reloads += 1; },

--- a/tests/unit/settings.test.ts
+++ b/tests/unit/settings.test.ts
@@ -89,6 +89,7 @@ describe("settings", () => {
       skillCooldownColor: { kind: "preset", preset: "red" },
       extendedMemoryEnabled: false,
       autoRelogAfterReload: false,
+      memoryWarningPosition: null,
       showDiagnostics: false,
       dataStrategy: "full",
       // Automatic app-update checks remain a separate preference from the
@@ -200,6 +201,7 @@ describe("settings", () => {
       skillCooldownColor: { kind: "preset", preset: "red" },
       extendedMemoryEnabled: false,
       autoRelogAfterReload: false,
+      memoryWarningPosition: null,
       showDiagnostics: true,
       dataStrategy: "full",
       autoCheckUpdates: true,
@@ -624,6 +626,7 @@ describe("settings", () => {
       "formatVersion",
       "gwonmacTools",
       "lastUpdateCheckAt",
+      "memoryWarningPosition",
       "quickItemMove",
       "renderScale",
       "resignEnabled",
@@ -760,6 +763,7 @@ describe("settings", () => {
       skillCooldownColor: { kind: "preset", preset: "red" },
       extendedMemoryEnabled: false,
       autoRelogAfterReload: false,
+      memoryWarningPosition: null,
       showDiagnostics: true,
       dataStrategy: "full",
       // Fields that alpha never wrote arrive at their defaults — deliberately
@@ -861,5 +865,19 @@ describe("settings", () => {
     );
     // Refused, not reinterpreted, and not destroyed: the bytes are still there.
     assert.deepEqual(JSON.parse(await readFile(backup, "utf8")), future);
+  });
+});
+
+
+describe("memory warning position", () => {
+  it("stores only bounded viewport ratios", () => {
+    assert.equal(parseSettings({}).memoryWarningPosition, null);
+    assert.deepEqual(parseSettingsPatch({ memoryWarningPosition: { x: 0.25, y: 1 } }), {
+      memoryWarningPosition: { x: 0.25, y: 1 },
+    });
+    for (const value of [{ x: -1, y: 0 }, { x: 0, y: 2 }, { x: NaN, y: 0 },
+      { x: 0, y: Infinity }, { x: 0 }, { x: 0, y: 0, extra: true }, "0,0"]) {
+      assert.throws(() => parseSettingsPatch({ memoryWarningPosition: value }), AppError);
+    }
   });
 });


### PR DESCRIPTION
The memory warning can now be moved out of the way, and later warnings remember the chosen position. Drag its heading or focus the heading and use arrow keys; Shift moves one pixel at a time.

Position is stored in the existing validated settings record as bounded viewport ratios. It stays inside the window after resize or expanding Details. The warning remains non-modal, and its existing reload and automatic-return controls keep their behavior. A failed save restores the last saved position and reports the failure.

Verification: `pnpm run check`, build, and focused Electron tests passed across the stack. Tests cover pointer movement, keyboard movement, settings persistence across reload, and a smaller viewport with Details expanded. Interactive offline exploration confirmed dragging and use of the moved controls. Temporary exploration processes and synthetic profiles were cleaned up.

This adds one optional position preference, defaulting to the existing top placement. No migration is needed; older versions may forget this cosmetic preference. Include persistence behavior in the normal release train's QA.

Prepared with GPT-6 in Codex.
