### PR TITLE
feat(launcher): update funding figures from GitHub without an app release

### DIFF
--- a/apps/launcher/src/App.test.ts
+++ b/apps/launcher/src/App.test.ts
@@ -3,7 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { LauncherNativeApi, LauncherSnapshot } from "@shared/launcher-contracts";
 import App from "./App.vue";
 import { fixtureSnapshot } from "./fixtures";
-import { funding } from "./funding";
+import funding from "@shared/funding.json";
 
 function installNative(overrides: Record<string, unknown>): LauncherNativeApi {
   const native = {
@@ -126,6 +126,25 @@ describe("unified launcher shell", () => {
     expect(wrapper.get(".funding-banner").text()).not.toContain("Downloading game files");
     expect(wrapper.get(".launchbar").text()).toContain("Downloading game files");
     expect(wrapper.find(".priority-banner").exists()).toBe(false);
+  });
+
+  it("updates funding from the native snapshot and caps a fully funded bar", async () => {
+    let publish: (snapshot: LauncherSnapshot) => void = () => undefined;
+    installNative({ state: {
+      get: async () => fixtureSnapshot,
+      onChange(listener: typeof publish) { publish = listener; return () => undefined; },
+    } });
+    const wrapper = mount(App);
+    await flushPromises();
+    publish({ ...fixtureSnapshot, revision: fixtureSnapshot.revision + 1, funding: { raisedEuros: 160, goalEuros: 150 } });
+    await flushPromises();
+    const progress = wrapper.get('[role="progressbar"][aria-label="Project funding"]');
+    expect(progress.attributes("aria-valuetext")).toBe("€160 of €150 funded");
+    expect(progress.attributes("aria-valuenow")).toBe("150");
+    expect(progress.get("i").attributes("style")).toContain("100%");
+    expect(progress.text()).toContain("€160");
+    expect(progress.text()).toContain("€150");
+    wrapper.unmount();
   });
 
   it("keeps Home focused on content and moves account management to Accounts", async () => {

--- a/apps/launcher/src/App.vue
+++ b/apps/launcher/src/App.vue
@@ -20,7 +20,6 @@ import type { CacheInfo } from "@shared/contracts";
 import type { ProfileId } from "@shared/multiple-accounts";
 import { parseProfileName, profileNameKey } from "@shared/multiple-accounts";
 import { fixtureSnapshotFor } from "./fixtures";
-import { funding } from "./funding";
 import AccountsView from "./components/AccountsView.vue";
 import BaseModal from "./components/BaseModal.vue";
 import FeedbackView from "./components/FeedbackView.vue";
@@ -59,6 +58,7 @@ const allSettingsGroups: readonly {
 // Native snapshots are replaced as a whole. Deep Vue proxies cannot cross
 // Electron's context bridge when a saved preset is reused in an edit.
 const snapshot = shallowRef<LauncherSnapshot>(fixtureSnapshotFor(window.location.search));
+const funding = computed(() => snapshot.value.funding);
 const settingsGroups = allSettingsGroups;
 const settingsContent = ref<HTMLElement | null>(null);
 const settingsSaveState = ref<"idle" | "saving" | "failed" | "saved">("idle");
@@ -454,7 +454,7 @@ async function resetGameFiles() {
 
     <section v-if="route !== 'settings'" class="funding-banner" aria-label="Project funding">
       <div><strong>Support gwonmac</strong></div>
-      <div class="funding-progress" role="progressbar" aria-label="Project funding" :aria-valuenow="funding.raisedEuros" :aria-valuemax="funding.goalEuros" :aria-valuemin="0" :aria-valuetext="`€${funding.raisedEuros} of €${funding.goalEuros} funded`">
+      <div class="funding-progress" role="progressbar" aria-label="Project funding" :aria-valuenow="Math.min(funding.raisedEuros, funding.goalEuros)" :aria-valuemax="funding.goalEuros" :aria-valuemin="0" :aria-valuetext="`€${funding.raisedEuros} of €${funding.goalEuros} funded`">
         <span>€{{ funding.raisedEuros }}</span><div><i :style="{ width: `${Math.min(100, funding.raisedEuros / funding.goalEuros * 100)}%` }" /></div><span>€{{ funding.goalEuros }}</span>
       </div>
       <button @click="openExternal('donate')">Support</button>

--- a/apps/launcher/src/fixtures.ts
+++ b/apps/launcher/src/fixtures.ts
@@ -1,3 +1,4 @@
+import funding from "@shared/funding.json";
 import type { LauncherSnapshot } from "@shared/launcher-contracts";
 import { DEFAULT_SETTINGS } from "@shared/contracts";
 import { resolveShortcuts } from "@shared/keyboard-shortcuts";
@@ -6,6 +7,7 @@ import { LEGACY_PRIMARY_PROFILE_ID, parseProfileId } from "@shared/multiple-acco
 
 export const fixtureSnapshot: LauncherSnapshot = {
   revision: 1,
+  funding,
   experience: {
     installationKind: "migrated-single",
     setup: "complete",

--- a/apps/launcher/src/funding.ts
+++ b/apps/launcher/src/funding.ts
@@ -1,2 +1,0 @@
-/** Owns the published funding figures used by the launcher banner. */
-export const funding = Object.freeze({ raisedEuros: 86, goalEuros: 120 });

--- a/apps/launcher/tsconfig.json
+++ b/apps/launcher/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "resolveJsonModule": true,
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -86,12 +86,22 @@ checking changed compiled code; preserve the session requested for handoff.
 
 ## Update project funding
 
-Edit `raisedEuros` and `goalEuros` in
-[`apps/launcher/src/funding.ts`](../apps/launcher/src/funding.ts).
-Use the confirmed euro totals and keep the goal greater than zero. The launcher
-uses these figures for the visible amounts, accessible description, and bar.
-Run `pnpm --filter @gwonmac/launcher-ui test` and `pnpm run check`.
-The new totals reach installed apps with the next application update.
+Edit [`src/shared/funding.json`](../src/shared/funding.json) on GitHub and merge
+the change into `main`. Set `raisedEuros` to the confirmed amount and
+`goalEuros` to the target, using whole euros. The goal must be greater than zero.
+Keep only these two fields. No app release or website deployment is needed.
+
+The launcher fetches this exact file from GitHub when its window first
+connects. Restart the app to check a changed amount; GitHub caching can delay
+its appearance. Fetching never blocks startup or Play. Invalid responses and
+network failures leave the displayed figures unchanged. Each app ships a copy
+of the same file as its offline fallback. A successful fetch updates memory
+for the current session; no separate disk cache is stored.
+
+This requires an app version with remote funding support. Older versions keep
+their bundled figures. Validate changes with
+`node --import ./scripts/ts-hook.mjs --test tests/unit/launcher-funding.test.ts`
+and `pnpm run check`.
 
 ## Disposable launcher fixtures
 

--- a/src/main/core/launcher-funding.ts
+++ b/src/main/core/launcher-funding.ts
@@ -1,0 +1,42 @@
+/**
+ * Reads the two project funding figures from one fixed GitHub file. This
+ * optional request never blocks play or grants remote control of the app.
+ */
+import bundledFunding from "../../shared/funding.json" with { type: "json" };
+import type { LauncherSnapshot } from "../../shared/launcher-contracts.js";
+import { readBoundedResponse } from "./bounded-response.js";
+
+export const FUNDING_URL = "https://raw.githubusercontent.com/Mat4m0/gwonmac/main/src/shared/funding.json";
+
+export function parseLauncherFunding(value: unknown): LauncherSnapshot["funding"] {
+  if (!value || typeof value !== "object" || Array.isArray(value)
+    || Object.keys(value).length !== 2
+    || !("raisedEuros" in value) || !("goalEuros" in value)
+    || typeof value.raisedEuros !== "number" || typeof value.goalEuros !== "number"
+    || !Number.isSafeInteger(value.raisedEuros) || value.raisedEuros < 0
+    || !Number.isSafeInteger(value.goalEuros) || value.goalEuros <= 0) {
+    throw new Error("Funding must contain a non-negative raised amount and a positive goal in whole euros.");
+  }
+  return Object.freeze({ raisedEuros: value.raisedEuros, goalEuros: value.goalEuros });
+}
+
+export const BUNDLED_FUNDING = parseLauncherFunding(bundledFunding);
+
+export async function fetchLauncherFunding(
+  fetch: (url: string, init: RequestInit) => Promise<Response>,
+): Promise<LauncherSnapshot["funding"] | null> {
+  try {
+    const response = await fetch(FUNDING_URL, {
+      signal: AbortSignal.timeout(8_000),
+      redirect: "error",
+      credentials: "omit",
+      cache: "no-cache",
+      headers: { accept: "application/json" },
+    });
+    if (!response.ok) return null;
+    const bytes = await readBoundedResponse(response, 1024);
+    return parseLauncherFunding(JSON.parse(new TextDecoder().decode(bytes)) as unknown);
+  } catch {
+    return null;
+  }
+}

--- a/src/main/launcher-orchestrator.ts
+++ b/src/main/launcher-orchestrator.ts
@@ -35,6 +35,7 @@ export interface LauncherOrchestratorOptions {
   readonly hasActiveClient: () => boolean;
   readonly getProgress: () => DownloadProgress;
   readonly getAppUpdate: () => AppUpdateState;
+  readonly getFunding: () => LauncherSnapshot["funding"];
   readonly getSettings: () => AppSettings;
   readonly getNews: (track: AppSettings["updateTrack"], preferences: LauncherSnapshot["preferences"]) => LauncherSnapshot["news"];
   readonly toolsLoaded: () => boolean;
@@ -70,6 +71,7 @@ export class LauncherOrchestrator {
     const fixture = this.options.developmentFixtures ? "fixture" as const : "placeholder" as const;
     return {
       revision: this.revision,
+      funding: this.options.getFunding(),
       experience: {
         installationKind: document.installationKind,
         setup: document.setupVersion > 0 ? "complete" : "pending",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -44,6 +44,7 @@ import { AUTOMATION_COMMAND } from "../shared/automation.js";
 import { ClientRuntime } from "./client-runtime.js";
 import { RendererClientSessions } from "./renderer-client-sessions.js";
 import { loadSettings } from "./core/settings.js";
+import { BUNDLED_FUNDING, fetchLauncherFunding } from "./core/launcher-funding.js";
 import { LauncherNewsService } from "./core/launcher-news.js";
 import {
   loadDiagnosticProfile,
@@ -570,6 +571,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
     paths.launcherState,
     loadedLauncherState.document,
   );
+  let launcherFunding = BUNDLED_FUNDING;
   const launcherNews = new LauncherNewsService({
     cachePath: paths.launcherNewsCache,
     fetch: (url, init) => net.fetch(url, init),
@@ -805,6 +807,7 @@ if (primaryInstance) void app.whenReady().then(async () => {
     getProgress: () => clientRuntime.progress,
     getAppUpdate: () => appUpdaterController!.getState(),
     getSettings: () => currentSettings ?? settings,
+    getFunding: () => launcherFunding,
     getNews: (track, contentPreferences) => launcherNews.snapshot(track, contentPreferences),
     toolsLoaded: () => enhancementSelection.tools,
     getTexturePacks: () => texturePacks.snapshot(),
@@ -850,6 +853,11 @@ if (primaryInstance) void app.whenReady().then(async () => {
     connected: () => {
       logEvent({ k: "launcher.connected" });
       void launcherNews.refresh().then(() => launcherOrchestrator!.publish());
+      void fetchLauncherFunding((url, init) => net.fetch(url, init)).then((funding) => {
+        if (!funding) return;
+        launcherFunding = funding;
+        launcherOrchestrator!.publish();
+      });
     },
     snapshot: () => launcherOrchestrator!.snapshot(),
     create: async ({ name, appearance }) => {

--- a/src/shared/funding.json
+++ b/src/shared/funding.json
@@ -1,0 +1,4 @@
+{
+  "raisedEuros": 86,
+  "goalEuros": 120
+}

--- a/src/shared/launcher-contracts.ts
+++ b/src/shared/launcher-contracts.ts
@@ -281,6 +281,7 @@ export type LauncherReadiness =
   | { readonly state: "offline-playable" };
 
 export interface LauncherSnapshot {
+  readonly funding: Readonly<{ raisedEuros: number; goalEuros: number }>;
   readonly revision: number;
   readonly experience: Readonly<{
     installationKind: LauncherInstallationKind;

--- a/tests/unit/launcher-funding.test.ts
+++ b/tests/unit/launcher-funding.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { BUNDLED_FUNDING, FUNDING_URL, fetchLauncherFunding, parseLauncherFunding } from "../../src/main/core/launcher-funding.ts";
+
+test("the checked-in fallback is valid and overfunding is allowed", () => {
+  assert.deepEqual(parseLauncherFunding(BUNDLED_FUNDING), BUNDLED_FUNDING);
+  assert.deepEqual(parseLauncherFunding({ raisedEuros: 150, goalEuros: 120 }), { raisedEuros: 150, goalEuros: 120 });
+});
+
+test("remote funding accepts only the two bounded numeric fields", () => {
+  for (const invalid of [
+    null, [], {}, { raisedEuros: 86 }, { raisedEuros: "86", goalEuros: 120 },
+    { raisedEuros: -1, goalEuros: 120 }, { raisedEuros: 1.5, goalEuros: 120 },
+    { raisedEuros: 86, goalEuros: 0 }, { raisedEuros: 86, goalEuros: Infinity },
+    { raisedEuros: Number.MAX_SAFE_INTEGER + 1, goalEuros: 120 },
+    { raisedEuros: 86, goalEuros: 120, url: "https://example.com" },
+  ]) assert.throws(() => parseLauncherFunding(invalid));
+});
+
+test("fetches only the fixed GitHub file without credentials or redirects", async () => {
+  const updated = { raisedEuros: 95, goalEuros: 150 };
+  const result = await fetchLauncherFunding(async (url, init) => {
+    assert.equal(url, FUNDING_URL);
+    assert.equal(init.redirect, "error");
+    assert.equal(init.credentials, "omit");
+    assert.equal(init.cache, "no-cache");
+    assert.ok(init.signal instanceof AbortSignal);
+    return Response.json(updated);
+  });
+  assert.deepEqual(result, updated);
+});
+
+test("failed, invalid, and oversized responses leave the caller's figures unchanged", async () => {
+  for (const response of [
+    new Response(null, { status: 404 }), new Response("not JSON"),
+    Response.json({ raisedEuros: 99, goalEuros: 0 }),
+    new Response(" ".repeat(1025)),
+    new Response("{}", { headers: { "content-length": "1025" } }),
+  ]) assert.equal(await fetchLauncherFunding(async () => response), null);
+  assert.equal(await fetchLauncherFunding(async () => { throw new Error("offline"); }), null);
+});

--- a/tests/unit/launcher-orchestrator.test.ts
+++ b/tests/unit/launcher-orchestrator.test.ts
@@ -1,3 +1,4 @@
+import funding from "../../src/shared/funding.json" with { type: "json" };
 import assert from "node:assert/strict";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -90,6 +91,7 @@ async function fixture(options: { allowUnreadyLaunch?: boolean } = {}) {
     getProgress: () => progress,
     getAppUpdate: () => ({ phase: "idle", currentVersion: "1.0.0" }),
     getSettings: () => DEFAULT_SETTINGS,
+    getFunding: () => funding,
     getNews: () => ({ status: "loading", stories: [] }),
     toolsLoaded: () => false,
     developmentFixtures: true,

--- a/tsconfig.tests.json
+++ b/tsconfig.tests.json
@@ -11,6 +11,7 @@
   // rather than by an `include` glob, so `tsconfig.json` stays the one place
   // that decides what `src` means.
   "compilerOptions": {
+    "resolveJsonModule": true,
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",


### PR DESCRIPTION
## What changed

Funding totals can now change without publishing a new app version. Maintainers edit `src/shared/funding.json` on GitHub and merge it into `main`; the launcher fetches that exact file when it starts.

## Why

Bundled figures required a release for every donation or goal change. One JSON file now owns the remote figures and the bundled offline fallback. The earlier launcher-only funding constants are removed.

## Invariant

Electron main accepts only a non-negative raised amount and a positive goal in whole euros. The fixed GitHub request has an 8-second timeout and a 1 KiB response limit, sends no credentials, and rejects redirects. It cannot change URLs, settings, or app behavior. Startup and Play never wait for it. A failed request leaves the current figures unchanged; a fresh offline session starts with the bundled copy. No disk cache, server, or polling job is added.

The launcher receives the figures through its existing snapshot. Both the visible bar and accessible values update together, including when funding exceeds the goal.

## Delivery

Third layer of stack #419, targeting `refactor/remove-launcher-tour` (#418). The JSON endpoint becomes available after merge to `main`. One app release is required to introduce remote funding support; later JSON edits require neither an app release nor a website deployment. Restarting the app fetches updates, subject to GitHub caching.

## Verification

- `pnpm check` passed, including 81 launcher tests.
- Focused funding and launcher-orchestrator tests passed.
- `pnpm build` and `pnpm package:built` passed.
- Browser exploration checked Home and Accounts funding presentation.
- `pnpm test:packaged` passed, including launcher startup, cached-profile launch, Tools isolation, and rollback safety.
- GitHub Application verification passed for `f102f339f888af586119ec77384300a0cc63f902`, including the full runtime suite and packaged-app tests. Security analysis passed.

- [x] I kept this pull request focused.
- [x] I ran the relevant checks.
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [x] I updated documentation when behavior or an invariant changed.

Prepared with GPT-6 in Codex desktop.
