### PR TITLE
fix(tools): prevent quick item moves from editing locked trades

### DIFF
--- a/docs/enhancement-development.md
+++ b/docs/enhancement-development.md
@@ -123,8 +123,23 @@ Stack matching follows Toolbox's model-file, dye, and encoded-name checks and
 requires stackable items. Name reads are bounded. Control-Shift-click opens one
 native quantity prompt at the source, as in Toolbox. Its selected amount enters
 the same stack-first transfer path at the deferred game-thread boundary. Another
-native move cancels prompt ownership. Unrelated native moves pass through;
-trade behavior is unchanged.
+native move cancels prompt ownership. Unrelated native moves pass through.
+
+Trade edits require the exact initiated state, as in GWCA's Wasm TradeMgr.
+Submitted, accepted, and unknown trade states consume inventory and cart
+shortcuts without adding, removing, or depositing items. Partner offers never
+move. Storage withdrawals remain available while an offer is locked.
+The deferred command retains its action and target cart in its existing
+mailbox. Execution rechecks the source, trade state, and cart. A changed route
+or cart cancels the click instead of selecting another destination. Selecting
+Change Offer permits new clicks; rejected clicks are never replayed.
+
+The trade tests execute the generated slot wrapper, handler, and drain together.
+They distinguish storage and trade frames, check refusal without native
+fallthrough, and exercise offer/window changes between capture and execution.
+The real-client artifact test validates certification separately. Before release,
+confirm submitted-offer clicks and Change Offer recovery in a developer build,
+with storage open and closed. Automated fixtures do not establish live gameplay.
 
 The renderer sends two modifier bits and owns the scratch region defined by
 [the shared contract](../src/shared/quick-item-move-contract.ts). Its 64 temporary

--- a/src/main/certification/enhancement-builds.ts
+++ b/src/main/certification/enhancement-builds.ts
@@ -36,17 +36,17 @@ export const ENHANCEMENT_BUILDS: readonly KnownEnhancementBuild[] =
       // ENHANCEMENT_TRANSFORM_ABI or any config word changes.
       outputSha256: Object.freeze({
         "features-601":
-          "06e7e534f680cc1ec2c049229b1a7c5e0c8379a46b68ebd8269b972484a22424",
+          "01fbd2857f9df5456237f1182c898d2edc541e438018d08b6fd85edc1223da99",
         "features-e01":
-          "771c917b5bd59b9d96ae404dac7a8156c3c8b97ffff3914c323f13e4672aa4f6",
+          "134becd3f6dab64df1b7db6a19a008981fc8f1bf4d187e2a27571e892e8c302c",
         "features-fff":
-          "421914a8add1c9cd6d88f0124d943a296260bb9e459700d11ab71a9cfc40ae2a",
+          "8de1f98f1bab9478f757908a8f9139937555aa704a387a8f8a09d537cff5604d",
         "features-1fff":
-          "5aa56c8aadeaddf490948811558cb70fd4528d54109de20167794c75ca50b301",
+          "ba0d15ac088c13ab97d1b8675e685bc87c5698e6461372c3933f72c710ed6ea3",
         "features-2fff":
-          "f4570ddbd87c876ac6fecbadd5db957108689922efa9077b6c06bac3aab5a350",
+          "24d891930002b81435c9faae86dc84ecc54c2b33036b1be1bb00065c71bab836",
         "features-3fff":
-          "6d843b14c4b468452e7277b9f00a1a2defeaece3a6596d066de331a53b9da0a9",
+          "fd88cc4f63af870026e3e12399b602dc79a8a7ab97f399cdb1151f58c446a605",
       }),
       programId: 1,
       // The verifier derives this bounded identity from the exact module; it is

--- a/src/main/certification/enhancement-quick-item-move-transform.ts
+++ b/src/main/certification/enhancement-quick-item-move-transform.ts
@@ -54,13 +54,16 @@ const ITEM_CONTEXT_OFFSET = Object.freeze({ inventory: 0xf8 });
 const ITEM_ARRAY_OFFSET = Object.freeze({ buffer: 0xb8, size: 0xc0 });
 const ITEM_BYTES = 0x54;
 const TRADE_OFFSET = Object.freeze({ flags: 0, playerItems: 0x14, playerItemCount: 0x1c });
-const TRADE_INITIATED_FLAG = 1;
+// GWCA's Wasm TradeMgr permits add/remove only in this exact state. The
+// native GmTradeCart add path asserts !playerAdded || !m_isDisabled.
+const TRADE_EDITABLE_FLAGS = 1;
 const TRADE_MAX_ITEMS = 7;
 const STORAGE_PANE = Object.freeze({ count: 15, material: 14 });
 const NUMBER_PREFERENCE_STORAGE_PANE = 20;
 const MATERIAL_SLOT_COUNT = 42;
 const NOT_TRADABLE_INTERACTION = 0x100;
 const MOVE_DIRECTION = Object.freeze({ store: 1, withdraw: 2 });
