### PR TITLE
test(release): keep signed account checks unblocked on main

### DIFF
--- a/tests/signed-keychain-runtime.ts
+++ b/tests/signed-keychain-runtime.ts
@@ -95,26 +95,24 @@ async function useSecrets(
     appPath,
     productName: channelConfig.productName,
     userData: profile,
-    openFirstProfile: true,
   });
+  let gamePage = running.page;
   try {
-    let gamePage = running.page;
-    if (accountName !== "Main account") {
-      const launcher = running.launcherPage;
-      if (!launcher) throw new Error("the signed app did not expose the unified launcher");
-      let target = (await launcher.evaluate(() => window.launcherNative.state.get()))
+    // Open only the account under test; an unfinished Main launch blocks the queue.
+    const launcher = running.launcherPage;
+    if (!launcher) throw new Error("the signed app did not expose the unified launcher");
+    let target = (await launcher.evaluate(() => window.launcherNative.state.get()))
+      .profiles.find((candidate) => candidate.name === accountName);
+    if (!target) {
+      await launcher.evaluate(
+        (name) => window.launcherNative.profiles.create({ name }),
+        accountName,
+      );
+      target = (await launcher.evaluate(() => window.launcherNative.state.get()))
         .profiles.find((candidate) => candidate.name === accountName);
-      if (!target) {
-        await launcher.evaluate(
-          (name) => window.launcherNative.profiles.create({ name }),
-          accountName,
-        );
-        target = (await launcher.evaluate(() => window.launcherNative.state.get()))
-          .profiles.find((candidate) => candidate.name === accountName);
-      }
-      if (!target) throw new Error(`could not create signed test account ${accountName}`);
-      gamePage = await openPackagedProfile(running, target.id);
     }
+    if (!target) throw new Error(`could not create signed test account ${accountName}`);
+    gamePage = await openPackagedProfile(running, target.id);
     console.log(`signed keychain: ${accountName}: ${action}: invoking`);
     const result = await gamePage.evaluate(
       async ({ action: next, value }) => {
@@ -154,7 +152,7 @@ async function useSecrets(
     return result;
   } finally {
     console.log(`signed keychain: ${accountName}: ${action}: closing`);
-    await closePackagedApp(running);
+    await closePackagedApp({ ...running, page: gamePage });
     console.log(`signed keychain: ${accountName}: ${action}: closed`);
   }
 }


### PR DESCRIPTION
The signed release test opened Main before testing a second account. The offline Main launch could hold the startup queue and time out before the second account reached its Keychain checks. Each invocation now opens only the account it tests and closes that game window.

Forward-port of #426, canonical release commit `6c7faafd3bd9d1b08972b32634e16e66a493f018`, with `git cherry-pick -x`. No production code, credential assertions, or timeouts change.

Verification:
- The source PR passed full GitHub Application verification.
- The corrected launch sequence passed five account launches against the retained signed beta app, using disposable data and volatile secrets.
- The exact signed Stable 2026.8.10 → Beta 2026.9.1-beta.1 → Stable roundtrip passed.
- Source local verification had two native focus/pointer-lock failures; both passed isolated reruns. Packaging and packaged smoke passed.
- This forward-port runs `pnpm check`; full GitHub verification is required before merge.

The real signed Keychain persistence proof still runs in the release workflow. Local volatile-secret checks do not prove Keychain persistence.

Prepared with Codex.
