### PR TITLE
fix(font): correct native glyph polarity and spacing

### DIFF
--- a/docs/content-pipeline.md
+++ b/docs/content-pipeline.md
@@ -126,6 +126,11 @@ bounded streams, then converts their 94 printable ASCII glyphs to separate
 TrueType families in memory. The shared Guild Wars interface theme loads them
 from `gw://app/game-font.ttf` and `gw://app/game-font-display.ttf`.
 
+Two-color glyphs start with the alpha named by their mode, then alternate after
+each run. Palette glyphs retain all 16 alpha levels during decoding. The
+TrueType metrics preserve each outline's left bearing. Digits retain the
+existing proportional spacing adjustment for interface text.
+
 The local archive remains the source of truth. GWonMac does not commit, cache,
 package, or redistribute the game glyphs or the converted font. If the file is
 missing or ArenaNet changes its format, the request fails closed and the theme
@@ -135,15 +140,21 @@ ASCII also use that fallback.
 ### Font calibration
 
 Run `pnpm font:calibrate` after changing the body converter. Add
-`-- --role display --text "Primary Quests"` to calibrate the display face. The
+`-- --role display` to calibrate the display face. The
 command reads the selected bounded strike from the local installed game,
-renders threshold candidates through Chromium at its native physical size, and
+renders all 94 glyphs through Chromium at the strike's native physical size, and
 writes reference, rendered, difference, and numeric-error results under `/tmp`.
+The JSON report includes each character's error, coverage change, and missing
+glyph status for each threshold. Add `--text "Primary Quests"` to inspect a
+specific string and its spacing instead of the complete character grid.
 
-The original grayscale strike is the reference; a screenshot is not. Generated
+The decoded grayscale strike is the rendering reference. This comparison cannot
+detect a decoder error shared by both images. Independent synthetic tests cover
+run polarity, palette levels, bounds, character mapping, and outline bearings.
+Inspect symbols in the grid as well as the aggregate score. Generated
 reports are disposable local evidence and must not be committed because they
 contain ArenaNet glyph pixels. The converter's default contour threshold is the
-best measured candidate from this loop, while a final visual check still guards
+best measured candidate across the grid, while a final visual check still guards
 against a metric rewarding an obviously poor shape.
 
 At startup, the native store scans chunk residency once. It updates the

--- a/scripts/calibrate-game-font.ts
+++ b/scripts/calibrate-game-font.ts
@@ -4,8 +4,10 @@
  * The player's own archive is the reference. Nothing from it is committed:
  * this command writes a disposable report under `/tmp` unless `--out` says
  * otherwise. Each candidate outline is rasterised by Chromium at the strike's
- * native physical size, aligned against the original grayscale
- * strike, scored by alpha error, and shown beside a heat-map difference.
+ * native physical size, compared against the decoded grayscale strike, scored by alpha error, and
+ * shown beside a heat-map difference. The default atlas checks every supported
+ * glyph; --text checks spacing in a specific string. Decoder regression tests
+ * are independent of this comparison, which cannot detect a shared decode bug.
  *
  *   pnpm font:calibrate
  *   pnpm font:calibrate -- --role display --text "Primary Quests"
@@ -46,10 +48,16 @@ const outDir = path.resolve(flag(
     ? "/tmp/gwonmac-font-calibration"
     : "/tmp/gwonmac-font-calibration-display",
 ));
-const sample = flag("text", role === "display" ? "Primary Quests" : "Seek Party");
+const atlas = !args.includes("--text");
+const sample = flag("text", Array.from({ length: 94 }, (_, index) =>
+  String.fromCharCode(0x21 + index)).join(""));
+if (!sample || [...sample].some((character) => {
+  const code = character.codePointAt(0)!;
+  return code < 0x20 || code > 0x7e;
+})) throw new Error("--text must contain only printable ASCII characters");
 const manifestPath = path.join(gameDir, "artifacts", "manifest.json");
 const decoderPath = path.resolve("build/native/gw-dat-decode");