+const CLICK_ACTION = Object.freeze({ ...MOVE_DIRECTION, addToTrade: 3, removeFromTrade: 4 });
 const ITEM_MOUSE_ACTION = Object.freeze({
   addToTrade: 2,
   mouseUp: 7,
@@ -641,84 +644,102 @@ const effectiveModifiers = (g: QuickItemMoveGlobals) => concat(
 export function quickItemMoveHandler(c: QuickHandlerConfig): Uint8Array {
   const g = c.globals;
   return concat(
-    // params item id, frame id; locals item, bag, contexts, game, trade, cart, dialog, rows, count, index, scratch, qty
-    uleb(1), uleb(12), op(0x7f),
+    // params item id, frame id; locals item, bag, contexts, game, trade, cart,
+    // dialog, rows, count, index, scratch, quantity, action, trade flags
+    uleb(1), uleb(14), op(0x7f),
     global(g.enabled), op(0x45), effectiveModifiers(g), i32(1),
       op(0x71, 0x45, 0x72, 0x04, 0x40), ret(0), op(0x0b),
     global(g.scratch), op(0x45, 0x04, 0x40), ret(0), op(0x0b),
-    local(0), call(c.itemLookup), setLocal(2), local(2), op(0x45, 0x04, 0x40), ret(0), op(0x0b),
-    local(2), load(ITEM_OFFSET.bag), setLocal(3), local(3), op(0x45, 0x04, 0x40), ret(0), op(0x0b),
-    i32(c.layout.contextRoot), load(), setLocal(4), local(4), op(0x45, 0x04, 0x40), ret(0), op(0x0b),
-    local(4), load(c.layout.gameContextSlot * 4), setLocal(5), local(5), op(0x45, 0x04, 0x40), ret(0), op(0x0b),
+    local(0), call(c.itemLookup), setLocal(2), requireMemory(2, ITEM_BYTES),
+    local(2), load(ITEM_OFFSET.bag), setLocal(3), requireMemory(3, BAG_OFFSET.itemCount + 4),
+    i32(c.layout.contextRoot), load(), setLocal(4), requireMemory(4, c.layout.gameContextSlot * 4 + 4),
+    local(4), load(c.layout.gameContextSlot * 4), setLocal(5), requireMemory(5, GAME_CONTEXT_OFFSET.trade + 4),
     local(5), load(GAME_CONTEXT_OFFSET.trade), setLocal(6),
-    // UI callbacks only capture intent. Native UI messages are sent from the
-    // certified recurring game-thread boundary on the next frame.
-    global(g.draining), op(0x45, 0x04, 0x40),
-      local(6), op(0x04, 0x7f),
-        local(6), load(TRADE_OFFSET.flags), i32(TRADE_INITIATED_FLAG), op(0x71, 0x45, 0x45),
-      op(0x05), i32(0), op(0x0b),
-      i32(c.certificate.storageFrameHash), call(c.findFrame), op(0x45, 0x45, 0x72, 0x45),
-      op(0x04, 0x40), ret(0), op(0x0b),
-      global(c.pendingGlobal), op(0x04, 0x40), ret(0), op(0x0b),
+    local(6), op(0x04, 0x40),
+      requireMemory(6, TRADE_OFFSET.playerItemCount + 4),
+      local(6), load(TRADE_OFFSET.flags), setLocal(15),
+    op(0x0b),
+    // Classify the source independently of permission to edit the offer.
+    // A locked/unknown trade must never turn an inventory or cart click into
+    // a storage deposit. Consume those shortcuts without native fallthrough.
+    local(15), op(0x04, 0x40),
+      local(1), i32(c.certificate.tradeCartFrameHash), call(c.findAncestor), setLocal(7),
+      local(1), i32(c.certificate.tradeDialogFrameHash), call(c.findAncestor), setLocal(8),
+      local(7), op(0x04, 0x40),
+        i32(CLICK_ACTION.removeFromTrade), setLocal(14),
+      op(0x05),
+        local(8), op(0x04, 0x40), ret(1), op(0x0b),
+        local(3), load(), i32(BAG_TYPE.inventory), op(0x46, 0x04, 0x40),
+          i32(CLICK_ACTION.addToTrade), setLocal(14),
+        op(0x0b),
+      op(0x0b),
+      local(14), op(0x04, 0x40),
+        local(15), i32(TRADE_EDITABLE_FLAGS), op(0x47, 0x04, 0x40), ret(1), op(0x0b),
+        i32(c.certificate.tradeCartFrameHash), call(c.findFrame), setLocal(8),
+        local(8), op(0x45, 0x04, 0x40), ret(1), op(0x0b),
+        local(7), op(0x04, 0x40),
+          local(7), local(8), op(0x47, 0x04, 0x40), ret(1), op(0x0b),
+        op(0x0b), local(8), setLocal(7),
+      op(0x0b),
+    op(0x0b),
+    local(14), op(0x45, 0x04, 0x40),
+      local(3), load(), i32(BAG_TYPE.storage), op(0x46),
+        local(3), load(), i32(BAG_TYPE.materialStorage), op(0x46, 0x72, 0x04, 0x40),
+        i32(CLICK_ACTION.withdraw), setLocal(14),
+      op(0x05),
+        local(3), load(), i32(BAG_TYPE.inventory), op(0x47, 0x04, 0x40), ret(0), op(0x0b),
+        i32(CLICK_ACTION.store), setLocal(14),
+      op(0x0b),
+      i32(c.certificate.storageFrameHash), call(c.findFrame), op(0x45, 0x04, 0x40), ret(0), op(0x0b),
+    op(0x0b),
+    // UI callbacks capture only intent. The spare mailbox words retain the
+    // action and cart identity; a changed route/window cancels on the next
+    // game-thread tick instead of moving the item somewhere else.
+    global(g.draining), op(0x04, 0x40),
+      local(14), global(c.argumentGlobalBase + 2), op(0x47),
+      local(7), global(c.argumentGlobalBase + 3), op(0x47, 0x72, 0x04, 0x40), ret(1), op(0x0b),
+    op(0x05),
+      global(c.pendingGlobal), op(0x04, 0x40), ret(1), op(0x0b),
       global(g.scratch), i32(0), store(QUICK_ITEM_MOVE_PROMPT.quantity),
-      local(0), setGlobal(c.argumentGlobalBase),
-      local(1), setGlobal(c.argumentGlobalBase + 1),
+      local(0), setGlobal(c.argumentGlobalBase), local(1), setGlobal(c.argumentGlobalBase + 1),
+      local(14), setGlobal(c.argumentGlobalBase + 2), local(7), setGlobal(c.argumentGlobalBase + 3),
       global(g.modifiers), setGlobal(g.intentModifiers),
       i32(QUICK_ITEM_MOVE_COMMAND), setGlobal(c.pendingGlobal), ret(1),
     op(0x0b),
-    local(6), op(0x04, 0x40),
-      local(6), load(TRADE_OFFSET.flags), i32(TRADE_INITIATED_FLAG),
-        op(0x71, 0x45, 0x45, 0x04, 0x40),
-        // Frame ancestry is relevant only to an active trade. Avoid touching
-        // transient trade UI records during ordinary storage clicks.
-        local(1), i32(c.certificate.tradeCartFrameHash), call(c.findAncestor), setLocal(7),
-        local(1), i32(c.certificate.tradeDialogFrameHash), call(c.findAncestor), setLocal(8),
-        // Own cart click removes only an id present in the player's offer array.
-        local(7), op(0x04, 0x40),
-          local(6), load(TRADE_OFFSET.playerItems), setLocal(9),
-            local(6), load(TRADE_OFFSET.playerItemCount), setLocal(10), i32(0), setLocal(11),
-          op(0x02, 0x40, 0x03, 0x40), local(11), local(10), op(0x4f, 0x0d), uleb(1),
-            local(9), local(11), i32(8), op(0x6c, 0x6a), load(), local(0), op(0x46, 0x04, 0x40),
-              global(g.scratch), setLocal(12), local(12), i32(0), store(),
-                local(12), i32(ITEM_MOUSE_ACTION.removeFromTrade), store(4),
-                local(12), i32(ITEM_MOUSE_ACTION.state), store(8),
-                local(12), local(0), store(12), local(12), i32(0), store(16),
-              local(7), i32(c.frameDispatchOffset), op(0x6a), i32(UI_MESSAGE.frameMouseAction),
-                local(12), i32(0), call(c.frameDispatch), ret(1),
-            op(0x0b), local(11), i32(1), op(0x6a), setLocal(11), op(0x0c), uleb(0),
-          op(0x0b, 0x0b), ret(0),
-        op(0x0b),
-        // Any other trade descendant is the partner cart and is never changed.
-        local(8), op(0x04, 0x40), ret(0), op(0x0b),
-        // Inventory takes trade precedence while both windows are open.
-        local(3), load(), i32(BAG_TYPE.inventory), op(0x46, 0x04, 0x40),
-          local(2), load(ITEM_OFFSET.interaction), i32(NOT_TRADABLE_INTERACTION), op(0x71, 0x04, 0x40), ret(0), op(0x0b),
-          local(6), load(TRADE_OFFSET.playerItemCount), i32(TRADE_MAX_ITEMS), op(0x4f, 0x04, 0x40), ret(0), op(0x0b),
-          local(6), load(TRADE_OFFSET.playerItems), setLocal(9), i32(0), setLocal(11),
-          op(0x02, 0x40, 0x03, 0x40), local(11), local(6), load(TRADE_OFFSET.playerItemCount), op(0x4f, 0x0d), uleb(1),
-            local(9), local(11), i32(8), op(0x6c, 0x6a), load(), local(0), op(0x46, 0x04, 0x40), ret(0), op(0x0b),
-            local(11), i32(1), op(0x6a), setLocal(11), op(0x0c), uleb(0),
-          op(0x0b, 0x0b),
-          i32(c.certificate.tradeCartFrameHash), call(c.findFrame), setLocal(7), local(7), op(0x45, 0x04, 0x40), ret(0), op(0x0b),
-          global(g.scratch), setLocal(12), local(12), i32(0), store(),
-            local(12), i32(ITEM_MOUSE_ACTION.addToTrade), store(4),
-            local(12), i32(ITEM_MOUSE_ACTION.state), store(8),
-            local(12), local(12), i32(20), op(0x6a), store(12),
-            local(12), i32(0), store(16), local(12), local(0), store(20),
-          effectiveModifiers(g), i32(2), op(0x71), op(0x04, 0x7f), i32(0), op(0x05),
-            local(2), load16(ITEM_OFFSET.quantity), op(0x0b), setLocal(13), local(12), local(13), store(24),
-          local(7), i32(c.frameDispatchOffset), op(0x6a), i32(UI_MESSAGE.frameMouseAction),
-            local(12), i32(0), call(c.frameDispatch), ret(1),
-        op(0x0b),
+    local(14), i32(CLICK_ACTION.addToTrade), op(0x4f, 0x04, 0x40),
+      local(6), load(TRADE_OFFSET.playerItemCount), setLocal(10),
+      local(10), i32(TRADE_MAX_ITEMS), op(0x4b, 0x04, 0x40), ret(1), op(0x0b),
+      local(6), load(TRADE_OFFSET.playerItems), setLocal(9),
+      local(10), op(0x04, 0x40),
+        local(9), op(0x45), local(9), memoryBytes(), local(10), i32(8), op(0x6c, 0x6b, 0x4b, 0x72, 0x04, 0x40),
+          ret(1), op(0x0b),
       op(0x0b),
+      // One bounded membership scan serves both add and remove.
+      op(0x02, 0x40, 0x03, 0x40),
+        local(11), local(10), op(0x4f, 0x0d), uleb(1),
+        local(9), local(11), i32(8), op(0x6c, 0x6a), load(), local(0), op(0x46, 0x0d), uleb(1),
+        local(11), i32(1), op(0x6a), setLocal(11), op(0x0c), uleb(0),
+      op(0x0b, 0x0b),
+      global(g.scratch), setLocal(12),
+      local(14), i32(CLICK_ACTION.removeFromTrade), op(0x46, 0x04, 0x40),
+        local(11), local(10), op(0x4f, 0x04, 0x40), ret(1), op(0x0b),
+        local(12), i32(0), store(), local(12), i32(ITEM_MOUSE_ACTION.removeFromTrade), store(4),
+        local(12), i32(ITEM_MOUSE_ACTION.state), store(8),
+        local(12), local(0), store(12), local(12), i32(0), store(16),
+      op(0x05),
+        local(11), local(10), op(0x49), local(10), i32(TRADE_MAX_ITEMS), op(0x4f, 0x72),
+        local(2), load(ITEM_OFFSET.interaction), i32(NOT_TRADABLE_INTERACTION), op(0x71, 0x72, 0x04, 0x40), ret(1), op(0x0b),
+        local(12), i32(0), store(), local(12), i32(ITEM_MOUSE_ACTION.addToTrade), store(4),
+        local(12), i32(ITEM_MOUSE_ACTION.state), store(8),
+        local(12), local(12), i32(20), op(0x6a), store(12),
+        local(12), i32(0), store(16), local(12), local(0), store(20),
+        effectiveModifiers(g), i32(2), op(0x71), op(0x04, 0x7f), i32(0), op(0x05),
+          local(2), load16(ITEM_OFFSET.quantity), op(0x0b), setLocal(13), local(12), local(13), store(24),
+      op(0x0b),
+      local(7), i32(c.frameDispatchOffset), op(0x6a), i32(UI_MESSAGE.frameMouseAction),
+        local(12), i32(0), call(c.frameDispatch), ret(1),
     op(0x0b),
-    // Storage items always withdraw, even during a trade.
-    local(3), load(), i32(BAG_TYPE.storage), op(0x46),
-      local(3), load(), i32(BAG_TYPE.materialStorage), op(0x46, 0x72, 0x04, 0x40),
-      i32(MOVE_DIRECTION.withdraw), setLocal(11),
-    op(0x05), local(3), load(), i32(BAG_TYPE.inventory), op(0x46, 0x04, 0x40),
-      i32(MOVE_DIRECTION.store), setLocal(11), op(0x05), ret(0), op(0x0b), op(0x0b),
-    local(0), local(2), load16(ITEM_OFFSET.quantity), local(11), call(c.storageExecutor), op(0x0b),
+    local(0), local(2), load16(ITEM_OFFSET.quantity), local(14), call(c.storageExecutor), op(0x0b),
   );
 }
 

--- a/src/shared/enhancement-contracts.ts
+++ b/src/shared/enhancement-contracts.ts
@@ -351,7 +351,7 @@ export {
   ENHANCEMENT_LAYOUT_WORD_COUNT,
   ENHANCEMENT_PARTY_DIRTY_MESSAGE_COUNT,
 } from "./enhancement-config.js";
-export const ENHANCEMENT_TRANSFORM_ABI = 54;
+export const ENHANCEMENT_TRANSFORM_ABI = 55;
 
 export const ENHANCEMENT_CHAT_FILTER_MASKS = Object.freeze({
   allyDrops: 1,

--- a/tests/unit/enhancement-quick-item-move-transform.test.ts
+++ b/tests/unit/enhancement-quick-item-move-transform.test.ts
@@ -69,6 +69,10 @@ const handlerState = Object.freeze({
   frameItem20: 17,
   frameQuantity: 18,
   uiMessage: 19,
+  storageFrame: 25,
+  frameCalls: 26,
+  originalCalls: 27,
+  storageCalls: 28,
 });
 
 const storageState = Object.freeze({
@@ -89,16 +93,18 @@ function handlerModule(): Uint8Array {
   const certificate = build.quickItemMove!;
   const layout = { ...build.preGameControls!.layout, contextRoot: 32, gameContextSlot: 0 };
   const types = concat(
-    uleb(5),
+    uleb(6),
     op(0x60), uleb(1), op(0x7f), uleb(1), op(0x7f),
     op(0x60), uleb(3), op(0x7f, 0x7f, 0x7f), uleb(0),
     op(0x60), uleb(2), op(0x7f, 0x7f), uleb(1), op(0x7f),
     op(0x60), uleb(4), op(0x7f, 0x7f, 0x7f, 0x7f), uleb(0),
     op(0x60), uleb(3), op(0x7f, 0x7f, 0x7f), uleb(1), op(0x7f),
+    op(0x60), uleb(0), uleb(0),
   );
   const returnGlobal = (index: number) => concat(uleb(0), global(index), op(0x0b));
   const frameDispatch = concat(
     uleb(0),
+    global(handlerState.frameCalls), i32(1), op(0x6a), setGlobal(handlerState.frameCalls),
     local(1), setGlobal(handlerState.frameMessage),
     local(2), load(4), setGlobal(handlerState.frameAction),
     local(2), load(12), setGlobal(handlerState.frameItem12),
@@ -113,6 +119,7 @@ function handlerModule(): Uint8Array {
   );
   const storageExecutor = concat(
     uleb(0),
+    global(handlerState.storageCalls), i32(1), op(0x6a), setGlobal(handlerState.storageCalls),
     local(0), setGlobal(handlerState.storageItem),
     local(1), setGlobal(handlerState.storageQuantity),
     local(2), setGlobal(handlerState.storageDirection),
@@ -141,17 +148,18 @@ function handlerModule(): Uint8Array {
     WASM_HEADER,
     encodeSection({ id: 1, body: types }),
     encodeSection({ id: 3, body: concat(
-      uleb(9), uleb(0), uleb(0), uleb(1), uleb(0), uleb(2), uleb(3), uleb(2), uleb(4), uleb(2),
+      uleb(15), uleb(0), uleb(0), uleb(1), uleb(0), uleb(2), uleb(3), uleb(2), uleb(4), uleb(2),
+      uleb(2), uleb(5), uleb(1), uleb(1), uleb(2), uleb(0),
     ) }),
     encodeSection({ id: 5, body: concat(uleb(1), op(0x00), uleb(1)) }),
     encodeSection({ id: 6, body: concat(
-      uleb(23), mutableGlobal(1), mutableGlobal(1), mutableGlobal(2_048),
-      mutableGlobal(1), mutableGlobal(1), mutableGlobal(), mutableGlobal(),
+      uleb(29), mutableGlobal(1), mutableGlobal(1), mutableGlobal(2_048),
+      mutableGlobal(), mutableGlobal(1), mutableGlobal(), mutableGlobal(),
       mutableGlobal(256), ...Array.from({ length: 12 }, () => mutableGlobal()),
-      mutableGlobal(), mutableGlobal(), mutableGlobal(),
+      ...Array.from({ length: 9 }, () => mutableGlobal()),
     ) }),
     encodeSection({ id: 7, body: concat(
-      uleb(12 + stateExports.length),
+      uleb(16 + stateExports.length),
       exported("memory", 0x02, 0), exported("handler", 0x00, 8),
       exported("itemLookup", 0x00, 0), exported("storageExecutor", 0x00, 7),
       exported("enabled", 0x03, globals.enabled),
@@ -161,18 +169,29 @@ function handlerModule(): Uint8Array {
       exported("intentModifiers", 0x03, globals.intentModifiers),
       exported("pending", 0x03, 20), exported("pendingItem", 0x03, 21),
       exported("pendingFrame", 0x03, 22),
+      exported("drain", 0x00, 10), exported("click", 0x00, 12),
+      exported("configure", 0x00, 13), exported("setModifiers", 0x00, 14),
       ...stateExports,
     ) }),
     encodeSection({ id: 10, body: encodeCode([
       returnGlobal(handlerState.itemPointer),
       concat(uleb(0), i32(0), op(0x0b)),
       uiDispatcher,
-      returnGlobal(handlerState.cartFrame),
+      concat(uleb(0), local(0), i32(certificate.tradeCartFrameHash), op(0x46, 0x04, 0x7f),
+        global(handlerState.cartFrame), op(0x05),
+        local(0), i32(certificate.storageFrameHash), op(0x46, 0x04, 0x7f),
+          global(handlerState.storageFrame), op(0x05), i32(0), op(0x0b, 0x0b, 0x0b)),
       concat(uleb(0), i32(1), op(0x0b)),
       frameDispatch,
       findAncestor,
       storageExecutor,
       body,
+      quickItemMoveDispatch(globals, 8, 7),
+      concat(uleb(0), quickItemMoveDrain(20, 21, globals, 9), op(0x0b)),
+      concat(uleb(0), global(handlerState.originalCalls), i32(1), op(0x6a), setGlobal(handlerState.originalCalls), op(0x0b)),
+      quickItemMoveSlotWrapper(11, 8, false, 0),
+      quickItemMoveConfigure(globals, 20),
+      quickItemMoveModifiers(globals),
     ]) }),
   );
 }
@@ -480,116 +499,189 @@ test("captured clicks drain once from the deferred game-thread branch", async ()
   assert.equal(exportedGlobal("calls").value, 1);
 });
 
-test("handler routes inventory, storage, own offers, and partner offers safely", async () => {
+async function clickFixture() {
   const instance = await instantiate(handlerModule());
-  const exports = instance.exports as Record<string, WebAssembly.ExportValue>;
-  const memory = exports.memory as WebAssembly.Memory;
-  const handler = exports.handler as (itemId: number, frameId: number) => number;
-  const state = (nameValue: keyof typeof handlerState) => exports[nameValue] as WebAssembly.Global;
-  const view = new DataView(memory.buffer);
+  const exports = instance.exports;
+  const view = new DataView((exports.memory as WebAssembly.Memory).buffer);
+  const state = (key: keyof typeof handlerState) => exports[key] as WebAssembly.Global;
+  const pending = exports.pending as WebAssembly.Global;
+  const u32 = (address: number, value: number) => view.setUint32(address, value, true);
   const itemId = 1_234;
   const item = 256;
   const bag = 512;
   const game = 160;
   const trade = 768;
   const offer = 896;
-  view.setUint32(32, 128, true);
-  view.setUint32(128, game, true);
-  view.setUint32(item + 12, bag, true);
+  u32(32, 128); u32(128, game); u32(item + 12, bag);
   view.setUint16(item + 76, 9, true);
-  view.setUint32(bag + 4, 1, true);
-  assert.equal((exports.enabled as WebAssembly.Global).value, 1);
-  assert.equal((exports.modifiers as WebAssembly.Global).value, 1);
-  assert.equal((exports.scratch as WebAssembly.Global).value, 2_048);
-  assert.equal(state("itemPointer").value, item);
-  assert.equal((exports.itemLookup as (id: number) => number)(itemId), item);
-
-  view.setUint32(bag, 1, true);
-  state("cartFrame").value = 1;
-  (exports.draining as WebAssembly.Global).value = 0;
-  assert.equal(handler(itemId, 10), 1);
-  assert.equal((exports.pending as WebAssembly.Global).value, -20);
-  assert.equal((exports.pendingItem as WebAssembly.Global).value, itemId);
-  assert.equal((exports.pendingFrame as WebAssembly.Global).value, 10);
-  assert.equal(state("storageDirection").value, 0, "the UI callback must not move synchronously");
-  (exports.pending as WebAssembly.Global).value = 0;
-  (exports.draining as WebAssembly.Global).value = 1;
-  state("cartFrame").value = 0;
-
-  const resetSignals = () => {
-    for (const key of ["storageItem", "storageQuantity", "storageDirection", "frameMessage",
-      "frameAction", "frameItem12", "frameItem20", "frameQuantity", "uiMessage"] as const) {
-      state(key).value = 0;
-    }
-    state("cartAncestor").value = 0;
-    state("dialogAncestor").value = 0;
-    view.setUint32(game + 0x58, 0, true);
+  u32(bag, 1); u32(bag + 4, 1);
+  // The real inventory wrapper resolves an item from the callback's slot list.
+  u32(64 + 4, 49); u32(64 + 8, 4_096); u32(4_096, 4_128);
+  u32(4_128 + 8, 4_192); u32(4_128 + 16, 1); u32(4_192, itemId);
+  u32(96, 10); u32(96 + 4, 2); u32(96 + 8, 7);
+  const click = () => (exports.click as (message: number, action: number, context: number) => void)(64, 96, 0);
+  const drain = exports.drain as () => void;
+  const setTrade = (flags: number, source: "inventory" | "own" | "partner" = "inventory") => {
+    u32(game + 0x58, trade); u32(trade, flags);
+    u32(trade + 20, offer); u32(trade + 28, source === "own" ? 1 : 0); u32(offer, itemId);
+    state("cartFrame").value = 1_000;
+    state("cartAncestor").value = source === "own" ? 1_000 : 0;
+    state("dialogAncestor").value = source === "inventory" ? 0 : 2_000;
   };
+  const noMoves = () => {
+    assert.equal(state("frameCalls").value, 0, "no native trade action");
+    assert.equal(state("storageCalls").value, 0, "no storage fallback");
+    assert.equal(state("uiMessage").value, 0, "no quantity prompt");
+  };
+  return { exports, view, u32, state, pending, itemId, item, bag, game, trade, offer, click, drain, setTrade, noMoves };
+}
 
-  (exports.enabled as WebAssembly.Global).value = 0;
-  assert.equal(handler(itemId, 10), 0);
-  assert.equal(state("storageDirection").value, 0);
-  (exports.enabled as WebAssembly.Global).value = 1;
-  (exports.modifiers as WebAssembly.Global).value = 0;
-  (exports.intentModifiers as WebAssembly.Global).value = 0;
-  assert.equal(handler(itemId, 10), 0);
-  assert.equal(state("storageDirection").value, 0);
-  (exports.modifiers as WebAssembly.Global).value = 1;
-  (exports.intentModifiers as WebAssembly.Global).value = 1;
+test("locked and unknown trade states consume inventory and cart shortcuts without native fallthrough", async () => {
+  for (const flags of [2, 3, 4, 5, 6, 7, 8, 9, 0xffff_ffff]) {
+    for (const source of ["inventory", "own", "partner"] as const) {
+      for (const storage of [0, 1_500]) {
+        for (const modifiers of [1, 3]) {
+          const f = await clickFixture();
+          f.setTrade(flags, source);
+          f.state("storageFrame").value = storage;
+          (f.exports.setModifiers as (value: number) => number)(modifiers);
+          f.click(); f.click(); f.drain();
+          assert.equal(f.pending.value, 0);
+          f.noMoves();
+          assert.equal(f.state("originalCalls").value, 0, `flags=${flags}, source=${source}, storage=${storage}, modifiers=${modifiers}`);
+        }
+      }
+    }
+  }
+});
 
-  resetSignals();
-  view.setUint32(bag, 1, true);
-  const inventoryResult = handler(itemId, 10);
-  assert.equal(state("storageDirection").value, 1);
-  assert.equal(state("storageQuantity").value, 9);
-  assert.equal(inventoryResult, 1);
+test("editable trade adds and removes once; partner offers never move", async () => {
+  for (const source of ["inventory", "own", "partner"] as const) {
+    for (const storage of [0, 1_500]) {
+      for (const modifiers of [1, 3]) {
+        const f = await clickFixture(); f.setTrade(1, source);
+        f.state("storageFrame").value = storage;
+        (f.exports.setModifiers as (value: number) => number)(modifiers);
+        f.click(); f.noMoves();
+        f.drain(); f.drain();
+        assert.equal(f.pending.value, 0);
+        assert.equal(f.state("storageCalls").value, 0);
+        assert.equal(f.state("originalCalls").value, 0);
+        if (source === "partner") { f.noMoves(); continue; }
+        assert.equal(f.state("frameCalls").value, 1);
+        assert.equal(f.state("frameAction").value, source === "own" ? 9 : 2);
+        assert.equal(f.state(source === "own" ? "frameItem12" : "frameItem20").value, f.itemId);
+        if (source === "inventory") assert.equal(f.state("frameQuantity").value, modifiers === 3 ? 0 : 9);
+      }
+    }
+  }
+});
 
-  resetSignals();
-  (exports.modifiers as WebAssembly.Global).value = 3;
-  (exports.intentModifiers as WebAssembly.Global).value = 3;
-  assert.equal(handler(itemId, 10), 1);
-  assert.equal(state("storageDirection").value, 1);
-  assert.equal(state("storageQuantity").value, 9);
-  (exports.modifiers as WebAssembly.Global).value = 1;
-  (exports.intentModifiers as WebAssembly.Global).value = 1;
+test("trade intent cancels when locked, closed, replaced or reclassified before draining", async () => {
+  for (const source of ["inventory", "own"] as const) {
+    for (const change of ["submitted", "accepted", "combined", "unknown", "closed", "missing", "cartGone", "cartReplaced", "sourceMoved", "partner"] as const) {
+      const f = await clickFixture(); f.setTrade(1, source);
+      f.state("storageFrame").value = 1_500;
+      f.click(); assert.equal(f.pending.value, -20); f.noMoves();
+      switch (change) {
+        case "submitted": f.u32(f.trade, 3); break;
+        case "accepted": f.u32(f.trade, 5); break;
+        case "combined": f.u32(f.trade, 7); break;
+        case "unknown": f.u32(f.trade, 9); break;
+        case "closed": f.u32(f.trade, 0); break;
+        case "missing": f.u32(f.game + 0x58, 0); break;
+        case "cartGone": f.state("cartFrame").value = 0; break;
+        case "cartReplaced": f.state("cartFrame").value = 1_100; break;
+        case "sourceMoved":
+          f.u32(f.bag, 4); f.state("cartAncestor").value = 0; f.state("dialogAncestor").value = 0; break;
+        case "partner": f.state("cartAncestor").value = 0; f.state("dialogAncestor").value = 2_000; break;
+      }
+      f.drain(); f.drain(); f.noMoves();
+      assert.equal(f.pending.value, 0, change);
+      assert.equal((f.exports.draining as WebAssembly.Global).value, 0);
+    }
+  }
+});
 
-  resetSignals();
-  view.setUint32(bag, 4, true);
-  view.setUint32(game + 0x58, trade, true);
-  view.setUint32(trade, 3, true);
-  assert.equal(handler(itemId, 10), 1);
-  assert.equal(state("storageDirection").value, 2, "storage withdrawal wins during trade");
+test("storage withdrawals remain available during locked trades and deposits never turn into offers", async () => {
+  for (const flags of [0, 1, 3, 5, 7, 9]) {
+    for (const bagType of [4, 5]) {
+      const f = await clickFixture(); f.setTrade(flags);
+      f.state("storageFrame").value = 1_500; f.u32(f.bag, bagType);
+      f.click(); f.noMoves(); f.drain();
+      assert.equal(f.state("storageCalls").value, 1);
+      assert.equal(f.state("storageDirection").value, 2);
+      assert.equal(f.state("frameCalls").value, 0);
+    }
+  }
+  for (const flags of [1, 3]) {
+    const f = await clickFixture(); f.state("storageFrame").value = 1_500;
+    f.click(); assert.equal(f.pending.value, -20);
+    f.setTrade(flags); f.drain(); f.noMoves();
+  }
+  const f = await clickFixture(); f.state("storageFrame").value = 1_500;
+  f.click(); f.drain();
+  assert.equal(f.state("storageCalls").value, 1);
+  assert.equal(f.state("storageDirection").value, 1);
+});
 
-  resetSignals();
-  view.setUint32(bag, 1, true);
-  view.setUint32(game + 0x58, trade, true);
-  view.setUint32(trade, 3, true);
-  view.setUint32(trade + 20, offer, true);
-  view.setUint32(trade + 28, 0, true);
-  state("cartFrame").value = 1_000;
-  assert.equal(handler(itemId, 10), 1);
-  assert.equal(state("frameAction").value, 2);
-  assert.equal(state("frameItem20").value, itemId);
-  assert.equal(state("frameQuantity").value, 9);
+test("trade edits reject full, duplicate, absent and malformed offer rows", async () => {
+  for (const refusal of ["full", "duplicate", "untradable", "absent", "oversized", "nullRows", "outOfBounds"] as const) {
+    const f = await clickFixture(); f.setTrade(1, refusal === "absent" ? "own" : "inventory");
+    switch (refusal) {
+      case "full": f.u32(f.trade + 28, 7); f.u32(f.offer, 999); break;
+      case "duplicate": f.u32(f.trade + 28, 1); break;
+      case "untradable": f.u32(f.item + 0x28, 0x100); break;
+      case "absent": f.u32(f.offer, 999); break;
+      case "oversized": f.u32(f.trade + 28, 0xffff_ffff); break;
+      case "nullRows": f.u32(f.trade + 28, 1); f.u32(f.trade + 20, 0); break;
+      case "outOfBounds": f.u32(f.trade + 28, 1); f.u32(f.trade + 20, 65_532); break;
+    }
+    f.click(); f.drain(); f.noMoves();
+  }
+});
 
-  resetSignals();
-  state("cartAncestor").value = 1_000;
-  view.setUint32(game + 0x58, trade, true);
-  view.setUint32(trade, 1, true);
-  view.setUint32(trade + 20, offer, true);
-  view.setUint32(trade + 28, 1, true);
-  view.setUint32(offer, itemId, true);
-  assert.equal(handler(itemId, 10), 1);
-  assert.equal(state("frameAction").value, 9);
-  assert.equal(state("frameItem12").value, itemId);
+test("busy or disabled quick moves do not replay; Change Offer enables new clicks", async () => {
+  const f = await clickFixture(); f.setTrade(1);
+  f.click(); f.click(); f.drain(); f.drain();
+  assert.equal(f.state("frameCalls").value, 1);
+  assert.equal(f.state("originalCalls").value, 0);
+  f.click();
+  (f.exports.configure as (enabled: number, scratch: number) => number)(0, 2_048);
+  f.drain(); assert.equal(f.pending.value, 0);
+  assert.equal(f.state("frameCalls").value, 1);
+  f.click(); assert.equal(f.state("originalCalls").value, 1, "disabled feature preserves native clicks");
+  (f.exports.configure as (enabled: number, scratch: number) => number)(1, 2_048);
+  (f.exports.setModifiers as (value: number) => number)(1);
+  f.setTrade(3); f.click(); assert.equal(f.pending.value, 0);
+  f.setTrade(1); f.drain(); assert.equal(f.state("frameCalls").value, 1, "unlock does not replay rejected clicks");
+  f.click(); f.drain(); assert.equal(f.state("frameCalls").value, 2);
+});
 
-  resetSignals();
-  state("dialogAncestor").value = 2_000;
-  view.setUint32(game + 0x58, trade, true);
-  view.setUint32(trade, 1, true);
-  assert.equal(handler(itemId, 10), 0);
-  assert.equal(state("storageDirection").value, 0, "partner offers remain untouched");
-  assert.equal(state("frameMessage").value, 0);
+test("ordinary clicks pass through and unavailable destinations cannot capture or replay moves", async () => {
+  const f = await clickFixture(); f.setTrade(1);
+  (f.exports.setModifiers as (value: number) => number)(0);
+  f.click(); f.drain(); f.noMoves();
+  assert.equal(f.state("originalCalls").value, 1);
+  (f.exports.setModifiers as (value: number) => number)(1);
+  f.pending.value = 123;
+  f.click(); f.drain(); f.noMoves();
+  assert.equal(f.pending.value, 123, "another native command retains its mailbox");
+  f.pending.value = 0;
+  f.state("cartFrame").value = 0;
+  f.click(); f.drain(); f.noMoves();
+  assert.equal(f.pending.value, 0);
+  f.setTrade(1, "own"); f.state("cartAncestor").value = 1_100;
+  f.click(); f.drain(); f.noMoves();
+  assert.equal(f.pending.value, 0, "an obsolete cart cannot target its replacement");
+
+  const storage = await clickFixture();
+  storage.click(); storage.drain(); storage.noMoves();
+  assert.equal(storage.state("originalCalls").value, 1, "closed storage leaves the native click alone");
+  storage.state("storageFrame").value = 1_500;
+  storage.click(); storage.state("storageFrame").value = 0;
+  storage.drain(); storage.noMoves();
+  assert.equal(storage.pending.value, 0);
 });
 
 


### PR DESCRIPTION
Control-clicking an inventory item after submitting a trade offer could reach the native client's disabled-cart assertion and freeze the client. Quick Item Move now permits trade edits only in the exact editable state, matching GWCA's WebAssembly TradeMgr. Locked-offer shortcuts are consumed without native fallthrough or an unintended storage deposit; storage withdrawals remain available.

The existing deferred mailbox retains the intended action and target cart. If the offer locks, the trade closes, or the click route or target cart changes before execution, the click is cancelled. Add and remove share one bounded offer-membership check. The transform ABI and all six retained output digests are updated.

Validation:

- Required macOS Application verification (including packaging and packaged-app tests) and all CodeQL checks passed on `1878e747`.
- `pnpm check` passed: type checks, lint, links, 1,652 unit tests, 182 policy tests, and both UI unit suites.
- `pnpm build` and all 99 integration tests passed.
- Local official-client Quick Item Move certification passed; all six regenerated profile outputs passed WASM validation. Native inspection located the `!playerAdded || !m_isDisabled` assertion in `GmTradeCart.cpp` on the injected add-action path.
- Generated wrapper/handler/drain tests cover locked and unknown states, both modifiers, own and partner offers, storage routing, state changes between capture and execution, malformed offers, repeated clicks, disabling, and Change Offer recovery. Restoring the old bitmask in memory caused three regression tests to fail.
- Browser exploration of a temporary synthetic WASM fixture confirmed refusal, withdrawal, recovery, and deferred cancellation. The fixture and server were closed afterward.

Live two-player gameplay has not been verified. Before release, use a developer build to check submitted-offer clicks and Change Offer recovery with storage open and closed. Recommend developer-build QA before inclusion in a Beta train; this PR does not publish a release.

Authored and verified with Codex (GPT-6), Node's WASM test harness, and Codex browser automation.
