### PR TITLE
fix/launcher funding

### DIFF
--- a/apps/launcher/src/App.test.ts
+++ b/apps/launcher/src/App.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { LauncherNativeApi, LauncherSnapshot } from "@shared/launcher-contracts";
 import App from "./App.vue";
 import { fixtureSnapshot } from "./fixtures";
+import { funding } from "./funding";
 
 function installNative(overrides: Record<string, unknown>): LauncherNativeApi {
   const native = {
@@ -114,6 +115,13 @@ describe("unified launcher shell", () => {
     const wrapper = mount(App);
 
     expect(wrapper.get(".funding-banner").text()).toContain("Support gwonmac");
+    const progress = wrapper.get('[role="progressbar"][aria-label="Project funding"]');
+    expect(progress.attributes("aria-valuenow")).toBe(String(funding.raisedEuros));
+    expect(progress.attributes("aria-valuemax")).toBe(String(funding.goalEuros));
+    expect(progress.attributes("aria-valuetext")).toBe(`€${funding.raisedEuros} of €${funding.goalEuros} funded`);
+    expect(progress.text()).toContain(`€${funding.raisedEuros}`);
+    expect(progress.text()).toContain(`€${funding.goalEuros}`);
+    expect(progress.get("i").attributes("style")).toContain(`${Math.min(100, funding.raisedEuros / funding.goalEuros * 100)}%`);
     expect(wrapper.get(".funding-banner").text()).not.toContain("yearly project costs");
     expect(wrapper.get(".funding-banner").text()).not.toContain("Downloading game files");
     expect(wrapper.get(".launchbar").text()).toContain("Downloading game files");

--- a/apps/launcher/src/App.vue
+++ b/apps/launcher/src/App.vue
@@ -20,6 +20,7 @@ import type { CacheInfo } from "@shared/contracts";
 import type { ProfileId } from "@shared/multiple-accounts";
 import { parseProfileName, profileNameKey } from "@shared/multiple-accounts";
 import { fixtureSnapshotFor } from "./fixtures";
+import { funding } from "./funding";
 import AccountsView from "./components/AccountsView.vue";
 import BaseModal from "./components/BaseModal.vue";
 import FeedbackView from "./components/FeedbackView.vue";
@@ -161,7 +162,6 @@ watch(route, (page) => {
   void runAction("The starting page could not be remembered.", () => native.experience.updatePreferences({ lastPlayPage: page }));
 });
 const synchronized = ref(!native);
-const fixtureContent = computed(() => snapshot.value.contentAvailability.news === "fixture");
 onMounted(async () => {
   if (!native) return;
   unsubscribeNavigation = native.navigation.onRequest(navigateFromMain);
@@ -466,8 +466,8 @@ async function resetGameFiles() {
 
     <section v-if="route !== 'settings'" class="funding-banner" aria-label="Project funding">
       <div><strong>Support gwonmac</strong></div>
-      <div class="funding-progress" :aria-label="fixtureContent ? '€42 of €125 funded' : '€125 yearly cost'">
-        <span>{{ fixtureContent ? '€42' : 'Yearly costs' }}</span><div><i :style="{ width: fixtureContent ? '34%' : '0%' }" /></div><span>€125</span>
+      <div class="funding-progress" role="progressbar" aria-label="Project funding" :aria-valuenow="funding.raisedEuros" :aria-valuemax="funding.goalEuros" :aria-valuemin="0" :aria-valuetext="`€${funding.raisedEuros} of €${funding.goalEuros} funded`">
+        <span>€{{ funding.raisedEuros }}</span><div><i :style="{ width: `${Math.min(100, funding.raisedEuros / funding.goalEuros * 100)}%` }" /></div><span>€{{ funding.goalEuros }}</span>
       </div>
       <button @click="openExternal('donate')">Support</button>
     </section>

--- a/apps/launcher/src/funding.ts
+++ b/apps/launcher/src/funding.ts
@@ -1,0 +1,2 @@
+/** Owns the published funding figures used by the launcher banner. */
+export const funding = Object.freeze({ raisedEuros: 86, goalEuros: 120 });

--- a/apps/launcher/src/style.css
+++ b/apps/launcher/src/style.css
@@ -32,7 +32,7 @@ nav button.active { color: #f7d180; background: rgba(232, 183, 92, .08); }
 .funding-banner span { color: var(--muted); font-size: 12px; white-space: nowrap; }
 .funding-progress { min-width: 0; display: grid; grid-template-columns: auto minmax(80px, 1fr) auto; align-items: center; gap: 9px; }
 .funding-progress div { height: 6px; overflow: hidden; border-radius: 99px; background: rgba(255,255,255,.1); }
-.funding-progress i { display: block; width: 34%; height: 100%; background: linear-gradient(90deg, #c77c2b, #f0c869); }
+.funding-progress i { display: block; height: 100%; background: linear-gradient(90deg, #c77c2b, #f0c869); }
 .funding-banner button, .secondary { padding: 8px 12px; border-radius: 9px; border: 1px solid var(--line); background: var(--control); }
 main { width: 100%; min-width: 0; min-height: 0; overflow: hidden; display: grid; grid-template-columns: minmax(0, 1.15fr) minmax(450px, .85fr); }
 main.artwork-only { grid-template-columns: 1fr; }

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -84,6 +84,15 @@ launcher; restore it with **Window → Show Launcher**. Do not click Play merely
 to verify startup. Report the worktree, launch mode, and profile. Rebuild before
 checking changed compiled code; preserve the session requested for handoff.
 
+## Update project funding
+
+Edit `raisedEuros` and `goalEuros` in
+[`apps/launcher/src/funding.ts`](../apps/launcher/src/funding.ts).
+Use the confirmed euro totals and keep the goal greater than zero. The launcher
+uses these figures for the visible amounts, accessible description, and bar.
+Run `pnpm --filter @gwonmac/launcher-ui test` and `pnpm run check`.
+The new totals reach installed apps with the next application update.
+
 ## Disposable launcher fixtures
 
 Use `pnpm launcher:fixture` to open a fresh launcher against a temporary


### PR DESCRIPTION
## What changed

The launcher now shows the confirmed €86 raised toward the €120 goal. One funding file owns both amounts, the progress bar, and its accessible description.

## Why

The banner used placeholder figures in development and an empty yearly-cost bar in the app. Maintainers can now update two values in `apps/launcher/src/funding.ts`; the documented procedure ships them with the next application update.

## Invariant

The visible amounts, progress width, and accessible values all derive from the same figures. Development and packaged launchers use the same funding data.

## Delivery

First layer of the pre-beta stack, targeting `main`. Include it in the planned Beta train. No remote funding service or application updater behavior is added.

## Verification

- `pnpm check` passed.
- `pnpm build` passed.
- Browser exploration verified the bar on Home and Accounts.

- [x] I kept this pull request focused.
- [x] I ran the relevant checks.
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [x] I updated documentation when behavior or an invariant changed.

Prepared with GPT-6 in Codex desktop.
