### PR TITLE
test(release): keep client capability expectations complete

### DIFF
--- a/tests/client-artifact/template-save-recert.test.ts
+++ b/tests/client-artifact/template-save-recert.test.ts
@@ -54,6 +54,7 @@ import {
 import {
   ENHANCEMENT_CAPABILITY_PRESETS,
   enhancementCapabilitiesForProfile,
+  type EnhancementCapabilities,
 } from "../../src/shared/enhancement-contracts.js";
 import { inspectLocalActionRoleCandidates } from "../../src/main/certification/enhancement-local-actions-proof.js";
 import {
@@ -170,6 +171,8 @@ test("the template-save verifier makes a fail-closed decision for a real client"
     quickItemMove: false,
     playerEffectObservation: false,
     effectIconGeometry: true,
+    resignAction: false,
+    whisperChat: false,
   });
   const verifyFeatureMutation = (candidate: Uint8Array) =>
     verifyLocalClientBytes(candidate, withoutCharacterSwitch);
@@ -190,7 +193,9 @@ test("the template-save verifier makes a fail-closed decision for a real client"
     quickItemMove: true,
     playerEffectObservation: true,
     effectIconGeometry: true,
-  });
+    resignAction: true,
+    whisperChat: true,
+  } satisfies EnhancementCapabilities);
   // If this is a statically shipped build, the shape locator must still
   // reproduce that record exactly. Unknown builds are intentionally decided
   // by the local verifier instead of making this test demand a release.
@@ -328,7 +333,9 @@ test("the template-save verifier makes a fail-closed decision for a real client"
     quickItemMove: false,
     playerEffectObservation: false,
     effectIconGeometry: false,
-  });
+    resignAction: false,
+    whisperChat: false,
+  } satisfies EnhancementCapabilities);
   assert.deepEqual(addressDecision.reasons, []);
   const addressTemplateBuild = addressDecision.templateSaveBuild;
   const addressEnhancementBuild = addressDecision.enhancementBuild;
@@ -353,7 +360,9 @@ test("the template-save verifier makes a fail-closed decision for a real client"
     quickItemMove: false,
     playerEffectObservation: false,
     effectIconGeometry: false,
-  });
+    resignAction: false,
+    whisperChat: false,
+  } satisfies EnhancementCapabilities);
 
   const areaInfo = playRegionLocation.playRegionLayout.areaInfo;
   const areaLookupLocal = parsed.bodies.findIndex((body) =>


### PR DESCRIPTION
The beta release stopped in exact-client qualification because the test's expected capability object omitted Resign and Whisper Chat. The verifier correctly proved both features, so deep equality rejected its additional fields before packaging or signing.

Update the complete capability expectations and type-check them with `satisfies EnhancementCapabilities`. Future capability additions now produce an ordinary TypeScript error instead of first failing this release-only assertion. The focused mutation cohort explicitly leaves the new independent features unrequested, preserving its existing refusal scope; the unmodified-client assertion requires both features to be proved.

Only one test file changes. Application behavior, verifier authority, accepted client shapes, and release gates are unchanged.

Verification:

- The previously failing real-client qualification test and static relocation test passed against the downloaded official client: 2 passed, no skips, including the mutation/refusal matrix (369 seconds).
- `pnpm check` passed.
- Local checks, build, integration, release, and Tools browser suites passed. Electron finished with 149 passes, one skip, and two native-window failures; both passed an isolated rerun without code changes. The original full-gate invocation was not green. `pnpm package:built` and `pnpm test:packaged` passed.
- GitHub Application verification passed in run 34155168838, including runtime, packaging, and the final verification gate.

Failure evidence: release run 34154140185. Targets `release/2026.9.1` as a release blocker. After squash merge, forward-port its canonical release commit to main with `git cherry-pick -x`, then retry the real release on the corrected green release commit. No dry run was requested.

Prepared with Codex using the repository test harness.