-const thresholds = [0x60, 0x70, 0x80, 0x90, 0xa0, 0xb0, 0xc0, 0xd0, 0xe0];
+const thresholds = Array.from({ length: 33 }, (_, index) => 0x60 + index * 4);
 
 const manifest = parsePublishedClientManifest(
   JSON.parse(await readFile(manifestPath, "utf8")),
@@ -84,12 +92,13 @@ interface CandidateResult {
   referencePng: string;
   renderedPng: string;
   differencePng: string;
+  glyphs: { character: string; error: number; coverageDelta: number; missing: boolean }[];
 }
 
 const browser = await chromium.launch({ headless: true });
 const page = await browser.newPage({ viewport: { width: 1180, height: 900 } });
 const results = await page.evaluate(
-  async ({ candidates, glyphs, metrics, sample }) => {
+  async ({ candidates, glyphs, metrics, sample, atlas }) => {
     const margin = 3;
     const glyphFor = (character: string) => {
       const code = character.charCodeAt(0);
@@ -101,8 +110,18 @@ const results = await page.evaluate(
       (total, character) => total + advance(character),
       0,
     );
-    const width = contentWidth + margin * 2;
-    const height = metrics.lineHeight + margin * 2;
+    const columns = 16;
+    const cellWidth = metrics.em + margin * 2;
+    const cellHeight = metrics.lineHeight + margin * 2;
+    const width = atlas ? columns * cellWidth : contentWidth + margin * 2;
+    const height = atlas ? Math.ceil(sample.length / columns) * cellHeight : cellHeight;
+    let textPen = margin;
+    const placements = [...sample].map((character, index) => {
+      const x = atlas ? (index % columns) * cellWidth + margin : textPen;
+      const y = atlas ? Math.floor(index / columns) * cellHeight + margin : margin;
+      textPen += advance(character);
+      return { character, x, y };
+    });
 
     const makeCanvas = () => {
       const canvas = document.createElement("canvas");
@@ -114,14 +133,13 @@ const results = await page.evaluate(
     const referenceContext = reference.getContext("2d", { willReadFrequently: true });
     if (!referenceContext) throw new Error("Chromium did not provide a 2D canvas");
     const referenceImage = referenceContext.createImageData(width, height);
-    let pen = margin;
-    for (const character of sample) {
+    for (const { character, x: pen, y: row } of placements) {
       const glyph = glyphFor(character);
       if (glyph) {
         for (let y = 0; y < glyph.height; y += 1) {
           for (let x = 0; x < glyph.width; x += 1) {
             const alpha = glyph.pixels[y * glyph.width + x] ?? 0;
-            const at = ((margin + glyph.top + y) * width + pen + x) * 4;
+            const at = ((row + glyph.top + y) * width + pen + x) * 4;
             referenceImage.data[at] = 255;
             referenceImage.data[at + 1] = 255;
             referenceImage.data[at + 2] = 255;
@@ -129,7 +147,6 @@ const results = await page.evaluate(
           }
         }
       }
-      pen += advance(character);
     }
     referenceContext.putImageData(referenceImage, 0, 0);
     const referenceAlpha = referenceContext.getImageData(0, 0, width, height).data;
@@ -179,7 +196,13 @@ const results = await page.evaluate(
       context.fillStyle = "white";
       context.font = `400 ${metrics.em}px ${family}`;
       context.textBaseline = "alphabetic";
-      context.fillText(sample, margin, margin + metrics.baseline);
+      if (atlas) {
+        for (const { character, x, y } of placements) {
+          context.fillText(character, x, y + metrics.baseline);
+        }
+      } else {
+        context.fillText(sample, margin, margin + metrics.baseline);
+      }
       const renderedImage = context.getImageData(0, 0, width, height);
 
       let best = { x: 0, y: 0, ...score(renderedImage.data, 0, 0) };
@@ -190,6 +213,28 @@ const results = await page.evaluate(
         }
       }
 
+      // A whole-atlas average can conceal one missing symbol. Report every
+      // cell separately as well; keep the unaligned render visible in the PNG.
+      const glyphResults = atlas ? placements.map(({ character, x, y }) => {
+        let error = 0;
+        let referenceCoverage = 0;
+        let renderedCoverage = 0;
+        for (let cy = y - margin; cy < y - margin + cellHeight; cy++) {
+          for (let cx = x - margin; cx < x - margin + cellWidth; cx++) {
+            const referenceValue = referenceAlpha[(cy * width + cx) * 4 + 3] ?? 0;
+            const renderedValue = renderedImage.data[(cy * width + cx) * 4 + 3] ?? 0;
+            error += Math.abs(referenceValue - renderedValue);
+            referenceCoverage += referenceValue;
+            renderedCoverage += renderedValue;
+          }
+        }
+        return {
+          character,
+          error: error / (cellWidth * cellHeight * 255),
+          coverageDelta: (renderedCoverage - referenceCoverage) / Math.max(referenceCoverage, 1),
+          missing: referenceCoverage > 0 && renderedCoverage === 0,
+        };
+      }) : [];
       const difference = makeCanvas();
       const differenceContext = difference.getContext("2d");
       if (!differenceContext) throw new Error("Chromium did not provide a 2D canvas");
@@ -213,6 +258,7 @@ const results = await page.evaluate(
       differenceContext.putImageData(differenceImage, 0, 0);
       output.push({
         threshold: candidate.threshold,
+        glyphs: glyphResults,
         error: best.error,
         coverageDelta: best.coverageDelta,
         referencePng: reference.toDataURL("image/png"),
@@ -222,7 +268,7 @@ const results = await page.evaluate(
     }
     return output;
   },
-  { candidates, glyphs, metrics, sample },
+  { candidates, glyphs, metrics, sample, atlas },
 ) as CandidateResult[];
 
 results.sort((left, right) => left.error - right.error);
@@ -240,33 +286,35 @@ await Promise.all([
   writeFile(path.join(outDir, "report.json"), JSON.stringify({
     sample,
     role,
+    atlas,
     physicalPixelSize: metrics.em,
     bestThreshold: best.threshold,
-    candidates: results.map(({ threshold, error, coverageDelta }) => ({
+    candidates: results.map(({ threshold, error, coverageDelta, glyphs }) => ({
       threshold,
       error,
       coverageDelta,
+      glyphs,
     })),
   }, null, 2)),
 ]);
 
 await page.setContent(`<!doctype html><meta charset="utf-8"><style>
   :root { color-scheme: dark; font-family: ui-sans-serif, system-ui, sans-serif; }
-  body { width: 1080px; margin: 0; padding: 40px; background: #0c0b0a; color: #eee9df; }
+  body { width: ${atlas ? Math.max(1080, (metrics.em + 6) * 16 * 3 + 150) : 1080}px; margin: 0; padding: 40px; background: #0c0b0a; color: #eee9df; }
   h1 { margin: 0 0 8px; font-size: 28px; }
   p { color: #aaa397; }
   .summary { margin-bottom: 28px; }
   .grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
   article { padding: 18px; border: 1px solid #454038; border-radius: 10px; background: #171410; }
   h2 { margin: 0 0 14px; color: #e7c982; font-size: 16px; }
-  img { width: auto; height: auto; min-width: 100%; image-rendering: pixelated; background: #241b14; }
+  img { width: 100%; height: auto; image-rendering: pixelated; background: #241b14; }
   table { width: 100%; margin-top: 28px; border-collapse: collapse; font-variant-numeric: tabular-nums; }
   th, td { padding: 8px 10px; border-bottom: 1px solid #39352f; text-align: right; }
   th:first-child, td:first-child { text-align: left; }
   tr.best { color: #f2d58e; font-weight: 700; }
 </style>
 <h1>Guild Wars ${role} font calibration</h1>
-<p class="summary">“${sample.replaceAll("&", "&amp;").replaceAll("<", "&lt;")}” at ${metrics.em} physical pixels · best alpha threshold: 0x${best.threshold.toString(16)} · mean error ${(best.error * 100).toFixed(2)}%</p>
+<p class="summary">${atlas ? "All 94 printable non-space ASCII glyphs" : `“${sample.replaceAll("&", "&amp;").replaceAll("<", "&lt;")}”`} at ${metrics.em} physical pixels · best alpha threshold: 0x${best.threshold.toString(16)} · mean error ${(best.error * 100).toFixed(2)}%</p>
 <div class="grid">
   <article><h2>Original archive strike</h2><img src="${best.referencePng}"></article>
   <article><h2>Chromium render</h2><img src="${best.renderedPng}"></article>
@@ -286,4 +334,5 @@ console.log(JSON.stringify({
   bestThreshold: `0x${best.threshold.toString(16)}`,
   meanAlphaError: best.error,
   coverageDelta: best.coverageDelta,
+  missingGlyphs: best.glyphs.filter(({ missing }) => missing).map(({ character }) => character),
 }, null, 2));

--- a/src/main/core/gw-font.ts
+++ b/src/main/core/gw-font.ts
@@ -61,9 +61,9 @@ export const GUILD_WARS_FONT_METRICS = GUILD_WARS_BODY_FONT;
 const MAX_RECTANGLES_PER_GLYPH = 2_048;
 const MAX_TOTAL_RECTANGLES = 65_536;
 const UNITS_PER_EM = 1024;
-// Measured by `pnpm font:calibrate` against the original grayscale strike.
-const BODY_OUTLINE_THRESHOLD = 0xa0;
-const DISPLAY_OUTLINE_THRESHOLD = 0xe0;
+// Measured by `pnpm font:calibrate` across all 94 decoded glyphs.
+const BODY_OUTLINE_THRESHOLD = 0xb4;
+const DISPLAY_OUTLINE_THRESHOLD = 0xc4;
 const OUTLINE_SAMPLE_SCALE = 4;
 
 export interface GameFontBuildOptions {
@@ -149,7 +149,7 @@ function decodeGlyph(
   while (written < pixelCount) {
     let length: number;
     if (mode === 0 || mode === 15) {
-      alpha ^= 0xff;
+      // The mode is the first run's alpha, not the previous run's alpha.
       length = input.run();
     } else {
       const value = input.read();
@@ -161,6 +161,7 @@ function decodeGlyph(
     }
     pixels.fill(alpha, written, written + length);
     written += length;
+    if (mode === 0 || mode === 15) alpha ^= 0xff;
   }
   return { glyph: { top, width, height, pixels }, bytes: input.bytesRead };
 }
@@ -267,8 +268,8 @@ function interpolatedAlpha(
 /**
  * Trace the game's grayscale mask on a quarter-pixel grid, then merge equal
  * horizontal runs into outline rectangles. The interpolation retains where a
- * soft edge crosses half opacity; tracing the source pixels directly produced
- * the visibly stepped curves the bitmap's alpha levels were meant to hide.
+ * soft edge crosses the calibrated threshold. Tracing source pixels directly
+ * produced the stepped curves the bitmap's alpha levels were meant to hide.
  */
 function bitmapRectangles(
   glyph: GameGlyph,
@@ -512,6 +513,11 @@ export function buildGuildWarsTrueType(
   }
   const advances = metrics.map(({ advance }) =>
     Math.max(1, Math.round(advance * UNITS_PER_EM / strike.em)));
+  // Use the outline's xMin as its left bearing to preserve the source inset
+  // and satisfy head's xMin/lsb flag. Zero shifts padded glyphs left in Chromium.
+  const leftBearings = glyfParts.map((glyph) => glyph.readInt16BE(2));
+  const rightBearings = glyfParts.map((glyph, index) =>
+    advances[index]! - glyph.readInt16BE(6));
   const maxRectangles = Math.max(0, ...rectangles.map((value) => value.length));
   const ascent = Math.round(strike.baseline * UNITS_PER_EM / strike.em);
   const descent = Math.round((strike.baseline - strike.em) * UNITS_PER_EM / strike.em);
@@ -537,9 +543,9 @@ export function buildGuildWarsTrueType(
   hhea.writeInt16BE(descent, 6);
   hhea.writeInt16BE(lineGap, 8);
   hhea.writeUInt16BE(Math.max(...advances), 10);
-  hhea.writeInt16BE(0, 12);
-  hhea.writeInt16BE(0, 14);
-  hhea.writeInt16BE(Math.max(...advances), 16);
+  hhea.writeInt16BE(Math.min(...leftBearings), 12);
+  hhea.writeInt16BE(Math.min(...rightBearings), 14);
+  hhea.writeInt16BE(Math.max(...glyfParts.map((glyph) => glyph.readInt16BE(6))), 16);
   hhea.writeInt16BE(1, 18);
   hhea.writeInt16BE(0, 20);
   hhea.writeUInt16BE(sourceGlyphs.length, 34);
@@ -562,7 +568,8 @@ export function buildGuildWarsTrueType(
     ["glyf", Buffer.concat(glyfParts)],
     ["head", head],
     ["hhea", hhea],
-    ["hmtx", Buffer.concat(advances.map((advance) => Buffer.concat([u16(advance), i16(0)])))],
+    ["hmtx", Buffer.concat(advances.map((advance, index) =>
+      Buffer.concat([u16(advance), i16(leftBearings[index]!)])))],
     ["loca", Buffer.concat(loca.map(u32))],
     ["maxp", maxp],
     ["name", nameTable(strike)],

--- a/tests/unit/guild-wars-font.test.ts
+++ b/tests/unit/guild-wars-font.test.ts
@@ -67,13 +67,74 @@ test("the Guild Wars nibble stream decodes every printable ASCII glyph", () => {
 });
 
 test("alternating runs cannot overrun a glyph", () => {
-  // top=0, width=2, height=2, mode=0, then runs of two lit and two clear.
+  // top=0, width=2, height=2, mode=0, then runs of two clear and two lit.
   const glyphs = decodeGameFontRange(repeatedGlyph([0x10, 0x01, 0x11]));
-  assert.deepEqual([...glyphs[0]!.pixels], [0xff, 0xff, 0x00, 0x00]);
+  assert.deepEqual([...glyphs[0]!.pixels], [0x00, 0x00, 0xff, 0xff]);
   assert.throws(
     () => decodeGameFontRange(repeatedGlyph([0x00, 0x00, 0x1f])),
     /run exceeds its bitmap/,
   );
+});
+
+test("binary symbols preserve the first run's polarity in both strikes", () => {
+  // Synthetic 3x3 + and = masks, plus solid | and _ strokes. These exercise
+  // both starting alphas without including any proprietary glyph bytes.
+  const plus = packedNibbles([0, 2, 2, 0, 0, 0, 0, 2, 0, 0, 0]);
+  const equals = packedNibbles([0, 2, 2, 15, 2, 2, 2]);
+  const bar = packedNibbles([0, 0, 2, 15, 2]);
+  const underscore = packedNibbles([3, 2, 0, 15, 2]);
+  const masks = new Map([
+    ["+", { bytes: plus, pixels: [0, 255, 0, 255, 255, 255, 0, 255, 0] }],
+    ["=", { bytes: equals, pixels: [255, 255, 255, 0, 0, 0, 255, 255, 255] }],
+    ["|", { bytes: bar, pixels: [255, 255, 255] }],
+    ["_", { bytes: underscore, pixels: [255, 255, 255] }],
+  ]);
+  const source = Array.from({ length: GLYPH_COUNT }, () => plus);
+  for (const [character, mask] of masks) source[character.charCodeAt(0) - 0x21] = mask.bytes;
+  for (const strike of [undefined, GUILD_WARS_DISPLAY_FONT]) {
+    const glyphs = decodeGameFontRange(Uint8Array.from(source.flat()), strike);
+    for (const [character, mask] of masks) {
+      assert.deepEqual([...glyphs[character.charCodeAt(0) - 0x21]!.pixels], mask.pixels, character);
+    }
+  }
+});
+
+test("palette glyphs retain all alpha levels and endpoint runs", () => {
+  const source = packedNibbles([
+    0, 15, 2, 0, 1, // width=24, height=1, palette mode
+    0, 4, // five transparent pixels
+    1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+    15, 4, // five opaque pixels
+  ]);
+  for (let mode = 1; mode < 15; mode++) {
+    const variant = [...source];
+    variant[2] = (variant[2]! & 0xf0) | mode;
+    const glyphs = decodeGameFontRange(repeatedGlyph(variant));
+    assert.deepEqual([...glyphs[0]!.pixels], [
+      0, 0, 0, 0, 0,
+      0x66, 0x79, 0x8d, 0x97, 0xa5, 0xaf, 0xbd,
+      0xc6, 0xce, 0xd6, 0xde, 0xe7, 0xef, 0xf7,
+      255, 255, 255, 255, 255,
+    ]);
+  }
+});
+
+test("long binary runs cross rows without losing polarity", () => {
+  // 24x2 bitmap: 32 opaque pixels, then 16 transparent pixels.
+  const source = packedNibbles([0, 15, 2, 1, 15, 15, 15, 1, 15, 0]);
+  assert.deepEqual(
+    [...decodeGameFontRange(repeatedGlyph(source))[0]!.pixels],
+    [...Array<number>(32).fill(255), ...Array<number>(16).fill(0)],
+  );
+});
+
+test("truncated, extra, and incomplete ranges are refused", () => {
+  assert.throws(() => decodeGameFontRange(Uint8Array.of(0)), /ended inside a nibble/);
+  assert.throws(() => decodeGameFontRange(Uint8Array.of(0, 0xf0)), /ended inside a nibble/);
+  assert.throws(() => decodeGameFontRange(Uint8Array.of(0, 0xf0, 0)), /instead of 94/);
+  assert.throws(() => decodeGameFontRange(Uint8Array.from([
+    ...repeatedGlyph([0, 0xf0, 0]), 0, 0xf0, 0,
+  ])), /95 glyphs instead of 94/);
 });
 
 test("the converted result is a complete checksummed TrueType font", () => {
@@ -95,17 +156,17 @@ test("the original display strike builds as a separate browser family", () => {
     font,
     buildGuildWarsTrueType(repeatedGlyph([0x00, 0x10, 0x01]), {
       strike: GUILD_WARS_DISPLAY_FONT,
-      outlineThreshold: 0xe0,
+      outlineThreshold: 0xc4,
     }),
   );
 });
 
 test("the measured contour remains the default and calibration inputs are bounded", () => {
-  const strike = repeatedGlyph([0x00, 0x00, 0x00]);
+  const strike = repeatedGlyph([0x00, 0xf0, 0x00]);
   const font = buildGuildWarsTrueType(strike);
   assert.deepEqual(
     font,
-    buildGuildWarsTrueType(strike, { outlineThreshold: 0xa0 }),
+    buildGuildWarsTrueType(strike, { outlineThreshold: 0xb4 }),
   );
   assert.notDeepEqual(
     font,
@@ -134,6 +195,39 @@ test("a narrow numeral gets balanced proportional spacing", () => {
   const advance = (character: string) =>
     font.readUInt16BE(hmtx + glyphId(character) * 4);
   assert.ok(advance("1") < advance("2"));
+});
+
+test("every character maps to an outline with its actual left bearing", () => {
+  // Give each character a stem at a different inset. Check the encoded cmap,
+  // metrics and outline together so an otherwise valid font cannot silently
+  // shift punctuation or map a symbol to the next character.
+  const source = Array.from({ length: GLYPH_COUNT }, (_, index) => {
+    const inset = index % 4;
+    const pixels = Array.from({ length: 7 }, (_, x) => x === inset ? 15 : 0);
+    return packedNibbles([0, 6, 0, 1, ...pixels.flatMap((alpha) => [alpha, 0])]);
+  });
+  const font = buildGuildWarsTrueType(Uint8Array.from(source.flat()), {
+    outlineSampleScale: 1,
+  });
+  const cmap = tableOffset(font, "cmap") + 12;
+  const glyf = tableOffset(font, "glyf");
+  const loca = tableOffset(font, "loca");
+  const hmtx = tableOffset(font, "hmtx");
+  assert.equal(font.readUInt16BE(cmap), 4);
+  assert.equal(font.readUInt16BE(cmap + 14), 0x7e);
+  assert.equal(font.readUInt16BE(cmap + 20), 0x20);
+  const delta = font.readInt16BE(cmap + 24);
+  for (let character = 0x21; character <= 0x7e; character++) {
+    const id = character + delta;
+    assert.equal(id, character - 0x21 + 2);
+    const outline = glyf + font.readUInt32BE(loca + id * 4);
+    assert.equal(font.readInt16BE(outline), 1, `visible ${String.fromCharCode(character)}`);
+    const left = font.readInt16BE(outline + 2);
+    assert.equal(font.readInt16BE(hmtx + id * 4 + 2), left);
+    if (character < 0x30 || character > 0x39) {
+      assert.equal(left, Math.round(((character - 0x21) % 4) * 1024 / 24));
+    }
+  }
 });
 
 test("an unsupported font is refused once for its immutable client generation", async () => {


### PR DESCRIPTION
## What changed

The native Guild Wars UI font now displays `+` and `=` with the correct polarity and restores the missing `|` and `_`. Glyphs keep their intended left spacing, and both font faces are recalibrated against all 94 supported characters.

## Why

The two-color decoder switched alpha before the first run, inverting its mask. The generated TrueType font also declared zero left bearings, shifting padded glyphs in Chromium. Fix both shared owners instead of adding symbol-specific replacements.

Calibration now checks the complete character grid and reports errors and missing glyphs per character. Its documentation explains that comparing two outputs from the same decoder cannot prove the decoder itself is correct.

## Invariant

Synthetic tests cover both starting alphas, all palette modes and levels, extended runs, malformed ranges, ASCII mapping, and outline bearings. Fonts remain derived locally from the player's archive; non-ASCII characters retain the existing fallback.

## Delivery

Stacked on #436, which updates only the dependencies that blocked the audit. Merge #436 into `main` first, then this font correction. Recommend a Developer Build for visual acceptance, with Beta consideration when grouped into a release because font metrics and weight affect the shared UI. No release or deployment is included. Live-game visual QA remains unverified.

## Verification

- `pnpm run check` passed: type checks, lint, Markdown links, unit and policy tests, Tools tests, and launcher tests.
- The 14 focused font unit tests passed.
- Ran `scripts/calibrate-game-font.ts` directly through the repository TypeScript hook for both local strikes, checking all 94 glyphs across 33 threshold candidates.
- Chromium rendered every supported glyph at eight UI sizes across both faces, with no missing glyphs. Inspected a before/after input and typography preview at 2× display density.
- Generated fonts and visual evidence stay outside the repository.
- The dependency audit blocker is fixed in the lower layer, #436. Its frozen install, high-severity audit, application checks, website build, and website smoke checks passed locally. The 14 font tests passed again after rebasing. [GitHub Application verification](https://github.com/Mat4m0/gwonmac/actions/runs/34682953210) passed for this exact head, including runtime tests, packaged-app tests, and the final required gate. Website verification and CodeQL also passed.

- [x] I kept this pull request focused.
- [x] I ran the relevant checks.
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [x] I updated documentation when behavior or an invariant changed.

Prepared with Codex (GPT-6) using the repository test harness and Playwright/Chromium.
