### PR TITLE
fix(release): retain the beta's Stable rollback proof

### DIFF
--- a/docs/release-verification.md
+++ b/docs/release-verification.md
@@ -263,9 +263,10 @@ latest published Stable
 
 Each launch must report its exact version. Settings, Builds, Teams, window state,
 and profile-origin browser storage must remain readable and writable. No profile
-or chunk-directory reset can occur. The candidate must use only settings keys
-and values already owned by Stable. Returning Stable must preserve untouched
-values.
+or chunk-directory reset can occur. The candidate must preserve every
+Stable-owned settings key and its accepted values. Returning Stable must
+preserve untouched values. Additive candidate-only preferences may return to
+their safe defaults after a deliberate downgrade through the older Stable.
 
 For the unified-launcher cutover, the disposable cohort also contains a
 released Single Account mode document and a dormant Multiple Accounts
@@ -276,8 +277,10 @@ must leave all three documents byte-for-byte as the candidate left them. This
 is filesystem evidence only; the separate signed Keychain gate proves saved
 login continuity.
 
-This proof prevents a hidden compatibility store. A public candidate cannot be
-the first release that introduces a durable settings key that it writes.
+This proof compares settings through the keys owned by the rollback Stable.
+It refuses missing keys and changed Stable-owned values without adding a
+hidden compatibility store. It does not require the older Stable to preserve
+preferences that only the candidate owns.
 
 A feature-owned document is allowed only when the published Stable never reads,
 rewrites, or deletes that path. Travel uses this rule for

--- a/scripts/release-settings-compatibility.ts
+++ b/scripts/release-settings-compatibility.ts
@@ -61,3 +61,21 @@ export function validateCandidateSettings(
   }
   return settings;
 }
+
+/** Compare a candidate through the durable settings surface the rollback Stable owns. */
+export function projectStableOwnedSettings(
+  candidate: unknown,
+  stable: unknown,
+): Record<string, unknown> {
+  const candidateSettings = settingsRecord(candidate);
+  const stableSettings = settingsRecord(stable);
+  const projected: Record<string, unknown> = {};
+  for (const key of Object.keys(stableSettings)) {
+    assert.ok(
+      Object.hasOwn(candidateSettings, key),
+      `candidate settings omit Stable-owned key ${key}`,
+    );
+    projected[key] = candidateSettings[key];
+  }
+  return projected;
+}

--- a/scripts/verify-stable-beta-roundtrip.ts
+++ b/scripts/verify-stable-beta-roundtrip.ts
@@ -4,12 +4,11 @@
  *
  * This intentionally launches the two signed app bundles, not two source
  * checkouts. It is the stable-enabler gate for the first Beta and the recurring
- * compatibility gate after that. There is no migration framework: if a
- * candidate adds a durable settings key or accepted value that Stable does not
- * already own, or changes any durable shape in a way Stable cannot round-trip,
- * the release is refused. New settings therefore expand in Stable first and
- * may be used by a later candidate; old fields contract only after the
- * supported Stable baseline no longer needs them.
+ * compatibility gate after that. Stable-owned settings and player data must
+ * survive unchanged. A candidate may add settings that the older Stable does
+ * not own; deliberately returning to that Stable may discard those additive
+ * preferences, and a later candidate recreates their safe defaults. The proof
+ * still refuses a candidate that removes or changes any Stable-owned field.
  */
 import assert from "node:assert/strict";
 import { randomUUID } from "node:crypto";
@@ -69,6 +68,7 @@ import {
 import { seedCachedClient } from "../tests/helpers/cached-client.ts";
 import {
   canonicalizeStableSettings,
+  projectStableOwnedSettings,
   validateCandidateSettings,
 } from "./release-settings-compatibility.ts";
 
@@ -472,32 +472,39 @@ const candidateSettingsDomains = Array.from(
   },
 );
 
