### PR TITLE
test(release): launch only the account under Keychain test

### DIFF
--- a/tests/signed-keychain-runtime.ts
+++ b/tests/signed-keychain-runtime.ts
@@ -95,26 +95,24 @@ async function useSecrets(
     appPath,
     productName: channelConfig.productName,
     userData: profile,
-    openFirstProfile: true,
   });
+  let gamePage = running.page;
   try {
-    let gamePage = running.page;
-    if (accountName !== "Main account") {
-      const launcher = running.launcherPage;
-      if (!launcher) throw new Error("the signed app did not expose the unified launcher");
-      let target = (await launcher.evaluate(() => window.launcherNative.state.get()))
+    // Open only the account under test; an unfinished Main launch blocks the queue.
+    const launcher = running.launcherPage;
+    if (!launcher) throw new Error("the signed app did not expose the unified launcher");
+    let target = (await launcher.evaluate(() => window.launcherNative.state.get()))
+      .profiles.find((candidate) => candidate.name === accountName);
+    if (!target) {
+      await launcher.evaluate(
+        (name) => window.launcherNative.profiles.create({ name }),
+        accountName,
+      );
+      target = (await launcher.evaluate(() => window.launcherNative.state.get()))
         .profiles.find((candidate) => candidate.name === accountName);
-      if (!target) {
-        await launcher.evaluate(
-          (name) => window.launcherNative.profiles.create({ name }),
-          accountName,
-        );
-        target = (await launcher.evaluate(() => window.launcherNative.state.get()))
-          .profiles.find((candidate) => candidate.name === accountName);
-      }
-      if (!target) throw new Error(`could not create signed test account ${accountName}`);
-      gamePage = await openPackagedProfile(running, target.id);
     }
+    if (!target) throw new Error(`could not create signed test account ${accountName}`);
+    gamePage = await openPackagedProfile(running, target.id);
     console.log(`signed keychain: ${accountName}: ${action}: invoking`);
     const result = await gamePage.evaluate(
       async ({ action: next, value }) => {
@@ -154,7 +152,7 @@ async function useSecrets(
     return result;
   } finally {
     console.log(`signed keychain: ${accountName}: ${action}: closing`);
-    await closePackagedApp(running);
+    await closePackagedApp({ ...running, page: gamePage });
     console.log(`signed keychain: ${accountName}: ${action}: closed`);
   }
 }


### PR DESCRIPTION
The signed release passed client qualification, signing, notarization, and package smoke checks, then timed out before saving credentials for the second account. The Keychain test always opened Main first. That unfinished offline fixture launch could hold the account startup queue, preventing the requested second account from opening.

Open only the named account for each Keychain operation, and close the actual game page used by that operation. Keep all credential-isolation, relaunch, move, replacement, and cleanup assertions. No application code, timeout, signing configuration, or Keychain policy changes.

Verification:

- Downloaded the retained signed candidate from failed run 34156814979 and verified ZIP checksums and app signatures.
- Exercised the corrected launch block against that exact signed app for Main → Second → Second → Main → Second. All five passed with exactly one game window. This used disposable profiles and volatile secrets; it does not claim signed Keychain persistence.
- The subsequent exact signed Stable 2026.8.10 → candidate 2026.9.1-beta.1 → Stable round-trip passed locally, including settings and player-data compatibility. This checks the next release gate before another rebuild.
- `pnpm check`, build, integration, release, and Tools browser tests passed. Electron finished with 149 passes, one skip, and two focus/pointer-lock failures; both passed isolated reruns without changes. The initial full-gate invocation was not green. `pnpm package:built` and `pnpm test:packaged` passed. GitHub Application verification passed in run 34158644526, including runtime, packaging, and the final gate.

The actual signed Keychain persistence proof remains required on the ephemeral release runner. Targets release/2026.9.1 as a release blocker. Forward-port the canonical squash commit to main after merge, then retry the real release without a dry run.

Prepared with Codex using the repository test harness. Temporary launch probe removed; signed artifacts retained outside the repository for diagnosis.
