### PR TITLE
feat(maps): simplify and remember elite capture choices

### DIFF
--- a/apps/tools/src/EliteSkillsApp.test.ts
+++ b/apps/tools/src/EliteSkillsApp.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { flushPromises, mount } from "@vue/test-utils";
 import { ref } from "vue";
+import EliteMarkers from "./components/EliteMarkers.vue";
 import EliteSkillsApp from "./EliteSkillsApp.vue";
 import { ELITE_FIXTURE_SKILLS, eliteFixtureView } from "./elite-fixture";
 import { createSkillCatalogue } from "./skill-catalog";
@@ -30,6 +31,58 @@ async function planner(trackingHost = host()) {
 const lissah = ELITE_LOCATIONS.find((entry) => entry.boss === "Lissah the Packleader")!;
 
 describe("Elite Skills", () => {
+  it("saves a drag once on release and cancels it when the map closes", async () => {
+    const api = host();
+    const wrapper = await planner(api);
+    const grip = wrapper.get<HTMLElement>('.elite-panel-resize');
+    grip.element.setPointerCapture = vi.fn();
+    const before = vi.mocked(api.update).mock.calls.length;
+    await grip.trigger('pointerdown', { pointerId: 1, clientX: 0, clientY: 500 });
+    await grip.trigger('pointermove', { pointerId: 1, clientX: 50, clientY: 452 });
+    expect(vi.mocked(api.update).mock.calls).toHaveLength(before);
+    await grip.trigger('pointerup', { pointerId: 1 });
+    await flushPromises();
+    expect(vi.mocked(api.update).mock.calls).toHaveLength(before + 1);
+    await grip.trigger('pointerdown', { pointerId: 2, clientX: 0, clientY: 500 });
+    await grip.trigger('pointermove', { pointerId: 2, clientX: 0, clientY: 600 });
+    await wrapper.setProps({ view: { ...eliteFixtureView(), world: null } });
+    await flushPromises();
+    expect(vi.mocked(api.update).mock.calls).toHaveLength(before + 1);
+    wrapper.unmount();
+  });
+  it("resizes within map bounds and restores each character's height", async () => {
+    const api = host();
+    const wrapper = await planner(api);
+    const view = eliteFixtureView();
+    const maxHeight = Math.min(view.world!.box.height - 24, window.innerHeight - view.world!.box.top - 28);
+    const height = () => Number.parseFloat(wrapper.get<HTMLElement>('.elite-panel').element.style.height);
+    expect(height()).toBe(Math.min(maxHeight, Math.max(440, window.innerHeight * 0.8)));
+    const grip = wrapper.get('[aria-label="Resize Elite Skills height"]');
+    await grip.trigger('keydown', { key: 'ArrowUp', shiftKey: true });
+    await flushPromises();
+    const smaller = height();
+    expect(smaller).toBeLessThan(maxHeight);
+    expect((await api.get({ characterKey: view.characterKey! })).view.panelHeightRatio).toBe(smaller / window.innerHeight);
+    await wrapper.get('[aria-label="Collapse Elite Skills"]').trigger('click');
+    expect(wrapper.get<HTMLElement>('.elite-map-summary').element.style.height).toBe('');
+    await wrapper.get('.elite-map-trigger').trigger('click');
+    expect(height()).toBe(smaller);
+    await wrapper.setProps({ view: eliteFixtureView(false, true) });
+    await flushPromises();
+    await wrapper.get('.elite-map-trigger').trigger('click');
+    expect(height()).toBe(Math.min(maxHeight, Math.max(440, window.innerHeight * 0.8)));
+    await wrapper.setProps({ view });
+    await flushPromises();
+    expect(height()).toBe(smaller);
+    wrapper.unmount();
+    const restarted = await planner(api);
+    expect(Number.parseFloat(restarted.get<HTMLElement>('.elite-panel').element.style.height)).toBe(smaller);
+    const nextGrip = restarted.get('[aria-label="Resize Elite Skills height"]');
+    for (let index = 0; index < 20; index++) await nextGrip.trigger('keydown', { key: 'ArrowDown', shiftKey: true });
+    expect(Number.parseFloat(restarted.get<HTMLElement>('.elite-panel').element.style.height)).toBe(maxHeight);
+    restarted.unmount();
+  });
+
   it("finds a skill through boss and area names, and carries the selected boss to the mission map", async () => {
     const wrapper = await planner();
     await wrapper.get('input[type="search"]').setValue("Lissah");
@@ -39,7 +92,7 @@ describe("Elite Skills", () => {
     const target = wrapper.findAll('.elite-location').find((entry) => entry.text().includes('Lissah'))!;
     await target.get('button').trigger('click');
     await flushPromises();
-    expect(target.text()).toContain('Tracking this boss');
+    expect(target.text()).toContain('Current target');
     await wrapper.setProps({ view: eliteFixtureView(true) });
     expect(wrapper.find('.elite-panel').exists()).toBe(false);
     expect(wrapper.get('.elite-map-trigger').attributes('title')).toContain('Lissah');
@@ -57,6 +110,63 @@ describe("Elite Skills", () => {
     await wrapper.setProps({ view: { ...eliteFixtureView(true), mapId: 55 } });
     expect(wrapper.findAll('.elite-marker')).toHaveLength(0);
     expect(wrapper.get('.elite-map-trigger').attributes('title')).toContain('Target is in Bjora Marches');
+    wrapper.unmount();
+  });
+  it("saves a matching skill directly without expanding it or changing the target", async () => {
+    const api = host();
+    const wrapper = await planner(api);
+    await wrapper.get('input[type="search"]').setValue('Hundred Blades');
+    const markers = wrapper.findAll('.elite-marker').map(marker => marker.attributes('aria-label'));
+    await wrapper.get('[aria-label="Save Hundred Blades"]').trigger('click');
+    await flushPromises();
+    expect(wrapper.get('.elite-result-main').attributes('aria-expanded')).toBe('false');
+    expect(wrapper.find('.elite-inline-detail').exists()).toBe(false);
+    expect(wrapper.get('[aria-label="Unsave Hundred Blades"]').attributes('aria-pressed')).toBe('true');
+    expect(wrapper.findAll('.elite-marker').map(marker => marker.attributes('aria-label'))).toEqual(markers);
+    const saved = await api.get({ characterKey: eliteFixtureView().characterKey! });
+    expect(saved.skills).toContain(ELITE_FIXTURE_SKILLS.find(skill => skill.name === 'Hundred Blades')!.id);
+    expect(saved.activeLocation).toBe(null);
+    await wrapper.get('[aria-label="Unsave Hundred Blades"]').trigger('click');
+    await flushPromises();
+    expect((await api.get({ characterKey: eliteFixtureView().characterKey! })).skills).toEqual([]);
+    wrapper.unmount();
+  });
+  it("keeps one inline detail open while preserving filters and neighboring results", async () => {
+    const wrapper = await planner();
+    const count = wrapper.findAll('.elite-result').length;
+    await wrapper.findAll('.elite-result-main')[0]!.trigger('click');
+    expect(wrapper.findAll('.elite-inline-detail')).toHaveLength(1);
+    expect(wrapper.findAll('.elite-result')).toHaveLength(count);
+    expect(wrapper.get('input[type="search"]').isVisible()).toBe(true);
+    await wrapper.findAll('.elite-result-main')[1]!.trigger('click');
+    expect(wrapper.findAll('.elite-inline-detail')).toHaveLength(1);
+    expect(wrapper.findAll('.elite-result-main')[0]!.attributes('aria-expanded')).toBe('false');
+    expect(wrapper.findAll('.elite-result-main')[1]!.attributes('aria-expanded')).toBe('true');
+    wrapper.unmount();
+  });
+  it("selects each profession independently and persists deselect-all across remounts", async () => {
+    const api = host();
+    let wrapper = await planner(api);
+    expect(wrapper.findAll('.elite-profession')).toHaveLength(10);
+    expect(wrapper.findAll('.elite-profession img')).toHaveLength(10);
+    await wrapper.findAll('button').find(button => button.text() === 'Deselect all')!.trigger('click');
+    expect(wrapper.findAll('.elite-marker')).toHaveLength(0);
+    expect(wrapper.findAll('.elite-result')).toHaveLength(0);
+    for (const name of ['Warrior', 'Ranger', 'Monk', 'Necromancer', 'Mesmer', 'Elementalist', 'Assassin', 'Ritualist', 'Paragon', 'Dervish']) {
+      const choice = wrapper.get(`.elite-profession[aria-label="${name}"]`);
+      await choice.trigger('click');
+      expect(choice.attributes('aria-pressed')).toBe('true');
+      expect(wrapper.findAll('.elite-profession[aria-pressed="true"]')).toHaveLength(1);
+      await choice.trigger('click');
+    }
+    await flushPromises();
+    wrapper.unmount();
+    wrapper = await planner(api);
+    expect(wrapper.findAll('.elite-profession[aria-pressed="true"]')).toHaveLength(0);
+    expect(wrapper.findAll('.elite-marker')).toHaveLength(0);
+    await wrapper.findAll('button').find(button => button.text() === 'Select all')!.trigger('click');
+    expect(wrapper.findAll('.elite-profession[aria-pressed="true"]')).toHaveLength(10);
+    expect(wrapper.findAll('.elite-result').length).toBeGreaterThan(0);
     wrapper.unmount();
   });
   it("keeps unknown skills visible and uses character learned status", async () => {
@@ -93,7 +203,7 @@ describe("Elite Skills", () => {
     expect(markers[0]?.outside).toBe(true);
     expect(markers[0]!.x).toBeLessThan(view.mission!.box.width);
   });
-  it("keeps nearby and alternate positions as individual skill markers", () => {
+  it("deduplicates touching copies and preserves the active boss position", () => {
     const surface = { box: { left: 0, top: 0, width: 400, height: 300 },
       transform: { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 } };
     const locations = [
@@ -102,18 +212,20 @@ describe("Elite Skills", () => {
     ];
     const markers = eliteMarkers(locations, surface, 'b');
     expect(markers.map(marker => [marker.key, marker.x, marker.location.id])).toEqual([
-      ['a:0', 35, 'a'], ['a:1', 36, 'a'], ['b:0', 37, 'b'],
+      ['b:0', 37, 'b'],
     ]);
+    expect(markers[0]!.locations.map(location => location.id)).toEqual(['a', 'b']);
     expect(markers.filter(marker => marker.active).map(marker => marker.location.id)).toEqual(['b']);
   });
-  it("maintains keyboard focus through opening, details, back, and collapse", async () => {
+  it("maintains keyboard focus through opening, inline details, and collapse", async () => {
     const wrapper = await planner();
     expect(document.activeElement).toBe(wrapper.get('input[type="search"]').element);
     await wrapper.get('input[type="search"]').setValue('Eviscerate');
     const row = wrapper.get('.elite-result-main');
+    (row.element as HTMLButtonElement).focus();
     await row.trigger('click', { detail: 0 });
-    expect(document.activeElement).toBe(wrapper.get('.elite-back').element);
-    await wrapper.get('.elite-back').trigger('click', { detail: 0 });
+    expect(wrapper.get('.elite-result-main').attributes('aria-expanded')).toBe('true');
+    await wrapper.get('.elite-result-main').trigger('click', { detail: 0 });
     expect(document.activeElement).toBe(wrapper.get('.elite-result-main').element);
     expect(wrapper.get<HTMLInputElement>('input[type="search"]').element.value).toBe('Eviscerate');
     await wrapper.get('[aria-label="Collapse Elite Skills"]').trigger('click', { detail: 0 });
@@ -145,7 +257,7 @@ describe("Elite Skills", () => {
 
 
 describe("elite map preferences", () => {
-  it("keeps the same markers through details, back and collapse, and restores list position", async () => {
+  it("keeps the same markers through inline details and collapse without losing list position", async () => {
     const wrapper = await planner();
     const markers = () => wrapper.findAll('.elite-marker').map(marker => marker.attributes('aria-label'));
     const original = markers();
@@ -153,7 +265,7 @@ describe("elite map preferences", () => {
     wrapper.get<HTMLElement>('.elite-panel-content').element.scrollTop = 177;
     await wrapper.get('.elite-result-main').trigger('click');
     expect(markers()).toEqual(original);
-    await wrapper.get('.elite-back').trigger('click');
+    await wrapper.get('.elite-result-main').trigger('click');
     expect(wrapper.get<HTMLElement>('.elite-panel-content').element.scrollTop).toBe(177);
     await wrapper.get('[aria-label="Collapse Elite Skills"]').trigger('click');
     expect(markers()).toEqual(original);
@@ -188,25 +300,23 @@ describe("elite map preferences", () => {
     expect(wrapper.get<HTMLInputElement>('input[type="search"]').element.value).toBe('');
     wrapper.unmount();
   });
-  it("follows both live professions only in My professions mode", async () => {
+  it("follows both live professions only in Current class mode", async () => {
     const wrapper = await planner();
     const names = () => wrapper.findAll('.elite-result').map(row => row.text()).join(' ');
-    await wrapper.findAll('button').find(button => button.text() === 'My professions')!.trigger('click');
+    await wrapper.findAll('button').find(button => button.text() === 'Current class')!.trigger('click');
     expect(names()).toContain('Barrage');
     expect(names()).toContain('Eviscerate');
     expect(names()).not.toContain('Restore Condition');
     await wrapper.setProps({ view: eliteFixtureView(false, false, false, 3) });
     expect(names()).not.toContain('Barrage');
     expect(names()).toContain('Restore Condition');
-    await wrapper.findAll('button').find(button => button.text() === 'Choose…')!.trigger('click');
-    const choices = wrapper.findAll('.elite-profession-choices label');
-    await choices.find(label => label.text() === 'Warrior')!.get('input').setValue(true);
-    await choices.find(label => label.text() === 'Ranger')!.get('input').setValue(true);
+    await wrapper.get('.elite-profession[aria-label="Monk"]').trigger('click');
+    await wrapper.get('.elite-profession[aria-label="Ranger"]').trigger('click');
     expect(names()).toContain('Barrage');
     expect(names()).not.toContain('Restore Condition');
     await wrapper.setProps({ view: { ...eliteFixtureView(), observation: { status: 'waiting' } } });
     expect(names()).toContain('Barrage');
-    await wrapper.findAll('button').find(button => button.text() === 'My professions')!.trigger('click');
+    await wrapper.findAll('button').find(button => button.text() === 'Current class')!.trigger('click');
     expect(wrapper.findAll('.elite-result')).toHaveLength(0);
     expect(wrapper.text()).toContain('Your professions are unavailable');
     wrapper.unmount();
@@ -246,7 +356,7 @@ describe("elite map preferences", () => {
     await wrapper.get('.elite-result-main').trigger('click');
     expect(wrapper.findAll('.elite-marker')).toHaveLength(count);
     await wrapper.findAll('button').find(button => button.text() === 'Show only this skill')!.trigger('click');
-    await wrapper.get('.elite-back').trigger('click');
+    await wrapper.get('.elite-result-main').trigger('click');
     expect(wrapper.findAll('.elite-result')).toHaveLength(1);
     expect(wrapper.text()).toContain('Clear skill focus');
     wrapper.unmount();
@@ -328,5 +438,62 @@ describe("elite hover previews", () => {
     expect(wrapper.find('[role="tooltip"]').exists()).toBe(false);
     expect(wrapper.find('.elite-panel').exists()).toBe(true);
     wrapper.unmount();
+  });
+});
+
+
+describe("overlapping elite markers", () => {
+  it("deduplicates the real Sorrow's Furnace row without hiding another area or distant spawn", () => {
+    const row = ELITE_LOCATIONS.filter(location => location.mapId === 190);
+    const surface = { box: { left: 0, top: 0, width: 800, height: 600 }, transform: { a: 1, b: 0, c: 0, d: 1, e: -4800, f: -5200 } };
+    const marks = eliteMarkers(row, surface, null);
+    expect(marks).toHaveLength(6);
+    const anguish = marks.find(marker => marker.location.skillId === 54)!;
+    expect(anguish.locations.map(location => location.boss).sort()).toEqual(['Garbok Handsmasher', 'Hierophant Morlog', 'Korvald Willcrusher', 'Vokur Grimshackles']);
+    const otherArea = { ...anguish.location, id: 'other-area', mapId: 100 };
+    const distant = { ...anguish.location, id: 'distant', points: [[5300, 5500]] as const };
+    expect(eliteMarkers([...row, otherArea, distant], surface, null)).toHaveLength(8);
+  });
+  it("keeps every boss behind one shared skill marker", async () => {
+    const surface = { box: { left: 0, top: 0, width: 400, height: 300 }, transform: { a: 1, b: 0, c: 0, d: 1, e: 0, f: 0 } };
+    const a = { ...lissah, id: 'a', points: [[80, 80], [81, 80]] as const };
+    const b = { ...lissah, id: 'b', points: [[80, 80]] as const };
+    const far = { ...lissah, id: 'far', points: [[180, 80]] as const };
+    const wrapper = mount(EliteMarkers, { props: { surface, locations: [a, b, far], activeLocation: null,
+      previewLocationId: null, catalogue: createSkillCatalogue(ELITE_FIXTURE_SKILLS), label: 'Test locations' } });
+    expect(wrapper.findAll('.elite-marker')).toHaveLength(2);
+    await wrapper.get('.elite-marker').trigger('pointerenter');
+    expect(wrapper.emitted('inspect')![0]).toEqual([a, 80, 80, false, [a, b]]);
+    await wrapper.setProps({ locations: [a, far] });
+    await wrapper.get('.elite-marker').trigger('focus');
+    expect(wrapper.emitted('inspect')!.at(-1)).toEqual([a, 80, 80, true, [a]]);
+    wrapper.unmount();
+  });
+  it("keeps overlapping choices reachable, changes the preview, and opens details without filtering", async () => {
+    const wrapper = await planner();
+    const view = eliteFixtureView();
+    await wrapper.setProps({ view: { ...view, world: { ...view.world!, transform: { a: 0.001, b: 0, c: 0, d: 0.001, e: 100, f: 100 } } } });
+    await wrapper.get('[aria-label="Collapse Elite Skills"]').trigger('click');
+    const original = wrapper.findAll('.elite-marker').map(marker => marker.attributes('aria-label'));
+    await wrapper.get('.elite-marker').trigger('pointerenter');
+    expect(wrapper.get('.elite-preview').attributes('role')).toBe('region');
+    const choices = wrapper.findAll('.elite-nearby-choice');
+    expect(choices.length).toBeGreaterThan(1);
+    expect(new Set(choices.map(choice => choice.attributes('aria-label')!.split(' —')[0])).size).toBe(choices.length);
+    const barrage = choices.find(choice => choice.attributes('aria-label')!.startsWith('Barrage —'))!;
+    vi.useFakeTimers();
+    try {
+      await wrapper.get('.elite-marker').trigger('pointerleave');
+      await wrapper.get('.elite-preview').trigger('pointerenter');
+      await barrage.trigger('pointerenter');
+      await vi.advanceTimersByTimeAsync(150);
+      expect(wrapper.get('.elite-preview .inspector-identity strong').text()).toBe('Barrage');
+      expect(wrapper.findAll('.elite-preview-bosses li').length).toBeGreaterThan(1);
+      expect(wrapper.findAll('.elite-marker').map(marker => marker.attributes('aria-label'))).toEqual(original);
+      await barrage.trigger('click');
+      expect(wrapper.find('.elite-preview').exists()).toBe(false);
+      expect(wrapper.get('.elite-panel .inspector-identity strong').text()).toBe('Barrage');
+      expect(wrapper.findAll('.elite-marker').map(marker => marker.attributes('aria-label'))).toEqual(original);
+    } finally { wrapper.unmount(); vi.useRealTimers(); }
   });
 });

--- a/apps/tools/src/EliteSkillsApp.test.ts
+++ b/apps/tools/src/EliteSkillsApp.test.ts
@@ -11,9 +11,10 @@ import { travelCharacterKey, type TravelCharacterKey } from "../../../src/shared
 import { eliteMarkers } from "./elite-map-markers";
 
 function host(): EliteTrackingHost {
-  let current = EMPTY_ELITE_TRACKING;
-  return { get: vi.fn(async () => current), update: vi.fn(async ({ change }) => {
-    current = changeEliteTracking(current, change, ELITE_LOCATIONS); return current;
+  const saved = new Map<string, EliteTracking>();
+  return { get: vi.fn(async ({ characterKey }) => saved.get(characterKey) ?? EMPTY_ELITE_TRACKING), update: vi.fn(async ({ characterKey, change }) => {
+    const current = changeEliteTracking(saved.get(characterKey) ?? EMPTY_ELITE_TRACKING, change, ELITE_LOCATIONS);
+    saved.set(characterKey, current); return current;
   }) };
 }
 async function planner(trackingHost = host()) {
@@ -22,7 +23,8 @@ async function planner(trackingHost = host()) {
     catalogueProblem: "", trackingHost, openWiki: vi.fn(), reloadSkills: vi.fn(),
   } });
   await flushPromises();
-  await wrapper.get('.elite-map-trigger').trigger('click');
+  if (wrapper.find('.elite-map-trigger').exists()) await wrapper.get('.elite-map-trigger').trigger('click');
+  await flushPromises();
   return wrapper;
 }
 const lissah = ELITE_LOCATIONS.find((entry) => entry.boss === "Lissah the Packleader")!;
@@ -40,21 +42,21 @@ describe("Elite Skills", () => {
     expect(target.text()).toContain('Tracking this boss');
     await wrapper.setProps({ view: eliteFixtureView(true) });
     expect(wrapper.find('.elite-panel').exists()).toBe(false);
-    expect(wrapper.get('.elite-mission-tracker').text()).toContain('Lissah');
+    expect(wrapper.get('.elite-map-trigger').attributes('title')).toContain('Lissah');
     expect(wrapper.findAll('.elite-marker')).toHaveLength(1);
     await wrapper.get('.elite-marker').trigger('pointerenter');
     expect(wrapper.find('.elite-preview').exists()).toBe(true);
     await wrapper.setProps({ view: { ...eliteFixtureView(true), mission: null } });
     expect(wrapper.find('.elite-preview').exists()).toBe(false);
     expect(wrapper.find('.elite-marker').exists()).toBe(false);
-    expect(wrapper.find('.elite-mission-tracker').exists()).toBe(false);
+    expect(wrapper.find('.elite-map-summary').exists()).toBe(false);
     const missionView = eliteFixtureView(true);
     await wrapper.setProps({ view: { ...missionView, mission: { box: missionView.mission!.box, transform: null } } });
     expect(wrapper.findAll('.elite-marker')).toHaveLength(0);
-    expect(wrapper.get('.elite-mission-tracker').text()).toContain('Boss markers are unavailable in this area');
+    expect(wrapper.get('.elite-map-trigger').attributes('title')).toContain('Boss markers are unavailable in this area');
     await wrapper.setProps({ view: { ...eliteFixtureView(true), mapId: 55 } });
     expect(wrapper.findAll('.elite-marker')).toHaveLength(0);
-    expect(wrapper.get('.elite-mission-tracker').text()).toContain('Target is in Bjora Marches');
+    expect(wrapper.get('.elite-map-trigger').attributes('title')).toContain('Target is in Bjora Marches');
     wrapper.unmount();
   });
   it("keeps unknown skills visible and uses character learned status", async () => {
@@ -67,16 +69,17 @@ describe("Elite Skills", () => {
     expect(wrapper.findAll('.elite-result').map((entry) => entry.text()).join()).toContain('Eviscerate');
     wrapper.unmount();
   });
-  it("shows failed saves as unchanged and retries the intended action", async () => {
+  it("keeps unsaved changes visible and retries the intended action", async () => {
     const api = host();
     const update = vi.spyOn(api, 'update');
-    update.mockRejectedValueOnce(new Error('disk full'));
     const wrapper = await planner(api);
     await wrapper.get('input[type="search"]').setValue('Eviscerate');
+    await flushPromises();
+    update.mockRejectedValueOnce(new Error('disk full'));
     await wrapper.get('.elite-track-button').trigger('click');
     await flushPromises();
-    expect(wrapper.get('[role="alert"]').text()).toContain('saved plan is unchanged');
-    expect(wrapper.get('.elite-track-button').attributes('aria-pressed')).toBe('false');
+    expect(wrapper.get('[role="alert"]').text()).toContain('Changes are not saved');
+    expect(wrapper.get('.elite-track-button').attributes('aria-pressed')).toBe('true');
     await wrapper.get('[role="alert"] .ui-button').trigger('click');
     await flushPromises();
     expect(wrapper.get('.elite-track-button').attributes('aria-pressed')).toBe('true');
@@ -113,7 +116,7 @@ describe("Elite Skills", () => {
     await wrapper.get('.elite-back').trigger('click', { detail: 0 });
     expect(document.activeElement).toBe(wrapper.get('.elite-result-main').element);
     expect(wrapper.get<HTMLInputElement>('input[type="search"]').element.value).toBe('Eviscerate');
-    await wrapper.get('[aria-label="Close Elite Skills"]').trigger('click', { detail: 0 });
+    await wrapper.get('[aria-label="Collapse Elite Skills"]').trigger('click', { detail: 0 });
     expect(document.activeElement).toBe(wrapper.get('.elite-map-trigger').element);
     wrapper.unmount();
   });
@@ -126,16 +129,204 @@ describe("Elite Skills", () => {
     const controller = useEliteTracking(character, api);
     character.value = travelCharacterKey('fedcba9876543210');
     await flushPromises();
-    resolveLoad({ skills: [338], activeLocation: lissah.id, missionMap: true });
+    resolveLoad({ ...EMPTY_ELITE_TRACKING, skills: [338], activeLocation: lissah.id, missionMap: true });
     await flushPromises();
     expect(controller.tracking.value.skills).toEqual([]);
     void controller.change({ kind: 'track', skillId: 338 });
     character.value = null;
     await flushPromises();
-    resolveSave({ skills: [338], activeLocation: lissah.id, missionMap: true });
+    resolveSave({ ...EMPTY_ELITE_TRACKING, skills: [338], activeLocation: lissah.id, missionMap: true });
     await flushPromises();
     expect(controller.tracking.value.skills).toEqual([]);
     expect(controller.loaded.value).toBe(false);
     controller.dispose();
+  });
+});
+
+
+describe("elite map preferences", () => {
+  it("keeps the same markers through details, back and collapse, and restores list position", async () => {
+    const wrapper = await planner();
+    const markers = () => wrapper.findAll('.elite-marker').map(marker => marker.attributes('aria-label'));
+    const original = markers();
+    expect(original.length).toBeGreaterThan(1);
+    wrapper.get<HTMLElement>('.elite-panel-content').element.scrollTop = 177;
+    await wrapper.get('.elite-result-main').trigger('click');
+    expect(markers()).toEqual(original);
+    await wrapper.get('.elite-back').trigger('click');
+    expect(wrapper.get<HTMLElement>('.elite-panel-content').element.scrollTop).toBe(177);
+    await wrapper.get('[aria-label="Collapse Elite Skills"]').trigger('click');
+    expect(markers()).toEqual(original);
+    expect(wrapper.get('.elite-map-trigger').attributes('title')).toContain('All professions');
+    wrapper.unmount();
+  });
+  it("restores Hundred Blades and panel preference after restart and native map closure", async () => {
+    const api = host();
+    let wrapper = await planner(api);
+    await wrapper.get('input[type="search"]').setValue('Hundred Blades');
+    await flushPromises();
+    await wrapper.setProps({ view: { ...eliteFixtureView(), world: null } });
+    expect(wrapper.find('.elite-panel').exists()).toBe(false);
+    await wrapper.setProps({ view: eliteFixtureView() });
+    expect(wrapper.find('.elite-panel').exists()).toBe(true);
+    wrapper.unmount();
+    wrapper = await planner(api);
+    expect(wrapper.get<HTMLInputElement>('input[type="search"]').element.value).toBe('Hundred Blades');
+    expect(wrapper.findAll('.elite-result')).toHaveLength(1);
+    await wrapper.get('[aria-label="Collapse Elite Skills"]').trigger('click');
+    await flushPromises();
+    wrapper.unmount();
+    const saved = await api.get({ characterKey: eliteFixtureView().characterKey! });
+    expect(saved.view.panelOpen).toBe(false);
+    wrapper = mount(EliteSkillsApp, { props: { view: eliteFixtureView(), catalogue: createSkillCatalogue(ELITE_FIXTURE_SKILLS),
+      catalogueVersion: 1, catalogueProblem: '', trackingHost: api, openWiki: vi.fn(), reloadSkills: vi.fn() } });
+    await flushPromises();
+    expect(wrapper.find('.elite-panel').exists()).toBe(false);
+    expect(wrapper.get('.elite-map-trigger').attributes('title')).toContain('Hundred Blades');
+    await wrapper.get('.elite-map-trigger').trigger('click');
+    await wrapper.findAll('button').find(button => button.text() === 'Clear search')!.trigger('click');
+    expect(wrapper.get<HTMLInputElement>('input[type="search"]').element.value).toBe('');
+    wrapper.unmount();
+  });
+  it("follows both live professions only in My professions mode", async () => {
+    const wrapper = await planner();
+    const names = () => wrapper.findAll('.elite-result').map(row => row.text()).join(' ');
+    await wrapper.findAll('button').find(button => button.text() === 'My professions')!.trigger('click');
+    expect(names()).toContain('Barrage');
+    expect(names()).toContain('Eviscerate');
+    expect(names()).not.toContain('Restore Condition');
+    await wrapper.setProps({ view: eliteFixtureView(false, false, false, 3) });
+    expect(names()).not.toContain('Barrage');
+    expect(names()).toContain('Restore Condition');
+    await wrapper.findAll('button').find(button => button.text() === 'Choose…')!.trigger('click');
+    const choices = wrapper.findAll('.elite-profession-choices label');
+    await choices.find(label => label.text() === 'Warrior')!.get('input').setValue(true);
+    await choices.find(label => label.text() === 'Ranger')!.get('input').setValue(true);
+    expect(names()).toContain('Barrage');
+    expect(names()).not.toContain('Restore Condition');
+    await wrapper.setProps({ view: { ...eliteFixtureView(), observation: { status: 'waiting' } } });
+    expect(names()).toContain('Barrage');
+    await wrapper.findAll('button').find(button => button.text() === 'My professions')!.trigger('click');
+    expect(wrapper.findAll('.elite-result')).toHaveLength(0);
+    expect(wrapper.text()).toContain('Your professions are unavailable');
+    wrapper.unmount();
+  });
+  it("shares filters with untracked mission markers and applies the mission visibility switch", async () => {
+    const wrapper = await planner();
+    await wrapper.get('input[type="search"]').setValue('Lissah');
+    await wrapper.setProps({ view: eliteFixtureView(true) });
+    expect(wrapper.findAll('.elite-marker')).toHaveLength(1);
+    await wrapper.get('.elite-map-summary input').setValue(false);
+    expect(wrapper.findAll('.elite-marker')).toHaveLength(0);
+    await wrapper.get('.elite-map-summary input').setValue(true);
+    await wrapper.get('.elite-map-trigger').trigger('click');
+    await wrapper.get('input[type="search"]').setValue('Hundred Blades');
+    expect(wrapper.findAll('.elite-marker')).toHaveLength(0);
+    wrapper.unmount();
+  });
+  it("isolates search and marker visibility between characters", async () => {
+    const api = host();
+    const wrapper = await planner(api);
+    await wrapper.get('input[type="search"]').setValue('Hundred Blades');
+    await wrapper.findAll('.elite-panel-footer label').find(label => label.text() === 'Show world map markers')!.get('input').setValue(false);
+    await flushPromises();
+    await wrapper.setProps({ view: eliteFixtureView(false, true) });
+    await flushPromises();
+    expect(wrapper.get('.elite-map-trigger').attributes('title')).not.toContain('Hundred Blades');
+    expect(wrapper.findAll('.elite-marker').length).toBeGreaterThan(0);
+    await wrapper.setProps({ view: eliteFixtureView() });
+    await flushPromises();
+    expect(wrapper.get<HTMLInputElement>('input[type="search"]').element.value).toBe('Hundred Blades');
+    expect(wrapper.findAll('.elite-marker')).toHaveLength(0);
+    wrapper.unmount();
+  });
+  it("only focuses a skill through an explicit action", async () => {
+    const wrapper = await planner();
+    const count = wrapper.findAll('.elite-marker').length;
+    await wrapper.get('.elite-result-main').trigger('click');
+    expect(wrapper.findAll('.elite-marker')).toHaveLength(count);
+    await wrapper.findAll('button').find(button => button.text() === 'Show only this skill')!.trigger('click');
+    await wrapper.get('.elite-back').trigger('click');
+    expect(wrapper.findAll('.elite-result')).toHaveLength(1);
+    expect(wrapper.text()).toContain('Clear skill focus');
+    wrapper.unmount();
+  });
+  it("finishes rapid edits for the correct character while a save is pending", async () => {
+    const character = ref<TravelCharacterKey | null>(travelCharacterKey('0123456789abcdef'));
+    const api = host();
+    const update = api.update;
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => { release = resolve; });
+    api.update = vi.fn(async value => { await gate; return update(value); });
+    const plan = useEliteTracking(character, api);
+    await flushPromises();
+    for (const search of ['H', 'Hundred', 'Hundred Blades']) plan.change({ kind: 'view', view: { ...plan.tracking.value.view, search } });
+    plan.change({ kind: 'track', skillId: 338 });
+    expect(plan.tracking.value.view.search).toBe('Hundred Blades');
+    character.value = travelCharacterKey('fedcba9876543210');
+    await flushPromises();
+    release();
+    await flushPromises();
+    expect(plan.tracking.value.view.search).toBe('');
+    expect(plan.tracking.value.skills).toEqual([]);
+    const old = await api.get({ characterKey: '0123456789abcdef' });
+    expect(old.view.search).toBe('Hundred Blades');
+    expect(old.skills).toEqual([338]);
+    plan.dispose();
+  });
+  it("waits for queued edits when returning to a character before its save completes", async () => {
+    const key = travelCharacterKey('0123456789abcdef');
+    const character = ref<TravelCharacterKey | null>(key);
+    const api = host();
+    const update = api.update;
+    let release!: () => void;
+    const gate = new Promise<void>(resolve => { release = resolve; });
+    api.update = async value => { await gate; return update(value); };
+    const plan = useEliteTracking(character, api);
+    await flushPromises();
+    plan.change({ kind: 'view', view: { ...plan.tracking.value.view, search: 'H' } });
+    plan.change({ kind: 'view', view: { ...plan.tracking.value.view, search: 'Hundred Blades' } });
+    character.value = travelCharacterKey('fedcba9876543210');
+    await flushPromises();
+    character.value = key;
+    await flushPromises();
+    expect(plan.loaded.value).toBe(false);
+    release();
+    await flushPromises();
+    expect(plan.tracking.value.view.search).toBe('Hundred Blades');
+    expect(plan.loaded.value).toBe(true);
+    plan.dispose();
+  });
+
+});
+
+
+describe("elite hover previews", () => {
+  it("allows crossing onto a preview and removes it immediately when the map closes", async () => {
+    const wrapper = await planner();
+    vi.useFakeTimers();
+    try {
+      const row = wrapper.get('.elite-result-main');
+      await row.trigger('pointerenter');
+      expect(wrapper.get('[role="tooltip"]').attributes('id')).toBe(row.attributes('aria-describedby'));
+      await row.trigger('pointerleave');
+      await wrapper.get('[role="tooltip"]').trigger('pointerenter');
+      await vi.advanceTimersByTimeAsync(150);
+      expect(wrapper.find('[role="tooltip"]').exists()).toBe(true);
+      await wrapper.setProps({ view: { ...eliteFixtureView(), world: null } });
+      expect(wrapper.find('[role="tooltip"]').exists()).toBe(false);
+      await vi.advanceTimersByTimeAsync(150);
+      expect(wrapper.find('[role="tooltip"]').exists()).toBe(false);
+    } finally { wrapper.unmount(); vi.useRealTimers(); }
+  });
+  it("opens keyboard previews without motion and lets Escape dismiss them", async () => {
+    const wrapper = await planner();
+    const row = wrapper.get('.elite-result-main');
+    await row.trigger('focus');
+    expect(wrapper.get('[role="tooltip"]').attributes('data-keyboard')).toBe('');
+    await row.trigger('keydown', { key: 'Escape' });
+    expect(wrapper.find('[role="tooltip"]').exists()).toBe(false);
+    expect(wrapper.find('.elite-panel').exists()).toBe(true);
+    wrapper.unmount();
   });
 });

--- a/apps/tools/src/EliteSkillsApp.vue
+++ b/apps/tools/src/EliteSkillsApp.vue
@@ -1,6 +1,7 @@
 <!-- Elite skill discovery and one capture plan shared by both native maps. -->
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, ref, shallowRef, watch } from "vue";
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, shallowRef, watch } from "vue";
+import { installResizeGrip } from "../../../src/shared/ui/resize";
 import type { EliteMapView } from "../../../src/shared/elite-map";
 import { ELITE_LOCATIONS } from "../../../src/shared/elite-locations";
 import { eliteContinent, eliteLearned, type EliteLocation, type EliteViewPreferences } from "../../../src/shared/elite-skills";
@@ -13,6 +14,7 @@ import { useEliteTracking, type EliteTrackingHost } from "./use-elite-tracking";
 import SkillDetails from "./components/SkillDetails.vue";
 import EliteMarkers from "./components/EliteMarkers.vue";
 import EliteFilters from "./components/EliteFilters.vue";
+import EliteCaptureLocation from "./components/EliteCaptureLocation.vue";
 import "./styles/elite-skills.css";
 const props = defineProps<{
   view: EliteMapView; catalogue: SkillCatalogue; catalogueVersion: number;
@@ -26,10 +28,7 @@ const wikiProblem = ref("");
 const selectedId = ref<number | null>(null);
 const root = ref<HTMLElement | null>(null);
 const mapTrigger = ref<HTMLButtonElement | null>(null);
-const detailBack = ref<HTMLButtonElement | null>(null);
 const filters = ref<InstanceType<typeof EliteFilters> | null>(null);
-const panel = ref<HTMLElement | null>(null);
-let resultsScroll = 0;
 const character = computed(() => props.view.characterKey);
 const plan = useEliteTracking(character, props.trackingHost);
 const { tracking, busy, loaded, problem } = plan;
@@ -42,10 +41,15 @@ function resetFilters() {
 }
 const party = shallowRef(unavailableParty());
 watch(() => props.view.observation, (observation) => { party.value = liveParty(observation); }, { immediate: true });
-const detailsSkill = computed(() => selectedId.value === null ? null : skill(selectedId.value));
 const active = computed(() => ELITE_LOCATIONS.find((entry) => entry.id === tracking.value.activeLocation) ?? null);
 const blocked = computed(() => !loaded.value || problem.value !== "");
-const preview = ref<{ location: EliteLocation; x: number; y: number; keyboard: boolean } | null>(null);
+const preview = ref<{ location: EliteLocation; x: number; y: number; keyboard: boolean; nearby: readonly EliteLocation[] } | null>(null);
+const nearbySkills = computed(() => [...new Map(preview.value?.nearby.map(location => [location.skillId, location])).values()]);
+const previewBosses = computed(() => {
+  if (!preview.value) return [];
+  const locations = [preview.value.location, ...preview.value.nearby.filter(location => location.skillId === preview.value?.location.skillId)];
+  return [...new Map(locations.map(location => [`${location.mapId}:${location.boss}`, location])).values()];
+});
 const previewElement = ref<HTMLElement | null>(null);
 let previewClose: ReturnType<typeof setTimeout> | undefined;
 function keepPreview() { clearTimeout(previewClose); }
@@ -55,6 +59,9 @@ function hidePreview() {
 }
 function dismissPreview(event: KeyboardEvent) {
   if (!preview.value) return;
+  if (previewElement.value?.contains(document.activeElement)) {
+    root.value?.querySelector<HTMLButtonElement>('.elite-marker[aria-describedby="elite-skill-preview"]')?.focus({ preventScroll: true });
+  }
   keepPreview(); preview.value = null;
   event.preventDefault(); event.stopPropagation();
 }
@@ -73,9 +80,9 @@ const selectedProfessions = computed(() => {
 const filterSummary = computed(() => {
   const pref = preferences.value;
   return [pref.focusedSkill !== null ? skill(pref.focusedSkill).name : pref.search ? `“${pref.search}”` : "",
-    pref.mode === "tracked" ? "Tracked" : "",
+    pref.mode === "tracked" ? "Saved skills" : "",
     selectedProfessions.value === null ? "All professions" : selectedProfessions.value.length
-      ? selectedProfessions.value.map(name => PROFESSIONS[name].name).join(" + ") : "My professions unavailable",
+      ? selectedProfessions.value.map(name => PROFESSIONS[name].name).join(" + ") : pref.professions.kind === "mine" ? "Current professions unavailable" : "No professions selected",
     pref.hideLearned ? "Hide learned" : "", pref.region].filter(Boolean).join(" · ");
 });
 const normalized = (text: string) => text.normalize("NFKD").replace(/\p{M}/gu, "").toLocaleLowerCase();
@@ -92,6 +99,7 @@ const matching = computed(() => {
     return !needle || normalized(`${info.name} ${info.attribute ?? ""} ${entry.boss} ${guildWarsMapName(entry.mapId)}`).includes(needle);
   });
 });
+watch(() => matching.value.map(location => location.id).join("|"), () => { preview.value = null; });
 const results = computed(() => {
   const bySkill = new Map<number, EliteLocation[]>();
   for (const entry of matching.value) {
@@ -109,11 +117,40 @@ const missionSurface = computed(() => {
   const mission = props.view.mission;
   return mission?.transform ? { box: mission.box, transform: mission.transform } : null;
 });
-const panelStyle = computed(() => {
+const viewport = ref({ width: window.innerWidth, height: window.innerHeight });
+const resizeGrip = ref<HTMLButtonElement | null>(null);
+const resizing = ref(false);
+const draggedHeight = ref<number | null>(null);
+function measureViewport() { viewport.value = { width: window.innerWidth, height: window.innerHeight }; }
+onMounted(() => window.addEventListener("resize", measureViewport));
+onBeforeUnmount(() => window.removeEventListener("resize", measureViewport));
+const panelPosition = computed(() => {
   const box = props.view.world?.box;
-  return box ? { top: `${box.top + 12}px`, right: `${Math.max(12, window.innerWidth - box.left - box.width + 12)}px`,
-    maxHeight: `${Math.max(140, Math.min(box.height - 24, window.innerHeight - box.top - 24))}px` } : {};
+  return box ? { top: `${Math.max(12, box.top + 12)}px`, right: `${Math.max(12, viewport.value.width - box.left - box.width + 12)}px` } : {};
 });
+const panelMaxHeight = computed(() => {
+  const box = props.view.world?.box;
+  const top = box ? Math.max(12, box.top + 12) : 16;
+  return Math.max(0, Math.min(box ? box.height - 24 : Infinity, viewport.value.height - top - 16));
+});
+const panelHeight = computed(() => Math.min(panelMaxHeight.value,
+  Math.max(440, draggedHeight.value ?? viewport.value.height * preferences.value.panelHeightRatio)));
+const panelStyle = computed(() => ({ ...panelPosition.value, height: `${panelHeight.value}px` }));
+watch(resizeGrip, (handle, _, onCleanup) => {
+  if (!handle) return;
+  const saveHeight = () => {
+    if (draggedHeight.value === null) return;
+    updatePreferences({ panelHeightRatio: Math.max(0.2, Math.min(1, draggedHeight.value / viewport.value.height)) });
+    draggedHeight.value = null;
+  };
+  const dispose = installResizeGrip(handle, {
+    size: () => ({ width: 356, height: panelHeight.value }),
+    limits: () => ({ minWidth: 356, maxWidth: 356, minHeight: 440, maxHeight: panelMaxHeight.value }),
+    resize: (_, height) => { draggedHeight.value = height; if (!resizing.value) saveHeight(); },
+    setActive: (active) => { resizing.value = active; if (!active) saveHeight(); },
+  });
+  onCleanup(() => { draggedHeight.value = null; dispose(); });
+}, { flush: "post" });
 const trackerStyle = computed(() => {
   const box = props.view.mission?.box;
   return box ? { left: `${box.left + 8}px`, top: `${box.top + 8}px`, right: "auto", maxWidth: `${Math.max(140, box.width - 16)}px` } : {};
@@ -137,8 +174,7 @@ function setOpen(value: boolean, keyboard = false, remember = true) {
   keepPreview(); open.value = value; preview.value = null;
   emit("openChange", value);
   if (keyboard) void nextTick(() => {
-    const target = value ? selectedId.value === null ? filters.value?.searchInput : detailBack.value
-      : mapTrigger.value;
+    const target = value ? filters.value?.searchInput : mapTrigger.value;
     target?.focus({ preventScroll: true });
   });
 }
@@ -150,18 +186,27 @@ function find(id: number) {
   selectedId.value = id;
   focusSkill(id);
   browse();
+  revealSelected();
+}
+function revealSelected(keyboard = false) {
+  void nextTick(() => {
+    const row = root.value?.querySelector<HTMLButtonElement>(`[data-skill-id="${selectedId.value}"]`);
+    row?.scrollIntoView?.({ block: "nearest" });
+    if (keyboard) row?.focus({ preventScroll: true });
+  });
 }
 function selectLocation(location: EliteLocation, keyboard = false) {
-  resultsScroll = panel.value?.scrollTop ?? resultsScroll;
   selectedId.value = location.skillId;
-  void nextTick(() => { if (panel.value) panel.value.scrollTop = 0; });
-  setOpen(true, keyboard);
+  setOpen(true);
+  revealSelected(keyboard);
 }
-function inspect(location: EliteLocation | null, x: number, y: number, keyboard = false) {
+function inspect(location: EliteLocation | null, x: number, y: number, keyboard = false, nearby: readonly EliteLocation[] = []) {
   if (!location) { hidePreview(); return; }
   keepPreview();
-  const next = { location, x: Math.max(8, Math.min(window.innerWidth - 328, x + 20)),
-    y: Math.max(8, Math.min(window.innerHeight - 200, y + 16)), keyboard };
+  // Place beside the marker instead of clamping the card over nearby pointer targets.
+  const left = x + 340 <= window.innerWidth - 8 ? x + 20 : x - 340;
+  const next = { location, x: Math.max(8, Math.min(window.innerWidth - 328, left)),
+    y: Math.max(8, Math.min(window.innerHeight - 488, y + 16)), keyboard, nearby };
   preview.value = next;
   const shown = preview.value;
   void nextTick(() => {
@@ -170,39 +215,32 @@ function inspect(location: EliteLocation | null, x: number, y: number, keyboard 
     preview.value = { ...next };
   });
 }
+function previewNearby(location: EliteLocation) {
+  if (!preview.value) return;
+  keepPreview();
+  preview.value = { ...preview.value, location };
+}
+function leavePreviewFocus(event: FocusEvent) {
+  if (!(event.relatedTarget instanceof Node) || !previewElement.value?.contains(event.relatedTarget)) hidePreview();
+}
 function inspectRow(location: EliteLocation, event: PointerEvent | FocusEvent) {
-  if (!(event.currentTarget instanceof HTMLElement)) return;
+  if (selectedId.value === location.skillId || !(event.currentTarget instanceof HTMLElement)) return;
   const box = event.currentTarget.getBoundingClientRect();
   inspect(location, box.left - 352, box.top - 16, event.type === "focus");
 }
-function showDetails(id: number, event: MouseEvent) {
-  resultsScroll = panel.value?.scrollTop ?? 0;
-  selectedId.value = id; preview.value = null;
-  void nextTick(() => {
-    if (panel.value) panel.value.scrollTop = 0;
-    if (event.detail === 0) detailBack.value?.focus({ preventScroll: true });
-  });
+function showDetails(id: number) {
+  selectedId.value = selectedId.value === id ? null : id;
+  keepPreview(); preview.value = null;
 }
 function focusSkill(id: number) {
   updatePreferences({ search: "", focusedSkill: id, professions: { kind: "all" }, region: "", mode: "browse", hideLearned: false, worldMap: true });
-}
-function back(event?: MouseEvent) {
-  const id = selectedId.value;
-  selectedId.value = null;
-  void nextTick(() => {
-    if (panel.value) panel.value.scrollTop = resultsScroll;
-    if (event?.detail !== 0) return;
-    const row = root.value?.querySelector<HTMLButtonElement>(`[data-skill-id="${id}"]`);
-    (row ?? filters.value?.searchInput)?.focus({ preventScroll: true });
-  });
 }
 function close(event?: MouseEvent) {
   const keyboard = event ? event.detail === 0 : root.value?.contains(document.activeElement) === true;
   setOpen(false, keyboard);
 }
-function cannotCapture(location: EliteLocation) { return /impossible to capture/i.test(location.note ?? ""); }
 function toggleTrack(id: number) { void plan.change({ kind: tracked(id) ? "remove" : "track", skillId: id }); }
-watch(character, () => { selectedId.value = null; preview.value = null; resultsScroll = 0; setOpen(false, false, false); });
+watch(character, () => { selectedId.value = null; preview.value = null; setOpen(false, false, false); });
 watch(() => [Boolean(props.view.world), loaded.value] as const, ([world, ready], [previous]) => {
   if (!world && previous) setOpen(false, false, false);
   else if (world && ready) setOpen(preferences.value.panelOpen, false, false);
@@ -219,7 +257,7 @@ defineExpose({ find, close });
       :active-location="tracking.activeLocation" :preview-location-id="preview?.location.id ?? null" :catalogue="catalogue" label="Elite capture locations on world map" @select="selectLocation" @inspect="inspect" />
     <EliteMarkers v-if="missionSurface && tracking.missionMap && (!character || loaded)" :surface="missionSurface" :locations="missionLocations"
       :active-location="tracking.activeLocation" :preview-location-id="preview?.location.id ?? null" :catalogue="catalogue" label="Elite capture locations on mission map" @select="selectLocation" @inspect="inspect" />
-    <div v-if="(view.world || view.mission) && !open" class="ui-frame elite-map-summary" :style="view.world ? panelStyle : trackerStyle">
+    <div v-if="(view.world || view.mission) && !open" class="ui-frame elite-map-summary" :style="view.world ? panelPosition : trackerStyle">
       <label class="elite-visibility" title="Show elites on this map"><input type="checkbox" aria-label="Show elites" :checked="view.world ? preferences.worldMap : tracking.missionMap" :disabled="!!character && !loaded"
         @change="view.world ? updatePreferences({ worldMap: !preferences.worldMap }) : plan.change({ kind: 'mission-map', show: !tracking.missionMap })"></label>
       <button ref="mapTrigger" class="ui-button elite-map-trigger" aria-label="Open Elite Skills" :aria-expanded="false"
@@ -229,13 +267,11 @@ defineExpose({ find, close });
       <span v-if="problem" class="elite-summary-problem" role="alert" :title="loaded ? 'Changes are not saved. Open Elite Skills to retry.' : 'Your setup could not load. Open Elite Skills to retry.'"
         :aria-label="loaded ? 'Changes are not saved. Open Elite Skills to retry.' : 'Your setup could not load. Open Elite Skills to retry.'">!</span>
     </div>
-    <section v-if="open" class="ui-frame elite-panel" :style="panelStyle" aria-label="Elite skills">
+    <section v-if="open" class="ui-frame elite-panel" :data-resizing="resizing || undefined" :style="panelStyle" aria-label="Elite skills">
       <header class="ui-panel-head">
-        <button v-if="detailsSkill" ref="detailBack" class="ui-button elite-back" @click="back"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m14 6-6 6 6 6"/></svg>Back to results</button>
-        <h2 v-else>Elite skills</h2>
-        <button class="ui-button" aria-label="Collapse Elite Skills" @click="close">Collapse</button>
+        <h2>Elite skills</h2>
+        <button class="ui-button" aria-label="Collapse Elite Skills" @click="close">Hide panel</button>
       </header>
-      <div ref="panel" class="ui-scroll elite-panel-content">
       <div v-if="problem" class="elite-message" role="alert">
         <p>{{ problem }}</p><button class="ui-button" :disabled="busy" @click="plan.retry">Retry</button>
         <button v-if="loaded" class="ui-link" @click="plan.dismissError">Restore saved setup</button>
@@ -243,53 +279,70 @@ defineExpose({ find, close });
       <p v-if="wikiProblem" class="elite-message" role="alert">{{ wikiProblem }}</p>
       <div v-if="catalogueProblem" class="elite-message" role="status"><p>{{ catalogueProblem }}</p><button class="ui-link" @click="reloadSkills">Reload skills</button></div>
       <p v-if="catalogueVersion === 0 && !catalogueProblem" class="elite-save-state" role="status">Loading skill details…</p>
-      <p v-if="!view.characterKey" class="elite-message">Select a PvE character to save a capture plan. You can still browse.</p>
-      <p v-else class="elite-save-state" role="status">{{ busy ? loaded ? 'Saving setup…' : 'Loading your setup…' : problem ? 'Changes not saved' : 'Saved for this character' }}</p>
-      <template v-if="detailsSkill">
-        <div class="elite-detail-toolbar"><button class="ui-button" :aria-pressed="tracked(detailsSkill.id)" :disabled="blocked" @click="toggleTrack(detailsSkill.id)">{{ tracked(detailsSkill.id) ? 'Stop tracking skill' : 'Track skill' }}</button><button class="ui-button" :disabled="!!character && !loaded" @click="focusSkill(detailsSkill.id)">Show only this skill</button></div>
-        <div class="ui-scroll elite-detail-scroll">
-          <SkillDetails :skill="detailsSkill" />
-          <p class="elite-learned" :data-learned="learned(detailsSkill.id)">{{ learned(detailsSkill.id) === 'learned' ? 'Learned by this character' : learned(detailsSkill.id) === 'not-learned' ? 'Not learned by this character' : 'Learned status unavailable' }}</p>
-          <h3>Capture locations</h3>
-          <div v-for="location in selectedLocations" :key="location.id" class="elite-location" :data-active="active?.id === location.id">
-            <div class="elite-location-heading"><strong>{{ location.boss }}</strong><span v-if="active?.id === location.id">Active</span></div>
-            <p>{{ guildWarsMapName(location.mapId) }}<span v-if="location.mapId === view.mapId"> · Here now</span></p>
-            <p class="elite-location-note" v-if="location.note">{{ location.note }}</p>
-            <p class="elite-support">{{ location.points.length === 0 ? 'Boss position unavailable' : location.points.length > 1 ? `${location.points.length} possible positions` : 'Known spawn location' }}</p>
-            <div class="elite-actions"><button class="ui-button" :disabled="blocked || cannotCapture(location)" :aria-pressed="active?.id === location.id" @click="plan.change({kind: 'target', locationId: location.id})">{{ cannotCapture(location) ? 'Cannot capture here' : active?.id === location.id ? 'Tracking this boss' : 'Track this boss' }}</button>
-              <button class="ui-link" @click="showWiki(location, 'boss')">Boss wiki</button></div>
-          </div>
-          <button v-if="selectedLocations[0]" class="ui-link" @click="showWiki(selectedLocations[0], 'skill')">Skill wiki</button>
-        </div>
-      </template>
-      <template v-else>
-        <EliteFilters ref="filters" :preferences="preferences" :tracked-count="tracking.skills.length" :disabled="!!character && !loaded"
-          :my-professions="party.player?.professions ?? null" :learned-available="!!party.characterSkills" :summary="filterSummary"
-          @change="updatePreferences" @reset="resetFilters" />
-        <div class="elite-results-heading"><span>{{ results.length }} {{ results.length === 1 ? 'skill' : 'skills' }}</span></div>
+      <p v-if="!view.characterKey" class="elite-message">Select a PvE character to save skills. You can still browse.</p>
+      <div class="elite-filter-panel"><EliteFilters ref="filters" :preferences="preferences" :tracked-count="tracking.skills.length" :disabled="!!character && !loaded"
+        :my-professions="party.player?.professions ?? null" :learned-available="!!party.characterSkills"
+        @change="updatePreferences" @reset="resetFilters" /></div>
+      <div class="elite-results-heading"><span>{{ results.length }} {{ results.length === 1 ? 'skill' : 'skills' }}</span><span v-if="busy" role="status">{{ loaded ? 'Saving…' : 'Loading setup…' }}</span></div>
+      <div class="ui-scroll elite-panel-content">
         <div class="elite-results">
-          <div v-if="!results.length" class="ui-empty"><strong>{{ preferences.mode === 'tracked' && !tracking.skills.length ? 'Plan your first capture' : 'No matching skills' }}</strong><p>{{ preferences.mode === 'tracked' && !tracking.skills.length ? 'Browse skills and track one you want to learn.' : 'Try another name or clear the filters.' }}</p><button class="ui-button" @click="resetFilters">Show all skills</button></div>
-          <div v-for="result in results" :key="result.skill.id" class="elite-result">
-            <button class="elite-result-main" :data-skill-id="result.skill.id" :aria-describedby="preview?.location.skillId === result.skill.id ? 'elite-skill-preview' : undefined" @click="showDetails(result.skill.id, $event)" @pointerenter="inspectRow(result.locations[0]!, $event)" @pointerleave="hidePreview" @focus="inspectRow(result.locations[0]!, $event)" @blur="hidePreview">
-              <span class="ui-slot elite-skill-icon" :data-profession="result.skill.profession" data-elite><img v-if="result.skill.iconUrl" :src="result.skill.iconUrl" alt="" draggable="false"><span v-else>{{ result.skill.profession?.slice(0, 1) ?? '?' }}</span></span>
-              <span><strong>{{ result.skill.name }}</strong><small>{{ result.skill.profession ? PROFESSIONS[result.skill.profession].name : 'Profession unavailable' }} · {{ result.locations.length }} {{ result.locations.length === 1 ? 'location' : 'locations' }}</small><small v-if="learned(result.skill.id) === 'learned'">Learned</small></span>
-            </button>
-            <button class="ui-button elite-track-button" :aria-label="`${tracked(result.skill.id) ? 'Stop tracking' : 'Track'} ${result.skill.name}`" :aria-pressed="tracked(result.skill.id)" :disabled="blocked" @click="toggleTrack(result.skill.id)"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m12 3 2.8 5.7 6.2.9-4.5 4.4 1.1 6.2-5.6-3-5.6 3 1.1-6.2L3 9.6l6.2-.9Z" /></svg></button>
+          <div v-if="!results.length" class="ui-empty"><strong>{{ selectedProfessions?.length === 0 ? 'Choose a profession' : preferences.mode === 'tracked' && !tracking.skills.length ? 'No saved skills yet' : 'No matching skills' }}</strong><p>{{ selectedProfessions?.length === 0 ? 'Select a class above to see its elite skills.' : preferences.mode === 'tracked' && !tracking.skills.length ? 'Use the star beside a skill to save it for this character.' : 'Try another name or clear the filters.' }}</p><button class="ui-button" @click="resetFilters">Show all skills</button></div>
+          <div v-for="result in results" :key="result.skill.id" class="elite-result" :data-expanded="selectedId === result.skill.id">
+            <div class="elite-result-heading">
+              <button class="elite-result-main" :data-skill-id="result.skill.id" :aria-expanded="selectedId === result.skill.id" :aria-controls="`elite-detail-${result.skill.id}`"
+                :aria-describedby="preview?.location.skillId === result.skill.id ? 'elite-skill-preview' : undefined" @click="showDetails(result.skill.id)" @pointerenter="inspectRow(result.locations[0]!, $event)" @pointerleave="hidePreview" @focus="inspectRow(result.locations[0]!, $event)" @blur="hidePreview">
+                <span class="ui-slot elite-skill-icon" :data-profession="result.skill.profession" data-elite><img v-if="result.skill.iconUrl" :src="result.skill.iconUrl" alt="" draggable="false"><span v-else>{{ result.skill.profession?.slice(0, 1) ?? '?' }}</span></span>
+                <span class="elite-result-label"><strong>{{ result.skill.name }}</strong><small>{{ result.skill.attribute?.replace(/([a-z])([A-Z])/gu, '$1 $2') ?? (result.skill.profession ? PROFESSIONS[result.skill.profession].name : 'Profession unavailable') }}<span v-if="learned(result.skill.id) === 'learned'" class="elite-learned-badge"> · ✓ Learned</span></small></span>
+                <span class="elite-result-chevron" aria-hidden="true">{{ selectedId === result.skill.id ? '−' : '+' }}</span>
+              </button>
+              <button class="ui-button elite-track-button" :aria-label="`${tracked(result.skill.id) ? 'Unsave' : 'Save'} ${result.skill.name}`" :title="tracked(result.skill.id) ? 'Remove from saved skills' : 'Save skill for this character'" :aria-pressed="tracked(result.skill.id)" :disabled="blocked" @click="toggleTrack(result.skill.id)"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m12 3 2.8 5.7 6.2.9-4.5 4.4 1.1 6.2-5.6-3-5.6 3 1.1-6.2L3 9.6l6.2-.9Z" /></svg></button>
+            </div>
+            <div v-if="selectedId === result.skill.id" :id="`elite-detail-${result.skill.id}`" class="elite-inline-detail">
+              <SkillDetails :skill="result.skill" />
+              <p v-if="learned(result.skill.id) === 'unknown'" class="elite-support">Learned status unavailable</p>
+              <h3>Capture from</h3>
+              <EliteCaptureLocation v-if="selectedLocations[0]" :location="selectedLocations[0]" :active="active?.id === selectedLocations[0].id" :here="selectedLocations[0].mapId === view.mapId" :disabled="blocked"
+                @target="plan.change({ kind: 'target', locationId: selectedLocations[0]!.id })" @wiki="showWiki(selectedLocations[0]!, 'boss')" />
+              <details v-if="selectedLocations.length > 1" class="elite-other-locations">
+                <summary>{{ selectedLocations.length - 1 }} other capture {{ selectedLocations.length === 2 ? 'location' : 'locations' }}</summary>
+                <EliteCaptureLocation v-for="location in selectedLocations.slice(1)" :key="location.id" :location="location" :active="active?.id === location.id" :here="location.mapId === view.mapId" :disabled="blocked"
+                  @target="plan.change({ kind: 'target', locationId: location.id })" @wiki="showWiki(location, 'boss')" />
+              </details>
+              <div class="elite-detail-links"><button class="ui-link" :disabled="!!character && !loaded" @click="focusSkill(result.skill.id)">Show only this skill</button><button v-if="selectedLocations[0]" class="ui-link" @click="showWiki(selectedLocations[0], 'skill')">Skill wiki</button></div>
+            </div>
           </div>
         </div>
-      </template>
       </div>
       <footer class="elite-panel-footer">
-        <label class="elite-check"><input type="checkbox" :checked="tracking.missionMap" :disabled="blocked" @change="plan.change({ kind: 'mission-map', show: !tracking.missionMap })"> Show elites on mission map</label>
-        <p v-if="active">{{ missionMessage }}</p>
-        <p v-else-if="!view.world">Open the world map to view capture locations.</p>
-        <label class="elite-check"><input type="checkbox" :checked="preferences.worldMap" :disabled="!!character && !loaded" @change="updatePreferences({ worldMap: !preferences.worldMap })"> Show world map markers</label>
+        <p v-if="active" class="elite-current-target" :title="missionMessage"><strong>Target: {{ active.boss }}</strong></p>
+        <details class="elite-map-display"><summary>Map display</summary>
+          <p v-if="active">{{ missionMessage }}</p>
+          <label class="elite-check"><input type="checkbox" :checked="tracking.missionMap" :disabled="blocked" @change="plan.change({ kind: 'mission-map', show: !tracking.missionMap })"> Show elites on mission map</label>
+          <label class="elite-check"><input type="checkbox" :checked="preferences.worldMap" :disabled="!!character && !loaded" @change="updatePreferences({ worldMap: !preferences.worldMap })"> Show world map markers</label>
+        </details>
       </footer>
+      <button ref="resizeGrip" class="elite-panel-resize" aria-label="Resize Elite Skills height" title="Drag to resize · Arrow keys adjust height" :disabled="!!character && !loaded"><span aria-hidden="true"></span></button>
     </section>
-    <aside v-if="preview" id="elite-skill-preview" ref="previewElement" class="ui-frame elite-preview" :data-keyboard="preview.keyboard ? '' : undefined" @pointerenter="keepPreview" @pointerleave="hidePreview" :style="{ left: `${preview.x}px`, top: `${preview.y}px` }" role="tooltip">
+    <aside v-if="preview" id="elite-skill-preview" ref="previewElement" class="ui-frame elite-preview" :data-keyboard="preview.keyboard ? '' : undefined" @pointerenter="keepPreview" @pointerleave="hidePreview" @focusin="keepPreview" @focusout="leavePreviewFocus" :style="{ left: `${preview.x}px`, top: `${preview.y}px`, maxHeight: `min(480px, calc(100dvh - ${preview.y + 8}px))` }" :role="preview.nearby.length > 1 ? 'region' : 'tooltip'" :aria-label="preview.nearby.length > 1 ? 'Nearby elite skills' : undefined">
       <div class="ui-scroll elite-preview-content">
-        <SkillDetails :skill="skill(preview.location.skillId)" />
-        <p>{{ preview.location.boss }} · {{ guildWarsMapName(preview.location.mapId) }}</p>
+        <div v-if="nearbySkills.length > 1" class="elite-nearby">
+          <span class="elite-field-label">Nearby skills · Click to open</span>
+          <div class="elite-nearby-choices" role="group" aria-label="Nearby capture locations">
+            <button v-for="location in nearbySkills" :key="location.skillId" class="elite-nearby-choice"
+              :data-previewed="preview.location.skillId === location.skillId ? '' : undefined"
+              :aria-label="`${skill(location.skillId).name} — ${location.boss} · ${guildWarsMapName(location.mapId)}`"
+              @pointerenter="previewNearby(location)" @focus="previewNearby(location)" @click="selectLocation(location, $event.detail === 0)">
+              <img v-if="skill(location.skillId).iconUrl" :src="skill(location.skillId).iconUrl!" alt="" draggable="false">
+              <span v-else aria-hidden="true">{{ skill(location.skillId).name.split(' ').map(part => part[0]).join('').slice(0, 3) }}</span>
+            </button>
+          </div>
+        </div>
+        <SkillDetails :skill="skill(preview.location.skillId)">
+          <template #context><div class="elite-preview-bosses">
+          <p v-if="previewBosses.length > 1" class="elite-field-label">Possible bosses · {{ previewBosses.length }}</p>
+          <ul><li v-for="boss in previewBosses" :key="boss.id">{{ boss.boss }} <span>· {{ guildWarsMapName(boss.mapId) }}</span></li></ul>
+          </div></template>
+        </SkillDetails>
       </div>
     </aside>
   </div>

--- a/apps/tools/src/EliteSkillsApp.vue
+++ b/apps/tools/src/EliteSkillsApp.vue
@@ -3,15 +3,16 @@
 import { computed, nextTick, onBeforeUnmount, ref, shallowRef, watch } from "vue";
 import type { EliteMapView } from "../../../src/shared/elite-map";
 import { ELITE_LOCATIONS } from "../../../src/shared/elite-locations";
-import { ELITE_REGIONS, eliteContinent, eliteLearned, type EliteLocation } from "../../../src/shared/elite-skills";
+import { eliteContinent, eliteLearned, type EliteLocation, type EliteViewPreferences } from "../../../src/shared/elite-skills";
 import { guildWarsMapName } from "../../../src/shared/guild-wars-map-names";
 import { liveParty, unavailableParty } from "../../../src/shared/builds/live-party";
 import { PROFESSIONS } from "../../../src/shared/builds/heroes";
-import { skillId } from "../../../src/shared/builds/library";
+import { skillId, type Profession } from "../../../src/shared/builds/library";
 import type { SkillCatalogue, SkillPresentation } from "./skill-catalog";
 import { useEliteTracking, type EliteTrackingHost } from "./use-elite-tracking";
 import SkillDetails from "./components/SkillDetails.vue";
 import EliteMarkers from "./components/EliteMarkers.vue";
+import EliteFilters from "./components/EliteFilters.vue";
 import "./styles/elite-skills.css";
 const props = defineProps<{
   view: EliteMapView; catalogue: SkillCatalogue; catalogueVersion: number;
@@ -22,44 +23,72 @@ const props = defineProps<{
 const emit = defineEmits<{ openChange: [open: boolean] }>();
 const open = ref(false);
 const wikiProblem = ref("");
-const markersEnabled = ref(true);
-const search = ref("");
-const profession = ref("");
-const region = ref("");
-const hideLearned = ref(true);
-const mode = ref<"browse" | "tracked">("browse");
 const selectedId = ref<number | null>(null);
 const root = ref<HTMLElement | null>(null);
 const mapTrigger = ref<HTMLButtonElement | null>(null);
 const detailBack = ref<HTMLButtonElement | null>(null);
-const manageTracked = ref<HTMLButtonElement | null>(null);
-const searchInput = ref<HTMLInputElement | null>(null);
+const filters = ref<InstanceType<typeof EliteFilters> | null>(null);
+const panel = ref<HTMLElement | null>(null);
+let resultsScroll = 0;
 const character = computed(() => props.view.characterKey);
 const plan = useEliteTracking(character, props.trackingHost);
 const { tracking, busy, loaded, problem } = plan;
+const preferences = computed(() => tracking.value.view);
+function updatePreferences(value: Partial<EliteViewPreferences>) {
+  plan.change({ kind: "view", view: { ...preferences.value, ...value } });
+}
+function resetFilters() {
+  updatePreferences({ search: "", professions: { kind: "all" }, region: "", mode: "browse", hideLearned: false, focusedSkill: null });
+}
 const party = shallowRef(unavailableParty());
 watch(() => props.view.observation, (observation) => { party.value = liveParty(observation); }, { immediate: true });
 const detailsSkill = computed(() => selectedId.value === null ? null : skill(selectedId.value));
 const active = computed(() => ELITE_LOCATIONS.find((entry) => entry.id === tracking.value.activeLocation) ?? null);
-const blocked = computed(() => busy.value || !loaded.value || problem.value !== "");
-const preview = ref<{ location: EliteLocation; x: number; y: number } | null>(null);
+const blocked = computed(() => !loaded.value || problem.value !== "");
+const preview = ref<{ location: EliteLocation; x: number; y: number; keyboard: boolean } | null>(null);
+const previewElement = ref<HTMLElement | null>(null);
+let previewClose: ReturnType<typeof setTimeout> | undefined;
+function keepPreview() { clearTimeout(previewClose); }
+function hidePreview() {
+  keepPreview();
+  previewClose = setTimeout(() => { preview.value = null; }, 100);
+}
+function dismissPreview(event: KeyboardEvent) {
+  if (!preview.value) return;
+  keepPreview(); preview.value = null;
+  event.preventDefault(); event.stopPropagation();
+}
 function skill(id: number): SkillPresentation {
   void props.catalogueVersion;
   return props.catalogue.get(skillId(id));
 }
 const learned = (id: number) => eliteLearned(id, party.value.characterSkills);
 const tracked = (id: number) => tracking.value.skills.includes(id);
+const selectedProfessions = computed(() => {
+  const filter = preferences.value.professions;
+  if (filter.kind === "all") return null;
+  if (filter.kind === "custom") return filter.values;
+  return party.value.player?.professions?.filter((value): value is Profession => value !== null) ?? [];
+});
+const filterSummary = computed(() => {
+  const pref = preferences.value;
+  return [pref.focusedSkill !== null ? skill(pref.focusedSkill).name : pref.search ? `“${pref.search}”` : "",
+    pref.mode === "tracked" ? "Tracked" : "",
+    selectedProfessions.value === null ? "All professions" : selectedProfessions.value.length
+      ? selectedProfessions.value.map(name => PROFESSIONS[name].name).join(" + ") : "My professions unavailable",
+    pref.hideLearned ? "Hide learned" : "", pref.region].filter(Boolean).join(" · ");
+});
 const normalized = (text: string) => text.normalize("NFKD").replace(/\p{M}/gu, "").toLocaleLowerCase();
 const matching = computed(() => {
-  const needle = normalized(search.value.trim());
+  const needle = normalized(preferences.value.search.trim());
   return ELITE_LOCATIONS.filter((entry) => {
     const info = skill(entry.skillId);
     if (!props.catalogue.has(skillId(entry.skillId)) || !info.elite) return false;
-    if (profession.value && info.profession !== profession.value) return false;
-    if (region.value && entry.region !== region.value) return false;
-    if (mode.value === "tracked" && !tracked(entry.skillId)) return false;
-    // A tracked skill stays visible long enough to inspect its new learned state.
-    if (mode.value === "browse" && hideLearned.value && learned(entry.skillId) === "learned" && !tracked(entry.skillId)) return false;
+    if (selectedProfessions.value && (!info.profession || !selectedProfessions.value.includes(info.profession))) return false;
+    if (preferences.value.focusedSkill !== null && entry.skillId !== preferences.value.focusedSkill) return false;
+    if (preferences.value.region && entry.region !== preferences.value.region) return false;
+    if (preferences.value.mode === "tracked" && !tracked(entry.skillId)) return false;
+    if (preferences.value.hideLearned && learned(entry.skillId) === "learned") return false;
     return !needle || normalized(`${info.name} ${info.attribute ?? ""} ${entry.boss} ${guildWarsMapName(entry.mapId)}`).includes(needle);
   });
 });
@@ -74,16 +103,12 @@ const results = computed(() => {
 });
 const selectedLocations = computed(() => ELITE_LOCATIONS.filter((entry) => entry.skillId === selectedId.value)
   .sort((a, b) => Number(b.mapId === props.view.mapId) - Number(a.mapId === props.view.mapId) || a.boss.localeCompare(b.boss)));
-const mapLocations = computed(() => selectedId.value !== null
-  ? selectedLocations.value : matching.value);
-const worldLocations = computed(() => mapLocations.value.filter((entry) => eliteContinent(entry.region) === props.view.world?.continent));
-const missionLocations = computed(() => ELITE_LOCATIONS.filter((entry) => entry.mapId === props.view.mapId && tracked(entry.skillId)
-  && (active.value?.skillId !== entry.skillId || active.value.id === entry.id)));
+const worldLocations = computed(() => matching.value.filter((entry) => eliteContinent(entry.region) === props.view.world?.continent));
+const missionLocations = computed(() => matching.value.filter((entry) => entry.mapId === props.view.mapId));
 const missionSurface = computed(() => {
   const mission = props.view.mission;
   return mission?.transform ? { box: mission.box, transform: mission.transform } : null;
 });
-const showWorldMarkers = computed(() => markersEnabled.value);
 const panelStyle = computed(() => {
   const box = props.view.world?.box;
   return box ? { top: `${box.top + 12}px`, right: `${Math.max(12, window.innerWidth - box.left - box.width + 12)}px`,
@@ -91,15 +116,15 @@ const panelStyle = computed(() => {
 });
 const trackerStyle = computed(() => {
   const box = props.view.mission?.box;
-  return box ? { left: `${box.left + 8}px`, top: `${box.top + 8}px`, width: `${Math.max(140, Math.min(292, box.width - 16))}px` } : {};
+  return box ? { left: `${box.left + 8}px`, top: `${box.top + 8}px`, right: "auto", maxWidth: `${Math.max(140, box.width - 16)}px` } : {};
 });
 const missionMessage = computed(() => {
   if (!tracking.value.missionMap) return "Mission map markers are off.";
-  if (!active.value) return "Choose a boss to focus your hunt.";
+  if (props.view.mission && !props.view.mission.transform) return "Boss markers are unavailable in this area. Use the capture notes.";
+  if (!active.value) return `${new Set(missionLocations.value.map(entry => entry.skillId)).size} matching skills in this area.`;
   if (active.value.points.length === 0) return "Boss position unavailable. Use the encounter notes.";
   if (active.value.mapId !== props.view.mapId) return `Target is in ${guildWarsMapName(active.value.mapId)}.`;
-  if (!props.view.mission) return "Open the mission map to see tracked bosses.";
-  if (!props.view.mission.transform) return "Boss markers are unavailable in this area. Use the capture notes.";
+  if (!props.view.mission) return "Open the mission map to see capture locations.";
   return "Known spawn location; this is not a live boss position.";
 });
 async function showWiki(location: EliteLocation, page: "boss" | "skill") {
@@ -107,12 +132,13 @@ async function showWiki(location: EliteLocation, page: "boss" | "skill") {
   try { await props.openWiki(location, page); }
   catch { wikiProblem.value = "The wiki could not open. Try the link again."; }
 }
-function setOpen(value: boolean, keyboard = false) {
-  open.value = value; preview.value = null;
+function setOpen(value: boolean, keyboard = false, remember = true) {
+  if (remember) updatePreferences({ panelOpen: value });
+  keepPreview(); open.value = value; preview.value = null;
   emit("openChange", value);
   if (keyboard) void nextTick(() => {
-    const target = value ? selectedId.value === null ? searchInput.value : detailBack.value
-      : mapTrigger.value ?? manageTracked.value;
+    const target = value ? selectedId.value === null ? filters.value?.searchInput : detailBack.value
+      : mapTrigger.value;
     target?.focus({ preventScroll: true });
   });
 }
@@ -121,32 +147,53 @@ function browse(event?: MouseEvent) {
 }
 function find(id: number) {
   if (!ELITE_LOCATIONS.some((entry) => entry.skillId === id)) return;
-  selectedId.value = id; search.value = "";
+  selectedId.value = id;
+  focusSkill(id);
   browse();
 }
 function selectLocation(location: EliteLocation, keyboard = false) {
+  resultsScroll = panel.value?.scrollTop ?? resultsScroll;
   selectedId.value = location.skillId;
+  void nextTick(() => { if (panel.value) panel.value.scrollTop = 0; });
   setOpen(true, keyboard);
 }
-function inspect(location: EliteLocation | null, x: number, y: number) {
-  preview.value = location ? { location, x: Math.max(8, Math.min(window.innerWidth - 312, x + 20)),
-    y: Math.max(8, Math.min(window.innerHeight - 350, y + 16)) } : null;
+function inspect(location: EliteLocation | null, x: number, y: number, keyboard = false) {
+  if (!location) { hidePreview(); return; }
+  keepPreview();
+  const next = { location, x: Math.max(8, Math.min(window.innerWidth - 328, x + 20)),
+    y: Math.max(8, Math.min(window.innerHeight - 200, y + 16)), keyboard };
+  preview.value = next;
+  const shown = preview.value;
+  void nextTick(() => {
+    if (preview.value !== shown || !previewElement.value) return;
+    next.y = Math.max(8, Math.min(next.y, window.innerHeight - previewElement.value.offsetHeight - 8));
+    preview.value = { ...next };
+  });
 }
 function inspectRow(location: EliteLocation, event: PointerEvent | FocusEvent) {
   if (!(event.currentTarget instanceof HTMLElement)) return;
   const box = event.currentTarget.getBoundingClientRect();
-  inspect(location, box.left - 332, box.top - 16);
+  inspect(location, box.left - 352, box.top - 16, event.type === "focus");
 }
 function showDetails(id: number, event: MouseEvent) {
+  resultsScroll = panel.value?.scrollTop ?? 0;
   selectedId.value = id; preview.value = null;
-  if (event.detail === 0) void nextTick(() => detailBack.value?.focus({ preventScroll: true }));
+  void nextTick(() => {
+    if (panel.value) panel.value.scrollTop = 0;
+    if (event.detail === 0) detailBack.value?.focus({ preventScroll: true });
+  });
+}
+function focusSkill(id: number) {
+  updatePreferences({ search: "", focusedSkill: id, professions: { kind: "all" }, region: "", mode: "browse", hideLearned: false, worldMap: true });
 }
 function back(event?: MouseEvent) {
   const id = selectedId.value;
   selectedId.value = null;
-  if (event?.detail === 0) void nextTick(() => {
+  void nextTick(() => {
+    if (panel.value) panel.value.scrollTop = resultsScroll;
+    if (event?.detail !== 0) return;
     const row = root.value?.querySelector<HTMLButtonElement>(`[data-skill-id="${id}"]`);
-    (row ?? searchInput.value)?.focus({ preventScroll: true });
+    (row ?? filters.value?.searchInput)?.focus({ preventScroll: true });
   });
 }
 function close(event?: MouseEvent) {
@@ -155,43 +202,51 @@ function close(event?: MouseEvent) {
 }
 function cannotCapture(location: EliteLocation) { return /impossible to capture/i.test(location.note ?? ""); }
 function toggleTrack(id: number) { void plan.change({ kind: tracked(id) ? "remove" : "track", skillId: id }); }
-watch(character, () => { selectedId.value = null; preview.value = null; });
-watch(() => props.view.world, (value, previous) => { if (!value && previous) setOpen(false); });
-watch(() => props.view.mission, (value, previous) => { if (!value && previous) preview.value = null; });
-let choseDefaultProfession = false;
-watch(() => party.value.player?.professions, (pair) => {
-  if (!choseDefaultProfession && pair) { profession.value = pair[0]; choseDefaultProfession = true; }
-}, { immediate: true });
-onBeforeUnmount(plan.dispose);
+watch(character, () => { selectedId.value = null; preview.value = null; resultsScroll = 0; setOpen(false, false, false); });
+watch(() => [Boolean(props.view.world), loaded.value] as const, ([world, ready], [previous]) => {
+  if (!world && previous) setOpen(false, false, false);
+  else if (world && ready) setOpen(preferences.value.panelOpen, false, false);
+});
+watch(() => props.view.mission, (value, previous) => {
+  if (!value && previous) { preview.value = null; if (!props.view.world) setOpen(false, false, false); }
+});
+onBeforeUnmount(() => { keepPreview(); plan.dispose(); });
 defineExpose({ find, close });
 </script>
 <template>
-  <div ref="root" class="elite-skills-root">
-    <EliteMarkers v-if="view.world && showWorldMarkers" :surface="view.world" :locations="open ? worldLocations : ELITE_LOCATIONS.filter(entry => tracked(entry.skillId) && eliteContinent(entry.region) === view.world?.continent)"
-      :active-location="tracking.activeLocation" :catalogue="catalogue" label="Elite capture locations on world map" @select="selectLocation" @inspect="inspect" />
-    <EliteMarkers v-if="missionSurface && tracking.missionMap" :surface="missionSurface" :locations="missionLocations"
-      :active-location="tracking.activeLocation" :catalogue="catalogue" label="Tracked capture locations on mission map" @select="selectLocation" @inspect="inspect" />
-    <button v-if="view.world && !open" ref="mapTrigger" class="ui-button elite-map-trigger" :style="panelStyle" aria-label="Open Elite Skills" @click="browse">
-      <svg viewBox="0 0 24 24" aria-hidden="true"><path d="m12 3 8 9-8 9-8-9Z"/><path d="M12 8v8M8 12h8"/></svg>
-      Elite skills <span v-if="tracking.skills.length">{{ tracking.skills.length }}</span>
-    </button>
+  <div ref="root" class="elite-skills-root" @keydown.esc="dismissPreview">
+    <EliteMarkers v-if="view.world && preferences.worldMap && (!character || loaded)" :surface="view.world" :locations="worldLocations"
+      :active-location="tracking.activeLocation" :preview-location-id="preview?.location.id ?? null" :catalogue="catalogue" label="Elite capture locations on world map" @select="selectLocation" @inspect="inspect" />
+    <EliteMarkers v-if="missionSurface && tracking.missionMap && (!character || loaded)" :surface="missionSurface" :locations="missionLocations"
+      :active-location="tracking.activeLocation" :preview-location-id="preview?.location.id ?? null" :catalogue="catalogue" label="Elite capture locations on mission map" @select="selectLocation" @inspect="inspect" />
+    <div v-if="(view.world || view.mission) && !open" class="ui-frame elite-map-summary" :style="view.world ? panelStyle : trackerStyle">
+      <label class="elite-visibility" title="Show elites on this map"><input type="checkbox" aria-label="Show elites" :checked="view.world ? preferences.worldMap : tracking.missionMap" :disabled="!!character && !loaded"
+        @change="view.world ? updatePreferences({ worldMap: !preferences.worldMap }) : plan.change({ kind: 'mission-map', show: !tracking.missionMap })"></label>
+      <button ref="mapTrigger" class="ui-button elite-map-trigger" aria-label="Open Elite Skills" :aria-expanded="false"
+        :title="[filterSummary, view.mission && !view.world ? [active?.boss, missionMessage].filter(Boolean).join(' · ') : ''].filter(Boolean).join(' — ')" @click="browse">
+        Elite skills<svg viewBox="0 0 24 24" aria-hidden="true"><path d="m9 5 7 7-7 7"/></svg>
+      </button>
+      <span v-if="problem" class="elite-summary-problem" role="alert" :title="loaded ? 'Changes are not saved. Open Elite Skills to retry.' : 'Your setup could not load. Open Elite Skills to retry.'"
+        :aria-label="loaded ? 'Changes are not saved. Open Elite Skills to retry.' : 'Your setup could not load. Open Elite Skills to retry.'">!</span>
+    </div>
     <section v-if="open" class="ui-frame elite-panel" :style="panelStyle" aria-label="Elite skills">
       <header class="ui-panel-head">
-        <button v-if="detailsSkill" ref="detailBack" class="ui-button elite-back" @click="back"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m14 6-6 6 6 6"/></svg>Back to skills</button>
+        <button v-if="detailsSkill" ref="detailBack" class="ui-button elite-back" @click="back"><svg viewBox="0 0 24 24" aria-hidden="true"><path d="m14 6-6 6 6 6"/></svg>Back to results</button>
         <h2 v-else>Elite skills</h2>
-        <button class="ui-button" aria-label="Close Elite Skills" @click="close">Close</button>
+        <button class="ui-button" aria-label="Collapse Elite Skills" @click="close">Collapse</button>
       </header>
+      <div ref="panel" class="ui-scroll elite-panel-content">
       <div v-if="problem" class="elite-message" role="alert">
         <p>{{ problem }}</p><button class="ui-button" :disabled="busy" @click="plan.retry">Retry</button>
-        <button v-if="loaded" class="ui-link" @click="plan.dismissError">Keep saved plan</button>
+        <button v-if="loaded" class="ui-link" @click="plan.dismissError">Restore saved setup</button>
       </div>
       <p v-if="wikiProblem" class="elite-message" role="alert">{{ wikiProblem }}</p>
       <div v-if="catalogueProblem" class="elite-message" role="status"><p>{{ catalogueProblem }}</p><button class="ui-link" @click="reloadSkills">Reload skills</button></div>
       <p v-if="catalogueVersion === 0 && !catalogueProblem" class="elite-save-state" role="status">Loading skill details…</p>
       <p v-if="!view.characterKey" class="elite-message">Select a PvE character to save a capture plan. You can still browse.</p>
-      <p v-else-if="busy" class="elite-save-state" role="status">{{ loaded ? 'Saving plan…' : 'Loading your plan…' }}</p>
+      <p v-else class="elite-save-state" role="status">{{ busy ? loaded ? 'Saving setup…' : 'Loading your setup…' : problem ? 'Changes not saved' : 'Saved for this character' }}</p>
       <template v-if="detailsSkill">
-        <div class="elite-detail-toolbar"><button class="ui-button" :aria-pressed="tracked(detailsSkill.id)" :disabled="blocked" @click="toggleTrack(detailsSkill.id)">{{ tracked(detailsSkill.id) ? 'Stop tracking skill' : 'Track skill' }}</button></div>
+        <div class="elite-detail-toolbar"><button class="ui-button" :aria-pressed="tracked(detailsSkill.id)" :disabled="blocked" @click="toggleTrack(detailsSkill.id)">{{ tracked(detailsSkill.id) ? 'Stop tracking skill' : 'Track skill' }}</button><button class="ui-button" :disabled="!!character && !loaded" @click="focusSkill(detailsSkill.id)">Show only this skill</button></div>
         <div class="ui-scroll elite-detail-scroll">
           <SkillDetails :skill="detailsSkill" />
           <p class="elite-learned" :data-learned="learned(detailsSkill.id)">{{ learned(detailsSkill.id) === 'learned' ? 'Learned by this character' : learned(detailsSkill.id) === 'not-learned' ? 'Not learned by this character' : 'Learned status unavailable' }}</p>
@@ -208,19 +263,14 @@ defineExpose({ find, close });
         </div>
       </template>
       <template v-else>
-        <div class="elite-search-controls">
-          <label class="elite-search"><span class="elite-field-label">Search skill, boss or area</span><input ref="searchInput" v-model="search" type="search" class="ui-input" placeholder="Try Eviscerate or a boss name" /></label>
-          <div class="elite-filters"><label><span class="elite-field-label">Profession</span><select v-model="profession" class="ui-select"><option value="">All professions</option><option v-for="(facts, name) in PROFESSIONS" :key="name" :value="name">{{ facts.name }}</option></select></label>
-            <label><span class="elite-field-label">Capture region</span><select v-model="region" class="ui-select"><option value="">All regions</option><option v-for="name in ELITE_REGIONS" :key="name">{{ name }}</option></select></label></div>
-          <label class="elite-check"><input v-model="hideLearned" type="checkbox" /> Hide learned skills</label>
-          <p v-if="!party.characterSkills" class="elite-support">Learned status unavailable. All matching skills stay visible.</p>
-          <div class="elite-modes" role="group" aria-label="Skills to show"><button class="ui-button" :aria-pressed="mode === 'browse'" @click="mode = 'browse'">Browse</button><button class="ui-button" :aria-pressed="mode === 'tracked'" @click="mode = 'tracked'">Tracked <span>{{ tracking.skills.length }}</span></button></div>
-        </div>
+        <EliteFilters ref="filters" :preferences="preferences" :tracked-count="tracking.skills.length" :disabled="!!character && !loaded"
+          :my-professions="party.player?.professions ?? null" :learned-available="!!party.characterSkills" :summary="filterSummary"
+          @change="updatePreferences" @reset="resetFilters" />
         <div class="elite-results-heading"><span>{{ results.length }} {{ results.length === 1 ? 'skill' : 'skills' }}</span></div>
-        <div class="ui-scroll elite-results">
-          <div v-if="!results.length" class="ui-empty"><strong>{{ mode === 'tracked' && !tracking.skills.length ? 'Plan your first capture' : 'No matching skills' }}</strong><p>{{ mode === 'tracked' && !tracking.skills.length ? 'Browse skills and track one you want to learn.' : 'Try another name or clear the filters.' }}</p><button class="ui-button" @click="search = ''; profession = ''; region = ''; mode = 'browse'; hideLearned = false">Show all skills</button></div>
+        <div class="elite-results">
+          <div v-if="!results.length" class="ui-empty"><strong>{{ preferences.mode === 'tracked' && !tracking.skills.length ? 'Plan your first capture' : 'No matching skills' }}</strong><p>{{ preferences.mode === 'tracked' && !tracking.skills.length ? 'Browse skills and track one you want to learn.' : 'Try another name or clear the filters.' }}</p><button class="ui-button" @click="resetFilters">Show all skills</button></div>
           <div v-for="result in results" :key="result.skill.id" class="elite-result">
-            <button class="elite-result-main" :data-skill-id="result.skill.id" @click="showDetails(result.skill.id, $event)" @pointerenter="inspectRow(result.locations[0]!, $event)" @pointerleave="preview = null" @focus="inspectRow(result.locations[0]!, $event)" @blur="preview = null">
+            <button class="elite-result-main" :data-skill-id="result.skill.id" :aria-describedby="preview?.location.skillId === result.skill.id ? 'elite-skill-preview' : undefined" @click="showDetails(result.skill.id, $event)" @pointerenter="inspectRow(result.locations[0]!, $event)" @pointerleave="hidePreview" @focus="inspectRow(result.locations[0]!, $event)" @blur="hidePreview">
               <span class="ui-slot elite-skill-icon" :data-profession="result.skill.profession" data-elite><img v-if="result.skill.iconUrl" :src="result.skill.iconUrl" alt="" draggable="false"><span v-else>{{ result.skill.profession?.slice(0, 1) ?? '?' }}</span></span>
               <span><strong>{{ result.skill.name }}</strong><small>{{ result.skill.profession ? PROFESSIONS[result.skill.profession].name : 'Profession unavailable' }} · {{ result.locations.length }} {{ result.locations.length === 1 ? 'location' : 'locations' }}</small><small v-if="learned(result.skill.id) === 'learned'">Learned</small></span>
             </button>
@@ -228,20 +278,19 @@ defineExpose({ find, close });
           </div>
         </div>
       </template>
+      </div>
       <footer class="elite-panel-footer">
-        <label class="elite-check"><input type="checkbox" :checked="tracking.missionMap" :disabled="blocked" @change="plan.change({ kind: 'mission-map', show: !tracking.missionMap })"> Show tracked on mission map</label>
+        <label class="elite-check"><input type="checkbox" :checked="tracking.missionMap" :disabled="blocked" @change="plan.change({ kind: 'mission-map', show: !tracking.missionMap })"> Show elites on mission map</label>
         <p v-if="active">{{ missionMessage }}</p>
         <p v-else-if="!view.world">Open the world map to view capture locations.</p>
-        <label class="elite-check"><input v-model="markersEnabled" type="checkbox"> Show world map markers</label>
+        <label class="elite-check"><input type="checkbox" :checked="preferences.worldMap" :disabled="!!character && !loaded" @change="updatePreferences({ worldMap: !preferences.worldMap })"> Show world map markers</label>
       </footer>
     </section>
-    <aside v-if="view.mission && tracking.skills.length && !view.world && !open" class="ui-frame elite-mission-tracker" :style="trackerStyle" aria-label="Elite skill tracker">
-      <strong>{{ active ? skill(active.skillId).name : `${tracking.skills.length} tracked skills` }}</strong>
-      <span v-if="active">{{ active.boss }}</span><p>{{ missionMessage }}</p><button ref="manageTracked" class="ui-link" @click="mode = 'tracked'; browse($event)">Manage tracked skills</button>
-    </aside>
-    <aside v-if="preview" class="ui-frame elite-preview" :style="{ left: `${preview.x}px`, top: `${preview.y}px` }" role="tooltip">
-      <SkillDetails :skill="skill(preview.location.skillId)" />
-      <p>{{ preview.location.boss }} · {{ guildWarsMapName(preview.location.mapId) }}</p>
+    <aside v-if="preview" id="elite-skill-preview" ref="previewElement" class="ui-frame elite-preview" :data-keyboard="preview.keyboard ? '' : undefined" @pointerenter="keepPreview" @pointerleave="hidePreview" :style="{ left: `${preview.x}px`, top: `${preview.y}px` }" role="tooltip">
+      <div class="ui-scroll elite-preview-content">
+        <SkillDetails :skill="skill(preview.location.skillId)" />
+        <p>{{ preview.location.boss }} · {{ guildWarsMapName(preview.location.mapId) }}</p>
+      </div>
     </aside>
   </div>
 </template>

--- a/apps/tools/src/components/EliteCaptureLocation.vue
+++ b/apps/tools/src/components/EliteCaptureLocation.vue
@@ -1,0 +1,17 @@
+<!-- A capture choice keeps notes and coordinate availability beside its target action. -->
+<script setup lang="ts">
+import type { EliteLocation } from "../../../../src/shared/elite-skills";
+import { guildWarsMapName } from "../../../../src/shared/guild-wars-map-names";
+defineProps<{ location: EliteLocation; active: boolean; here: boolean; disabled: boolean }>();
+const emit = defineEmits<{ target: []; wiki: [] }>();
+</script>
+<template>
+  <div class="elite-location" :data-active="active">
+    <div class="elite-location-heading"><strong>{{ location.boss }}</strong><span v-if="here">In this area</span></div>
+    <p>{{ guildWarsMapName(location.mapId) }}</p>
+    <p class="elite-support">{{ location.points.length === 0 ? 'Boss position unavailable. Use the notes.' : location.points.length > 1 ? `${location.points.length} possible positions` : 'Known spawn location' }}</p>
+    <details v-if="location.note" class="elite-encounter-notes"><summary>Encounter notes</summary><p class="elite-location-note">{{ location.note }}</p></details>
+    <div class="elite-actions"><button class="ui-button elite-target-button" :disabled="disabled || /impossible to capture/i.test(location.note ?? '')" :aria-pressed="active" @click="emit('target')">{{ /impossible to capture/i.test(location.note ?? '') ? 'Cannot capture here' : active ? 'Current target' : 'Set target' }}</button>
+      <button class="ui-link" @click="emit('wiki')">Boss wiki</button></div>
+  </div>
+</template>

--- a/apps/tools/src/components/EliteFilters.vue
+++ b/apps/tools/src/components/EliteFilters.vue
@@ -1,57 +1,67 @@
-<!-- Filter choices apply to both maps whether the planner is expanded or collapsed. -->
+<!-- The same character-owned filters drive results and both maps, even when collapsed. -->
 <script setup lang="ts">
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import { ELITE_REGIONS, type EliteViewPreferences } from "../../../../src/shared/elite-skills";
 import { PROFESSIONS } from "../../../../src/shared/builds/heroes";
+import { professionPresentation } from "../../../../src/shared/profession-assets";
 import type { Profession, ProfessionPair } from "../../../../src/shared/builds/library";
 const props = defineProps<{
   preferences: EliteViewPreferences; trackedCount: number; disabled: boolean;
-  myProfessions: ProfessionPair | null; learnedAvailable: boolean; summary: string;
+  myProfessions: ProfessionPair | null; learnedAvailable: boolean;
 }>();
 const emit = defineEmits<{ change: [value: Partial<EliteViewPreferences>]; reset: [] }>();
 const searchInput = ref<HTMLInputElement | null>(null);
-const chooseProfessions = ref(props.preferences.professions.kind === "custom");
-function toggleProfession(name: Profession) {
+const professions = Object.entries(PROFESSIONS).map(([code, facts]) => ({ ...facts, code: code as Profession, icon: professionPresentation(facts.id)!.icon }));
+const selected = computed(() => {
   const filter = props.preferences.professions;
-  const selected = filter.kind === "custom" ? filter.values : [];
-  const values = selected.includes(name) ? selected.filter(value => value !== name) : [...selected, name];
-  emit("change", { professions: values.length ? { kind: "custom", values } : { kind: "all" }, focusedSkill: null });
+  return filter.kind === "all" ? professions.map(p => p.code) : filter.kind === "custom" ? filter.values
+    : props.myProfessions?.filter((value): value is Profession => value !== null) ?? [];
+});
+const allSelected = computed(() => selected.value.length === professions.length);
+const selectionLabel = computed(() => selected.value.length === 0
+  ? props.preferences.professions.kind === "mine" ? "Your professions are unavailable. Select them manually." : "No professions selected"
+  : allSelected.value ? "All professions" : selected.value.length <= 2
+    ? selected.value.map(code => PROFESSIONS[code].name).join(" + ") : `${selected.value.length} professions selected`);
+function toggleProfession(name: Profession) {
+  const values = selected.value.includes(name) ? selected.value.filter(value => value !== name) : [...selected.value, name];
+  emit("change", { professions: { kind: "custom", values }, focusedSkill: null });
 }
 defineExpose({ searchInput });
 </script>
 <template>
   <fieldset class="elite-search-controls" aria-label="Map filters" :disabled="disabled">
-
-    <label class="elite-search"><span class="elite-field-label">Search skill, boss or area</span>
-      <input ref="searchInput" type="search" class="ui-input" maxlength="200" placeholder="Try Hundred Blades or a boss name" :value="preferences.search"
+    <label class="elite-search"><span class="elite-search-label">Search skill, boss or area</span>
+      <input ref="searchInput" type="search" class="ui-input" maxlength="200" placeholder="Find an elite skill…" :value="preferences.search"
         @input="emit('change', { search: ($event.target as HTMLInputElement).value, focusedSkill: null })" />
     </label>
-    <div class="elite-modes" role="group" aria-label="Skills to show">
-      <button class="ui-button" :aria-pressed="preferences.mode === 'browse'" @click="emit('change', { mode: 'browse', focusedSkill: null })">All skills</button>
-      <button class="ui-button" :aria-pressed="preferences.mode === 'tracked'" @click="emit('change', { mode: 'tracked', focusedSkill: null })">Tracked <span>{{ trackedCount }}</span></button>
+    <div class="elite-profession-choices" role="group" aria-label="Professions">
+      <button v-for="profession in professions" :key="profession.code" class="elite-profession" :data-profession="profession.code"
+        :aria-label="profession.name" :aria-pressed="selected.includes(profession.code)" :title="profession.name" @click="toggleProfession(profession.code)">
+        <img :src="profession.icon" alt="" draggable="false"><span aria-hidden="true">{{ profession.code }}</span>
+        <span v-if="selected.includes(profession.code)" class="elite-profession-check" aria-hidden="true">✓</span>
+        <span class="elite-profession-name" aria-hidden="true">{{ profession.name }}</span>
+      </button>
     </div>
-    <div class="elite-profession-controls">
-      <span class="elite-field-label" id="elite-profession-label">Professions</span>
-      <div class="elite-modes" role="group" aria-labelledby="elite-profession-label">
-        <button class="ui-button" :aria-pressed="preferences.professions.kind === 'all'" @click="chooseProfessions = false; emit('change', { professions: { kind: 'all' }, focusedSkill: null })">All</button>
-        <button class="ui-button" :aria-pressed="preferences.professions.kind === 'mine'" @click="chooseProfessions = false; emit('change', { professions: { kind: 'mine' }, focusedSkill: null })">My professions</button>
-        <button class="ui-button" :aria-expanded="chooseProfessions" aria-controls="elite-profession-choices" @click="chooseProfessions = !chooseProfessions">Choose…</button>
-      </div>
-      <div v-if="chooseProfessions" id="elite-profession-choices" class="elite-profession-choices" role="group" aria-label="Choose professions">
-        <label v-for="(facts, name) in PROFESSIONS" :key="name" class="elite-check"><input type="checkbox"
-          :checked="preferences.professions.kind === 'custom' && preferences.professions.values.includes(name)" @change="toggleProfession(name)">{{ facts.name }}</label>
-      </div>
-      <p v-if="preferences.professions.kind === 'mine' && !myProfessions" class="elite-support">Your professions are unavailable. Choose professions manually, or show all.</p>
+    <div class="elite-profession-shortcuts">
+      <button class="ui-link" @click="emit('change', { professions: allSelected ? { kind: 'custom', values: [] } : { kind: 'all' }, focusedSkill: null })">{{ allSelected ? 'Deselect all' : 'Select all' }}</button>
+      <button class="ui-link" :aria-pressed="preferences.professions.kind === 'mine'" title="Use this character’s primary and secondary professions"
+        @click="emit('change', { professions: { kind: 'mine' }, focusedSkill: null })">Current class</button>
     </div>
-    <label class="elite-check"><input type="checkbox" :checked="preferences.hideLearned" @change="emit('change', { hideLearned: !preferences.hideLearned })">Hide learned skills</label>
-    <p v-if="!learnedAvailable" class="elite-support">Learned status unavailable. All matching skills stay visible.</p>
-    <details class="elite-more-filters" :open="!!preferences.region"><summary>More filters<span v-if="preferences.region"> · {{ preferences.region }}</span></summary>
-      <label class="elite-search"><span class="elite-field-label">Capture region</span><select class="ui-select" :value="preferences.region"
-        @change="emit('change', { region: ($event.target as HTMLSelectElement).value as EliteViewPreferences['region'], focusedSkill: null })">
-        <option value="">All regions</option><option v-for="name in ELITE_REGIONS" :key="name">{{ name }}</option>
+    <p v-if="preferences.professions.kind === 'mine' || selected.length === 0" class="elite-support">{{ selectionLabel }}<span v-if="preferences.professions.kind === 'mine' && selected.length"> · primary &amp; secondary</span></p>
+    <label class="elite-check"><input type="checkbox" :checked="preferences.hideLearned" @change="emit('change', { hideLearned: !preferences.hideLearned })">Hide already learned</label>
+    <p v-if="!learnedAvailable" class="elite-support">Learned status unavailable. Matching skills stay visible.</p>
+    <div class="elite-filter-bottom">
+      <label><span class="elite-field-label">Show </span><select class="ui-select" aria-label="Skills to show" :value="preferences.mode"
+        @change="emit('change', { mode: ($event.target as HTMLSelectElement).value as EliteViewPreferences['mode'], focusedSkill: null })">
+        <option value="browse">All matching skills</option><option value="tracked">Saved skills ({{ trackedCount }})</option>
       </select></label>
-    </details>
-    <div class="elite-active-filters"><span>{{ summary }}</span><button class="ui-link" @click="emit('reset')">Reset filters</button></div>
+      <details class="elite-more-filters" :open="!!preferences.region"><summary>More filters</summary>
+        <label class="elite-search"><span class="elite-field-label">Capture region</span><select class="ui-select" :value="preferences.region"
+          @change="emit('change', { region: ($event.target as HTMLSelectElement).value as EliteViewPreferences['region'], focusedSkill: null })">
+          <option value="">All regions</option><option v-for="name in ELITE_REGIONS" :key="name">{{ name }}</option>
+        </select></label><button class="ui-link" @click="emit('reset')">Reset filters</button>
+      </details>
+    </div>
     <button v-if="preferences.search || preferences.focusedSkill !== null" class="ui-link elite-clear-search" @click="emit('change', { search: '', focusedSkill: null })">Clear {{ preferences.focusedSkill !== null ? 'skill focus' : 'search' }}</button>
   </fieldset>
 </template>

--- a/apps/tools/src/components/EliteFilters.vue
+++ b/apps/tools/src/components/EliteFilters.vue
@@ -1,0 +1,57 @@
+<!-- Filter choices apply to both maps whether the planner is expanded or collapsed. -->
+<script setup lang="ts">
+import { ref } from "vue";
+import { ELITE_REGIONS, type EliteViewPreferences } from "../../../../src/shared/elite-skills";
+import { PROFESSIONS } from "../../../../src/shared/builds/heroes";
+import type { Profession, ProfessionPair } from "../../../../src/shared/builds/library";
+const props = defineProps<{
+  preferences: EliteViewPreferences; trackedCount: number; disabled: boolean;
+  myProfessions: ProfessionPair | null; learnedAvailable: boolean; summary: string;
+}>();
+const emit = defineEmits<{ change: [value: Partial<EliteViewPreferences>]; reset: [] }>();
+const searchInput = ref<HTMLInputElement | null>(null);
+const chooseProfessions = ref(props.preferences.professions.kind === "custom");
+function toggleProfession(name: Profession) {
+  const filter = props.preferences.professions;
+  const selected = filter.kind === "custom" ? filter.values : [];
+  const values = selected.includes(name) ? selected.filter(value => value !== name) : [...selected, name];
+  emit("change", { professions: values.length ? { kind: "custom", values } : { kind: "all" }, focusedSkill: null });
+}
+defineExpose({ searchInput });
+</script>
+<template>
+  <fieldset class="elite-search-controls" aria-label="Map filters" :disabled="disabled">
+
+    <label class="elite-search"><span class="elite-field-label">Search skill, boss or area</span>
+      <input ref="searchInput" type="search" class="ui-input" maxlength="200" placeholder="Try Hundred Blades or a boss name" :value="preferences.search"
+        @input="emit('change', { search: ($event.target as HTMLInputElement).value, focusedSkill: null })" />
+    </label>
+    <div class="elite-modes" role="group" aria-label="Skills to show">
+      <button class="ui-button" :aria-pressed="preferences.mode === 'browse'" @click="emit('change', { mode: 'browse', focusedSkill: null })">All skills</button>
+      <button class="ui-button" :aria-pressed="preferences.mode === 'tracked'" @click="emit('change', { mode: 'tracked', focusedSkill: null })">Tracked <span>{{ trackedCount }}</span></button>
+    </div>
+    <div class="elite-profession-controls">
+      <span class="elite-field-label" id="elite-profession-label">Professions</span>
+      <div class="elite-modes" role="group" aria-labelledby="elite-profession-label">
+        <button class="ui-button" :aria-pressed="preferences.professions.kind === 'all'" @click="chooseProfessions = false; emit('change', { professions: { kind: 'all' }, focusedSkill: null })">All</button>
+        <button class="ui-button" :aria-pressed="preferences.professions.kind === 'mine'" @click="chooseProfessions = false; emit('change', { professions: { kind: 'mine' }, focusedSkill: null })">My professions</button>
+        <button class="ui-button" :aria-expanded="chooseProfessions" aria-controls="elite-profession-choices" @click="chooseProfessions = !chooseProfessions">Choose…</button>
+      </div>
+      <div v-if="chooseProfessions" id="elite-profession-choices" class="elite-profession-choices" role="group" aria-label="Choose professions">
+        <label v-for="(facts, name) in PROFESSIONS" :key="name" class="elite-check"><input type="checkbox"
+          :checked="preferences.professions.kind === 'custom' && preferences.professions.values.includes(name)" @change="toggleProfession(name)">{{ facts.name }}</label>
+      </div>
+      <p v-if="preferences.professions.kind === 'mine' && !myProfessions" class="elite-support">Your professions are unavailable. Choose professions manually, or show all.</p>
+    </div>
+    <label class="elite-check"><input type="checkbox" :checked="preferences.hideLearned" @change="emit('change', { hideLearned: !preferences.hideLearned })">Hide learned skills</label>
+    <p v-if="!learnedAvailable" class="elite-support">Learned status unavailable. All matching skills stay visible.</p>
+    <details class="elite-more-filters" :open="!!preferences.region"><summary>More filters<span v-if="preferences.region"> · {{ preferences.region }}</span></summary>
+      <label class="elite-search"><span class="elite-field-label">Capture region</span><select class="ui-select" :value="preferences.region"
+        @change="emit('change', { region: ($event.target as HTMLSelectElement).value as EliteViewPreferences['region'], focusedSkill: null })">
+        <option value="">All regions</option><option v-for="name in ELITE_REGIONS" :key="name">{{ name }}</option>
+      </select></label>
+    </details>
+    <div class="elite-active-filters"><span>{{ summary }}</span><button class="ui-link" @click="emit('reset')">Reset filters</button></div>
+    <button v-if="preferences.search || preferences.focusedSkill !== null" class="ui-link elite-clear-search" @click="emit('change', { search: '', focusedSkill: null })">Clear {{ preferences.focusedSkill !== null ? 'skill focus' : 'search' }}</button>
+  </fieldset>
+</template>

--- a/apps/tools/src/components/EliteMarkers.vue
+++ b/apps/tools/src/components/EliteMarkers.vue
@@ -5,34 +5,43 @@ import type { EliteLocation } from "../../../../src/shared/elite-skills";
 import type { EliteMapSurface } from "../../../../src/shared/elite-map";
 import type { SkillCatalogue } from "../skill-catalog";
 import { skillId } from "../../../../src/shared/builds/library";
-import { eliteMarkers } from "../elite-map-markers";
+import { eliteMarkers, type EliteMarker } from "../elite-map-markers";
 const props = defineProps<{
   surface: EliteMapSurface; locations: readonly EliteLocation[];
   activeLocation: string | null; previewLocationId: string | null; catalogue: SkillCatalogue; label: string;
 }>();
 const emit = defineEmits<{
   select: [location: EliteLocation, keyboard: boolean];
-  inspect: [location: EliteLocation | null, x: number, y: number, keyboard?: boolean];
+  inspect: [location: EliteLocation | null, x: number, y: number, keyboard?: boolean, nearby?: readonly EliteLocation[]];
 }>();
 const markers = computed(() => eliteMarkers(props.locations, props.surface, props.activeLocation));
 const boxStyle = computed(() => Object.fromEntries(Object.entries(props.surface.box).map(([key, value]) => [key, `${value}px`])));
-const name = (location: EliteLocation) => `${props.catalogue.get(skillId(location.skillId)).name} — ${location.boss}`;
+function inspect(marker: EliteMarker, keyboard = false) {
+  // Use the visible, filtered positions. Alternate points of one boss need only one choice.
+  const nearby = [...new Map(markers.value
+    .filter(other => Math.abs(other.x - marker.x) < 28 && Math.abs(other.y - marker.y) < 28)
+    .flatMap(other => other.locations.map(location => [location.id, location] as const))).values()];
+  emit("inspect", marker.location, props.surface.box.left + marker.x, props.surface.box.top + marker.y, keyboard, nearby);
+}
+const name = (marker: EliteMarker) => `${props.catalogue.get(skillId(marker.location.skillId)).name} — ${[...new Set(marker.locations.map(location => location.boss))].join(", ")}`;
 </script>
 <template>
   <div class="elite-markers" :style="boxStyle" :aria-label="label">
     <button v-for="marker in markers" :key="marker.key" class="elite-marker"
       :class="{ 'elite-marker--active': marker.active, 'elite-marker--outside': marker.outside }"
       :style="{ left: `${marker.x}px`, top: `${marker.y}px` }"
-      :aria-describedby="previewLocationId === marker.location.id ? 'elite-skill-preview' : undefined"
-      :aria-label="`${name(marker.location)}${marker.outside ? '; outside this map view' : '; known spawn'}`"
+      :aria-describedby="marker.locations.some(location => location.id === previewLocationId) ? 'elite-skill-preview' : undefined"
+      :aria-label="`${name(marker)}${marker.outside ? '; outside this map view' : '; known spawn'}`"
       @click="emit('select', marker.location, $event.detail === 0)"
-      @pointerenter="emit('inspect', marker.location, surface.box.left + marker.x, surface.box.top + marker.y)"
+      @pointerenter="inspect(marker)"
       @pointerleave="emit('inspect', null, 0, 0)"
-      @focus="emit('inspect', marker.location, surface.box.left + marker.x, surface.box.top + marker.y, true)"
+      @focus="inspect(marker, true)"
       @blur="emit('inspect', null, 0, 0)">
+      <span class="elite-marker-art">
         <img v-if="catalogue.get(skillId(marker.location.skillId)).iconUrl"
           :src="catalogue.get(skillId(marker.location.skillId)).iconUrl!" alt="" draggable="false">
         <svg v-else viewBox="0 0 24 24" aria-hidden="true"><path d="m12 3 8 9-8 9-8-9Z" /></svg>
+      </span>
       <span v-if="marker.active" class="elite-marker-label">{{ marker.outside ? 'Outside map view' : marker.location.boss }}</span>
     </button>
   </div>

--- a/apps/tools/src/components/EliteMarkers.vue
+++ b/apps/tools/src/components/EliteMarkers.vue
@@ -8,11 +8,11 @@ import { skillId } from "../../../../src/shared/builds/library";
 import { eliteMarkers } from "../elite-map-markers";
 const props = defineProps<{
   surface: EliteMapSurface; locations: readonly EliteLocation[];
-  activeLocation: string | null; catalogue: SkillCatalogue; label: string;
+  activeLocation: string | null; previewLocationId: string | null; catalogue: SkillCatalogue; label: string;
 }>();
 const emit = defineEmits<{
   select: [location: EliteLocation, keyboard: boolean];
-  inspect: [location: EliteLocation | null, x: number, y: number];
+  inspect: [location: EliteLocation | null, x: number, y: number, keyboard?: boolean];
 }>();
 const markers = computed(() => eliteMarkers(props.locations, props.surface, props.activeLocation));
 const boxStyle = computed(() => Object.fromEntries(Object.entries(props.surface.box).map(([key, value]) => [key, `${value}px`])));
@@ -23,11 +23,12 @@ const name = (location: EliteLocation) => `${props.catalogue.get(skillId(locatio
     <button v-for="marker in markers" :key="marker.key" class="elite-marker"
       :class="{ 'elite-marker--active': marker.active, 'elite-marker--outside': marker.outside }"
       :style="{ left: `${marker.x}px`, top: `${marker.y}px` }"
+      :aria-describedby="previewLocationId === marker.location.id ? 'elite-skill-preview' : undefined"
       :aria-label="`${name(marker.location)}${marker.outside ? '; outside this map view' : '; known spawn'}`"
       @click="emit('select', marker.location, $event.detail === 0)"
       @pointerenter="emit('inspect', marker.location, surface.box.left + marker.x, surface.box.top + marker.y)"
       @pointerleave="emit('inspect', null, 0, 0)"
-      @focus="emit('inspect', marker.location, surface.box.left + marker.x, surface.box.top + marker.y)"
+      @focus="emit('inspect', marker.location, surface.box.left + marker.x, surface.box.top + marker.y, true)"
       @blur="emit('inspect', null, 0, 0)">
         <img v-if="catalogue.get(skillId(marker.location.skillId)).iconUrl"
           :src="catalogue.get(skillId(marker.location.skillId)).iconUrl!" alt="" draggable="false">

--- a/apps/tools/src/components/SkillDetails.vue
+++ b/apps/tools/src/components/SkillDetails.vue
@@ -37,6 +37,7 @@ function hideBrokenIcon(event: Event): void {
         <small v-if="skill.elite" class="skill-elite-label">Elite · One per bar</small>
       </span>
     </div>
+    <slot name="context" />
     <dl v-if="stats.length || skill.aftercastSeconds" class="skill-stats" aria-label="Skill costs and timings">
       <div v-for="stat in stats" :key="stat.label" :title="`${stat.label}: ${stat.value}${stat.suffix}`">
         <dt><img :src="stat.icon" :alt="stat.label" width="20" height="20" draggable="false"></dt>

--- a/apps/tools/src/elite-fixture.ts
+++ b/apps/tools/src/elite-fixture.ts
@@ -16,10 +16,14 @@ const fixtureSkills = [
 ] as const;
 export const ELITE_FIXTURE_SKILLS: readonly SkillPresentation[] = fixtureSkills.map(({ boss, name, profession, attribute }) => {
   const location = ELITE_LOCATIONS.find((entry) => entry.boss === boss)!;
+  const color = profession === "W" ? "#ad7431" : profession === "R" ? "#37774b" : "#416caa";
+  const initials = name.split(" ").map(part => part[0]).join("").slice(0, 2);
+  // Reproduce the client texture's baked-in 4px rim so marker polish is visible offline.
+  const iconUrl = `data:image/svg+xml,${encodeURIComponent(`<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"><rect width="64" height="64" fill="#000"/><rect x="4" y="4" width="56" height="56" fill="${color}"/><path d="M4 60 60 4v56Z" fill="#000" opacity=".25"/><text x="32" y="40" text-anchor="middle" fill="#fff" font-family="sans-serif" font-size="24">${initials}</text></svg>`)}`;
   return { id: skillId(location.skillId), name, profession, attribute,
     elite: true, availability: "pve", energyCost: profession === "W" ? 0 : 5, adrenalineCost: profession === "W" ? 8 : 0, healthCost: 0, overcast: 0,
     activationSeconds: profession === "Mo" ? 0.75 : 0, aftercastSeconds: 0.75, rechargeSeconds: profession === "Mo" ? 2 : 0,
-    description: "Illustrative skill details for the offline fixture. In game, the exact description and costs come from the installed client.", iconUrl: null };
+    description: "Illustrative skill details for the offline fixture. In game, the exact description and costs come from the installed client.", iconUrl };
 });
 const characterA = travelCharacterKey("0123456789abcdef");
 const characterB = travelCharacterKey("fedcba9876543210");
@@ -41,9 +45,12 @@ export function mountEliteFixture(target: HTMLElement): void {
   controls.className = "elite-fixture-controls";
   controls.style.cssText = "position:fixed;left:24px;top:16px;display:flex;gap:8px;flex-wrap:wrap;z-index:5;right:24px";
   const label = document.createElement("strong"); label.textContent = "Elite Skills · offline map fixture"; controls.append(label);
-  let mission = false, otherCharacter = false, learned = false, failSave = false, mapOpen = true, secondary = 2;
+  let mission = false, otherCharacter = false, learned = false, failSave = false, mapOpen = true, secondary = 2, crowded = false;
+  const fullCatalogue = new URLSearchParams(window.location.search).has("fullCatalogue");
+  const skills = fullCatalogue ? [...new Set(ELITE_LOCATIONS.map(entry => entry.skillId))].map(id =>
+    ELITE_FIXTURE_SKILLS.find(skill => skill.id === id) ?? { ...ELITE_FIXTURE_SKILLS[0]!, id: skillId(id), name: `Fixture elite ${id}` }) : ELITE_FIXTURE_SKILLS;
   const app = mountEliteSkills(target, {
-    initialView: eliteFixtureView(), loadSkills: async () => ELITE_FIXTURE_SKILLS,
+    initialView: eliteFixtureView(), loadSkills: async () => skills,
     onOpenChange: () => {},
     openWiki: (entry, page) => { label.textContent = `Wiki action: ${page === "boss" ? entry.boss : entry.skillId}`; },
     tracking: {
@@ -66,11 +73,13 @@ export function mountEliteFixture(target: HTMLElement): void {
   map.textContent = "Native map artwork appears here in game. This fixture verifies overlay placement and interaction.";
   document.body.prepend(map);
   function update() {
-    const view = eliteFixtureView(mission, otherCharacter, learned, secondary);
+    const original = eliteFixtureView(mission, otherCharacter, learned, secondary);
+    const view = crowded && original.world ? { ...original, world: { ...original.world, transform: { a: 0.003, b: 0, c: 0, d: 0.003, e: 180, f: 180 } } } : original;
     app.update(mapOpen ? view : { ...view, world: null, mission: null });
   }
   for (const [name, run] of [
     ["World / mission map", () => { mission = !mission; update(); }],
+    ["Spread / overlap markers", () => { crowded = !crowded; update(); }],
     ["Close / open map", () => { mapOpen = !mapOpen; update(); }],
     ["Change secondary profession", () => { secondary = secondary === 2 ? 3 : 2; update(); }],
     ["Switch character", () => { otherCharacter = !otherCharacter; update(); }],

--- a/apps/tools/src/elite-fixture.ts
+++ b/apps/tools/src/elite-fixture.ts
@@ -6,21 +6,28 @@ import { skillId } from "../../../src/shared/builds/library";
 import type { EliteMapView } from "../../../src/shared/elite-map";
 import type { SkillPresentation } from "./skill-catalog";
 import { mountEliteSkills } from "./elite-mount";
-const fixtureBosses = ["Lissah the Packleader", "Fenrir", "Jormungand", "Warrior's Construct"];
-export const ELITE_FIXTURE_SKILLS: readonly SkillPresentation[] = fixtureBosses.map((boss, index) => {
+const fixtureSkills = [
+  { boss: "Lissah the Packleader", name: "Eviscerate", profession: "W", attribute: "AxeMastery" },
+  { boss: "Fenrir", name: "Crippling Slash", profession: "W", attribute: "Swordsmanship" },
+  { boss: "Jormungand", name: "Earth Shaker", profession: "W", attribute: "HammerMastery" },
+  { boss: "Warrior's Construct", name: "Hundred Blades", profession: "W", attribute: "Swordsmanship" },
+  { boss: "Markis", name: "Barrage", profession: "R", attribute: "Marksmanship" },
+  { boss: "Dwayna's Cursed", name: "Restore Condition", profession: "Mo", attribute: "ProtectionPrayers" },
+] as const;
+export const ELITE_FIXTURE_SKILLS: readonly SkillPresentation[] = fixtureSkills.map(({ boss, name, profession, attribute }) => {
   const location = ELITE_LOCATIONS.find((entry) => entry.boss === boss)!;
-  return { id: skillId(location.skillId), name: ["Eviscerate", "Crippling Slash", "Earth Shaker", "Hundred Blades"][index]!,
-    profession: "W", attribute: ["AxeMastery", "Swordsmanship", "HammerMastery", "Swordsmanship"][index] as "AxeMastery" | "Swordsmanship" | "HammerMastery",
-    elite: true, availability: "pve", energyCost: 0, adrenalineCost: 8, healthCost: 0, overcast: 0,
-    activationSeconds: 0, aftercastSeconds: 0, rechargeSeconds: 0,
+  return { id: skillId(location.skillId), name, profession, attribute,
+    elite: true, availability: "pve", energyCost: profession === "W" ? 0 : 5, adrenalineCost: profession === "W" ? 8 : 0, healthCost: 0, overcast: 0,
+    activationSeconds: profession === "Mo" ? 0.75 : 0, aftercastSeconds: 0.75, rechargeSeconds: profession === "Mo" ? 2 : 0,
     description: "Illustrative skill details for the offline fixture. In game, the exact description and costs come from the installed client.", iconUrl: null };
 });
 const characterA = travelCharacterKey("0123456789abcdef");
 const characterB = travelCharacterKey("fedcba9876543210");
 const location = ELITE_LOCATIONS.find((entry) => entry.boss === "Lissah the Packleader")!;
-export function eliteFixtureView(mission = false, otherCharacter = false, learned = false): EliteMapView {
+export function eliteFixtureView(mission = false, otherCharacter = false, learned = false, secondary = 2): EliteMapView {
   return { characterKey: otherCharacter ? characterB : characterA, mapId: location.mapId,
-    observation: { status: "ready", partyObserved: true, party: { status: "ready", playRegion: "pve", rosterObserved: false,
+    observation: { status: "ready", partyObserved: true, party: { status: "ready", playRegion: "pve", rosterObserved: true, slotCount: 1,
+      slots: [{ index: 0, occupied: true, hero: null, agentId: 10, level: 20, professions: [1, secondary], behaviour: null, skills: null, disabled: null, attributes: null }],
       characterSkills: { knownThrough: 5000, unlocked: learned ? [338] : [] } } },
     world: mission ? null : { continent: 0,
       box: { left: 24, top: 88, width: window.innerWidth - 48, height: window.innerHeight - 160 },
@@ -34,7 +41,7 @@ export function mountEliteFixture(target: HTMLElement): void {
   controls.className = "elite-fixture-controls";
   controls.style.cssText = "position:fixed;left:24px;top:16px;display:flex;gap:8px;flex-wrap:wrap;z-index:5;right:24px";
   const label = document.createElement("strong"); label.textContent = "Elite Skills · offline map fixture"; controls.append(label);
-  let mission = false, otherCharacter = false, learned = false, failSave = false;
+  let mission = false, otherCharacter = false, learned = false, failSave = false, mapOpen = true, secondary = 2;
   const app = mountEliteSkills(target, {
     initialView: eliteFixtureView(), loadSkills: async () => ELITE_FIXTURE_SKILLS,
     onOpenChange: () => {},
@@ -58,9 +65,14 @@ export function mountEliteFixture(target: HTMLElement): void {
   map.style.cssText = "position:fixed;left:24px;top:88px;right:24px;bottom:72px;border:1px solid var(--ui-line);background:var(--ui-well-fill);padding:24px;color:var(--ui-text-muted);pointer-events:none";
   map.textContent = "Native map artwork appears here in game. This fixture verifies overlay placement and interaction.";
   document.body.prepend(map);
-  function update() { app.update(eliteFixtureView(mission, otherCharacter, learned)); }
+  function update() {
+    const view = eliteFixtureView(mission, otherCharacter, learned, secondary);
+    app.update(mapOpen ? view : { ...view, world: null, mission: null });
+  }
   for (const [name, run] of [
     ["World / mission map", () => { mission = !mission; update(); }],
+    ["Close / open map", () => { mapOpen = !mapOpen; update(); }],
+    ["Change secondary profession", () => { secondary = secondary === 2 ? 3 : 2; update(); }],
     ["Switch character", () => { otherCharacter = !otherCharacter; update(); }],
     ["Learn / unlearn Eviscerate", () => { learned = !learned; update(); }],
     ["Fail / restore saves", () => { failSave = !failSave; label.textContent = failSave ? "Fixture: saves will fail" : "Elite Skills · offline map fixture"; }],

--- a/apps/tools/src/elite-map-markers.ts
+++ b/apps/tools/src/elite-map-markers.ts
@@ -3,6 +3,7 @@ import type { EliteLocation } from "../../../src/shared/elite-skills";
 import type { EliteMapSurface } from "../../../src/shared/elite-map";
 export type EliteMarker = Readonly<{
   key: string; x: number; y: number; location: EliteLocation;
+  locations: readonly EliteLocation[];
   active: boolean; outside: boolean;
 }>;
 export function eliteMarkers(
@@ -23,8 +24,22 @@ export function eliteMarkers(
       if (outside && !active) return;
       const x = Math.max(inset, Math.min(surface.box.width - inset, px));
       const y = Math.max(inset, Math.min(surface.box.height - inset, py));
-      markers.push({ key: `${location.id}:${index}`, x, y, location, active, outside });
+      markers.push({ key: `${location.id}:${index}`, x, y, location, locations: [location], active, outside });
     });
   }
-  return markers;
+  // Deduplicate artwork only where same-skill markers touch in the same map area.
+  // Keep source locations and positions intact for boss choices and capture targets.
+  const groups: EliteMarker[][] = [];
+  for (const marker of markers) {
+    const touching = groups.filter(group => group.some(other =>
+      other.location.skillId === marker.location.skillId && other.location.mapId === marker.location.mapId
+      && other.outside === marker.outside && Math.abs(other.x - marker.x) <= 24 && Math.abs(other.y - marker.y) <= 24));
+    const combined = [...touching.flat(), marker];
+    for (const group of touching) groups.splice(groups.indexOf(group), 1);
+    groups.push(combined);
+  }
+  return groups.map(group => {
+    const representative = group.find(marker => marker.active) ?? group[0]!;
+    return { ...representative, locations: [...new Map(group.map(marker => [marker.location.id, marker.location])).values()] };
+  });
 }

--- a/apps/tools/src/styles/elite-skills.css
+++ b/apps/tools/src/styles/elite-skills.css
@@ -2,24 +2,38 @@
 .elite-skills-root { position: fixed; inset: 0; z-index: 4; pointer-events: none; color: var(--ui-text); font: var(--ui-font-size) / var(--ui-line-height) var(--ui-font); }
 .elite-skills-root *, .elite-skills-root *::before, .elite-skills-root *::after { box-sizing: border-box; }
 .elite-skills-root svg { width: 18px; height: 18px; fill: none; stroke: currentColor; stroke-width: 1.7; stroke-linecap: round; stroke-linejoin: round; }
-.elite-panel, .elite-map-trigger { position: fixed; top: 16px; right: 16px; pointer-events: auto; }
-.elite-map-trigger { display: flex; align-items: center; gap: var(--ui-space-2); }
+.elite-skills-root .elite-panel, .elite-skills-root .elite-map-summary { position: fixed; top: 16px; right: 16px; pointer-events: auto; }
+.elite-map-summary { display: flex; align-items: center; width: max-content; max-width: calc(100vw - 24px); padding: 4px; background: var(--ui-panel-fill); }
+.elite-visibility { display: grid; place-items: center; width: 40px; height: 40px; cursor: pointer; }
+.elite-visibility input { margin: 0; accent-color: var(--ui-accent); cursor: inherit; }
+.elite-map-trigger { display: inline-flex; align-items: center; gap: var(--ui-space-2); min-height: 40px; white-space: nowrap; }
+.elite-map-trigger svg { width: 14px; height: 14px; }
+.elite-summary-problem { padding-inline: var(--ui-space-2); color: var(--ui-accent); font-weight: bold; }
 .elite-panel { display: flex; flex-direction: column; width: min(356px, calc(100vw - 24px)); max-height: calc(100dvh - 32px); background: var(--ui-panel-fill); overflow: hidden; }
 .elite-panel .ui-panel-head { position: sticky; top: 0; z-index: 3; background-color: var(--ui-panel-fill); display: flex; align-items: center; justify-content: space-between; flex-shrink: 0; }
+.elite-panel-content { min-height: 0; overflow-y: auto; flex: 1; }
 .elite-panel h2 { margin: 0; color: var(--ui-text-bright); font-size: var(--ui-font-size-lg); }
 .elite-back { display: inline-flex; align-items: center; gap: var(--ui-space-1); }
-.elite-search-controls { display: grid; gap: var(--ui-space-3); padding: var(--ui-space-4); }
-.elite-search, .elite-filters label { display: grid; gap: var(--ui-space-1); min-width: 0; }
+.elite-search-controls { border: 0; margin: 0; min-width: 0; display: grid; gap: var(--ui-space-3); padding: var(--ui-space-4); }
+.elite-search { display: grid; gap: var(--ui-space-1); min-width: 0; }
 .elite-field-label { color: var(--ui-text-muted); font-size: var(--ui-font-size-sm); }
-.elite-search input, .elite-filters select { width: 100%; min-width: 0; }
-.elite-filters { display: grid; grid-template-columns: 1fr 1fr; gap: var(--ui-space-2); }
+.elite-search input, .elite-search select { width: 100%; min-width: 0; }
+.elite-profession-controls { display: grid; gap: var(--ui-space-2); }
+.elite-profession-choices { display: grid; grid-template-columns: 1fr 1fr; gap: var(--ui-space-2); padding-block: var(--ui-space-2); }
+.elite-active-filters { display: flex; align-items: baseline; gap: var(--ui-space-2); font-size: var(--ui-font-size-sm); color: var(--ui-text-muted); }
+.elite-active-filters span { flex: 1; overflow-wrap: anywhere; }
+.elite-active-filters button { flex-shrink: 0; }
+.elite-clear-search { justify-self: start; }
+.elite-more-filters summary { cursor: pointer; color: var(--ui-text-muted); font-size: var(--ui-font-size-sm); }
+.elite-more-filters[open] summary { margin-bottom: var(--ui-space-2); }
 .elite-check { display: flex; align-items: center; gap: var(--ui-space-2); font-size: var(--ui-font-size-sm); cursor: pointer; }
 .elite-check input { accent-color: var(--ui-accent); }
 .elite-modes { display: flex; gap: var(--ui-space-2); }
 .elite-modes .ui-button { flex: 1; }
+.elite-profession-controls .elite-modes .ui-button:nth-child(2) { flex: 1.7; }
 .elite-modes span { margin-left: var(--ui-space-2); font-variant-numeric: tabular-nums; }
 .elite-results-heading { display: flex; align-items: center; justify-content: space-between; padding: 0 var(--ui-space-4) var(--ui-space-2); color: var(--ui-text-muted); font-size: var(--ui-font-size-sm); }
-.elite-results { min-height: 100px; overflow-y: auto; flex: 1 1 auto; padding: 0 var(--ui-space-2) var(--ui-space-2); }
+.elite-results { padding: 0 var(--ui-space-2) var(--ui-space-2); }
 .elite-result { display: flex; align-items: center; min-height: 64px; border-bottom: 1px solid var(--ui-line); }
 .elite-result-main { display: flex; flex: 1; gap: var(--ui-space-3); padding: var(--ui-space-2); align-items: center; min-width: 0; text-align: left; color: var(--ui-text); background: transparent; border: 0; border-radius: var(--ui-radius-sm); font: inherit; cursor: pointer; }
 .elite-result-main:hover { background: var(--ui-hover); }
@@ -30,9 +44,8 @@
 .elite-skill-icon img { width: 100%; height: 100%; object-fit: cover; }
 .elite-track-button { width: 34px; padding: 6px; flex-shrink: 0; }
 .elite-track-button[aria-pressed="true"] svg { fill: var(--ui-accent); }
-.elite-detail-toolbar { display: flex; gap: var(--ui-space-2); justify-content: space-between; align-items: center; padding: var(--ui-space-3) var(--ui-space-4); }
-.elite-detail-scroll { min-height: 80px; overflow-y: auto; padding: var(--ui-space-4); }
-.skill-details { display: grid; gap: var(--ui-space-3); }
+.elite-detail-toolbar { display: flex; flex-wrap: wrap; gap: var(--ui-space-2); justify-content: space-between; align-items: center; padding: var(--ui-space-3) var(--ui-space-4); }
+.elite-detail-scroll { padding: var(--ui-space-4); }
 .elite-detail-scroll h3 { color: var(--ui-text-bright); font-size: var(--ui-font-size); margin: var(--ui-space-5) 0 var(--ui-space-2); }
 .elite-location { padding: var(--ui-space-3) 0; border-top: 1px solid var(--ui-line); }
 .elite-location-heading { display: flex; gap: var(--ui-space-2); justify-content: space-between; color: var(--ui-text-bright); }
@@ -56,21 +69,21 @@
 .elite-marker--active { outline: 2px solid var(--ui-accent); z-index: 1; }
 .elite-marker--outside { border-style: dashed; }
 .elite-marker-label { position: absolute; top: 32px; width: max-content; max-width: 180px; padding: 3px 6px; background: var(--ui-panel-fill); color: var(--ui-text-bright); font-size: var(--ui-font-size-sm); pointer-events: none; }
-.elite-mission-tracker { display: grid; gap: var(--ui-space-1); position: fixed; padding: var(--ui-space-3); background: var(--ui-panel-fill); pointer-events: auto; }
-.elite-mission-tracker strong { color: var(--ui-text-bright); }
-.elite-mission-tracker p { margin: var(--ui-space-1) 0; color: var(--ui-text-muted); font-size: var(--ui-font-size-sm); }
-.elite-mission-tracker .ui-link { justify-self: start; }
-.elite-preview { position: fixed; width: 300px; max-height: 340px; overflow: hidden; pointer-events: none; padding: var(--ui-space-4); background: var(--ui-panel-fill); z-index: 2; }
-.elite-preview > p { margin-bottom: 0; font-size: var(--ui-font-size-sm); color: var(--ui-text-muted); }
+.elite-preview { position: fixed; display: flex; width: min(320px, calc(100vw - 16px)); max-height: min(480px, calc(100dvh - 16px)); overflow: hidden; pointer-events: auto; background: var(--ui-panel-fill); z-index: 2; }
+.elite-preview-content { min-width: 0; min-height: 0; overflow-y: auto; overflow-x: hidden; padding: var(--ui-space-4); flex: 1; }
+.elite-preview-content > p { margin-bottom: 0; font-size: var(--ui-font-size-sm); color: var(--ui-text-muted); }
 .elite-preview .inspector-identity { display: grid; }
 .elite-skills-root button:focus-visible { outline: 2px solid var(--ui-focus); outline-offset: 2px; }
-@media (max-width: 650px) { .elite-preview { display: none; } .elite-panel { right: 12px !important; } }
+@media (max-width: 650px) { .elite-panel { right: 12px !important; } }
 @media (max-height: 600px) { .elite-search-controls { gap: var(--ui-space-2); padding: var(--ui-space-2) var(--ui-space-3); } .elite-panel-footer { padding: var(--ui-space-2) var(--ui-space-3); } }
 
 .elite-panel .inspector-identity { display: grid; }
 
-/* Short native map frames scroll as one panel so errors cannot displace controls. */
-@media (max-height: 700px) {
-  .elite-panel { display: block; overflow-y: auto; }
-  .elite-panel .elite-results, .elite-panel .elite-detail-scroll { overflow: visible; min-height: 0; }
+/* Enter gently; native map closure still removes the preview in the same render. */
+@media (hover: hover) and (pointer: fine) and (prefers-reduced-motion: no-preference) {
+  .elite-preview:not([data-keyboard]) { transition: opacity 125ms cubic-bezier(0.19, 1, 0.22, 1), transform 125ms cubic-bezier(0.19, 1, 0.22, 1); }
+  @starting-style {
+    .elite-preview:not([data-keyboard]) { opacity: 0; transform: translateY(3px); }
+  }
 }
+.elite-result-main:hover .elite-skill-icon, .elite-result-main:focus-visible .elite-skill-icon { outline: 1px solid var(--ui-focus); outline-offset: 2px; }

--- a/apps/tools/src/styles/elite-skills.css
+++ b/apps/tools/src/styles/elite-skills.css
@@ -9,44 +9,52 @@
 .elite-map-trigger { display: inline-flex; align-items: center; gap: var(--ui-space-2); min-height: 40px; white-space: nowrap; }
 .elite-map-trigger svg { width: 14px; height: 14px; }
 .elite-summary-problem { padding-inline: var(--ui-space-2); color: var(--ui-accent); font-weight: bold; }
-.elite-panel { display: flex; flex-direction: column; width: min(356px, calc(100vw - 24px)); max-height: calc(100dvh - 32px); background: var(--ui-panel-fill); overflow: hidden; }
+.elite-panel { display: flex; flex-direction: column; width: min(356px, calc(100vw - 24px)); height: 80dvh; max-height: calc(100dvh - 32px); background: rgb(from var(--ui-panel-fill) r g b / 1); overflow: hidden; }
 .elite-panel .ui-panel-head { position: sticky; top: 0; z-index: 3; background-color: var(--ui-panel-fill); display: flex; align-items: center; justify-content: space-between; flex-shrink: 0; }
-.elite-panel-content { min-height: 0; overflow-y: auto; flex: 1; }
+.elite-panel-content { min-height: min(120px, 20dvh); overflow-y: auto; flex: 1 1 0px; }
 .elite-panel h2 { margin: 0; color: var(--ui-text-bright); font-size: var(--ui-font-size-lg); }
-.elite-back { display: inline-flex; align-items: center; gap: var(--ui-space-1); }
-.elite-search-controls { border: 0; margin: 0; min-width: 0; display: grid; gap: var(--ui-space-3); padding: var(--ui-space-4); }
+.elite-search-controls { border: 0; margin: 0; min-width: 0; display: grid; gap: var(--ui-space-2); padding: var(--ui-space-3); }
+.elite-filter-panel { min-height: 0; max-height: min(50%, max(100px, calc(100% - 240px))); overflow: auto; flex: 0 1 auto; }
 .elite-search { display: grid; gap: var(--ui-space-1); min-width: 0; }
 .elite-field-label { color: var(--ui-text-muted); font-size: var(--ui-font-size-sm); }
 .elite-search input, .elite-search select { width: 100%; min-width: 0; }
-.elite-profession-controls { display: grid; gap: var(--ui-space-2); }
-.elite-profession-choices { display: grid; grid-template-columns: 1fr 1fr; gap: var(--ui-space-2); padding-block: var(--ui-space-2); }
-.elite-active-filters { display: flex; align-items: baseline; gap: var(--ui-space-2); font-size: var(--ui-font-size-sm); color: var(--ui-text-muted); }
-.elite-active-filters span { flex: 1; overflow-wrap: anywhere; }
-.elite-active-filters button { flex-shrink: 0; }
+.elite-profession-choices { display: grid; grid-template-columns: repeat(5, minmax(0, 1fr)); gap: 4px; }
+.elite-profession { position: relative; display: grid; justify-items: center; gap: 2px; min-height: 48px; padding: 4px; border: 1px solid var(--ui-line); border-radius: var(--ui-radius-sm); background: transparent; color: var(--ui-text-muted); cursor: pointer; font: var(--ui-font-size-sm) var(--ui-font); }
+.elite-profession img { width: 26px; height: 26px; opacity: .55; }
+.elite-profession[aria-pressed="true"] { background: var(--ui-hover); border-color: var(--ui-accent); color: var(--ui-text-bright); }
+.elite-profession[aria-pressed="true"] img, .elite-profession:hover img { opacity: 1; }
+.elite-profession:hover { background: var(--ui-hover); }
+.elite-profession-check { position: absolute; top: 2px; right: 3px; font: 10px sans-serif; color: var(--ui-accent); }
+.elite-profession-name { display: none; position: absolute; bottom: calc(100% + 3px); z-index: 5; padding: 4px 7px; border-radius: var(--ui-radius-sm); background: rgb(from var(--ui-panel-fill) r g b / 1); color: var(--ui-text-bright); white-space: nowrap; pointer-events: none; }
+.elite-profession:hover, .elite-profession:focus-visible { z-index: 4; }
+.elite-profession:hover .elite-profession-name, .elite-profession:focus-visible .elite-profession-name { display: block; }
+.elite-profession-shortcuts { display: flex; align-items: center; justify-content: space-between; gap: var(--ui-space-2); }
+.elite-profession-shortcuts button { min-height: 30px; padding: 2px 4px; font-size: var(--ui-font-size-sm); }
+.elite-profession-shortcuts [aria-pressed="true"] { background: var(--ui-hover); border-radius: var(--ui-radius-sm); }
+.elite-filter-bottom { display: flex; flex-wrap: wrap; align-items: start; justify-content: space-between; gap: var(--ui-space-2); }
+.elite-filter-bottom .ui-select { padding: 4px; min-height: 30px; font-size: var(--ui-font-size-sm); max-width: 100%; }
+.elite-filter-bottom .elite-more-filters { flex: 1; min-width: 95px; }
+.elite-more-filters summary { padding-block: 5px; }
+.elite-more-filters[open] { flex-basis: 100%; }
+.elite-more-filters .ui-link { margin-top: var(--ui-space-2); }
 .elite-clear-search { justify-self: start; }
 .elite-more-filters summary { cursor: pointer; color: var(--ui-text-muted); font-size: var(--ui-font-size-sm); }
 .elite-more-filters[open] summary { margin-bottom: var(--ui-space-2); }
 .elite-check { display: flex; align-items: center; gap: var(--ui-space-2); font-size: var(--ui-font-size-sm); cursor: pointer; }
 .elite-check input { accent-color: var(--ui-accent); }
-.elite-modes { display: flex; gap: var(--ui-space-2); }
-.elite-modes .ui-button { flex: 1; }
-.elite-profession-controls .elite-modes .ui-button:nth-child(2) { flex: 1.7; }
-.elite-modes span { margin-left: var(--ui-space-2); font-variant-numeric: tabular-nums; }
-.elite-results-heading { display: flex; align-items: center; justify-content: space-between; padding: 0 var(--ui-space-4) var(--ui-space-2); color: var(--ui-text-muted); font-size: var(--ui-font-size-sm); }
+.elite-results-heading { flex-shrink: 0; display: flex; align-items: center; justify-content: space-between; padding: 0 var(--ui-space-4) var(--ui-space-2); color: var(--ui-text-muted); font-size: var(--ui-font-size-sm); }
 .elite-results { padding: 0 var(--ui-space-2) var(--ui-space-2); }
-.elite-result { display: flex; align-items: center; min-height: 64px; border-bottom: 1px solid var(--ui-line); }
+.elite-result { border-bottom: 1px solid var(--ui-line); }
 .elite-result-main { display: flex; flex: 1; gap: var(--ui-space-3); padding: var(--ui-space-2); align-items: center; min-width: 0; text-align: left; color: var(--ui-text); background: transparent; border: 0; border-radius: var(--ui-radius-sm); font: inherit; cursor: pointer; }
 .elite-result-main:hover { background: var(--ui-hover); }
-.elite-result-main > span:last-child { display: grid; gap: 2px; min-width: 0; }
+.elite-result-label { display: grid; gap: 2px; min-width: 0; }
 .elite-result-main strong { color: var(--ui-text-bright); overflow-wrap: anywhere; }
 .elite-result-main small { color: var(--ui-text-muted); font-size: var(--ui-font-size-sm); }
 .elite-skill-icon { width: 38px; height: 38px; flex: 0 0 38px; }
 .elite-skill-icon img { width: 100%; height: 100%; object-fit: cover; }
-.elite-track-button { width: 34px; padding: 6px; flex-shrink: 0; }
+.elite-track-button { width: 40px; min-height: 40px; padding: 8px; flex-shrink: 0; background: transparent; border: 1px solid transparent; box-shadow: none; }
+.elite-track-button:hover { background: var(--ui-hover); border-color: var(--ui-line); }
 .elite-track-button[aria-pressed="true"] svg { fill: var(--ui-accent); }
-.elite-detail-toolbar { display: flex; flex-wrap: wrap; gap: var(--ui-space-2); justify-content: space-between; align-items: center; padding: var(--ui-space-3) var(--ui-space-4); }
-.elite-detail-scroll { padding: var(--ui-space-4); }
-.elite-detail-scroll h3 { color: var(--ui-text-bright); font-size: var(--ui-font-size); margin: var(--ui-space-5) 0 var(--ui-space-2); }
 .elite-location { padding: var(--ui-space-3) 0; border-top: 1px solid var(--ui-line); }
 .elite-location-heading { display: flex; gap: var(--ui-space-2); justify-content: space-between; color: var(--ui-text-bright); }
 .elite-location-heading > span { color: var(--ui-accent); font-size: var(--ui-font-size-sm); }
@@ -54,30 +62,38 @@
 .elite-location-note { white-space: pre-line; font-family: var(--ui-font-reading); color: var(--ui-text); line-height: 1.5; }
 .elite-support { font-size: var(--ui-font-size-sm); color: var(--ui-text-muted); margin: 0; }
 .elite-actions { display: flex; align-items: center; flex-wrap: wrap; gap: var(--ui-space-3); margin-top: var(--ui-space-3); }
-.elite-learned { color: var(--ui-text-muted); font-size: var(--ui-font-size-sm); margin-bottom: 0; }
-.elite-learned[data-learned="learned"] { color: var(--ui-success); }
-.elite-panel-footer { flex-shrink: 0; display: grid; gap: var(--ui-space-2); padding: var(--ui-space-3) var(--ui-space-4); border-top: 1px solid var(--ui-line); }
+.elite-panel-footer { max-height: 20%; overflow: auto; flex-shrink: 0; display: grid; gap: 4px; padding: 6px var(--ui-space-3); border-top: 1px solid var(--ui-line); }
 .elite-panel-footer p { margin: 0; font-size: var(--ui-font-size-sm); color: var(--ui-text-muted); }
 .elite-message { padding: var(--ui-space-3) var(--ui-space-4); background: var(--ui-well-fill); font-size: var(--ui-font-size-sm); }
 .elite-message p { margin: 0 0 var(--ui-space-2); }
 .elite-message .ui-link { margin-left: var(--ui-space-2); }
 .elite-save-state { margin: 0; padding: 0 var(--ui-space-4); font-size: var(--ui-font-size-sm); }
 .elite-markers { position: fixed; pointer-events: none; overflow: hidden; }
-.elite-marker { position: absolute; display: grid; place-items: center; width: 28px; height: 28px; padding: 2px; transform: translate(-50%, -50%); border: 1px solid var(--ui-outline); background: var(--ui-panel-fill); border-radius: var(--ui-radius-sm); color: var(--ui-text-bright); pointer-events: auto; cursor: pointer; }
-.elite-marker img { width: 22px; height: 22px; }
-.elite-marker:hover, .elite-marker:focus-visible { z-index: 2; outline: 2px solid var(--ui-focus); }
-.elite-marker--active { outline: 2px solid var(--ui-accent); z-index: 1; }
-.elite-marker--outside { border-style: dashed; }
+.elite-marker { position: absolute; display: grid; place-items: center; width: 28px; height: 28px; padding: 2px; transform: translate(-50%, -50%); border: 0; background: transparent; color: var(--ui-text-bright); pointer-events: auto; cursor: pointer; }
+.elite-marker-art { display: grid; place-items: center; width: 24px; height: 24px; border: 1px solid rgb(0 0 0 / 70%); border-radius: 2px; background: var(--ui-panel-fill); }
+/* Client skill textures have a 4px rim inside 64px. Display only the inner 56px;
+   leave the decoded asset untouched for other consumers and keep one CSS edge. */
+.elite-marker img { display: block; width: 22px; height: 22px; border-radius: 1px; clip-path: inset(6.25%); transform: scale(calc(64 / 56)); }
+.elite-marker--active { z-index: 1; }
+.elite-marker--active .elite-marker-art { border-color: var(--ui-accent); box-shadow: 0 0 0 1px var(--ui-accent); }
+.elite-marker--outside .elite-marker-art { border-style: dashed; }
+.elite-marker:hover, .elite-marker:focus-visible { z-index: 3; }
+.elite-skills-root .elite-marker:focus-visible { outline: none; }
+.elite-marker:hover .elite-marker-art, .elite-marker:focus-visible .elite-marker-art { border-color: var(--ui-focus); box-shadow: 0 0 0 1px var(--ui-focus), 0 2px 6px rgb(0 0 0 / 45%); }
 .elite-marker-label { position: absolute; top: 32px; width: max-content; max-width: 180px; padding: 3px 6px; background: var(--ui-panel-fill); color: var(--ui-text-bright); font-size: var(--ui-font-size-sm); pointer-events: none; }
 .elite-preview { position: fixed; display: flex; width: min(320px, calc(100vw - 16px)); max-height: min(480px, calc(100dvh - 16px)); overflow: hidden; pointer-events: auto; background: var(--ui-panel-fill); z-index: 2; }
 .elite-preview-content { min-width: 0; min-height: 0; overflow-y: auto; overflow-x: hidden; padding: var(--ui-space-4); flex: 1; }
+.elite-nearby { margin-bottom: var(--ui-space-3); padding-bottom: var(--ui-space-2); border-bottom: 1px solid var(--ui-line); }
+.elite-nearby-choices { display: flex; flex-wrap: wrap; gap: 2px; margin-top: var(--ui-space-1); }
+.elite-nearby-choice { display: grid; place-items: center; width: 40px; height: 40px; padding: 3px; background: transparent; border: 1px solid transparent; border-radius: var(--ui-radius-sm); color: var(--ui-text-bright); cursor: pointer; }
+.elite-nearby-choice img { width: 32px; height: 32px; border-radius: 1px; }
+.elite-nearby-choice[data-previewed], .elite-nearby-choice:hover { border-color: var(--ui-focus); background: var(--ui-hover); }
 .elite-preview-content > p { margin-bottom: 0; font-size: var(--ui-font-size-sm); color: var(--ui-text-muted); }
 .elite-preview .inspector-identity { display: grid; }
 .elite-skills-root button:focus-visible { outline: 2px solid var(--ui-focus); outline-offset: 2px; }
 @media (max-width: 650px) { .elite-panel { right: 12px !important; } }
-@media (max-height: 600px) { .elite-search-controls { gap: var(--ui-space-2); padding: var(--ui-space-2) var(--ui-space-3); } .elite-panel-footer { padding: var(--ui-space-2) var(--ui-space-3); } }
+@media (max-height: 600px) { .elite-search-controls { gap: var(--ui-space-2); padding: var(--ui-space-2) var(--ui-space-3); } }
 
-.elite-panel .inspector-identity { display: grid; }
 
 /* Enter gently; native map closure still removes the preview in the same render. */
 @media (hover: hover) and (pointer: fine) and (prefers-reduced-motion: no-preference) {
@@ -87,3 +103,39 @@
   }
 }
 .elite-result-main:hover .elite-skill-icon, .elite-result-main:focus-visible .elite-skill-icon { outline: 1px solid var(--ui-focus); outline-offset: 2px; }
+
+/* Results keep their context while one skill opens in place. */
+.elite-result-heading { display: flex; align-items: center; min-height: 58px; }
+.elite-result[data-expanded="true"] { background: var(--ui-hover); }
+.elite-result-chevron { margin-left: auto; color: var(--ui-accent); }
+.elite-inline-detail { padding: var(--ui-space-2) var(--ui-space-3) var(--ui-space-3); font-size: var(--ui-font-size-sm); }
+.elite-inline-detail .inspector-identity { display: none; }
+.elite-inline-detail h3 { font-size: var(--ui-font-size-sm); margin: var(--ui-space-4) 0 var(--ui-space-1); color: var(--ui-text-muted); }
+.elite-inline-detail .skill-description p { margin: 0; }
+.elite-inline-detail .skill-description { font-family: var(--ui-font-reading); line-height: 1.5; }
+.elite-inline-detail .elite-location:first-of-type { border-top: 0; }
+.elite-target-button { flex: 1; }
+.elite-target-button[aria-pressed="true"] { color: var(--ui-accent); }
+.elite-other-locations summary, .elite-encounter-notes summary, .elite-map-display summary { cursor: pointer; color: var(--ui-text-muted); font-size: var(--ui-font-size-sm); padding: var(--ui-space-2) 0; }
+.elite-detail-links { display: flex; flex-wrap: wrap; justify-content: space-between; gap: var(--ui-space-2); margin-top: var(--ui-space-3); }
+.elite-detail-links .ui-link { font-size: var(--ui-font-size-sm); }
+.elite-map-display .elite-check { padding-block: var(--ui-space-2); }
+.elite-current-target { display: grid; gap: 2px; }
+.elite-current-target strong { color: var(--ui-accent); font-weight: normal; }
+.elite-learned-badge { color: var(--ui-success); }
+
+.elite-search-label { position: absolute; width: 1px; height: 1px; overflow: hidden; clip-path: inset(50%); white-space: nowrap; }
+
+/* Keep the resize target in flow, clear of map controls and result scrolling. */
+.elite-panel-resize { display: grid; place-items: center; flex: 0 0 18px; width: 100%; padding: 0; border: 0; background: transparent; color: var(--ui-text-muted); cursor: ns-resize; touch-action: none; }
+.elite-panel-resize span { width: 32px; height: 3px; border-radius: 2px; background: currentColor; }
+.elite-panel-resize:hover, .elite-panel-resize:focus-visible, .elite-panel[data-resizing] .elite-panel-resize { color: var(--ui-accent); background: var(--ui-hover); }
+.elite-panel[data-resizing] { user-select: none; }
+
+.elite-panel-footer .elite-map-display summary { padding-block: 2px; }
+
+.elite-preview-bosses { margin-top: var(--ui-space-3); font-size: var(--ui-font-size-sm); }
+.elite-preview-bosses p { margin: 0 0 var(--ui-space-2); }
+.elite-preview-bosses ul { list-style: none; margin: 0; padding: 0; display: grid; gap: var(--ui-space-2); }
+.elite-preview-bosses li { color: var(--ui-text-bright); }
+.elite-preview-bosses li span { color: var(--ui-text-muted); }

--- a/apps/tools/src/use-elite-tracking.ts
+++ b/apps/tools/src/use-elite-tracking.ts
@@ -1,6 +1,7 @@
-/** Owns asynchronous character-plan loading and saving, including stale responses. */
+/** Owns character-plan loading and ordered saves without dropping rapid edits. */
 import { ref, shallowRef, watch, type Ref } from "vue";
-import { EMPTY_ELITE_TRACKING, type EliteChange, type EliteTracking, type EliteUpdate } from "../../../src/shared/elite-skills";
+import { ELITE_LOCATIONS } from "../../../src/shared/elite-locations";
+import { EMPTY_ELITE_TRACKING, changeEliteTracking, type EliteChange, type EliteTracking, type EliteUpdate } from "../../../src/shared/elite-skills";
 import type { TravelCharacterKey } from "../../../src/shared/travel-history";
 export interface EliteTrackingHost {
   get(value: { characterKey: string }): Promise<EliteTracking>;
@@ -11,49 +12,82 @@ export function useEliteTracking(character: Ref<TravelCharacterKey | null>, host
   const busy = ref(false);
   const problem = ref("");
   const loaded = ref(false);
-  let epoch = 0;
-  let retryAction: (() => Promise<void>) | null = null;
+  function session() {
+    return { key: character.value, confirmed: EMPTY_ELITE_TRACKING,
+      pending: [] as EliteChange[], saving: false };
+  }
+  let current = session();
+  const pendingSaves = new Map<TravelCharacterKey, Promise<void>>();
+  let disposed = false;
+  const owns = (owner: ReturnType<typeof session>) => !disposed && owner === current;
   async function load() {
-    const key = character.value;
-    const ownEpoch = ++epoch;
+    const owner = current = session();
     tracking.value = EMPTY_ELITE_TRACKING;
     loaded.value = false;
     problem.value = "";
-    retryAction = null;
-    busy.value = key !== null;
-    if (key === null) return;
+    busy.value = owner.key !== null;
+    if (owner.key === null) return;
     try {
-      const next = await host.get({ characterKey: key });
-      if (ownEpoch !== epoch) return;
-      tracking.value = next;
+      // Returning to a character must load the final queued edit, not an intermediate save.
+      const pending = pendingSaves.get(owner.key);
+      if (pending) await pending;
+      if (!owns(owner)) return;
+      const next = await host.get({ characterKey: owner.key });
+      if (!owns(owner)) return;
+      owner.confirmed = tracking.value = next;
       loaded.value = true;
     } catch {
-      if (ownEpoch !== epoch) return;
-      problem.value = "Your tracked skills could not be loaded.";
-      retryAction = load;
-    } finally { if (ownEpoch === epoch) busy.value = false; }
+      if (owns(owner)) problem.value = "Your elite skills setup could not be loaded.";
+    } finally { if (owns(owner)) busy.value = false; }
   }
-  async function change(value: EliteChange) {
-    const key = character.value;
-    if (key === null || busy.value || !loaded.value) return;
-    const ownEpoch = epoch;
-    busy.value = true;
-    problem.value = "";
+  async function drain(owner: ReturnType<typeof session>) {
+    if (owner.saving || owner.key === null) return;
+    owner.saving = true;
+    if (owns(owner)) { busy.value = true; problem.value = ""; }
     try {
-      const next = await host.update({ characterKey: key, change: value });
-      if (ownEpoch !== epoch) return;
-      tracking.value = next;
-      retryAction = null;
+      // Finish already-requested saves for the old character after a switch.
+      while (owner.pending.length) {
+        const change = owner.pending[0]!;
+        owner.confirmed = await host.update({ characterKey: owner.key, change });
+        owner.pending.shift();
+        if (owns(owner)) tracking.value = owner.pending.reduce(
+          (state, next) => changeEliteTracking(state, next, ELITE_LOCATIONS), owner.confirmed);
+      }
     } catch {
-      if (ownEpoch !== epoch) return;
-      problem.value = "Could not save this change. Your saved plan is unchanged.";
-      retryAction = () => change(value);
-    } finally { if (ownEpoch === epoch) busy.value = false; }
+      if (owns(owner)) problem.value = "Changes are not saved. Retry, or restore your saved setup.";
+    } finally {
+      owner.saving = false;
+      if (owns(owner)) busy.value = false;
+    }
   }
-  const stop = watch(character, () => { void load(); }, { immediate: true });
+  function save(owner = current) {
+    if (owner.saving || owner.key === null) return;
+    const key = owner.key;
+    const completion = drain(owner);
+    pendingSaves.set(key, completion);
+    void completion.finally(() => {
+      if (pendingSaves.get(key) === completion) pendingSaves.delete(key);
+    });
+    return completion;
+  }
+  function change(value: EliteChange) {
+    if (disposed || (current.key !== null && !loaded.value)) return;
+    tracking.value = changeEliteTracking(tracking.value, value, ELITE_LOCATIONS);
+    if (current.key === null) return;
+    // Only the latest consecutive view edit matters; tracking actions retain their order.
+    const last = current.pending.length - 1;
+    if (value.kind === "view" && last > 0 && current.pending[last]?.kind === "view") current.pending[last] = value;
+    else current.pending.push(value);
+    if (!problem.value) void save();
+  }
+  const stop = watch(character, () => { void load(); }, { immediate: true, flush: "sync" });
   return { tracking, busy, loaded, problem, change, reload: load,
-    retry: () => retryAction?.(),
-    dismissError: () => { problem.value = ""; retryAction = null; },
-    dispose: () => { epoch++; stop(); },
+    retry: () => loaded.value ? save() : load(),
+    dismissError: () => {
+      current.pending.length = 0;
+      tracking.value = current.confirmed;
+      problem.value = "";
+    },
+    dispose: () => { disposed = true; stop(); },
   };
 }

--- a/docs/elite-skills.md
+++ b/docs/elite-skills.md
@@ -16,8 +16,12 @@ must never become a marker at zero or an invented entrance.
 Main stores `elite-tracking.json` beside each account profile's build library.
 The existing privacy-safe character key separates characters. Named actions
 are validated and serialized before an atomic save. Concurrent actions merge
-against current disk state. Tracking records only skill IDs, one active boss,
-and the mission-map preference. It does not record learned skills, routes,
+against current disk state. Tracking records skill IDs, one active boss, and
+each character’s map preferences.
+Preferences include search, profession selection, region, learned and tracked
+filters, explicit skill focus, marker visibility, and the expanded panel choice.
+An absent preferences object uses defaults without discarding an existing plan.
+Tracking does not record learned skills, routes,
 character names, or account unlocks. Corrupt documents are quarantined.
 
 A skill is learned only when the current character's live observation says so.
@@ -28,23 +32,40 @@ Account unlocks never imply that the current character learned a skill.
 
 Enable **Maps**, then open the native world map. **Elite skills** opens the
 planner in its upper-right corner. Search matches skill, boss, and area names.
-Profession, capture-region, learned-status, and tracked filters reduce the list.
+**All skills** and **Tracked** choose the skill scope. **All**, **My professions**,
+and **Choose…** select professions. My professions follows the observed primary
+and secondary professions. Manual selections stay fixed. If live professions
+are unavailable, My professions shows no results and offers manual selection.
+**Hide learned skills** applies to tracked skills too. Capture region is under
+**More filters**. **Reset filters** shows all skills without changing visibility.
 Hover or focus a skill for a preview. Open it for full details and capture notes.
-The sticky detail header keeps **Back to skills** and **Close** visible. Back retains
-the current search and filters.
+The sticky detail header keeps **Back to results** and **Collapse** visible. Back
+retains search, filters, and list position. Inspection does not change markers.
+**Show only this skill** explicitly focuses both maps; **Clear skill focus** exits it.
 The Builds skill inspector opens the same details through **Find capture locations**.
 Both interfaces read descriptions, mechanics, and skill artwork from the installed client.
 The shared detail component shows locally bundled Tango-style cost and timing icons
 with accessible labels. See [icon attribution](../THIRD-PARTY-NOTICES.md#guild-wars-wiki-stat-icons).
+Hover previews stay available while the pointer crosses onto them. They fit within
+the viewport and scroll for long descriptions. Keyboard previews open immediately;
+pointer previews use a short entrance when reduced motion is not requested.
+Closing either native map removes its preview immediately, with no exit animation.
 
 Track a skill to save it for this character. **Track this boss** also selects
-one active capture location. Closing the planner leaves only tracked markers.
+one active capture location. Collapsing the planner preserves all filtered markers.
+A compact row keeps only a visibility checkbox and the **Elite skills** button.
+Hover the button to see the active filters and mission target status. Open it to
+change or clear filters; collapsing does not change which markers appear.
+Search and visibility survive restart. Opening the native world map restores the
+saved panel choice; closing a native map never overwrites that choice.
+No panel opens automatically during login or gameplay without a world map.
 Each known position keeps its own skill icon, including nearby positions. A
 selected boss outside the map view has an edge indicator. Pan and zoom remain
 native game controls.
 
-The mission map shows only tracked locations whose map ID matches the current
-instance. It requires matching certified frame generations, a valid world
+The mission map uses the same filtered locations, limited to the current map ID.
+Its visibility toggle is separate from world-map visibility. Both maps require
+matching certified frame generations, a valid world
 anchor, and a current area that belongs to the campaign world map. Unsupported
 areas, transitions, and stale observations withdraw the affected markers.
 Known positions are spawn references, never observations of a living boss.
@@ -52,7 +73,10 @@ Empty coordinates remain a notes-only capture target.
 
 Disabling Maps removes the planner and stops its frame reads. Changing the
 character clears learned status and loads that character's saved plan. Failed
-saves retain the confirmed plan and offer retry. Wiki buttons resolve reviewed
+saves retain unsaved edits visibly and offer **Retry** or **Restore saved setup**.
+Ordered saves preserve rapid typing and finish for their original character after
+a character switch; old responses never replace the new character’s setup.
+Wiki buttons resolve reviewed
 boss or skill entries through a closed, validated main-process action.
 
 ## Verification
@@ -63,7 +87,7 @@ wiki input validation. Tools component tests cover searching, tracking,
 character changes, learned status, failure recovery, and marker placement.
 
 Run `pnpm tools:dev`, then open `/?elites` for an offline interaction fixture.
-It uses four illustrative skill records and synthetic map frames. It does not
+It uses six illustrative skill records and synthetic map frames. It does not
 prove native alignment, game input, or capture behavior. Live game QA must
 check a known boss on both maps, native pan/zoom, an area transition, character
 switching, and Maps off/on. Keep the standard live cartography checks as the

--- a/docs/elite-skills.md
+++ b/docs/elite-skills.md
@@ -31,35 +31,57 @@ Account unlocks never imply that the current character learned a skill.
 ## Map planner
 
 Enable **Maps**, then open the native world map. **Elite skills** opens the
-planner in its upper-right corner. Search matches skill, boss, and area names.
-**All skills** and **Tracked** choose the skill scope. **All**, **My professions**,
-and **Choose…** select professions. My professions follows the observed primary
-and secondary professions. Manual selections stay fixed. If live professions
-are unavailable, My professions shows no results and offers manual selection.
-**Hide learned skills** applies to tracked skills too. Capture region is under
-**More filters**. **Reset filters** shows all skills without changing visibility.
-Hover or focus a skill for a preview. Open it for full details and capture notes.
-The sticky detail header keeps **Back to results** and **Collapse** visible. Back
-retains search, filters, and list position. Inspection does not change markers.
-**Show only this skill** explicitly focuses both maps; **Clear skill focus** exits it.
+planner in its upper-right corner. Its default height is 80% of the screen,
+limited to the available map space. The list reserves space for skill rows even
+when the filter controls need their own scrollbar. Drag the bottom grip to change its height,
+or focus the grip and use Up/Down (Shift takes larger steps). Height is saved
+for each character and fits smaller windows automatically. Filters retain their
+own space above the scrolling skill list, including with a full catalogue. Search matches skill, boss, and area names.
+**All matching skills** and **Saved skills** choose the skill scope. The ten
+profession icons toggle each class independently. **Select all** and **Deselect all**
+include or exclude every profession. An empty selection remains empty after restart.
+**Current class** follows the observed primary and secondary professions. Manual
+selections stay fixed. If live professions are unavailable, Current class shows
+no results and offers manual selection. **Hide already learned** uses this
+character's learned skills and also applies to saved skills. Capture region and
+**Reset filters** are under **More filters**.
+
+Hover or focus a skill for a preview. Click a result to expand its details in
+place; only one result expands at a time. The search, filters, and neighboring
+results remain available. Click the same row to close its details. The star on
+every row saves or removes that skill without opening details or choosing a boss.
+The first capture location is visible; other locations and encounter notes expand
+on demand. Inspection never changes map filters. **Show only this skill** explicitly
+focuses both maps; **Clear skill focus** exits it.
 The Builds skill inspector opens the same details through **Find capture locations**.
 Both interfaces read descriptions, mechanics, and skill artwork from the installed client.
 The shared detail component shows locally bundled Tango-style cost and timing icons
 with accessible labels. See [icon attribution](../THIRD-PARTY-NOTICES.md#guild-wars-wiki-stat-icons).
+Markers crop the built-in four-pixel rim from the client’s 64-pixel skill textures
+for display only. Decoded assets remain unchanged. One thin CSS edge surrounds
+the inner artwork, with a steady pointer target. Hover or
+keyboard focus brings the individual marker above its neighbors. When positions
+overlap, the preview offers each distinct skill once. Touching copies of the same
+skill in the same map area share one marker; distant positions remain separate.
+The hover card lists all possible bosses for the selected skill. The active boss
+keeps its source position. Hover or focus an icon to inspect it; click to open
+its capture details without changing filters.
+These choices use only the visible, filtered markers and do not move boss positions.
 Hover previews stay available while the pointer crosses onto them. They fit within
 the viewport and scroll for long descriptions. Keyboard previews open immediately;
 pointer previews use a short entrance when reduced motion is not requested.
 Closing either native map removes its preview immediately, with no exit animation.
 
-Track a skill to save it for this character. **Track this boss** also selects
-one active capture location. Collapsing the planner preserves all filtered markers.
+**Save** keeps a skill for this character. **Set target** also saves the skill
+and selects one active capture location. The footer shows that target and keeps
+world and mission visibility switches under **Map display**. Collapsing the planner preserves all filtered markers.
 A compact row keeps only a visibility checkbox and the **Elite skills** button.
 Hover the button to see the active filters and mission target status. Open it to
 change or clear filters; collapsing does not change which markers appear.
 Search and visibility survive restart. Opening the native world map restores the
 saved panel choice; closing a native map never overwrites that choice.
 No panel opens automatically during login or gameplay without a world map.
-Each known position keeps its own skill icon, including nearby positions. A
+Different skills keep their own icons; repeated artwork at a shared spot is deduplicated. A
 selected boss outside the map view has an edge indicator. Pan and zoom remain
 native game controls.
 
@@ -87,7 +109,8 @@ wiki input validation. Tools component tests cover searching, tracking,
 character changes, learned status, failure recovery, and marker placement.
 
 Run `pnpm tools:dev`, then open `/?elites` for an offline interaction fixture.
-It uses six illustrative skill records and synthetic map frames. It does not
+It uses six illustrative skill records and synthetic map frames. Add
+`&fullCatalogue` to exercise a full-length list with synthetic skill names. It does not
 prove native alignment, game input, or capture behavior. Live game QA must
 check a known boss on both maps, native pan/zoom, an area transition, character
 switching, and Maps off/on. Keep the standard live cartography checks as the

--- a/src/shared/elite-skills.ts
+++ b/src/shared/elite-skills.ts
@@ -3,9 +3,27 @@
  * Learned skills remain live observations, never a second saved completion ledger.
  */
 import { isTravelCharacterKey, type TravelCharacterKey } from "./travel-history.js";
+import { PROFESSIONS } from "./builds/heroes.js";
+import type { Profession } from "./builds/library.js";
 
 export const ELITE_REGIONS = ["Tyria", "Cantha", "Elona", "Eye of the North"] as const;
 export type EliteRegion = typeof ELITE_REGIONS[number];
+export type EliteProfessionFilter = Readonly<{ kind: "all" | "mine" }>
+  | Readonly<{ kind: "custom"; values: readonly Profession[] }>;
+export type EliteViewPreferences = Readonly<{
+  search: string;
+  professions: EliteProfessionFilter;
+  region: EliteRegion | "";
+  hideLearned: boolean;
+  mode: "browse" | "tracked";
+  worldMap: boolean;
+  panelOpen: boolean;
+  focusedSkill: number | null;
+}>;
+export const DEFAULT_ELITE_VIEW: EliteViewPreferences = Object.freeze({
+  search: "", professions: Object.freeze({ kind: "all" }), region: "",
+  hideLearned: true, mode: "browse", worldMap: true, panelOpen: false, focusedSkill: null,
+});
 export type EliteLocation = Readonly<{
   id: string;
   skillId: number;
@@ -20,13 +38,15 @@ export type EliteTracking = Readonly<{
   skills: readonly number[];
   activeLocation: string | null;
   missionMap: boolean;
+  view: EliteViewPreferences;
 }>;
 export const EMPTY_ELITE_TRACKING: EliteTracking = Object.freeze({
-  skills: Object.freeze([]), activeLocation: null, missionMap: true,
+  skills: Object.freeze([]), activeLocation: null, missionMap: true, view: DEFAULT_ELITE_VIEW,
 });
 export type EliteChange =
   | Readonly<{ kind: "track" | "remove"; skillId: number }>
   | Readonly<{ kind: "target"; locationId: string }>
+  | Readonly<{ kind: "view"; view: EliteViewPreferences }>
   | Readonly<{ kind: "mission-map"; show: boolean }>;
 export type EliteUpdate = Readonly<{ characterKey: TravelCharacterKey; change: EliteChange }>;
 
@@ -41,6 +61,32 @@ function exact(value: Record<string, unknown>, keys: readonly string[]): void {
     throw new TypeError("Elite tracking contains unexpected fields");
   }
 }
+export function parseEliteView(value: unknown): EliteViewPreferences {
+  const input = object(value);
+  exact(input, ["search", "professions", "region", "hideLearned", "mode", "worldMap", "panelOpen", "focusedSkill"]);
+  const filter = object(input.professions);
+  let professions: EliteProfessionFilter;
+  if (filter.kind === "all" || filter.kind === "mine") {
+    exact(filter, ["kind"]);
+    professions = { kind: filter.kind };
+  } else if (filter.kind === "custom") {
+    exact(filter, ["kind", "values"]);
+    if (!Array.isArray(filter.values) || filter.values.length < 1 || filter.values.length > 10
+      || !filter.values.every((value: unknown): value is Profession => typeof value === "string" && Object.hasOwn(PROFESSIONS, value))
+      || new Set(filter.values).size !== filter.values.length) throw new TypeError("Invalid professions");
+    professions = { kind: "custom", values: Object.freeze([...filter.values]) };
+  } else throw new TypeError("Invalid profession filter");
+  const region = input.region === "" ? "" : ELITE_REGIONS.find(region => region === input.region);
+  if (typeof input.search !== "string" || input.search.length > 200
+    || region === undefined
+    || typeof input.hideLearned !== "boolean" || typeof input.worldMap !== "boolean" || typeof input.panelOpen !== "boolean"
+    || (input.mode !== "browse" && input.mode !== "tracked")
+    || (input.focusedSkill !== null && (typeof input.focusedSkill !== "number" || !Number.isSafeInteger(input.focusedSkill)
+      || input.focusedSkill < 1 || input.focusedSkill > 10_000))) throw new TypeError("Invalid map preferences");
+  return Object.freeze({ search: input.search, professions: Object.freeze(professions),
+    region, hideLearned: input.hideLearned, mode: input.mode,
+    worldMap: input.worldMap, panelOpen: input.panelOpen, focusedSkill: input.focusedSkill });
+}
 export function parseEliteCharacter(value: unknown): Readonly<{ characterKey: TravelCharacterKey }> {
   const input = object(value);
   exact(input, ["characterKey"]);
@@ -52,6 +98,10 @@ export function parseEliteUpdate(value: unknown): EliteUpdate {
   exact(input, ["characterKey", "change"]);
   const { characterKey } = parseEliteCharacter({ characterKey: input.characterKey });
   const change = object(input.change);
+  if (change.kind === "view") {
+    exact(change, ["kind", "view"]);
+    return { characterKey, change: { kind: "view", view: parseEliteView(change.view) } };
+  }
   if (change.kind === "track" || change.kind === "remove") {
     exact(change, ["kind", "skillId"]);
     if (typeof change.skillId !== "number" || !Number.isSafeInteger(change.skillId)
@@ -74,7 +124,9 @@ export function parseEliteUpdate(value: unknown): EliteUpdate {
 }
 export function parseEliteTracking(value: unknown, locations: readonly EliteLocation[]): EliteTracking {
   const input = object(value);
-  exact(input, ["skills", "activeLocation", "missionMap"]);
+  // An absent view means the player has not saved map preferences yet.
+  exact(input, "view" in input ? ["skills", "activeLocation", "missionMap", "view"] : ["skills", "activeLocation", "missionMap"]);
+  const view = "view" in input ? parseEliteView(input.view) : DEFAULT_ELITE_VIEW;
   const known = new Set(locations.map((location) => location.skillId));
   if (!Array.isArray(input.skills) || input.skills.length > known.size
     || input.skills.some((id: unknown) => typeof id !== "number" || !known.has(id))
@@ -86,11 +138,17 @@ export function parseEliteTracking(value: unknown, locations: readonly EliteLoca
     location.id === active && skills.includes(location.skillId)))) {
     throw new TypeError("Active boss must belong to a tracked skill");
   }
-  return Object.freeze({ skills: Object.freeze(skills), activeLocation: active, missionMap: input.missionMap });
+  if (view.focusedSkill !== null && !known.has(view.focusedSkill)) throw new TypeError("Unknown focused skill");
+  return Object.freeze({ skills: Object.freeze(skills), activeLocation: active, missionMap: input.missionMap, view });
 }
 export function changeEliteTracking(
   current: EliteTracking, change: EliteChange, locations: readonly EliteLocation[],
 ): EliteTracking {
+  if (change.kind === "view") {
+    const view = parseEliteView(change.view);
+    if (view.focusedSkill !== null && !locations.some(entry => entry.skillId === view.focusedSkill)) throw new TypeError("Unknown focused skill");
+    return { ...current, view };
+  }
   if (change.kind === "mission-map") return { ...current, missionMap: change.show };
   if (change.kind === "target") {
     const location = locations.find((entry) => entry.id === change.locationId);

--- a/src/shared/elite-skills.ts
+++ b/src/shared/elite-skills.ts
@@ -18,11 +18,12 @@ export type EliteViewPreferences = Readonly<{
   mode: "browse" | "tracked";
   worldMap: boolean;
   panelOpen: boolean;
+  panelHeightRatio: number;
   focusedSkill: number | null;
 }>;
 export const DEFAULT_ELITE_VIEW: EliteViewPreferences = Object.freeze({
   search: "", professions: Object.freeze({ kind: "all" }), region: "",
-  hideLearned: true, mode: "browse", worldMap: true, panelOpen: false, focusedSkill: null,
+  hideLearned: true, mode: "browse", worldMap: true, panelOpen: false, panelHeightRatio: 0.8, focusedSkill: null,
 });
 export type EliteLocation = Readonly<{
   id: string;
@@ -63,7 +64,9 @@ function exact(value: Record<string, unknown>, keys: readonly string[]): void {
 }
 export function parseEliteView(value: unknown): EliteViewPreferences {
   const input = object(value);
-  exact(input, ["search", "professions", "region", "hideLearned", "mode", "worldMap", "panelOpen", "focusedSkill"]);
+  const keys = ["search", "professions", "region", "hideLearned", "mode", "worldMap", "panelOpen", "focusedSkill"];
+  exact(input, "panelHeightRatio" in input ? [...keys, "panelHeightRatio"] : keys);
+  const panelHeightRatio = "panelHeightRatio" in input ? input.panelHeightRatio : DEFAULT_ELITE_VIEW.panelHeightRatio;
   const filter = object(input.professions);
   let professions: EliteProfessionFilter;
   if (filter.kind === "all" || filter.kind === "mine") {
@@ -71,13 +74,14 @@ export function parseEliteView(value: unknown): EliteViewPreferences {
     professions = { kind: filter.kind };
   } else if (filter.kind === "custom") {
     exact(filter, ["kind", "values"]);
-    if (!Array.isArray(filter.values) || filter.values.length < 1 || filter.values.length > 10
+    if (!Array.isArray(filter.values) || filter.values.length > 10
       || !filter.values.every((value: unknown): value is Profession => typeof value === "string" && Object.hasOwn(PROFESSIONS, value))
       || new Set(filter.values).size !== filter.values.length) throw new TypeError("Invalid professions");
     professions = { kind: "custom", values: Object.freeze([...filter.values]) };
   } else throw new TypeError("Invalid profession filter");
   const region = input.region === "" ? "" : ELITE_REGIONS.find(region => region === input.region);
   if (typeof input.search !== "string" || input.search.length > 200
+    || typeof panelHeightRatio !== "number" || !Number.isFinite(panelHeightRatio) || panelHeightRatio < 0.2 || panelHeightRatio > 1
     || region === undefined
     || typeof input.hideLearned !== "boolean" || typeof input.worldMap !== "boolean" || typeof input.panelOpen !== "boolean"
     || (input.mode !== "browse" && input.mode !== "tracked")
@@ -85,7 +89,7 @@ export function parseEliteView(value: unknown): EliteViewPreferences {
       || input.focusedSkill < 1 || input.focusedSkill > 10_000))) throw new TypeError("Invalid map preferences");
   return Object.freeze({ search: input.search, professions: Object.freeze(professions),
     region, hideLearned: input.hideLearned, mode: input.mode,
-    worldMap: input.worldMap, panelOpen: input.panelOpen, focusedSkill: input.focusedSkill });
+    worldMap: input.worldMap, panelOpen: input.panelOpen, panelHeightRatio, focusedSkill: input.focusedSkill });
 }
 export function parseEliteCharacter(value: unknown): Readonly<{ characterKey: TravelCharacterKey }> {
   const input = object(value);

--- a/tests/unit/elite-skills.test.ts
+++ b/tests/unit/elite-skills.test.ts
@@ -6,7 +6,7 @@ import { describe, it } from "node:test";
 import { ELITE_LOCATIONS } from "../../src/shared/elite-locations.js";
 import { EliteTrackingStore } from "../../src/main/core/elite-tracking.js";
 import {
-  EMPTY_ELITE_TRACKING, changeEliteTracking, eliteContinent, eliteLearned, parseEliteTracking, parseEliteUpdate,
+  DEFAULT_ELITE_VIEW, EMPTY_ELITE_TRACKING, changeEliteTracking, eliteContinent, eliteLearned, parseEliteTracking, parseEliteUpdate,
 } from "../../src/shared/elite-skills.js";
 import { travelCharacterKey } from "../../src/shared/travel-history.js";
 
@@ -61,6 +61,45 @@ describe("elite capture plans", () => {
       assert.deepEqual(await restart.get(join(dir, "profile-b.json"), characterA), EMPTY_ELITE_TRACKING);
       await writeFile(path, "broken");
       assert.deepEqual(await restart.get(path, characterA), EMPTY_ELITE_TRACKING);
+    } finally { await rm(dir, { recursive: true, force: true }); }
+  });
+});
+
+
+describe("elite view persistence", () => {
+  it("validates bounded preferences and rejects malformed or unknown choices", () => {
+    const valid = { ...DEFAULT_ELITE_VIEW, search: "Hundred Blades", professions: { kind: "custom", values: ["W", "R"] } };
+    const parse = (view: unknown) => parseEliteUpdate({ characterKey: characterA, change: { kind: "view", view } });
+    assert.doesNotThrow(() => parse(valid));
+    for (const patch of [
+      { search: "x".repeat(201) }, { search: 1 }, { region: "Unknown" }, { worldMap: 1 }, { panelOpen: null },
+      { hideLearned: "yes" }, { mode: "all" }, { focusedSkill: -1 }, { focusedSkill: 1.5 }, { extra: true },
+      { professions: { kind: "custom", values: [] } }, { professions: { kind: "custom", values: ["W", "W"] } },
+      { professions: { kind: "custom", values: ["Warrior"] } }, { professions: { kind: "mine", values: ["W"] } },
+    ]) assert.throws(() => parse({ ...valid, ...patch }));
+    assert.throws(() => changeEliteTracking(EMPTY_ELITE_TRACKING,
+      { kind: "view", view: { ...DEFAULT_ELITE_VIEW, focusedSkill: 9999 } }, ELITE_LOCATIONS));
+  });
+  it("restores all preferences after a store restart without replacing capture plans", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "gwonmac-elite-view-"));
+    const path = join(dir, "tracking.json");
+    try {
+      // Existing capture plans can have no saved map preferences.
+      await writeFile(path, JSON.stringify({ formatVersion: 1, characters: {
+        [characterA]: { skills: [338], activeLocation: lissah.id, missionMap: false },
+      } }));
+      const store = new EliteTrackingStore();
+      assert.deepEqual((await store.get(path, characterA)).view, DEFAULT_ELITE_VIEW);
+      const view = { ...DEFAULT_ELITE_VIEW, search: "Hundred Blades", professions: { kind: "mine" as const },
+        panelOpen: true, worldMap: false, region: "Cantha" as const, hideLearned: false, mode: "tracked" as const };
+      await store.update(path, { characterKey: characterA, change: { kind: "view", view } });
+      const restart = new EliteTrackingStore();
+      const saved = await restart.get(path, characterA);
+      assert.deepEqual(saved.view, view);
+      assert.deepEqual(saved.skills, [338]);
+      assert.equal(saved.activeLocation, lissah.id);
+      assert.equal(saved.missionMap, false);
+      assert.deepEqual(await restart.get(path, characterB), EMPTY_ELITE_TRACKING);
     } finally { await rm(dir, { recursive: true, force: true }); }
   });
 });

--- a/tests/unit/elite-skills.test.ts
+++ b/tests/unit/elite-skills.test.ts
@@ -71,14 +71,20 @@ describe("elite view persistence", () => {
     const valid = { ...DEFAULT_ELITE_VIEW, search: "Hundred Blades", professions: { kind: "custom", values: ["W", "R"] } };
     const parse = (view: unknown) => parseEliteUpdate({ characterKey: characterA, change: { kind: "view", view } });
     assert.doesNotThrow(() => parse(valid));
+    assert.doesNotThrow(() => parse({ ...valid, professions: { kind: "custom", values: [] } }));
     for (const patch of [
-      { search: "x".repeat(201) }, { search: 1 }, { region: "Unknown" }, { worldMap: 1 }, { panelOpen: null },
+      { search: "x".repeat(201) }, { search: 1 }, { region: "Unknown" }, { worldMap: 1 }, { panelOpen: null }, { panelHeightRatio: 0 }, { panelHeightRatio: 1.1 }, { panelHeightRatio: NaN }, { panelHeightRatio: "0.8" },
       { hideLearned: "yes" }, { mode: "all" }, { focusedSkill: -1 }, { focusedSkill: 1.5 }, { extra: true },
-      { professions: { kind: "custom", values: [] } }, { professions: { kind: "custom", values: ["W", "W"] } },
+      { professions: { kind: "custom", values: ["W", "W"] } },
       { professions: { kind: "custom", values: ["Warrior"] } }, { professions: { kind: "mine", values: ["W"] } },
     ]) assert.throws(() => parse({ ...valid, ...patch }));
     assert.throws(() => changeEliteTracking(EMPTY_ELITE_TRACKING,
       { kind: "view", view: { ...DEFAULT_ELITE_VIEW, focusedSkill: 9999 } }, ELITE_LOCATIONS));
+  });
+  it("defaults height for saved preferences written before resizing was added", () => {
+    const { panelHeightRatio, ...view } = DEFAULT_ELITE_VIEW;
+    const parsed = parseEliteUpdate({ characterKey: characterA, change: { kind: "view", view } });
+    assert.deepEqual(parsed.change, { kind: "view", view: { ...view, panelHeightRatio } });
   });
   it("restores all preferences after a store restart without replacing capture plans", async () => {
     const dir = await mkdtemp(join(tmpdir(), "gwonmac-elite-view-"));
@@ -91,7 +97,7 @@ describe("elite view persistence", () => {
       const store = new EliteTrackingStore();
       assert.deepEqual((await store.get(path, characterA)).view, DEFAULT_ELITE_VIEW);
       const view = { ...DEFAULT_ELITE_VIEW, search: "Hundred Blades", professions: { kind: "mine" as const },
-        panelOpen: true, worldMap: false, region: "Cantha" as const, hideLearned: false, mode: "tracked" as const };
+        panelOpen: true, panelHeightRatio: 0.65, worldMap: false, region: "Cantha" as const, hideLearned: false, mode: "tracked" as const };
       await store.update(path, { characterKey: characterA, change: { kind: "view", view } });
       const restart = new EliteTrackingStore();
       const saved = await restart.get(path, characterA);
@@ -100,6 +106,9 @@ describe("elite view persistence", () => {
       assert.equal(saved.activeLocation, lissah.id);
       assert.equal(saved.missionMap, false);
       assert.deepEqual(await restart.get(path, characterB), EMPTY_ELITE_TRACKING);
+      const none = { ...view, professions: { kind: "custom" as const, values: [] } };
+      await restart.update(path, { characterKey: characterA, change: { kind: "view", view: none } });
+      assert.deepEqual((await new EliteTrackingStore().get(path, characterA)).view.professions, none.professions);
     } finally { await rm(dir, { recursive: true, force: true }); }
   });
 });


### PR DESCRIPTION
## What changed

Find and save elite skills without losing the map or opening a separate details screen. Ten profession icons toggle classes individually; Select all, Deselect all, Current class (primary and secondary), and Hide already learned provide quick filtering. A star saves a matching skill directly from its result row.

## Why

The previous panel hid too much context, repeated nearby icons, and could let filters or results consume all available space. Details now expand within the list. The panel starts at roughly 80% screen height, resizes from its bottom grip, reserves visible skill rows, and collapses to one small control row.

## Invariant

- Search, professions, region, saved/learned filters, explicit skill focus, map visibility, panel expansion, and height belong to the existing per-character capture plan. Current class follows secondary-profession changes; manual selections and an empty selection stay fixed.
- Ordered saves preserve rapid edits and cannot replace another character's state. Existing plans keep their saved skills and boss; an absent height uses the default. Learned status remains a live observation.
- Inspection and quick saving do not filter markers or select a boss. Show only this skill and Set target remain explicit actions. Both maps share filters and retain independent visibility switches.
- Touching copies of the same skill in the same map area share one icon and list all possible bosses. Different skills and distant locations remain separate. The active boss retains its source position.
- Map icons display the inner artwork with a thin edge; client assets remain unchanged. Hover cards support nearby skill choices, keyboard focus, reduced motion, and immediate removal on native map close.

## Delivery

Final layer of stack #432, targeting `feat/skill-detail-icons` (#433). Merge order: #429 → #430 → #431 → #433 → #434. Recommend Beta consideration for persisted preferences and the full native Maps integration before release; no release is requested here.

## Verification

- `pnpm check` passed after rebasing onto main `c04c7736`.
- Focused tests cover restart, character isolation, secondary professions, empty selections, queued saves, quick saving, inline details, resizing/cancellation, shared-spawn deduplication, and native preview removal.
- Real browser exploration used 301 fixture skills, both themes, small windows, dragging, keyboard resizing, independent scrolling, and all four Sorrow's Furnace boss names. The production app was built and opened using the existing game cache; Matthias approved the in-game result.
- Main now includes #436, which fixes the dependency audit blocker from the earlier runs.

- [Application verification](https://github.com/Mat4m0/gwonmac/actions/runs/34684312052) passed on `496b27c2`, including runtime and packaged-app checks.

- [x] I kept this pull request focused.
- [x] I ran the relevant checks.
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [x] I updated documentation when behavior or an invariant changed.