-async function proveStableAcceptsCandidateSettingDomains(
+async function proveStablePreservesOwnedSettingDomains(
   cohort: Cohort,
   stablePath: string,
 ): Promise<void> {
+  const stableBaseline = await withPackagedApp(cohort, stablePath, async (stable) =>
+    canonicalizeStableSettings(
+      await stable.page.evaluate(() => window.gwNative.settings.get()),
+      { disk: false },
+    )
+  );
   for (const [index, settings] of candidateSettingsDomains.entries()) {
+    const expected = projectStableOwnedSettings(settings, stableBaseline);
     await saveSettings(path.join(cohort.userData, "settings.json"), settings);
     await withPackagedApp(cohort, stablePath, async (stable) => {
       const read = await stable.page.evaluate(() => window.gwNative.settings.get());
       assert.deepEqual(
         canonicalizeStableSettings(read, { disk: false }),
-        settings,
-        `latest Stable refused candidate settings-domain case ${index + 1}`,
+        expected,
+        `latest Stable changed an owned settings-domain value in case ${index + 1}`,
       );
       assert.deepEqual(
         canonicalizeStableSettings(
           await stable.page.evaluate(() => window.gwNative.settings.set({})),
           { disk: false },
         ),
-        settings,
-        `latest Stable could not rewrite candidate settings-domain case ${index + 1}`,
+        expected,
+        `latest Stable could not rewrite its owned settings-domain values in case ${index + 1}`,
       );
     });
     assert.deepEqual(
       canonicalizeStableSettings(await readSettingsDocument(cohort), { disk: true }),
-      settings,
-      `latest Stable changed candidate settings-domain case ${index + 1}`,
+      expected,
+      `latest Stable changed its owned settings-domain values on disk in case ${index + 1}`,
     );
   }
   const names = await readdir(cohort.userData);
@@ -507,9 +514,6 @@ async function proveStableAcceptsCandidateSettingDomains(
     "latest Stable quarantined a candidate-owned settings value",
   );
 }
-
-const sortedKeys = (value: Record<string, unknown>): string[] =>
-  Object.keys(value).sort();
 
 async function readCoreCanonical(page: Page): Promise<{
   settings: Record<string, unknown>;
@@ -544,13 +548,20 @@ async function proveCoreRoundTrip(cohort: Cohort): Promise<void> {
   await withPackagedApp(cohort, candidateApp!, async (core) => {
     const initial = await readCoreCanonical(core.page);
     assert.deepEqual(initial.toolNamespaces, [], "candidate Core launch exposed a Tools namespace");
-    assert.deepEqual(initial.settings, stableSettings, "candidate changed Stable-owned Core settings");
+    assert.deepEqual(
+      projectStableOwnedSettings(initial.settings, stableSettings),
+      stableSettings,
+      "candidate changed Stable-owned Core settings",
+    );
     assert.equal(initial.settings.buildLibrary, false, "candidate lost the legacy Apply-Team opt-out");
     const changed = validateCandidateSettings(
       await updateCandidateSettings(core, { showDiagnostics: true }),
       { disk: false },
     );
-    assert.deepEqual(changed, { ...stableSettings, showDiagnostics: true });
+    assert.deepEqual(
+      projectStableOwnedSettings(changed, stableSettings),
+      { ...stableSettings, showDiagnostics: true },
+    );
     await roundTripProfileStore(core.page, "stable-core-template", "candidate-core-template");
     await assertWindowMatchesPersistedState(candidateWindowState, core.page);
   });
@@ -719,8 +730,8 @@ const finalLibrary: BuildLibrary = {
 };
 
 async function proveToolsRoundTrip(toolsCohort: Cohort): Promise<void> {
-  console.log("stable/beta compatibility: Stable accepts candidate value domains");
-  await proveStableAcceptsCandidateSettingDomains(toolsCohort, stablePath);
+  console.log("stable/beta compatibility: Stable preserves its owned value domains");
+  await proveStablePreservesOwnedSettingDomains(toolsCohort, stablePath);
   await writeFile(
     path.join(toolsCohort.userData, "settings.json"),
     JSON.stringify({
@@ -825,16 +836,23 @@ async function proveToolsRoundTrip(toolsCohort: Cohort): Promise<void> {
   assertCandidateAdoptedWithoutChangingStableOwners(candidateLauncherDocuments);
   await publishWindowSize(toolsCohort, 960, 680);
   const candidateSettingsDocument = await readSettingsDocument(toolsCohort);
-  assert.deepEqual(
-    sortedKeys(validateCandidateSettings(candidateSettingsDocument, { disk: true })),
-    sortedKeys(canonicalizeStableSettings(stableSettingsDocument, { disk: true })),
-    "candidate introduced or removed a durable settings key; ship the schema expansion in Stable before the beta/RC uses it",
+  const stableSettingsBeforeCandidate = canonicalizeStableSettings(
+    stableSettingsDocument,
+    { disk: true },
+  );
+  const candidateSettings = validateCandidateSettings(
+    candidateSettingsDocument,
+    { disk: true },
+  );
+  const stableSettingsAfterCandidate = projectStableOwnedSettings(
+    candidateSettings,
+    stableSettingsBeforeCandidate,
   );
 
   console.log("stable/beta compatibility: the same Stable reads and writes again");
   const rollbackWindowState = await readPersistedWindowState(toolsCohort);
   const expectedFinalSettings: Record<string, unknown> = {
-    ...validateCandidateSettings(candidateSettingsDocument, { disk: true }),
+    ...stableSettingsAfterCandidate,
     showDiagnostics: false,
     updateTrack: "stable",
   };
@@ -851,8 +869,8 @@ async function proveToolsRoundTrip(toolsCohort: Cohort): Promise<void> {
     assert.equal(returnedSettings.buildLibrary, false, "rollback Stable lost the opt-out");
     assert.deepEqual(
       returnedSettings,
-      validateCandidateSettings(candidateSettingsDocument, { disk: true }),
-      "Stable did not read every candidate-written settings value",
+      stableSettingsAfterCandidate,
+      "Stable changed a candidate-written setting it owns",
     );
     await updateStableSettings(running, { buildLibrary: true });
     const returned = await readToolsCanonical(running.page);

--- a/tests/policy/source-release-pipeline.test.ts
+++ b/tests/policy/source-release-pipeline.test.ts
@@ -344,8 +344,8 @@ test("the Stable rollback proof respects the Build Library feature gate", () => 
 test("the Stable domain proof writes through the candidate rollback serializer", () => {
   const roundTrip = read("scripts/verify-stable-beta-roundtrip.ts");
   const domainProof = roundTrip.slice(
-    roundTrip.indexOf("async function proveStableAcceptsCandidateSettingDomains"),
-    roundTrip.indexOf("const sortedKeys"),
+    roundTrip.indexOf("async function proveStablePreservesOwnedSettingDomains"),
+    roundTrip.indexOf("async function readCoreCanonical"),
   );
 
   assert.match(
@@ -356,6 +356,7 @@ test("the Stable domain proof writes through the candidate rollback serializer",
     domainProof,
     /JSON\.stringify\(\{ formatVersion: 1, \.\.\.settings \}\)/,
   );
+  assert.match(domainProof, /projectStableOwnedSettings\(settings, stableBaseline\)/);
 });
 
 test("the Stable rollback proof preserves unified-launcher cutover documents", () => {

--- a/tests/unit/release-settings-compatibility.test.ts
+++ b/tests/unit/release-settings-compatibility.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
   canonicalizeStableSettings,
+  projectStableOwnedSettings,
   validateCandidateSettings,
 } from "../../scripts/release-settings-compatibility.ts";
 
@@ -50,6 +51,28 @@ describe("release settings compatibility", () => {
         { disk: true },
       ),
       /formatVersion changed/u,
+    );
+  });
+
+  it("projects additive candidate settings through the rollback Stable's ownership", () => {
+    const stable = { renderScale: 2, buildLibrary: false };
+    assert.deepEqual(
+      projectStableOwnedSettings(
+        { ...stable, cartographyOverlayEnabled: true },
+        stable,
+      ),
+      stable,
+    );
+    assert.deepEqual(
+      projectStableOwnedSettings(
+        { ...stable, renderScale: 1.5, cartographyOverlayEnabled: true },
+        stable,
+      ),
+      { renderScale: 1.5, buildLibrary: false },
+    );
+    assert.throws(
+      () => projectStableOwnedSettings({ renderScale: 2 }, stable),
+      /omit Stable-owned key buildLibrary/u,
     );
   });
 });


### PR DESCRIPTION
The next beta starts from main, which missed the rollback-proof correction already used by the published beta. Its release gate would refuse additive feature preferences again.

Forward-port #345 from canonical release commit `0c1c908b9e15e001344ccc5c3dbdb8a6dd474ee1` with `git cherry-pick -x`, and align the owning release document. Every Stable-owned setting must remain present and retain an accepted value. Only candidate-only preferences may reset after a deliberate downgrade through older Stable. Player data, profile storage, window state, and quarantine checks stay strict.

This changes the verification harness and its documentation, not application runtime behavior. The original change was proven against exact signed Stable → Beta → Stable packages; the new candidate must still run its own signed proof.

Verification: focused compatibility/pipeline tests and `pnpm check` passed. The local runtime gate passed its checks, build, integration, release, and Tools browser suites. Electron finished with 149 passes, one skip, and two native-window failures; both failures passed an isolated rerun without code changes. The original full-gate invocation was not green. `pnpm package:built` and `pnpm test:packaged` passed. GitHub Application verification passed in run 34148050130, including runtime, packaging, and the final verification job. CodeQL passed.

Prepared with Codex using the repository test harness. Target: main, before cutting 2026.9.1-beta.1.
