### PR TITLE
test: isolate Playwright output from development profiles

### DIFF
--- a/.github/workflows/macos-verify.yml
+++ b/.github/workflows/macos-verify.yml
@@ -82,9 +82,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: electron-failure-${{ github.run_id }}-${{ github.run_attempt }}
-          path: |
-            test-results
-            apps/tools/test-results
+          path: test-results
           if-no-files-found: ignore
           retention-days: 7
 

--- a/apps/tools/playwright.config.ts
+++ b/apps/tools/playwright.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
+  // A suite may clear only its own output, never other local evidence or profiles.
+  outputDir: "../../test-results/tools-e2e",
   testDir: "./tests",
   timeout: 20_000,
   fullyParallel: true,

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -89,6 +89,8 @@ Cache provisioning does not require copying account settings or credentials.
 Keep logs, screenshots, and the profile path in ignored `test-results/`, outside
 `build/`: the build command deletes that directory. Do not redirect into the
 same file that a command is reading to recover its profile path.
+Playwright suites own only `test-results/electron/` and `test-results/tools-e2e/`.
+Keep development evidence and profiles outside those disposable suite directories.
 
 Use `cua.getState()` for discovery. Confirm the process working directory and
 profile, then attach through its debugger or exact running app path. App lookup

--- a/tests/electron/playwright.config.ts
+++ b/tests/electron/playwright.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
+  // A suite may clear only its own output, never other local evidence or profiles.
+  outputDir: "../../test-results/electron",
   testDir: ".",
   testMatch: /.*\.spec\.ts$/,
   globalSetup: "./global-setup.ts",


### PR DESCRIPTION
## What changed

Playwright writes Electron and Tools results into separate subdirectories. Starting a suite no longer clears unrelated development profiles or evidence under `test-results/`.

## Why

The previous Electron default cleared the shared results directory. This was reproduced during native-rendering verification. CI now collects both suites from the same results root.

## Invariant

Each suite owns only its disposable output directory. Both suites preserved an independent sentinel outside their directories.

## Delivery

Targets `main`; first layer of the native-rendering stack. No application release is needed for this tooling fix.

## Verification

Tools end-to-end suite: 42 passed. Focused Electron checks: four passed. Workflow policy, lint, and documentation-link checks passed.

- [x] I kept this pull request focused.
- [x] I ran the relevant checks.
- [x] I did not add game binaries, credentials, diagnostics, or private traffic.
- [x] I updated documentation when behavior or an invariant changed.
