### PR TITLE
chore(release): prepare version 2026.9.1-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "guild-wars",
   "productName": "Guild Wars Reforged",
-  "version": "2026.8.10",
+  "version": "2026.9.1-beta.1",
   "private": true,
   "packageManager": "pnpm@11.13.1",
   "type": "module",


### PR DESCRIPTION
Prepare the first beta of the new 2026.9.1 train from the completed launcher and Tools work on main. It includes the merged funding update, guided-tour removal, and both corrections retained from the previous beta.

This PR changes only the application version to `2026.9.1-beta.1`. The frozen source is `8aa5c07c145f07b227572b012301fa740404adae`; subsequent release changes are limited to release blockers.

The version matches `release/2026.9.1` and identifies a Beta. Its macOS build number `2609.1.31` is newer than Beta 4's `2609.0.34`.

Verification: type checks, lint, unit/policy tests, build, integration, release, and Tools browser tests passed locally. Electron completed with 148 passes, one skip, and three UI failures; all three passed an isolated rerun without code changes. The original full-gate invocation was not green. `pnpm package:built` and `pnpm test:packaged` passed. The selected main source passed Application verification in run 34150269973. GitHub Application verification passed for this PR in run 34151191827, including the full macOS runtime, package, website, and final verification gates. The initial release-branch creation run refused GitHub's all-zero previous SHA; the PR has a valid comparison base, and merging this version PR supplies a normal previous commit for the release-branch gate.

After merge and green verification on the exact release commit, run Versioned release with `dry_run=true`. Signing approval, current-client qualification, the exact signed rollback proof, and Matthias's live draft acceptance remain release gates. Nothing is published by this PR.

Prepared with Codex using the repository test harness.
