### PR TITLE
fix(input): preserve Ctrl-Shift-Space for target calling

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -118,6 +118,9 @@ layout. Horizontal is the default and follows the character-selection order.
 The search bar is shown by default and can be hidden there. The layout and search
 choices last for the current app session.
 
+Build Library defaults to **Command-B**. **Control-Shift-Space** remains a
+Guild Wars control for calling the selected target without attacking.
+
 Shortcuts use macOS Command combinations such as Command-T. Normal editing and
 application shortcuts such as Command-C, Command-V, Command-Q, and Command-W
 remain reserved. If a new or restored shortcut conflicts with any feature,

--- a/src/renderer/toolbox-foundation.ts
+++ b/src/renderer/toolbox-foundation.ts
@@ -27,8 +27,6 @@ const OVERLAY_CSS = `
 }
 `;
 
-const TOGGLE_CODE = "Space";
-
 export interface MountedTool {
   setVisible(visible: boolean): void;
   setActive?(active: boolean): void;
@@ -176,19 +174,6 @@ export function createToolboxFoundation(
     }, true);
   }
 
-  const onToggleChord = (event: KeyboardEvent) => {
-    if (
-      !availability.builds
-      || event.code !== TOGGLE_CODE
-      || !event.ctrlKey
-      || !event.shiftKey
-      || event.altKey
-      || event.metaKey
-    ) return;
-    event.preventDefault();
-    event.stopImmediatePropagation();
-    toggle(builds);
-  };
   const onBuildsCommand = (event: Event) => {
     if (!availability.builds) return;
     event.preventDefault();
@@ -215,7 +200,6 @@ export function createToolboxFoundation(
   mirrorCursor();
   window.addEventListener("gw:tools-toggle", onBuildsCommand);
   window.addEventListener("gw:trade-toggle", onTradeCommand);
-  window.addEventListener("keydown", onToggleChord, true);
 
   return {
     update(next: ToolboxState) {
@@ -238,7 +222,6 @@ export function createToolboxFoundation(
       cursorMirror.disconnect();
       window.removeEventListener("gw:tools-toggle", onBuildsCommand);
       window.removeEventListener("gw:trade-toggle", onTradeCommand);
-      window.removeEventListener("keydown", onToggleChord, true);
       window.dispatchEvent(new CustomEvent("gw:input-reset"));
       if (root.contains(document.activeElement)) canvas.focus({ preventScroll: true });
       style.remove();

--- a/src/renderer/tools-host.ts
+++ b/src/renderer/tools-host.ts
@@ -3,7 +3,7 @@
  * Toolbox overlay.
  *
  * This module is deliberately thin. The overlay already owns the boundary —
- * the toggle chord, the event stops, pointer-lock release, the cursor mirror,
+ * the toggle command, the event stops, pointer-lock release, the cursor mirror,
  * focus transfer and teardown — so a tool needs none of that again. An earlier
  * version of this file created its own root element beside the canvas and
  * re-implemented the input protection; two boundaries around one panel is how

--- a/tests/electron/input-toolbox.spec.ts
+++ b/tests/electron/input-toolbox.spec.ts
@@ -212,11 +212,23 @@ test.describe("renderer Tools input", () => {
         // the game's global handlers. Events on Tools chrome must never reach
         // them; events on the game canvas always must, and a release for a
         // press the canvas received must arrive even when it lands elsewhere.
-        window.addEventListener("keydown", () => {
+        window.addEventListener("keydown", (event) => {
+          if (event.code === "Space") {
+            document.body.dataset.toolboxSpaceDown = JSON.stringify({
+              control: event.ctrlKey, shift: event.shiftKey,
+              prevented: event.defaultPrevented,
+            });
+          }
           gameKeys += 1;
           document.body.dataset.toolboxGameKeys = String(gameKeys);
         });
         window.addEventListener("keyup", (event) => {
+          if (event.code === "Space") {
+            document.body.dataset.toolboxSpaceUp = JSON.stringify({
+              control: event.ctrlKey, shift: event.shiftKey,
+              prevented: event.defaultPrevented,
+            });
+          }
           gameKeyUps += 1;
           document.body.dataset.toolboxGameKeyUps = String(gameKeyUps);
           document.body.dataset.toolboxLastKeyUp = event.code;
@@ -375,8 +387,27 @@ test.describe("renderer Tools input", () => {
       await expect(tool).toBeHidden();
       await expect(body).toHaveAttribute("data-toolbox-game-keys", "3");
 
-      await page.keyboard.press("Control+Shift+Space");
+      await page.evaluate(() => window.dispatchEvent(
+        new CustomEvent("gw:tools-toggle", { cancelable: true }),
+      ));
       await expect(tool).toBeVisible();
+
+      // Target calling belongs to Guild Wars, with the library open or closed.
+      for (const visible of [true, false]) {
+        if (!visible) await page.keyboard.press("Escape");
+        await page.keyboard.press("Control+Shift+Space");
+        const expected = JSON.stringify({ control: true, shift: true, prevented: false });
+        await expect(body).toHaveAttribute("data-toolbox-space-down", expected);
+        await expect(body).toHaveAttribute("data-toolbox-space-up", expected);
+        await expect(tool).toBeVisible({ visible });
+        await page.evaluate(() => {
+          delete document.body.dataset.toolboxSpaceDown;
+          delete document.body.dataset.toolboxSpaceUp;
+        });
+      }
+      await page.evaluate(() => window.dispatchEvent(
+        new CustomEvent("gw:tools-toggle", { cancelable: true }),
+      ));
 
       // The same Escape closes Tools after a game click left focus on canvas.
       const gameKeysBeforeCanvasEscape = await body.getAttribute(
@@ -389,8 +420,10 @@ test.describe("renderer Tools input", () => {
         gameKeysBeforeCanvasEscape ?? "",
       );
 
-      // The chord toggles from anywhere.
-      await page.keyboard.press("Control+Shift+Space");
+      // The app command toggles from anywhere.
+      await page.evaluate(() => window.dispatchEvent(
+        new CustomEvent("gw:tools-toggle", { cancelable: true }),
+      ));
       await expect(tool).toBeVisible();
 
       // A tool that hides itself has to say so, because the overlay cannot see
@@ -398,7 +431,9 @@ test.describe("renderer Tools input", () => {
       // and the next toggle closes an already-hidden tool.
       await page.getByRole("button", { name: "Close tool" }).click();
       await expect(tool).toBeHidden();
-      await page.keyboard.press("Control+Shift+Space");
+      await page.evaluate(() => window.dispatchEvent(
+        new CustomEvent("gw:tools-toggle", { cancelable: true }),
+      ));
       await expect(tool).toBeVisible();
 
       // The menu route: the main process sends `tools.toggle`, and the renderer


### PR DESCRIPTION
Ctrl+Shift+Space opened Build Library instead of letting Guild Wars call “I’m targeting XX”. A hard-coded renderer shortcut intercepted the game control independently of the configurable app shortcuts.

Remove that duplicate shortcut. Build Library keeps its existing configurable Command+B shortcut and menu command. No saved settings or game bindings change.

Verification:
- `pnpm check` passed.
- `pnpm build` passed.
- All three Electron Tools input tests passed, including Space down/up reaching the game with Ctrl and Shift intact while the library is open and closed.
- Explored the offline embedded library and inspected its screenshot; target calling leaves its visibility unchanged and Escape closes it.

Live party-chat output is not verified. Recommend target-calling QA in a Developer Build before release inclusion; this PR does not publish a release.

Implemented with Codex (GPT-6) in an isolated worktree.
