### PR TITLE
test(release): retain complete client capability expectations

### DIFF
--- a/tests/client-artifact/template-save-recert.test.ts
+++ b/tests/client-artifact/template-save-recert.test.ts
@@ -54,6 +54,7 @@ import {
 import {
   ENHANCEMENT_CAPABILITY_PRESETS,
   enhancementCapabilitiesForProfile,
+  type EnhancementCapabilities,
 } from "../../src/shared/enhancement-contracts.js";
 import { inspectLocalActionRoleCandidates } from "../../src/main/certification/enhancement-local-actions-proof.js";
 import {
@@ -170,6 +171,8 @@ test("the template-save verifier makes a fail-closed decision for a real client"
     quickItemMove: false,
     playerEffectObservation: false,
     effectIconGeometry: true,
+    resignAction: false,
+    whisperChat: false,
   });
   const verifyFeatureMutation = (candidate: Uint8Array) =>
     verifyLocalClientBytes(candidate, withoutCharacterSwitch);
@@ -190,7 +193,9 @@ test("the template-save verifier makes a fail-closed decision for a real client"
     quickItemMove: true,
     playerEffectObservation: true,
     effectIconGeometry: true,
-  });
+    resignAction: true,
+    whisperChat: true,
+  } satisfies EnhancementCapabilities);
   // If this is a statically shipped build, the shape locator must still
   // reproduce that record exactly. Unknown builds are intentionally decided
   // by the local verifier instead of making this test demand a release.
@@ -328,7 +333,9 @@ test("the template-save verifier makes a fail-closed decision for a real client"
     quickItemMove: false,
     playerEffectObservation: false,
     effectIconGeometry: false,
-  });
+    resignAction: false,
+    whisperChat: false,
+  } satisfies EnhancementCapabilities);
   assert.deepEqual(addressDecision.reasons, []);
   const addressTemplateBuild = addressDecision.templateSaveBuild;
   const addressEnhancementBuild = addressDecision.enhancementBuild;
@@ -353,7 +360,9 @@ test("the template-save verifier makes a fail-closed decision for a real client"
     quickItemMove: false,
     playerEffectObservation: false,
     effectIconGeometry: false,
-  });
+    resignAction: false,
+    whisperChat: false,
+  } satisfies EnhancementCapabilities);
 
   const areaInfo = playRegionLocation.playRegionLayout.areaInfo;
   const areaLookupLocal = parsed.bodies.findIndex((body) =>


### PR DESCRIPTION
Keep the beta's exact-client qualification correction on main so the next release does not repeat the same failure.

Forward-port #424 from canonical release commit `e501e2900f771cca87e06c3f13f9868bd97ab352` using `git cherry-pick -x`. The test expects Resign and Whisper Chat and requires complete capability objects at type-check time. Only the same test file changes; no runtime or verifier behavior changes.

Verification: `pnpm check` passed on this branch. Its tree differs from the verified release tree only in the application version. The source fix passed the real-client mutation/refusal proof, packaged checks, and GitHub Application verification in run 34155168838. The earlier local full gate had two native-window failures that passed isolated reruns; its original invocation was not green. This PR's GitHub Application verification passed in run 34156249728, including runtime, packaging, the final verification gate, and CodeQL.

The current beta retry already contains this correction. This PR retains it on main and does not change the release version.

Prepared with Codex using the repository test harness.
